### PR TITLE
adapter: use STORAGE ReadHold instead of custom hold tracking in adapter

### DIFF
--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -20,7 +20,7 @@
 //! `mz_ore` wrapper either.
 #![allow(clippy::disallowed_types)]
 
-use std::collections::{btree_map, BTreeMap, BTreeSet, HashMap};
+use std::collections::{btree_map, hash_map, BTreeMap, BTreeSet, HashMap};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Deref;
@@ -32,6 +32,7 @@ use mz_compute_types::ComputeInstanceId;
 use mz_ore::instrument;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::session::metadata::SessionMetadata;
+use mz_storage_types::read_holds::ReadHold as StorageReadHold;
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::Serialize;
 use timely::progress::frontier::MutableAntichain;
@@ -173,12 +174,12 @@ impl<T: Eq + Hash + Ord> TimelineReadHolds<T> {
 /// [ReadHolds] are used for short-lived read holds. For example, when
 /// processing peeks or rendering dataflows. These are never downgraded but they
 /// _are_ released automatically when being dropped.
-pub struct ReadHolds<T: Eq + Hash + Ord> {
+pub struct ReadHolds<T: TimelyTimestamp> {
     pub inner: ReadHoldsInner<T>,
     dropped_read_holds_tx: tokio::sync::mpsc::UnboundedSender<ReadHoldsInner<T>>,
 }
 
-impl<T: Eq + Hash + Ord> ReadHolds<T> {
+impl<T: TimelyTimestamp> ReadHolds<T> {
     /// Return empty `ReadHolds`.
     pub fn new(
         read_holds: ReadHoldsInner<T>,
@@ -190,7 +191,6 @@ impl<T: Eq + Hash + Ord> ReadHolds<T> {
         }
     }
 }
-
 impl<T: TimelyTimestamp + Lattice> ReadHolds<T> {
     pub fn merge(&mut self, mut other: Self) {
         // Now, when other is dropped we don't release the holds anymore.
@@ -200,7 +200,7 @@ impl<T: TimelyTimestamp + Lattice> ReadHolds<T> {
     }
 }
 
-impl<T: Eq + Hash + Ord> Deref for ReadHolds<T> {
+impl<T: TimelyTimestamp> Deref for ReadHolds<T> {
     type Target = ReadHoldsInner<T>;
 
     fn deref(&self) -> &ReadHoldsInner<T> {
@@ -208,7 +208,7 @@ impl<T: Eq + Hash + Ord> Deref for ReadHolds<T> {
     }
 }
 
-impl<T: Debug + Eq + Hash + Ord> Debug for ReadHolds<T> {
+impl<T: TimelyTimestamp> Debug for ReadHolds<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ReadHolds")
             .field("read_holds", &self.inner)
@@ -216,7 +216,7 @@ impl<T: Debug + Eq + Hash + Ord> Debug for ReadHolds<T> {
     }
 }
 
-impl<T: Eq + Hash + Ord> Drop for ReadHolds<T> {
+impl<T: TimelyTimestamp> Drop for ReadHolds<T> {
     fn drop(&mut self) {
         let inner_holds = std::mem::take(&mut self.inner);
 
@@ -236,12 +236,12 @@ impl<T: Eq + Hash + Ord> Drop for ReadHolds<T> {
 /// Inner state of [ReadHolds]. We have this separate so that we can send the
 /// inner state along a channel, for releasing when dropped.
 #[derive(Debug)]
-pub struct ReadHoldsInner<T> {
-    pub storage_holds: HashMap<GlobalId, MutableAntichain<T>>,
+pub struct ReadHoldsInner<T: TimelyTimestamp> {
+    pub storage_holds: HashMap<GlobalId, StorageReadHold<T>>,
     pub compute_holds: HashMap<(ComputeInstanceId, GlobalId), MutableAntichain<T>>,
 }
 
-impl<T: Eq + Hash + Ord> ReadHoldsInner<T> {
+impl<T: TimelyTimestamp> ReadHoldsInner<T> {
     /// Return empty `ReadHolds`.
     pub fn new() -> Self {
         ReadHoldsInner {
@@ -269,12 +269,13 @@ impl<T: TimelyTimestamp + Lattice> ReadHoldsInner<T> {
     pub fn least_valid_read(&self) -> Antichain<T> {
         let mut since = Antichain::from_elem(T::minimum());
         for (_id, hold) in self.storage_holds.iter() {
-            since.join_assign(&hold.frontier().to_owned());
+            since.join_assign(&hold.since().to_owned());
         }
 
         for (_id, hold) in self.compute_holds.iter() {
             since.join_assign(&hold.frontier().to_owned());
         }
+
         since
     }
 
@@ -288,7 +289,7 @@ impl<T: TimelyTimestamp + Lattice> ReadHoldsInner<T> {
         let mut since = Antichain::new();
 
         if let Some(hold) = self.storage_holds.get(desired_id) {
-            since.extend(hold.frontier().to_owned());
+            since.extend(hold.since().to_owned());
         }
 
         for ((_instance, id), hold) in self.compute_holds.iter() {
@@ -302,9 +303,16 @@ impl<T: TimelyTimestamp + Lattice> ReadHoldsInner<T> {
     }
 
     pub fn merge(&mut self, other: Self) {
-        for (id, mut other_hold) in other.storage_holds {
-            let hold = self.storage_holds.entry(id).or_default();
-            hold.update_iter(other_hold.updates().cloned());
+        for (id, other_hold) in other.storage_holds {
+            let existing_hold = self.storage_holds.entry(id);
+            match existing_hold {
+                hash_map::Entry::Occupied(mut o) => {
+                    o.get_mut().merge_assign(other_hold);
+                }
+                hash_map::Entry::Vacant(v) => {
+                    v.insert(other_hold);
+                }
+            }
         }
         for (id, mut other_hold) in other.compute_holds {
             let hold = self.compute_holds.entry(id).or_default();
@@ -313,7 +321,7 @@ impl<T: TimelyTimestamp + Lattice> ReadHoldsInner<T> {
     }
 }
 
-impl<T: Eq + Hash + Ord> Default for ReadHoldsInner<T> {
+impl<T: TimelyTimestamp> Default for ReadHoldsInner<T> {
     fn default() -> Self {
         ReadHoldsInner::new()
     }
@@ -374,6 +382,11 @@ impl crate::coord::Coordinator {
         id_bundle: &CollectionIdBundle,
         compaction_window: CompactionWindow,
     ) {
+        // When initializing read policies we acquire a hold from STORAGE. We
+        // have to keep those until we install our read policy all the way at
+        // the end.
+        let mut stashed_storage_holds = Vec::new();
+
         // Creates a `ReadHolds` struct that contains a read hold for each id in
         // `id_bundle`. The time of each read holds is at `time`, if possible
         // otherwise it is at the lowest possible time, meaning the implied
@@ -381,35 +394,33 @@ impl crate::coord::Coordinator {
         //
         // This does not apply the read holds in STORAGE or COMPUTE. The code
         // below applies those, after ensuring that read capabilities exist.
-        let initialize_read_holds = |coord: &mut Coordinator,
-                                     time: mz_repr::Timestamp,
-                                     id_bundle: &CollectionIdBundle|
+        let mut initialize_read_holds = |coord: &mut Coordinator,
+                                         time: mz_repr::Timestamp,
+                                         id_bundle: &CollectionIdBundle|
          -> TimelineReadHolds<mz_repr::Timestamp> {
             let mut read_holds = TimelineReadHolds::new();
             let time = Antichain::from_elem(time);
 
             for id in id_bundle.storage_ids.iter() {
-                // TODO(aljoscha): This is a bit iffy, because we're using the
-                // since without having a read hold in place. In this case it's
-                // fine because we are the one controlling the read policy and
-                // the storage controller currently cannot advance its frontiers
-                // concurrently.
-                //
-                // This will be fixed properly in a future commit that makes the
-                // storage controller concurrent.
-                let (read_frontier, _upper) = coord
+                // Figure out at what since we can hold for this collection. We
+                // will use that for the initial policy that we're installing
+                // below.
+                let storage_hold = coord
                     .controller
                     .storage
-                    .collection_frontiers(*id)
+                    .acquire_read_hold(*id)
                     .expect("collection does not exist");
 
-                let time = time.join(&read_frontier);
+                let time = time.join(storage_hold.since());
                 read_holds
                     .holds
                     .entry(time)
                     .or_default()
                     .storage_ids
                     .insert(*id);
+
+                // Stash the hold until we update/initialize the policy below.
+                stashed_storage_holds.push(storage_hold);
             }
             for (compute_instance, compute_ids) in id_bundle.compute_ids.iter() {
                 let compute = coord.controller.active_compute();
@@ -503,6 +514,10 @@ impl crate::coord::Coordinator {
         self.controller
             .storage
             .set_read_policy(storage_policy_updates);
+
+        // Now that we installed our read policy updates we can relinquish holds
+        // that we used to determine and hold collection sinces.
+        drop(stashed_storage_holds);
     }
 
     /// Attempt to update the timestamp of the read holds on the indicated collections from the
@@ -528,37 +543,24 @@ impl crate::coord::Coordinator {
                     .or_default()
                     .extend(&id_bundle);
                 for id in id_bundle.storage_ids {
-                    // TODO(aljoscha): This is a bit iffy, because we're using
-                    // the since without having a read hold in place. In this
-                    // case it's fine because we are the one controlling the
-                    // read policy and the storage controller currently cannot
-                    // advance its frontiers concurrently.
-                    //
-                    // This will be fixed properly in a future commit that makes
-                    // the storage controller concurrent.
-                    let (read_frontier, _upper) = self
-                        .controller
-                        .storage
-                        .collection_frontiers(id)
-                        .expect("missing storage collection");
+                    // NOTE: We don't verify that the new frontier is beyond the
+                    // old frontier. The timeline read hold for storage
+                    // collections is largely advisory, and "real" read holds
+                    // that we acquire via `acquire_read_hold` go directly to
+                    // STORAGE to acquire read holds at the earliest legal time.
 
-                    assert!(read_frontier.le(&new_time.borrow()),
-                            "Storage collection {:?} has read frontier {:?} not less-equal new time {:?}; old time: {:?}",
-                            id,
-                            read_frontier,
-                            new_time,
-                            old_time,
-                    );
                     let read_needs = self
                         .storage_read_capabilities
                         .get_mut(&id)
                         .expect("id does not exist");
+
                     read_needs
                         .holds
                         .update_iter(new_time.iter().map(|t| (*t, 1)));
                     read_needs
                         .holds
                         .update_iter(old_time.iter().map(|t| (*t, -1)));
+
                     storage_policy_changes.push((id, read_needs.policy()));
                 }
 
@@ -681,20 +683,11 @@ impl crate::coord::Coordinator {
                 let policy: ReadPolicy<Timestamp> = match compaction_window {
                     Some(compaction_window) => compaction_window.into(),
                     None => {
-                        // We didn't get an initial policy, so set the current
-                        // since as a static policy.
-                        //
-                        // N.B. This is a bit iffy, because we're using the
-                        // since without having a read hold in place. In this
-                        // case it's fine because we didn't yet install a
-                        // ReadPolicy at the controller, and the since will stay
-                        // put until we put in place such a policy.
-                        let (since, _upper) = self
-                            .controller
-                            .storage
-                            .collection_frontiers(*id)
-                            .expect("missing storage collection");
-                        ReadPolicy::ValidFrom(since)
+                        // We didn't get an initial policy, so put in place the
+                        // most conservative policy in order to not accidentally
+                        // give a very lax policy to STORAGE. This will get
+                        // updated once the "real" policies are put in place.
+                        ReadPolicy::ValidFrom(Antichain::from_elem(mz_repr::Timestamp::MIN))
                     }
                 };
 
@@ -784,29 +777,29 @@ impl crate::coord::Coordinator {
         // `id_bundle`. The time of each read holds is at `time`, if possible
         // otherwise it is at the lowest possible time.
         //
-        // This does not apply the read holds in STORAGE or COMPUTE. The code
-        // below applies those in the correct read capability.
+        // This does not apply the read holds in COMPUTE. The code below applies
+        // those in the correct read capability.
         let mut read_holds = ReadHoldsInner::new();
         let time_antichain = Antichain::from_elem(Timestamp::MIN);
 
-        for id in id_bundle.storage_ids.iter() {
-            // TODO(aljoscha): This is a bit iffy, because we're using the since
-            // without having a read hold in place. In this case it's fine
-            // because we are the one controlling the read policy and the
-            // storage controller currently cannot advance its frontiers
-            // concurrently.
-            //
-            // This will be fixed properly in a future commit that makes the
-            // storage controller concurrent.
-            let (read_frontier, _upper) = self
-                .controller
-                .storage
-                .collection_frontiers(*id)
-                .expect("missing storage collection");
-            let time_antichain = time_antichain.join(&read_frontier);
-            let hold_chain = MutableAntichain::from(time_antichain);
-            read_holds.storage_holds.insert(*id, hold_chain);
+        let desired_storage_holds = id_bundle.storage_ids.iter().map(|id| *id).collect_vec();
+        let storage_read_holds = self
+            .controller
+            .storage
+            .acquire_read_holds(desired_storage_holds)
+            .expect("missing collections");
+
+        for storage_read_hold in storage_read_holds {
+            let prev = read_holds
+                .storage_holds
+                .insert(storage_read_hold.id(), storage_read_hold);
+
+            assert!(
+                prev.is_none(),
+                "can only store one storage ReadHold per collection"
+            );
         }
+
         for (compute_instance, compute_ids) in id_bundle.compute_ids.iter() {
             let compute = self.controller.active_compute();
             for id in compute_ids.iter() {
@@ -821,15 +814,6 @@ impl crate::coord::Coordinator {
                     .insert((*compute_instance, *id), hold_chain);
             }
         }
-
-        // Update STORAGE read policies.
-        let mut policy_changes = Vec::new();
-        for (id, hold) in read_holds.storage_holds.iter_mut() {
-            let read_needs = self.ensure_storage_capability(id, None);
-            read_needs.holds.update_iter(hold.updates().cloned());
-            policy_changes.push((*id, read_needs.policy()));
-        }
-        self.controller.storage.set_read_policy(policy_changes);
 
         // Update COMPUTE read policies
         let mut policy_changes: HashMap<_, Vec<_>> = HashMap::new();
@@ -850,6 +834,7 @@ impl crate::coord::Coordinator {
         }
 
         let read_holds = ReadHolds::new(read_holds, self.dropped_read_holds_tx.clone());
+        tracing::debug!(?read_holds, "acquire_read_holds");
         read_holds
     }
 
@@ -879,22 +864,9 @@ impl crate::coord::Coordinator {
     /// `ReadHolds`, and its behavior will be erratic if called on anything else,
     /// or if called more than once on the same bundle of read holds.
     pub(super) fn release_read_holds(&mut self, mut read_holdses: Vec<ReadHoldsInner<Timestamp>>) {
-        // Update STORAGE read policies.
-        let mut storage_policy_changes = Vec::new();
-        for read_holds in read_holdses.iter_mut() {
-            for (id, hold) in read_holds.storage_holds.iter_mut() {
-                // It's possible that a concurrent DDL statement has already dropped this GlobalId
-                if let Some(read_needs) = self.storage_read_capabilities.get_mut(id) {
-                    let inverted_hold = hold.updates().map(|(t, diff)| (*t, -diff));
-                    read_needs.holds.update_iter(inverted_hold);
-                    storage_policy_changes.push((*id, read_needs.policy()));
-                }
-            }
-        }
-
-        self.controller
-            .storage
-            .set_read_policy(storage_policy_changes);
+        tracing::debug!(?read_holdses, "release_read_holds");
+        // STORAGE read holds are released implicitly by dropping the STORAGE
+        // ReadHolds.
 
         // Update COMPUTE read policies
         let mut policy_changes_per_instance = BTreeMap::new();

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1021,7 +1021,7 @@ where
             }
 
             storage_dependencies.push(*source_id);
-            replica_input_frontier.join_assign(&since.to_owned());
+            replica_input_frontier.join_assign(&since);
         }
 
         // Validate indexes have `since.less_equal(as_of)`.

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -32,6 +32,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_storage_client::controller::{IntrospectionType, StorageController};
+use mz_storage_types::read_holds::ReadHoldError;
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::Serialize;
 use thiserror::Error;
@@ -86,6 +87,15 @@ impl From<CollectionMissing> for DataflowCreationError {
     }
 }
 
+impl From<ReadHoldError> for DataflowCreationError {
+    fn from(error: ReadHoldError) -> Self {
+        match error {
+            ReadHoldError::CollectionMissing(id) => DataflowCreationError::CollectionMissing(id),
+            ReadHoldError::SinceViolation(id) => DataflowCreationError::SinceViolation(id),
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub(super) enum PeekError {
     #[error("collection does not exist: {0}")]
@@ -99,6 +109,15 @@ pub(super) enum PeekError {
 impl From<CollectionMissing> for PeekError {
     fn from(error: CollectionMissing) -> Self {
         Self::CollectionMissing(error.0)
+    }
+}
+
+impl From<ReadHoldError> for PeekError {
+    fn from(error: ReadHoldError) -> Self {
+        match error {
+            ReadHoldError::CollectionMissing(id) => PeekError::CollectionMissing(id),
+            ReadHoldError::SinceViolation(id) => PeekError::SinceViolation(id),
+        }
     }
 }
 
@@ -999,29 +1018,25 @@ where
         let mut storage_dependencies = Vec::new();
         let mut compute_dependencies = Vec::new();
 
+        // Any potentially acquired STORAGE read holds. We acquire them and
+        // check whether our as_of is valid. They are dropped once we installed
+        // read capabilities manually.
+        //
+        // TODO: Instead of acquiring these and then dropping later, we should
+        // instead store them and don't "manually" acquire read holds using
+        // `update_read_capabilities`.
+        let mut storage_read_holds = Vec::new();
+
         // Validate sources have `since.less_equal(as_of)`.
         for source_id in dataflow.source_imports.keys() {
-            // NOTE: This provides only some level of protection. If the
-            // caller has not acquired read holds the since might move on
-            // concurrently.
-            //
-            // TODO: We are comparing against the implied capability here, which
-            // is being held back because adapter acquired read holds via
-            // controlling the policy. Once we add support for Storage
-            // ReadHolds, we should acquire read holds from storage here and
-            // assert that they are good for the as_of that we're planning to
-            // install our dataflow with.
-            let (since, _upper) = self
+            let storage_read_hold = self
                 .storage_controller
-                .collection_frontiers(*source_id)
-                .map_err(|_| DataflowCreationError::CollectionMissing(*source_id))?;
-
-            if !(timely::order::PartialOrder::less_equal(&since, as_of)) {
-                Err(DataflowCreationError::SinceViolation(*source_id))?;
-            }
+                .acquire_read_hold_at_time(*source_id, as_of.clone())?;
 
             storage_dependencies.push(*source_id);
-            replica_input_frontier.join_assign(&since);
+            replica_input_frontier.join_assign(storage_read_hold.since());
+
+            storage_read_holds.push(storage_read_hold);
         }
 
         // Validate indexes have `since.less_equal(as_of)`.
@@ -1065,6 +1080,10 @@ where
             .collect();
         self.storage_controller
             .update_read_capabilities(&mut storage_read_updates);
+        // Drop the acquired read holds after we installed our old-style, manual
+        // read capabilities.
+        drop(storage_read_holds);
+
         // Update compute read capabilities for inputs.
         let compute_read_updates = compute_dependencies
             .iter()
@@ -1336,24 +1355,24 @@ where
         target_replica: Option<ReplicaId>,
         peek_target: PeekTarget,
     ) -> Result<(), PeekError> {
-        let owned_since;
-        let since = match &peek_target {
-            PeekTarget::Index { .. } => self.compute.collection(id)?.read_capabilities.frontier(),
-            PeekTarget::Persist { .. } => {
-                // NOTE: This provides only some level of protection. If the
-                // caller has not acquired read holds the since might move on
-                // concurrently.
-                let (since, _upper) = self
-                    .storage_controller
-                    .collection_frontiers(id)
-                    .map_err(|_| PeekError::CollectionMissing(id))?;
-
-                owned_since = since;
-                owned_since.borrow()
+        // When querying persist directly, we acquire read holds and verify that
+        // we can actually acquire them at the right time.
+        let mut maybe_storage_read_hold = None;
+        match &peek_target {
+            PeekTarget::Index { .. } => {
+                let since = self.compute.collection(id)?.read_capabilities.frontier();
+                if !since.less_equal(&timestamp) {
+                    return Err(PeekError::SinceViolation(id));
+                }
             }
-        };
-        if !since.less_equal(&timestamp) {
-            return Err(PeekError::SinceViolation(id));
+
+            PeekTarget::Persist { .. } => {
+                let storage_read_hold = self
+                    .storage_controller
+                    .acquire_read_hold_at_time(id, Antichain::from_elem(timestamp.clone()))?;
+
+                maybe_storage_read_hold = Some(storage_read_hold);
+            }
         }
 
         if let Some(target) = target_replica {
@@ -1371,6 +1390,10 @@ where
                 .storage_controller
                 .update_read_capabilities(&mut updates),
         };
+
+        // Drop the acquired read hold after we installed our old-style, manual
+        // read capabilities.
+        drop(maybe_storage_read_hold);
 
         let otel_ctx = OpenTelemetryContext::obtain();
         self.compute.peeks.insert(

--- a/src/storage-types/src/lib.rs
+++ b/src/storage-types/src/lib.rs
@@ -17,6 +17,7 @@ pub mod dyncfgs;
 pub mod errors;
 pub mod instances;
 pub mod parameters;
+pub mod read_holds;
 pub mod read_policy;
 pub mod shim;
 pub mod sinks;

--- a/src/storage-types/src/read_holds.rs
+++ b/src/storage-types/src/read_holds.rs
@@ -1,0 +1,193 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Debug;
+
+use mz_repr::GlobalId;
+use thiserror::Error;
+use timely::progress::{Antichain, ChangeBatch, Timestamp as TimelyTimestamp};
+use timely::PartialOrder;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// Token that represents a hold on a collection. This prevents the since of the
+/// collection from progressing beyond the hold. In other words, it cannot
+/// become true that our hold is `less_than` the since.
+///
+/// This [ReadHold] is safe to drop. The installed read hold will be returned to
+/// the issuer behind the scenes.
+pub struct ReadHold<T: TimelyTimestamp> {
+    /// Identifies that collection that we have a hold on.
+    id: GlobalId,
+
+    /// The times at which we hold.
+    since: Antichain<T>,
+
+    /// For communicating changes to this read hold back to whoever issued it.
+    holds_tx: UnboundedSender<(GlobalId, ChangeBatch<T>)>,
+}
+
+impl<T: TimelyTimestamp> Debug for ReadHold<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadHold")
+            .field("id", &self.id)
+            .field("since", &self.since)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T: TimelyTimestamp> ReadHold<T> {
+    pub fn new(
+        id: GlobalId,
+        since: Antichain<T>,
+        holds_tx: UnboundedSender<(GlobalId, ChangeBatch<T>)>,
+    ) -> Self {
+        Self {
+            id,
+            since,
+            holds_tx,
+        }
+    }
+
+    /// Returns the [GlobalId] of the collection that this [ReadHold] is for.
+    pub fn id(&self) -> GlobalId {
+        self.id
+    }
+
+    /// Returns the frontier at which this [ReadHold] is holding back the since
+    /// of the collection identified by `id`. This does not mean that the
+    /// overall since of the collection is what we report here. Only that it is
+    /// _at least_ held back to the reported frontier by this read hold.
+    pub fn since(&self) -> &Antichain<T> {
+        &self.since
+    }
+
+    /// Merges `other` into `self`, keeping the overall read hold.
+    ///
+    /// # Panics
+    /// Panics when trying to merge a [ReadHold] for a different collection
+    /// (different [GlobalId]) or when trying to merge a [ReadHold] from a
+    /// different issuer.
+    pub fn merge_assign(&mut self, mut other: ReadHold<T>) {
+        assert_eq!(
+            self.id, other.id,
+            "can only merge ReadHolds for the same ID"
+        );
+        assert!(
+            self.holds_tx.same_channel(&other.holds_tx),
+            "can only merge ReadHolds that come from the same issuer"
+        );
+
+        let mut changes = ChangeBatch::new();
+
+        changes.extend(self.since.iter().map(|t| (t.clone(), -1)));
+
+        changes.extend(other.since.iter().map(|t| (t.clone(), -1)));
+        // It's very important that we clear the since of other. Otherwise, it's
+        // Drop impl would try and drop it again, by sending another ChangeBatch
+        // on drop.
+        let other_since = std::mem::take(&mut other.since);
+
+        self.since.extend(other_since.into_iter());
+
+        // Record the new requirements, which we're guaranteed to be possible
+        // because we're only retracing the two merged sinces together with this
+        // in one go.
+        changes.extend(self.since.iter().map(|t| (t.clone(), 1)));
+
+        match self.holds_tx.send((self.id.clone(), changes)) {
+            Ok(_) => (),
+            Err(e) => {
+                panic!("cannot merge ReadHold: {}", e);
+            }
+        }
+    }
+
+    /// Downgrades `self` to the given `frontier`. Returns `Err` when the new
+    /// frontier is `less_than` the frontier at which this [ReadHold] is
+    /// holding.
+    pub fn try_downgrade(&mut self, frontier: Antichain<T>) -> Result<(), anyhow::Error> {
+        if PartialOrder::less_than(&frontier, &self.since) {
+            return Err(anyhow::anyhow!(
+                "new frontier {:?} is not beyond current since {:?}",
+                frontier,
+                self.since
+            ));
+        }
+
+        let mut changes = ChangeBatch::new();
+
+        changes.extend(self.since.iter().map(|t| (t.clone(), -1)));
+        changes.extend(frontier.iter().map(|t| (t.clone(), 1)));
+        self.since = frontier;
+
+        if !changes.is_empty() {
+            // If the other side already hung up, that's ok.
+            let _ = self.holds_tx.send((self.id.clone(), changes));
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: TimelyTimestamp> Clone for ReadHold<T> {
+    fn clone(&self) -> Self {
+        if self.id.is_user() {
+            tracing::trace!("cloning ReadHold on {}: {:?}", self.id, self.since);
+        }
+
+        // Let the other end know.
+        let mut changes = ChangeBatch::new();
+
+        changes.extend(self.since.iter().map(|t| (t.clone(), 1)));
+
+        if !changes.is_empty() {
+            // We do care about sending here. If the other end hung up we don't
+            // really have a read hold anymore.
+            match self.holds_tx.send((self.id.clone(), changes)) {
+                Ok(_) => (),
+                Err(e) => {
+                    panic!("cannot clone ReadHold: {}", e);
+                }
+            }
+        }
+
+        Self {
+            id: self.id.clone(),
+            since: self.since.clone(),
+            holds_tx: self.holds_tx.clone(),
+        }
+    }
+}
+
+impl<T: TimelyTimestamp> Drop for ReadHold<T> {
+    fn drop(&mut self) {
+        if !self.since.is_empty() {
+            if self.id.is_user() {
+                tracing::trace!("dropping ReadHold on {}: {:?}", self.id, self.since);
+            }
+            let mut changes = ChangeBatch::new();
+
+            changes.extend(self.since.iter().map(|t| (t.clone(), -1)));
+            self.since.clear();
+
+            if !changes.is_empty() {
+                // If the other side already hung up, that's ok.
+                let _ = self.holds_tx.send((self.id, changes));
+            }
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ReadHoldError {
+    #[error("collection does not exist: {0}")]
+    CollectionMissing(GlobalId),
+    #[error("desired read hold frontier is not beyond the since of collection: {0}")]
+    SinceViolation(GlobalId),
+}


### PR DESCRIPTION
Preparatory work for https://github.com/MaterializeInc/materialize/issues/24845, where we want to introduce more concurrency
to the Coordinator and Controllers.

Before, adapter would track outstanding `ReadHolds` in its own state and
continually update the `ReadPolicy` of storage collections based on a base
policy and outstanding read holds.

Now, we go directly to STORAGE for acquiring ephemeral `ReadHolds`. Note
that the adapter still keeps `TimelineReadHolds` for collections, which
control the `ReadPolicy` that we continually update. This is so that
timeline-dependent collections remain readable at the oracle read
timestamp even when there are no outstanding other (ephemeral) read
holds.

This leaves the COMPUTE part of `ReadHolds` untouched.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
