### PR TITLE
ssh-connection test: Adapt expected error msg

### DIFF
--- a/test/ssh-connection/validate-failures.td
+++ b/test/ssh-connection/validate-failures.td
@@ -12,14 +12,14 @@
     USER 'mz',
     PORT 22
   ) WITH (VALIDATE);
-contains:failed to connect to the remote host: Could not resolve hostname
+contains:failed to lookup address information
 
 ! CREATE CONNECTION IF NOT EXISTS invalid_port TO SSH TUNNEL (
     HOST 'ssh-bastion-host',
     USER 'mz',
     PORT 23
   ) WITH (VALIDATE);
-contains:failed to connect to the remote host: connect to host ssh-bastion-host port 23: Connection refused
+regex:failed to connect to the remote host: connect to host .* port 23: Connection refused
 
 > CREATE CONNECTION IF NOT EXISTS invalid_user TO SSH TUNNEL (
     HOST 'ssh-bastion-host',
@@ -28,9 +28,9 @@ contains:failed to connect to the remote host: connect to host ssh-bastion-host 
   );
 
 ! VALIDATE CONNECTION invalid_user;
-contains:failed to connect to the remote host: invalid@ssh-bastion-host: Permission denied (publickey,keyboard-interactive).
+regex:failed to connect to the remote host: invalid@.*: Permission denied \(publickey,keyboard-interactive\)\.
 
 > DROP CONNECTION invalid_user;
 
 ! VALIDATE CONNECTION thancred;
-contains:failed to connect to the remote host: mz@ssh-bastion-host: Permission denied (publickey,keyboard-interactive).
+regex:failed to connect to the remote host: mz@.*: Permission denied \(publickey,keyboard-interactive\)\.


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/7438

Caused by https://github.com/MaterializeInc/materialize/pull/26186
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
