### PR TITLE
build: deny `protobuf-src`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -179,6 +179,14 @@ wrappers = [
     "pulldown-cmark",
 ]
 
+# We shouldn't manually vendor `protoc`, instead rely on it through `mz-build-tools`.
+[[bans.deny]]
+name = "protobuf-src"
+wrappers = [
+    "mz-build-tools",
+    "protobuf-native",
+]
+
 [advisories]
 ignore = [
     # Consider switching `yaml-rust` to the actively maintained `yaml-rust2` fork of the original project


### PR DESCRIPTION
Deny any dependencies on `protobuf-src`, folks should depend on `protoc` via `mz-build-tools`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
