### PR TITLE
[persist] Add some metrics that track the current state of a spine

### DIFF
--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -330,24 +330,16 @@ impl StateVersions {
                     .inline_part_bytes
                     .set(u64::cast_from(size_metrics.inline_part_bytes));
 
-                {
-                    // Capture and report spine-batch-specific metrics.
-                    let mut compact_batches = 0;
-                    let mut compacting_batches = 0;
-                    let mut noncompact_batches = 0;
-                    for batch in new_state.collections.trace.spine_batches() {
-                        if batch.is_compact() {
-                            compact_batches += 1;
-                        } else if batch.is_merging() {
-                            compacting_batches += 1;
-                        } else {
-                            noncompact_batches += 1;
-                        }
-                    }
-                    shard_metrics.compact_batches.set(compact_batches);
-                    shard_metrics.compacting_batches.set(compacting_batches);
-                    shard_metrics.noncompact_batches.set(noncompact_batches);
-                }
+                let spine_metrics = new_state.collections.trace.spine_metrics();
+                shard_metrics
+                    .compact_batches
+                    .set(spine_metrics.compact_batches);
+                shard_metrics
+                    .compacting_batches
+                    .set(spine_metrics.compacting_batches);
+                shard_metrics
+                    .noncompact_batches
+                    .set(spine_metrics.noncompact_batches);
 
                 Ok((CaSResult::Committed, new))
             }


### PR DESCRIPTION
### Motivation

For #16607, it would be useful to know exactly how "compact" a particular spine is.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
