### PR TITLE
adapter,controller: restrict access to innards of storage controller

### DIFF
--- a/src/adapter/src/coord/cluster_scheduling.rs
+++ b/src/adapter/src/coord/cluster_scheduling.rs
@@ -57,12 +57,12 @@ impl Coordinator {
                                     self.catalog().get_entry(id).item()
                                 {
                                     if mv.refresh_schedule.is_some() {
-                                        Some(&self
+                                        let (_since, write_frontier) = self
                                             .controller
                                             .storage
-                                            .collection(*id)
-                                            .expect("the storage controller should know about MVs that exist in the catalog")
-                                            .write_frontier)
+                                              .collection_frontiers(*id)
+                                            .expect("the storage controller should know about MVs that exist in the catalog");
+                                        Some(write_frontier)
                                     } else {
                                         None
                                     }
@@ -77,7 +77,7 @@ impl Coordinator {
                             rehydration_time_estimate,
                             refresh_mv_write_frontiers
                                 .into_iter()
-                                .fold(Antichain::new(), |ac1, ac2| Lattice::meet(&ac1, ac2)),
+                                .fold(Antichain::new(), |ac1, ac2| Lattice::meet(&ac1, &ac2)),
                         ));
                     }
                 }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1015,7 +1015,7 @@ impl Coordinator {
         sink: &Sink,
     ) -> Result<(), AdapterError> {
         // Validate `sink.from` is in fact a storage collection
-        self.controller.storage.collection(sink.from)?;
+        self.controller.storage.check_exists(sink.from)?;
 
         let status_id = Some(
             self.catalog()

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -232,11 +232,9 @@ impl Coordinator {
         let live_shards: BTreeSet<_> = self
             .controller
             .storage
-            .collections()
-            // A collection is dropped if its read capability has been advanced
-            // to the empty antichain.
-            .filter(|(_id, collection)| !collection.read_capabilities.is_empty())
-            .flat_map(|(_id, collection)| {
+            .active_collection_metadatas()
+            .into_iter()
+            .flat_map(|(_id, collection_metadata)| {
                 let CollectionMetadata {
                     data_shard,
                     remap_shard,
@@ -251,8 +249,8 @@ impl Coordinator {
                     persist_location: _,
                     relation_desc: _,
                     txns_shard: _,
-                } = &collection.collection_metadata;
-                [*remap_shard, *status_shard, Some(*data_shard)].into_iter()
+                } = collection_metadata;
+                [remap_shard, status_shard, Some(data_shard)].into_iter()
             })
             .filter_map(|shard| shard)
             .collect();

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -527,9 +527,8 @@ impl crate::coord::Coordinator {
                 let metadata = self
                     .controller
                     .storage
-                    .collection(coll_id)
+                    .collection_metadata(coll_id)
                     .expect("storage collection for fast-path peek")
-                    .collection_metadata
                     .clone();
                 (
                     peek_command,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -852,16 +852,16 @@ impl Coordinator {
                     _ => {}
                 }
             }
-            self.controller.install_watch_set(
+            self.controller.install_storage_watch_set(
                 transitive_storage_deps,
                 ts,
                 Box::new((uuid, StatementLifecycleEvent::StorageDependenciesFinished)),
             );
-            self.controller.install_watch_set(
+            self.controller.install_compute_watch_set(
                 transitive_compute_deps,
                 ts,
                 Box::new((uuid, StatementLifecycleEvent::ComputeDependenciesFinished)),
-            );
+            )
         }
         let max_query_result_size = std::cmp::min(
             ctx.session().vars().max_query_result_size(),

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -110,25 +110,19 @@ impl TimestampProvider for Frontiers {
         self.compute.get(&(instance, id)).unwrap().write.borrow()
     }
 
-    fn storage_read_capabilities<'a>(
-        &'a self,
-        id: GlobalId,
-    ) -> timely::progress::frontier::AntichainRef<'a, Timestamp> {
-        self.storage.get(&id).unwrap().read.borrow()
-    }
-
-    fn storage_implied_capability<'a>(
-        &'a self,
-        id: GlobalId,
-    ) -> &'a timely::progress::Antichain<Timestamp> {
-        &self.storage.get(&id).unwrap().read
-    }
-
-    fn storage_write_frontier<'a>(
-        &'a self,
-        id: GlobalId,
-    ) -> &'a timely::progress::Antichain<Timestamp> {
-        &self.storage.get(&id).unwrap().write
+    fn storage_frontiers(
+        &self,
+        ids: Vec<GlobalId>,
+    ) -> Vec<(
+        GlobalId,
+        timely::progress::Antichain<Timestamp>,
+        timely::progress::Antichain<Timestamp>,
+    )> {
+        self.storage
+            .iter()
+            .filter(|(id, _frontiers)| ids.contains(id))
+            .map(|(id, frontiers)| (*id, frontiers.read.clone(), frontiers.write.clone()))
+            .collect()
     }
 
     fn acquire_read_holds(&mut self, id_bundle: &CollectionIdBundle) -> ReadHolds<Timestamp> {


### PR DESCRIPTION
Preparatory work for https://github.com/MaterializeInc/materialize/issues/24845, where we
want to introduce more concurrency to the Coordinator and Controllers.

We restrict access to `CollectionState`, because we plan to move that
out of `StorageController`. But it's good in general to hide this
internal detail of the controller.

Access to `CollectionState` is replaced by more targeted methods, this
means there's now more methods but they return "smaller" things.
Additionally, the new methods return owned data rather than references
into controller state. This would not be necessary for how the
controller and calling code work now, but future refactoring will make
it so that state inside the controller is behind a shareable mutex, so
we start handing out owned data now in preparation for that.

### Tips for Reviewers

There's some controversial bits in there that I marked with `WIP`: before the change, some call sites were using the _implied capability_ when wanting the "since" of a collection, and some were looking at the _frontier of read capabilities_. I changed most of them to use the _implied capability_, it's what `collection_frontiers` gives you. But there is one internal usage where we report storage frontiers, and that one is still reporting the _frontier of read capabilities_.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
