### PR TITLE
sql: specify schemas for more builtins

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1709,7 +1709,7 @@ macro_rules! privilege_fn {
                     OR $1 IS NULL
                     OR $2 IS NULL
                     OR $3 IS NULL
-                    OR $1 NOT IN (SELECT oid FROM mz_roles)
+                    OR $1 NOT IN (SELECT oid FROM mz_catalog.mz_roles)
                     OR $2 NOT IN (SELECT oid FROM {catalog_tbl})
                     THEN NULL
                     ELSE COALESCE(
@@ -1729,7 +1729,7 @@ macro_rules! privilege_fn {
                                         {catalog_tbl}.oid = $2
                                 )
                                     AS user_privs (privilege)
-                                LEFT JOIN mz_roles ON
+                                LEFT JOIN mz_catalog.mz_roles ON
                                         mz_internal.mz_aclitem_grantee(privilege) = mz_roles.id
                             WHERE
                                 mz_internal.mz_aclitem_grantee(privilege) = '{public_role}' OR pg_has_role($1, mz_roles.oid, 'USAGE')
@@ -2423,8 +2423,8 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                 OR $2 IS NULL
                 OR $3 IS NULL
                 THEN NULL
-                WHEN $1 NOT IN (SELECT oid FROM mz_roles)
-                OR $2 NOT IN (SELECT oid FROM mz_roles)
+                WHEN $1 NOT IN (SELECT oid FROM mz_catalog.mz_roles)
+                OR $2 NOT IN (SELECT oid FROM mz_catalog.mz_roles)
                 THEN false
                 ELSE $2::text IN (SELECT UNNEST(mz_internal.mz_role_oid_memberships() -> $1::text))
                 END",
@@ -3532,7 +3532,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                 OR $1 IS NULL
                 OR $2 IS NULL
                 OR $3 IS NULL
-                OR $1 NOT IN (SELECT oid FROM mz_roles)
+                OR $1 NOT IN (SELECT oid FROM mz_catalog.mz_roles)
                 THEN NULL
                 ELSE COALESCE(
                     (
@@ -3551,7 +3551,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                                     mz_clusters.name = $2
                             )
                                 AS user_privs (privilege)
-                            LEFT JOIN mz_roles ON
+                            LEFT JOIN mz_catalog.mz_roles ON
                                     mz_internal.mz_aclitem_grantee(privilege) = mz_roles.id
                         WHERE
                             mz_internal.mz_aclitem_grantee(privilege) = '{}' OR pg_has_role($1, mz_roles.oid, 'USAGE')
@@ -3595,7 +3595,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                 WHEN NOT mz_internal.mz_validate_privileges($2)
                 OR $1 IS NULL
                 OR $2 IS NULL
-                OR $1 NOT IN (SELECT oid FROM mz_roles)
+                OR $1 NOT IN (SELECT oid FROM mz_catalog.mz_roles)
                 THEN NULL
                 ELSE COALESCE(
                     (
@@ -3604,8 +3604,8 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                                 mz_internal.mz_acl_item_contains_privilege(privileges, $2)
                             )
                                 AS has_system_privilege
-                        FROM mz_system_privileges
-                        LEFT JOIN mz_roles ON
+                        FROM mz_catalog.mz_system_privileges
+                        LEFT JOIN mz_catalog.mz_roles ON
                                 mz_internal.mz_aclitem_grantee(privileges) = mz_roles.id
                         WHERE
                             mz_internal.mz_aclitem_grantee(privileges) = '{}' OR pg_has_role($1, mz_roles.oid, 'USAGE')
@@ -4168,7 +4168,7 @@ pub static MZ_INTERNAL_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(
                         SELECT
                             (
                                 SELECT s.oid
-                                FROM mz_schemas AS s
+                                FROM mz_catalog.mz_schemas AS s
                                 LEFT JOIN mz_databases AS d ON s.database_id = d.id
                                 WHERE
                                     (
@@ -4194,7 +4194,7 @@ pub static MZ_INTERNAL_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(
                 WHEN $1 IS NULL THEN NULL
                 ELSE (
                     mz_unsafe.mz_error_if_null(
-                        (SELECT oid FROM mz_roles WHERE name = $1),
+                        (SELECT oid FROM mz_catalog.mz_roles WHERE name = $1),
                         'role \"' || $1 || '\" does not exist'
                     )
                 )

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -810,16 +810,16 @@ static VALID_CASTS: Lazy<BTreeMap<(ScalarBaseType, ScalarBaseType), CastImpl>> =
                 FROM
                     (SELECT mz_internal.mz_aclitem_grantee($1) AS grantee_role_id),
                     (SELECT mz_internal.mz_aclitem_grantor($1) AS grantor_role_id)
-                LEFT JOIN mz_roles AS grantee_role ON grantee_role_id = grantee_role.id
-                LEFT JOIN mz_roles AS grantor_role ON grantor_role_id = grantor_role.id
+                LEFT JOIN mz_catalog.mz_roles AS grantee_role ON grantee_role_id = grantee_role.id
+                LEFT JOIN mz_catalog.mz_roles AS grantor_role ON grantor_role_id = grantor_role.id
             )"),
         (MzAclItem, AclItem) => Explicit: sql_impl_cast("(
                 SELECT makeaclitem(
                     (CASE mz_internal.mz_aclitem_grantee($1)
                         WHEN 'p' THEN 0
-                        ELSE (SELECT oid FROM mz_roles WHERE id = mz_internal.mz_aclitem_grantee($1))
+                        ELSE (SELECT oid FROM mz_catalog.mz_roles WHERE id = mz_internal.mz_aclitem_grantee($1))
                     END),
-                    (SELECT oid FROM mz_roles WHERE id = mz_internal.mz_aclitem_grantor($1)),
+                    (SELECT oid FROM mz_catalog.mz_roles WHERE id = mz_internal.mz_aclitem_grantor($1)),
                     (SELECT array_to_string(mz_internal.mz_format_privileges(mz_internal.mz_aclitem_privileges($1)), ',')),
                     -- GRANT OPTION isn't implemented so we hardcode false.
                     false
@@ -840,16 +840,16 @@ static VALID_CASTS: Lazy<BTreeMap<(ScalarBaseType, ScalarBaseType), CastImpl>> =
                 FROM
                     (SELECT mz_internal.aclitem_grantee($1) AS grantee_oid),
                     (SELECT mz_internal.aclitem_grantor($1) AS grantor_oid)
-                LEFT JOIN mz_roles AS grantee_role ON grantee_oid = grantee_role.oid
-                LEFT JOIN mz_roles AS grantor_role ON grantor_oid = grantor_role.oid
+                LEFT JOIN mz_catalog.mz_roles AS grantee_role ON grantee_oid = grantee_role.oid
+                LEFT JOIN mz_catalog.mz_roles AS grantor_role ON grantor_oid = grantor_role.oid
             )"),
         (AclItem, MzAclItem) => Explicit: sql_impl_cast("(
                 SELECT mz_internal.make_mz_aclitem(
                     (CASE mz_internal.aclitem_grantee($1)
                         WHEN 0 THEN 'p'
-                        ELSE (SELECT id FROM mz_roles WHERE oid = mz_internal.aclitem_grantee($1))
+                        ELSE (SELECT id FROM mz_catalog.mz_roles WHERE oid = mz_internal.aclitem_grantee($1))
                     END),
-                    (SELECT id FROM mz_roles WHERE oid = mz_internal.aclitem_grantor($1)),
+                    (SELECT id FROM mz_catalog.mz_roles WHERE oid = mz_internal.aclitem_grantor($1)),
                     (SELECT array_to_string(mz_internal.mz_format_privileges(mz_internal.aclitem_privileges($1)), ','))
                 )
             )")


### PR DESCRIPTION
Clearly these aren't necessary, but seems good to follow convention. Maybe one day we can enforce this, and having them in place will help that.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a