### PR TITLE
postgres-consistency test: Ignore REAL/DECIMAL difference in IN

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -222,6 +222,7 @@ class PgPreExecutionInconsistencyIgnoreFilter(
             (
                 db_operation.is_tagged(TAG_EQUALITY_ORDERING)
                 or db_operation.is_tagged(TAG_EQUALITY)
+                or db_operation.pattern == "position($ IN $)"
             )
             and expression.args[0].resolve_return_type_category()
             == DataTypeCategory.NUMERIC


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/issues/26323 can also happen with IN operator, see https://buildkite.com/materialize/nightly/builds/7464#018eebef-0763-4a28-9f82-1a2ee1e1e7aa

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
