### PR TITLE
adapter: remove PlanContext usage and fields

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -810,15 +810,10 @@ impl CatalogState {
 
     pub(crate) fn deserialize_plan(
         &self,
-        id: GlobalId,
         create_sql: &str,
         force_if_exists_skip: bool,
     ) -> Result<(Plan, ResolvedIds), AdapterError> {
-        // TODO - The `None` needs to be changed if we ever allow custom
-        // logical compaction windows in user-defined objects.
-        let pcx = PlanContext::zero()
-            .with_planning_id(id)
-            .with_ignore_if_exists_errors(force_if_exists_skip);
+        let pcx = PlanContext::zero().with_ignore_if_exists_errors(force_if_exists_skip);
         let mut session_catalog = self.for_system_session();
         Self::parse_plan(create_sql, Some(&pcx), &mut session_catalog)
     }
@@ -854,10 +849,9 @@ impl CatalogState {
         id: GlobalId,
         create_sql: &str,
     ) -> Result<CatalogItem, AdapterError> {
-        // TODO - The `None` needs to be changed if we ever allow custom
-        // logical compaction windows in user-defined objects.
-        let pcx = PlanContext::zero().with_planning_id(id);
-        self.parse_item(id, create_sql, Some(&pcx), false, None)
+        // TODO - The custom_logical_compaction_window `None` needs to be changed if we ever allow
+        // custom logical compaction windows in user-defined objects.
+        self.parse_item(id, create_sql, None, false, None)
     }
 
     /// Parses the given SQL string into a `CatalogItem`.

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -148,7 +148,7 @@ impl Coordinator {
         };
 
         let state = self.catalog().state();
-        let plan_result = state.deserialize_plan(id, &item.create_sql, true);
+        let plan_result = state.deserialize_plan(&item.create_sql, true);
         let (plan, resolved_ids) = return_if_err!(plan_result, ctx);
 
         let plan::Plan::CreateIndex(plan) = plan else {

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -172,7 +172,7 @@ impl Coordinator {
         };
 
         let state = self.catalog().state();
-        let plan_result = state.deserialize_plan(id, &item.create_sql, true);
+        let plan_result = state.deserialize_plan(&item.create_sql, true);
         let (plan, resolved_ids) = return_if_err!(plan_result, ctx);
 
         let plan::Plan::CreateMaterializedView(plan) = plan else {

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -142,7 +142,7 @@ impl Coordinator {
         };
 
         let state = self.catalog().state();
-        let plan_result = state.deserialize_plan(id, &item.create_sql, true);
+        let plan_result = state.deserialize_plan(&item.create_sql, true);
         let (plan, resolved_ids) = return_if_err!(plan_result, ctx);
 
         let plan::Plan::CreateView(plan) = plan else {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1601,7 +1601,6 @@ impl Params {
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, Copy)]
 pub struct PlanContext {
     pub wall_time: DateTime<Utc>,
-    pub planning_id: Option<GlobalId>,
     pub ignore_if_exists_errors: bool,
 }
 
@@ -1609,7 +1608,6 @@ impl PlanContext {
     pub fn new(wall_time: DateTime<Utc>) -> Self {
         Self {
             wall_time,
-            planning_id: None,
             ignore_if_exists_errors: false,
         }
     }
@@ -1620,14 +1618,8 @@ impl PlanContext {
     pub fn zero() -> Self {
         PlanContext {
             wall_time: now::to_datetime(NOW_ZERO()),
-            planning_id: None,
             ignore_if_exists_errors: false,
         }
-    }
-
-    pub fn with_planning_id(mut self, id: GlobalId) -> Self {
-        self.planning_id = Some(id);
-        self
     }
 
     pub fn with_ignore_if_exists_errors(mut self, value: bool) -> Self {


### PR DESCRIPTION
The planning_id field was never read, so can be removed.

`Some(PlanContext::zero())` is the same as `None` during startup, so simplify one calling site to use None instead.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a