### PR TITLE
storage: cleanup autospill test

### DIFF
--- a/test/upsert/autospill/03-rocksdb.td
+++ b/test/upsert/autospill/03-rocksdb.td
@@ -36,6 +36,13 @@ fish:AREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISHAREALLYBIGFISH
   ORDER BY s.name
 true true 3
 
+$ set-from-sql var=previous-bytes-2
+SELECT
+  (SUM(u.bytes_indexed))::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
+  WHERE s.name = 'autospill'
+
 # Removing all the inserted keys
 $ kafka-ingest format=bytes topic=autospill key-format=bytes key-terminator=:
 fish:
@@ -45,13 +52,15 @@ animal:
 > SELECT count(*) from autospill;
 0
 
-# records_indexed should be zero
+# records_indexed should be zero.
+# bytes_indexed will still have tombstones, but should be smaller than when
+# there are full values.
 > SELECT
-    SUM(u.bytes_indexed),
+    SUM(u.bytes_indexed) < ${previous-bytes-2},
     SUM(u.records_indexed)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name = 'autospill'
   GROUP BY s.name
   ORDER BY s.name
-30 0
+true 0


### PR DESCRIPTION
sorry i missed this @def- !

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
