### PR TITLE
columnar: Refactor `PartEncoder`, add `decode_into(...)` to `PartDecoder`

### DIFF
--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -46,7 +46,7 @@ use crate::maelstrom::txn_list_append_single::codec_impls::{
 use crate::maelstrom::Args;
 
 /// Key of the persist shard used by [Transactor]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MaelstromKey(u64);
 
 /// Val of the persist shard used by [Transactor]

--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -749,8 +749,7 @@ mod codec_impls {
     pub struct MaelstromKeySchema;
 
     impl Schema<MaelstromKey> for MaelstromKeySchema {
-        type Encoder<'a> = SimpleEncoder<'a, MaelstromKey, u64>;
-
+        type Encoder = SimpleEncoder<MaelstromKey, u64>;
         type Decoder = SimpleDecoder<MaelstromKey, u64>;
 
         fn columns(&self) -> DynStructCfg {
@@ -761,7 +760,7 @@ mod codec_impls {
             SimpleSchema::<MaelstromKey, u64>::decoder(cols, |val, ret| ret.0 = val)
         }
 
-        fn encoder<'a>(&self, cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+        fn encoder(&self, cols: ColumnsMut) -> Result<Self::Encoder, String> {
             SimpleSchema::<MaelstromKey, u64>::encoder(cols, |val| val.0)
         }
     }
@@ -793,8 +792,7 @@ mod codec_impls {
     pub struct MaelstromValSchema;
 
     impl Schema<MaelstromVal> for MaelstromValSchema {
-        type Encoder<'a> = SimpleEncoder<'a, MaelstromVal, Vec<u8>>;
-
+        type Encoder = SimpleEncoder<MaelstromVal, Vec<u8>>;
         type Decoder = SimpleDecoder<MaelstromVal, Vec<u8>>;
 
         fn columns(&self) -> DynStructCfg {
@@ -807,7 +805,7 @@ mod codec_impls {
             })
         }
 
-        fn encoder<'a>(&self, cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+        fn encoder(&self, cols: ColumnsMut) -> Result<Self::Encoder, String> {
             SimpleSchema::<MaelstromVal, Vec<u8>>::push_encoder(cols, |col, val| {
                 let mut buf = Vec::new();
                 MaelstromVal::encode(val, &mut buf);

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -629,8 +629,8 @@ pub(crate) struct EncodedPart<T> {
 
 impl<K, V, T, D> FetchedPart<K, V, T, D>
 where
-    K: Debug + Codec,
-    V: Debug + Codec,
+    K: Debug + Codec + Default,
+    V: Debug + Codec + Default,
     T: Timestamp + Lattice + Codec64,
     D: Semigroup + Codec64 + Send + Sync,
 {
@@ -694,8 +694,8 @@ where
 
 impl<K, V, T, D> Iterator for FetchedPart<K, V, T, D>
 where
-    K: Debug + Codec,
-    V: Debug + Codec,
+    K: Debug + Codec + Default,
+    V: Debug + Codec + Default,
     T: Timestamp + Lattice + Codec64,
     D: Semigroup + Codec64 + Send + Sync,
 {

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -129,24 +129,32 @@ pub(crate) fn part_stats_for_legacy_part<K: Codec, V: Codec>(
     // This is a laughably inefficient placeholder implementation of stats
     // on the old part format. We don't intend to make this fast, rather we
     // intend to compute stats on the new part format.
-    let mut new_format = PartBuilder::new(schemas.key.as_ref(), schemas.val.as_ref());
-    let mut builder = new_format.get_mut();
-    let mut key = schemas.key.encoder(builder.key)?;
-    let mut val = schemas.val.encoder(builder.val)?;
+    let (cfg, builder) = PartBuilder::new(schemas.key.as_ref(), schemas.val.as_ref());
+    let PartBuilder {
+        key,
+        val,
+        mut ts,
+        mut diff,
+    } = builder;
+
+    let mut key_encoder = schemas.key.encoder(key)?;
+    let mut val_encoder = schemas.val.encoder(val)?;
+
     for x in part {
         for ((k, v), t, d) in x.iter() {
             let k = K::decode(k)?;
             let v = V::decode(v)?;
-            key.encode(&k);
-            val.encode(&v);
-            builder.ts.push(i64::from_le_bytes(t));
-            builder.diff.push(i64::from_le_bytes(d));
+            key_encoder.encode(&k);
+            val_encoder.encode(&v);
+            ts.push(i64::from_le_bytes(t));
+            diff.push(i64::from_le_bytes(d));
         }
     }
-    drop(key);
-    drop(val);
-    let new_format = new_format.finish()?;
-    PartStats::new(&new_format)
+    let key_cols = key_encoder.finish();
+    let val_cols = val_encoder.finish();
+    let part = cfg.into_part(key_cols, val_cols, ts, diff)?;
+
+    PartStats::new(&part)
 }
 
 /// Statistics about the contents of a shard as_of some time.

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 
 use mz_dyncfg::{Config, ConfigSet};
 use mz_persist::indexed::columnar::ColumnarRecords;
-use mz_persist_types::columnar::{PartEncoder, Schema};
 use mz_persist_types::part::PartBuilder;
 use mz_persist_types::stats::PartStats;
 use mz_persist_types::Codec;
@@ -129,30 +128,18 @@ pub(crate) fn part_stats_for_legacy_part<K: Codec, V: Codec>(
     // This is a laughably inefficient placeholder implementation of stats
     // on the old part format. We don't intend to make this fast, rather we
     // intend to compute stats on the new part format.
-    let (cfg, builder) = PartBuilder::new(schemas.key.as_ref(), schemas.val.as_ref());
-    let PartBuilder {
-        key,
-        val,
-        mut ts,
-        mut diff,
-    } = builder;
-
-    let mut key_encoder = schemas.key.encoder(key)?;
-    let mut val_encoder = schemas.val.encoder(val)?;
-
+    let mut builder = PartBuilder::new(schemas.key.as_ref(), schemas.val.as_ref())?;
     for x in part {
         for ((k, v), t, d) in x.iter() {
             let k = K::decode(k)?;
             let v = V::decode(v)?;
-            key_encoder.encode(&k);
-            val_encoder.encode(&v);
-            ts.push(i64::from_le_bytes(t));
-            diff.push(i64::from_le_bytes(d));
+            let t = i64::from_le_bytes(t);
+            let d = i64::from_le_bytes(d);
+
+            builder.push(&k, &v, t, d);
         }
     }
-    let key_cols = key_encoder.finish();
-    let val_cols = val_encoder.finish();
-    let part = cfg.into_part(key_cols, val_cols, ts, diff)?;
+    let part = builder.finish();
 
     PartStats::new(&part)
 }

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -180,8 +180,8 @@ impl<T: Timestamp + Lattice + TotalOrder + Codec64> DataSnapshot<T> {
         data_read: &mut ReadHandle<K, V, T, D>,
     ) -> Result<impl Stream<Item = ((Result<K, String>, Result<V, String>), T, D)>, Since<T>>
     where
-        K: Debug + Codec + Ord,
-        V: Debug + Codec + Ord,
+        K: Debug + Codec + Ord + Default,
+        V: Debug + Codec + Ord + Default,
         D: Semigroup + Codec64 + Send + Sync,
     {
         let data_write = WriteHandle::from_read(data_read, "unblock_read");

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -60,7 +60,8 @@ impl PartEncoder<()> for UnitSchemaEncoder {
 }
 
 impl PartDecoder<()> for UnitSchema {
-    fn decode(&self, _idx: usize, _val: &mut ()) {}
+    fn decode(&self, _idx: usize) {}
+    fn decode_into(&self, _idx: usize, _val: &mut ()) {}
 }
 
 impl Schema<()> for UnitSchema {
@@ -150,8 +151,14 @@ pub struct SimpleDecoder<X, T: Data> {
     decode: for<'a> fn(T::Ref<'a>, &mut X),
 }
 
-impl<X, T: Data> PartDecoder<X> for SimpleDecoder<X, T> {
-    fn decode(&self, idx: usize, val: &mut X) {
+impl<X: Default, T: Data> PartDecoder<X> for SimpleDecoder<X, T> {
+    fn decode(&self, idx: usize) -> X {
+        let mut val = X::default();
+        self.decode_into(idx, &mut val);
+        val
+    }
+
+    fn decode_into(&self, idx: usize, val: &mut X) {
         (self.decode)(ColumnGet::<T>::get(self.col.as_ref(), idx), val)
     }
 }

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -57,8 +57,7 @@ impl PartEncoder<()> for UnitSchemaEncoder {
 }
 
 impl PartDecoder<()> for UnitSchema {
-    fn decode(&self, _idx: usize) {}
-    fn decode_into(&self, _idx: usize, _val: &mut ()) {}
+    fn decode(&self, _idx: usize, _val: &mut ()) {}
 }
 
 impl Schema<()> for UnitSchema {
@@ -149,13 +148,7 @@ pub struct SimpleDecoder<X, T: Data> {
 }
 
 impl<X: Default, T: Data> PartDecoder<X> for SimpleDecoder<X, T> {
-    fn decode(&self, idx: usize) -> X {
-        let mut val = X::default();
-        self.decode_into(idx, &mut val);
-        val
-    }
-
-    fn decode_into(&self, idx: usize, val: &mut X) {
+    fn decode(&self, idx: usize, val: &mut X) {
         (self.decode)(ColumnGet::<T>::get(self.col.as_ref(), idx), val)
     }
 }
@@ -918,11 +911,7 @@ impl<T> PartEncoder<T> for TodoSchema<T> {
 }
 
 impl<T> PartDecoder<T> for TodoSchema<T> {
-    fn decode(&self, _idx: usize) -> T {
-        panic!("TODO")
-    }
-
-    fn decode_into(&self, _idx: usize, _val: &mut T) {
+    fn decode(&self, _idx: usize, _val: &mut T) {
         panic!("TODO")
     }
 }

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -36,9 +36,6 @@ use crate::dyn_struct::{
 use crate::stats::{BytesStats, NoneStats, OptionStats, PrimitiveStats, StatsFn, StructStats};
 use crate::{Codec, Codec64, Opaque, ShardId};
 
-/// Static instance of [`UnitSchema`] provided for convenience.
-pub static UNIT_SCHEMA: UnitSchema = UnitSchema;
-
 /// An implementation of [Schema] for [()].
 #[derive(Debug, Default)]
 pub struct UnitSchema;

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -173,8 +173,7 @@ pub(crate) mod sealed {
 /// while DataType is object-safe and has exhaustiveness checking. A Data impl
 /// can be mapped to its corresponding DataType via [ColumnCfg::as_type] and
 /// back via DataType::data_fn.
-#[derive(Debug, Clone)]
-#[cfg_attr(debug_assertions, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DataType {
     /// Whether this type is optional.
     pub optional: bool,

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -245,10 +245,11 @@ pub trait PartEncoder<T> {
 /// types.
 pub trait PartDecoder<T> {
     /// Decodes the value at the given index.
-    ///
-    /// Implementations of this should reuse allocations within the passed value
-    /// whenever possible.
-    fn decode(&self, idx: usize, val: &mut T);
+    fn decode(&self, idx: usize) -> T;
+
+    /// Decodes the value at the given index, reusing allocations within the
+    /// passed value.
+    fn decode_into(&self, idx: usize, val: &mut T);
 }
 
 /// A description of the structure of a [crate::Codec] implementor.
@@ -298,14 +299,13 @@ pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(
     // Sanity check that we can compute stats.
     let _stats = part.key_stats().expect("stats should be compute-able");
 
-    let mut actual = T::default();
     assert_eq!(part.len(), 1);
     let part = part.key_ref();
-    schema.decoder(part)?.decode(0, &mut actual);
-    if &actual != val {
+    let actual = schema.decoder(part)?.decode(0);
+    if &actual != value {
         Err(format!(
             "validate_roundtrip expected {:?} but got {:?}",
-            val, actual
+            value, actual
         ))
     } else {
         Ok(())

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -173,7 +173,8 @@ pub(crate) mod sealed {
 /// while DataType is object-safe and has exhaustiveness checking. A Data impl
 /// can be mapped to its corresponding DataType via [ColumnCfg::as_type] and
 /// back via DataType::data_fn.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
+#[cfg_attr(debug_assertions, derive(PartialEq))]
 pub struct DataType {
     /// Whether this type is optional.
     pub optional: bool,

--- a/src/persist-types/src/dyn_col.rs
+++ b/src/persist-types/src/dyn_col.rs
@@ -136,7 +136,6 @@ impl DynColumnMut {
         typ.data_fn(NewUntypedDataFn)
     }
 
-    #[cfg(debug_assertions)]
     pub(crate) fn typ(&self) -> &DataType {
         &self.0
     }

--- a/src/persist-types/src/dyn_col.rs
+++ b/src/persist-types/src/dyn_col.rs
@@ -136,6 +136,7 @@ impl DynColumnMut {
         typ.data_fn(NewUntypedDataFn)
     }
 
+    #[cfg(debug_assertions)]
     pub(crate) fn typ(&self) -> &DataType {
         &self.0
     }

--- a/src/persist-types/src/dyn_struct.rs
+++ b/src/persist-types/src/dyn_struct.rs
@@ -338,44 +338,20 @@ impl ColumnPush<Option<DynStruct>> for DynStructMut {
 impl DynStructMut {
     /// Create a [`DynStructMut`] from individual parts.
     ///
-    /// Returns an error if the data types in `cfg` do not match those in the
-    /// provided `cols`.
+    /// Note: it's up to the user to ensure the provided `cfg` has the same column types as the
+    /// provided `cols`. We can't validate it here because [`DataType`]s are not easily comparable.
     pub fn from_parts(
         cfg: DynStructCfg,
         len: usize,
         validity: Option<MutableBitmap>,
         cols: Vec<DynColumnMut>,
-    ) -> Result<Self, String> {
-        let data_types_match = cfg
-            .cols
-            .iter()
-            .map(|(_name, data_type, _stats)| data_type)
-            .zip(cols.iter().map(|col| col.typ()))
-            .all(|(dt_a, dt_b)| dt_a == dt_b);
-        if !data_types_match {
-            let cfg_cols = cfg
-                .cols
-                .iter()
-                .map(|(_, data_type, _)| data_type)
-                .cloned()
-                .collect::<Vec<_>>();
-            let other_cols = cols
-                .iter()
-                .map(|col| col.typ())
-                .cloned()
-                .collect::<Vec<_>>();
-
-            return Err(format!(
-                "found mismatched column types! cfg: {cfg_cols:?}, other: {other_cols:?}"
-            ));
-        }
-
-        Ok(DynStructMut {
+    ) -> Self {
+        DynStructMut {
             cfg,
             len,
             validity,
             cols,
-        })
+        }
     }
 
     /// Returns the number of elements in this column

--- a/src/persist-types/src/dyn_struct.rs
+++ b/src/persist-types/src/dyn_struct.rs
@@ -74,8 +74,8 @@ impl Default for DynStructRef<'_> {
 /// A [crate::columnar::ColumnGet] impl for [DynStruct].
 #[derive(Debug)]
 pub struct DynStructCol {
-    len: usize,
-    cfg: DynStructCfg,
+    pub(crate) len: usize,
+    pub(crate) cfg: DynStructCfg,
     pub(crate) validity: Option<<bool as Data>::Col>,
     pub(crate) cols: Vec<DynColumnRef>,
 }
@@ -322,13 +322,8 @@ impl ColumnPush<Option<DynStruct>> for DynStructMut {
         // keep it for completeness and also so that any future changes to the
         // code consider it.
         let len = self.len;
-        if let Some(validity) = self.validity.as_ref() {
-            debug_assert_eq!(len, validity.len());
-        }
-        let mut validity = ValidityMut {
-            len,
-            validity: &mut self.validity,
-        };
+        let validity = self.validity.get_or_insert_with(MutableBitmap::default);
+        debug_assert_eq!(len, validity.len());
 
         if let Some(val) = val {
             validity.push(true);
@@ -341,15 +336,62 @@ impl ColumnPush<Option<DynStruct>> for DynStructMut {
 }
 
 impl DynStructMut {
+    /// Create a [`DynStructMut`] from individual parts.
+    ///
+    /// Returns an error if the data types in `cfg` do not match those in the
+    /// provided `cols`.
+    pub fn from_parts(
+        cfg: DynStructCfg,
+        len: usize,
+        validity: Option<MutableBitmap>,
+        cols: Vec<DynColumnMut>,
+    ) -> Result<Self, String> {
+        let data_types_match = cfg
+            .cols
+            .iter()
+            .map(|(_name, data_type, _stats)| data_type)
+            .zip(cols.iter().map(|col| col.typ()))
+            .all(|(dt_a, dt_b)| dt_a == dt_b);
+        if !data_types_match {
+            let cfg_cols = cfg
+                .cols
+                .iter()
+                .map(|(_, data_type, _)| data_type)
+                .cloned()
+                .collect::<Vec<_>>();
+            let other_cols = cols
+                .iter()
+                .map(|col| col.typ())
+                .cloned()
+                .collect::<Vec<_>>();
+
+            return Err(format!(
+                "found mismatched column types! cfg: {cfg_cols:?}, other: {other_cols:?}"
+            ));
+        }
+
+        Ok(DynStructMut {
+            cfg,
+            len,
+            validity,
+            cols,
+        })
+    }
+
     /// Returns the number of elements in this column
     pub fn len(&self) -> usize {
         self.len
     }
 
+    /// Returns the configuration for this column.
+    pub fn cfg(&self) -> &DynStructCfg {
+        &self.cfg
+    }
+
     /// Explodes this _non-optional_ struct column into its component fields.
     ///
     /// Panics if this struct is optional.
-    pub fn as_mut<'a>(&'a mut self) -> ColumnsMut<'a> {
+    pub fn as_mut(self) -> ColumnsMut {
         let ColumnsMut {
             len,
             validity,
@@ -368,26 +410,26 @@ impl DynStructMut {
     ///
     /// If the column is actually non-option, succeeds and acts as if every
     /// value is a Some.
-    pub fn as_opt_mut<'a>(&'a mut self) -> ColumnsMut<'a, ValidityMut<'a>> {
+    pub fn as_opt_mut(self) -> ColumnsMut<ValidityMut> {
         debug_assert_eq!(self.cfg.cols.len(), self.cols.len());
         let cols = self
             .cfg
             .cols
             .iter()
-            .zip(self.cols.iter_mut())
+            .zip(self.cols.into_iter())
             .map(|((name, _typ, _stats_fn), col)| {
                 #[cfg(debug_assertions)]
                 {
                     assert_eq!(_typ, col.typ());
                 }
-                (name.as_str(), col)
+                (name.as_str().into(), col)
             })
             .collect();
         ColumnsMut {
-            len: &mut self.len,
+            len: self.len,
             validity: ValidityMut {
                 len: 0,
-                validity: &mut self.validity,
+                validity: self.validity,
             },
             cols,
         }
@@ -485,18 +527,18 @@ impl ValidityRef {
 /// elided if every value is true. This is the common case for the `Ok` struct
 /// of our `SourceData`, so seems worth opting in to ourselves.
 #[derive(Debug)]
-pub struct ValidityMut<'a> {
+pub struct ValidityMut {
     len: usize,
-    validity: &'a mut Option<<bool as Data>::Mut>,
+    validity: Option<MutableBitmap>,
 }
 
-impl ValidityMut<'_> {
+impl ValidityMut {
     /// Pushes whether a column of optional structs is Some at the given index.
     /// If this is false, the contents of the struct's component fields at `idx`
     /// can be anything.
     pub fn push(&mut self, valid: bool) {
         if valid {
-            if let Some(validity) = self.validity {
+            if let Some(validity) = &mut self.validity {
                 validity.push(valid);
             }
         } else {
@@ -508,6 +550,11 @@ impl ValidityMut<'_> {
             validity.push(valid);
         }
         self.len += 1;
+    }
+
+    /// Consumes `self` returning the inner parts.
+    pub fn into_parts(self) -> (usize, Option<MutableBitmap>) {
+        (self.len, self.validity)
     }
 }
 
@@ -558,15 +605,15 @@ impl<V> ColumnsRef<V> {
 /// [Self::col] and the [Self::finish] called to verify that all columns have
 /// been accounted for.
 #[derive(Debug)]
-pub struct ColumnsMut<'a, V = ()> {
-    len: &'a mut usize,
+pub struct ColumnsMut<V = ()> {
+    len: usize,
     validity: V,
-    pub(crate) cols: BTreeMap<&'a str, &'a mut DynColumnMut>,
+    pub(crate) cols: BTreeMap<Box<str>, DynColumnMut>,
 }
 
-impl<'a, V> ColumnsMut<'a, V> {
+impl<V> ColumnsMut<V> {
     /// Removes the named column from the set.
-    pub fn col<T: Data>(&mut self, name: &str) -> Result<&'a mut T::Mut, String> {
+    pub fn col<T: Data>(&mut self, name: &str) -> Result<Box<T::Mut>, String> {
         let col = self
             .cols
             .remove(name)
@@ -575,11 +622,15 @@ impl<'a, V> ColumnsMut<'a, V> {
     }
 
     /// Verifies that all columns in the set have been removed.
-    pub fn finish(self) -> Result<(&'a mut usize, V), String> {
+    pub fn finish(self) -> Result<(usize, V), String> {
         if self.cols.is_empty() {
             Ok((self.len, self.validity))
         } else {
-            let names = self.cols.iter().map(|(x, _)| *x).collect::<Vec<_>>();
+            let names = self
+                .cols
+                .iter()
+                .map(|(x, _)| x.as_ref())
+                .collect::<Vec<_>>();
             Err(format!("unused cols: {}", names.join(" ")))
         }
     }

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -152,7 +152,9 @@ impl PersistLocation {
 /// The [std::string::ToString::to_string] format of this may be stored durably
 /// or otherwise used as an interchange format. It can be parsed back using
 /// [str::parse] or [std::str::FromStr::from_str].
-#[derive(Arbitrary, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Arbitrary, Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
+)]
 #[serde(try_from = "String", into = "String")]
 pub struct ShardId([u8; 16]);
 

--- a/src/persist-types/src/parquet.rs
+++ b/src/persist-types/src/parquet.rs
@@ -112,9 +112,10 @@ pub fn validate_roundtrip<T: Default + PartialEq + Debug, S: Schema<T>>(
     let part = decode_part(&mut std::io::Cursor::new(&encoded), schema, &UnitSchema)
         .map_err(|err| err.to_string())?;
 
+    let mut actual = T::default();
     assert_eq!(part.len(), 1);
     let part = part.key_ref();
-    let actual = schema.decoder(part)?.decode(0);
+    schema.decoder(part)?.decode(0, &mut actual);
     if &actual != value {
         Err(format!(
             "validate_roundtrip expected {:?} but got {:?}",

--- a/src/persist-types/src/parquet.rs
+++ b/src/persist-types/src/parquet.rs
@@ -23,8 +23,8 @@ use arrow2::io::parquet::write::{
 };
 use parquet2::write::{DynIter, FileWriter, WriteOptions as ParquetWriteOptions};
 
-use crate::codec_impls::{UnitSchema, UNIT_SCHEMA};
-use crate::columnar::{PartDecoder, PartEncoder, Schema};
+use crate::codec_impls::UnitSchema;
+use crate::columnar::{PartDecoder, Schema};
 use crate::part::{Part, PartBuilder};
 
 /// Encodes the given part into our parquet-based serialization format.
@@ -100,26 +100,9 @@ pub fn validate_roundtrip<T: Default + PartialEq + Debug, S: Schema<T>>(
     schema: &S,
     value: &T,
 ) -> Result<(), String> {
-    let (cfg, builder) = PartBuilder::new(schema, &UNIT_SCHEMA);
-    let PartBuilder {
-        key,
-        val,
-        mut ts,
-        mut diff,
-    } = builder;
-
-    let mut key_encoder = schema.encoder(key)?;
-    let mut val_encoder = UNIT_SCHEMA.encoder(val)?;
-
-    key_encoder.encode(value);
-    val_encoder.encode(&());
-    ts.push(1u64);
-    diff.push(1i64);
-
-    let key_columns = key_encoder.finish();
-    let val_columns = val_encoder.finish();
-
-    let part = cfg.into_part(key_columns, val_columns, ts, diff)?;
+    let mut builder = PartBuilder::new(schema, &UnitSchema)?;
+    builder.push(value, &(), 1u64, 1i64);
+    let part = builder.finish();
 
     // Sanity check that we can compute stats.
     let _stats = part.key_stats().expect("stats should be compute-able");

--- a/src/persist-types/src/parquet.rs
+++ b/src/persist-types/src/parquet.rs
@@ -23,7 +23,7 @@ use arrow2::io::parquet::write::{
 };
 use parquet2::write::{DynIter, FileWriter, WriteOptions as ParquetWriteOptions};
 
-use crate::codec_impls::UnitSchema;
+use crate::codec_impls::{UnitSchema, UNIT_SCHEMA};
 use crate::columnar::{PartDecoder, PartEncoder, Schema};
 use crate::part::{Part, PartBuilder};
 
@@ -129,14 +129,13 @@ pub fn validate_roundtrip<T: Default + PartialEq + Debug, S: Schema<T>>(
     let part = decode_part(&mut std::io::Cursor::new(&encoded), schema, &UnitSchema)
         .map_err(|err| err.to_string())?;
 
-    let mut actual = T::default();
     assert_eq!(part.len(), 1);
     let part = part.key_ref();
-    schema.decoder(part)?.decode(0, &mut actual);
-    if &actual != val {
+    let actual = schema.decoder(part)?.decode(0);
+    if &actual != value {
         Err(format!(
             "validate_roundtrip expected {:?} but got {:?}",
-            val, actual
+            value, actual
         ))
     } else {
         Ok(())

--- a/src/persist-types/src/txn.rs
+++ b/src/persist-types/src/txn.rs
@@ -53,9 +53,9 @@ impl TxnsEntry {
 /// shard (which will allow mz to present it as a normal introspection source).
 pub trait TxnsCodec: Debug {
     /// The `K` type used in the txns shard.
-    type Key: Debug + Codec;
+    type Key: Debug + Codec + Default;
     /// The `V` type used in the txns shard.
-    type Val: Debug + Codec;
+    type Val: Debug + Codec + Default;
 
     /// Returns the Schemas to use with [Self::Key] and [Self::Val].
     fn schemas() -> (<Self::Key as Codec>::Schema, <Self::Val as Codec>::Schema);

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -13,8 +13,8 @@ use std::hint::black_box;
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
 use mz_persist::metrics::ColumnarMetrics;
-use mz_persist_types::codec_impls::UnitSchema;
-use mz_persist_types::columnar::{PartDecoder, PartEncoder};
+use mz_persist_types::codec_impls::UNIT_SCHEMA;
+use mz_persist_types::columnar::{PartDecoder, PartEncoder, Schema};
 use mz_persist_types::part::{Part, PartBuilder};
 use mz_persist_types::Codec;
 use mz_repr::adt::date::Date;
@@ -380,7 +380,7 @@ fn bench_roundtrip(c: &mut Criterion) {
 
         b.iter(|| {
             for idx in 0..rows.len() {
-                decoder.decode(idx, &mut row);
+                decoder.decode_into(idx, &mut row);
                 // We create a packer which clears the row.
                 let _ = row.packer();
             }

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -349,7 +349,7 @@ fn bench_roundtrip(c: &mut Criterion) {
 
         b.iter(|| {
             for idx in 0..rows.len() {
-                decoder.decode_into(idx, &mut row);
+                decoder.decode(idx, &mut row);
                 // We create a packer which clears the row.
                 let _ = row.packer();
             }

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -736,13 +736,7 @@ impl RowDecoder {
 }
 
 impl PartDecoder<Row> for RowDecoder {
-    fn decode(&self, idx: usize) -> Row {
-        let mut val = Row::default();
-        self.decode_into(idx, &mut val);
-        val
-    }
-
-    fn decode_into(&self, idx: usize, val: &mut Row) {
+    fn decode(&self, idx: usize, val: &mut Row) {
         let mut packer = val.packer();
         for decoder in self.col_decoders.iter() {
             decoder.decode(idx, &mut packer);

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -21,7 +21,7 @@ use mz_ore::cast::CastFrom;
 use mz_persist_types::columnar::{
     ColumnCfg, ColumnGet, ColumnPush, Data, DataType, OpaqueData, PartDecoder, PartEncoder, Schema,
 };
-use mz_persist_types::dyn_col::DynColumnRef;
+use mz_persist_types::dyn_col::{DynColumnMut, DynColumnRef};
 use mz_persist_types::dyn_struct::{ColumnsMut, ColumnsRef, DynStructCfg, ValidityRef};
 use mz_persist_types::stats::{AtomicBytesStats, BytesStats, DynStats, OptionStats, StatsFn};
 use mz_persist_types::Codec;
@@ -736,7 +736,13 @@ impl RowDecoder {
 }
 
 impl PartDecoder<Row> for RowDecoder {
-    fn decode(&self, idx: usize, val: &mut Row) {
+    fn decode(&self, idx: usize) -> Row {
+        let mut val = Row::default();
+        self.decode_into(idx, &mut val);
+        val
+    }
+
+    fn decode_into(&self, idx: usize, val: &mut Row) {
         let mut packer = val.packer();
         for decoder in self.col_decoders.iter() {
             decoder.decode(idx, &mut packer);

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -232,7 +232,7 @@ pub trait DatumToPersistFn<R> {
     fn call<T: DatumToPersist>(self) -> R
     where
         DatumDecoder: From<DataRef<T>>,
-        for<'a> DatumEncoder<'a>: From<DataMut<'a, T>>;
+        DatumEncoder: From<DataMut<T>>;
 }
 
 macro_rules! data_to_persist_primitive {
@@ -543,41 +543,41 @@ impl DatumToPersist for Option<Jsonb> {
 /// A helper for adapting mz's [Datum] to persist's columnar [Data].
 #[enum_dispatch]
 #[derive(Debug)]
-pub enum DatumEncoder<'a> {
-    Bool(DataMut<'a, bool>),
-    OptBool(DataMut<'a, Option<bool>>),
-    Int16(DataMut<'a, i16>),
-    OptInt16(DataMut<'a, Option<i16>>),
-    Int32(DataMut<'a, i32>),
-    OptInt32(DataMut<'a, Option<i32>>),
-    Int64(DataMut<'a, i64>),
-    OptInt64(DataMut<'a, Option<i64>>),
-    UInt8(DataMut<'a, u8>),
-    OptUInt8(DataMut<'a, Option<u8>>),
-    UInt16(DataMut<'a, u16>),
-    OptUInt16(DataMut<'a, Option<u16>>),
-    UInt32(DataMut<'a, u32>),
-    OptUInt32(DataMut<'a, Option<u32>>),
-    UInt64(DataMut<'a, u64>),
-    OptUInt64(DataMut<'a, Option<u64>>),
-    Float32(DataMut<'a, f32>),
-    OptFloat32(DataMut<'a, Option<f32>>),
-    Float64(DataMut<'a, f64>),
-    OptFloat64(DataMut<'a, Option<f64>>),
-    Date(DataMut<'a, Date>),
-    OptDate(DataMut<'a, Option<Date>>),
-    Bytes(DataMut<'a, Vec<u8>>),
-    OptBytes(DataMut<'a, Option<Vec<u8>>>),
-    String(DataMut<'a, String>),
-    OptString(DataMut<'a, Option<String>>),
-    Jsonb(DataMut<'a, Jsonb>),
-    OptJsonb(DataMut<'a, Option<Jsonb>>),
-    MzTimestamp(DataMut<'a, Timestamp>),
-    OptMzTimestamp(DataMut<'a, Option<Timestamp>>),
-    Todo(DataMut<'a, ProtoDatumToPersist>),
-    OptTodo(DataMut<'a, NullableProtoDatumToPersist>),
-    TodoNoStats(DataMut<'a, ProtoDatumToPersistNoStats>),
-    OptTodoNoStats(DataMut<'a, NullableProtoDatumToPersistNoStats>),
+pub enum DatumEncoder {
+    Bool(DataMut<bool>),
+    OptBool(DataMut<Option<bool>>),
+    Int16(DataMut<i16>),
+    OptInt16(DataMut<Option<i16>>),
+    Int32(DataMut<i32>),
+    OptInt32(DataMut<Option<i32>>),
+    Int64(DataMut<i64>),
+    OptInt64(DataMut<Option<i64>>),
+    UInt8(DataMut<u8>),
+    OptUInt8(DataMut<Option<u8>>),
+    UInt16(DataMut<u16>),
+    OptUInt16(DataMut<Option<u16>>),
+    UInt32(DataMut<u32>),
+    OptUInt32(DataMut<Option<u32>>),
+    UInt64(DataMut<u64>),
+    OptUInt64(DataMut<Option<u64>>),
+    Float32(DataMut<f32>),
+    OptFloat32(DataMut<Option<f32>>),
+    Float64(DataMut<f64>),
+    OptFloat64(DataMut<Option<f64>>),
+    Date(DataMut<Date>),
+    OptDate(DataMut<Option<Date>>),
+    Bytes(DataMut<Vec<u8>>),
+    OptBytes(DataMut<Option<Vec<u8>>>),
+    String(DataMut<String>),
+    OptString(DataMut<Option<String>>),
+    Jsonb(DataMut<Jsonb>),
+    OptJsonb(DataMut<Option<Jsonb>>),
+    MzTimestamp(DataMut<Timestamp>),
+    OptMzTimestamp(DataMut<Option<Timestamp>>),
+    Todo(DataMut<ProtoDatumToPersist>),
+    OptTodo(DataMut<NullableProtoDatumToPersist>),
+    TodoNoStats(DataMut<ProtoDatumToPersistNoStats>),
+    OptTodoNoStats(DataMut<NullableProtoDatumToPersistNoStats>),
 }
 
 /// An `enum_dispatch` companion for `DatumEncoder`.
@@ -585,9 +585,10 @@ pub enum DatumEncoder<'a> {
 /// This allows us to do Datum encoding without dynamic dispatch. It's a pretty
 /// hot path, so the hassle is worth it.
 #[enum_dispatch(DatumEncoder)]
-pub trait DatumEncoderT<'a> {
+pub trait DatumEncoderT {
     fn encode(&mut self, datum: Datum);
     fn encode_default(&mut self);
+    fn finish(self) -> DynColumnMut;
 }
 
 /// A newtype wrapper for `&mut T::Mut`.
@@ -595,48 +596,60 @@ pub trait DatumEncoderT<'a> {
 /// This is necessary for enum_dispatch to create From/TryInto (conflicting
 /// impls if we try to store `&mut T::Mut` directly in the enum variants), but
 /// it's also a convenient place to hang a std::fmt::Debug impl.
-pub struct DataMut<'a, T: DatumToPersist>(&'a mut <T::Data as Data>::Mut);
+pub struct DataMut<T: DatumToPersist>(Box<<T::Data as Data>::Mut>);
 
-impl<T: DatumToPersist> std::fmt::Debug for DataMut<'_, T> {
+impl<T: DatumToPersist> std::fmt::Debug for DataMut<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct(&format!("DataMut<{}>", std::any::type_name::<T>()))
             .finish_non_exhaustive()
     }
 }
 
-impl<'a, T: DatumToPersist> DatumEncoderT<'a> for DataMut<'a, T> {
+impl<T: DatumToPersist> DatumEncoderT for DataMut<T> {
     fn encode(&mut self, datum: Datum) {
-        T::encode(self.0, datum);
+        T::encode(&mut self.0, datum);
     }
     fn encode_default(&mut self) {
-        T::encode_default(self.0);
+        T::encode_default(&mut self.0);
+    }
+    fn finish(self) -> DynColumnMut {
+        DynColumnMut::new::<T::Data>(self.0)
     }
 }
 
 /// An implementation of [PartEncoder] for [Row].
 #[derive(Debug)]
-pub struct RowEncoder<'a> {
-    len: &'a mut usize,
-    col_encoders: Vec<DatumEncoder<'a>>,
+pub struct RowEncoder {
+    len: usize,
+    col_encoders: Vec<DatumEncoder>,
 }
 
-impl<'a> RowEncoder<'a> {
+impl RowEncoder {
     /// Returns the underlying DatumEncoders, one per column in the Row.
-    pub fn col_encoders(&mut self) -> &mut [DatumEncoder<'a>] {
+    pub fn col_encoders(&mut self) -> &mut [DatumEncoder] {
         &mut self.col_encoders
     }
 
     pub fn inc_len(&mut self) {
-        *self.len += 1;
+        self.len += 1;
     }
 }
 
-impl<'a> PartEncoder<'a, Row> for RowEncoder<'a> {
+impl PartEncoder<Row> for RowEncoder {
     fn encode(&mut self, val: &Row) {
-        *self.len += 1;
+        self.len += 1;
         for (encoder, datum) in self.col_encoders.iter_mut().zip(val.iter()) {
             encoder.encode(datum);
         }
+    }
+
+    fn finish(self) -> (usize, Vec<DynColumnMut>) {
+        let cols = self
+            .col_encoders
+            .into_iter()
+            .map(|encoder| encoder.finish())
+            .collect();
+        (self.len, cols)
     }
 }
 
@@ -756,15 +769,12 @@ impl RelationDesc {
         Ok((validity, RowDecoder { col_decoders }))
     }
 
-    pub fn encoder<'a, V>(
-        &self,
-        mut part: ColumnsMut<'a, V>,
-    ) -> Result<(V, RowEncoder<'a>), String> {
-        struct DatumEncoderFn<'a, 'b, V>(&'b str, &'b mut ColumnsMut<'a, V>);
-        impl<'a, 'b, V> DatumToPersistFn<DatumEncoder<'a>> for DatumEncoderFn<'a, 'b, V> {
-            fn call<T: DatumToPersist>(self) -> DatumEncoder<'a>
+    pub fn encoder<'a, V>(&self, mut part: ColumnsMut<V>) -> Result<(V, RowEncoder), String> {
+        struct DatumEncoderFn<'b, V>(&'b str, &'b mut ColumnsMut<V>);
+        impl<'b, V> DatumToPersistFn<DatumEncoder> for DatumEncoderFn<'b, V> {
+            fn call<T: DatumToPersist>(self) -> DatumEncoder
             where
-                for<'c> DatumEncoder<'c>: From<DataMut<'c, T>>,
+                DatumEncoder: From<DataMut<T>>,
             {
                 let DatumEncoderFn(name, part) = self;
                 let col = part
@@ -785,7 +795,7 @@ impl RelationDesc {
 }
 
 impl Schema<Row> for RelationDesc {
-    type Encoder<'a> = RowEncoder<'a>;
+    type Encoder = RowEncoder;
     type Decoder = RowDecoder;
 
     fn columns(&self) -> DynStructCfg {
@@ -811,7 +821,7 @@ impl Schema<Row> for RelationDesc {
         Ok(decoder)
     }
 
-    fn encoder<'a>(&self, part: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+    fn encoder<'a>(&self, part: ColumnsMut) -> Result<Self::Encoder, String> {
         let ((), encoder) = self.encoder(part)?;
         Ok(encoder)
     }

--- a/src/storage-types/benches/row.rs
+++ b/src/storage-types/benches/row.rs
@@ -73,7 +73,7 @@ fn decode_structured(schema: &RelationDesc, part: &Part, len: usize) -> SourceDa
     let decoder = <RelationDesc as Schema<SourceData>>::decoder(schema, part.key_ref()).unwrap();
     let mut data = SourceData(Ok(Row::default()));
     for idx in 0..len {
-        decoder.decode(idx, &mut data);
+        decoder.decode_into(idx, &mut data);
         black_box(&data);
     }
     data

--- a/src/storage-types/benches/row.rs
+++ b/src/storage-types/benches/row.rs
@@ -12,8 +12,8 @@ use std::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
 use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
 use mz_persist::metrics::ColumnarMetrics;
-use mz_persist_types::codec_impls::{UnitSchema, UNIT_SCHEMA};
-use mz_persist_types::columnar::{PartDecoder, PartEncoder, Schema};
+use mz_persist_types::codec_impls::UnitSchema;
+use mz_persist_types::columnar::{PartDecoder, Schema};
 use mz_persist_types::part::{Part, PartBuilder};
 use mz_persist_types::Codec;
 use mz_repr::{ColumnType, Datum, ProtoRow, RelationDesc, Row, ScalarType};
@@ -44,29 +44,11 @@ fn decode_legacy(part: &ColumnarRecords) -> SourceData {
 }
 
 fn encode_structured(schema: &RelationDesc, data: &[SourceData]) -> Part {
-    let (cfg, builder) = PartBuilder::new::<SourceData, _, _, _>(schema, &UnitSchema);
-    let PartBuilder {
-        key,
-        val,
-        mut ts,
-        mut diff,
-    } = builder;
-
-    let mut key_encoder = <RelationDesc as Schema<SourceData>>::encoder(schema, key).unwrap();
-    let mut val_encoder = UNIT_SCHEMA.encoder(val).unwrap();
+    let mut builder = PartBuilder::new(schema, &UnitSchema).expect("success");
     for data in data.iter() {
-        key_encoder.encode(data);
-        val_encoder.encode(&());
+        builder.push(data, &(), 1u64, 1i64);
     }
-    let key_cols = key_encoder.finish();
-    let val_cols = val_encoder.finish();
-
-    for _ in data.iter() {
-        ts.push(1u64);
-        diff.push(1i64);
-    }
-
-    cfg.into_part(key_cols, val_cols, ts, diff).unwrap()
+    builder.finish()
 }
 
 fn decode_structured(schema: &RelationDesc, part: &Part, len: usize) -> SourceData {

--- a/src/storage-types/benches/row.rs
+++ b/src/storage-types/benches/row.rs
@@ -55,7 +55,7 @@ fn decode_structured(schema: &RelationDesc, part: &Part, len: usize) -> SourceDa
     let decoder = <RelationDesc as Schema<SourceData>>::decoder(schema, part.key_ref()).unwrap();
     let mut data = SourceData(Ok(Row::default()));
     for idx in 0..len {
-        decoder.decode_into(idx, &mut data);
+        decoder.decode(idx, &mut data);
         black_box(&data);
     }
     data

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1092,8 +1092,7 @@ impl PartEncoder<SourceData> for SourceDataEncoder {
         // Collect all of the columns from the inner RowEncoder to a single 'ok' column.
         let (_, ok_validity) = self.ok_validity.into_parts();
         let (ok_len, ok_cols) = self.ok.finish();
-        let ok_col = DynStructMut::from_parts(self.ok_cfg, ok_len, ok_validity, ok_cols)
-            .expect("parts to roundtrip");
+        let ok_col = DynStructMut::from_parts(self.ok_cfg, ok_len, ok_validity, ok_cols);
 
         let ok_col = DynColumnMut::new::<Option<DynStruct>>(Box::new(ok_col));
         let err_col = DynColumnMut::new::<Option<Vec<u8>>>(self.err);

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -956,7 +956,6 @@ impl RustType<ProtoSourceConnection> for GenericSourceConnection<InlinedConnecti
 #[repr(transparent)]
 pub struct SourceData(pub Result<Row, DataflowError>);
 
-#[cfg(test)]
 impl Default for SourceData {
     fn default() -> Self {
         SourceData(Ok(Row::default()))
@@ -1115,13 +1114,7 @@ pub struct SourceDataDecoder {
 }
 
 impl PartDecoder<SourceData> for SourceDataDecoder {
-    fn decode(&self, idx: usize) -> SourceData {
-        let mut val = SourceData(Ok(Row::default()));
-        self.decode_into(idx, &mut val);
-        val
-    }
-
-    fn decode_into(&self, idx: usize, val: &mut SourceData) {
+    fn decode(&self, idx: usize, val: &mut SourceData) {
         let err = ColumnGet::<Option<Vec<u8>>>::get(self.err.as_ref(), idx);
         match (self.ok_validity.get(idx), err) {
             (true, None) => {

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1116,7 +1116,13 @@ pub struct SourceDataDecoder {
 }
 
 impl PartDecoder<SourceData> for SourceDataDecoder {
-    fn decode(&self, idx: usize, val: &mut SourceData) {
+    fn decode(&self, idx: usize) -> SourceData {
+        let mut val = SourceData(Ok(Row::default()));
+        self.decode_into(idx, &mut val);
+        val
+    }
+
+    fn decode_into(&self, idx: usize, val: &mut SourceData) {
         let err = ColumnGet::<Option<Vec<u8>>>::get(self.err.as_ref(), idx);
         match (self.ok_validity.get(idx), err) {
             (true, None) => {

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -23,7 +23,10 @@ use itertools::Itertools;
 use mz_persist_types::columnar::{
     ColumnFormat, ColumnGet, ColumnPush, Data, DataType, PartDecoder, PartEncoder, Schema,
 };
-use mz_persist_types::dyn_struct::{DynStruct, DynStructCfg, ValidityMut, ValidityRef};
+use mz_persist_types::dyn_col::DynColumnMut;
+use mz_persist_types::dyn_struct::{
+    DynStruct, DynStructCfg, DynStructMut, ValidityMut, ValidityRef,
+};
 use mz_persist_types::stats::StatsFn;
 use mz_persist_types::Codec;
 use mz_proto::{IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
@@ -1053,16 +1056,17 @@ impl Codec for SourceData {
 /// This mostly delegates the encoding logic to [RowEncoder], but flatmaps in
 /// an Err column.
 #[derive(Debug)]
-pub struct SourceDataEncoder<'a> {
-    len: &'a mut usize,
-    ok_validity: ValidityMut<'a>,
-    ok: RowEncoder<'a>,
-    err: &'a mut <Option<Vec<u8>> as Data>::Mut,
+pub struct SourceDataEncoder {
+    len: usize,
+    ok_cfg: DynStructCfg,
+    ok_validity: ValidityMut,
+    ok: RowEncoder,
+    err: Box<<Option<Vec<u8>> as Data>::Mut>,
 }
 
-impl<'a> PartEncoder<'a, SourceData> for SourceDataEncoder<'a> {
+impl PartEncoder<SourceData> for SourceDataEncoder {
     fn encode(&mut self, val: &SourceData) {
-        *self.len += 1;
+        self.len += 1;
         match val.as_ref() {
             Ok(row) => {
                 self.ok_validity.push(true);
@@ -1070,7 +1074,7 @@ impl<'a> PartEncoder<'a, SourceData> for SourceDataEncoder<'a> {
                 for (encoder, datum) in self.ok.col_encoders().iter_mut().zip(row.iter()) {
                     encoder.encode(datum);
                 }
-                ColumnPush::<Option<Vec<u8>>>::push(self.err, None);
+                ColumnPush::<Option<Vec<u8>>>::push(self.err.as_mut(), None);
             }
             Err(err) => {
                 self.ok_validity.push(false);
@@ -1079,9 +1083,24 @@ impl<'a> PartEncoder<'a, SourceData> for SourceDataEncoder<'a> {
                     encoder.encode_default();
                 }
                 let err = err.into_proto().encode_to_vec();
-                ColumnPush::<Option<Vec<u8>>>::push(self.err, Some(err.as_slice()));
+                ColumnPush::<Option<Vec<u8>>>::push(self.err.as_mut(), Some(err.as_slice()));
             }
         }
+    }
+
+    fn finish(self) -> (usize, Vec<DynColumnMut>) {
+        // Collect all of the columns from the inner RowEncoder to a single 'ok' column.
+        let (_, ok_validity) = self.ok_validity.into_parts();
+        let (ok_len, ok_cols) = self.ok.finish();
+        let ok_col = DynStructMut::from_parts(self.ok_cfg, ok_len, ok_validity, ok_cols)
+            .expect("parts to roundtrip");
+
+        let ok_col = DynColumnMut::new::<Option<DynStruct>>(Box::new(ok_col));
+        let err_col = DynColumnMut::new::<Option<Vec<u8>>>(self.err);
+
+        let cols = vec![ok_col, err_col];
+
+        (self.len, cols)
     }
 }
 
@@ -1127,8 +1146,7 @@ impl PartDecoder<SourceData> for SourceDataDecoder {
 }
 
 impl Schema<SourceData> for RelationDesc {
-    type Encoder<'a> = SourceDataEncoder<'a>;
-
+    type Encoder = SourceDataEncoder;
     type Decoder = SourceDataDecoder;
 
     fn columns(&self) -> DynStructCfg {
@@ -1169,16 +1187,18 @@ impl Schema<SourceData> for RelationDesc {
         })
     }
 
-    fn encoder<'a>(
+    fn encoder(
         &self,
-        mut cols: mz_persist_types::dyn_struct::ColumnsMut<'a>,
-    ) -> Result<Self::Encoder<'a>, String> {
+        mut cols: mz_persist_types::dyn_struct::ColumnsMut,
+    ) -> Result<Self::Encoder, String> {
         let ok = cols.col::<Option<DynStruct>>("ok")?;
         let err = cols.col::<Option<Vec<u8>>>("err")?;
         let (len, ()) = cols.finish()?;
+        let ok_cfg = ok.cfg().clone();
         let (ok_validity, ok) = RelationDesc::encoder(self, ok.as_opt_mut())?;
         Ok(SourceDataEncoder {
             len,
+            ok_cfg,
             ok_validity,
             ok,
             err,


### PR DESCRIPTION
This PR was split out from https://github.com/MaterializeInc/materialize/pull/26605



### Motivation

This refactors `PartEncoder` to take ownership of the columns it's encoding into, rather than just mutable references. More detail is provided in https://github.com/MaterializeInc/materialize/pull/26605 but the tl;dr is we only want to downcast `dyn Array`s once, and there isn't any lifetime that we can associate with the borrows to achieve this.

It also renames the existing `PartDecoder::decode(idx, &mut V)` method to `PartDecoder::decode_into(...)` and adds a new `PartDecoder::decode(idx) -> V` method. The goal of `decode_into(...)` is it allows you to re-use allocations where possible, but that isn't currently applicable when decoding from our structured columnar data. When decoding with `Codec` we go from `&[u8]` -> `ProtoRow` -> `Row`, so it's very helpful to retain the intermediate `ProtoRow` to reduce allocations. But with columnar data we go directly from `dyn arrow::Array` -> `Row`, so there isn't any intermediate step to retain. Also we return the `Row`s we decode as part of an iterator, so there isn't any way to reclaim them for re-use.

In practice without `PartDecoder::decode(idx)` we end up with a pattern like:
```
let mut val = V::default();
decoder.decode_into(idx, &mut val);
val
```
Instead of requiring our generic parameters `K` and `V` to implement `Default`, it was easier to add the new method.

### Tips for reviewer

This PR is broken up into two commits:

1. Refactor to `PartEncoder`
2. New methods on `PartDecoder`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
