### PR TITLE
Copy-to-S3 TPCH testing with CSV and Parquet 

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -67,3 +67,6 @@ yamllint==1.33.0
 confluent-kafka==2.1.1
 fastavro==1.8.2
 websocket-client==1.7.0
+pyarrow-stubs==10.0.1.7
+pyarrow==15.0.2
+minio==7.2.5

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1459,6 +1459,30 @@ steps:
     agents:
       queue: linux-aarch64
 
+  - group: "Copy To S3"
+    key: copy-to-s3
+    steps:
+    - id: copy-to-s3-1-replica
+      label: "Copy To S3 (1 replica)"
+      depends_on: build-aarch64
+      timeout_in_minutes: 60
+      plugins:
+        - ./ci/plugins/mzcompose:
+            composition: copy-to-s3
+      agents:
+        queue: linux-aarch64-large
+
+    - id: copy-to-s3-2-replicas
+      label: "Copy To S3 (2 replicas)"
+      depends_on: build-aarch64
+      timeout_in_minutes: 60
+      plugins:
+        - ./ci/plugins/mzcompose:
+            composition: copy-to-s3
+            args: [--default-size=2]
+      agents:
+        queue: linux-aarch64-large
+
   - group: "Language tests"
     key: language-tests
     steps:

--- a/test/copy-to-s3/copy-to-s3-minio.td
+++ b/test/copy-to-s3/copy-to-s3-minio.td
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# COPY TO expressions should immediately succeed or fail on their first runs
+$ set-max-tries max-tries=1
+
+> CREATE SCHEMA tpch1gb
+> CREATE SOURCE tpch1gb.source FROM LOAD GENERATOR TPCH (SCALE FACTOR 1) FOR ALL TABLES
+
+> COPY tpch1gb.customer TO 's3://copytos3/test/tpch1gb/customer'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.lineitem TO 's3://copytos3/test/tpch1gb/lineitem'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.nation TO 's3://copytos3/test/tpch1gb/nation'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.orders TO 's3://copytos3/test/tpch1gb/orders'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.part TO 's3://copytos3/test/tpch1gb/part'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.partsupp TO 's3://copytos3/test/tpch1gb/partsupp'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.region TO 's3://copytos3/test/tpch1gb/region'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.supplier TO 's3://copytos3/test/tpch1gb/supplier'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );

--- a/test/copy-to-s3/mzcompose
+++ b/test/copy-to-s3/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/copy-to-s3/mzcompose.py
+++ b/test/copy-to-s3/mzcompose.py
@@ -1,0 +1,140 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+import csv
+from io import BytesIO, StringIO
+
+import pyarrow.parquet  #
+from minio import Minio
+
+from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.minio import Minio as MinioService
+from materialize.mzcompose.services.testdrive import Testdrive
+
+SERVICES = [
+    MinioService(
+        setup_materialize=True,
+        additional_directories=["copytos3"],
+        ports=["9000:9000", "9001:9001"],
+        allow_host_ports=True,
+    ),
+    Materialized(),  # Overridden below
+    Testdrive(),  # Overridden below
+]
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    parser.add_argument(
+        "--default-size",
+        type=int,
+        default=1,  # Reduced memory
+        help="Use SIZE 'N-N' for replicas and SIZE 'N' for sources",
+    )
+
+    args = parser.parse_args()
+
+    dependencies = ["minio", "materialized"]
+
+    testdrive = Testdrive(
+        forward_buildkite_shard=True,
+        aws_region=None,
+        validate_catalog_store=True,
+        default_timeout="1800s",
+        volumes_extra=["mzdata:/mzdata"],
+        external_minio=True,
+        no_reset=True,
+    )
+
+    materialized = Materialized(
+        default_size=args.default_size,
+        external_minio=True,
+    )
+
+    with c.override(testdrive, materialized):
+        c.up(*dependencies)
+
+        c.sql(
+            "ALTER SYSTEM SET max_clusters = 50;",
+            port=6877,
+            user="mz_system",
+        )
+
+        s3 = Minio(
+            f"127.0.0.1:{c.default_port('minio')}",
+            "minioadmin",
+            "minioadmin",
+            region="minio",
+            secure=False,
+        )
+        c.run_testdrive_files("setup.td")
+
+        for size in [
+            "tpch10mb",
+            "tpch1gb",
+            # "tpch10gb",  # SELECT(*) in Mz is way too slow
+        ]:
+            c.run_testdrive_files(f"{size}.td")
+            for table in [
+                "customer",
+                "lineitem",
+                "nation",
+                "orders",
+                "part",
+                "partsupp",
+                "region",
+                "supplier",
+            ]:
+                expected = sorted(
+                    [
+                        [str(c) for c in row]
+                        for row in c.sql_query(f"SELECT * FROM {size}.{table}")
+                    ]
+                )
+                actual_csv = []
+                for obj in s3.list_objects(
+                    "copytos3", f"test/{size}/csv/{table}/", recursive=True
+                ):
+                    assert obj.object_name is not None
+                    response = s3.get_object("copytos3", obj.object_name)
+                    f = StringIO(response.data.decode("utf-8"))
+                    response.close()
+                    response.release_conn()
+                    del response
+                    actual_csv.extend([row for row in csv.reader(f)])
+                    del f
+                actual_csv.sort()
+                assert (
+                    actual_csv == expected
+                ), f"Table {table}\nActual:\n{actual_csv[0:3]}\n...\n\nExpected:\n{expected[0:3]}\n..."
+                del actual_csv
+
+                actual_parquet = []
+                for obj in s3.list_objects(
+                    "copytos3", f"test/{size}/parquet/{table}/", recursive=True
+                ):
+                    assert obj.object_name is not None
+                    response = s3.get_object("copytos3", obj.object_name)
+                    f = BytesIO(response.data)
+                    response.close()
+                    response.release_conn()
+                    del response
+                    actual_parquet.extend(
+                        [
+                            [str(c) for c in row.values()]
+                            for row in pyarrow.parquet.read_table(f).to_pylist()
+                        ]
+                    )
+                    del f
+                actual_parquet.sort()
+                assert (
+                    actual_parquet == expected
+                ), f"Table {table}\nActual:\n{actual_parquet[0:3]}\n...\n\nExpected:\n{expected[0:3]}\n..."
+                del actual_parquet

--- a/test/copy-to-s3/setup.td
+++ b/test/copy-to-s3/setup.td
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-max-tries max-tries=1
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_aws_connection = true;
+ALTER SYSTEM SET enable_copy_to_expr = true;
+ALTER SYSTEM SET max_sources = 50;
+ALTER SYSTEM SET max_result_size = '100 GB';
+
+> CREATE SECRET aws_secret AS '${arg.aws-secret-access-key}'
+
+> CREATE CONNECTION aws_conn
+  TO AWS (
+    ACCESS KEY ID = '${arg.aws-access-key-id}',
+    SECRET ACCESS KEY = SECRET aws_secret,
+    ENDPOINT = '${arg.aws-endpoint}',
+    REGION = 'us-east-1'
+  );

--- a/test/copy-to-s3/tpch10gb.td
+++ b/test/copy-to-s3/tpch10gb.td
@@ -1,0 +1,112 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# COPY TO expressions should immediately succeed or fail on their first runs
+$ set-max-tries max-tries=1
+
+> CREATE SCHEMA tpch10gb
+> CREATE SOURCE tpch10gb.source FROM LOAD GENERATOR TPCH (SCALE FACTOR 10) FOR ALL TABLES
+
+> COPY tpch10gb.customer TO 's3://copytos3/test/tpch10gb/csv/customer'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10gb.lineitem TO 's3://copytos3/test/tpch10gb/csv/lineitem'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10gb.nation TO 's3://copytos3/test/tpch10gb/csv/nation'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10gb.orders TO 's3://copytos3/test/tpch10gb/csv/orders'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10gb.part TO 's3://copytos3/test/tpch10gb/csv/part'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10gb.partsupp TO 's3://copytos3/test/tpch10gb/csv/partsupp'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10gb.region TO 's3://copytos3/test/tpch10gb/csv/region'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10gb.supplier TO 's3://copytos3/test/tpch10gb/csv/supplier'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+
+> COPY (SELECT c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal::text, c_mktsegment, c_comment FROM tpch10gb.customer) TO 's3://copytos3/test/tpch10gb/parquet/customer'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "10GB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity::text, l_extendedprice::text, l_discount::text, l_tax::text, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment FROM tpch10gb.lineitem) TO 's3://copytos3/test/tpch10gb/parquet/lineitem'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "10GB",
+    FORMAT = 'parquet'
+  );
+> COPY tpch10gb.nation TO 's3://copytos3/test/tpch10gb/parquet/nation'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "10GB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT o_orderkey, o_custkey, o_orderstatus, o_totalprice::text, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment FROM tpch10gb.orders) TO 's3://copytos3/test/tpch10gb/parquet/orders'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "10GB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice::text, p_comment FROM tpch10gb.part) TO 's3://copytos3/test/tpch10gb/parquet/part'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "10GB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT ps_partkey, ps_suppkey, ps_availqty, ps_supplycost::text, ps_comment FROM tpch10gb.partsupp) TO 's3://copytos3/test/tpch10gb/parquet/partsupp'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "10GB",
+    FORMAT = 'parquet'
+  );
+> COPY tpch10gb.region TO 's3://copytos3/test/tpch10gb/parquet/region'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "10GB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal::text, s_comment FROM tpch10gb.supplier) TO 's3://copytos3/test/tpch10gb/parquet/supplier'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "10GB",
+    FORMAT = 'parquet'
+  );

--- a/test/copy-to-s3/tpch10mb.td
+++ b/test/copy-to-s3/tpch10mb.td
@@ -1,0 +1,112 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# COPY TO expressions should immediately succeed or fail on their first runs
+$ set-max-tries max-tries=1
+
+> CREATE SCHEMA tpch10mb
+> CREATE SOURCE tpch10mb.source FROM LOAD GENERATOR TPCH (SCALE FACTOR 0.01) FOR ALL TABLES
+
+> COPY tpch10mb.customer TO 's3://copytos3/test/tpch10mb/csv/customer'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10mb.lineitem TO 's3://copytos3/test/tpch10mb/csv/lineitem'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10mb.nation TO 's3://copytos3/test/tpch10mb/csv/nation'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10mb.orders TO 's3://copytos3/test/tpch10mb/csv/orders'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10mb.part TO 's3://copytos3/test/tpch10mb/csv/part'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10mb.partsupp TO 's3://copytos3/test/tpch10mb/csv/partsupp'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10mb.region TO 's3://copytos3/test/tpch10mb/csv/region'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch10mb.supplier TO 's3://copytos3/test/tpch10mb/csv/supplier'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+
+> COPY (SELECT c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal::text, c_mktsegment, c_comment FROM tpch10mb.customer) TO 's3://copytos3/test/tpch10mb/parquet/customer'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity::text, l_extendedprice::text, l_discount::text, l_tax::text, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment FROM tpch10mb.lineitem) TO 's3://copytos3/test/tpch10mb/parquet/lineitem'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );
+> COPY tpch10mb.nation TO 's3://copytos3/test/tpch10mb/parquet/nation'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT o_orderkey, o_custkey, o_orderstatus, o_totalprice::text, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment FROM tpch10mb.orders) TO 's3://copytos3/test/tpch10mb/parquet/orders'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice::text, p_comment FROM tpch10mb.part) TO 's3://copytos3/test/tpch10mb/parquet/part'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT ps_partkey, ps_suppkey, ps_availqty, ps_supplycost::text, ps_comment FROM tpch10mb.partsupp) TO 's3://copytos3/test/tpch10mb/parquet/partsupp'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );
+> COPY tpch10mb.region TO 's3://copytos3/test/tpch10mb/parquet/region'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal::text, s_comment FROM tpch10mb.supplier) TO 's3://copytos3/test/tpch10mb/parquet/supplier'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );

--- a/test/copy-to-s3/tpch1gb.td
+++ b/test/copy-to-s3/tpch1gb.td
@@ -1,0 +1,112 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# COPY TO expressions should immediately succeed or fail on their first runs
+$ set-max-tries max-tries=1
+
+> CREATE SCHEMA tpch1gb
+> CREATE SOURCE tpch1gb.source FROM LOAD GENERATOR TPCH (SCALE FACTOR 1) FOR ALL TABLES
+
+> COPY tpch1gb.customer TO 's3://copytos3/test/tpch1gb/csv/customer'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.lineitem TO 's3://copytos3/test/tpch1gb/csv/lineitem'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.nation TO 's3://copytos3/test/tpch1gb/csv/nation'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.orders TO 's3://copytos3/test/tpch1gb/csv/orders'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.part TO 's3://copytos3/test/tpch1gb/csv/part'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.partsupp TO 's3://copytos3/test/tpch1gb/csv/partsupp'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.region TO 's3://copytos3/test/tpch1gb/csv/region'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+> COPY tpch1gb.supplier TO 's3://copytos3/test/tpch1gb/csv/supplier'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+
+> COPY (SELECT c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal::text, c_mktsegment, c_comment FROM tpch1gb.customer) TO 's3://copytos3/test/tpch1gb/parquet/customer'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity::text, l_extendedprice::text, l_discount::text, l_tax::text, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment FROM tpch1gb.lineitem) TO 's3://copytos3/test/tpch1gb/parquet/lineitem'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "1GB",
+    FORMAT = 'parquet'
+  );
+> COPY tpch1gb.nation TO 's3://copytos3/test/tpch1gb/parquet/nation'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "1GB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT o_orderkey, o_custkey, o_orderstatus, o_totalprice::text, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment FROM tpch1gb.orders) TO 's3://copytos3/test/tpch1gb/parquet/orders'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "1GB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice::text, p_comment FROM tpch1gb.part) TO 's3://copytos3/test/tpch1gb/parquet/part'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "1GB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT ps_partkey, ps_suppkey, ps_availqty, ps_supplycost::text, ps_comment FROM tpch1gb.partsupp) TO 's3://copytos3/test/tpch1gb/parquet/partsupp'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "1GB",
+    FORMAT = 'parquet'
+  );
+> COPY tpch1gb.region TO 's3://copytos3/test/tpch1gb/parquet/region'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "1GB",
+    FORMAT = 'parquet'
+  );
+> COPY (SELECT s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal::text, s_comment FROM tpch1gb.supplier) TO 's3://copytos3/test/tpch1gb/parquet/supplier'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "1GB",
+    FORMAT = 'parquet'
+  );


### PR DESCRIPTION
This is now in a good state, just blocked until the 2 PRs it depends on merge.

Edit: Now good to go: Nightly is green with it: https://buildkite.com/materialize/nightly/builds/7517
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
