### PR TITLE
storage/copy-to-s3: Support `COPY <item> TO ..` for all data-producing item types

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -306,7 +306,7 @@ impl_display_t!(InsertStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CopyRelation<T: AstInfo> {
-    Table {
+    Named {
         name: T::ItemName,
         columns: Vec<Ident>,
     },
@@ -419,7 +419,7 @@ impl<T: AstInfo> AstDisplay for CopyStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("COPY ");
         match &self.relation {
-            CopyRelation::Table { name, columns } => {
+            CopyRelation::Named { name, columns } => {
                 f.write_node(name);
                 if !columns.is_empty() {
                     f.write_str("(");

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5374,14 +5374,14 @@ impl<'a> Parser<'a> {
             let columns = self
                 .parse_parenthesized_column_list(Optional)
                 .map_parser_err(StatementKind::Copy)?;
-            CopyRelation::Table { name, columns }
+            CopyRelation::Named { name, columns }
         };
         let (direction, target) = match self
             .expect_one_of_keywords(&[FROM, TO])
             .map_parser_err(StatementKind::Copy)?
         {
             FROM => {
-                if let CopyRelation::Table { .. } = relation {
+                if let CopyRelation::Named { .. } = relation {
                     // Ok.
                 } else {
                     return parser_err!(

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -18,14 +18,14 @@ COPY t(a, b) FROM STDIN
 ----
 COPY t(a, b) FROM STDIN
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [Ident("a"), Ident("b")] }, direction: From, target: Stdin, options: [] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [Ident("a"), Ident("b")] }, direction: From, target: Stdin, options: [] })
 
 parse-statement
 COPY t FROM STDIN
 ----
 COPY t FROM STDIN
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [] })
 
 parse-statement
 COPY (select 1) TO STDOUT
@@ -46,35 +46,35 @@ COPY t(a, b) TO STDOUT
 ----
 COPY t(a, b) TO STDOUT
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [Ident("a"), Ident("b")] }, direction: To, target: Stdout, options: [] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [Ident("a"), Ident("b")] }, direction: To, target: Stdout, options: [] })
 
 parse-statement
 COPY t TO STDOUT WITH (FORMAT TEXT)
 ----
 COPY t TO STDOUT WITH (FORMAT = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("text")]))) }] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("text")]))) }] })
 
 parse-statement
 COPY t TO STDOUT WITH (FORMAT CSV)
 ----
 COPY t TO STDOUT WITH (FORMAT = csv)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }] })
 
 parse-statement
 COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '|', NULL 'NULL', QUOTE '"', ESCAPE '\\', HEADER false)
 ----
 COPY t FROM STDIN WITH (FORMAT = csv, DELIMITER = '|', NULL = 'NULL', QUOTE = '"', ESCAPE = '\\', HEADER = false)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }, CopyOption { name: Delimiter, value: Some(Value(String("|"))) }, CopyOption { name: Null, value: Some(Value(String("NULL"))) }, CopyOption { name: Quote, value: Some(Value(String("\""))) }, CopyOption { name: Escape, value: Some(Value(String("\\\\"))) }, CopyOption { name: Header, value: Some(Value(Boolean(false))) }] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }, CopyOption { name: Delimiter, value: Some(Value(String("|"))) }, CopyOption { name: Null, value: Some(Value(String("NULL"))) }, CopyOption { name: Quote, value: Some(Value(String("\""))) }, CopyOption { name: Escape, value: Some(Value(String("\\\\"))) }, CopyOption { name: Header, value: Some(Value(Boolean(false))) }] })
 
 parse-statement
 COPY t TO STDOUT (format = text)
 ----
 COPY t TO STDOUT WITH (FORMAT = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("text")]))) }] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("text")]))) }] })
 
 parse-statement
 COPY t TO STDOUT ()
@@ -88,7 +88,7 @@ COPY t TO STDIN
 ----
 COPY t TO stdin
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Identifier([Ident("stdin")])), options: [] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Identifier([Ident("stdin")])), options: [] })
 
 parse-statement
 COPY (select 1) FROM STDIN
@@ -111,7 +111,7 @@ COPY t TO 's3://path/' WITH (FORMAT = csv, MAX FILE SIZE = 10240, AWS CONNECTION
 ----
 COPY t TO 's3://path/' WITH (FORMAT = csv, MAX FILE SIZE = 10240, AWS CONNECTION = aws_conn)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Value(String("s3://path/"))), options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }, CopyOption { name: MaxFileSize, value: Some(Value(Number("10240"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Value(String("s3://path/"))), options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }, CopyOption { name: MaxFileSize, value: Some(Value(Number("10240"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
 
 # S3 path can be a scalar expression
 parse-statement
@@ -119,21 +119,21 @@ COPY t TO 's3://path/' || mz_now() WITH (FORMAT = csv, MAX FILE SIZE = '100MB', 
 ----
 COPY t TO 's3://path/' || mz_now() WITH (FORMAT = csv, MAX FILE SIZE = '100MB', AWS CONNECTION = aws_conn)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }, CopyOption { name: MaxFileSize, value: Some(Value(String("100MB"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("csv")]))) }, CopyOption { name: MaxFileSize, value: Some(Value(String("100MB"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
 
 parse-statement
 COPY t TO 's3://path/' || mz_now() WITH (FORMAT = parquet, MAX FILE SIZE = '100MB', AWS CONNECTION = aws_conn)
 ----
 COPY t TO 's3://path/' || mz_now() WITH (FORMAT = parquet, MAX FILE SIZE = '100MB', AWS CONNECTION = aws_conn)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("parquet")]))) }, CopyOption { name: MaxFileSize, value: Some(Value(String("100MB"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("mz_now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [CopyOption { name: Format, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("parquet")]))) }, CopyOption { name: MaxFileSize, value: Some(Value(String("100MB"))) }, CopyOption { name: AwsConnection, value: Some(Item(Name(UnresolvedItemName([Ident("aws_conn")])))) }] })
 
 parse-statement
 COPY t TO 's3://path/' || repeat('1', 2)
 ----
 COPY t TO 's3://path/' || repeat('1', 2)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("repeat")])), args: Args { args: [Value(String("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [] }, direction: To, target: Expr(Op { op: Op { namespace: None, op: "||" }, expr1: Value(String("s3://path/")), expr2: Some(Function(Function { name: Name(UnresolvedItemName([Ident("repeat")])), args: Args { args: [Value(String("1")), Value(Number("2"))], order_by: [] }, filter: None, over: None, distinct: false })) }), options: [] })
 
 parse-statement
 COPY (select * from t) TO 's3://path/' || repeat('1', 2)
@@ -155,14 +155,14 @@ COPY t(column1, column2) TO 's3://path/'
 ----
 COPY t(column1, column2) TO 's3://path/'
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [Ident("column1"), Ident("column2")] }, direction: To, target: Expr(Value(String("s3://path/"))), options: [] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [Ident("column1"), Ident("column2")] }, direction: To, target: Expr(Value(String("s3://path/"))), options: [] })
 
 parse-statement
 COPY t(column1, column2) TO '/any/path/'
 ----
 COPY t(column1, column2) TO '/any/path/'
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedItemName([Ident("t")])), columns: [Ident("column1"), Ident("column2")] }, direction: To, target: Expr(Value(String("/any/path/"))), options: [] })
+Copy(CopyStatement { relation: Named { name: Name(UnresolvedItemName([Ident("t")])), columns: [Ident("column1"), Ident("column2")] }, direction: To, target: Expr(Value(String("/any/path/"))), options: [] })
 
 parse-statement
 COPY (select * from t order by 1) TO 's3://path/' || repeat('1', 2)

--- a/src/sql-pretty/src/doc.rs
+++ b/src/sql-pretty/src/doc.rs
@@ -38,7 +38,7 @@ fn doc_display_pass<'a, T: AstDisplay>(v: &T) -> RcDoc<'a, ()> {
 
 pub(crate) fn doc_copy<T: AstInfo>(v: &CopyStatement<T>) -> RcDoc {
     let relation = match &v.relation {
-        CopyRelation::Table { name, columns } => {
+        CopyRelation::Named { name, columns } => {
             let mut relation = doc_display_pass(name);
             if !columns.is_empty() {
                 relation = bracket_doc(

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -96,7 +96,18 @@ contains:MAX FILE SIZE cannot be less than 16MB
 1
 2
 
+
 > COPY (SELECT a FROM t) TO 's3://copytos3/test/2'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = "100MB",
+    FORMAT = 'csv'
+  );
+
+# copy should work on non-table objects (views, etc)
+> CREATE VIEW my_view AS SELECT a FROM t WHERE a < 2;
+
+> COPY my_view TO 's3://copytos3/test/2_5'
   WITH (
     AWS CONNECTION = aws_conn,
     MAX FILE SIZE = "100MB",
@@ -135,6 +146,9 @@ $ s3-verify-data bucket=copytos3 key=${key-1}
 $ s3-verify-data bucket=copytos3 key=test/2
 1
 2
+
+$ s3-verify-data bucket=copytos3 key=test/2_5
+1
 
 $ s3-verify-data bucket=copytos3 key=test/3
 "{1,2}",f,Infinity,"{""s"":""abc""}",1,32767,2147483647,9223372036854775807,12345678901234567890123.4567890123456789,2010-10-10,10:10:10,2010-10-10 10:10:10,00:00:00,aaaa,\x5c7841414141,това е,\xd182d0b5d0bad181d182


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

@def- discovered in https://github.com/MaterializeInc/materialize/pull/26688 that `COPY <source> TO "s3://.....` would fail with an obscure error `ERROR: cannot insert into source '<source>'`.

This led me to discover that `COPY TO .. S3` was only working for select statements and tables but no other catalog item types (mat views, views, sources, etc).


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer


It turns out we were using the `query::plan_copy_from` method to describe all copy statements that referenced an item directly (rather than a SELECT expression). This meant that `plan_copy_from` asserted that the item was a table, since we can't copy into other item types, which has no relevance to `copy-to`. 

This fix just pulls out the logic we need for generating copy statement-descriptions in `plan_copy_from` into a `plan_copy_item` method, and leaving the table-assertion in the `plan_copy_from` method.


<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
