### PR TITLE
doc/user: remove mentions to PopSQL

### DIFF
--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -163,7 +163,6 @@ support for these modules.
 | psql         | {{< supportLevel production >}}  | See [SQL Clients](/integrations/sql-clients/#psql) for more details. Some backslash meta-commands are not yet supported {{% gh 9721 %}}.
 | DBeaver      | {{< supportLevel production >}}  | Connect using the [Materialize database driver](/integrations/sql-clients/#dbeaver). See [SQL Clients](/integrations/sql-clients/#dbeaver) for more details.                   |
 | DataGrip IDE | {{< supportLevel beta >}}        | Connect using the [PostgreSQL database driver](https://www.jetbrains.com/datagrip/features/postgresql/). See [SQL Clients](/integrations/sql-clients/#datagrip) for more details.
-| PopSQL       | {{< supportLevel beta >}}        | Connect using a [Materialize connection](https://docs.popsql.com/docs/connecting-to-materialize). See [SQL Clients](/integrations/sql-clients/#popsql) for more details.
 | pgAdmin      | {{< supportLevel in-progress >}} | Not supported yet {{% gh 5874 %}}. Subscribe via "Notify Me" to register interest. | [](#notify) |
 | TablePlus    | {{< supportLevel alpha >}}       | Connect using the [PostgreSQL database driver](https://tableplus.com/blog/2019/09/jdbc-connection-strings.html). See [SQL Clients](/integrations/sql-clients/#tableplus) for more details.
 | VSCode       | {{< supportLevel production >}}  | Connect using the [Materialize extension for VS Code](https://github.com/MaterializeInc/vscode-extension).

--- a/doc/user/content/integrations/sql-clients.md
+++ b/doc/user/content/integrations/sql-clients.md
@@ -121,17 +121,6 @@ Alternatively, you can change the default value of the `cluster` configuration
 parameter for a specific user (i.e. role) using the [`ALTER
 ROLE...SET`](/sql/alter-role) command.
 
-### PopSQL
-
-[//]: # "TODO(morsapaes) Extend with instructions to use dbt-materialize once we
-yank this out as a standalone guide."
-
-To connect to Materialize using [PopSQL](https://popsql.com/), follow the
-documentation to [create a Materialize connection](https://docs.popsql.com/docs/connecting-to-materialize)
-and use the credentials provided in the Materialize console.
-
-<img width="1552" alt="Screenshot 2023-12-28 at 18 24 35" src="https://github.com/MaterializeInc/materialize/assets/23521087/2e219233-9f6c-4326-8b5e-acdfd49da342">
-
 ### TablePlus
 
 {{< note >}}


### PR DESCRIPTION
PopSQL was acquired by Timescale and, as a result, is deprecating the Materialize connector. 😔 Removing all mentions. Also removing it from the integrations gallery in [Console #]().