### PR TITLE
explain: fix tracing fast path regression

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -70,7 +70,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_eager_delta_joins": "true",
     "enable_envelope_debezium_in_subscribe": "true",
     "enable_equivalence_propagation": "true",
-    "enable_explain_broken": "true",
     "enable_expressions_in_limit_syntax": "true",
     "enable_logical_compaction_window": "true",
     "enable_multi_worker_storage_persist_sink": "true",

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -541,7 +541,6 @@ impl Coordinator {
             df_meta,
             explain_ctx:
                 ExplainPlanContext {
-                    broken,
                     config,
                     format,
                     stage,
@@ -585,10 +584,6 @@ impl Coordinator {
             stage,
             plan::ExplaineeStatementKind::CreateIndex,
         )?;
-
-        if broken {
-            tracing_core::callsite::rebuild_interest_cache();
-        }
 
         Ok(StageResult::Response(Self::send_immediate_rows(rows)))
     }

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -812,7 +812,6 @@ impl Coordinator {
             df_meta,
             explain_ctx:
                 ExplainPlanContext {
-                    broken,
                     config,
                     format,
                     stage,
@@ -851,10 +850,6 @@ impl Coordinator {
             stage,
             plan::ExplaineeStatementKind::CreateMaterializedView,
         )?;
-
-        if broken {
-            tracing_core::callsite::rebuild_interest_cache();
-        }
 
         Ok(StageResult::Response(Self::send_immediate_rows(rows)))
     }

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -429,7 +429,6 @@ impl Coordinator {
                 },
             explain_ctx:
                 ExplainPlanContext {
-                    broken,
                     config,
                     format,
                     stage,
@@ -465,10 +464,6 @@ impl Coordinator {
             stage,
             plan::ExplaineeStatementKind::CreateView,
         )?;
-
-        if broken {
-            tracing_core::callsite::rebuild_interest_cache();
-        }
 
         Ok(StageResult::Response(Self::send_immediate_rows(rows)))
     }

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -942,7 +942,6 @@ impl Coordinator {
             df_meta,
             explain_ctx:
                 ExplainPlanContext {
-                    broken,
                     config,
                     format,
                     stage,
@@ -986,10 +985,6 @@ impl Coordinator {
             stage,
             plan::ExplaineeStatementKind::Select,
         )?;
-
-        if broken {
-            tracing_core::callsite::rebuild_interest_cache();
-        }
 
         Ok(Self::send_immediate_rows(rows))
     }

--- a/src/adapter/src/explain/optimizer_trace.rs
+++ b/src/adapter/src/explain/optimizer_trace.rs
@@ -40,14 +40,12 @@ use crate::AdapterError;
 /// optimization pipeline.
 ///
 /// Internally, this will create a layered [`tracing::subscriber::Subscriber`]
-/// consisting of one layer for each supported plan type `T`.
+/// consisting of one layer for each supported plan type `T` and wrap it into a
+/// [`dispatcher::Dispatch`] instance.
 ///
-/// Use `tracing::dispatcher::set_default` to trace in synchronous context.
-/// Use `tracing::instrument::WithSubscriber::with_subscriber(&optimizer_trace)` to trace the result of a `Future`.
-///
-/// The [`OptimizerTrace::collect_all`] method on the created instance can be
-/// then used to collect the trace, and [`OptimizerTrace::collect_all`] to obtain
-/// the collected trace as a vector of [`TraceEntry`] instances.
+/// Use [`OptimizerTrace::into_rows`] or [`OptimizerTrace::into_plan_insights`]
+/// to cleanly destroy the [`OptimizerTrace`] instance and obtain the tracing
+/// result.
 pub struct OptimizerTrace(dispatcher::Dispatch);
 
 impl std::fmt::Debug for OptimizerTrace {
@@ -78,24 +76,32 @@ impl OptimizerTrace {
                 .with(PlanTrace::<DataflowDescription<Plan>>::new(filter()))
                 // Don't filter for FastPathPlan entries (there can be at most one).
                 .with(PlanTrace::<FastPathPlan>::new(None))
-                .with(PlanTrace::<UsedIndexes>::new(None));
+                .with(PlanTrace::<UsedIndexes>::new(None))
+                // All optimizer spans are `TRACE` and up. Technically this slows down the system
+                // by skipping the tracing fast path DURING an `EXPLAIN`, but we haven't
+                // seen this be a problem (yet).
+                //
+                // Note that we typically do NOT use global filters like this, preferring
+                // per-layer ones, but we are forced to because per-layer filters
+                // require an `Arc<dyn Subscriber + LookupSpan>`, which isn't a trait
+                // exposed by tracing, for now.
+                .with(tracing::level_filters::LevelFilter::TRACE);
 
             OptimizerTrace(dispatcher::Dispatch::new(subscriber))
         } else {
+            // This codepath should not be taken except in tests, and is left here as a
+            // convenience.
             let subscriber = tracing_subscriber::registry()
-                // Collect `explain_plan` types that are not used in the regular explain
-                // path, but are useful when instrumenting code for debugging purposes.
                 .with(PlanTrace::<String>::new(filter()))
                 .with(PlanTrace::<HirScalarExpr>::new(filter()))
                 .with(PlanTrace::<MirScalarExpr>::new(filter()))
-                // Collect `explain_plan` types that are used in the regular explain path.
                 .with(PlanTrace::<HirRelationExpr>::new(filter()))
                 .with(PlanTrace::<MirRelationExpr>::new(filter()))
                 .with(PlanTrace::<DataflowDescription<OptimizedMirRelationExpr>>::new(filter()))
                 .with(PlanTrace::<DataflowDescription<Plan>>::new(filter()))
-                // Don't filter for FastPathPlan entries (there can be at most one).
                 .with(PlanTrace::<FastPathPlan>::new(None))
-                .with(PlanTrace::<UsedIndexes>::new(None));
+                .with(PlanTrace::<UsedIndexes>::new(None))
+                .with(tracing::level_filters::LevelFilter::TRACE);
 
             OptimizerTrace(dispatcher::Dispatch::new(subscriber))
         }
@@ -231,9 +237,22 @@ impl OptimizerTrace {
             }
         };
 
+        // We assume that any `Dispatch` cloned from this `OptimizerTrace` has long been dropped
+        // (any usage that doesn't use this is incorrect and is losing this data). We rebuild the
+        // tracing interest cache, as this `OptimizerTrace` is acting like a reload-layer, and
+        // tracing needs to be recalculate what the max level is, using this often-unknown
+        // API. Note that the reference to the `Dispatch` in self MUST be dropped before
+        // re-calculating interest.
+        //
+        // Before this is dropped and rebuilt, there is small extra cost to all `DEBUG` spans and
+        // events, if the other layers (otel and stderr) are only interested in `INFO`.
+        drop(self);
+        tracing_core::callsite::rebuild_interest_cache();
         Ok(rows)
     }
 
+    /// Collect a [`insights::PlanInsights`] with insights about the the
+    /// optimized plans rendered as a JSON `String`.
     pub fn into_plan_insights(
         self,
         features: &OptimizerFeatures,
@@ -262,7 +281,7 @@ impl OptimizerTrace {
 
     /// Collect all traced plans for all plan types `T` that are available in
     /// the wrapped [`dispatcher::Dispatch`].
-    pub fn collect_all(
+    fn collect_all(
         &self,
         format: ExplainFormat,
         config: &ExplainConfig,
@@ -338,7 +357,7 @@ impl OptimizerTrace {
     }
 
     /// Collects the global optimized plan from the trace, if it exists.
-    pub fn collect_global_plan(&self) -> Option<DataflowDescription<OptimizedMirRelationExpr>> {
+    fn collect_global_plan(&self) -> Option<DataflowDescription<OptimizedMirRelationExpr>> {
         self.0
             .downcast_ref::<PlanTrace<DataflowDescription<OptimizedMirRelationExpr>>>()
             .and_then(|trace| trace.find(NamedPlan::Global.path()))
@@ -346,7 +365,7 @@ impl OptimizerTrace {
     }
 
     /// Collects the fast path plan from the trace, if it exists.
-    pub fn collect_fast_path_plan(&self) -> Option<FastPathPlan> {
+    fn collect_fast_path_plan(&self) -> Option<FastPathPlan> {
         self.0
             .downcast_ref::<PlanTrace<FastPathPlan>>()
             .and_then(|trace| trace.find(NamedPlan::FastPath.path()))

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -463,9 +463,6 @@ fn plan_explainee(
         }
         Explainee::Select(select, broken) => {
             let (plan, desc) = plan_select_inner(scx, *select, params, None)?;
-            if broken {
-                scx.require_feature_flag(&vars::ENABLE_EXPLAIN_BROKEN)?;
-            }
             crate::plan::Explainee::Statement(ExplaineeStatement::Select { broken, plan, desc })
         }
         Explainee::CreateView(mut stmt, broken) => {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1923,13 +1923,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_explain_broken,
-        desc: "EXPLAIN ... BROKEN <query> syntax",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_comment,
         desc: "the COMMENT ON feature for objects",
         default: true,

--- a/test/sqllogictest/explain/broken_statements.slt
+++ b/test/sqllogictest/explain/broken_statements.slt
@@ -26,11 +26,6 @@ ALTER SYSTEM SET enable_unsafe_functions = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_explain_broken = true
-----
-COMPLETE 0
-
 mode cockroach
 
 # EXPLAIN ... BROKEN <select>

--- a/test/tracing/mzcompose.py
+++ b/test/tracing/mzcompose.py
@@ -136,6 +136,14 @@ def workflow_basic(c: Composition) -> None:
         info = requests.get(f"http://localhost:{port}/api/tracing").json()
         assert info["current_level_filter"] == "info"
 
+        # Assert `EXPLAIN` doesn't break things in steady-state.
+        c.sql(
+            "EXPLAIN SELECT 1",
+            print_statement=False,
+        )
+        info = requests.get(f"http://localhost:{port}/api/tracing").json()
+        assert info["current_level_filter"] == "info"
+
 
 def workflow_clusterd(c: Composition) -> None:
     c.up("materialized", "clusterd")


### PR DESCRIPTION
Fixes a regression in #23124 
See the changed test for an example of how the tracing fast path would be broken until another change rebuilt the cache.

@aalexandrov I also took this time to completely remove the `BROKEN` references everywhere!

### Motivation
  * This PR fixes a previously unreported bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
