### PR TITLE
doc/user: add kapa.ai widget

### DIFF
--- a/doc/user/assets/sass/_base.scss
+++ b/doc/user/assets/sass/_base.scss
@@ -2,35 +2,41 @@
 /* ----- Basic Setup ----- */
 /* ------------------------------------------------- */
 
-:root {
-    --nav-height: 6.5rem;
+$rem-scale: 0.625;
 
-    --h1: 4.8rem;
-    --h2: 2.8rem;
-    --h3: 2.4rem;
-    --h4: 1.8rem;
-    --h5: 1.6rem;
-    --base: 1.6rem;
-    --sm: 1.4rem;
-    --xsm: 1.2rem;
+@function rem($rem) {
+    @return $rem-scale * $rem * 1rem;
+}
+
+:root {
+    --nav-height: #{rem(6.5)};
+
+    --h1: #{rem(4.8)};
+    --h2: #{rem(2.8)};
+    --h3: #{rem(2.4)};
+    --h4: #{rem(1.8)};
+    --h5: #{rem(1.6)};
+    --base: #{rem(1.6)};
+    --sm: #{rem(1.4)};
+    --xsm: #{rem(1.2)};
 
     @media(max-width: 850px) {
-        --h1: 3.4rem;
-        --h2: 2.6rem;
-        --h3: 2.2rem;
-        --h4: 1.8rem;
-        --h5: 1.6rem;
+        --h1: #{rem(3.4)};
+        --h2: #{rem(2.6)};
+        --h3: #{rem(2.2)};
+        --h4: #{rem(1.8)};
+        --h5: #{rem(1.6)};
     }
 
-    --pico: 0.5rem;
-    --nano: 1rem;
-    --micro: 1.5rem;
-    --milli: 2rem;
-    --xx-small: 2.5rem;
-    --x-small: 3rem;
-    --small: 4rem;
-    --medium: 5rem;
-    --large: 6rem;
+    --pico: #{rem(0.5)};
+    --nano: #{rem(1)};
+    --micro: #{rem(1.5)};
+    --milli: #{rem(2)};
+    --xx-small: #{rem(2.5)};
+    --x-small: #{rem(3)};
+    --small: #{rem(4)};
+    --medium: #{rem(5)};
+    --large: #{rem(6)};
 
     --graidient-primary: linear-gradient(270deg,
         hsl(270deg 68% 58%) 0%,
@@ -70,7 +76,7 @@
     --gray-lighter: #dddd;
     --gray-lightest: #eeeeee;
 
-    --shadow-default: 0 0.625rem 1.5rem 0rem rgba(0, 0, 0, 0.08);
+    --shadow-default: 0 #{rem(0.625)} #{rem(1.5)} #{rem(0)} rgba(0, 0, 0, 0.08);
 }
 
 body.dark {
@@ -98,7 +104,7 @@ body.dark {
     --body: var(--gray);
     --highlight: #e0a5fb;
 
-    --shadow-default: 0 0.625rem 1.5rem 0 rgba(0, 0, 0, 0.4);
+    --shadow-default: 0 #{rem(0.625)} #{rem(1.5)} 0 rgba(0, 0, 0, 0.4);
     --note: #fffad411;
     --note-border: #b9a61545;
     --note-after: #fbe2d9;
@@ -158,10 +164,6 @@ body.light {
     box-sizing: border-box;
 }
 
-html {
-    font-size: 62.5%;
-}
-
 body {
     font-family: "Inter", sans-serif;
     color: var(--important);
@@ -174,7 +176,7 @@ body {
     overflow-x: hidden;
 
     @media(max-width: 500px) {
-        font-size: 1.5rem;
+        font-size: rem(1.5);
     }
 }
 
@@ -266,11 +268,11 @@ a {
     letter-spacing: 0.1em;
     background: var(--graidient-primary);
     color: var(--white);
-    padding: 0.6rem 1.2rem;
+    padding: rem(0.6) rem(1.2);
     border-radius: 8px;
 
     svg {
-        margin-right: .6rem;
+        margin-right: rem(.6);
         width: 18px;
         height: 18px;
     }

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -103,7 +103,7 @@ p+p {
         }
 
         .highlight:only-child {
-            margin: 1rem 0;
+            margin: rem(1) 0;
 
             pre {
                 margin: 0;
@@ -111,8 +111,8 @@ p+p {
         }
 
         pre {
-            margin-left: 1.8rem;
-            margin: 1rem 0;
+            margin-left: rem(1.8);
+            margin: rem(1) 0;
             display: block;
         }
     }
@@ -133,17 +133,17 @@ p+p {
     pre+p,
     table+p,
     *+p {
-        margin-top: 1.6rem;
+        margin-top: rem(1.6);
     }
 
     p+table {
-        margin-top: 0.5rem;
+        margin-top: rem(0.5);
     }
 
     pre,
     .warning,
     .note {
-        font-size: 1.5rem;
+        font-size: rem(1.5);
         font-weight: 300;
     }
 
@@ -198,7 +198,7 @@ p+p {
         border-radius: 3px;
         padding: 1px;
         margin: var(--large) 0;
-        border-radius: 1.2rem;
+        border-radius: rem(1.2);
         box-shadow: var(--shadow-default);
 
         a {
@@ -240,7 +240,7 @@ p+p {
             width: 48px;
             height: 48px;
             position: absolute;
-            top: 2rem;
+            top: rem(2);
             background-size: contain;
         }
 
@@ -248,7 +248,7 @@ p+p {
         &.bulb,
         &.doc,
         &.touch {
-            padding-top: 8rem;
+            padding-top: rem(8);
         }
 
         &.book::before {
@@ -291,7 +291,7 @@ p+p {
         border-collapse: collapse;
         font-size: var(--sm);
         font-weight: 300;
-        line-height: 2.1rem;
+        line-height: rem(2.1);
 
         @media(max-width: 500px) {
             code {
@@ -309,7 +309,7 @@ p+p {
         border-bottom: 1px var(--highlight) solid;
         text-align: left;
         padding: 8px;
-        font-size: 1.3rem;
+        font-size: rem(1.3);
         vertical-align: bottom;
     }
 
@@ -336,10 +336,10 @@ p+p {
         border: 1px solid var(--divider-light);
         color: $black-v2;
         font-family: Courier, monospace;
-        font-size: 1.5rem;
-        margin: 1rem 0 0.5rem;
+        font-size: rem(1.5);
+        margin: rem(1) 0 rem(0.5);
         overflow: auto;
-        padding: 1.6rem;
+        padding: rem(1.6);
 
         code {
             color: $black-v2;
@@ -352,13 +352,13 @@ p+p {
     code {
         font-family: "Fira Code", Courier, monospace;
         font-variant-ligatures: none;
-        font-size: 1.3rem;
+        font-size: rem(1.3);
         font-weight: 500;
         background: var(--code-block);
         border: 1px solid var(--divider-light);
         box-sizing: border-box;
         border-radius: 2px;
-        padding: 0.1rem 0.25rem 0rem;
+        padding: rem(0.1) rem(0.25) rem(0);
         color: var(--code-simple);
         background: var(--code-simple-bg);
     }
@@ -377,7 +377,7 @@ p+p {
         margin: 0;
 
         li {
-            margin-bottom: 0.5rem;
+            margin-bottom: rem(0.5);
         }
     }
 
@@ -395,9 +395,9 @@ p+p {
 
          >li {
             counter-increment: list-counter;
-            min-height: 5rem;
+            min-height: rem(5);
             position: relative;
-            padding: 1.6rem 0 1.6rem 6rem;
+            padding: rem(1.6) 0 rem(1.6) rem(6);
             border-top: 1px solid var(--divider-light);
 
             ul,
@@ -412,29 +412,29 @@ p+p {
             }
 
             @media(max-width: 850px) {
-                padding-left: 4.5rem;
+                padding-left: rem(4.5);
             }
 
             @media(max-width: 480px) {
-                padding-left: 3rem;
+                padding-left: rem(3);
             }
 
             &:before {
                 content: counter(list-counter);
                 color: var(--orchid);
-                font-size: 3rem;
+                font-size: rem(3);
                 font-weight: 100;
                 position: absolute;
                 top: 100;
-                left: 1rem;
+                left: rem(1);
 
                 @media(max-width: 850px) {
-                    font-size: 4rem;
-                    left: .5rem;
+                    font-size: rem(4);
+                    left: rem(.5);
                 }
 
                 @media(max-width: 480px) {
-                    font-size: 3.5rem;
+                    font-size: rem(3.5);
                     left: 0;
                 }
             }
@@ -452,7 +452,7 @@ p+p {
     hr {
         border: none;
         border-top: 1px solid $medium-grey-v2;
-        margin: 3.6rem auto;
+        margin: rem(3.6) auto;
         width: 80%;
     }
 
@@ -522,13 +522,13 @@ p+p {
     .private-preview,
     .public-preview {
         box-sizing: border-box;
-        margin: 1.6rem 0;
-        padding: 1.6rem 1.6rem 1.6rem 10.4rem;
+        margin: rem(1.6) 0;
+        padding: rem(1.6) rem(1.6) rem(1.6) rem(10.4);
         position: relative;
-        border-radius: 1.2rem;
+        border-radius: rem(1.2);
 
         @media(max-width: 510px) {
-            padding: 1rem 1rem 1rem 6rem;
+            padding: rem(1) rem(1) rem(1) rem(6);
         }
 
         p:first-of-type {
@@ -540,28 +540,28 @@ p+p {
             position: absolute;
             top: -1px;
             right: -1px;
-            border-width: 0 1.6rem 1.6rem 0;
+            border-width: 0 rem(1.6) rem(1.6) 0;
             border-style: solid;
         }
 
         .gutter {
             position: absolute;
-            left: 1.6rem;
-            top: 1.8rem;
+            left: rem(1.6);
+            top: rem(1.8);
             line-height: 23px;
-            font-size: 1.2rem;
+            font-size: rem(1.2);
             font-weight: bold;
             text-transform: uppercase;
 
             @media(max-width: 510px) {
-                top: 1.2rem;
+                top: rem(1.2);
             }
         }
     }
 
     .warning {
         @media(max-width: 510px) {
-            padding-left: 9rem;
+            padding-left: rem(9);
         }
     }
 
@@ -571,8 +571,8 @@ p+p {
         color: #fff;
         display: inline-block;
         font-weight: 500;
-        margin: 3.2rem 0;
-        padding: 2rem 6.4rem;
+        margin: rem(3.2) 0;
+        padding: rem(2) rem(6.4);
         opacity: 1;
         transition: opacity 350ms ease;
 
@@ -604,8 +604,8 @@ p+p {
 
     .release-date+ul,
     .release-date+ol {
-        margin-top: 1.6rem;
-        padding-left: 3.2rem;
+        margin-top: rem(1.6);
+        padding-left: rem(3.2);
     }
 
     .symbol {
@@ -613,7 +613,7 @@ p+p {
     }
 
     .breadcrumb {
-        font-size: 1.4rem;
+        font-size: rem(1.4);
         letter-spacing: 0.03em;
         text-transform: uppercase;
         color: var(--sub);
@@ -621,7 +621,7 @@ p+p {
 
         a {
             color: var(--sub) !important;
-            margin: 0 0.8rem;
+            margin: 0 rem(0.8);
 
             &:hover {
                 color: $black-v2;
@@ -637,9 +637,9 @@ p+p {
 
 #helpful {
     border-top: 1px solid $grey;
-    margin-top: 4.8rem;
+    margin-top: rem(4.8);
     max-width: 40%;
-    padding-top: 0.8rem;
+    padding-top: rem(0.8);
     text-align: center;
 
     table {
@@ -656,7 +656,7 @@ p+p {
         color: $purple;
         display: inline-block;
         font-weight: bold;
-        padding: 1.1rem 0;
+        padding: rem(1.1) 0;
         width: 100%;
     }
 
@@ -667,7 +667,7 @@ p+p {
 
 // Navigation tabs (tab+tabs.html)
 .code-tabs {
-    margin: 1rem 0;
+    margin: rem(1) 0;
 
     .nav-tabs {
         list-style: none;
@@ -682,7 +682,7 @@ p+p {
 
         li {
             display: inline-block;
-            margin: 0 0.1rem;
+            margin: 0 rem(0.1);
             padding: 0;
             position: relative;
             bottom: -1px;
@@ -691,17 +691,17 @@ p+p {
             a {
                 color: var(--body);
                 display: block;
-                padding: 0.8rem 3.2rem;
-                font-size: 1.6rem;
+                padding: rem(0.8) rem(3.2);
+                font-size: rem(1.6);
                 text-decoration: none;
                 font-weight: 500;
 
                 @media(max-width: 850px) {
-                    padding: 0.8rem 2.5rem;
+                    padding: rem(0.8) rem(2.5);
                 }
 
                 @media(max-width: 380px) {
-                    padding: 0.8rem 1.5rem;
+                    padding: rem(0.8) rem(1.5);
                 }
 
                 &:hover {
@@ -725,7 +725,7 @@ p+p {
 
     .tab-pane {
         display: none;
-        padding: 1.6rem 0;
+        padding: rem(1.6) 0;
 
         &.active {
             display: block;
@@ -748,7 +748,7 @@ p+p {
             display: flex;
 
             input[type="email"] {
-                font-size: 0.8rem;
+                font-size: rem(0.8);
                 padding: 7px 5px 6px 5px;
                 border-radius: $border-radius;
                 border: none;
@@ -810,7 +810,7 @@ p+p {
 
 .table-scrollable {
     box-shadow: inset 0 -4px 3px -3px $medium-grey-v2;
-    margin: 1rem 0 3rem;
+    margin: rem(1) 0 rem(3);
     overflow: auto;
 
     .table-container {
@@ -837,7 +837,7 @@ p+p {
     }
 
     &+* {
-        margin-top: 3rem !important;
+        margin-top: rem(3) !important;
     }
 }
 
@@ -871,7 +871,7 @@ p+p {
 .copy_button {
     display: none;
     position: absolute;
-    font-size: 1.2rem;
+    font-size: rem(1.2);
     font-weight: 300;
     border: none;
     background-color: $grey-light;
@@ -905,11 +905,11 @@ p+p {
         display: flex;
 
         input[type="email"] {
-            font-size: 1.4rem;
-            padding: .5rem;
+            font-size: rem(1.4);
+            padding: rem(.5);
             border-radius: $border-radius;
             border: none;
-            margin-right: .8rem;
+            margin-right: rem(.8);
             background: var(--bg);
             color: var(--important);
             border: 1px solid var(--divider-light);
@@ -925,7 +925,7 @@ p+p {
         width: 100%;
         color: var(--important);
         margin-top: var(--nano);
-        padding: .4rem .8rem;
+        padding: rem(.4) rem(.8);
         font-size: var(--xsm);
         border-bottom-left-radius: $border-radius;
         border-bottom-right-radius: $border-radius;
@@ -1089,11 +1089,11 @@ div.json_widget {
 }
 
 .notify_button {
-    font-size: 1rem;
-    padding: 0.4rem 0.8rem;
+    font-size: rem(1);
+    padding: rem(0.4) rem(0.8);
 
     &.success {
-        width: 8rem;
+        width: rem(8);
     }
 }
 

--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -89,7 +89,7 @@ table.inline-headings {
     }
 
     .DocSearch-Button-Placeholder {
-        font-size: 1.6rem;
+        font-size: rem(1.6);
         font-weight: 300;
 
         @media(max-width: 768px) {
@@ -150,7 +150,7 @@ table.inline-headings {
     overflow-y: auto;
     height: 100vh;
     display: flex;
-    font-size: 1.3rem;
+    font-size: rem(1.3);
     overflow-x: hidden;
 
     &,
@@ -242,7 +242,7 @@ table.inline-headings {
         padding-left: 0;
 
         ul ul {
-            margin-left: 0.8rem;
+            margin-left: rem(0.8);
         }
     }
 
@@ -259,7 +259,7 @@ table.inline-headings {
         }
 
         &>ul {
-            margin-bottom: 1.5rem;
+            margin-bottom: rem(1.5);
         }
     }
 
@@ -267,8 +267,8 @@ table.inline-headings {
     li.level-3 {
         >ul {
             display: none;
-            padding-top: 0.5rem;
-            margin-bottom: 0.625rem;
+            padding-top: rem(0.5);
+            margin-bottom: rem(0.625);
 
             &:before,
             &:after {
@@ -325,7 +325,7 @@ table.inline-headings {
 .toc {
     max-width: fit-content;
     min-width: 180px;
-    padding: var(--x-small) 2rem;
+    padding: var(--x-small) rem(2);
     position: sticky;
     top: 0;
     height: 100vh;
@@ -339,7 +339,7 @@ table.inline-headings {
     h2 {
         font-size: var(--xsm);
         letter-spacing: 0.1em;
-        margin: 0 0 0.75rem 0;
+        margin: 0 0 rem(0.75) 0;
         padding: 0;
         display: inline-block;
         color: var(--highlight);
@@ -357,7 +357,7 @@ table.inline-headings {
     }
 
     li {
-        padding: 0.25rem 0;
+        padding: rem(0.25) 0;
     }
 
     a {
@@ -448,8 +448,8 @@ table.inline-headings {
     }
 
     svg {
-        height: 2.2rem;
-        width: 2.2rem;
+        height: rem(2.2);
+        width: rem(2.2);
         fill: var(--gray-mid);
     }
 

--- a/doc/user/assets/sass/_mixins.scss
+++ b/doc/user/assets/sass/_mixins.scss
@@ -1,7 +1,7 @@
 @mixin card {
     background: var(--card-light);
     border: 1px solid var(--divider-light);
-    border-radius: 1.2rem;
+    border-radius: rem(1.2);
 
     box-shadow: var(--shadow-default);
 }

--- a/doc/user/assets/sass/_nav.scss
+++ b/doc/user/assets/sass/_nav.scss
@@ -64,7 +64,7 @@
     &-logo {
         display: flex;
         font-weight: 600;
-        font-size: 1.8rem;
+        font-size: rem(1.8);
         color: var(--important);
 
         a {
@@ -72,14 +72,14 @@
         }
 
         svg {
-            margin-right: 1.5rem;
+            margin-right: rem(1.5);
         }
     }
 }
 
 .toggle {
     display: none;
-    transform: translateX(.8rem);
+    transform: translateX(rem(.8));
 
     @media(max-width: 850px) {
         display: initial;
@@ -90,8 +90,8 @@
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        height: 4.8rem;
-        width: 4.8rem;
+        height: rem(4.8);
+        width: rem(4.8);
         border-radius: 12px;
         transition: all .2s cubic-bezier(0, 0, 0.2, 1);
 
@@ -99,8 +99,8 @@
         &::before,
         &::after {
             background: var(--sub);
-            height: .2rem;
-            width: 2.4rem;
+            height: rem(.2);
+            width: rem(2.4);
             transition: all .2s cubic-bezier(0, 0, 0.2, 1);
         }
 
@@ -110,11 +110,11 @@
         }
 
         &::before {
-            margin-bottom: .6rem;
+            margin-bottom: rem(.6);
         }
 
         &::after {
-            margin-top: .6rem;
+            margin-top: rem(.6);
         }
     }
 
@@ -170,8 +170,8 @@ button.close-topics {
     right: 0;
     transform: translateX(50%) translateY(50%);
     background: var(--bg);
-    height: 4.8rem;
-    width: 4.8rem;
+    height: rem(4.8);
+    width: rem(4.8);
     border: 1px solid var(--divider-light);
     border-radius: 100%;
     box-shadow: var(--shadow-default);

--- a/doc/user/assets/sass/_railroad_diagrams.scss
+++ b/doc/user/assets/sass/_railroad_diagrams.scss
@@ -1,5 +1,5 @@
 .rr-diagram {
-    margin: 1.5rem 0;
+    margin: rem(1.5) 0;
     overflow: auto;
 
     .line {

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -86,6 +86,20 @@ toCSS | fingerprint }}
   });
 </script>
 
+<script
+  async
+  src="https://widget.kapa.ai/kapa-widget.bundle.js"
+  data-website-id="8afe5064-c908-44bd-8cd9-805d9e740fb9"
+  data-project-name="Materialize"
+  data-project-color="#472E85"
+  data-project-logo="https://avatars.githubusercontent.com/u/47674186?s=200&v=4"
+  data-modal-title="Materialize AI"
+  data-modal-disclaimer="This is a custom LLM for Materialize with access to developer docs, guides and blog posts. Answers may be inaccurate. Consult the official Materialize documentation to verify any answers provided by Materialize AI."
+  data-modal-example-questions="Why is my query slow?,How do I check my source's status?"
+  data-search-mode-enabled="true"
+  >
+</script>
+
 {{if hugo.IsProduction}} {{/* Google Analytics */}}
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-HYXTGZN2KT"></script>
 <script>


### PR DESCRIPTION
The kapa.ai widget provides users with access to an LLM trained on Materialize's documentation, guides, and blog posts that is capable of answering technical questions about Materialize.

Here's how it looks:

<img width="1840" alt="image" src="https://github.com/MaterializeInc/materialize/assets/882976/556b73a8-f994-4600-939e-c31bf4fe4989">

<img width="1840" alt="image" src="https://github.com/MaterializeInc/materialize/assets/882976/a154beec-6ff0-4a67-af5d-5286bcabf826">


### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
