### PR TITLE
doc/user: patch free trial FAQs

### DIFF
--- a/doc/user/content/free-trial-faqs.md
+++ b/doc/user/content/free-trial-faqs.md
@@ -7,13 +7,19 @@ menu:
     weight: 20
 ---
 
-When you [sign up for Materialize](https://materialize.com/register/), you get a free trial account so you can explore the product and start building! This page answers some frequently asked questions about free trials.
+When you [sign up for Materialize](https://materialize.com/register/), you get a
+free trial account so you can explore the product and start building! This page
+answers some frequently asked questions about free trials.
 
 ## What are the limits of a free trial?
 
-In Materialize, [clusters](/get-started/key-concepts/#clusters) are the pools of compute resources for running your workloads. The size and replication factor of each cluster determines its [credit usage](/sql/create-cluster/#credit-usage).
+In Materialize, [clusters](/get-started/key-concepts/#clusters) are the pools of
+compute resources for running your workloads. The size and replication factor
+of each cluster determines its [credit usage](/sql/create-cluster/#credit-usage).
 
-During your free trial, the credit consumption rate across all clusters in a region cannot exceed 4 credits per hour at any point in time. This limit should accommodate most trial scenarios.
+During your free trial, the credit consumption rate across all clusters in a
+region cannot exceed 4 credits per hour at any point in time. This limit should
+accommodate most trial scenarios.
 
 For example, let's say you have 3 clusters in a region:
 
@@ -21,19 +27,23 @@ Cluster     | Size      | Replication factor | Credits per hour
 ------------|-----------|--------------------|-----------------
 `ingest`    | `50cc`    | 1                  | 0.5
 `compute`   | `50cc`    | 2                  | 1 (0.5 each)
-`quickstart`| `50cc`    | 1                  | 0.5
+`quickstart`| `100cc`   | 1                  | 1
 
-In this case, your credit consumption rate would be 2 credits per hour, which is under the rate limit of 4 credits per hour.
+In this case, your credit consumption rate would be 2.5 credits per hour, which
+is under the rate limit of 4 credits per hour.
 
 ## How long does a free trial last?
 
 14 days.
 
-If you need additional time, please [chat with our team](http://materialize.com/convert-account/). Otherwise, Materialize will delete your resources and data at the end of the trial period.
+If you need additional time, please [chat with our team](http://materialize.com/convert-account/).
+Otherwise, Materialize will delete your resources and data at the end of the
+trial period.
 
 ## How do I monitor my credit consumption rate?
 
-To see your current credit consumption rate, measured in credits per hour, run the following query:
+To see your current credit consumption rate, measured in credits per hour, run
+the following query against Materialize:
 
 ```sql
 SELECT sum(s.credits_per_hour) AS credit_consumption_rate
@@ -41,21 +51,31 @@ SELECT sum(s.credits_per_hour) AS credit_consumption_rate
   JOIN mz_internal.mz_cluster_replica_sizes s ON r.size = s.size;
 ```
 
-For example, if you start your free trial with the [getting started guide](/get-started/), you'll end up consuming credits at a rate of `3.5` per hour:
+For example, if you start your free trial by following the [getting started guide](/get-started/quickstart),
+or if you otherwise only use the pre-installed `quickstart` cluster
+(`100cc`), you will end up consuming `1` credit per hour:
 
 ```nofmt
  credit_consumption_rate
 -------------------------
-                     3.5
+                      1
 (1 row)
 ```
 
 ## Can I go over the credit rate limit?
 
-No, you cannot go over the rate limit of 4 credits per hour at any time during your free trial. If you try to add a replica that puts you over the limit, Materialize will return an error.
+No, you cannot go over the rate limit of 4 credits per hour at any time during
+your free trial. If you try to add a replica that puts you over the limit,
+Materialize will return an error similar to:
+
+```sql
+Error: creating cluster replica would violate max_credit_consumption_rate limit (desired: 6, limit: 4, current: 3)
+Hint: Drop an existing cluster replica or contact support to request a limit increase.
+```
 
 If you need additional resources during your trial, [chat with our team](http://materialize.com/convert-account/).
 
 ## How do I get help during my trial?
 
-If you have questions about Materialize or need support, reach out to us in our [Community Slack](https://materialize.com/s/chat).
+If you have questions about Materialize or need support, reach out to us in our
+[Community Slack](https://materialize.com/s/chat).

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -62,7 +62,7 @@ with.
             name            |      type      | size
     ------------------------+----------------+------
      accounts               | subsource      | null
-     auction_house          | load-generator | 25cc
+     auction_house          | load-generator | null
      auction_house_progress | progress       | null
      auctions               | subsource      | null
      bids                   | subsource      | null

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -28,7 +28,7 @@ cluster at any time.
 {{< note >}}
 The default value for the `cluster` session parameter is `quickstart`.
 If the `quickstart` cluster is dropped, you must run [`SET cluster`](/sql/select/#ad-hoc-queries)
-to choose a valid cluster in order to run `SELECT` queries. A _superuser _(i.e. `Organization Admin`)
+to choose a valid cluster in order to run `SELECT` queries. A _superuser_ (i.e. `Organization Admin`)
 can also run [`ALTER SYSTEM SET cluster`](/sql/alter-system-set) to change the
 default value.
 {{< /note >}}


### PR DESCRIPTION
We seem to frequently point prospects to the free trial FAQ page, which is slightly outdated. Please double-check my math!

Also took the chance to patch a few related typos.