### PR TITLE
orchestrator-kubernetes: downgrade disk capacity warning

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -636,10 +636,13 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                                 Some(DiskLimit(disk_limit)),
                             ) => {
                                 let disk_capacity = if disk_limit.0 < disk_capacity {
-                                    // We warn and not error because all the above cases are
-                                    // relatively common.
-                                    tracing::warn!(
-                                        "disk capacity {} is larger than the disk limit {} ?",
+                                    // We issue an informational message instead
+                                    // of a warning or error because all the
+                                    // above cases are relatively common.
+                                    tracing::info!(
+                                        "disk capacity {} is larger than the disk limit {}; \
+                                        disk usage will indicate 100% full before the disk is truly full; \
+                                        as long as the delta is small this is not a cause for concern",
                                         disk_capacity,
                                         disk_limit.0
                                     );


### PR DESCRIPTION
We see frequently that a cluster's disk capacity is greater than its limit. This is odd, but not usually a cause for concern. The impact is that we may display that the disk is 100% full before the disk is actually 100% full. As long as the delta is small, the discrepency is basically unnoticeable.

So, downgrade the warning! log to an info! log, and also indicate the expected impact in the log message.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
