### PR TITLE
upsert test: Adapt test results to new reality

### DIFF
--- a/test/upsert/autospill/03-rocksdb.td
+++ b/test/upsert/autospill/03-rocksdb.td
@@ -45,7 +45,7 @@ animal:
 > SELECT count(*) from autospill;
 0
 
-# Both bytes_indexed and records_indexed should be zero
+# records_indexed should be zero
 > SELECT
     SUM(u.bytes_indexed),
     SUM(u.records_indexed)
@@ -54,4 +54,4 @@ animal:
   WHERE s.name = 'autospill'
   GROUP BY s.name
   ORDER BY s.name
-0 0
+30 0


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/26636

@guswynn Does this make sense?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
