### PR TITLE
ci: feature benchmark: annotate regressions

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -182,9 +182,6 @@ class Report:
     def extend(self, comparisons: Iterable[Comparator]) -> None:
         self._comparisons.extend(comparisons)
 
-    def print(self) -> None:
-        print(self)
-
     def __str__(self) -> str:
         output_lines = []
 

--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -182,7 +182,7 @@ class Report:
     def extend(self, comparisons: Iterable[Comparator]) -> None:
         self._comparisons.extend(comparisons)
 
-    def dump(self) -> None:
+    def print(self) -> None:
         print(self)
 
     def __str__(self) -> str:

--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -183,22 +183,33 @@ class Report:
         self._comparisons.extend(comparisons)
 
     def dump(self) -> None:
-        print(
+        print(self)
+
+    def __str__(self) -> str:
+        output_lines = []
+
+        output_lines.append(
             f"{'NAME':<35} | {'TYPE':<9} | {'THIS':^15} | {'OTHER':^15} | {'Regression?':^13} | 'THIS' is:"
         )
-        print("-" * 100)
+        output_lines.append("-" * 100)
 
         for comparison in self._comparisons:
             regression = "!!YES!!" if comparison.is_regression() else "no"
-            print(
+            output_lines.append(
                 f"{comparison.name:<35} | {comparison.type:<9} | {comparison.this_as_str():>15} | {comparison.other_as_str():>15} | {regression:^13} | {comparison.human_readable()}"
             )
 
+        return "\n".join(output_lines)
+
 
 class SingleReport(Report):
-    def dump(self) -> None:
-        print(f"{'NAME':<25} | {'THIS':^11}")
-        print("-" * 50)
+    def __str__(self) -> str:
+        output_lines = []
+
+        output_lines.append(f"{'NAME':<25} | {'THIS':^11}")
+        output_lines.append("-" * 50)
 
         for comparison in self._comparisons:
-            print(f"{comparison.name:<25} | {comparison.this():>11.3f}")
+            output_lines.append(f"{comparison.name:<25} | {comparison.this():>11.3f}")
+
+        return "\n".join(output_lines)

--- a/misc/python/materialize/mzcompose/test_result.py
+++ b/misc/python/materialize/mzcompose/test_result.py
@@ -58,8 +58,9 @@ class FailedTestExecutionError(UIError):
     def __init__(
         self,
         errors: list[TestFailureDetails],
+        error_summary: str = "At least one test failed",
     ):
-        super().__init__("At least one test failed")
+        super().__init__(error_summary)
         self.errors = errors
 
 

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -449,7 +449,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             latest_report_by_scenario_name[scenario.__name__] = report
 
             print(f"+++ Benchmark Report for cycle {cycle + 1}:")
-            report.print()
+            print(report)
 
         scenarios_to_run = scenarios_with_regressions
         if len(scenarios_to_run) == 0:

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -441,7 +441,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 scenarios_with_regressions.append(scenario)
 
             print(f"+++ Benchmark Report for cycle {cycle + 1}:")
-            report.dump()
+            report.print()
 
         scenarios_to_run = scenarios_with_regressions
         if len(scenarios_to_run) == 0:

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -18,6 +18,10 @@ from materialize import buildkite
 from materialize.docker import is_image_tag_of_version
 from materialize.mz_version import MzVersion
 from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.test_result import (
+    FailedTestExecutionError,
+    TestFailureDetails,
+)
 from materialize.version_ancestor_overrides import (
     get_ancestor_overrides_for_performance_regressions,
 )
@@ -420,6 +424,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     scenarios_with_regressions = []
+    latest_report_by_scenario_name: dict[str, Report] = dict()
+
     for cycle in range(0, args.max_retries):
         print(
             f"Cycle {cycle + 1} with scenarios: {', '.join([scenario.__name__ for scenario in scenarios_to_run])}"
@@ -440,6 +446,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             if any([c.is_regression() for c in comparators]):
                 scenarios_with_regressions.append(scenario)
 
+            latest_report_by_scenario_name[scenario.__name__] = report
+
             print(f"+++ Benchmark Report for cycle {cycle + 1}:")
             report.print()
 
@@ -448,13 +456,20 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             break
 
     if len(scenarios_with_regressions) > 0:
-        (
-            all_regressions_justified,
-            justified_regressions_infos,
-        ) = _are_regressions_justified(
+        justification_by_scenario_name = _check_regressions_justified(
             scenarios_with_regressions,
             this_tag=args.this_tag,
             baseline_tag=args.other_tag,
+        )
+
+        justifications = [
+            justification
+            for justification in justification_by_scenario_name.values()
+            if justification is not None
+        ]
+
+        all_regressions_justified = len(justification_by_scenario_name) == len(
+            justifications
         )
 
         print("+++ Regressions")
@@ -467,34 +482,35 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         if all_regressions_justified:
             print("All regressions are justified:")
-            print(justified_regressions_infos)
-        elif len(justified_regressions_infos) > 0:
+            print("\n".join(justifications))
+        elif len(justifications) > 0:
             print("Some regressions are justified:")
-            print(justified_regressions_infos)
+            print("\n".join(justifications))
 
         if not all_regressions_justified:
             sys.exit(1)
 
 
-def _are_regressions_justified(
+def _check_regressions_justified(
     scenarios_with_regressions: list[type[Scenario]],
     this_tag: str | None,
     baseline_tag: str | None,
-) -> tuple[bool, str]:
-    all_regressions_justified = True
-    comments = []
+) -> dict[str, str | None]:
+    """
+    :return: justification per scenario name if justified else None
+    """
+    justification_by_scenario_name: dict[str, str | None] = dict()
 
     for scenario_class in scenarios_with_regressions:
         regressions_justified, comment = _is_regression_justified(
             scenario_class, this_tag=this_tag, baseline_tag=baseline_tag
         )
 
-        if regressions_justified:
-            comments.append(comment)
-        else:
-            all_regressions_justified = False
+        justification_by_scenario_name[scenario_class.__name__] = (
+            comment if regressions_justified else None
+        )
 
-    return all_regressions_justified, "\n".join(comments)
+    return justification_by_scenario_name
 
 
 def _is_regression_justified(


### PR DESCRIPTION
I did not have the time to check the annotation on a real build but the generated junit xml file looked reasonable.

```
	<testsuite disabled="0" errors="1" failures="0" name="feature-benchmark" skipped="0" tests="1" time="0">
		<testcase name="GroupBy" classname="feature-benchmark">
			<error type="error" message="New regression">NAME                                | TYPE      |      THIS       |      OTHER      |  Regression?  | 'THIS' is:
----------------------------------------------------------------------------------------------------
GroupBy                             | wallclock |           0.682 |           0.680 |    !!YES!!    | 0.3 pct   more/slower
GroupBy                             | messages  |            None |            None |      no       | N/A
GroupBy                             | memory    |        3313.065 |        3402.710 |      no       | 2.6 pct   less/faster</error>
		</testcase>
	</testsuite>
```

I will add something similar for the scalability framework after my holidays.