### PR TITLE
adapter: use ReadHolds to determine least valid read

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1332,9 +1332,7 @@ pub struct Coordinator {
     ///
     /// Upon completing a transaction, this timestamp should be removed from the holds
     /// in `self.read_capability[id]`, using the `release_read_holds` method.
-    ///
-    /// We use a Vec because `ReadHolds` doesn't have a way of tracking multiplicity.
-    txn_read_holds: BTreeMap<ConnectionId, Vec<read_policy::ReadHolds<Timestamp>>>,
+    txn_read_holds: BTreeMap<ConnectionId, read_policy::ReadHolds<Timestamp>>,
 
     /// Access to the peek fields should be restricted to methods in the [`peek`] API.
     /// A map from pending peek ids to the queue into which responses are sent, and

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2273,7 +2273,7 @@ impl Coordinator {
             .acquire_read_holds(mz_repr::Timestamp::minimum(), &direct_dependencies, false)
             .expect("can acquire un-precise read holds");
 
-        let min_as_of = self.least_valid_read(&direct_dependencies);
+        let min_as_of = self.least_valid_read(&read_holds);
 
         // We must not select an `as_of` that is beyond any times that have not yet been written to
         // downstream storage collections (i.e., materialized views). If we would, we might skip

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -897,10 +897,7 @@ impl Coordinator {
             // NOTE: The Drop impl of ReadHolds makes sure that the hold is
             // released when we don't use it.
             if acquire_read_holds {
-                self.txn_read_holds
-                    .entry(session.conn_id().clone())
-                    .or_insert_with(Vec::new)
-                    .push(read_holds);
+                self.store_transaction_read_holds(session, read_holds);
             }
 
             if oracle_timestamp != timestamp {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -888,12 +888,20 @@ impl Coordinator {
             // Acquire read holds _before_ we determine the least valid read.
             // Otherwise, we're not guaranteed that the since frontier doesn't
             // advance forward from underneath us.
-            if acquire_read_holds {
-                self.acquire_read_holds_auto_cleanup(session, timestamp, &ids, false)
-                    .expect("precise==false, so acquiring read holds always succeeds");
-            }
+            let read_holds = self
+                .acquire_read_holds(timestamp, &ids, false)
+                .expect("precise==false, so acquiring read holds always succeeds");
+            let least_valid_read = self.least_valid_read(&read_holds);
+            timestamp.advance_by(least_valid_read.borrow());
 
-            timestamp.advance_by(self.least_valid_read(&ids).borrow());
+            // NOTE: The Drop impl of ReadHolds makes sure that the hold is
+            // released when we don't use it.
+            if acquire_read_holds {
+                self.txn_read_holds
+                    .entry(session.conn_id().clone())
+                    .or_insert_with(Vec::new)
+                    .push(read_holds);
+            }
 
             if oracle_timestamp != timestamp {
                 warn!(%cmvs.name, %oracle_timestamp, %timestamp, "REFRESH MV's inputs are not readable at the oracle read ts");

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1043,7 +1043,7 @@ impl Coordinator {
         let read_holds = self
             .acquire_read_holds(mz_repr::Timestamp::MIN, &id_bundle, false)
             .expect("can acquire read holds");
-        let as_of = self.least_valid_read(&id_bundle);
+        let as_of = self.least_valid_read(&read_holds);
 
         let storage_sink_from_entry = self.catalog().get_entry(&sink.from);
         let storage_sink_desc = mz_storage_types::sinks::StorageSinkDesc {

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -244,6 +244,11 @@ impl<T: Eq + Hash + Ord> ReadHoldsInner<T> {
             })
     }
 
+    /// Returns an iterator over all times at which a read hold exists.
+    pub fn times(&self) -> impl Iterator<Item = &Antichain<T>> {
+        self.holds.keys()
+    }
+
     /// Returns an iterator over all storage ids and the time at which their read hold exists.
     fn storage_ids(&self) -> impl Iterator<Item = (&Antichain<T>, &GlobalId)> {
         self.holds

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -34,7 +34,9 @@ use mz_repr::{GlobalId, Timestamp};
 use mz_sql::session::metadata::SessionMetadata;
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::Serialize;
+use timely::progress::frontier::MutableAntichain;
 use timely::progress::Antichain;
+use timely::progress::Timestamp as TimelyTimestamp;
 
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timeline::{TimelineContext, TimelineState};
@@ -171,7 +173,7 @@ impl<T: Eq + Hash + Ord> TimelineReadHolds<T> {
 /// [ReadHolds] are used for short-lived read holds. For example, when
 /// processing peeks or rendering dataflows. These are never downgraded but they
 /// _are_ released automatically when being dropped.
-pub struct ReadHolds<T> {
+pub struct ReadHolds<T: Eq + Hash + Ord> {
     pub inner: ReadHoldsInner<T>,
     dropped_read_holds_tx: tokio::sync::mpsc::UnboundedSender<ReadHoldsInner<T>>,
 }
@@ -189,7 +191,16 @@ impl<T: Eq + Hash + Ord> ReadHolds<T> {
     }
 }
 
-impl<T> Deref for ReadHolds<T> {
+impl<T: TimelyTimestamp + Lattice> ReadHolds<T> {
+    pub fn merge(&mut self, mut other: Self) {
+        // Now, when other is dropped we don't release the holds anymore.
+        // Instead we take ownership and move them to ourselves.
+        let other_inner = std::mem::take(&mut other.inner);
+        self.inner.merge(other_inner)
+    }
+}
+
+impl<T: Eq + Hash + Ord> Deref for ReadHolds<T> {
     type Target = ReadHoldsInner<T>;
 
     fn deref(&self) -> &ReadHoldsInner<T> {
@@ -197,7 +208,7 @@ impl<T> Deref for ReadHolds<T> {
     }
 }
 
-impl<T: Debug> Debug for ReadHolds<T> {
+impl<T: Debug + Eq + Hash + Ord> Debug for ReadHolds<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ReadHolds")
             .field("read_holds", &self.inner)
@@ -205,11 +216,15 @@ impl<T: Debug> Debug for ReadHolds<T> {
     }
 }
 
-impl<T> Drop for ReadHolds<T> {
+impl<T: Eq + Hash + Ord> Drop for ReadHolds<T> {
     fn drop(&mut self) {
         let inner_holds = std::mem::take(&mut self.inner);
 
-        tracing::debug!("dropping ReadHolds on {:?}", inner_holds.holds.values());
+        tracing::debug!(
+            "dropping ReadHolds on storage {:?} and compute {:?} ",
+            inner_holds.storage_holds.keys(),
+            inner_holds.compute_holds.keys()
+        );
 
         let res = self.dropped_read_holds_tx.send(inner_holds);
         if let Err(e) = res {
@@ -222,77 +237,62 @@ impl<T> Drop for ReadHolds<T> {
 /// inner state along a channel, for releasing when dropped.
 #[derive(Debug)]
 pub struct ReadHoldsInner<T> {
-    pub holds: HashMap<Antichain<T>, CollectionIdBundle>,
+    pub storage_holds: HashMap<GlobalId, MutableAntichain<T>>,
+    pub compute_holds: HashMap<(ComputeInstanceId, GlobalId), MutableAntichain<T>>,
 }
 
 impl<T: Eq + Hash + Ord> ReadHoldsInner<T> {
     /// Return empty `ReadHolds`.
     pub fn new() -> Self {
         ReadHoldsInner {
-            holds: HashMap::new(),
+            storage_holds: HashMap::new(),
+            compute_holds: HashMap::new(),
         }
     }
 
     /// Return a `CollectionIdBundle` containing all the IDs in the
     /// [ReadHoldsInner].
     pub fn id_bundle(&self) -> CollectionIdBundle {
-        self.holds
-            .values()
-            .fold(CollectionIdBundle::default(), |mut accum, id_bundle| {
-                accum.extend(id_bundle);
-                accum
-            })
-    }
+        let mut res = CollectionIdBundle::default();
+        for id in self.storage_holds.keys() {
+            res.storage_ids.insert(*id);
+        }
+        for (instance_id, id) in self.compute_holds.keys() {
+            res.compute_ids.entry(*instance_id).or_default().insert(*id);
+        }
 
-    /// Returns an iterator over all times at which a read hold exists.
-    pub fn times(&self) -> impl Iterator<Item = &Antichain<T>> {
-        self.holds.keys()
-    }
-
-    /// Returns an iterator over all storage ids and the time at which their read hold exists.
-    fn storage_ids(&self) -> impl Iterator<Item = (&Antichain<T>, &GlobalId)> {
-        self.holds
-            .iter()
-            .flat_map(|(time, id_bundle)| std::iter::repeat(time).zip(id_bundle.storage_ids.iter()))
-    }
-
-    /// Returns an iterator over all compute ids by compute instance and the time at which their
-    /// read hold exists.
-    fn compute_ids(
-        &self,
-    ) -> impl Iterator<
-        Item = (
-            &ComputeInstanceId,
-            impl Iterator<Item = (&Antichain<T>, &GlobalId)>,
-        ),
-    > {
-        let compute_instances: BTreeSet<_> = self
-            .holds
-            .iter()
-            .flat_map(|(_, id_bundle)| id_bundle.compute_ids.keys())
-            .collect();
-
-        compute_instances.into_iter().map(|compute_instance| {
-            let inner_iter = self
-                .holds
-                .iter()
-                .filter_map(|(time, id_bundle)| {
-                    id_bundle
-                        .compute_ids
-                        .get(compute_instance)
-                        .map(|ids| std::iter::repeat(time).zip(ids.iter()))
-                })
-                .flatten();
-            (compute_instance, inner_iter)
-        })
+        res
     }
 }
 
-impl<T> Default for ReadHoldsInner<T> {
-    fn default() -> Self {
-        ReadHoldsInner {
-            holds: Default::default(),
+impl<T: TimelyTimestamp + Lattice> ReadHoldsInner<T> {
+    pub fn least_valid_read(&self) -> Antichain<T> {
+        let mut since = Antichain::from_elem(T::minimum());
+        for (_id, hold) in self.storage_holds.iter() {
+            since.join_assign(&hold.frontier().to_owned());
         }
+
+        for (_id, hold) in self.compute_holds.iter() {
+            since.join_assign(&hold.frontier().to_owned());
+        }
+        since
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        for (id, mut other_hold) in other.storage_holds {
+            let hold = self.storage_holds.entry(id).or_default();
+            hold.update_iter(other_hold.updates().cloned());
+        }
+        for (id, mut other_hold) in other.compute_holds {
+            let hold = self.compute_holds.entry(id).or_default();
+            hold.update_iter(other_hold.updates().cloned());
+        }
+    }
+}
+
+impl<T: Eq + Hash + Ord> Default for ReadHoldsInner<T> {
+    fn default() -> Self {
+        ReadHoldsInner::new()
     }
 }
 
@@ -753,12 +753,8 @@ impl crate::coord::Coordinator {
                 .expect("collection does not exist");
             let read_frontier = collection.implied_capability.clone();
             let time_antichain = time_antichain.join(&read_frontier);
-            read_holds
-                .holds
-                .entry(time_antichain)
-                .or_default()
-                .storage_ids
-                .insert(*id);
+            let hold_chain = MutableAntichain::from(time_antichain);
+            read_holds.storage_holds.insert(*id, hold_chain);
         }
         for (compute_instance, compute_ids) in id_bundle.compute_ids.iter() {
             let compute = self.controller.active_compute();
@@ -768,54 +764,67 @@ impl crate::coord::Coordinator {
                     .expect("collection does not exist");
                 let read_frontier = collection.read_capability().clone();
                 let time_antichain = time_antichain.join(&read_frontier);
+                let hold_chain = MutableAntichain::from(time_antichain);
                 read_holds
-                    .holds
-                    .entry(time_antichain)
-                    .or_default()
-                    .compute_ids
-                    .entry(*compute_instance)
-                    .or_default()
-                    .insert(*id);
+                    .compute_holds
+                    .insert((*compute_instance, *id), hold_chain);
             }
         }
 
         if precise {
+            let mut too_late: HashMap<_, CollectionIdBundle> = HashMap::new();
+            for (id, hold) in read_holds.storage_holds.iter() {
+                if !hold.frontier().iter().all(|hold_time| *hold_time == time) {
+                    let owned_frontier = hold.frontier().to_owned();
+                    too_late
+                        .entry(owned_frontier)
+                        .or_default()
+                        .storage_ids
+                        .insert(*id);
+                }
+            }
+            for ((instance_id, id), hold) in read_holds.compute_holds.iter() {
+                if !hold.frontier().iter().all(|hold_time| *hold_time == time) {
+                    let owned_frontier = hold.frontier().to_owned();
+                    too_late
+                        .entry(owned_frontier)
+                        .or_default()
+                        .compute_ids
+                        .entry(*instance_id)
+                        .or_default()
+                        .insert(*id);
+                }
+            }
             // If we are not able to acquire read holds precisely at the specified time (only later), then error out.
-            let too_late = read_holds
-                .holds
-                .iter()
-                .filter_map(|(antichain, ids)| {
-                    if antichain.iter().all(|hold_time| *hold_time == time) {
-                        None
-                    } else {
-                        Some((antichain.clone(), ids.clone()))
-                    }
-                })
-                .collect_vec();
             if !too_late.is_empty() {
-                return Err(too_late);
+                return Err(too_late.into_iter().collect_vec());
             }
         }
 
         // Update STORAGE read policies.
         let mut policy_changes = Vec::new();
-        for (time, id) in read_holds.storage_ids() {
+        for (id, hold) in read_holds.storage_holds.iter_mut() {
             let read_needs = self.ensure_storage_capability(id, None);
-            read_needs.holds.update_iter(time.iter().map(|t| (*t, 1)));
+            read_needs.holds.update_iter(hold.updates().cloned());
             policy_changes.push((*id, read_needs.policy()));
         }
         self.controller.storage.set_read_policy(policy_changes);
+
         // Update COMPUTE read policies
-        for (compute_instance, compute_ids) in read_holds.compute_ids() {
-            let mut policy_changes = Vec::new();
-            for (time, id) in compute_ids {
-                let read_needs = self.ensure_compute_capability(compute_instance, id, None);
-                read_needs.holds.update_iter(time.iter().map(|t| (*t, 1)));
-                policy_changes.push((*id, read_needs.policy()));
-            }
-            let mut compute = self.controller.active_compute();
+        let mut policy_changes: HashMap<_, Vec<_>> = HashMap::new();
+        for ((compute_instance, id), hold) in read_holds.compute_holds.iter_mut() {
+            let read_needs = self.ensure_compute_capability(compute_instance, id, None);
+            read_needs.holds.update_iter(hold.updates().cloned());
+            policy_changes
+                .entry(*compute_instance)
+                .or_default()
+                .push((*id, read_needs.policy()));
+        }
+
+        let mut compute = self.controller.active_compute();
+        for (compute_instance, policy_changes) in policy_changes {
             compute
-                .set_read_policy(*compute_instance, policy_changes)
+                .set_read_policy(compute_instance, policy_changes)
                 .unwrap_or_terminate("cannot fail to set read policy");
         }
 
@@ -852,38 +861,40 @@ impl crate::coord::Coordinator {
     /// `initialize_read_holds`, `acquire_read_holds`, or `update_read_hold` that returned
     /// `ReadHolds`, and its behavior will be erratic if called on anything else,
     /// or if called more than once on the same bundle of read holds.
-    pub(super) fn release_read_holds(&mut self, read_holdses: Vec<ReadHoldsInner<Timestamp>>) {
+    pub(super) fn release_read_holds(&mut self, mut read_holdses: Vec<ReadHoldsInner<Timestamp>>) {
         // Update STORAGE read policies.
         let mut storage_policy_changes = Vec::new();
-        for read_holds in read_holdses.iter() {
-            for (time, id) in read_holds.storage_ids() {
+        for read_holds in read_holdses.iter_mut() {
+            for (id, hold) in read_holds.storage_holds.iter_mut() {
                 // It's possible that a concurrent DDL statement has already dropped this GlobalId
                 if let Some(read_needs) = self.storage_read_capabilities.get_mut(id) {
-                    read_needs.holds.update_iter(time.iter().map(|t| (*t, -1)));
+                    let inverted_hold = hold.updates().map(|(t, diff)| (*t, -diff));
+                    read_needs.holds.update_iter(inverted_hold);
                     storage_policy_changes.push((*id, read_needs.policy()));
                 }
             }
         }
+
         self.controller
             .storage
             .set_read_policy(storage_policy_changes);
+
         // Update COMPUTE read policies
-        let mut compute = self.controller.active_compute();
         let mut policy_changes_per_instance = BTreeMap::new();
-        for read_holds in read_holdses.iter() {
-            for (compute_instance, compute_ids) in read_holds.compute_ids() {
+        for read_holds in read_holdses.iter_mut() {
+            for ((compute_instance, id), hold) in read_holds.compute_holds.iter_mut() {
                 let policy_changes = policy_changes_per_instance
                     .entry(compute_instance)
                     .or_insert_with(Vec::new);
-                for (time, id) in compute_ids {
-                    // It's possible that a concurrent DDL statement has already dropped this GlobalId
-                    if let Some(read_needs) = self.compute_read_capabilities.get_mut(id) {
-                        read_needs.holds.update_iter(time.iter().map(|t| (*t, -1)));
-                        policy_changes.push((*id, read_needs.policy()));
-                    }
+                // It's possible that a concurrent DDL statement has already dropped this GlobalId
+                if let Some(read_needs) = self.compute_read_capabilities.get_mut(id) {
+                    let inverted_hold = hold.updates().map(|(t, diff)| (*t, -diff));
+                    read_needs.holds.update_iter(inverted_hold);
+                    policy_changes.push((*id, read_needs.policy()));
                 }
             }
         }
+        let mut compute = self.controller.active_compute();
         for (compute_instance, policy_changes) in policy_changes_per_instance {
             if compute.instance_exists(*compute_instance) {
                 compute

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -459,7 +459,7 @@ impl Coordinator {
                 let read_holds = coord
                     .acquire_read_holds(mz_repr::Timestamp::minimum(), &id_bundle, false)
                     .expect("can acquire read holds");
-                let since = coord.least_valid_read(&id_bundle);
+                let since = coord.least_valid_read(&read_holds);
                 df_desc.set_as_of(since);
 
                 // Emit notices.

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -29,7 +29,7 @@ use mz_sql_parser::ast;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
 use timely::progress::Antichain;
-use timely::progress::Timestamp;
+use timely::PartialOrder;
 use tracing::Span;
 
 use crate::command::ExecuteResponse;
@@ -540,8 +540,68 @@ impl Coordinator {
     ) -> Result<StageResult<Box<CreateMaterializedViewStage>>, AdapterError> {
         // Timestamp selection
         let id_bundle = dataflow_import_id_bundle(global_lir_plan.df_desc(), cluster_id);
-        let (read_holds, dataflow_as_of, storage_as_of, until) =
-            self.select_timestamps(id_bundle, refresh_schedule.as_ref())?;
+
+        let read_holds_owned;
+        let read_holds = if let Some(txn_reads) = self.txn_read_holds.get(session.conn_id()) {
+            // In some cases, for example when REFRESH is used, the preparatory
+            // stages will already have acquired ReadHolds, we can re-use those.
+
+            // Verify that all acquired read holds are for exactly the same
+            // bundle of IDs, which are also the reads that we have determined
+            // above.
+            for read_holds in txn_reads.iter() {
+                assert!(
+                    id_bundle.difference(&read_holds.id_bundle()).is_empty(),
+                    "read holds {:?} does not have the expected IDs {:?}",
+                    read_holds,
+                    id_bundle
+                );
+            }
+
+            // Pick the read hold with the lowest time, specifically the read
+            // hold where the join of all the times at which it holds is lowest.
+            //
+            // This assumes that we don't have "weird" combinations of read
+            // holds, for example one hold that has early holds for one set of
+            // collections and late holds for another set of collections, and
+            // then another hold that has these sets reversed. If we had that
+            // case, the best overall hold to pick would be a combined hold
+            // where we pick the lowest time for each collection. It should not
+            // be too hard to do that, but also seems overkill for our purposes
+            // here.
+            let mut earliest_hold = &txn_reads[0];
+            let mut earliest_time =
+                earliest_hold
+                    .times()
+                    .fold(Antichain::new(), |mut acc, time| {
+                        acc.join_assign(&time);
+                        acc
+                    });
+
+            for read_hold in &txn_reads[1..] {
+                let hold_time = read_hold.times().fold(Antichain::new(), |mut acc, time| {
+                    acc.join_assign(&time);
+                    acc
+                });
+                if PartialOrder::less_than(&hold_time, &earliest_time) {
+                    earliest_hold = read_hold;
+                    earliest_time = hold_time;
+                }
+            }
+
+            earliest_hold
+        } else {
+            // No one has acquired holds, make sure we can determine an as_of
+            // and render our dataflow below.
+            read_holds_owned = self
+                .acquire_read_holds(mz_repr::Timestamp::MIN, &id_bundle, false)
+                .expect("can always acquire non-precise read holds");
+            &read_holds_owned
+        };
+
+        let (dataflow_as_of, storage_as_of, until) =
+            self.select_timestamps(id_bundle, refresh_schedule.as_ref(), read_holds)?;
+
         tracing::info!(
             dataflow_as_of = ?dataflow_as_of,
             storage_as_of = ?storage_as_of,
@@ -676,10 +736,6 @@ impl Coordinator {
             })
             .await;
 
-        // Only drop the read holds once the dataflow has been installed,
-        // which acquires its own read holds.
-        drop(read_holds);
-
         match transact_result {
             Ok(_) => Ok(ExecuteResponse::CreatedMaterializedView),
             Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
@@ -701,28 +757,26 @@ impl Coordinator {
     /// Select the initial `dataflow_as_of`, `storage_as_of`, and `until` frontiers for a
     /// materialized view.
     fn select_timestamps(
-        &mut self,
+        &self,
         id_bundle: CollectionIdBundle,
         refresh_schedule: Option<&RefreshSchedule>,
+        read_holds: &ReadHolds<mz_repr::Timestamp>,
     ) -> Result<
         (
-            ReadHolds<mz_repr::Timestamp>,
             Antichain<mz_repr::Timestamp>,
             Antichain<mz_repr::Timestamp>,
             Antichain<mz_repr::Timestamp>,
         ),
         AdapterError,
     > {
-        // Acquire read holds _before_ determining the least valid read.
-        // Otherwise the frontier might advance away from under us,
-        // concurrently.
-        let read_holds = self
-            .acquire_read_holds(mz_repr::Timestamp::minimum(), &id_bundle, false)
-            .expect("can always acquire non-precise read holds");
+        assert!(
+            id_bundle.difference(&read_holds.id_bundle()).is_empty(),
+            "we must have read holds for all involved collections"
+        );
 
         // For non-REFRESH MVs both the `dataflow_as_of` and the `storage_as_of` should be simply
         // `least_valid_read`.
-        let least_valid_read = self.least_valid_read(&id_bundle);
+        let least_valid_read = self.least_valid_read(read_holds);
         let mut dataflow_as_of = least_valid_read.clone();
         let mut storage_as_of = least_valid_read.clone();
 
@@ -770,7 +824,7 @@ impl Coordinator {
             .and_then(|r| r.try_step_forward());
         let until = Antichain::from_iter(until_ts);
 
-        Ok((read_holds, dataflow_as_of, storage_as_of, until))
+        Ok((dataflow_as_of, storage_as_of, until))
     }
 
     #[instrument]

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -1167,9 +1167,6 @@ impl Coordinator {
         // returns to the coordinator.
 
         if let Some(txn_reads) = self.txn_read_holds.get(session.conn_id()) {
-            assert_eq!(txn_reads.len(), 1);
-            let txn_reads = &txn_reads[0];
-
             // Find referenced ids not in the read hold. A reference could be caused by a
             // user specifying an object in a different schema than the first query. An
             // index could be caused by a CREATE INDEX after the transaction started.
@@ -1191,10 +1188,7 @@ impl Coordinator {
                 });
             }
         } else if let Some(read_holds) = read_holds {
-            self.txn_read_holds
-                .entry(session.conn_id().clone())
-                .or_insert_with(Vec::new)
-                .push(read_holds);
+            self.store_transaction_read_holds(session, read_holds);
         }
 
         // TODO: Checking for only `InTransaction` and not `Implied` (also `Started`?) seems

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -462,11 +462,7 @@ pub trait TimestampProvider {
         &self,
         read_holds: &ReadHolds<mz_repr::Timestamp>,
     ) -> Antichain<mz_repr::Timestamp> {
-        let mut since = Antichain::from_elem(Timestamp::minimum());
-        for hold in read_holds.times() {
-            since.join_assign(hold);
-        }
-        since
+        read_holds.least_valid_read()
     }
 
     /// Acquires [ReadHolds], for the given `id_bundle` at the earliest possible


### PR DESCRIPTION
Preparatory work for https://github.com/MaterializeInc/materialize/issues/24845, where we want to introduce more concurrency to the Coordinator and Controllers.

Before, we were acquiring read holds and then looking at the since/implied capability of collections.

If/when the controller can advance its frontiers concurrently, the only safe/defensive thing we can do is look at our ReadHolds for determining a least valid read.

@MaterializeInc/testing You might want to know about this, look at it, just because it futzes with how we determine a read timestamp. In practice, this should not affect the determined timestamp, though, but it will make it so it continues working in a more concurrent future.

@teskje You might be interested!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
