### PR TITLE
adapter: log manual uses of mz_introspection

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -77,6 +77,19 @@ impl Coordinator {
             let responses = ExecuteResponse::generated_from(&PlanKind::from(&plan));
             ctx.tx_mut().set_allowed(responses);
 
+            // Warn about users explicitly selecting the mz_introspection cluster. We are thinking
+            // about renaming this cluster, and this helps us gauge how much of a breaking change
+            // doing so would be.
+            // TODO(#26731): remove this warning again
+            let session = ctx.session();
+            if !session.user().is_internal() && session.vars().cluster() == "mz_introspection" {
+                tracing::warn!(
+                    github_26731 = true,
+                    user = session.user().name,
+                    "user manually selected `mz_introspection` cluster"
+                );
+            }
+
             // Scope the borrow of the Catalog because we need to mutate the Coordinator state below.
             let target_cluster = match ctx.session().transaction().cluster() {
                 // Use the current transaction's cluster.


### PR DESCRIPTION
This PR adds logging for queries that explicitly select the `mz_introspection` cluster. This is in preparation of renaming said cluster, to gauge how much of a breaking change doing so would be.

[Slack thread.](https://materializeinc.slack.com/archives/C063H5S7NKE/p1713368560676129)

### Motivation

  * This PR adds a known-desirable feature.

Preparation for #26731 

### Tips for reviewer

This seems to work as intended (skips system users, works with both `SET cluster` and connection string options), but there might be a better place to put the logging.

The log message is tagged with a `github_26731` field so it can be disabled if it turns out too noisy with this log filter:
```
[{github_26731}]=error,info
```

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
