### PR TITLE
sql: restrict variadic left join lowering #26707

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1238,6 +1238,17 @@ steps:
               composition: rqg
               args: ["banking", "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: rqg-left-join-stacks
+        label: "RQG left join stacks workload"
+        depends_on: build-aarch64
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-aarch64-small
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: rqg
+              args: ["left-join-stacks", "--seed=$BUILDKITE_JOB_ID"]
+
   - id: crdb-restarts
     label: "CRDB rolling restarts"
     depends_on: build-aarch64

--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -399,6 +399,19 @@ fn decompose_equations(predicate: &MirScalarExpr) -> Option<Vec<(usize, usize)>>
             _ => return None,
         }
     }
+
+    // Remove duplicates
+    equations.sort();
+    equations.dedup();
+
+    // Ensure that every rhs column c2 appears only once. Otherwise, we have at
+    // least two lhs columns c1 and c1' that are rendered equal by the same c2
+    // column. The VOJ lowering will then produce a plan that will incorrectly
+    // push down a local filter c1 = c1' to the lhs (see #26707).
+    if equations.iter().duplicates_by(|(_, c)| c).next().is_some() {
+        return None;
+    }
+
     Some(equations)
 }
 

--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -242,6 +242,8 @@ pub(crate) fn attempt_left_join_magic(
                         .iter()
                         .map(|(_, r)| MirScalarExpr::column(r - oa - ba).call_is_null().not()),
                 )
+                // Retain only the keys referenced on the right side of the LEFT
+                // JOIN equations.
                 .project(
                     equations
                         .iter()
@@ -263,11 +265,19 @@ pub(crate) fn attempt_left_join_magic(
                 .project({
                     // By default, we'll place post-pended nulls in each location.
                     // We will overwrite this with instructions to find augmenting values.
+
+                    // Start with a projection that retains the last |rt|
+                    // columns corresponding to the NULLs from the above
+                    // .map(...) call.
                     let mut projection =
                         (equations.len()..equations.len() + rt.len()).collect::<Vec<_>>();
+                    // Replace NULLs columns corresponding to rhs columns
+                    // referenced in an ON equation with the actual rhs value
+                    // (located at `index`).
                     for (index, (_, right)) in equations.iter().enumerate() {
                         projection[*right - oa - ba] = index;
                     }
+
                     projection
                 });
 

--- a/test/rqg/Dockerfile
+++ b/test/rqg/Dockerfile
@@ -28,7 +28,7 @@ ADD https://api.github.com/repos/MaterializeInc/RQG/git/refs/heads/main version.
 
 RUN git clone --single-branch https://github.com/MaterializeInc/RQG.git \
     && cd RQG \
-    && git checkout d00f4c44c425782ea4485d26fcb6aa9bc5734de4
+    && git checkout 720346b8b8bea7329b443dcfdb72c8b0591eb6d2
 
 ENTRYPOINT ["/usr/bin/perl"]
 

--- a/test/rqg/datasets/star_schema.sql
+++ b/test/rqg/datasets/star_schema.sql
@@ -20,54 +20,52 @@ SET search_path = 'star';
 -- Fact table and data
 -- -------------------
 
-CREATE TABLE ft (k INT, v INT NOT NULL);
+CREATE TABLE ft (k INT, v INT NOT NULL, fk1 INT, fk2 INT);
 CREATE INDEX ft_i1 ON ft(k);
-CREATE INDEX ft_i2 ON ft(v, k);
-
 
 INSERT INTO ft VALUES
   -- one NULL row in ft
-  (NULL, 0),
-  -- 1 and 2 have 2 rows each in ft
-  (1, 1), (1, 1),
-  (2, 2), (2, 2),
-  (3, 3),
-  (4, 4),
-  -- mixed row for 5
-  (5, 5), (NULL, 5)
+  (NULL, 100, 1, 2),
+  -- 1-5 have one row each
+  (1, 101, 1, 2),
+  (2, 102, 2, 3),
+  (3, 103, 3, 4),
+  (4, 104, 4, 5),
+  (5, 105, 5, 6)
   -- 7 is not present in either table
   ;
 
 -- Dimension table and data (d1)
 -- -----------------------------
 
-CREATE TABLE d1 (k INT, v INT NOT NULL);
-CREATE INDEX d1_i1 ON d1(k);
-CREATE INDEX d1_i2 ON d1(v, k);
+CREATE TABLE d1 (pk1 INT, pk2 INT NOT NULL, v INT NOT NULL);
+CREATE INDEX d1_i1 ON d1(pk1, pk2);
 
 INSERT INTO d1 VALUES
-  (NULL, 0), (NULL, 0), -- two NULL rows in d1
+  (NULL, 0, 0),
+  (0, 0, 1),
   -- 1 not present in d1
-  (2, 2), (2, 2),
-  (3, 3),
+  (2, 3, 0), (3, 2, 1),
+  (3, 4, 0),
   -- 4 has no rows in d1
-  (5, 5),
-  (6, 6)
+  (5, 6, 0),
+  (6, 7, 0)
   -- 7 is not present in either table
   ;
 
 -- Dimension table and data (d2)
 -- -----------------------------
 
-CREATE TABLE d2 (k INT, v INT NOT NULL);
+CREATE TABLE d2 (pk1 INT, pk2 INT NOT NULL, v INT NOT NULL);
+CREATE INDEX d2_i1 ON d2(pk1, pk2);
 
 INSERT INTO d2 VALUES
-  (NULL, 0),
+  (NULL, 0, 0),
   -- 1 not present in d2
-  (2, 2),
-  (3, 3), (3, 3),
-  (4, 4),
-  (NULL, 5)
+  (2, 3, 0),
+  (3, 4, 0), (4, 3, 1),
+  (4, 5, 0),
+  (NULL, 5, 0)
   -- 6 has no rows in d2
   -- 7 is not present in either table
   ;
@@ -75,17 +73,17 @@ INSERT INTO d2 VALUES
 -- Dimension table and data (d3)
 -- -----------------------------
 
-CREATE TABLE d3 (k INT, v INT NOT NULL);
-CREATE INDEX d3_i1 ON d3(k);
+CREATE TABLE d3 (pk1 INT, pk2 INT NOT NULL, v INT NOT NULL);
+CREATE INDEX d3_i1 ON d3(pk1, pk2);
 
 INSERT INTO d3 VALUES
-  (NULL, 0),
+  (0, 0, 1),
   -- 1 not present in d3
-  (NULL, 2),
-  (3, 3), (3, 3),
+  (NULL, 2, 0),
+  (3, 4, 0), (4, 3, 1),
   -- 4 has no rows in d3
-  (5, 5),
-  (6, 6), (6, 6)
+  (5, 6, 0),
+  (6, 7, 0), (7, 6, 1)
   -- 7 is not present in either table
   ;
 
@@ -93,13 +91,13 @@ INSERT INTO d3 VALUES
 -- ---------------------
 
 CREATE MATERIALIZED VIEW ft_pk AS
-SELECT DISTINCT ON (k) k, v FROM ft WHERE k IS NOT NULL;
+SELECT DISTINCT ON (k) k, v FROM ft;
 
 CREATE MATERIALIZED VIEW d1_pk AS
-SELECT DISTINCT ON (k) k, v FROM d1 WHERE k IS NOT NULL;
+SELECT DISTINCT ON (pk1, pk2) pk1, pk2, v FROM d1;
 
 CREATE MATERIALIZED VIEW d2_pk AS
-SELECT DISTINCT ON (k) k, v FROM d2 WHERE k IS NOT NULL;
+SELECT DISTINCT ON (pk1, pk2) pk1, pk2, v FROM d2;
 
 CREATE MATERIALIZED VIEW d3_pk AS
-SELECT DISTINCT ON (k) k, v FROM d3 WHERE k IS NOT NULL;
+SELECT DISTINCT ON (pk1, pk2) pk1, pk2, v FROM d3;

--- a/test/rqg/datasets/star_schema.sql
+++ b/test/rqg/datasets/star_schema.sql
@@ -1,0 +1,105 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+-- Table definitions for a very simple star schema (one dimension and one fact table).
+
+-- Reset schema
+-- ------------
+
+DROP SCHEMA IF EXISTS star CASCADE;
+CREATE SCHEMA star;
+
+SET search_path = 'star';
+
+-- Fact table and data
+-- -------------------
+
+CREATE TABLE ft (k INT, v INT NOT NULL);
+CREATE INDEX ft_i1 ON ft(k);
+CREATE INDEX ft_i2 ON ft(v, k);
+
+
+INSERT INTO ft VALUES
+  -- one NULL row in ft
+  (NULL, 0),
+  -- 1 and 2 have 2 rows each in ft
+  (1, 1), (1, 1),
+  (2, 2), (2, 2),
+  (3, 3),
+  (4, 4),
+  -- mixed row for 5
+  (5, 5), (NULL, 5)
+  -- 7 is not present in either table
+  ;
+
+-- Dimension table and data (d1)
+-- -----------------------------
+
+CREATE TABLE d1 (k INT, v INT NOT NULL);
+CREATE INDEX d1_i1 ON d1(k);
+CREATE INDEX d1_i2 ON d1(v, k);
+
+INSERT INTO d1 VALUES
+  (NULL, 0), (NULL, 0), -- two NULL rows in d1
+  -- 1 not present in d1
+  (2, 2), (2, 2),
+  (3, 3),
+  -- 4 has no rows in d1
+  (5, 5),
+  (6, 6)
+  -- 7 is not present in either table
+  ;
+
+-- Dimension table and data (d2)
+-- -----------------------------
+
+CREATE TABLE d2 (k INT, v INT NOT NULL);
+
+INSERT INTO d2 VALUES
+  (NULL, 0),
+  -- 1 not present in d2
+  (2, 2),
+  (3, 3), (3, 3),
+  (4, 4),
+  (NULL, 5)
+  -- 6 has no rows in d2
+  -- 7 is not present in either table
+  ;
+
+-- Dimension table and data (d3)
+-- -----------------------------
+
+CREATE TABLE d3 (k INT, v INT NOT NULL);
+CREATE INDEX d3_i1 ON d3(k);
+
+INSERT INTO d3 VALUES
+  (NULL, 0),
+  -- 1 not present in d3
+  (NULL, 2),
+  (3, 3), (3, 3),
+  -- 4 has no rows in d3
+  (5, 5),
+  (6, 6), (6, 6)
+  -- 7 is not present in either table
+  ;
+
+-- PK materialized views
+-- ---------------------
+
+CREATE MATERIALIZED VIEW ft_pk AS
+SELECT DISTINCT ON (k) k, v FROM ft WHERE k IS NOT NULL;
+
+CREATE MATERIALIZED VIEW d1_pk AS
+SELECT DISTINCT ON (k) k, v FROM d1 WHERE k IS NOT NULL;
+
+CREATE MATERIALIZED VIEW d2_pk AS
+SELECT DISTINCT ON (k) k, v FROM d2 WHERE k IS NOT NULL;
+
+CREATE MATERIALIZED VIEW d3_pk AS
+SELECT DISTINCT ON (k) k, v FROM d3 WHERE k IS NOT NULL;

--- a/test/rqg/grammars/left_join_stacks.yy
+++ b/test/rqg/grammars/left_join_stacks.yy
@@ -66,80 +66,80 @@ table_name:
 left_join1:
   # Join against ft:
     LEFT JOIN table_name AS d1 ON( ft.col_name = d1.col_name )
-  | LEFT JOIN table_name AS d1 ON( ft.k = d1.k AND ft.v = d1.v )
+  | LEFT JOIN table_name AS d1 ON( ft.col_name = d1.col_name AND ft.col_name = d1.col_name )
 ;
 
 left_join2:
   # Join against ft:
     LEFT JOIN table_name AS d2 ON( ft.col_name = d2.col_name )
-  | LEFT JOIN table_name AS d2 ON( ft.k = d2.k AND ft.v = d2.v )
+  | LEFT JOIN table_name AS d2 ON( ft.col_name = d2.col_name AND ft.col_name = d2.col_name )
   # Join against d1:
   | LEFT JOIN table_name AS d2 ON( d1.col_name = d2.col_name )
-  | LEFT JOIN table_name AS d2 ON( d1.k = d2.k AND d1.v = d2.v )
+  | LEFT JOIN table_name AS d2 ON( d1.col_name = d2.col_name AND d1.col_name = d2.col_name )
 ;
 
 left_join3:
   # Join against ft:
     LEFT JOIN table_name AS d3 ON( ft.col_name = d3.col_name )
-  | LEFT JOIN table_name AS d3 ON( ft.k = d3.k AND ft.v = d3.v )
+  | LEFT JOIN table_name AS d3 ON( ft.col_name = d3.col_name AND ft.col_name = d3.col_name )
   # Join against d1:
   | LEFT JOIN table_name AS d3 ON( d1.col_name = d3.col_name )
-  | LEFT JOIN table_name AS d3 ON( d1.k = d3.k AND d1.v = d3.v )
+  | LEFT JOIN table_name AS d3 ON( d1.col_name = d3.col_name AND d1.col_name = d3.col_name )
   # Join against d2:
   | LEFT JOIN table_name AS d3 ON( d2.col_name = d3.col_name )
-  | LEFT JOIN table_name AS d3 ON( d2.k = d3.k AND d2.v = d3.v )
+  | LEFT JOIN table_name AS d3 ON( d2.col_name = d3.col_name AND d2.col_name = d3.col_name )
 ;
 
 left_join4:
   # Join against ft:
     LEFT JOIN table_name AS d4 ON( ft.col_name = d4.col_name )
-  | LEFT JOIN table_name AS d4 ON( ft.k = d4.k AND ft.v = d4.v )
+  | LEFT JOIN table_name AS d4 ON( ft.col_name = d4.col_name AND ft.col_name = d4.col_name )
   # Join against d1:
   | LEFT JOIN table_name AS d4 ON( d1.col_name = d4.col_name )
-  | LEFT JOIN table_name AS d4 ON( d1.k = d4.k AND d1.v = d4.v )
+  | LEFT JOIN table_name AS d4 ON( d1.col_name = d4.col_name AND d1.col_name = d4.col_name )
   # Join against d2:
   | LEFT JOIN table_name AS d4 ON( d2.col_name = d4.col_name )
-  | LEFT JOIN table_name AS d4 ON( d2.k = d4.k AND d2.v = d4.v )
+  | LEFT JOIN table_name AS d4 ON( d2.col_name = d4.col_name AND d2.col_name = d4.col_name )
   # Join against d3:
   | LEFT JOIN table_name AS d4 ON( d3.col_name = d4.col_name )
-  | LEFT JOIN table_name AS d4 ON( d3.k = d4.k AND d3.v = d4.v )
+  | LEFT JOIN table_name AS d4 ON( d3.col_name = d4.col_name AND d3.col_name = d4.col_name )
 ;
 
 left_join5:
   # Join against ft:
     LEFT JOIN table_name AS d5 ON( ft.col_name = d5.col_name )
-  | LEFT JOIN table_name AS d5 ON( ft.k = d5.k AND ft.v = d5.v )
+  | LEFT JOIN table_name AS d5 ON( ft.col_name = d5.col_name AND ft.col_name = d5.col_name )
   # Join against d1:
   | LEFT JOIN table_name AS d5 ON( d1.col_name = d5.col_name )
-  | LEFT JOIN table_name AS d5 ON( d1.k = d5.k AND d1.v = d5.v )
+  | LEFT JOIN table_name AS d5 ON( d1.col_name = d5.col_name AND d1.col_name = d5.col_name )
   # Join against d2:
   | LEFT JOIN table_name AS d5 ON( d2.col_name = d5.col_name )
-  | LEFT JOIN table_name AS d5 ON( d2.k = d5.k AND d2.v = d5.v )
+  | LEFT JOIN table_name AS d5 ON( d2.col_name = d5.col_name AND d2.col_name = d5.col_name )
   # Join against d3:
   | LEFT JOIN table_name AS d5 ON( d3.col_name = d5.col_name )
-  | LEFT JOIN table_name AS d5 ON( d3.k = d5.k AND d3.v = d5.v )
+  | LEFT JOIN table_name AS d5 ON( d3.col_name = d5.col_name AND d3.col_name = d5.col_name )
   # Join against d4:
   | LEFT JOIN table_name AS d5 ON( d4.col_name = d5.col_name )
-  | LEFT JOIN table_name AS d5 ON( d4.k = d5.k AND d4.v = d5.v )
+  | LEFT JOIN table_name AS d5 ON( d4.col_name = d5.col_name AND d4.col_name = d5.col_name )
 ;
 
 left_join6:
   # Join against ft:
     LEFT JOIN table_name AS d6 ON( ft.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( ft.k = d6.k AND ft.v = d6.v )
+  | LEFT JOIN table_name AS d6 ON( ft.col_name = d6.col_name AND ft.col_name = d6.col_name )
   # Join against d1:
   | LEFT JOIN table_name AS d6 ON( d1.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( d1.k = d6.k AND d1.v = d6.v )
+  | LEFT JOIN table_name AS d6 ON( d1.col_name = d6.col_name AND d1.col_name = d6.col_name )
   # Join against d2:
   | LEFT JOIN table_name AS d6 ON( d2.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( d2.k = d6.k AND d2.v = d6.v )
+  | LEFT JOIN table_name AS d6 ON( d2.col_name = d6.col_name AND d2.col_name = d6.col_name )
   # Join against d3:
   | LEFT JOIN table_name AS d6 ON( d3.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( d3.k = d6.k AND d3.v = d6.v )
+  | LEFT JOIN table_name AS d6 ON( d3.col_name = d6.col_name AND d3.col_name = d6.col_name )
   # Join against d4:
   | LEFT JOIN table_name AS d6 ON( d4.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( d4.k = d6.k AND d4.v = d6.v )
+  | LEFT JOIN table_name AS d6 ON( d4.col_name = d6.col_name AND d4.col_name = d6.col_name )
   # Join against d5:
   | LEFT JOIN table_name AS d6 ON( d5.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( d5.k = d6.k AND d5.v = d6.v )
+  | LEFT JOIN table_name AS d6 ON( d5.col_name = d6.col_name AND d5.col_name = d6.col_name )
 ;

--- a/test/rqg/grammars/left_join_stacks.yy
+++ b/test/rqg/grammars/left_join_stacks.yy
@@ -1,0 +1,145 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+explain:
+  EXPLAIN query
+;
+
+query:
+  select
+;
+
+select:
+  SELECT
+    select_table_alias.col_name AS c01,
+    select_table_alias.col_name AS c02,
+    select_table_alias.col_name AS c03,
+    select_table_alias.col_name AS c04,
+    select_table_alias.col_name AS c05,
+    select_table_alias.col_name AS c06,
+    select_table_alias.col_name AS c07,
+    select_table_alias.col_name AS c08,
+    select_table_alias.col_name AS c09,
+    select_table_alias.col_name AS c10
+  FROM
+    star.ft
+    left_join1
+    left_join2
+    left_join3
+    left_join4
+    left_join5
+    left_join6
+  ORDER BY
+    c01, c02, c03, c04, c05, c06, c07, c08, c09, c10
+;
+
+select_table_alias:
+    ft
+  | d1
+  | d2
+  | d3
+  | d4
+  | d5
+  | d6
+;
+
+col_name:
+    k
+  | v
+;
+
+table_name:
+    star.d1
+  | star.d2
+  | star.d3
+  | star.d1_pk
+  | star.d2_pk
+  | star.d3_pk
+;
+
+left_join1:
+  # Join against ft:
+    LEFT JOIN table_name AS d1 ON( ft.col_name = d1.col_name )
+  | LEFT JOIN table_name AS d1 ON( ft.k = d1.k AND ft.v = d1.v )
+;
+
+left_join2:
+  # Join against ft:
+    LEFT JOIN table_name AS d2 ON( ft.col_name = d2.col_name )
+  | LEFT JOIN table_name AS d2 ON( ft.k = d2.k AND ft.v = d2.v )
+  # Join against d1:
+  | LEFT JOIN table_name AS d2 ON( d1.col_name = d2.col_name )
+  | LEFT JOIN table_name AS d2 ON( d1.k = d2.k AND d1.v = d2.v )
+;
+
+left_join3:
+  # Join against ft:
+    LEFT JOIN table_name AS d3 ON( ft.col_name = d3.col_name )
+  | LEFT JOIN table_name AS d3 ON( ft.k = d3.k AND ft.v = d3.v )
+  # Join against d1:
+  | LEFT JOIN table_name AS d3 ON( d1.col_name = d3.col_name )
+  | LEFT JOIN table_name AS d3 ON( d1.k = d3.k AND d1.v = d3.v )
+  # Join against d2:
+  | LEFT JOIN table_name AS d3 ON( d2.col_name = d3.col_name )
+  | LEFT JOIN table_name AS d3 ON( d2.k = d3.k AND d2.v = d3.v )
+;
+
+left_join4:
+  # Join against ft:
+    LEFT JOIN table_name AS d4 ON( ft.col_name = d4.col_name )
+  | LEFT JOIN table_name AS d4 ON( ft.k = d4.k AND ft.v = d4.v )
+  # Join against d1:
+  | LEFT JOIN table_name AS d4 ON( d1.col_name = d4.col_name )
+  | LEFT JOIN table_name AS d4 ON( d1.k = d4.k AND d1.v = d4.v )
+  # Join against d2:
+  | LEFT JOIN table_name AS d4 ON( d2.col_name = d4.col_name )
+  | LEFT JOIN table_name AS d4 ON( d2.k = d4.k AND d2.v = d4.v )
+  # Join against d3:
+  | LEFT JOIN table_name AS d4 ON( d3.col_name = d4.col_name )
+  | LEFT JOIN table_name AS d4 ON( d3.k = d4.k AND d3.v = d4.v )
+;
+
+left_join5:
+  # Join against ft:
+    LEFT JOIN table_name AS d5 ON( ft.col_name = d5.col_name )
+  | LEFT JOIN table_name AS d5 ON( ft.k = d5.k AND ft.v = d5.v )
+  # Join against d1:
+  | LEFT JOIN table_name AS d5 ON( d1.col_name = d5.col_name )
+  | LEFT JOIN table_name AS d5 ON( d1.k = d5.k AND d1.v = d5.v )
+  # Join against d2:
+  | LEFT JOIN table_name AS d5 ON( d2.col_name = d5.col_name )
+  | LEFT JOIN table_name AS d5 ON( d2.k = d5.k AND d2.v = d5.v )
+  # Join against d3:
+  | LEFT JOIN table_name AS d5 ON( d3.col_name = d5.col_name )
+  | LEFT JOIN table_name AS d5 ON( d3.k = d5.k AND d3.v = d5.v )
+  # Join against d4:
+  | LEFT JOIN table_name AS d5 ON( d4.col_name = d5.col_name )
+  | LEFT JOIN table_name AS d5 ON( d4.k = d5.k AND d4.v = d5.v )
+;
+
+left_join6:
+  # Join against ft:
+    LEFT JOIN table_name AS d6 ON( ft.col_name = d6.col_name )
+  | LEFT JOIN table_name AS d6 ON( ft.k = d6.k AND ft.v = d6.v )
+  # Join against d1:
+  | LEFT JOIN table_name AS d6 ON( d1.col_name = d6.col_name )
+  | LEFT JOIN table_name AS d6 ON( d1.k = d6.k AND d1.v = d6.v )
+  # Join against d2:
+  | LEFT JOIN table_name AS d6 ON( d2.col_name = d6.col_name )
+  | LEFT JOIN table_name AS d6 ON( d2.k = d6.k AND d2.v = d6.v )
+  # Join against d3:
+  | LEFT JOIN table_name AS d6 ON( d3.col_name = d6.col_name )
+  | LEFT JOIN table_name AS d6 ON( d3.k = d6.k AND d3.v = d6.v )
+  # Join against d4:
+  | LEFT JOIN table_name AS d6 ON( d4.col_name = d6.col_name )
+  | LEFT JOIN table_name AS d6 ON( d4.k = d6.k AND d4.v = d6.v )
+  # Join against d5:
+  | LEFT JOIN table_name AS d6 ON( d5.col_name = d6.col_name )
+  | LEFT JOIN table_name AS d6 ON( d5.k = d6.k AND d5.v = d6.v )
+;

--- a/test/rqg/grammars/left_join_stacks.yy
+++ b/test/rqg/grammars/left_join_stacks.yy
@@ -17,18 +17,18 @@ query:
 
 select:
   SELECT
-    select_table_alias.col_name AS c01,
-    select_table_alias.col_name AS c02,
-    select_table_alias.col_name AS c03,
-    select_table_alias.col_name AS c04,
-    select_table_alias.col_name AS c05,
-    select_table_alias.col_name AS c06,
-    select_table_alias.col_name AS c07,
-    select_table_alias.col_name AS c08,
-    select_table_alias.col_name AS c09,
-    select_table_alias.col_name AS c10
+    ft.ft_col AS c01,
+    ft.ft_col AS c02,
+    dim_alias.dx_col AS c03,
+    dim_alias.dx_col AS c04,
+    dim_alias.dx_col AS c05,
+    dim_alias.dx_col AS c06,
+    dim_alias.dx_col AS c07,
+    dim_alias.dx_col AS c08,
+    dim_alias.dx_col AS c09,
+    dim_alias.dx_col AS c10
   FROM
-    star.ft
+    star.ft as ft
     left_join1
     left_join2
     left_join3
@@ -39,9 +39,8 @@ select:
     c01, c02, c03, c04, c05, c06, c07, c08, c09, c10
 ;
 
-select_table_alias:
-    ft
-  | d1
+dim_alias:
+    d1
   | d2
   | d3
   | d4
@@ -49,12 +48,30 @@ select_table_alias:
   | d6
 ;
 
-col_name:
+ft_col:
     k
   | v
+  | fk1
+  | fk2
 ;
 
-table_name:
+dx_col:
+    v
+  | pk1
+  | pk2
+;
+
+fk_col:
+    fk1
+  | fk2
+;
+
+pk_col:
+    k1
+  | k2
+;
+
+dim_table:
     star.d1
   | star.d2
   | star.d3
@@ -65,81 +82,124 @@ table_name:
 
 left_join1:
   # Join against ft:
-    LEFT JOIN table_name AS d1 ON( ft.col_name = d1.col_name )
-  | LEFT JOIN table_name AS d1 ON( ft.col_name = d1.col_name AND ft.col_name = d1.col_name )
+    LEFT JOIN dim_table AS d1 ON( ft.fk1 = d1.pk1 )
+  | LEFT JOIN dim_table AS d1 ON( ft.fk1 = d1.pk1 AND ft.fk2 = d1.pk2 )
+  | LEFT JOIN dim_table AS d1 ON( ft.fk1 = d1.pk2 AND ft.fk2 = d1.pk1 )
+  | LEFT JOIN dim_table AS d1 ON( ft.fk1 = d1.pk1 AND ft.fk1 = d1.pk2 )
 ;
 
 left_join2:
   # Join against ft:
-    LEFT JOIN table_name AS d2 ON( ft.col_name = d2.col_name )
-  | LEFT JOIN table_name AS d2 ON( ft.col_name = d2.col_name AND ft.col_name = d2.col_name )
+    LEFT JOIN dim_table AS d2 ON( ft.fk1 = d2.pk1 )
+  | LEFT JOIN dim_table AS d2 ON( ft.fk1 = d2.pk1 AND ft.fk2 = d2.pk2 )
+  | LEFT JOIN dim_table AS d2 ON( ft.fk1 = d2.pk2 AND ft.fk2 = d2.pk1 )
+  | LEFT JOIN dim_table AS d2 ON( ft.fk1 = d2.pk1 AND ft.fk1 = d2.pk2 )
   # Join against d1:
-  | LEFT JOIN table_name AS d2 ON( d1.col_name = d2.col_name )
-  | LEFT JOIN table_name AS d2 ON( d1.col_name = d2.col_name AND d1.col_name = d2.col_name )
+  | LEFT JOIN dim_table AS d2 ON( d1.pk1 = d2.pk1 )
+  | LEFT JOIN dim_table AS d2 ON( d1.pk1 = d2.pk1 AND d1.pk2 = d2.pk2 )
+  | LEFT JOIN dim_table AS d2 ON( d1.pk1 = d2.pk2 AND d1.pk2 = d2.pk1 )
+  | LEFT JOIN dim_table AS d2 ON( d1.pk1 = d2.pk1 AND d1.pk1 = d2.pk2 )
 ;
 
 left_join3:
   # Join against ft:
-    LEFT JOIN table_name AS d3 ON( ft.col_name = d3.col_name )
-  | LEFT JOIN table_name AS d3 ON( ft.col_name = d3.col_name AND ft.col_name = d3.col_name )
+    LEFT JOIN dim_table AS d3 ON( ft.fk1 = d3.pk1 )
+  | LEFT JOIN dim_table AS d3 ON( ft.fk1 = d3.pk1 AND ft.fk2 = d3.pk2 )
+  | LEFT JOIN dim_table AS d3 ON( ft.fk1 = d3.pk2 AND ft.fk2 = d3.pk1 )
+  | LEFT JOIN dim_table AS d3 ON( ft.fk1 = d3.pk1 AND ft.fk1 = d3.pk2 )
+  | LEFT JOIN dim_table AS d3 ON( ft.fk1 = d3.pk1 AND ft.fk2 = d3.pk1 ) # VOJ lowering for this is excluded in #26709
   # Join against d1:
-  | LEFT JOIN table_name AS d3 ON( d1.col_name = d3.col_name )
-  | LEFT JOIN table_name AS d3 ON( d1.col_name = d3.col_name AND d1.col_name = d3.col_name )
+  | LEFT JOIN dim_table AS d3 ON( d1.pk1 = d3.pk1 )
+  | LEFT JOIN dim_table AS d3 ON( d1.pk1 = d3.pk1 AND d1.pk2 = d3.pk2 )
+  | LEFT JOIN dim_table AS d3 ON( d1.pk1 = d3.pk2 AND d1.pk2 = d3.pk1 )
+  | LEFT JOIN dim_table AS d3 ON( d1.pk1 = d3.pk1 AND d1.pk1 = d3.pk2 )
   # Join against d2:
-  | LEFT JOIN table_name AS d3 ON( d2.col_name = d3.col_name )
-  | LEFT JOIN table_name AS d3 ON( d2.col_name = d3.col_name AND d2.col_name = d3.col_name )
+  | LEFT JOIN dim_table AS d3 ON( d2.pk1 = d3.pk1 )
+  | LEFT JOIN dim_table AS d3 ON( d2.pk1 = d3.pk1 AND d2.pk2 = d3.pk2 )
+  | LEFT JOIN dim_table AS d3 ON( d2.pk1 = d3.pk2 AND d2.pk2 = d3.pk1 )
+  | LEFT JOIN dim_table AS d3 ON( d2.pk1 = d3.pk1 AND d2.pk1 = d3.pk2 )
 ;
 
 left_join4:
   # Join against ft:
-    LEFT JOIN table_name AS d4 ON( ft.col_name = d4.col_name )
-  | LEFT JOIN table_name AS d4 ON( ft.col_name = d4.col_name AND ft.col_name = d4.col_name )
+    LEFT JOIN dim_table AS d4 ON( ft.fk1 = d4.pk1 )
+  | LEFT JOIN dim_table AS d4 ON( ft.fk1 = d4.pk1 AND ft.fk2 = d4.pk2 )
+  | LEFT JOIN dim_table AS d4 ON( ft.fk1 = d4.pk2 AND ft.fk2 = d4.pk1 )
+  | LEFT JOIN dim_table AS d4 ON( ft.fk1 = d4.pk1 AND ft.fk1 = d4.pk2 )
   # Join against d1:
-  | LEFT JOIN table_name AS d4 ON( d1.col_name = d4.col_name )
-  | LEFT JOIN table_name AS d4 ON( d1.col_name = d4.col_name AND d1.col_name = d4.col_name )
+  | LEFT JOIN dim_table AS d4 ON( d1.pk1 = d4.pk1 )
+  | LEFT JOIN dim_table AS d4 ON( d1.pk1 = d4.pk1 AND d1.pk2 = d4.pk2 )
+  | LEFT JOIN dim_table AS d4 ON( d1.pk1 = d4.pk2 AND d1.pk2 = d4.pk1 )
+  | LEFT JOIN dim_table AS d4 ON( d1.pk1 = d4.pk1 AND d1.pk1 = d4.pk2 )
   # Join against d2:
-  | LEFT JOIN table_name AS d4 ON( d2.col_name = d4.col_name )
-  | LEFT JOIN table_name AS d4 ON( d2.col_name = d4.col_name AND d2.col_name = d4.col_name )
+  | LEFT JOIN dim_table AS d4 ON( d2.pk1 = d4.pk1 )
+  | LEFT JOIN dim_table AS d4 ON( d2.pk1 = d4.pk1 AND d2.pk2 = d4.pk2 )
+  | LEFT JOIN dim_table AS d4 ON( d2.pk1 = d4.pk2 AND d2.pk2 = d4.pk1 )
+  | LEFT JOIN dim_table AS d4 ON( d2.pk1 = d4.pk1 AND d2.pk1 = d4.pk2 )
   # Join against d3:
-  | LEFT JOIN table_name AS d4 ON( d3.col_name = d4.col_name )
-  | LEFT JOIN table_name AS d4 ON( d3.col_name = d4.col_name AND d3.col_name = d4.col_name )
+  | LEFT JOIN dim_table AS d4 ON( d3.pk1 = d4.pk1 )
+  | LEFT JOIN dim_table AS d4 ON( d3.pk1 = d4.pk1 AND d3.pk2 = d4.pk2 )
+  | LEFT JOIN dim_table AS d4 ON( d3.pk1 = d4.pk2 AND d3.pk2 = d4.pk1 )
+  | LEFT JOIN dim_table AS d4 ON( d3.pk1 = d4.pk1 AND d3.pk1 = d4.pk2 )
 ;
 
 left_join5:
   # Join against ft:
-    LEFT JOIN table_name AS d5 ON( ft.col_name = d5.col_name )
-  | LEFT JOIN table_name AS d5 ON( ft.col_name = d5.col_name AND ft.col_name = d5.col_name )
+    LEFT JOIN dim_table AS d5 ON( ft.fk1 = d5.pk1 )
+  | LEFT JOIN dim_table AS d5 ON( ft.fk1 = d5.pk1 AND ft.fk2 = d5.pk2 )
+  | LEFT JOIN dim_table AS d5 ON( ft.fk1 = d5.pk2 AND ft.fk2 = d5.pk1 )
+  | LEFT JOIN dim_table AS d5 ON( ft.fk1 = d5.pk1 AND ft.fk1 = d5.pk2 )
   # Join against d1:
-  | LEFT JOIN table_name AS d5 ON( d1.col_name = d5.col_name )
-  | LEFT JOIN table_name AS d5 ON( d1.col_name = d5.col_name AND d1.col_name = d5.col_name )
+  | LEFT JOIN dim_table AS d5 ON( d1.pk1 = d5.pk1 )
+  | LEFT JOIN dim_table AS d5 ON( d1.pk1 = d5.pk1 AND d1.pk2 = d5.pk2 )
+  | LEFT JOIN dim_table AS d5 ON( d1.pk1 = d5.pk2 AND d1.pk2 = d5.pk1 )
+  | LEFT JOIN dim_table AS d5 ON( d1.pk1 = d5.pk1 AND d1.pk1 = d5.pk2 )
   # Join against d2:
-  | LEFT JOIN table_name AS d5 ON( d2.col_name = d5.col_name )
-  | LEFT JOIN table_name AS d5 ON( d2.col_name = d5.col_name AND d2.col_name = d5.col_name )
+  | LEFT JOIN dim_table AS d5 ON( d2.pk1 = d5.pk1 )
+  | LEFT JOIN dim_table AS d5 ON( d2.pk1 = d5.pk1 AND d2.pk2 = d5.pk2 )
+  | LEFT JOIN dim_table AS d5 ON( d2.pk1 = d5.pk2 AND d2.pk2 = d5.pk1 )
+  | LEFT JOIN dim_table AS d5 ON( d2.pk1 = d5.pk1 AND d2.pk1 = d5.pk2 )
   # Join against d3:
-  | LEFT JOIN table_name AS d5 ON( d3.col_name = d5.col_name )
-  | LEFT JOIN table_name AS d5 ON( d3.col_name = d5.col_name AND d3.col_name = d5.col_name )
+  | LEFT JOIN dim_table AS d5 ON( d3.pk1 = d5.pk1 )
+  | LEFT JOIN dim_table AS d5 ON( d3.pk1 = d5.pk1 AND d3.pk2 = d5.pk2 )
+  | LEFT JOIN dim_table AS d5 ON( d3.pk1 = d5.pk2 AND d3.pk2 = d5.pk1 )
+  | LEFT JOIN dim_table AS d5 ON( d3.pk1 = d5.pk1 AND d3.pk1 = d5.pk2 )
   # Join against d4:
-  | LEFT JOIN table_name AS d5 ON( d4.col_name = d5.col_name )
-  | LEFT JOIN table_name AS d5 ON( d4.col_name = d5.col_name AND d4.col_name = d5.col_name )
+  | LEFT JOIN dim_table AS d5 ON( d4.pk1 = d5.pk1 )
+  | LEFT JOIN dim_table AS d5 ON( d4.pk1 = d5.pk1 AND d4.pk2 = d5.pk2 )
+  | LEFT JOIN dim_table AS d5 ON( d4.pk1 = d5.pk2 AND d4.pk2 = d5.pk1 )
+  | LEFT JOIN dim_table AS d5 ON( d4.pk1 = d5.pk1 AND d4.pk1 = d5.pk2 )
 ;
 
 left_join6:
   # Join against ft:
-    LEFT JOIN table_name AS d6 ON( ft.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( ft.col_name = d6.col_name AND ft.col_name = d6.col_name )
+    LEFT JOIN dim_table AS d6 ON( ft.fk1 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( ft.fk1 = d6.pk1 AND ft.fk2 = d6.pk2 )
+  | LEFT JOIN dim_table AS d6 ON( ft.fk1 = d6.pk2 AND ft.fk2 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( ft.fk1 = d6.pk1 AND ft.fk1 = d6.pk2 )
   # Join against d1:
-  | LEFT JOIN table_name AS d6 ON( d1.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( d1.col_name = d6.col_name AND d1.col_name = d6.col_name )
+  | LEFT JOIN dim_table AS d6 ON( d1.pk1 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( d1.pk1 = d6.pk1 AND d1.pk2 = d6.pk2 )
+  | LEFT JOIN dim_table AS d6 ON( d1.pk1 = d6.pk2 AND d1.pk2 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( d1.pk1 = d6.pk1 AND d1.pk1 = d6.pk2 )
   # Join against d2:
-  | LEFT JOIN table_name AS d6 ON( d2.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( d2.col_name = d6.col_name AND d2.col_name = d6.col_name )
+  | LEFT JOIN dim_table AS d6 ON( d2.pk1 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( d2.pk1 = d6.pk1 AND d2.pk2 = d6.pk2 )
+  | LEFT JOIN dim_table AS d6 ON( d2.pk1 = d6.pk2 AND d2.pk2 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( d2.pk1 = d6.pk1 AND d2.pk1 = d6.pk2 )
   # Join against d3:
-  | LEFT JOIN table_name AS d6 ON( d3.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( d3.col_name = d6.col_name AND d3.col_name = d6.col_name )
+  | LEFT JOIN dim_table AS d6 ON( d3.pk1 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( d3.pk1 = d6.pk1 AND d3.pk2 = d6.pk2 )
+  | LEFT JOIN dim_table AS d6 ON( d3.pk1 = d6.pk2 AND d3.pk2 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( d3.pk1 = d6.pk1 AND d3.pk1 = d6.pk2 )
   # Join against d4:
-  | LEFT JOIN table_name AS d6 ON( d4.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( d4.col_name = d6.col_name AND d4.col_name = d6.col_name )
+  | LEFT JOIN dim_table AS d6 ON( d4.pk1 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( d4.pk1 = d6.pk1 AND d4.pk2 = d6.pk2 )
+  | LEFT JOIN dim_table AS d6 ON( d4.pk1 = d6.pk2 AND d4.pk2 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( d4.pk1 = d6.pk1 AND d4.pk1 = d6.pk2 )
   # Join against d5:
-  | LEFT JOIN table_name AS d6 ON( d5.col_name = d6.col_name )
-  | LEFT JOIN table_name AS d6 ON( d5.col_name = d6.col_name AND d5.col_name = d6.col_name )
+  | LEFT JOIN dim_table AS d6 ON( d5.pk1 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( d5.pk1 = d6.pk1 AND d5.pk2 = d6.pk2 )
+  | LEFT JOIN dim_table AS d6 ON( d5.pk1 = d6.pk2 AND d5.pk2 = d6.pk1 )
+  | LEFT JOIN dim_table AS d6 ON( d5.pk1 = d6.pk1 AND d5.pk1 = d6.pk2 )
 ;

--- a/test/sqllogictest/github-26707.slt
+++ b/test/sqllogictest/github-26707.slt
@@ -1,0 +1,102 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for #26707.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_variadic_left_join_lowering TO true;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE ft(k INT, v INT NOT NULL);
+
+statement ok
+CREATE TABLE dt(k INT, v INT NOT NULL);
+
+statement ok
+INSERT INTO ft VALUES
+  -- one NULL row in ft
+  (NULL, 0),
+  (1, 1),
+  (2, 2),
+  (3, 3),
+  (4, 4),
+  -- mixed row for 5
+  (5, 5)
+  -- 7 is not present in either table
+  ;
+
+statement ok
+INSERT INTO dt VALUES
+  (NULL, 0),
+  -- 1 not present in dt
+  (2, 2),
+  (3, 3),
+  (4, 4),
+  (NULL, 5)
+  -- 6 not present in dt
+  -- 7 is not present in either table
+  ;
+
+# The predicate on d1: (ft.k = d1.k AND ft.v = d1.k) implies a local predicate
+# on fk: (ft.k = ft.v). However, we should not filter out fk rows where this
+# predicate does not hold.
+#
+# At the moment, we `variadic_left::attempt_left_join_magic` just bails in such
+# cases.
+query IIIIII rowsort
+SELECT
+  ft.k AS ft_k,
+  ft.v AS ft_v,
+  d1.k AS d1_k,
+  d1.v AS d1_v,
+  d2.k AS d2_k,
+  d2.v AS d2_v
+FROM
+  ft
+  LEFT JOIN dt AS d1 ON (ft.k = d1.k AND ft.v = d1.k)
+  LEFT JOIN dt AS d2 ON (ft.k = d2.v);
+----
+1
+1
+NULL
+NULL
+NULL
+NULL
+2
+2
+2
+2
+2
+2
+3
+3
+3
+3
+3
+3
+4
+4
+4
+4
+4
+4
+5
+5
+NULL
+NULL
+NULL
+5
+NULL
+0
+NULL
+NULL
+NULL
+NULL


### PR DESCRIPTION
This is a fix for #26707 that works by further restricting the set of supported `ON` predicates. In particular, we skip variadic left join lowering for predicates of the form `lhs.x  = rhs.z AND lhs.y = rhs.z` which imply `x = y`.

### Motivation

  * This PR fixes a recognized bug.

Fixes #26707.

### Tips for reviewer

The fix is in the following commit

* sql: prevent `variadic_left` from pushing incorrect lhs filters

The first commit adds some more comments to `variadic_left.rs`, and the remaining commits add `*.slt` and `*.rqg` tests (those have been reviewed by @def- already).

To validate a proposed fix, run

```bash
RUST_BACKTRACE=full bin/sqllogictest -- test/sqllogictest/github-26707.slt
```

and

```bash
bin/mzcompose --find rqg run default left-join-stacks --queries 1000 --duration 3600
```

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
