### PR TITLE
Update to latest timely and differential

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,7 +1793,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#448e158aa9ff9f944eabb3a0a87d9801513251a6"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#07ed40c3c44e6fc43efa5decdaa6e57ba9ce7fac"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1849,7 +1849,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#448e158aa9ff9f944eabb3a0a87d9801513251a6"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#07ed40c3c44e6fc43efa5decdaa6e57ba9ce7fac"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -2207,6 +2207,17 @@ name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
+name = "flatcontainer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c781a27f1f232edc758a11be8eb2e391831fd4a264d6b954b7e7c3ed802758"
+dependencies = [
+ "cfg-if",
+ "paste",
+ "serde",
+]
 
 [[package]]
 name = "flate2"
@@ -8943,7 +8954,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#46b28dc48bf5ed26dc0a0d5dbbd53c7964526f27"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#dfb4721ac698a3a26dcecf7826d8a3f4fd23952f"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -8960,12 +8971,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#46b28dc48bf5ed26dc0a0d5dbbd53c7964526f27"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#dfb4721ac698a3a26dcecf7826d8a3f4fd23952f"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#46b28dc48bf5ed26dc0a0d5dbbd53c7964526f27"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#dfb4721ac698a3a26dcecf7826d8a3f4fd23952f"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -8981,16 +8992,17 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#46b28dc48bf5ed26dc0a0d5dbbd53c7964526f27"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#dfb4721ac698a3a26dcecf7826d8a3f4fd23952f"
 dependencies = [
  "columnation",
+ "flatcontainer",
  "serde",
 ]
 
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/timely-dataflow.git#46b28dc48bf5ed26dc0a0d5dbbd53c7964526f27"
+source = "git+https://github.com/MaterializeInc/timely-dataflow.git#dfb4721ac698a3a26dcecf7826d8a3f4fd23952f"
 
 [[package]]
 name = "tiny-keccak"

--- a/clippy.toml
+++ b/clippy.toml
@@ -57,6 +57,7 @@ disallowed-methods = [
     { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange", reason = "use the `MzArrange::mz_arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange_named", reason = "use the `MzArrange::mz_arrange_named` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::Arrange::arrange_core", reason = "use the `MzArrange::mz_arrange_core` function instead" },
+    { path = "differential_dataflow::operators::arrange::arrangement::arrange_core", reason = "use the `MzArrange::mz_arrange_core` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::Arranged::reduce_abelian", reason = "use the `MzArrange::mz_arrange_core` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::Arranged::reduce_core", reason = "use the `MzArrange::mz_arrange_core` function instead" },
     { path = "differential_dataflow::operators::arrange::arrangement::ArrangeByKey::arrange_by_key", reason = "use the `MzArrange::mz_arrange_named` function instead" },

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -69,7 +69,7 @@ notes = "Reads and writes files under a prefix controlled by the caller."
 [[audits.differential-dataflow]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:448e158aa9ff9f944eabb3a0a87d9801513251a6"
+version = "0.12.0@git:07ed40c3c44e6fc43efa5decdaa6e57ba9ce7fac"
 
 [[audits.domain]]
 who = "Matt Jibson <matt.jibson@gmail.com>"
@@ -295,22 +295,22 @@ delta = "3.8.0 -> 3.8.1"
 [[audits.timely]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:46b28dc48bf5ed26dc0a0d5dbbd53c7964526f27"
+version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f""
 
 [[audits.timely_bytes]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:46b28dc48bf5ed26dc0a0d5dbbd53c7964526f27"
+version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f""
 
 [[audits.timely_communication]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:46b28dc48bf5ed26dc0a0d5dbbd53c7964526f27"
+version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f""
 
 [[audits.timely_logging]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:46b28dc48bf5ed26dc0a0d5dbbd53c7964526f27"
+version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f""
 
 [[audits.tokio-postgres]]
 who = "Roshan Jobanputra <roshan@materialize.com>"

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -92,6 +92,11 @@ who = "Sean Loiselle <sean@materialize.io>"
 criteria = "safe-to-deploy"
 version = "0.3.26"
 
+[[audits.flatcontainer]]
+who = "Moritz Hoffmann <mh@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
 [[audits.funty]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
@@ -295,22 +300,22 @@ delta = "3.8.0 -> 3.8.1"
 [[audits.timely]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f""
+version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f"
 
 [[audits.timely_bytes]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f""
+version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f"
 
 [[audits.timely_communication]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f""
+version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f"
 
 [[audits.timely_logging]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f""
+version = "0.12.0@git:dfb4721ac698a3a26dcecf7826d8a3f4fd23952f"
 
 [[audits.tokio-postgres]]
 who = "Roshan Jobanputra <roshan@materialize.com>"

--- a/src/compute/src/extensions/reduce.rs
+++ b/src/compute/src/extensions/reduce.rs
@@ -34,8 +34,7 @@ where
         T2::ValOwned: Data,
         T2::Diff: Abelian,
         T2::Batch: Batch,
-        T2::Builder:
-            Builder<Output = T2::Batch, Item = ((T1::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
+        T2::Builder: Builder<Input = ((T1::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
         L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(T2::ValOwned, T2::Diff)>)
             + 'static,
         Arranged<G, TraceAgent<T2>>: ArrangementSize;
@@ -55,8 +54,7 @@ where
         T2::ValOwned: Data,
         T2::Diff: Abelian,
         T2::Batch: Batch,
-        T2::Builder:
-            Builder<Output = T2::Batch, Item = ((T1::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
+        T2::Builder: Builder<Input = ((T1::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
         L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(T2::ValOwned, T2::Diff)>)
             + 'static,
         Arranged<G, TraceAgent<T2>>: ArrangementSize,
@@ -92,8 +90,7 @@ where
         T1::ValOwned: Data,
         T1::Diff: Abelian,
         T1::Batch: Batch,
-        T1::Builder:
-            Builder<Output = T1::Batch, Item = ((T1::KeyOwned, T1::ValOwned), T1::Time, T1::Diff)>,
+        T1::Builder: Builder<Input = ((T1::KeyOwned, T1::ValOwned), T1::Time, T1::Diff)>,
         L1: FnMut(Tr::Key<'_>, &[(Tr::Val<'_>, Tr::Diff)], &mut Vec<(T1::ValOwned, T1::Diff)>)
             + 'static,
         T2: Trace
@@ -102,8 +99,7 @@ where
         T2::ValOwned: Data,
         T2::Diff: Abelian,
         T2::Batch: Batch,
-        T2::Builder:
-            Builder<Output = T2::Batch, Item = ((T2::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
+        T2::Builder: Builder<Input = ((T2::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
         L2: FnMut(Tr::Key<'_>, &[(Tr::Val<'_>, Tr::Diff)], &mut Vec<(T2::ValOwned, T2::Diff)>)
             + 'static,
         Arranged<G, TraceAgent<T1>>: ArrangementSize,
@@ -130,8 +126,7 @@ where
         T1::ValOwned: Data,
         T1::Diff: Abelian,
         T1::Batch: Batch,
-        T1::Builder:
-            Builder<Output = T1::Batch, Item = ((T1::KeyOwned, T1::ValOwned), T1::Time, T1::Diff)>,
+        T1::Builder: Builder<Input = ((T1::KeyOwned, T1::ValOwned), T1::Time, T1::Diff)>,
         L1: FnMut(Tr::Key<'_>, &[(Tr::Val<'_>, Tr::Diff)], &mut Vec<(T1::ValOwned, T1::Diff)>)
             + 'static,
         T2: Trace
@@ -140,8 +135,7 @@ where
         T2::ValOwned: Data,
         T2::Diff: Abelian,
         T2::Batch: Batch,
-        T2::Builder:
-            Builder<Output = T2::Batch, Item = ((T2::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
+        T2::Builder: Builder<Input = ((T2::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
         L2: FnMut(Tr::Key<'_>, &[(Tr::Val<'_>, Tr::Diff)], &mut Vec<(T2::ValOwned, T2::Diff)>)
             + 'static,
         Arranged<G, TraceAgent<T1>>: ArrangementSize,

--- a/src/compute/src/logging.rs
+++ b/src/compute/src/logging.rs
@@ -37,7 +37,7 @@ pub use crate::logging::initialize::initialize;
 /// Logs events as a timely stream, with progress statements.
 struct BatchLogger<T, E, P>
 where
-    P: EventPusher<Timestamp, (Duration, E, T)>,
+    P: EventPusher<Timestamp, Vec<(Duration, E, T)>>,
 {
     /// Time in milliseconds of the current expressed capability.
     time_ms: Timestamp,
@@ -53,7 +53,7 @@ where
 
 impl<T, E, P> BatchLogger<T, E, P>
 where
-    P: EventPusher<Timestamp, (Duration, E, T)>,
+    P: EventPusher<Timestamp, Vec<(Duration, E, T)>>,
 {
     /// Batch size in bytes for batches
     const BATCH_SIZE_BYTES: usize = 1 << 13;
@@ -121,7 +121,7 @@ where
 }
 impl<T, E, P> Drop for BatchLogger<T, E, P>
 where
-    P: EventPusher<Timestamp, (Duration, E, T)>,
+    P: EventPusher<Timestamp, Vec<(Duration, E, T)>>,
 {
     fn drop(&mut self) {
         self.event_pusher
@@ -135,7 +135,7 @@ where
 /// initialization code more convenient.
 #[derive(Clone)]
 struct EventQueue<E> {
-    link: Rc<EventLink<Timestamp, (Duration, WorkerIdentifier, E)>>,
+    link: Rc<EventLink<Timestamp, Vec<(Duration, WorkerIdentifier, E)>>>,
     activator: RcActivator,
 }
 

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -472,7 +472,7 @@ struct ArrangementSizeState {
 }
 
 type Update<D> = (D, Timestamp, Diff);
-type Pusher<D> = Counter<Timestamp, Update<D>, Tee<Timestamp, Update<D>>>;
+type Pusher<D> = Counter<Timestamp, Vec<Update<D>>, Tee<Timestamp, Vec<Update<D>>>>;
 type OutputSession<'a, D> = Session<'a, Timestamp, Vec<Update<D>>, Pusher<D>>;
 
 /// Bundled output sessions used by the demux operator.

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -187,7 +187,7 @@ pub(super) fn construct<A: Allocate>(
     })
 }
 
-type Pusher<D> = Tee<Timestamp, (D, Timestamp, Diff)>;
+type Pusher<D> = Tee<Timestamp, Vec<(D, Timestamp, Diff)>>;
 type OutputBuffer<'a, 'b, D> = ConsolidateBuffer<'a, 'b, Timestamp, D, Diff, Pusher<D>>;
 
 /// Bundled output buffers used by the demux operator.

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -352,7 +352,7 @@ struct MessageCount {
     records: i64,
 }
 
-type Pusher<D> = Tee<Timestamp, (D, Timestamp, Diff)>;
+type Pusher<D> = Tee<Timestamp, Vec<(D, Timestamp, Diff)>>;
 type OutputBuffer<'a, 'b, D> = ConsolidateBuffer<'a, 'b, Timestamp, D, Diff, Pusher<D>>;
 
 /// Bundled output buffers used by the demux operator.

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -615,7 +615,7 @@ where
         Tr1::ValOwned: Columnation + ExchangeData,
         Tr2: Trace + TraceReader<Time = G::Timestamp, Diff = Diff> + 'static,
         Tr2::Batch: Batch,
-        Tr2::Batcher: Batcher<Item = ((Tr1::KeyOwned, Tr1::ValOwned), G::Timestamp, Diff)>,
+        Tr2::Batcher: Batcher<Input = Vec<((Tr1::KeyOwned, Tr1::ValOwned), G::Timestamp, Diff)>>,
         Arranged<G, TraceAgent<Tr2>>: ArrangementSize,
     {
         use differential_dataflow::trace::cursor::MyTrait;

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -1068,7 +1068,7 @@ where
             '_,
             C::Time,
             I::Item,
-            timely::dataflow::channels::pushers::Tee<C::Time, I::Item>,
+            timely::dataflow::channels::pushers::Tee<C::Time, Vec<I::Item>>,
         >,
     ) where
         I: IntoIterator,

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -123,8 +123,13 @@ fn drain_through_mfp<T>(
     extensions: &[(Row, Diff)],
     mfp_plan: &MfpPlan,
     until: &Antichain<Timestamp>,
-    ok_output: &mut ConsolidateBuffer<T, Row, Diff, Tee<T, (Row, T, Diff)>>,
-    err_output: &mut ConsolidateBuffer<T, DataflowError, Diff, Tee<T, (DataflowError, T, Diff)>>,
+    ok_output: &mut ConsolidateBuffer<T, Row, Diff, Tee<T, Vec<(Row, T, Diff)>>>,
+    err_output: &mut ConsolidateBuffer<
+        T,
+        DataflowError,
+        Diff,
+        Tee<T, Vec<(DataflowError, T, Diff)>>,
+    >,
 ) where
     T: crate::render::RenderTimestamp,
 {

--- a/src/compute/src/render/join/mz_join_core.rs
+++ b/src/compute/src/render/join/mz_join_core.rs
@@ -584,7 +584,7 @@ where
     /// Process keys until at least `fuel` output tuples produced, or the work is exhausted.
     fn work<L, I, YFn>(
         &mut self,
-        output: &mut OutputHandle<T, (D, T, Diff), Tee<T, (D, T, Diff)>>,
+        output: &mut OutputHandle<T, (D, T, Diff), Tee<T, Vec<(D, T, Diff)>>>,
         mut result: L,
         yield_fn: YFn,
         work: &mut usize,

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -20,7 +20,7 @@ use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::trace::cursor::MyTrait;
-use differential_dataflow::trace::{Batch, Batcher, Trace, TraceReader};
+use differential_dataflow::trace::{Batch, Batcher, Builder, Trace, TraceReader};
 use differential_dataflow::{Collection, ExchangeData};
 use mz_compute_types::plan::reduce::{
     reduction_type, AccumulablePlan, BasicPlan, BucketedPlan, HierarchicalPlan, KeyValPlan,
@@ -510,7 +510,8 @@ where
         S: Scope<Timestamp = G::Timestamp>,
         T1: Trace<KeyOwned = Row, Time = G::Timestamp, Diff = Diff> + 'static,
         T1::Batch: Batch,
-        T1::Batcher: Batcher<Item = ((Row, T1::ValOwned), G::Timestamp, Diff)>,
+        T1::Batcher: Batcher<Input = Vec<((Row, T1::ValOwned), G::Timestamp, Diff)>>,
+        T1::Builder: Builder<Input = ((Row, T1::ValOwned), G::Timestamp, Diff)>,
         for<'a> T1::Key<'a>: std::fmt::Debug + ToDatumIter,
         T1::ValOwned: Columnation + ExchangeData + Default,
         Arranged<S, TraceAgent<T1>>: ArrangementSize,
@@ -522,7 +523,7 @@ where
                 Diff = Diff,
             > + 'static,
         T2::Batch: Batch,
-        T2::Batcher: Batcher<Item = ((Row, T2::ValOwned), G::Timestamp, Diff)>,
+        T2::Builder: Builder<Input = ((Row, T2::ValOwned), G::Timestamp, Diff)>,
         Arranged<S, TraceAgent<T2>>: ArrangementSize,
     {
         let error_logger = self.error_logger();
@@ -872,7 +873,7 @@ where
             + for<'a> TraceReader<Key<'a> = DatumSeq<'a>, Time = G::Timestamp, Diff = Diff>
             + 'static,
         Tr::Batch: Batch,
-        Tr::Batcher: Batcher<Item = ((Row, Tr::ValOwned), G::Timestamp, Diff)>,
+        Tr::Builder: Builder<Input = ((Row, Tr::ValOwned), G::Timestamp, Diff)>,
         Arranged<S, TraceAgent<Tr>>: ArrangementSize,
     {
         let error_logger = self.error_logger();
@@ -1146,7 +1147,7 @@ where
             + for<'a> TraceReader<Key<'a> = DatumSeq<'a>, Time = G::Timestamp, Diff = Diff>
             + 'static,
         Tr::Batch: Batch,
-        Tr::Batcher: Batcher<Item = ((Row, Tr::ValOwned), G::Timestamp, Diff)>,
+        Tr::Builder: Builder<Input = ((Row, Tr::ValOwned), G::Timestamp, Diff)>,
         Arranged<S, TraceAgent<Tr>>: ArrangementSize,
     {
         let error_logger = self.error_logger();

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -13,7 +13,7 @@
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
-use differential_dataflow::trace::{Batch, Batcher, Trace, TraceReader};
+use differential_dataflow::trace::{Batch, Builder, Trace, TraceReader};
 use differential_dataflow::Data;
 use mz_compute_types::plan::threshold::{BasicThresholdPlan, ThresholdPlan};
 use mz_expr::MirScalarExpr;
@@ -48,7 +48,7 @@ where
         > + 'static,
     T2::ValOwned: Columnation + Data,
     T2::Batch: Batch,
-    T2::Batcher: Batcher<Item = ((T1::KeyOwned, T2::ValOwned), G::Timestamp, Diff)>,
+    T2::Builder: Builder<Input = ((T1::KeyOwned, T2::ValOwned), G::Timestamp, Diff)>,
     L: Fn(&Diff) -> bool + 'static,
     Arranged<G, TraceAgent<T2>>: ArrangementSize,
 {

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
-use differential_dataflow::trace::{Batch, Batcher, Trace, TraceReader};
+use differential_dataflow::trace::{Batch, Builder, Trace, TraceReader};
 use differential_dataflow::{AsCollection, Collection};
 use mz_compute_types::plan::top_k::{
     BasicTopKPlan, MonotonicTop1Plan, MonotonicTopKPlan, TopKPlan,
@@ -486,7 +486,7 @@ where
         + for<'a> TraceReader<Key<'a> = DatumSeq<'a>, Time = G::Timestamp, Diff = Diff>
         + 'static,
     Tr::Batch: Batch,
-    Tr::Batcher: Batcher<Item = ((Row, Tr::ValOwned), G::Timestamp, Diff)>,
+    Tr::Builder: Builder<Input = ((Row, Tr::ValOwned), G::Timestamp, Diff)>,
     Arranged<G, TraceAgent<Tr>>: ArrangementSize,
 {
     let mut datum_vec = mz_repr::DatumVec::new();

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -28,11 +28,11 @@ use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
 use mz_persist_types::txn::TxnsCodec;
 use mz_persist_types::{Codec, Codec64, StepForward};
 use mz_timely_util::builder_async::{
-    AsyncInputHandle, Event, InputConnection, OperatorBuilder as AsyncOperatorBuilder,
-    PressOnDropButton,
+    AsyncInputHandle, Event as AsyncEvent, InputConnection,
+    OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::operators::capture::EventCore;
+use timely::dataflow::operators::capture::Event;
 use timely::dataflow::operators::{Broadcast, Capture, Leave, Map, Probe};
 use timely::dataflow::{ProbeHandle, Scope, Stream};
 use timely::order::TotalOrder;
@@ -361,10 +361,10 @@ where
             let event = passthrough_input
                 .next()
                 .await
-                .unwrap_or_else(|| Event::Progress(Antichain::new()));
+                .unwrap_or_else(|| AsyncEvent::Progress(Antichain::new()));
             match event {
                 // NB: Ignore the data_cap because this input is disconnected.
-                Event::Data(_data_cap, mut data) => {
+                AsyncEvent::Data(_data_cap, mut data) => {
                     // NB: Nothing to do here for `until` because both the
                     // `shard_source` (before this operator) and
                     // `mfp_and_decode` (after this operator) do the necessary
@@ -372,7 +372,7 @@ where
                     debug!("{} emitting data {:?}", name, data);
                     passthrough_output.give_container(&cap, &mut data).await;
                 }
-                Event::Progress(new_progress) => {
+                AsyncEvent::Progress(new_progress) => {
                     // If `until.less_equal(new_progress)`, it means that all
                     // subsequent batches will contain only times greater or
                     // equal to `until`, which means they can be dropped in
@@ -423,7 +423,7 @@ where
 {
     while let Some(event) = input.next().await {
         let xs = match event {
-            Event::Progress(logical_upper) => {
+            AsyncEvent::Progress(logical_upper) => {
                 if let Some(logical_upper) = logical_upper.into_option() {
                     if remap.logical_upper < logical_upper {
                         remap.logical_upper = logical_upper;
@@ -432,7 +432,7 @@ where
                 }
                 continue;
             }
-            Event::Data(_cap, xs) => xs,
+            AsyncEvent::Data(_cap, xs) => xs,
         };
         for x in xs {
             debug!("{} got remap {:?}", name, x);
@@ -499,7 +499,7 @@ pub struct DataSubscribe {
     pub(crate) worker: Worker<timely::communication::allocator::Thread>,
     data: ProbeHandle<u64>,
     txns: ProbeHandle<u64>,
-    capture: mpsc::Receiver<EventCore<u64, Vec<(String, u64, i64)>>>,
+    capture: mpsc::Receiver<Event<u64, Vec<(String, u64, i64)>>>,
     output: Vec<(String, u64, i64)>,
 
     _tokens: Vec<PressOnDropButton>,
@@ -615,8 +615,8 @@ impl DataSubscribe {
                 Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
             };
             match event {
-                EventCore::Progress(_) => {}
-                EventCore::Messages(_, mut msgs) => self.output.append(&mut msgs),
+                Event::Progress(_) => {}
+                Event::Messages(_, mut msgs) => self.output.append(&mut msgs),
             }
         }
     }
@@ -964,10 +964,10 @@ mod tests {
         }
         let actual = sub.capture.into_iter().collect::<Vec<_>>();
         let expected = vec![
-            EventCore::Messages(3, vec![("2".to_owned(), 3, 1), ("3".to_owned(), 3, 1)]),
-            EventCore::Messages(3, vec![("4".to_owned(), 4, 1)]),
-            EventCore::Progress(vec![(0, -1), (3, 1)]),
-            EventCore::Progress(vec![(3, -1)]),
+            Event::Messages(3, vec![("2".to_owned(), 3, 1), ("3".to_owned(), 3, 1)]),
+            Event::Messages(3, vec![("4".to_owned(), 4, 1)]),
+            Event::Progress(vec![(0, -1), (3, 1)]),
+            Event::Progress(vec![(3, -1)]),
         ];
         assert_eq!(actual, expected);
     }

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -1387,7 +1387,7 @@ mod tests {
     fn consumer_operator<G: Scope, O: Backpressureable + std::fmt::Debug>(
         scope: G,
         input: &Stream<G, O>,
-        feedback: timely::dataflow::operators::feedback::Handle<G, std::convert::Infallible>,
+        feedback: timely::dataflow::operators::feedback::Handle<G, Vec<std::convert::Infallible>>,
     ) -> UnboundedSender<()> {
         let (tx, mut rx) = unbounded_channel::<()>();
         let mut consumer = AsyncOperatorBuilder::new("consumer".to_string(), scope);

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -514,11 +514,11 @@ impl PendingWork {
         P: Push<
             Bundle<
                 (mz_repr::Timestamp, Subtime),
-                (
+                Vec<(
                     Result<Row, DataflowError>,
                     (mz_repr::Timestamp, Subtime),
                     Diff,
-                ),
+                )>,
             >,
         >,
         YFn: Fn(Instant, usize) -> bool,

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -35,7 +35,7 @@ use mz_timely_util::builder_async::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::channels::pushers::TeeCore;
+use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, ScopeParent, Stream};
 use timely::order::{PartialOrder, TotalOrder};
@@ -917,7 +917,7 @@ impl<G: Scope> UpsertErrorEmitter<G>
         &mut AsyncOutputHandle<
             <G as ScopeParent>::Timestamp,
             Vec<(OutputIndex, HealthStatusUpdate)>,
-            TeeCore<<G as ScopeParent>::Timestamp, Vec<(OutputIndex, HealthStatusUpdate)>>,
+            Tee<<G as ScopeParent>::Timestamp, Vec<(OutputIndex, HealthStatusUpdate)>>,
         >,
         &Capability<<G as ScopeParent>::Timestamp>,
     )
@@ -934,7 +934,7 @@ async fn process_upsert_state_error<G: Scope>(
     health_output: &mut AsyncOutputHandle<
         <G as ScopeParent>::Timestamp,
         Vec<(OutputIndex, HealthStatusUpdate)>,
-        TeeCore<<G as ScopeParent>::Timestamp, Vec<(OutputIndex, HealthStatusUpdate)>>,
+        Tee<<G as ScopeParent>::Timestamp, Vec<(OutputIndex, HealthStatusUpdate)>>,
     >,
     health_cap: &Capability<<G as ScopeParent>::Timestamp>,
 ) {

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -58,7 +58,7 @@ use std::rc::Rc;
 
 use differential_dataflow::Collection;
 use serde::{Deserialize, Serialize};
-use timely::dataflow::channels::pushers::TeeCore;
+use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::{CapabilitySet, Concat, Map, ToStream};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
@@ -310,13 +310,13 @@ async fn return_definite_error(
     data_handle: &mut AsyncOutputHandle<
         GtidPartition,
         Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>,
-        TeeCore<GtidPartition, Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>>,
+        Tee<GtidPartition, Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>>,
     >,
     data_cap_set: &CapabilitySet<GtidPartition>,
     definite_error_handle: &mut AsyncOutputHandle<
         GtidPartition,
         Vec<ReplicationError>,
-        TeeCore<GtidPartition, Vec<ReplicationError>>,
+        Tee<GtidPartition, Vec<ReplicationError>>,
     >,
     definite_error_cap_set: &CapabilitySet<GtidPartition>,
 ) -> () {

--- a/src/storage/src/source/mysql/replication/context.rs
+++ b/src/storage/src/source/mysql/replication/context.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::pin::Pin;
 
 use mysql_async::BinlogStream;
-use timely::dataflow::channels::pushers::TeeCore;
+use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::{Capability, CapabilitySet};
 use timely::progress::Antichain;
 use tracing::trace;
@@ -38,7 +38,7 @@ pub(super) struct ReplContext<'a> {
     pub(super) data_output: &'a mut AsyncOutputHandle<
         GtidPartition,
         Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>,
-        TeeCore<GtidPartition, Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>>,
+        Tee<GtidPartition, Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>>,
     >,
     pub(super) data_cap_set: &'a mut CapabilitySet<GtidPartition>,
     pub(super) upper_cap_set: &'a mut CapabilitySet<GtidPartition>,
@@ -59,7 +59,7 @@ impl<'a> ReplContext<'a> {
         data_output: &'a mut AsyncOutputHandle<
             GtidPartition,
             Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>,
-            TeeCore<GtidPartition, Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>>,
+            Tee<GtidPartition, Vec<((usize, Result<Row, DefiniteError>), GtidPartition, i64)>>,
         >,
         data_cap_set: &'a mut CapabilitySet<GtidPartition>,
         upper_cap_set: &'a mut CapabilitySet<GtidPartition>,

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -101,7 +101,7 @@ use postgres_protocol::message::backend::{
 };
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::channels::pushers::TeeCore;
+use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::operators::{Concat, Map};
 use timely::dataflow::{Scope, Stream};
@@ -445,7 +445,7 @@ async fn raw_stream<'a>(
     stats_output: &'a mut AsyncOutputHandle<
         MzOffset,
         Vec<ProgressStatisticsUpdate>,
-        TeeCore<MzOffset, Vec<ProgressStatisticsUpdate>>,
+        Tee<MzOffset, Vec<ProgressStatisticsUpdate>>,
     >,
     stats_cap: &'a Capability<MzOffset>,
 ) -> Result<

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -420,7 +420,7 @@ impl futures::Stream for RemapClock {
 fn remap_operator<G, FromTime, M>(
     scope: &G,
     config: RawSourceCreationConfig,
-    mut source_upper_rx: InstrumentedUnboundedReceiver<Event<FromTime, Infallible>, M>,
+    mut source_upper_rx: InstrumentedUnboundedReceiver<Event<FromTime, Vec<Infallible>>, M>,
     remap_relation_desc: RelationDesc,
 ) -> (Collection<G, FromTime, Diff>, PressOnDropButton)
 where
@@ -567,11 +567,11 @@ fn reclock_operator<G, FromTime, D, M>(
     mut source_rx: InstrumentedUnboundedReceiver<
         Event<
             FromTime,
-            (
+            Vec<(
                 (usize, Result<SourceMessage, SourceReaderError>),
                 FromTime,
                 D,
-            ),
+            )>,
         >,
         M,
     >,

--- a/src/timely-util/src/buffer.rs
+++ b/src/timely-util/src/buffer.rs
@@ -40,7 +40,7 @@ use timely::progress::Timestamp;
 /// time changes, or if the buffer capacity is reached.
 pub struct ConsolidateBuffer<'a, 'b, T, D: Data, R: Semigroup, P>
 where
-    P: Push<Bundle<T, (D, T, R)>> + 'a,
+    P: Push<Bundle<T, Vec<(D, T, R)>>> + 'a,
     T: Data + Timestamp + 'a,
     D: 'a,
 {
@@ -56,7 +56,7 @@ where
 impl<'a, 'b, T, D: Data, R: Semigroup, P> ConsolidateBuffer<'a, 'b, T, D, R, P>
 where
     T: Data + Timestamp + 'a,
-    P: Push<Bundle<T, (D, T, R)>> + 'a,
+    P: Push<Bundle<T, Vec<(D, T, R)>>> + 'a,
 {
     /// Create a new [ConsolidateBuffer], wrapping the provided session.
     ///
@@ -155,7 +155,7 @@ where
 
 impl<'a, 'b, T, D: Data, R: Semigroup, P> Drop for ConsolidateBuffer<'a, 'b, T, D, R, P>
 where
-    P: Push<Bundle<T, (D, T, R)>> + 'a,
+    P: Push<Bundle<T, Vec<(D, T, R)>>> + 'a,
     T: Data + Timestamp + 'a,
     D: 'a,
 {

--- a/src/timely-util/src/capture.rs
+++ b/src/timely-util/src/capture.rs
@@ -14,15 +14,15 @@
 // limitations under the License.
 
 use mz_ore::channel::{InstrumentedChannelMetric, InstrumentedUnboundedSender};
-use timely::dataflow::operators::capture::{EventCore, EventPusherCore};
+use timely::dataflow::operators::capture::{Event, EventPusher};
 
-pub struct UnboundedTokioCapture<T, D, M>(pub InstrumentedUnboundedSender<EventCore<T, D>, M>);
+pub struct UnboundedTokioCapture<T, D, M>(pub InstrumentedUnboundedSender<Event<T, Vec<D>>, M>);
 
-impl<T, D, M> EventPusherCore<T, D> for UnboundedTokioCapture<T, D, M>
+impl<T, D, M> EventPusher<T, Vec<D>> for UnboundedTokioCapture<T, D, M>
 where
     M: InstrumentedChannelMetric,
 {
-    fn push(&mut self, event: EventCore<T, D>) {
+    fn push(&mut self, event: Event<T, Vec<D>>) {
         // NOTE: An Err(x) result just means "data not accepted" most likely
         //       because the receiver is gone. No need to panic.
         let _ = self.0.send(event);

--- a/src/timely-util/src/event.rs
+++ b/src/timely-util/src/event.rs
@@ -11,7 +11,7 @@
 //!
 //! This is roughly based on [timely::dataflow::operators::capture::event].
 
-use timely::dataflow::operators::capture::{EventCore, EventPusherCore};
+use timely::dataflow::operators::capture::{Event, EventPusher};
 
 use crate::activator::RcActivator;
 
@@ -33,8 +33,8 @@ impl<E> ActivatedEventPusher<E> {
     }
 }
 
-impl<T, D, E: EventPusherCore<T, D>> EventPusherCore<T, D> for ActivatedEventPusher<E> {
-    fn push(&mut self, event: EventCore<T, D>) {
+impl<T, D, E: EventPusher<T, D>> EventPusher<T, D> for ActivatedEventPusher<E> {
+    fn push(&mut self, event: Event<T, D>) {
         self.inner.push(event);
         self.activator.activate();
     }

--- a/src/timely-util/src/replay.rs
+++ b/src/timely-util/src/replay.rs
@@ -46,7 +46,7 @@ pub trait MzReplay<T: Timestamp, D: Data, A: ActivatorTrait>: Sized {
 impl<T: Timestamp, D: Data, I, A: ActivatorTrait + 'static> MzReplay<T, D, A> for I
 where
     I: IntoIterator,
-    <I as IntoIterator>::Item: EventIterator<T, D> + 'static,
+    <I as IntoIterator>::Item: EventIterator<T, Vec<D>> + 'static,
 {
     /// Replay a collection of [EventIterator]s into a Timely stream.
     ///


### PR DESCRIPTION
Update to latest timely and differential versions. The changes reflect upstream changes, but no new functionality. There are two main classes of changes:
* We define more timely operators in terms of containers instead of elements. This causes several changes where previously we had a `D` to become a `Vec<D>`. In the future, this opens the possibility to supply a different container type.
* The arrangement APIs in differential have streamlined trait bounds, which we need to reflect in Materialize. Part of this is that `MzArrange` cannot call the `Arrange` implementation for `Collection`, but instead calls the freestanding function that sits underneath the `Arrange` trait.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
