### PR TITLE
docs: Callout `mz_role_parameters` in the docs for ALTER ROLE

### DIFF
--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -55,7 +55,9 @@ privileges. See [GRANT PRIVILEGE](../grant-privilege) for more details.
 
 When RBAC is enabled a role must have the `CREATEROLE` system privilege to alter another role.
 
-Like PostgreSQL, altering the configuration parameter for a role only affects **new sessions**. Also like PostgreSQL, role configuration parameters are **not inherited**.
+Like PostgreSQL, altering the configuration parameter for a role only affects **new sessions**.
+Also like PostgreSQL, role configuration parameters are **not inherited**. To view the
+current configuration parameter defaults for a role, see [`mz_role_parameters`](/sql/system-catalog/mz_catalog#mz_role_parameters).
 
 ## Examples
 


### PR DESCRIPTION
Adds a blurb to our docs that you view the current configuration parameter defaults for a role with the `mz_role_parameters` builtin table.

### Motivation

Update our docs

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
