### PR TITLE
testdrive: Alternative workaround for #19097

### DIFF
--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -309,6 +309,12 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   IN CLUSTER ${arg.single-replica-cluster}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
+
+# TODO: Remove skip when #19097 is fixed
+$ skip-end
+$ skip-if
+SELECT true
+
 > CREATE SINK snk
   IN CLUSTER ${arg.single-replica-cluster}
   FROM source_data

--- a/test/testdrive/char-varchar-distinct.td
+++ b/test/testdrive/char-varchar-distinct.td
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TODO: Remove skip when #19097 is fixed
-$ skip-if
-SELECT true
-
 #
 # Make sure the distinct operator inside a detaflow operates correctly
 # with respect to CHAR/VARCHAR, especially in the presence of trailing

--- a/test/testdrive/char-varchar-joins.td
+++ b/test/testdrive/char-varchar-joins.td
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TODO: Remove skip when #19097 is fixed
-$ skip-if
-SELECT true
-
 #
 # Confirm that joins and the equality comparisons inherent to join
 # procesisng work properly with the CHAR data type and trailing spaces.

--- a/test/testdrive/char-varchar-multibyte.td
+++ b/test/testdrive/char-varchar-multibyte.td
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TODO: Remove skip when #19097 is fixed
-$ skip-if
-SELECT true
-
 #
 # Make sure that multibyte characters are handled correctly
 #

--- a/test/testdrive/connection-alter.td
+++ b/test/testdrive/connection-alter.td
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TODO: Remove skip when #19097 is fixed
-$ skip-if
-SELECT true
-
 $ set-arg-default single-replica-cluster=quickstart
 #
 # Test basic connection functionality

--- a/test/testdrive/load-generator-key-value.td
+++ b/test/testdrive/load-generator-key-value.td
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TODO: Remove skip when #19097 is fixed
-$ skip-if
-SELECT true
-
 # Tests `LOAD GENERATOR KEY VALUE`
 
 $ set-arg-default default-replica-size=1


### PR DESCRIPTION
It seems to always fail after this sink is dropped, see for example https://buildkite.com/materialize/test/builds/80870#018ef022-3eac-48d5-a5cc-96295b158dc6

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
