### PR TITLE
dbt-materialize: ensure superuser check is autoroute-able

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_permission_validation.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_permission_validation.sql
@@ -20,13 +20,13 @@
 -- Have OWNERSHIP rights on the production clusters and schemas
 {% macro deploy_validate_permissions(clusters=[], schemas=[]) %}
 
-{% set is_not_super_user %}
-    SELECT mz_is_superuser() IS FALSE;
+{% set is_super_user %}
+    SELECT mz_is_superuser();
 {% endset %}
 
-{% set not_super_user = run_query(is_not_super_user) %}
+{% set super_user = run_query(is_super_user) %}
 {% if execute %}
-    {% if not_super_user.rows[0][0] %}
+    {% if not super_user.rows[0][0] %}
         {{ internal_ensure_database_permission() }}
         {{ internal_ensure_createcluster_permission() }}
         {{ internal_ensure_schema_ownership(schemas) }}


### PR DESCRIPTION
For whatever reason, `IS FALSE` breaks autorouting to mz_introspection. Instead of digging deeper, we remove this clause and negate the result in jinja.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

 This PR fixes a recognized bug.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
