### PR TITLE
feature-benchmark: Ignore new OptbenchTPCH regression on main

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -31,6 +31,12 @@ def get_ancestor_overrides_for_performance_regressions(
     # Commits must be ordered descending by their date.
     min_ancestor_mz_version_per_commit = dict()
 
+    if "OptbenchTPCH" in scenario_class_name:
+        # PR#26652 (explain: fix tracing fast path regression) significantly increased wallclock for OptbenchTPCH
+        min_ancestor_mz_version_per_commit[
+            "96c22562745f59010860bd825de5b4007a172c70"
+        ] = MzVersion.parse_mz("v0.97.0")
+
     if scenario_class_name == "FastPathFilterNoIndex":
         # PR#26084 (Optimize OffsetList) increased wallclock
         min_ancestor_mz_version_per_commit[
@@ -42,12 +48,6 @@ def get_ancestor_overrides_for_performance_regressions(
         min_ancestor_mz_version_per_commit[
             "da35946d636607a11fa27d5a8ea6e9939bf9525e"
         ] = MzVersion.parse_mz("v0.93.0")
-
-    if "OptbenchTPCH" in scenario_class_name:
-        # PR#24155 (equivalence propagation) significantly increased wallclock for OptbenchTPCH
-        min_ancestor_mz_version_per_commit[
-            "3cfaa8207faa7df087942cd44311a3e7b4534c25"
-        ] = MzVersion.parse_mz("v0.92.0")
 
     # add legacy entries
     min_ancestor_mz_version_per_commit.update(


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
