### PR TITLE
adapter: parse and optimize builtin views in parallel v2

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -388,7 +388,7 @@ pub struct ConnCatalog<'a> {
     /// This feature is necessary to allow re-planning of statements, which is
     /// either incredibly useful or required when altering item definitions.
     ///
-    /// Note that uses of this should field should be used by short-lived
+    /// Note that uses of this field should be used by short-lived
     /// catalogs.
     unresolvable_ids: BTreeSet<GlobalId>,
     conn_id: ConnectionId,
@@ -1855,6 +1855,7 @@ mod tests {
     use std::{env, iter};
 
     use itertools::Itertools;
+    use mz_catalog::memory::objects::CatalogItem;
     use tokio_postgres::types::Type;
     use tokio_postgres::NoTls;
     use uuid::Uuid;
@@ -1863,7 +1864,6 @@ mod tests {
         Builtin, BuiltinType, BUILTINS,
         REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_VIEW_FINGERPRINT_WHITESPACE,
     };
-    use mz_catalog::memory::objects::CatalogItem;
     use mz_catalog::SYSTEM_CONN_ID;
     use mz_controller_types::{ClusterId, ReplicaId};
     use mz_expr::MirScalarExpr;

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -630,39 +630,9 @@ impl CatalogState {
                     PrivilegeMap::default(),
                 );
             }
-            Builtin::View(view) => {
-                let item = self
-                    .parse_item(
-                        id,
-                        &view.create_sql(),
-                        None,
-                        false,
-                        None,
-                    )
-                    .unwrap_or_else(|e| {
-                        panic!(
-                            "internal error: failed to load bootstrap view:\n\
-                                {}\n\
-                                error:\n\
-                                {:?}\n\n\
-                                make sure that the schema name is specified in the builtin view's create sql statement.",
-                            view.name, e
-                        )
-                    });
-                let mut acl_items = vec![rbac::owner_privilege(
-                    mz_sql::catalog::ObjectType::View,
-                    MZ_SYSTEM_ROLE_ID,
-                )];
-                acl_items.extend_from_slice(&view.access);
-
-                self.insert_item(
-                    id,
-                    view.oid,
-                    name,
-                    item,
-                    MZ_SYSTEM_ROLE_ID,
-                    PrivilegeMap::from_mz_acl_items(acl_items),
-                );
+            Builtin::View(_) => {
+                // parse_views is responsible for inserting all builtin views.
+                unreachable!("views added elsewhere");
             }
 
             // Note: Element types must be loaded before array types.

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -9,17 +9,18 @@
 
 //! Logic related to opening a [`Catalog`].
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::iter;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use futures::future::{BoxFuture, FutureExt};
+use futures::future::{self, BoxFuture, FutureExt};
 use itertools::Itertools;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_catalog::builtin::{
-    Fingerprint, BUILTINS, BUILTIN_CLUSTERS, BUILTIN_CLUSTER_REPLICAS, BUILTIN_LOOKUP,
-    BUILTIN_PREFIXES, BUILTIN_ROLES,
+    Builtin, BuiltinView, Fingerprint, BUILTINS, BUILTIN_CLUSTERS, BUILTIN_CLUSTER_REPLICAS,
+    BUILTIN_LOOKUP, BUILTIN_PREFIXES, BUILTIN_ROLES,
 };
 use mz_catalog::config::StateConfig;
 use mz_catalog::durable::objects::{
@@ -42,22 +43,26 @@ use mz_ore::cast::usize_to_u64;
 use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::instrument;
 use mz_ore::now::to_datetime;
+use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::adt::mz_acl_item::PrivilegeMap;
 use mz_repr::namespaces::MZ_INTERNAL_SCHEMA;
 use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
 use mz_sql::catalog::{
-    CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem, CatalogItemType,
+    CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem, CatalogItemType, NameReference,
     RoleMembership, RoleVars,
 };
 use mz_sql::func::OP_IMPLS;
-use mz_sql::names::{QualifiedItemName, SchemaId};
+use mz_sql::names::{
+    ItemQualifiers, QualifiedItemName, ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier,
+};
 use mz_sql::session::user::{MZ_SYSTEM_ROLE_ID, SYSTEM_USER};
 use mz_sql::session::vars::{SessionVars, SystemVars, VarError, VarInput};
+use mz_sql::{plan, rbac};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_ssh_util::keys::SshKeyPairSet;
 use timely::Container;
-use tracing::{info, warn, Instrument};
+use tracing::{info, info_span, warn, Instrument};
 use uuid::Uuid;
 
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
@@ -339,10 +344,7 @@ impl Catalog {
                         diff,
                     }),
                     CatalogItemType::View | CatalogItemType::MaterializedView => {
-                        builtin_view_updates.push(StateUpdate {
-                            kind: StateUpdateKind::SystemObjectMapping(builtin_item_update),
-                            diff,
-                        })
+                        builtin_view_updates.push(builtin_item_update);
                     }
                     CatalogItemType::Table
                     | CatalogItemType::Source
@@ -356,26 +358,26 @@ impl Catalog {
                 }
             }
 
-            let updates = iter::empty()
+            let pre_view_updates = iter::empty()
                 .chain(pre_cluster_updates.into_iter())
                 .chain(builtin_type_updates.into_iter())
                 .chain(other_builtin_updates.into_iter())
-                // TODO(jkosh44/mjibson) Applying builtin views on startup is one of the slowest
-                // parts of startup. One fix for this would be to modify this code to do the
-                // following:
-                //
-                //   1. Apply all updates before the builtin views.
-                //   2. Apply builtin views in parallel.
-                //   3. Apply all updates after builtin views.
-                //
-                // Applying the builtin views in parallel is non-trivial because they still need to
-                // be applied in dependency order.
-                .chain(builtin_view_updates.into_iter())
+                .collect();
+            let builtin_views: Vec<_> = builtin_view_updates
+                .into_iter()
+                .map(|system_object_mapping| {
+                    let (_, builtin) = BUILTIN_LOOKUP.get(&system_object_mapping.description).expect("missing builtin view");
+                    (*builtin, system_object_mapping.unique_identifier.id)
+                })
+                .collect();
+            let post_view_updates = iter::empty()
                 .chain(cluster_updates.into_iter())
                 .chain(builtin_index_updates.into_iter())
                 .collect();
 
-            state.apply_updates_for_bootstrap(updates)?;
+            state.apply_updates_for_bootstrap(pre_view_updates)?;
+            Self::parse_views(&mut state, builtin_views).await;
+            state.apply_updates_for_bootstrap(post_view_updates)?;
 
             let last_seen_version = txn
                 .get_catalog_content_version()
@@ -436,6 +438,170 @@ impl Catalog {
         }
             .instrument(tracing::info_span!("catalog::initialize_state"))
             .boxed()
+    }
+
+    /// Install builtin views to the catalog. This is its own function so that views can be
+    /// optimized in parallel.
+    ///
+    /// The implementation is similar to `apply_updates_for_bootstrap` and determines dependency
+    /// problems by sniffing out specific errors and then retrying once those dependencies are
+    /// complete. This doesn't work for everything (casts, function implementations) so we also need
+    /// to have a bucket for everything at the end. Additionally, because this executes in parellel,
+    /// we must maintain a completed set otherwise races could result in orphaned views languishing
+    /// in awaiting with nothing retriggering the attempt.
+    #[instrument(name = "catalog::parse_views")]
+    async fn parse_views(
+        state: &mut CatalogState,
+        builtin_views: Vec<(&Builtin<NameReference>, GlobalId)>,
+    ) {
+        let mut handles = Vec::new();
+        let mut awaiting_id_dependencies: BTreeMap<GlobalId, Vec<GlobalId>> = BTreeMap::new();
+        let mut awaiting_name_dependencies: BTreeMap<String, Vec<GlobalId>> = BTreeMap::new();
+        // Some errors are due to the implementation of casts or SQL functions that depend on some
+        // view. Instead of figuring out the exact view dependency, delay these until the end.
+        let mut awaiting_all = Vec::new();
+        // Completed views, needed to avoid race conditions.
+        let mut completed_ids: BTreeSet<GlobalId> = BTreeSet::new();
+        let mut completed_names: BTreeSet<String> = BTreeSet::new();
+        // Avoid some reference lifetime issues by not passing `builtin` into the spawned task.
+        let mut views: BTreeMap<GlobalId, &BuiltinView> =
+            BTreeMap::from_iter(builtin_views.into_iter().map(|(builtin, id)| {
+                let Builtin::View(view) = builtin else {
+                    unreachable!("handled elsewhere");
+                };
+                (id, *view)
+            }));
+        let mut ready: VecDeque<GlobalId> = views.keys().cloned().collect();
+        while !handles.is_empty() || !ready.is_empty() || !awaiting_all.is_empty() {
+            if handles.is_empty() && ready.is_empty() {
+                // Enqueue the views that were waiting for all the others.
+                ready.extend(awaiting_all.drain(..));
+            }
+
+            // Spawn tasks for all ready views.
+            if !ready.is_empty() {
+                let spawn_state = Arc::new(state.clone());
+                while let Some(id) = ready.pop_front() {
+                    let view = views.get(&id).expect("must exist");
+                    let create_sql = view.create_sql();
+                    let mut span = info_span!(parent: None, "parse builtin view", name = view.name);
+                    OpenTelemetryContext::obtain().attach_as_parent_to(&mut span);
+                    let task_state = Arc::clone(&spawn_state);
+                    let handle = mz_ore::task::spawn(
+                        || "parse view",
+                        async move {
+                            let res = task_state.parse_item(id, &create_sql, None, false, None);
+                            (id, res)
+                        }
+                        .instrument(span),
+                    );
+                    handles.push(handle);
+                }
+            }
+            // Wait for a view to be ready.
+            let (handle, _idx, remaining) = future::select_all(handles).await;
+            handles = remaining;
+            let (id, res) = handle.expect("must join");
+            match res {
+                Ok(item) => {
+                    // Add item to catalog.
+                    let view = views.remove(&id).expect("must exist");
+                    let schema_id = state.ambient_schemas_by_name[view.schema];
+                    let qname = QualifiedItemName {
+                        qualifiers: ItemQualifiers {
+                            database_spec: ResolvedDatabaseSpecifier::Ambient,
+                            schema_spec: SchemaSpecifier::Id(schema_id),
+                        },
+                        item: view.name.into(),
+                    };
+                    let mut acl_items = vec![rbac::owner_privilege(
+                        mz_sql::catalog::ObjectType::View,
+                        MZ_SYSTEM_ROLE_ID,
+                    )];
+                    acl_items.extend_from_slice(&view.access);
+
+                    state.insert_item(
+                        id,
+                        view.oid,
+                        qname,
+                        item,
+                        MZ_SYSTEM_ROLE_ID,
+                        PrivilegeMap::from_mz_acl_items(acl_items),
+                    );
+
+                    // Enqueue any items waiting on this dependency.
+                    let mut resolved_dependent_items = Vec::new();
+                    if let Some(dependent_items) = awaiting_id_dependencies.remove(&id) {
+                        resolved_dependent_items.extend(dependent_items);
+                    }
+                    let entry = state.get_entry(&id);
+                    let full_name = state.resolve_full_name(entry.name(), None).to_string();
+                    if let Some(dependent_items) = awaiting_name_dependencies.remove(&full_name) {
+                        resolved_dependent_items.extend(dependent_items);
+                    }
+                    ready.extend(resolved_dependent_items);
+
+                    completed_ids.insert(id);
+                    completed_names.insert(full_name);
+                }
+                // If we were missing a dependency, wait for it to be added.
+                Err(AdapterError::PlanError(plan::PlanError::InvalidId(missing_dep))) => {
+                    if completed_ids.contains(&missing_dep) {
+                        ready.push_back(id);
+                    } else {
+                        awaiting_id_dependencies
+                            .entry(missing_dep)
+                            .or_default()
+                            .push(id);
+                    }
+                }
+                // If we were missing a dependency, wait for it to be added.
+                Err(AdapterError::PlanError(plan::PlanError::Catalog(
+                    SqlCatalogError::UnknownItem(missing_dep),
+                ))) => match GlobalId::from_str(&missing_dep) {
+                    Ok(missing_dep) => {
+                        if completed_ids.contains(&missing_dep) {
+                            ready.push_back(id);
+                        } else {
+                            awaiting_id_dependencies
+                                .entry(missing_dep)
+                                .or_default()
+                                .push(id);
+                        }
+                    }
+                    Err(_) => {
+                        if completed_names.contains(&missing_dep) {
+                            ready.push_back(id);
+                        } else {
+                            awaiting_name_dependencies
+                                .entry(missing_dep)
+                                .or_default()
+                                .push(id);
+                        }
+                    }
+                },
+                Err(AdapterError::PlanError(plan::PlanError::InvalidCast { .. })) => {
+                    awaiting_all.push(id);
+                }
+                Err(e) => panic!(
+                    "internal error: failed to load bootstrap view:\n\
+                        {name}\n\
+                        error:\n\
+                        {e:?}\n\n\
+                        Make sure that the schema name is specified in the builtin view's create sql statement.
+                        ",
+                    name = views.get(&id).expect("must exist").name,
+                ),
+            }
+        }
+
+        assert!(awaiting_id_dependencies.is_empty());
+        assert!(
+            awaiting_name_dependencies.is_empty(),
+            "awaiting_name_dependencies: {awaiting_name_dependencies:?}"
+        );
+        assert!(awaiting_all.is_empty());
+        assert!(views.is_empty());
     }
 
     /// Opens or creates a catalog that stores data at `path`.


### PR DESCRIPTION
Use a slower but more correct method to determine dependencies by sniffing out errors.

This reverts commit a1a2ad4e7b5e56f7a8f3055fdba5f894a594e460.

Fixes #26685

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a