### PR TITLE
parallel-workload: On HTTP read timeout don't assume the action succeeded

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -122,7 +122,8 @@ class Action:
         result = [
             "permission denied for",
             "must be owner of",
-            "network error",  # #21954, remove when fixed when fixed
+            "network error",  # TODO: Remove when #21954 is fixed
+            "HTTP read timeout",
         ]
         if exe.db.complexity in (Complexity.DDL, Complexity.DDLOnly):
             result.extend(
@@ -1153,8 +1154,7 @@ class DropClusterReplicaAction(Action):
 
             query = f"DROP CLUSTER REPLICA {cluster}.{replica}"
             try:
-                # TODO(def-) Reenable http when #26612 is fixed
-                exe.execute(query, http=Http.NO)
+                exe.execute(query, http=Http.RANDOM)
             except QueryError as e:
                 # expected, see #20465
                 if (

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -201,8 +201,8 @@ class Executor:
                     f"HTTP {r[0]['error']['code']}: {r[0]['error']['message']}\n{r[0]['error'].get('detail', '')}",
                     query,
                 )
-        except requests.exceptions.ReadTimeout:
-            pass
+        except requests.exceptions.ReadTimeout as e:
+            raise QueryError(f"HTTP read timeout: {e}", query)
         except requests.exceptions.ConnectionError:
             # Expected when Mz is killed
             if self.db.scenario not in (


### PR DESCRIPTION
Fixes: #26612

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
