### PR TITLE
sql-parser: correct parsing of `interval` keyword

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -583,9 +583,6 @@ impl<'a> Parser<'a> {
             Token::Keyword(NULLIF) => self.parse_nullif_expr(),
             Token::Keyword(EXISTS) => self.parse_exists_expr(),
             Token::Keyword(EXTRACT) => self.parse_extract_expr(),
-            Token::Keyword(INTERVAL) => {
-                Ok(Expr::Value(Value::Interval(self.parse_interval_value()?)))
-            }
             Token::Keyword(NOT) => Ok(Expr::Not {
                 expr: Box::new(self.parse_subexpr(Precedence::PrefixNot)?),
             }),

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1734,3 +1734,17 @@ SELECT * FROM t JOIN t USING (a) AS OF
 error: Expected a timestamp value after 'AS OF', found EOF
 SELECT * FROM t JOIN t USING (a) AS OF
                                       ^
+
+parse-statement
+SELECT interval
+----
+SELECT interval
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("interval")]), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT interval + '1h'
+----
+SELECT interval + '1h'
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Identifier([Ident("interval")]), expr2: Some(Value(String("1h"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -630,7 +630,7 @@ statement error Expected end of statement, found left parenthesis
 SELECT INTERVAL '2-3 3:4' DAY(1)
 
 # Only allow positive integer nanosecond precision
-statement error Expected literal unsigned integer, found operator
+statement error Expected end of statement, found string literal
 SELECT INTERVAL '1 day 2-3 4' SECOND(-1);
 
 # Arbitrary punctuation delimiters
@@ -1185,7 +1185,7 @@ SELECT INTERVAL '1.5 second 43 microseconds'
 statement error Cannot set MILLISECONDS or MICROSECONDS field if SECOND field has a fraction component
 SELECT INTERVAL '1.5 second 42 milliseconds 43 microseconds'
 
-statement error Expected one of YEAR or MONTH or DAY or HOUR or MINUTE or SECOND or YEARS or MONTHS or DAYS or HOURS or MINUTES or SECONDS, found identifier "milliseconds"
+statement error Expected end of statement, found string literal
 SELECT INTERVAL '6 days 1.5 second 42 milliseconds' HOURS to MILLISECONDS
 
 ## Millennium/Century/Decade parsing


### PR DESCRIPTION
To match PostgreSQL, treat `interval` as a non-reserved keyword. This allows it to be used as a column name without quoting.

This actually was very nearly already the case. When we implemented general typed string literals (77811560), we got this behavior "for free" for intervals, but failed to remove the *old* implementation for parsing interval values. So all we need to do in this commit is remove that old implementation, to allow the parsing of intervals to be entirely handled by the new general typed string literal parser, which correctly allows type names to *not* be treated as reserved keywords.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
