### PR TITLE
explain: remove `Filter` layer from `OptimizerTrace` stack

### DIFF
--- a/src/adapter/src/explain/optimizer_trace.rs
+++ b/src/adapter/src/explain/optimizer_trace.rs
@@ -79,16 +79,7 @@ impl OptimizerTrace {
                 .with(PlanTrace::<DataflowDescription<Plan>>::new(filter()))
                 // Don't filter for FastPathPlan entries (there can be at most one).
                 .with(PlanTrace::<FastPathPlan>::new(None))
-                .with(PlanTrace::<UsedIndexes>::new(None))
-                // All optimizer spans are `TRACE` and up. Technically this slows down the system
-                // by skipping the tracing fast path DURING an `EXPLAIN`, but we haven't
-                // seen this be a problem (yet).
-                //
-                // Note that we typically do NOT use global filters like this, preferring
-                // per-layer ones, but we are forced to because per-layer filters
-                // require an `Arc<dyn Subscriber + LookupSpan>`, which isn't a trait
-                // exposed by tracing, for now.
-                .with(tracing::level_filters::LevelFilter::TRACE);
+                .with(PlanTrace::<UsedIndexes>::new(None));
 
             OptimizerTrace(dispatcher::Dispatch::new(subscriber))
         } else {
@@ -103,8 +94,7 @@ impl OptimizerTrace {
                 .with(PlanTrace::<DataflowDescription<OptimizedMirRelationExpr>>::new(filter()))
                 .with(PlanTrace::<DataflowDescription<Plan>>::new(filter()))
                 .with(PlanTrace::<FastPathPlan>::new(None))
-                .with(PlanTrace::<UsedIndexes>::new(None))
-                .with(tracing::level_filters::LevelFilter::TRACE);
+                .with(PlanTrace::<UsedIndexes>::new(None));
 
             OptimizerTrace(dispatcher::Dispatch::new(subscriber))
         }


### PR DESCRIPTION
It's not clear why we need this, and it might be causing a regression in our optimization times.

This might be a root cause of #26673.

### Motivation

  * This PR fixes a recognized bug.

Fixes #26673.

### Tips for reviewer

I don't think we need the extra

```rust
.with(tracing::level_filters::LevelFilter::TRACE)
```

layer in `OptimizerTrace` because the `Filter` implementation for `PlanTrace` will always report interest in `target: "optimizer"` spans:

https://github.com/MaterializeInc/materialize/blob/aff40a76f99c8964e618a30f02956f4bdba4b985/src/repr/src/explain/tracing.rs#L214-L230

https://github.com/MaterializeInc/materialize/blob/aff40a76f99c8964e618a30f02956f4bdba4b985/src/repr/src/explain/tracing.rs#L245-L249

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
