### PR TITLE
compute: factor out `sink::correction` module

### DIFF
--- a/src/compute/src/sink.rs
+++ b/src/compute/src/sink.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 mod copy_to_s3_oneshot;
+mod correction;
 mod persist_sink;
 mod refresh;
 mod subscribe;

--- a/src/compute/src/sink/correction.rs
+++ b/src/compute/src/sink/correction.rs
@@ -1,0 +1,292 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! The `Correction` data structure used by `persist_sink::write_batches` to stash updates before
+//! they are written into batches.
+
+use std::collections::BTreeMap;
+use std::ops::{AddAssign, Bound, SubAssign};
+
+use differential_dataflow::consolidation::{consolidate, consolidate_updates};
+use differential_dataflow::Data;
+use itertools::Itertools;
+use mz_ore::iter::IteratorExt;
+use mz_persist_client::metrics::{SinkMetrics, SinkWorkerMetrics, UpdateDelta};
+use mz_repr::{Diff, Timestamp};
+use timely::progress::Antichain;
+use timely::PartialOrder;
+
+/// A collection holding `persist_sink` updates.
+///
+/// The `Correction` data structure is purpose-built for the `persist_sink::write_batches`
+/// operator:
+///
+///  * It stores updates by time, to enable efficient separation between updates that should
+///    be written to a batch and updates whose time has not yet arrived.
+///  * It eschews an interface for directly removing previously inserted updates. Instead, updates
+///    are removed by inserting them again, with negated diffs. Stored updates are continuously
+///    consolidated to give them opportunity to cancel each other out.
+///  * It provides an interface for advancing all contained updates to a given frontier.
+pub(super) struct Correction<D> {
+    /// Stashed updates by time.
+    updates: BTreeMap<Timestamp, ConsolidatingVec<D>>,
+
+    /// Total length and capacity of vectors in `updates`.
+    ///
+    /// Tracked to maintain metrics.
+    total_size: LengthAndCapacity,
+    /// Global persist sink metrics.
+    metrics: SinkMetrics,
+    /// Per-worker persist sink metrics.
+    worker_metrics: SinkWorkerMetrics,
+}
+
+impl<D> Correction<D> {
+    /// Construct a new `Correction` instance.
+    pub fn new(metrics: SinkMetrics, worker_metrics: SinkWorkerMetrics) -> Self {
+        Self {
+            updates: Default::default(),
+            total_size: Default::default(),
+            metrics,
+            worker_metrics,
+        }
+    }
+
+    /// Update persist sink metrics to the given new length and capacity.
+    fn update_metrics(&mut self, new_size: LengthAndCapacity) {
+        let old_size = self.total_size;
+        let len_delta = UpdateDelta::new(new_size.length, old_size.length);
+        let cap_delta = UpdateDelta::new(new_size.capacity, old_size.capacity);
+        self.metrics
+            .report_correction_update_deltas(len_delta, cap_delta);
+        self.worker_metrics
+            .report_correction_update_totals(new_size.length, new_size.capacity);
+
+        self.total_size = new_size;
+    }
+}
+
+impl<D: Data> Correction<D> {
+    /// Insert a batch of updates.
+    pub fn insert(&mut self, mut updates: Vec<(D, Timestamp, Diff)>) {
+        consolidate_updates(&mut updates);
+        updates.sort_unstable_by_key(|(_, time, _)| *time);
+
+        let mut new_size = self.total_size;
+        let mut updates = updates.into_iter().peekable();
+        while let Some(&(_, time, _)) = updates.peek() {
+            let data = updates
+                .peeking_take_while(|(_, t, _)| *t == time)
+                .map(|(d, _, r)| (d, r));
+
+            use std::collections::btree_map::Entry;
+            match self.updates.entry(time) {
+                Entry::Vacant(entry) => {
+                    let vec: ConsolidatingVec<_> = data.collect();
+                    new_size += (vec.len(), vec.capacity());
+                    entry.insert(vec);
+                }
+                Entry::Occupied(mut entry) => {
+                    let vec = entry.get_mut();
+                    new_size -= (vec.len(), vec.capacity());
+                    vec.extend(data);
+                    new_size += (vec.len(), vec.capacity());
+                }
+            }
+        }
+
+        self.update_metrics(new_size);
+    }
+
+    /// Consolidate and return updates within the given bounds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `lower` is not less than or equal to `upper`.
+    pub fn updates_within(
+        &mut self,
+        lower: &Antichain<Timestamp>,
+        upper: &Antichain<Timestamp>,
+    ) -> impl Iterator<Item = (D, Timestamp, Diff)> + ExactSizeIterator + '_ {
+        assert!(PartialOrder::less_equal(lower, upper));
+
+        let start = match lower.as_option() {
+            Some(ts) => Bound::Included(*ts),
+            None => Bound::Excluded(Timestamp::MAX),
+        };
+        let end = match upper.as_option() {
+            Some(ts) => Bound::Excluded(*ts),
+            None => Bound::Unbounded,
+        };
+
+        // Consolidate relevant times and compute the total number of updates.
+        let range = self.updates.range_mut((start, end));
+        let update_count = range.fold(0, |acc, (_, data)| {
+            data.consolidate();
+            acc + data.len()
+        });
+
+        let range = self.updates.range((start, end));
+        range
+            .flat_map(|(t, data)| data.iter().map(|(d, r)| (d.clone(), *t, *r)))
+            .exact_size(update_count)
+    }
+
+    /// Advance all contained updates by the given frontier.
+    ///
+    /// If the given frontier is empty, all remaining updates are discarded.
+    pub fn advance_by(&mut self, frontier: &Antichain<Timestamp>) {
+        let Some(target_ts) = frontier.as_option() else {
+            self.updates.clear();
+            self.update_metrics(Default::default());
+            return;
+        };
+
+        let mut new_size = self.total_size;
+        while let Some((ts, data)) = self.updates.pop_first() {
+            if frontier.less_equal(&ts) {
+                // We have advanced all updates that can advance.
+                self.updates.insert(ts, data);
+                break;
+            }
+
+            use std::collections::btree_map::Entry;
+            match self.updates.entry(*target_ts) {
+                Entry::Vacant(entry) => {
+                    entry.insert(data);
+                }
+                Entry::Occupied(mut entry) => {
+                    let vec = entry.get_mut();
+                    new_size -= (data.len(), data.capacity());
+                    new_size -= (vec.len(), vec.capacity());
+                    vec.extend(data);
+                    new_size += (vec.len(), vec.capacity());
+                }
+            }
+        }
+
+        self.update_metrics(new_size);
+    }
+}
+
+impl<D> Drop for Correction<D> {
+    fn drop(&mut self) {
+        self.update_metrics(Default::default());
+    }
+}
+
+/// Helper type for convenient tracking of length and capacity together.
+#[derive(Clone, Copy, Default)]
+struct LengthAndCapacity {
+    length: usize,
+    capacity: usize,
+}
+
+impl AddAssign<(usize, usize)> for LengthAndCapacity {
+    fn add_assign(&mut self, (len, cap): (usize, usize)) {
+        self.length += len;
+        self.capacity += cap;
+    }
+}
+
+impl SubAssign<(usize, usize)> for LengthAndCapacity {
+    fn sub_assign(&mut self, (len, cap): (usize, usize)) {
+        self.length -= len;
+        self.capacity -= cap;
+    }
+}
+
+/// A vector that consolidates its contents.
+///
+/// The vector is filled with updates until it reaches capacity. At this point, the updates are
+/// consolidated to free up space. This process repeats until the consolidation recovered less than
+/// half of the vector's capacity, at which point the capacity is doubled.
+struct ConsolidatingVec<D>(Vec<(D, Diff)>);
+
+impl<D: Ord> ConsolidatingVec<D> {
+    /// Return the length of the vector.
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Return the capacity of the vector.
+    fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    // Pushes `item` into the vector.
+    //
+    // If the vector does not have sufficient capacity, we try to consolidate and/or double its
+    // capacity.
+    //
+    // The worst-case cost of this function is O(n log n) in the number of items the vector stores,
+    // but amortizes to O(1).
+    fn push(&mut self, item: (D, Diff)) {
+        let capacity = self.0.capacity();
+        if self.0.len() == capacity {
+            // The vector is full. First, consolidate to try to recover some space.
+            self.consolidate();
+
+            // If consolidation didn't free at least half the available capacity, double the
+            // capacity. This ensures we won't consolidate over and over again with small gains.
+            if self.0.len() > capacity / 2 {
+                self.0.reserve(capacity);
+            }
+        }
+
+        self.0.push(item);
+    }
+
+    /// Consolidate the contents.
+    fn consolidate(&mut self) {
+        consolidate(&mut self.0);
+
+        // We may have the opportunity to reclaim allocated memory.
+        // Given that `push` will double the capacity when the vector is more than half full, and
+        // we want to avoid entering into a resizing cycle, we choose to only shrink if the
+        // vector's length is less than one fourth of its capacity.
+        if self.0.len() < self.0.capacity() / 4 {
+            self.0.shrink_to_fit();
+        }
+    }
+
+    /// Return an iterator over the borrowed items.
+    fn iter(&self) -> impl Iterator<Item = &(D, Diff)> {
+        self.0.iter()
+    }
+}
+
+impl<D> IntoIterator for ConsolidatingVec<D> {
+    type Item = (D, Diff);
+    type IntoIter = std::vec::IntoIter<(D, Diff)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<D> FromIterator<(D, Diff)> for ConsolidatingVec<D> {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = (D, Diff)>,
+    {
+        Self(Vec::from_iter(iter))
+    }
+}
+
+impl<D: Ord> Extend<(D, Diff)> for ConsolidatingVec<D> {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = (D, Diff)>,
+    {
+        for item in iter {
+            self.push(item);
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the `UpdateStash` and its internals to a new `correction` module, to remove some noise from the `persist_sink` operator implementation code. It also renames `UpdateStash` to `Correction`, to make it clear that this is not a generic collection type but one purpose-built for `persist_sink`.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
