### PR TITLE
storage: retry cleaning up rocksdb db's on startup

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -127,7 +127,6 @@ steps:
         - ./ci/plugins/mzcompose:
             composition: zippy
             args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=100000, --max-execution-time=8h]
-      skip: "Reenable when #19999 is fixed"
 
   - id: feature-benchmark-scale-plus-one
     label: "Feature benchmark against 'common-ancestor' with --scale=+1 %N"

--- a/misc/python/materialize/zippy/source_actions.py
+++ b/misc/python/materialize/zippy/source_actions.py
@@ -13,7 +13,7 @@ from textwrap import dedent
 from materialize.mzcompose.composition import Composition
 from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
 from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
-from materialize.zippy.kafka_capabilities import Envelope, KafkaRunning, TopicExists
+from materialize.zippy.kafka_capabilities import KafkaRunning, TopicExists
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.replica_capabilities import source_capable_clusters
 from materialize.zippy.source_capabilities import SourceExists
@@ -127,10 +127,6 @@ class AlterSourceConnection(Action):
         self, c: Composition, new_use_ssh_status: bool
     ) -> None:
         kafka_connection_name = f"{self.source.name}_kafka_conn"
-
-        if self.source.topic.envelope == Envelope.UPSERT:
-            # TODO: #25417 (alter upsert source)
-            return
 
         c.testdrive(
             dedent(

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -56,6 +56,10 @@ pub enum Error {
     /// A tokio thread used by the implementation panicked.
     #[error("tokio thread panicked")]
     TokioPanic(#[from] tokio::task::JoinError),
+
+    /// A tokio thread used by the implementation panicked.
+    #[error("failed to cleanup in time")]
+    CleanupTimeout(#[from] tokio::time::error::Elapsed),
 }
 
 /// Fixed options to configure a [`RocksDBInstance`]. These are not tuning parameters,
@@ -64,6 +68,9 @@ pub struct InstanceOptions {
     /// Whether or not to clear state at the instance
     /// path before starting.
     pub cleanup_on_new: bool,
+
+    /// If `cleanup_on_new`, how many times to try.
+    pub cleanup_tries: usize,
 
     /// Whether or not to write writes
     /// to the wal. This is not in `RocksDBTuningParameters` because it
@@ -76,9 +83,10 @@ pub struct InstanceOptions {
 
 impl InstanceOptions {
     /// A new `Options` object with reasonable defaults.
-    pub fn defaults_with_env(env: rocksdb::Env) -> Self {
+    pub fn defaults_with_env(env: rocksdb::Env, cleanup_tries: usize) -> Self {
         InstanceOptions {
             cleanup_on_new: true,
+            cleanup_tries,
             use_wal: false,
             env,
         }
@@ -241,24 +249,46 @@ where
         let dynamic_config = tuning_config.dynamic.clone();
         if options.cleanup_on_new && instance_path.exists() {
             let instance_path_owned = instance_path.to_owned();
-            mz_ore::task::spawn_blocking(
-                || {
-                    format!(
-                        "RocksDB instance at {}: cleanup on creation",
-                        instance_path.display()
+
+            // We require that cleanup of the DB succeeds. Otherwise, we could open a DB with old,
+            // incorrect data. Because of races with dataflow shutdown, we retry a few times here.
+            // 1s with a 2x backoff is ~30s after 5 tries.
+            //
+            // TODO(guswynn): remove this when we can wait on dataflow cleanup asynchronously in
+            // the controller.
+            let retry = mz_ore::retry::Retry::default()
+                .max_tries(options.cleanup_tries)
+                // Large DB's could take multiple seconds to run.
+                .initial_backoff(std::time::Duration::from_secs(1));
+
+            retry
+                .retry_async_canceling(|_rs| async {
+                    let instance_path_owned = instance_path_owned.clone();
+                    mz_ore::task::spawn_blocking(
+                        || {
+                            format!(
+                                "RocksDB instance at {}: cleanup on creation",
+                                instance_path.display()
+                            )
+                        },
+                        move || {
+                            if let Err(e) =
+                                DB::destroy(&RocksDBOptions::default(), &*instance_path_owned)
+                            {
+                                tracing::warn!(
+                                    "failed to cleanup rocksdb dir on creation {}: {}",
+                                    instance_path_owned.display(),
+                                    e.display_with_causes(),
+                                );
+                                Err(Error::from(e))
+                            } else {
+                                Ok(())
+                            }
+                        },
                     )
-                },
-                move || {
-                    if let Err(e) = DB::destroy(&RocksDBOptions::default(), &*instance_path_owned) {
-                        tracing::warn!(
-                            "failed to cleanup rocksdb dir on creation {}: {}",
-                            instance_path_owned.display(),
-                            e.display_with_causes(),
-                        );
-                    }
-                },
-            )
-            .await?;
+                    .await?
+                })
+                .await?;
         }
 
         // The buffer can be small here, as all interactions with it take `&mut self`.

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -50,7 +50,7 @@ async fn basic() -> Result<(), anyhow::Error> {
 
     let mut instance = RocksDBInstance::<String, String>::new(
         t.path(),
-        InstanceOptions::defaults_with_env(rocksdb::Env::new()?),
+        InstanceOptions::defaults_with_env(rocksdb::Env::new()?, 2),
         RocksDBConfig::new(Default::default(), None),
         shared_metrics_for_tests()?,
         instance_metrics_for_tests()?,
@@ -141,7 +141,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
 
     let instance1 = RocksDBInstance::<String, String>::new(
         t.path().join("1").as_path(),
-        InstanceOptions::defaults_with_env(rocksdb::Env::new()?),
+        InstanceOptions::defaults_with_env(rocksdb::Env::new()?, 2),
         rocksdb_config.clone(),
         shared_metrics_for_tests()?,
         instance_metrics_for_tests()?,
@@ -163,7 +163,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
 
     let instance2 = RocksDBInstance::<String, String>::new(
         t.path().join("2").as_path(),
-        InstanceOptions::defaults_with_env(rocksdb::Env::new()?),
+        InstanceOptions::defaults_with_env(rocksdb::Env::new()?, 2),
         rocksdb_config.clone(),
         shared_metrics_for_tests()?,
         instance_metrics_for_tests()?,
@@ -188,7 +188,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
 
     let instance3 = RocksDBInstance::<String, String>::new(
         t.path().join("3").as_path(),
-        InstanceOptions::defaults_with_env(rocksdb::Env::new()?),
+        InstanceOptions::defaults_with_env(rocksdb::Env::new()?, 2),
         rocksdb_config,
         shared_metrics_for_tests()?,
         instance_metrics_for_tests()?,

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -77,7 +77,7 @@ pub const STORAGE_UPSERT_PREVENT_SNAPSHOT_BUFFERING: Config<bool> = Config::new(
     "Prevent snapshot buffering in upsert.",
 );
 
-/// if `storage_upsert_prevent_snapshot_buffering` is true, this prevents the upsert
+/// If `storage_upsert_prevent_snapshot_buffering` is true, this prevents the upsert
 /// operator from buffering too many events from the upstream snapshot. In the absence
 /// of hydration flow control, this could prevent certain workloads from causing egregiously
 /// large writes to RocksDB.
@@ -85,6 +85,13 @@ pub const STORAGE_UPSERT_MAX_SNAPSHOT_BATCH_BUFFERING: Config<Option<usize>> = C
     "storage_upsert_max_snapshot_batch_buffering",
     None,
     "Limit snapshot buffering in upsert.",
+);
+
+/// How many times to try to cleanup old RocksDB DB's on disk before giving up.
+pub const STORAGE_ROCKSDB_CLEANUP_TRIES: Config<usize> = Config::new(
+    "storage_rocksdb_cleanup_tries",
+    5,
+    "How many times to try to cleanup old RocksDB DB's on disk before giving up.",
 );
 
 /// Adds the full set of all storage `Config`s.
@@ -96,4 +103,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENFORCE_EXTERNAL_ADDRESSES)
         .add(&STORAGE_UPSERT_PREVENT_SNAPSHOT_BUFFERING)
         .add(&STORAGE_UPSERT_MAX_SNAPSHOT_BATCH_BUFFERING)
+        .add(&STORAGE_ROCKSDB_CLEANUP_TRIES)
 }

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -217,6 +217,8 @@ where
     // this, to prevent unnecessary work.
     let wait_for_input_resumption =
         dyncfgs::DELAY_SOURCES_PAST_REHYDRATION.get(storage_configuration.config_set());
+    let rocksdb_cleanup_tries =
+        dyncfgs::STORAGE_ROCKSDB_CLEANUP_TRIES.get(storage_configuration.config_set());
 
     // Whether or not to partially drain the input buffer
     // to prevent buffering of the _upstream_ snapshot.
@@ -281,6 +283,7 @@ where
                             tuning_config: tuning,
                             shared_metrics: rocksdb_shared_metrics,
                             instance_metrics: rocksdb_instance_metrics,
+                            cleanup_tries: rocksdb_cleanup_tries,
                         },
                         spill_threshold,
                         rocksdb_in_use_metric,
@@ -303,7 +306,10 @@ where
                     rocksdb::RocksDB::new(
                         mz_rocksdb::RocksDBInstance::new(
                             &rocksdb_dir,
-                            mz_rocksdb::InstanceOptions::defaults_with_env(env),
+                            mz_rocksdb::InstanceOptions::defaults_with_env(
+                                env,
+                                rocksdb_cleanup_tries,
+                            ),
                             tuning,
                             rocksdb_shared_metrics,
                             rocksdb_instance_metrics,

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -259,9 +259,6 @@ where
             .join("upsert")
             .join(source_config.id.to_string())
             .join(source_config.worker_id.to_string());
-        let legacy_rocksdb_dir = scratch_directory
-            .join(source_config.id.to_string())
-            .join(source_config.worker_id.to_string());
 
         let env = instance_context.rocksdb_env.clone();
 
@@ -280,7 +277,6 @@ where
                     AutoSpillBackend::new(
                         RocksDBParams {
                             instance_path: rocksdb_dir,
-                            legacy_instance_path: legacy_rocksdb_dir,
                             env,
                             tuning_config: tuning,
                             shared_metrics: rocksdb_shared_metrics,
@@ -307,7 +303,6 @@ where
                     rocksdb::RocksDB::new(
                         mz_rocksdb::RocksDBInstance::new(
                             &rocksdb_dir,
-                            &legacy_rocksdb_dir,
                             mz_rocksdb::InstanceOptions::defaults_with_env(env),
                             tuning,
                             rocksdb_shared_metrics,

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -33,7 +33,6 @@ pub enum BackendType<O> {
 /// Params required to create rocksdb instance
 pub(crate) struct RocksDBParams {
     pub(crate) instance_path: PathBuf,
-    pub(crate) legacy_instance_path: PathBuf,
     pub(crate) env: rocksdb::Env,
     pub(crate) tuning_config: RocksDBConfig,
     pub(crate) shared_metrics: Arc<mz_rocksdb::RocksDBSharedMetrics>,
@@ -69,7 +68,6 @@ where
     async fn init_rocksdb(rocksdb_params: &RocksDBParams) -> RocksDB<O> {
         let RocksDBParams {
             instance_path,
-            legacy_instance_path,
             env,
             tuning_config,
             shared_metrics,
@@ -80,7 +78,6 @@ where
         RocksDB::new(
             mz_rocksdb::RocksDBInstance::new(
                 instance_path,
-                legacy_instance_path,
                 mz_rocksdb::InstanceOptions::defaults_with_env(env.clone()),
                 tuning_config.clone(),
                 Arc::clone(shared_metrics),

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -37,6 +37,7 @@ pub(crate) struct RocksDBParams {
     pub(crate) tuning_config: RocksDBConfig,
     pub(crate) shared_metrics: Arc<mz_rocksdb::RocksDBSharedMetrics>,
     pub(crate) instance_metrics: Arc<mz_rocksdb::RocksDBInstanceMetrics>,
+    pub(crate) cleanup_tries: usize,
 }
 
 pub struct AutoSpillBackend<O> {
@@ -72,13 +73,14 @@ where
             tuning_config,
             shared_metrics,
             instance_metrics,
+            cleanup_tries,
         } = rocksdb_params;
         tracing::info!("spilling to disk for upsert at {:?}", instance_path);
 
         RocksDB::new(
             mz_rocksdb::RocksDBInstance::new(
                 instance_path,
-                mz_rocksdb::InstanceOptions::defaults_with_env(env.clone()),
+                mz_rocksdb::InstanceOptions::defaults_with_env(env.clone(), *cleanup_tries),
                 tuning_config.clone(),
                 Arc::clone(shared_metrics),
                 Arc::clone(instance_metrics),

--- a/test/testdrive/kafka-avro-sinks-defaults.td
+++ b/test/testdrive/kafka-avro-sinks-defaults.td
@@ -52,10 +52,6 @@ $ kafka-ingest format=avro topic=upsert-avro key-format=avro key-schema=${upsert
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 
-# TODO: remove this when implementing #25417
-! ALTER CONNECTION kafka_conn SET (BROKER = '${testdrive.kafka-addr}');
-contains:cannot currently alter connections depended on by upsert sources
-
 # we split avro unions into separate columns
 > SELECT * FROM upsert_input;
 fisch  42  <null>   1000  <null>  hello

--- a/test/upsert/kafka-upsert-debezium-sources.td
+++ b/test/upsert/kafka-upsert-debezium-sources.td
@@ -81,6 +81,9 @@ $ set schema={
     ]
   }
 
+# The quickstart cluster doesn't seem to inherit from `disk_cluster_replicas_default`.
+> CREATE CLUSTER test_cluster SIZE '4'
+
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
@@ -96,12 +99,14 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
 {"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}, "op": "u", "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
 ! CREATE SOURCE doin_upsert
+  IN CLUSTER test_cluster
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
 contains:ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified
 
 > CREATE SOURCE doin_upsert
+  IN CLUSTER test_cluster
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
@@ -157,6 +162,7 @@ moros
 # contains:INCLUDE OFFSET with Debezium requires UPSERT semantics
 
 > CREATE SOURCE doin_upsert_metadata
+  IN CLUSTER test_cluster
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE PARTITION, OFFSET AS test_kafka_offset
@@ -189,6 +195,7 @@ id creature
 
 # Test that `WITH (START OFFSET=<whatever>)` works
 > CREATE SOURCE upsert_fast_forward
+  IN CLUSTER test_cluster
   FROM KAFKA CONNECTION kafka_conn (START OFFSET = [6], TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
@@ -200,6 +207,7 @@ id creature
 
 # test include metadata
 > CREATE SOURCE upsert_metadata
+  IN CLUSTER test_cluster
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE OFFSET, PARTITION
@@ -215,6 +223,7 @@ id   creature      offset  partition
 
 # test include metadata respects metadata order
 > CREATE SOURCE upsert_metadata_reordered
+  IN CLUSTER test_cluster
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE PARTITION, OFFSET
@@ -227,3 +236,20 @@ id   creature      partition  offset
 2    velociraptor  0          5
 3    triceratops   0          7
 4    chicken       0          10
+
+> ALTER CONNECTION kafka_conn SET (broker = 'abcd') WITH (validate = false);
+
+> ALTER CONNECTION kafka_conn SET (broker = '${testdrive.kafka-addr}') WITH (validate = true);
+
+> SELECT * FROM doin_upsert WHERE id = 3
+id creature
+-----------
+3  triceratops
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=7
+{"id": 3} {"before": {"row": {"id": 3, "creature": "triceratops"}}, "after": {"row": {"id": 3, "creature": "altered"}}, "op": "u", "source": {"file": "binlog11", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> SELECT * FROM doin_upsert WHERE id = 3
+id creature
+-----------
+3  altered


### PR DESCRIPTION
Possibly resolves #19999 and #25417

The past way of doing this ALLOWED us to skip errors on destruction of the db, and then panic on creation of the db; this is not only less flaky (we hope, at least in my local testing it isnt as flaky), but also safer, with us never trying to build a db before successfully deleting it.

### Motivation
  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
