### PR TITLE
compute: read capability reporting to fix per-replica read holds

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -831,6 +831,8 @@ pub struct CollectionState<T> {
     write_frontier: Antichain<T>,
     /// The write frontiers reported by individual replicas.
     replica_write_frontiers: BTreeMap<ReplicaId, Antichain<T>>,
+    /// The input frontiers reported by individual replicas.
+    replica_input_frontiers: BTreeMap<ReplicaId, Antichain<T>>,
 }
 
 impl<T> CollectionState<T> {
@@ -889,6 +891,7 @@ impl<T: ComputeControllerTimestamp> CollectionState<T> {
             compute_dependencies,
             write_frontier: upper,
             replica_write_frontiers: BTreeMap::new(),
+            replica_input_frontiers: BTreeMap::new(),
         }
     }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -100,11 +100,14 @@ pub enum ComputeControllerResponse<T> {
     /// produced. (The sink may produce no responses if its dataflow is dropped
     /// before completion.)
     CopyToResponse(GlobalId, Result<u64, anyhow::Error>),
-    /// See [`ComputeResponse::FrontierUpper`]
+    /// A response reporting advancement of a collection's upper frontier.
+    ///
+    /// Once a collection's upper (aka "write frontier") has advanced to beyond a given time, the
+    /// contents of the collection as of that time have been sealed and cannot change anymore.
     FrontierUpper {
-        /// TODO(#25239): Add documentation.
+        /// The ID of a compute collection.
         id: GlobalId,
-        /// TODO(#25239): Add documentation.
+        /// The new upper frontier of the identified compute collection.
         upper: Antichain<T>,
     },
 }

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1803,6 +1803,11 @@ where
             }
         }
 
+        // Apply an input frontier advancement.
+        if let Some(new_frontier) = frontiers.input_frontier {
+            // TODO
+        }
+
         response
     }
 

--- a/src/compute-client/src/controller/sequential_hydration.rs
+++ b/src/compute-client/src/controller/sequential_hydration.rs
@@ -157,6 +157,7 @@ where
             id,
             FrontiersResponse {
                 write_frontier: Some(upper),
+                ..
             },
         ) = resp
         {

--- a/src/compute-client/src/controller/sequential_hydration.rs
+++ b/src/compute-client/src/controller/sequential_hydration.rs
@@ -56,7 +56,7 @@ use tracing::debug;
 use crate::controller::ComputeControllerTimestamp;
 use crate::metrics::ReplicaMetrics;
 use crate::protocol::command::ComputeCommand;
-use crate::protocol::response::ComputeResponse;
+use crate::protocol::response::{ComputeResponse, FrontiersResponse};
 use crate::service::ComputeClient;
 
 /// A shareable token.
@@ -74,7 +74,7 @@ pub(super) struct SequentialHydration<C, T> {
     /// Tracked collections.
     ///
     /// Entries are inserted in response to observed `CreateDataflow` commands.
-    /// Entries are removed in response to `FrontierUpper` commands that report collection
+    /// Entries are removed in response to `Frontiers` commands that report collection
     /// hydration, or in response to `AllowCompaction` commands that specify the empty frontier.
     collections: BTreeMap<GlobalId, Collection<T>>,
     /// A queue of scheduled collections that are awaiting hydration.
@@ -153,7 +153,13 @@ where
 
     /// Observe a response and send resulting commands to the wrapped client.
     async fn observe_response(&mut self, resp: &ComputeResponse<T>) -> Result<(), anyhow::Error> {
-        if let ComputeResponse::FrontierUpper { id, upper } = resp {
+        if let ComputeResponse::Frontiers(
+            id,
+            FrontiersResponse {
+                write_frontier: Some(upper),
+            },
+        ) = resp
+        {
             if let Some(collection) = self.collections.remove(id) {
                 let hydrated = PartialOrder::less_than(&collection.as_of, upper);
                 if hydrated || upper.is_empty() {

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -514,7 +514,7 @@ impl<M> CommandMetrics<M> {
 /// Metrics keyed by `ComputeResponse` type.
 #[derive(Debug)]
 struct ResponseMetrics<M> {
-    frontier_upper: M,
+    frontiers: M,
     peek_response: M,
     subscribe_response: M,
     copy_to_response: M,
@@ -527,7 +527,7 @@ impl<M> ResponseMetrics<M> {
         F: Fn(&str) -> M,
     {
         Self {
-            frontier_upper: build_metric("frontier_upper"),
+            frontiers: build_metric("frontiers"),
             peek_response: build_metric("peek_response"),
             subscribe_response: build_metric("subscribe_response"),
             copy_to_response: build_metric("copy_to_response"),
@@ -539,7 +539,7 @@ impl<M> ResponseMetrics<M> {
         use crate::protocol::response::proto_compute_response::Kind::*;
 
         match proto.kind.as_ref().unwrap() {
-            FrontierUpper(_) => &self.frontier_upper,
+            Frontiers(_) => &self.frontiers,
             PeekResponse(_) => &self.peek_response,
             SubscribeResponse(_) => &self.subscribe_response,
             CopyToResponse(_) => &self.copy_to_response,

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -128,8 +128,8 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// should prefer panicking over producing incorrect results.
     ///
     /// After receiving a `CreateDataflow` command, if the created dataflow exports indexes or
-    /// storage sinks, the replica must produce [`FrontierUpper`] responses that report the
-    /// advancement of the `upper` frontiers of these compute collections.
+    /// storage sinks, the replica must produce [`Frontiers`] responses that report the
+    /// advancement of the frontiers of these compute collections.
     ///
     /// After receiving a `CreateDataflow` command, if the created dataflow exports subscribes, the
     /// replica must produce [`SubscribeResponse`]s that report the progress and results of the
@@ -144,7 +144,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// [`source_imports`]: DataflowDescription::source_imports
     /// [`index_imports`]: DataflowDescription::index_imports
     /// [`as_of`]: DataflowDescription::as_of
-    /// [`FrontierUpper`]: super::response::ComputeResponse::FrontierUpper
+    /// [`Frontiers`]: super::response::ComputeResponse::Frontiers
     /// [`SubscribeResponse`]: super::response::ComputeResponse::SubscribeResponse
     CreateDataflow(DataflowDescription<FlatPlan<T>, CollectionMetadata, T>),
 
@@ -184,11 +184,11 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// compute collections.
     ///
     /// A replica that receives an `AllowCompaction` command with the empty frontier must
-    /// eventually respond with a [`FrontierUpper`] response reporting the empty frontier for the
-    /// same collection. ([#16275])
+    /// eventually respond with [`Frontiers`] responses reporting empty frontiers for the
+    /// same collection. ([#16271])
     ///
-    /// [`FrontierUpper`]: super::response::ComputeResponse::FrontierUpper
-    /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
+    /// [`Frontiers`]: super::response::ComputeResponse::Frontiers
+    /// [#16271]: https://github.com/MaterializeInc/materialize/issues/16271
     AllowCompaction {
         /// TODO(#25239): Add documentation.
         id: GlobalId,

--- a/src/compute-client/src/protocol/response.proto
+++ b/src/compute-client/src/protocol/response.proto
@@ -53,6 +53,7 @@ message ProtoComputeResponse {
 
 message ProtoFrontiersResponse {
     mz_repr.antichain.ProtoU64Antichain write_frontier = 1;
+    mz_repr.antichain.ProtoU64Antichain input_frontier = 2;
 }
 
 message ProtoPeekResponse {

--- a/src/compute-client/src/protocol/response.proto
+++ b/src/compute-client/src/protocol/response.proto
@@ -15,13 +15,17 @@ import "proto/src/proto.proto";
 import "repr/src/antichain.proto";
 import "repr/src/global_id.proto";
 import "repr/src/row.proto";
-import "storage-client/src/client.proto";
 
 import "google/protobuf/empty.proto";
 
 package mz_compute_client.protocol.response;
 
 message ProtoComputeResponse {
+    message ProtoFrontiersKind {
+        mz_repr.global_id.ProtoGlobalId id = 1;
+        ProtoFrontiersResponse resp = 2;
+    }
+
     message ProtoPeekResponseKind {
         mz_proto.ProtoU128 id = 1;
         ProtoPeekResponse resp = 2;
@@ -39,12 +43,16 @@ message ProtoComputeResponse {
     }
 
     oneof kind {
-        mz_storage_client.client.ProtoTrace frontier_upper = 1;
+        ProtoFrontiersKind frontiers = 1;
         ProtoPeekResponseKind peek_response = 2;
         ProtoSubscribeResponseKind subscribe_response = 3;
         ProtoCopyToResponseKind copy_to_response = 4;
         ProtoStatusResponse status = 5;
     }
+}
+
+message ProtoFrontiersResponse {
+    mz_repr.antichain.ProtoU64Antichain write_frontier = 1;
 }
 
 message ProtoPeekResponse {

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -15,7 +15,6 @@ use mz_compute_types::plan::LirId;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_proto::{any_uuid, IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, Row};
-use mz_storage_client::client::ProtoTrace;
 use mz_timely_util::progress::any_antichain;
 use proptest::prelude::{any, Arbitrary, Just};
 use proptest::strategy::{BoxedStrategy, Strategy, Union};
@@ -37,51 +36,37 @@ include!(concat!(
 /// [`ComputeCommand`]: super::command::ComputeCommand
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ComputeResponse<T = mz_repr::Timestamp> {
-    /// `FrontierUpper` announces the advancement of the upper frontier of the specified compute
-    /// collection. The response contain a collection ID and that collection's new upper frontier.
+    /// `Frontiers` announces the advancement of the various frontiers of the specified compute
+    /// collection.
     ///
-    /// Upon receiving a `FrontierUpper` response, the controller may assume that the replica has
-    /// finished computing the given collection up to at least the given frontier. It may also
-    /// assume that the replica has finished reading from the collection’s inputs up to that
-    /// frontier.
-    ///
-    /// Replicas must send `FrontierUpper` responses for compute collections that are indexes or
-    /// storage sinks. Replicas must not send `FrontierUpper` responses for subscribes.
+    /// Replicas must send `Frontiers` responses for compute collections that are indexes or
+    /// storage sinks. Replicas must not send `Frontiers` responses for subscribes ([#16274]).
     ///
     /// Replicas must never report regressing frontiers. Specifically:
     ///
-    ///   * The first frontier reported for a collection must not be less than that collection's
-    ///     initial `as_of` frontier.
-    ///   * Subsequent reported frontiers for a collection must not be less than any frontier
-    ///     reported previously for the same collection.
+    ///   * The first frontier of any kind reported for a collection must not be less than that
+    ///     collection's initial `as_of` frontier.
+    ///   * Subsequent reported frontiers for a collection must not be less than any frontier of
+    ///     the same kind reported previously for the same collection.
     ///
-    /// Replicas must send a `FrontierUpper` response reporting advancement to the empty frontier
-    /// for a collection in two cases:
+    /// Replicas must send `Frontiers` responses that report each frontier kind to have advanced to
+    /// the empty frontier in response to an [`AllowCompaction` command] that allows compaction of
+    /// the collection to to the empty frontier, unless the frontier has previously advanced to the
+    /// empty frontier as part of the regular dataflow computation. ([#16271])
     ///
-    ///   * The collection has advanced to the empty frontier (e.g. because its inputs have advanced
-    ///     to the empty frontier).
-    ///   * The collection was dropped in response to an [`AllowCompaction` command] that advanced
-    ///     its read frontier to the empty frontier. ([#16275])
+    /// Once a frontier was reported to have been advanced to the empty frontier, the replica must
+    /// not send further `Frontiers` responses with non-`None` values for that frontier kind.
     ///
-    /// Once a collection was reported to have been advanced to the empty upper frontier:
-    ///
-    ///   * It must no longer read from its inputs.
-    ///   * The replica must not send further `FrontierUpper` responses for that collection.
-    ///
-    /// The replica must not send `FrontierUpper` responses for collections that have not
+    /// The replica must not send `Frontiers` responses for collections that have not
     /// been created previously by a [`CreateDataflow` command] or by a [`CreateInstance`
     /// command].
     ///
     /// [`AllowCompaction` command]: super::command::ComputeCommand::AllowCompaction
     /// [`CreateDataflow` command]: super::command::ComputeCommand::CreateDataflow
     /// [`CreateInstance` command]: super::command::ComputeCommand::CreateInstance
-    /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
-    FrontierUpper {
-        /// TODO(#25239): Add documentation.
-        id: GlobalId,
-        /// TODO(#25239): Add documentation.
-        upper: Antichain<T>,
-    },
+    /// [#16271]: https://github.com/MaterializeInc/materialize/issues/16271
+    /// [#16274]: https://github.com/MaterializeInc/materialize/issues/16274
+    Frontiers(GlobalId, FrontiersResponse<T>),
 
     /// `PeekResponse` reports the result of a previous [`Peek` command]. The peek is identified by
     /// a `Uuid` that matches the command's [`Peek::uuid`].
@@ -167,9 +152,9 @@ impl RustType<ProtoComputeResponse> for ComputeResponse<mz_repr::Timestamp> {
         use proto_compute_response::*;
         ProtoComputeResponse {
             kind: Some(match self {
-                ComputeResponse::FrontierUpper { id, upper } => FrontierUpper(ProtoTrace {
+                ComputeResponse::Frontiers(id, resp) => Frontiers(ProtoFrontiersKind {
                     id: Some(id.into_proto()),
-                    upper: Some(upper.into_proto()),
+                    resp: Some(resp.into_proto()),
                 }),
                 ComputeResponse::PeekResponse(id, resp, otel_ctx) => {
                     PeekResponse(ProtoPeekResponseKind {
@@ -198,10 +183,10 @@ impl RustType<ProtoComputeResponse> for ComputeResponse<mz_repr::Timestamp> {
     fn from_proto(proto: ProtoComputeResponse) -> Result<Self, TryFromProtoError> {
         use proto_compute_response::Kind::*;
         match proto.kind {
-            Some(FrontierUpper(trace)) => Ok(ComputeResponse::FrontierUpper {
-                id: trace.id.into_rust_if_some("ProtoTrace::id")?,
-                upper: trace.upper.into_rust_if_some("ProtoTrace::upper")?,
-            }),
+            Some(Frontiers(resp)) => Ok(ComputeResponse::Frontiers(
+                resp.id.into_rust_if_some("ProtoFrontiersKind::id")?,
+                resp.resp.into_rust_if_some("ProtoFrontiersKind::resp")?,
+            )),
             Some(PeekResponse(resp)) => Ok(ComputeResponse::PeekResponse(
                 resp.id.into_rust_if_some("ProtoPeekResponseKind::id")?,
                 resp.resp.into_rust_if_some("ProtoPeekResponseKind::resp")?,
@@ -232,8 +217,8 @@ impl Arbitrary for ComputeResponse<mz_repr::Timestamp> {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         Union::new(vec![
-            (any::<GlobalId>(), any_antichain())
-                .prop_map(|(id, upper)| ComputeResponse::FrontierUpper { id, upper })
+            (any::<GlobalId>(), any::<FrontiersResponse>())
+                .prop_map(|(id, resp)| ComputeResponse::Frontiers(id, resp))
                 .boxed(),
             (any_uuid(), any::<PeekResponse>())
                 .prop_map(|(id, resp)| {
@@ -247,6 +232,48 @@ impl Arbitrary for ComputeResponse<mz_repr::Timestamp> {
                 .prop_map(ComputeResponse::Status)
                 .boxed(),
         ])
+    }
+}
+
+/// A response reporting advancement of frontiers of a compute collection.
+///
+/// All contained frontier fields are optional. `None` values imply that the respective frontier
+/// has not advanced and the previously reported value is still current.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FrontiersResponse<T = mz_repr::Timestamp> {
+    /// The collection's new write frontier, if any.
+    ///
+    /// Upon receiving an updated `write_frontier`, the controller may assume that the contents of the
+    /// collection are sealed for all times less than that frontier. Once it has reported the
+    /// `write_frontier` as the empty frontier, the replica must no longer change the contents of the
+    /// collection.
+    pub write_frontier: Option<Antichain<T>>,
+}
+
+impl RustType<ProtoFrontiersResponse> for FrontiersResponse {
+    fn into_proto(&self) -> ProtoFrontiersResponse {
+        ProtoFrontiersResponse {
+            write_frontier: self.write_frontier.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoFrontiersResponse) -> Result<Self, TryFromProtoError> {
+        Ok(Self {
+            write_frontier: proto.write_frontier.into_rust()?,
+        })
+    }
+}
+
+impl Arbitrary for FrontiersResponse {
+    type Strategy = BoxedStrategy<Self>;
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        any_antichain()
+            .prop_map(|write| Self {
+                write_frontier: Some(write),
+            })
+            .boxed()
     }
 }
 

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -239,7 +239,7 @@ impl Arbitrary for ComputeResponse<mz_repr::Timestamp> {
 ///
 /// All contained frontier fields are optional. `None` values imply that the respective frontier
 /// has not advanced and the previously reported value is still current.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct FrontiersResponse<T = mz_repr::Timestamp> {
     /// The collection's new write frontier, if any.
     ///

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -592,6 +592,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         for (id, upper) in new_uppers {
             let frontiers = FrontiersResponse {
                 write_frontier: Some(upper),
+                input_frontier: None, // TODO
             };
             self.send_compute_response(ComputeResponse::Frontiers(id, frontiers));
         }
@@ -620,6 +621,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             );
             let frontiers = FrontiersResponse {
                 write_frontier: Some(Antichain::new()),
+                input_frontier: None, // TODO
             };
             self.send_compute_response(ComputeResponse::Frontiers(id, frontiers));
         }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -80,7 +80,7 @@ pub struct ComputeState {
     ///  * Subscribes report their frontiers through the `subscribe_response_buffer`.
     pub collections: BTreeMap<GlobalId, CollectionState>,
     /// Collections that were recently dropped and whose removal needs to be reported.
-    pub dropped_collections: Vec<GlobalId>,
+    pub dropped_collections: Vec<(GlobalId, CollectionState)>,
     /// The traces available for sharing across dataflows.
     pub traces: TraceManager,
     /// Shared buffer with SUBSCRIBE operator instances by which they can respond.
@@ -390,7 +390,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                 collection.logging = Some(logging);
             }
 
-            collection.set_reported_frontier(ReportedFrontier::NotReported {
+            collection.reset_reported_frontiers(ReportedFrontier::NotReported {
                 lower: as_of.clone(),
             });
 
@@ -477,8 +477,25 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         }
     }
 
+    /// Arrange for the given collection to be dropped.
+    ///
+    /// Collection dropping occurs in three phases:
+    ///
+    ///  1. This method removes the collection from the `ComputeState` and drops its dataflow
+    ///     tokens. It does _not_ yet drop the `CollectionState` but adds it to
+    ///     `dropped_collections`.
+    ///  2. The next step of the Timely worker lets the source operators observe the token drops
+    ///     and shut themselves down.
+    ///  3. `report_dropped_collections` removes the `CollectionState` from `dropped_collections`,
+    ///     emits any outstanding final responses required by the compute protocol, then drops the
+    ///     `CollectionState`.
+    ///
+    /// These steps ensure that we don't report a collection as dropped to the controller before it
+    /// has stopped reading from its inputs. Doing so would allow the controller to release its
+    /// read holds on the inputs, which could lead to panics from the replica trying to read
+    /// already compacted times.
     fn drop_collection(&mut self, id: GlobalId) {
-        let collection = self
+        let mut collection = self
             .compute_state
             .collections
             .remove(&id)
@@ -486,20 +503,16 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
 
         // If this collection is an index, remove its trace.
         self.compute_state.traces.del_trace(&id);
+        // If this collection is a sink, drop its sink token.
+        collection.sink_token.take();
 
         // If the collection is unscheduled, remove it from the list of waiting collections.
         self.compute_state.suspended_collections.remove(&id);
 
-        // We need to emit a final response reporting the dropping of this collection,
-        // unless:
-        //  * The collection is a subscribe, in which case we will emit a
-        //    `SubscribeResponse::Dropped` independently.
-        //  * The collection has already advanced to the empty frontier, in which case
-        //    the final `Frontiers` response already serves the purpose of reporting
-        //    the end of the dataflow.
-        if !collection.is_subscribe() && !collection.reported_frontier().is_empty() {
-            self.compute_state.dropped_collections.push(id);
-        }
+        // Remember the collection as dropped, for emission of outstanding final compute responses.
+        self.compute_state
+            .dropped_collections
+            .push((id, collection));
     }
 
     /// Initializes timely dataflow logging and publishes as a view.
@@ -543,14 +556,22 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         self.compute_state.compute_logger = Some(logger);
     }
 
-    /// Send progress information to the coordinator.
+    /// Send progress information to the controller.
     pub fn report_compute_frontiers(&mut self) {
-        let mut new_uppers = Vec::new();
+        let mut responses = Vec::new();
 
         // Maintain a single allocation for `new_frontier` to avoid allocating on every iteration.
         let mut new_frontier = Antichain::new();
 
         for (&id, collection) in self.compute_state.collections.iter_mut() {
+            // Subscribe frontiers are reported in `process_subscribes` instead.
+            if collection.is_subscribe() {
+                continue;
+            }
+
+            let reported = collection.reported_frontiers();
+
+            // Collect the write frontier and check for progress.
             new_frontier.clear();
             if let Some(traces) = self.compute_state.traces.get_mut(&id) {
                 assert!(
@@ -561,47 +582,44 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             } else if let Some(frontier) = &collection.sink_write_frontier {
                 new_frontier.clone_from(&frontier.borrow());
             } else {
-                // Subscribe frontiers are reported in `process_subscribes` instead.
-                if !collection.is_subscribe() {
-                    error!(id = ?id, "collection without frontier");
-                }
+                error!(id = ?id, "collection without write frontier");
                 continue;
             }
+            let new_write_frontier = reported
+                .write_frontier
+                .allows_reporting(&new_frontier)
+                .then(|| new_frontier.clone());
 
-            match collection.reported_frontier() {
-                ReportedFrontier::Reported(old_frontier) => {
-                    // In steady state it is not expected for `old_frontier` to be beyond
-                    // `new_frontier`. However, during reconciliation this can happen as we
-                    // artificially advance the frontiers of to-be-dropped collections to disable
-                    // frontier reporting for them.
-                    if !PartialOrder::less_than(old_frontier, &new_frontier) {
-                        continue; // nothing new to report
-                    }
-                }
-                ReportedFrontier::NotReported { lower } => {
-                    if !PartialOrder::less_equal(lower, &new_frontier) {
-                        continue; // lower bound for reporting not yet reached
-                    }
-                }
+            // Collect the input frontier and check for progress.
+            new_frontier.clear();
+            for probe in collection.input_probes.values() {
+                probe.with_frontier(|frontier| new_frontier.extend(frontier.iter().copied()));
+            }
+            let new_input_frontier = reported
+                .input_frontier
+                .allows_reporting(&new_frontier)
+                .then(|| new_frontier.clone());
+
+            if let Some(frontier) = &new_write_frontier {
+                collection
+                    .set_reported_write_frontier(ReportedFrontier::Reported(frontier.clone()));
+            }
+            if let Some(frontier) = &new_input_frontier {
+                collection
+                    .set_reported_input_frontier(ReportedFrontier::Reported(frontier.clone()));
             }
 
-            new_uppers.push((id, new_frontier.clone()));
-            collection.set_reported_frontier(ReportedFrontier::Reported(new_frontier.clone()));
-        }
-
-        for (id, upper) in new_uppers {
-            let frontiers = FrontiersResponse {
-                write_frontier: Some(upper),
-                input_frontier: None, // TODO
+            let response = FrontiersResponse {
+                write_frontier: new_write_frontier,
+                input_frontier: new_input_frontier,
             };
-            self.send_compute_response(ComputeResponse::Frontiers(id, frontiers));
+            if response.has_updates() {
+                responses.push((id, response));
+            }
         }
-    }
 
-    /// Update logging with the current dataflow input frontiers.
-    pub fn log_input_frontiers(&mut self) {
-        for collection in self.compute_state.collections.values_mut() {
-            collection.log_input_frontiers();
+        for (id, frontiers) in responses {
+            self.send_compute_response(ComputeResponse::Frontiers(id, frontiers));
         }
     }
 
@@ -609,21 +627,27 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
     pub fn report_dropped_collections(&mut self) {
         let dropped_collections = std::mem::take(&mut self.compute_state.dropped_collections);
 
-        // TODO(#16275): It is, in fact, wrong to report the dropping of a collection before it has
-        // advanced to the empty frontier by announcing that it has advanced to the empty
-        // frontier. We should introduce a new compute response variant that has the right
-        // semantics.
-        for id in dropped_collections {
-            // Sanity check: A collection that was dropped should not exist.
-            assert!(
-                !self.compute_state.collection_exists(id),
-                "tried to report a dropped collection that still exists: {id}"
-            );
+        for (id, collection) in dropped_collections {
+            // The compute protocol requires us to send a `Frontiers` response with empty frontiers
+            // when a collection was dropped, unless:
+            //  * The frontier was already reported as empty previously, or
+            //  * The collection is a subscribe.
+
+            if collection.is_subscribe() {
+                continue;
+            }
+
+            let reported = collection.reported_frontiers();
+            let write_frontier = (!reported.write_frontier.is_empty()).then(Antichain::new);
+            let input_frontier = (!reported.input_frontier.is_empty()).then(Antichain::new);
+
             let frontiers = FrontiersResponse {
-                write_frontier: Some(Antichain::new()),
-                input_frontier: None, // TODO
+                write_frontier,
+                input_frontier,
             };
-            self.send_compute_response(ComputeResponse::Frontiers(id, frontiers));
+            if frontiers.has_updates() {
+                self.send_compute_response(ComputeResponse::Frontiers(id, frontiers));
+            }
         }
     }
 
@@ -634,7 +658,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             // The compute protocol forbids reporting `Status` about collections that have advanced
             // to the empty frontier, so we ignore updates for those.
             let collection = self.compute_state.collections.get(&event.export_id);
-            if collection.map_or(true, |c| c.reported_frontier().is_empty()) {
+            if collection.map_or(true, |c| c.reported_frontiers().all_empty()) {
                 continue;
             }
 
@@ -713,23 +737,23 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                     SubscribeResponse::DroppedAt(_) => Antichain::new(),
                 };
 
-                match collection.reported_frontier() {
-                    ReportedFrontier::Reported(old_frontier) => {
-                        assert!(
-                            PartialOrder::less_than(old_frontier, &new_frontier),
-                            "new frontier {new_frontier:?} is not beyond \
-                             old frontier {old_frontier:?}"
-                        );
-                    }
-                    ReportedFrontier::NotReported { lower } => {
-                        assert!(
-                            PartialOrder::less_equal(lower, &new_frontier),
-                            "new frontier {new_frontier:?} is before lower bound {lower:?}"
-                        );
-                    }
-                }
+                let reported = collection.reported_frontiers();
+                assert!(
+                    reported.write_frontier.allows_reporting(&new_frontier),
+                    "subscribe write frontier regression: {:?} -> {:?}",
+                    reported.write_frontier,
+                    new_frontier,
+                );
+                assert!(
+                    reported.input_frontier.allows_reporting(&new_frontier),
+                    "subscribe input frontier regression: {:?} -> {:?}",
+                    reported.input_frontier,
+                    new_frontier,
+                );
 
-                collection.set_reported_frontier(ReportedFrontier::Reported(new_frontier));
+                collection
+                    .set_reported_write_frontier(ReportedFrontier::Reported(new_frontier.clone()));
+                collection.set_reported_input_frontier(ReportedFrontier::Reported(new_frontier));
             } else {
                 // Presumably tracking state for this subscribe was already dropped by
                 // `drop_collection`. There is nothing left to do for logging.
@@ -1298,8 +1322,32 @@ impl IndexPeek {
     }
 }
 
-/// A frontier we have reported to the controller, or the least frontier we are allowed to report.
+/// The frontiers we have reported to the controller for a collection.
 #[derive(Debug)]
+struct ReportedFrontiers {
+    /// The reported write frontier.
+    write_frontier: ReportedFrontier,
+    /// The reported input frontier.
+    input_frontier: ReportedFrontier,
+}
+
+impl ReportedFrontiers {
+    /// Creates a new `ReportedFrontiers` instance.
+    fn new() -> Self {
+        Self {
+            write_frontier: ReportedFrontier::new(),
+            input_frontier: ReportedFrontier::new(),
+        }
+    }
+
+    /// Returns whether all reported frontiers are empty.
+    fn all_empty(&self) -> bool {
+        self.write_frontier.is_empty() && self.input_frontier.is_empty()
+    }
+}
+
+/// A frontier we have reported to the controller, or the least frontier we are allowed to report.
+#[derive(Clone, Debug)]
 pub enum ReportedFrontier {
     /// A frontier has been previously reported.
     Reported(Antichain<Timestamp>),
@@ -1324,12 +1372,25 @@ impl ReportedFrontier {
             Self::NotReported { .. } => false,
         }
     }
+
+    /// Whether this `ReportedFrontier` allows reporting the given frontier.
+    ///
+    /// A `ReportedFrontier` allows reporting of another frontier if:
+    ///  * The other frontier is greater than the reported frontier.
+    ///  * The other frontier is greater than or equal to the lower bound.
+    fn allows_reporting(&self, other: &Antichain<Timestamp>) -> bool {
+        match self {
+            Self::Reported(frontier) => PartialOrder::less_than(frontier, other),
+            Self::NotReported { lower } => PartialOrder::less_equal(lower, other),
+        }
+    }
 }
 
 /// State maintained for a compute collection.
 pub struct CollectionState {
-    /// Tracks the frontier that has been reported to the controller.
-    reported_frontier: ReportedFrontier,
+    /// Tracks the frontiers that have been reported to the controller.
+    reported_frontiers: ReportedFrontiers,
+
     /// A token that should be dropped when this collection is dropped to clean up associated
     /// sink state.
     ///
@@ -1348,7 +1409,7 @@ pub struct CollectionState {
 impl CollectionState {
     fn new() -> Self {
         Self {
-            reported_frontier: ReportedFrontier::new(),
+            reported_frontiers: ReportedFrontiers::new(),
             sink_token: None,
             sink_write_frontier: None,
             input_probes: Default::default(),
@@ -1360,13 +1421,19 @@ impl CollectionState {
         self.sink_token.is_some() && self.sink_write_frontier.is_none()
     }
 
-    /// Return the frontier that has been reported to the controller.
-    pub fn reported_frontier(&self) -> &ReportedFrontier {
-        &self.reported_frontier
+    /// Return the frontiers that have been reported to the controller.
+    fn reported_frontiers(&self) -> &ReportedFrontiers {
+        &self.reported_frontiers
     }
 
-    /// Set the frontier that has been reported to the controller.
-    pub fn set_reported_frontier(&mut self, frontier: ReportedFrontier) {
+    /// Reset all reported frontiers to the given value.
+    pub fn reset_reported_frontiers(&mut self, frontier: ReportedFrontier) {
+        self.reported_frontiers.write_frontier = frontier.clone();
+        self.reported_frontiers.input_frontier = frontier;
+    }
+
+    /// Set the write frontier that has been reported to the controller.
+    fn set_reported_write_frontier(&mut self, frontier: ReportedFrontier) {
         if let Some(logging) = &mut self.logging {
             let time = match &frontier {
                 ReportedFrontier::Reported(frontier) => frontier.get(0).copied(),
@@ -1375,19 +1442,20 @@ impl CollectionState {
             logging.set_frontier(time);
         }
 
-        self.reported_frontier = frontier;
+        self.reported_frontiers.write_frontier = frontier;
     }
 
-    /// Update logging with the current input frontiers.
-    fn log_input_frontiers(&mut self) {
-        let Some(logging) = &mut self.logging else {
-            return;
-        };
-
-        for (id, probe) in &self.input_probes {
-            let new_time = probe.with_frontier(|frontier| frontier.as_option().copied());
-            logging.set_import_frontier(*id, new_time);
+    /// Set the input frontier that has been reported to the controller.
+    fn set_reported_input_frontier(&mut self, frontier: ReportedFrontier) {
+        // Use this opportunity to update our input frontier logging.
+        if let Some(logging) = &mut self.logging {
+            for (id, probe) in &self.input_probes {
+                let new_time = probe.with_frontier(|frontier| frontier.as_option().copied());
+                logging.set_import_frontier(*id, new_time);
+            }
         }
+
+        self.reported_frontiers.input_frontier = frontier;
     }
 }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -459,7 +459,6 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             // Report frontier information back the coordinator.
             if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {
                 compute_state.report_compute_frontiers();
-                compute_state.log_input_frontiers();
                 compute_state.report_dropped_collections();
                 compute_state.report_operator_hydration();
             }
@@ -731,7 +730,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                 //  * For dataflows we continue to use, reset to ensure we report something not
                 //    before the new `as_of` next.
                 //  * For dataflows we drop, set to the empty frontier, to ensure we don't report
-                //    anything for them. This is only needed until we implement #16275.
+                //    anything for them.
                 let retained = retain_ids.contains(&id);
                 let compaction = old_compaction.remove(&id);
                 let new_reported_frontier = match (retained, compaction) {
@@ -750,7 +749,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                     }
                 };
 
-                collection.set_reported_frontier(new_reported_frontier);
+                collection.reset_reported_frontiers(new_reported_frontier);
 
                 // Sink tokens should be retained for retained dataflows, and dropped for dropped
                 // dataflows.

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -256,6 +256,9 @@ where
             return;
         }
 
+        // Wait for the start signal before doing any work.
+        let () = start_signal.await;
+
         // Internally, the `open_leased_reader` call registers a new LeasedReaderId and then fires
         // up a background tokio task to heartbeat it. It is possible that we might get a
         // particularly adversarial scheduling where the CRDB query to register the id is sent and
@@ -285,13 +288,6 @@ where
         .await
         .expect("reader creation shouldn't panic")
         .expect("could not open persist shard");
-
-        // Wait for the start signal only after having obtained a read handle and therefore a read
-        // hold on the source shard. The compute controller is currently not able to correctly
-        // maintain read holds for inputs to REFRESH MVs, so it needs a little help.
-        //
-        // TODO(#16275): move this await before the reader initialization
-        let () = start_signal.await;
 
         let cfg = read.cfg.clone();
         let metrics = Arc::clone(&read.metrics);

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2506,7 +2506,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     assert count > 0, f"got {count}"
 
     # mz_compute_responses_total
-    count = metrics.get_responses_total("frontier_upper")
+    count = metrics.get_responses_total("frontiers")
     assert count > 0, f"got {count}"
     count = metrics.get_responses_total("peek_response")
     assert count == 2, f"got {count}"
@@ -2514,7 +2514,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     assert count == 0, f"got {count}"
 
     # mz_compute_response_message_bytes_total
-    count = metrics.get_response_bytes_total("frontier_upper")
+    count = metrics.get_response_bytes_total("frontiers")
     assert count > 0, f"got {count}"
     count = metrics.get_response_bytes_total("peek_response")
     assert count > 0, f"got {count}"


### PR DESCRIPTION
This PR renames the `FrontierUpper` response to `Frontiers` and adds to is a new `read_capability` field that reports for each compute collection the least time that the replica still needs to read from the collection inputs. Replicas emit read capability updates based on dataflow input frontiers they observe through the existing probes. The controller then uses this new information to maintain the per-replica read holds. Doing so fixes a bug where the controller would release read holds too early because they were based on the reported write frontiers, which can jump into the future for `REFRESH` materialized views.

This is an alternative version of https://github.com/MaterializeInc/materialize/pull/26594, which introduces a new `ReadCapability` response instead. The advantages of having a `Frontiers` response that reports various kinds of frontiers are:
* Less network overhead for the common case where multiple of a collection's frontiers advance at the same time.
* Less boilerplate/repeated documentation in the definition of the compute protocol.
* Easier introduction of new types of reported frontiers (e.g. progress frontiers).

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/16275

### Tips for reviewer

Commits can be reviewed separately.

Note that replicas only report a single read capability for each compute collection, rather than one per input. This is mostly to simplify the implementation, though it also reduces network traffic. There are no fundamental reasons against reporting capabilities per input, if it turns out that doing so would be beneficial.

Also note that unfortunately introducing the `read_capability` response does not allow us to remove the workaround of sending a `write_frontier = []` response for each dropped collection. As it turns out, the `ComputeClient`s (at least `PartitionedComputeState`) rely on that response to know when to clean up their frontier tracking state for a dropped collection. So removing the on-drop advancement of the write frontier is still blocked by https://github.com/MaterializeInc/materialize/issues/16271, after which the `ComputeClient`s will be able to drop their state based on observed `ComputeCommand`s instead.

@antiguru pointed out that `read_capability` is not a good name for the new frontier. I'm open for suggestions! `input_frontier` maybe? That's what we call it on the replica side.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
