### PR TITLE
adapter: parse and optimize builtin views in parallel

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use futures::Future;
 use itertools::Itertools;
-use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
 use mz_audit_log::{EventType, FullNameV1, ObjectType};
 use mz_build_info::DUMMY_BUILD_INFO;
@@ -29,9 +28,7 @@ use mz_catalog::builtin::{
 use mz_catalog::config::{ClusterReplicaSizeMap, Config, StateConfig};
 use mz_catalog::durable::{test_bootstrap_args, DurableCatalogState};
 use mz_catalog::memory::error::{Error, ErrorKind};
-use mz_catalog::memory::objects::{
-    CatalogEntry, CatalogItem, Cluster, ClusterReplica, Database, Role, Schema,
-};
+use mz_catalog::memory::objects::{CatalogEntry, Cluster, ClusterReplica, Database, Role, Schema};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_controller::clusters::ReplicaLocation;
 use mz_controller_types::{ClusterId, ReplicaId};
@@ -59,7 +56,7 @@ use mz_sql::names::{
     QualifiedItemName, QualifiedSchemaName, ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier,
     SystemObjectId, PUBLIC_ROLE_NAME,
 };
-use mz_sql::plan::{PlanContext, PlanNotice, StatementDesc};
+use mz_sql::plan::{PlanNotice, StatementDesc};
 use mz_sql::rbac;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_sql::session::user::{MZ_SYSTEM_ROLE_ID, SUPPORT_USER, SYSTEM_USER};
@@ -904,16 +901,6 @@ impl Catalog {
             .object_dependents(object_ids, conn_id, &mut except)
     }
 
-    pub(crate) fn cluster_replica_dependents(
-        &self,
-        cluster_id: ClusterId,
-        replica_id: ReplicaId,
-    ) -> Vec<ObjectId> {
-        let mut seen = BTreeSet::new();
-        self.state
-            .cluster_replica_dependents(cluster_id, replica_id, &mut seen)
-    }
-
     fn full_name_detail(name: &FullItemName) -> FullNameV1 {
         FullNameV1 {
             database: name.database.to_string(),
@@ -989,25 +976,6 @@ impl Catalog {
     #[mz_ore::instrument(level = "debug")]
     pub async fn confirm_leadership(&self) -> Result<(), AdapterError> {
         Ok(self.storage().await.confirm_leadership().await?)
-    }
-
-    /// Parses the given SQL string into a `CatalogItem`.
-    #[mz_ore::instrument]
-    fn parse_item(
-        &self,
-        id: GlobalId,
-        create_sql: &str,
-        pcx: Option<&PlanContext>,
-        is_retained_metrics_object: bool,
-        custom_logical_compaction_window: Option<CompactionWindow>,
-    ) -> Result<CatalogItem, AdapterError> {
-        self.state.parse_item(
-            id,
-            create_sql,
-            pcx,
-            is_retained_metrics_object,
-            custom_logical_compaction_window,
-        )
     }
 
     /// Return the ids of all log sources the given object depends on.

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -388,7 +388,7 @@ pub struct ConnCatalog<'a> {
     /// This feature is necessary to allow re-planning of statements, which is
     /// either incredibly useful or required when altering item definitions.
     ///
-    /// Note that uses of this should field should be used by short-lived
+    /// Note that uses of this field should be used by short-lived
     /// catalogs.
     unresolvable_ids: BTreeSet<GlobalId>,
     conn_id: ConnectionId,
@@ -1855,6 +1855,7 @@ mod tests {
     use std::{env, iter};
 
     use itertools::Itertools;
+    use mz_catalog::memory::objects::CatalogItem;
     use tokio_postgres::types::Type;
     use tokio_postgres::NoTls;
     use uuid::Uuid;
@@ -1886,7 +1887,7 @@ mod tests {
     use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
     use mz_sql::session::vars::VarInput;
 
-    use crate::catalog::{Catalog, CatalogItem, Op};
+    use crate::catalog::{Catalog, Op};
     use crate::optimize::dataflows::{prep_scalar_expr, EvalTime, ExprPrepStyle};
     use crate::session::Session;
 

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -622,39 +622,9 @@ impl CatalogState {
                     PrivilegeMap::default(),
                 );
             }
-            Builtin::View(view) => {
-                let item = self
-                    .parse_item(
-                        id,
-                        &view.create_sql(),
-                        None,
-                        false,
-                        None,
-                    )
-                    .unwrap_or_else(|e| {
-                        panic!(
-                            "internal error: failed to load bootstrap view:\n\
-                                {}\n\
-                                error:\n\
-                                {:?}\n\n\
-                                make sure that the schema name is specified in the builtin view's create sql statement.",
-                            view.name, e
-                        )
-                    });
-                let mut acl_items = vec![rbac::owner_privilege(
-                    mz_sql::catalog::ObjectType::View,
-                    MZ_SYSTEM_ROLE_ID,
-                )];
-                acl_items.extend_from_slice(&view.access);
-
-                self.insert_item(
-                    id,
-                    view.oid,
-                    name,
-                    item,
-                    MZ_SYSTEM_ROLE_ID,
-                    PrivilegeMap::from_mz_acl_items(acl_items),
-                );
+            Builtin::View(_) => {
+                // parse_views is responsible for inserting all builtin views.
+                unreachable!("views added elsewhere");
             }
 
             // Note: Element types must be loaded before array types.

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -820,13 +820,12 @@ impl CatalogState {
             .with_planning_id(id)
             .with_ignore_if_exists_errors(force_if_exists_skip);
         let mut session_catalog = self.for_system_session();
-        self.parse_plan(create_sql, Some(&pcx), &mut session_catalog)
+        Self::parse_plan(create_sql, Some(&pcx), &mut session_catalog)
     }
 
     /// Parses the given SQL string into a pair of [`Plan`] and a [`ResolvedIds)`.
     #[mz_ore::instrument]
     pub(crate) fn parse_plan(
-        &self,
         create_sql: &str,
         pcx: Option<&PlanContext>,
         catalog: &mut ConnCatalog,
@@ -873,7 +872,7 @@ impl CatalogState {
     ) -> Result<CatalogItem, AdapterError> {
         let mut session_catalog = self.for_system_session();
 
-        let (plan, resolved_ids) = self.parse_plan(create_sql, pcx, &mut session_catalog)?;
+        let (plan, resolved_ids) = Self::parse_plan(create_sql, pcx, &mut session_catalog)?;
 
         Ok(match plan {
             Plan::CreateTable(CreateTablePlan { table, .. }) => CatalogItem::Table(Table {

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -5269,12 +5269,12 @@ FROM
             END AS table_catalog,
             schemas.name AS table_schema,
             relations.name AS table_name
-        FROM mz_relations AS relations
-        JOIN mz_schemas AS schemas ON relations.schema_id = schemas.id
-        LEFT JOIN mz_databases AS databases ON schemas.database_id = databases.id
+        FROM mz_catalog.mz_relations AS relations
+        JOIN mz_catalog.mz_schemas AS schemas ON relations.schema_id = schemas.id
+        LEFT JOIN mz_catalog.mz_databases AS databases ON schemas.database_id = databases.id
         WHERE schemas.database_id IS NULL OR databases.name = current_database())
-    JOIN mz_roles AS grantor ON mz_internal.mz_aclitem_grantor(privileges) = grantor.id
-    LEFT JOIN mz_roles AS grantee ON mz_internal.mz_aclitem_grantee(privileges) = grantee.id)
+    JOIN mz_catalog.mz_roles AS grantor ON mz_internal.mz_aclitem_grantor(privileges) = grantor.id
+    LEFT JOIN mz_catalog.mz_roles AS grantee ON mz_internal.mz_aclitem_grantee(privileges) = grantee.id)
 WHERE
     -- WHERE clause is not guaranteed to short-circuit and 'PUBLIC' will cause an error when passed
     -- to pg_has_role. Therefore we need to use a CASE statement.
@@ -5891,7 +5891,7 @@ pub static MZ_SHOW_OBJECT_PRIVILEGES: Lazy<BuiltinView> = Lazy::new(|| BuiltinVi
     privileges.privilege_type AS privilege_type
 FROM
     (SELECT mz_internal.mz_aclexplode(privileges).*, schema_id, name, type
-    FROM mz_objects
+    FROM mz_catalog.mz_objects
     WHERE id NOT LIKE 's%') AS privileges
 LEFT JOIN mz_roles grantor ON privileges.grantor = grantor.id
 LEFT JOIN mz_roles grantee ON privileges.grantee = grantee.id

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -4061,7 +4061,7 @@ pub static MZ_INTERNAL_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(
                                 -- Return the fully-qualified name
                                 SELECT DISTINCT ARRAY[qual.d, qual.s, item.name]
                                 FROM
-                                    mz_objects AS item
+                                    mz_catalog.mz_objects AS item
                                 JOIN
                                 (
                                     SELECT
@@ -4069,9 +4069,9 @@ pub static MZ_INTERNAL_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(
                                         s.name AS s,
                                         s.id AS schema_id
                                     FROM
-                                        mz_schemas AS s
+                                        mz_catalog.mz_schemas AS s
                                         LEFT JOIN
-                                            (SELECT id, name FROM mz_databases)
+                                            (SELECT id, name FROM mz_catalog.mz_databases)
                                             AS d
                                             ON s.database_id = d.id
                                 ) AS qual


### PR DESCRIPTION
Install builtin views in parallel by dependency order, greatly speeding envd startup.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a