### PR TITLE
aws test: Adapt S3 error messages

### DIFF
--- a/test/aws-localstack/copy-to-s3/copy-to-s3.td
+++ b/test/aws-localstack/copy-to-s3/copy-to-s3.td
@@ -33,14 +33,14 @@ contains:AWS CONNECTION is required for COPY ... TO <expr>
   WITH (
     AWS CONNECTION = aws_conn
   );
-contains:only CSV format is supported for COPY ... TO <expr>
+contains:FORMAT TEXT not yet supported
 
 ! COPY t TO 's3://path/to/dir'
   WITH (
     AWS CONNECTION = aws_conn,
     FORMAT = 'binary'
   );
-contains:only CSV format is supported for COPY ... TO <expr>
+contains:FORMAT BINARY not yet supported
 
 ! COPY t TO '/path/'
   WITH (


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/26495
Seen failing in https://buildkite.com/materialize/nightly/builds/7416

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
