### PR TITLE
RBAC: Fix concurrent role drop check

### DIFF
--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -38,40 +38,45 @@ use crate::session::user::{MZ_SUPPORT_ROLE_ID, MZ_SYSTEM_ROLE_ID, SUPPORT_USER, 
 use crate::session::vars::SystemVars;
 
 /// Common checks that need to be performed before we can start checking a role's privileges.
-fn rbac_preamble(
+macro_rules! rbac_preamble {
+    ($catalog:expr, $session_meta:expr) => {
+        // PostgreSQL allows users that have their role dropped to perform some actions,
+        // such as `SET ROLE` and certain `SELECT` queries. We haven't implemented
+        // `SET ROLE` and feel it's safer to force to user to re-authenticate if their
+        // role is dropped.
+        if $catalog
+            .try_get_role(&$session_meta.role_metadata().current_role)
+            .is_none()
+        {
+            return Err(UnauthorizedError::ConcurrentRoleDrop(
+                $session_meta.role_metadata().current_role.clone(),
+            ));
+        };
+        if $catalog
+            .try_get_role(&$session_meta.role_metadata().session_role)
+            .is_none()
+        {
+            return Err(UnauthorizedError::ConcurrentRoleDrop(
+                $session_meta.role_metadata().session_role.clone(),
+            ));
+        };
+        if $catalog
+            .try_get_role(&$session_meta.role_metadata().authenticated_role)
+            .is_none()
+        {
+            return Err(UnauthorizedError::ConcurrentRoleDrop(
+                $session_meta.role_metadata().authenticated_role.clone(),
+            ));
+        };
+    };
+}
+
+/// Filters `RbacRequirements` based on the current user and RBAC related feature flags.
+fn filter_requirements(
     catalog: &impl SessionCatalog,
     session_meta: &dyn SessionMetadata,
     rbac_requirements: RbacRequirements,
 ) -> Result<RbacRequirements, UnauthorizedError> {
-    // PostgreSQL allows users that have their role dropped to perform some actions,
-    // such as `SET ROLE` and certain `SELECT` queries. We haven't implemented
-    // `SET ROLE` and feel it's safer to force to user to re-authenticate if their
-    // role is dropped.
-    if catalog
-        .try_get_role(&session_meta.role_metadata().current_role)
-        .is_none()
-    {
-        return Err(UnauthorizedError::ConcurrentRoleDrop(
-            session_meta.role_metadata().current_role.clone(),
-        ));
-    };
-    if catalog
-        .try_get_role(&session_meta.role_metadata().session_role)
-        .is_none()
-    {
-        return Err(UnauthorizedError::ConcurrentRoleDrop(
-            session_meta.role_metadata().session_role.clone(),
-        ));
-    };
-    if catalog
-        .try_get_role(&session_meta.role_metadata().authenticated_role)
-        .is_none()
-    {
-        return Err(UnauthorizedError::ConcurrentRoleDrop(
-            session_meta.role_metadata().authenticated_role.clone(),
-        ));
-    };
-
     // Skip RBAC non-mandatory checks if RBAC is disabled. However, we never skip RBAC checks for
     // system roles. This allows us to limit access of system users even when RBAC is off.
     let is_rbac_disabled = !is_rbac_enabled_for_session(catalog.system_vars(), session_meta)
@@ -284,6 +289,8 @@ pub fn check_usage(
     resolved_ids: &ResolvedIds,
     item_types: &BTreeSet<CatalogItemType>,
 ) -> Result<(), UnauthorizedError> {
+    rbac_preamble!(catalog, session);
+
     // Obtain all roles that the current session is a member of.
     let role_membership = catalog.collect_role_membership(&session.role_metadata().current_role);
 
@@ -308,7 +315,7 @@ pub fn check_usage(
 
     let mut rbac_requirements = RbacRequirements::empty();
     rbac_requirements.privileges = required_privileges;
-    let rbac_requirements = rbac_preamble(catalog, session, rbac_requirements)?;
+    let rbac_requirements = filter_requirements(catalog, session, rbac_requirements)?;
     let required_privileges = rbac_requirements.privileges;
 
     check_object_privileges(
@@ -331,6 +338,8 @@ pub fn check_plan(
     target_cluster_id: Option<ClusterId>,
     resolved_ids: &ResolvedIds,
 ) -> Result<(), UnauthorizedError> {
+    rbac_preamble!(catalog, session);
+
     let rbac_requirements = generate_rbac_requirements(
         catalog,
         plan,
@@ -338,7 +347,7 @@ pub fn check_plan(
         target_cluster_id,
         session.role_metadata().current_role,
     );
-    let rbac_requirements = rbac_preamble(catalog, session, rbac_requirements)?;
+    let rbac_requirements = filter_requirements(catalog, session, rbac_requirements)?;
     debug!(
         "rbac requirements {rbac_requirements:?} for plan {:?}",
         PlanKind::from(plan)

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -38,37 +38,40 @@ use crate::session::user::{MZ_SUPPORT_ROLE_ID, MZ_SYSTEM_ROLE_ID, SUPPORT_USER, 
 use crate::session::vars::SystemVars;
 
 /// Common checks that need to be performed before we can start checking a role's privileges.
-macro_rules! rbac_preamble {
-    ($catalog:expr, $session_meta:expr) => {
-        // PostgreSQL allows users that have their role dropped to perform some actions,
-        // such as `SET ROLE` and certain `SELECT` queries. We haven't implemented
-        // `SET ROLE` and feel it's safer to force to user to re-authenticate if their
-        // role is dropped.
-        if $catalog
-            .try_get_role(&$session_meta.role_metadata().current_role)
-            .is_none()
-        {
-            return Err(UnauthorizedError::ConcurrentRoleDrop(
-                $session_meta.role_metadata().current_role.clone(),
-            ));
-        };
-        if $catalog
-            .try_get_role(&$session_meta.role_metadata().session_role)
-            .is_none()
-        {
-            return Err(UnauthorizedError::ConcurrentRoleDrop(
-                $session_meta.role_metadata().session_role.clone(),
-            ));
-        };
-        if $catalog
-            .try_get_role(&$session_meta.role_metadata().authenticated_role)
-            .is_none()
-        {
-            return Err(UnauthorizedError::ConcurrentRoleDrop(
-                $session_meta.role_metadata().authenticated_role.clone(),
-            ));
-        };
+fn rbac_check_preamble(
+    catalog: &impl SessionCatalog,
+    session_meta: &dyn SessionMetadata,
+) -> Result<(), UnauthorizedError> {
+    // PostgreSQL allows users that have their role dropped to perform some actions,
+    // such as `SET ROLE` and certain `SELECT` queries. We haven't implemented
+    // `SET ROLE` and feel it's safer to force to user to re-authenticate if their
+    // role is dropped.
+    if catalog
+        .try_get_role(&session_meta.role_metadata().current_role)
+        .is_none()
+    {
+        return Err(UnauthorizedError::ConcurrentRoleDrop(
+            session_meta.role_metadata().current_role.clone(),
+        ));
     };
+    if catalog
+        .try_get_role(&session_meta.role_metadata().session_role)
+        .is_none()
+    {
+        return Err(UnauthorizedError::ConcurrentRoleDrop(
+            session_meta.role_metadata().session_role.clone(),
+        ));
+    };
+    if catalog
+        .try_get_role(&session_meta.role_metadata().authenticated_role)
+        .is_none()
+    {
+        return Err(UnauthorizedError::ConcurrentRoleDrop(
+            session_meta.role_metadata().authenticated_role.clone(),
+        ));
+    };
+
+    Ok(())
 }
 
 /// Filters `RbacRequirements` based on the session role metadata and RBAC related feature flags.
@@ -76,7 +79,7 @@ fn filter_requirements(
     catalog: &impl SessionCatalog,
     session_meta: &dyn SessionMetadata,
     rbac_requirements: RbacRequirements,
-) -> Result<RbacRequirements, UnauthorizedError> {
+) -> RbacRequirements {
     // Skip RBAC non-mandatory checks if RBAC is disabled. However, we never skip RBAC checks for
     // system roles. This allows us to limit access of system users even when RBAC is off.
     let is_rbac_disabled = !is_rbac_enabled_for_session(catalog.system_vars(), session_meta)
@@ -85,10 +88,10 @@ fn filter_requirements(
     // Skip RBAC checks on user items if the session is a superuser.
     let is_superuser = session_meta.is_superuser();
     if is_rbac_disabled || is_superuser {
-        return Ok(rbac_requirements.filter_to_mandatory_requirements());
+        return rbac_requirements.filter_to_mandatory_requirements();
     }
 
-    Ok(rbac_requirements)
+    rbac_requirements
 }
 
 // The default item types that most statements require USAGE privileges for.
@@ -289,7 +292,7 @@ pub fn check_usage(
     resolved_ids: &ResolvedIds,
     item_types: &BTreeSet<CatalogItemType>,
 ) -> Result<(), UnauthorizedError> {
-    rbac_preamble!(catalog, session);
+    rbac_check_preamble(catalog, session)?;
 
     // Obtain all roles that the current session is a member of.
     let role_membership = catalog.collect_role_membership(&session.role_metadata().current_role);
@@ -315,7 +318,7 @@ pub fn check_usage(
 
     let mut rbac_requirements = RbacRequirements::empty();
     rbac_requirements.privileges = required_privileges;
-    let rbac_requirements = filter_requirements(catalog, session, rbac_requirements)?;
+    let rbac_requirements = filter_requirements(catalog, session, rbac_requirements);
     let required_privileges = rbac_requirements.privileges;
 
     check_object_privileges(
@@ -338,7 +341,7 @@ pub fn check_plan(
     target_cluster_id: Option<ClusterId>,
     resolved_ids: &ResolvedIds,
 ) -> Result<(), UnauthorizedError> {
-    rbac_preamble!(catalog, session);
+    rbac_check_preamble(catalog, session)?;
 
     let rbac_requirements = generate_rbac_requirements(
         catalog,
@@ -347,7 +350,7 @@ pub fn check_plan(
         target_cluster_id,
         session.role_metadata().current_role,
     );
-    let rbac_requirements = filter_requirements(catalog, session, rbac_requirements)?;
+    let rbac_requirements = filter_requirements(catalog, session, rbac_requirements);
     debug!(
         "rbac requirements {rbac_requirements:?} for plan {:?}",
         PlanKind::from(plan)

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -71,7 +71,7 @@ macro_rules! rbac_preamble {
     };
 }
 
-/// Filters `RbacRequirements` based on the current user and RBAC related feature flags.
+/// Filters `RbacRequirements` based on the session role metadata and RBAC related feature flags.
 fn filter_requirements(
     catalog: &impl SessionCatalog,
     session_meta: &dyn SessionMetadata,


### PR DESCRIPTION
Previously, RBAC would check that a users role was still valid (i.e. not concurrently dropped) before doing anything else. 4db9a3cf24b2dc7454a9eeafa9644ab2ca305441 moved this check so that it happened after collecting the role membership. As a result, it was possible to try and look up a role in the catalog before checking that the role exists. This would cause a panic instead of a user error.

This commit fixes the described issue by moving the valid role check back to being the first thing that RBAC does.

Fixes #26622

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
