### PR TITLE
adapter: remove confirm_leadership from linearize_reads

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -784,16 +784,10 @@ impl Coordinator {
 
         if !ready_txns.is_empty() {
             // Sniff out one ctx, this is where tracing breaks down because we
-            // do one confirm_leadership for multiple peeks.
+            // process all outstanding txns as a batch here.
             let otel_ctx = ready_txns.first().expect("known to exist").otel_ctx.clone();
             let mut span = tracing::debug_span!("message_linearize_reads");
             otel_ctx.attach_as_parent_to(&mut span);
-
-            self.catalog_mut()
-                .confirm_leadership()
-                .instrument(span)
-                .await
-                .unwrap_or_terminate("unable to confirm leadership");
 
             let now = Instant::now();
             for ready_txn in ready_txns {


### PR DESCRIPTION
We don't need it anymore there because the distributed timestamp oracle now guarantees linearized read timestamps all by itself.

Light version of https://github.com/MaterializeInc/materialize/pull/26179

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
