### PR TITLE
dbt-materialize: release v1.7.7

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,11 @@
 # dbt-materialize Changelog
 
-## 1.7.6 - 2024-04-17
+## 1.7.7 - 2024-04-19
+
+* Tweak [`deploy_permission_validation]`](https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_permission_validation.sql)
+  macro to work around [#26738](https://github.com/MaterializeInc/materialize/issues/26738).
+
+## 1.7.6 - 2024-04-18
 
 * **Breaking change.** The `source` and `sink` materialization types no longer
     accept arbitrary SQL statements, and now accept the `cluster` configuration

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.7.6"
+version = "1.7.7"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.7.6",
+    version="1.7.7",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Patch release to fix blue/green deployment workflows, which hits #26738 in environments that dropped the pre-installed default cluster.