### PR TITLE
adapter/compute: Optimize environmentd handling of PeekResponse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8966,9 +8966,9 @@ dependencies = [
 
 [[package]]
 name = "streaming-iterator"
-version = "0.1.9"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+checksum = "303235c177994a476226b80d076bd333b7b560fb05bd242a10609d11b07f81f5"
 
 [[package]]
 name = "stringprep"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4482,6 +4482,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
+ "bytes",
  "bytesize",
  "chrono",
  "crossbeam-channel",
@@ -8965,9 +8966,9 @@ dependencies = [
 
 [[package]]
 name = "streaming-iterator"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303235c177994a476226b80d076bd333b7b560fb05bd242a10609d11b07f81f5"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "stringprep"

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -30,7 +30,7 @@ use mz_ore::result::ResultExt;
 use mz_ore::task::AbortOnDropHandle;
 use mz_ore::thread::JoinOnDropHandle;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::{GlobalId, Row, ScalarType};
+use mz_repr::{GlobalId, Row, RowIterator, ScalarType};
 use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::{EnvironmentId, SessionCatalog};
 use mz_sql::session::hint::ApplicationNameHint;
@@ -341,7 +341,10 @@ Issue a SQL query to get started. Need help?
 
     /// Executes a single SQL statement that returns rows as the
     /// `mz_support` user.
-    pub async fn introspection_execute_one(&self, sql: &str) -> Result<Vec<Row>, anyhow::Error> {
+    pub async fn introspection_execute_one(
+        &self,
+        sql: &str,
+    ) -> Result<Box<dyn RowIterator>, anyhow::Error> {
         // Connect to the coordinator.
         let conn_id = self.new_conn_id()?;
         let session = self.new_session(SessionConfig {

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -21,7 +21,7 @@ use mz_ore::soft_assert_no_log;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_pgcopy::CopyFormatParams;
 use mz_repr::role_id::RoleId;
-use mz_repr::{GlobalId, Row};
+use mz_repr::{GlobalId, RowIterator};
 use mz_sql::ast::{FetchDirection, Raw, Statement};
 use mz_sql::catalog::ObjectType;
 use mz_sql::plan::{ExecuteTimeout, Plan, PlanKind};
@@ -359,7 +359,10 @@ pub enum ExecuteResponse {
     },
     /// Like `SendingRows`, but the rows are known to be available
     /// immediately, and thus the execution is considered ended in the coordinator.
-    SendingRowsImmediate { rows: Vec<Row> },
+    SendingRowsImmediate {
+        #[derivative(Debug = "ignore")]
+        rows: Box<dyn RowIterator + Send + Sync>,
+    },
     /// The specified variable was set to a new value.
     SetVariable {
         name: String,

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -479,7 +479,7 @@ impl crate::coord::Coordinator {
                     ));
                 }
             }
-            let row_collection = RowCollection::new(results);
+            let row_collection = RowCollection::new(&results);
             let row_count = row_collection.count();
 
             let (ret, reason) =

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -820,7 +820,13 @@ impl Coordinator {
                 offset: 0,
                 project: (0..plan.returning[0].0.iter().count()).collect(),
             };
-            return match finishing.finish(RowCollection::new(plan.returning)) {
+            let max_returned_query_size = session.vars().max_query_result_size();
+
+            return match finishing.finish(
+                RowCollection::new(plan.returning),
+                plan.max_result_size,
+                Some(max_returned_query_size),
+            ) {
                 Ok(rows) => Ok(Self::send_immediate_rows(rows)),
                 Err(e) => Err(AdapterError::ResultSize(e)),
             };

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -823,7 +823,7 @@ impl Coordinator {
             let max_returned_query_size = session.vars().max_query_result_size();
 
             return match finishing.finish(
-                RowCollection::new(plan.returning),
+                RowCollection::new(&plan.returning),
                 plan.max_result_size,
                 Some(max_returned_query_size),
             ) {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2575,7 +2575,6 @@ impl Coordinator {
             let make_diffs =
                 move |mut rows: Box<dyn RowIterator>| -> Result<Vec<(Row, Diff)>, AdapterError> {
                     let arena = RowArena::new();
-                    // Use 2x row len incase there's some assignments.
                     let mut diffs = Vec::new();
                     let mut datum_vec = mz_repr::DatumVec::new();
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -32,7 +32,7 @@ use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
 use mz_repr::explain::json::json_string;
 use mz_repr::explain::{ExplainFormat, ExprHumanizer};
 use mz_repr::role_id::RoleId;
-use mz_repr::{Datum, Diff, GlobalId, Row, RowArena, Timestamp};
+use mz_repr::{Datum, Diff, GlobalId, Row, RowArena, RowIterator, Timestamp};
 use mz_sql::ast::{CreateSubsourceStatement, Ident, UnresolvedItemName, Value};
 use mz_sql::catalog::{
     CatalogCluster, CatalogClusterReplica, CatalogDatabase, CatalogError,
@@ -1555,9 +1555,8 @@ impl Coordinator {
         })?;
 
         let json_string = json_string(&json_value);
-        Ok(Self::send_immediate_rows(vec![Row::pack_slice(&[
-            Datum::String(&json_string),
-        ])]))
+        let row = Row::pack_slice(&[Datum::String(&json_string)]);
+        Ok(Self::send_immediate_rows(row))
     }
 
     pub(super) fn sequence_show_all_variables(
@@ -1568,17 +1567,19 @@ impl Coordinator {
             .map(|v| (v.name(), v.value(), v.description()))
             .collect::<Vec<_>>();
         rows.sort_by_cached_key(|(name, _, _)| name.to_lowercase());
-        Ok(Self::send_immediate_rows(
-            rows.into_iter()
-                .map(|(name, val, desc)| {
-                    Row::pack_slice(&[
-                        Datum::String(name),
-                        Datum::String(&val),
-                        Datum::String(desc),
-                    ])
-                })
-                .collect(),
-        ))
+
+        // TODO(parkmycar): Pack all of these into a single RowCollection.
+        let rows: Vec<_> = rows
+            .into_iter()
+            .map(|(name, val, desc)| {
+                Row::pack_slice(&[
+                    Datum::String(name),
+                    Datum::String(&val),
+                    Datum::String(desc),
+                ])
+            })
+            .collect();
+        Ok(Self::send_immediate_rows(rows))
     }
 
     pub(super) fn sequence_show_variable(
@@ -1597,7 +1598,7 @@ impl Coordinator {
                         .name()
                         .schema;
                     let row = Row::pack_slice(&[Datum::String(schema_name)]);
-                    Ok(Self::send_immediate_rows(vec![row]))
+                    Ok(Self::send_immediate_rows(row))
                 }
                 None => {
                     session.add_notice(AdapterNotice::NoResolvableSearchPathSchema {
@@ -1608,9 +1609,7 @@ impl Coordinator {
                             .map(|schema| schema.to_string())
                             .collect(),
                     });
-                    Ok(Self::send_immediate_rows(vec![Row::pack_slice(&[
-                        Datum::Null,
-                    ])]))
+                    Ok(Self::send_immediate_rows(Row::pack_slice(&[Datum::Null])))
                 }
             };
         }
@@ -1642,7 +1641,7 @@ impl Coordinator {
             let name = variable.value();
             session.add_notice(AdapterNotice::ClusterDoesNotExist { name });
         }
-        Ok(Self::send_immediate_rows(vec![row]))
+        Ok(Self::send_immediate_rows(row))
     }
 
     #[instrument]
@@ -1666,7 +1665,7 @@ impl Coordinator {
             .inspect_persist_state(plan.id)
             .await?;
         let jsonb = Jsonb::from_serde_json(state)?;
-        Ok(Self::send_immediate_rows(vec![jsonb.into_row()]))
+        Ok(Self::send_immediate_rows(jsonb.into_row()))
     }
 
     #[instrument]
@@ -1988,7 +1987,7 @@ impl Coordinator {
                 } else {
                     Datum::False
                 };
-                ctx.retire(Ok(Self::send_immediate_rows(vec![Row::pack_slice(&[res])])));
+                ctx.retire(Ok(Self::send_immediate_rows(Row::pack_slice(&[res]))));
             }
         }
     }
@@ -2573,49 +2572,53 @@ impl Coordinator {
                 timeout_dur = Duration::MAX;
             }
 
-            let make_diffs = move |rows: Vec<Row>| -> Result<Vec<(Row, Diff)>, AdapterError> {
-                let arena = RowArena::new();
-                // Use 2x row len incase there's some assignments.
-                let mut diffs = Vec::with_capacity(rows.len() * 2);
-                let mut datum_vec = mz_repr::DatumVec::new();
-                for row in rows {
-                    if !assignments.is_empty() {
-                        assert!(
-                            matches!(kind, MutationKind::Update),
-                            "only updates support assignments"
-                        );
-                        let mut datums = datum_vec.borrow_with(&row);
-                        let mut updates = vec![];
-                        for (idx, expr) in &assignments {
-                            let updated = match expr.eval(&datums, &arena) {
-                                Ok(updated) => updated,
-                                Err(e) => return Err(AdapterError::Unstructured(anyhow!(e))),
-                            };
-                            updates.push((*idx, updated));
+            let make_diffs =
+                move |mut rows: Box<dyn RowIterator>| -> Result<Vec<(Row, Diff)>, AdapterError> {
+                    let arena = RowArena::new();
+                    // Use 2x row len incase there's some assignments.
+                    let mut diffs = Vec::new();
+                    let mut datum_vec = mz_repr::DatumVec::new();
+
+                    while let Some(row) = rows.next() {
+                        if !assignments.is_empty() {
+                            assert!(
+                                matches!(kind, MutationKind::Update),
+                                "only updates support assignments"
+                            );
+                            let mut datums = datum_vec.borrow_with(row);
+                            let mut updates = vec![];
+                            for (idx, expr) in &assignments {
+                                let updated = match expr.eval(&datums, &arena) {
+                                    Ok(updated) => updated,
+                                    Err(e) => return Err(AdapterError::Unstructured(anyhow!(e))),
+                                };
+                                updates.push((*idx, updated));
+                            }
+                            for (idx, new_value) in updates {
+                                datums[idx] = new_value;
+                            }
+                            let updated = Row::pack_slice(&datums);
+                            diffs.push((updated, 1));
                         }
-                        for (idx, new_value) in updates {
-                            datums[idx] = new_value;
-                        }
-                        let updated = Row::pack_slice(&datums);
-                        diffs.push((updated, 1));
-                    }
-                    match kind {
-                        // Updates and deletes always remove the
-                        // current row. Updates will also add an
-                        // updated value.
-                        MutationKind::Update | MutationKind::Delete => diffs.push((row, -1)),
-                        MutationKind::Insert => diffs.push((row, 1)),
-                    }
-                }
-                for (row, diff) in &diffs {
-                    if *diff > 0 {
-                        for (idx, datum) in row.iter().enumerate() {
-                            desc.constraints_met(idx, &datum)?;
+                        match kind {
+                            // Updates and deletes always remove the
+                            // current row. Updates will also add an
+                            // updated value.
+                            MutationKind::Update | MutationKind::Delete => {
+                                diffs.push((row.to_owned(), -1))
+                            }
+                            MutationKind::Insert => diffs.push((row.to_owned(), 1)),
                         }
                     }
-                }
-                Ok(diffs)
-            };
+                    for (row, diff) in &diffs {
+                        if *diff > 0 {
+                            for (idx, datum) in row.iter().enumerate() {
+                                desc.constraints_met(idx, &datum)?;
+                            }
+                        }
+                    }
+                    Ok(diffs)
+                };
             let diffs = match peek_response {
                 ExecuteResponse::SendingRows { future: batch } => {
                     // TODO(jkosh44): This timeout should be removed;

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -245,9 +245,9 @@ impl Coordinator {
             }
         };
 
-        let rows = vec![Row::pack_slice(&[Datum::from(explain.as_str())])];
+        let row = Row::pack_slice(&[Datum::from(explain.as_str())]);
 
-        Ok(Self::send_immediate_rows(rows))
+        Ok(Self::send_immediate_rows(row))
     }
 
     // `explain_ctx` is an optional context set iff the state machine is initiated from

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -291,9 +291,9 @@ impl Coordinator {
             }
         };
 
-        let rows = vec![Row::pack_slice(&[Datum::from(explain.as_str())])];
+        let row = Row::pack_slice(&[Datum::from(explain.as_str())]);
 
-        Ok(Self::send_immediate_rows(rows))
+        Ok(Self::send_immediate_rows(row))
     }
 
     #[instrument]

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -218,9 +218,9 @@ impl Coordinator {
             }
         };
 
-        let rows = vec![Row::pack_slice(&[Datum::from(explain.as_str())])];
+        let row = Row::pack_slice(&[Datum::from(explain.as_str())]);
 
-        Ok(Self::send_immediate_rows(rows))
+        Ok(Self::send_immediate_rows(row))
     }
 
     #[instrument]

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -22,7 +22,7 @@ use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{instrument, task};
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
-use mz_repr::{Datum, GlobalId, Row, RowArena, Timestamp};
+use mz_repr::{Datum, GlobalId, IntoRowIterator, Row, RowArena, Timestamp};
 use mz_sql::ast::ExplainStage;
 use mz_sql::catalog::{CatalogCluster, SessionCatalog};
 // Import `plan` module, but only import select elements to avoid merge conflicts on use statements.
@@ -1072,7 +1072,8 @@ impl Coordinator {
             })
             .collect();
 
-        let rows = futures.try_collect().await?;
+        let rows: Vec<Row> = futures.try_collect().await?;
+        let rows = Box::new(rows.into_row_iter());
 
         Ok(ExecuteResponse::SendingRowsImmediate { rows })
     }

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -863,10 +863,9 @@ impl Coordinator {
                 Box::new((uuid, StatementLifecycleEvent::ComputeDependenciesFinished)),
             )
         }
-        let max_query_result_size = std::cmp::min(
-            ctx.session().vars().max_query_result_size(),
-            self.catalog().system_config().max_result_size(),
-        );
+
+        let max_query_size = ctx.session().vars().max_query_result_size();
+        let max_result_size = self.catalog().system_config().max_result_size();
 
         // Implement the peek, and capture the response.
         let resp = self
@@ -876,7 +875,8 @@ impl Coordinator {
                 optimizer.finishing().clone(),
                 optimizer.cluster_id(),
                 target_replica,
-                max_query_result_size,
+                max_result_size,
+                Some(max_query_size),
             )
             .await?;
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -26,7 +26,7 @@ use mz_ore::now::{EpochMillis, NowFn};
 use mz_pgwire_common::Format;
 use mz_repr::role_id::RoleId;
 use mz_repr::user::ExternalUserMetadata;
-use mz_repr::{Datum, Diff, GlobalId, Row, ScalarType, TimestampManipulation};
+use mz_repr::{Datum, Diff, GlobalId, Row, RowIterator, ScalarType, TimestampManipulation};
 use mz_sql::ast::{AstInfo, Raw, Statement, TransactionAccessMode};
 use mz_sql::plan::{Params, PlanContext, QueryWhen, StatementDesc};
 use mz_sql::session::metadata::SessionMetadata;
@@ -901,7 +901,7 @@ pub enum PortalState {
 /// State of an in-progress, rows-returning portal.
 pub struct InProgressRows {
     /// The current batch of rows.
-    pub current: Option<Vec<Row>>,
+    pub current: Option<Box<dyn RowIterator + Send + Sync>>,
     /// A stream from which to fetch more row batches.
     pub remaining: RecordFirstRowStream,
 }

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -149,7 +149,7 @@ impl From<&ExecuteResponse> for StatementEndedExecutionReason {
                 // can ever actually happen.
                 ExecuteResponse::SendingRowsImmediate { rows, .. } => {
                     StatementEndedExecutionReason::Success {
-                        rows_returned: Some(u64::cast_from(rows.len())),
+                        rows_returned: Some(u64::cast_from(rows.count())),
                         execution_strategy: Some(StatementExecutionStrategy::Constant),
                     }
                 }
@@ -176,7 +176,7 @@ impl From<&ExecuteResponse> for StatementEndedExecutionReason {
 
             ExecuteResponse::SendingRowsImmediate { rows, .. } => {
                 StatementEndedExecutionReason::Success {
-                    rows_returned: Some(u64::cast_from(rows.len())),
+                    rows_returned: Some(u64::cast_from(rows.count())),
                     execution_strategy: Some(StatementExecutionStrategy::Constant),
                 }
             }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.68"
+bytes = "1.3.0"
 bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.8"

--- a/src/compute-client/build.rs
+++ b/src/compute-client/build.rs
@@ -39,6 +39,7 @@ fn main() {
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
         .extern_path(".mz_repr.relation_and_scalar", "::mz_repr")
         .extern_path(".mz_repr.row", "::mz_repr")
+        .extern_path(".mz_repr.row.collection", "::mz_repr")
         .extern_path(".mz_repr.url", "::mz_repr::url")
         .extern_path(".mz_compute_types", "::mz_compute_types")
         .extern_path(".mz_cluster_client", "::mz_cluster_client")

--- a/src/compute-client/src/protocol/response.proto
+++ b/src/compute-client/src/protocol/response.proto
@@ -15,6 +15,7 @@ import "proto/src/proto.proto";
 import "repr/src/antichain.proto";
 import "repr/src/global_id.proto";
 import "repr/src/row.proto";
+import "repr/src/row/collection.proto";
 
 import "google/protobuf/empty.proto";
 
@@ -57,17 +58,8 @@ message ProtoFrontiersResponse {
 }
 
 message ProtoPeekResponse {
-    message ProtoRow {
-        mz_repr.row.ProtoRow row = 1;
-        uint64 diff = 2;
-    }
-
-    message ProtoRows {
-        repeated ProtoRow rows = 1;
-    }
-
     oneof kind {
-        ProtoRows rows = 1;
+        mz_repr.row.collection.ProtoRowCollection rows = 1;
         string error = 2;
         google.protobuf.Empty canceled = 3;
     }

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -345,7 +345,7 @@ impl Arbitrary for PeekResponse {
                 ),
                 1..11,
             )
-            .prop_map(|rows| PeekResponse::Rows(RowCollection::new(rows)))
+            .prop_map(|rows| PeekResponse::Rows(RowCollection::new(&rows)))
             .boxed(),
             ".*".prop_map(PeekResponse::Error).boxed(),
             Just(PeekResponse::Canceled).boxed(),

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -35,7 +35,7 @@ include!(concat!(
 /// from the compute controller.
 ///
 /// [`ComputeCommand`]: super::command::ComputeCommand
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// `Frontiers` announces the advancement of the various frontiers of the specified compute
     /// collection.
@@ -299,7 +299,7 @@ impl Arbitrary for FrontiersResponse {
 ///
 /// Note that each `Peek` expects to generate exactly one `PeekResponse`, i.e.
 /// we expect a 1:1 contract between `Peek` and `PeekResponse`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PeekResponse {
     /// Returned rows of a successful peek.
     Rows(RowCollection),

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -42,7 +42,7 @@ use mz_persist_client::Diagnostics;
 use mz_persist_txn::txn_cache::TxnsCache;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::fixed_length::{FromDatumIter, ToDatumIter};
-use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, Timestamp};
+use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena, RowCollection, Timestamp};
 use mz_storage_operators::stats::StatsCursor;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::sources::SourceData;
@@ -866,7 +866,7 @@ impl PendingPeek {
                 Ok(vec![])
             };
             let result = match result {
-                Ok(rows) => PeekResponse::Rows(rows),
+                Ok(rows) => PeekResponse::Rows(RowCollection::new(rows)),
                 Err(e) => PeekResponse::Error(e.to_string()),
             };
             match result_tx.send((result, start.elapsed())) {
@@ -1068,7 +1068,7 @@ impl IndexPeek {
         }
 
         let response = match self.collect_finished_data(max_result_size) {
-            Ok(rows) => PeekResponse::Rows(rows),
+            Ok(rows) => PeekResponse::Rows(RowCollection::new(rows)),
             Err(text) => PeekResponse::Error(text),
         };
         Some(response)

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -866,7 +866,7 @@ impl PendingPeek {
                 Ok(vec![])
             };
             let result = match result {
-                Ok(rows) => PeekResponse::Rows(RowCollection::new(rows)),
+                Ok(rows) => PeekResponse::Rows(RowCollection::new(&rows)),
                 Err(e) => PeekResponse::Error(e.to_string()),
             };
             match result_tx.send((result, start.elapsed())) {
@@ -1068,7 +1068,7 @@ impl IndexPeek {
         }
 
         let response = match self.collect_finished_data(max_result_size) {
-            Ok(rows) => PeekResponse::Rows(RowCollection::new(rows)),
+            Ok(rows) => PeekResponse::Rows(RowCollection::new(&rows)),
             Err(text) => PeekResponse::Error(text),
         };
         Some(response)

--- a/src/environmentd/src/telemetry.rs
+++ b/src/environmentd/src/telemetry.rs
@@ -78,7 +78,6 @@
 // https://app.segment.com/materializeinc/sources/cloud_dev/debugger.
 
 use mz_adapter::telemetry::{EventDetails, SegmentClientExt};
-use mz_ore::collections::CollectionExt;
 use mz_ore::retry::Retry;
 use mz_ore::task;
 use mz_repr::adt::jsonb::Jsonb;
@@ -136,7 +135,7 @@ async fn report_loop(
                     .active_subscribes
                     .with_label_values(&["user"])
                     .get();
-                let rows = adapter_client.introspection_execute_one(&format!("
+                let mut rows = adapter_client.introspection_execute_one(&format!("
                     SELECT jsonb_build_object(
                         'active_aws_privatelink_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'aws-privatelink')::int4,
                         'active_clusters', (SELECT count(*) FROM mz_clusters WHERE id LIKE 'u%')::int4,
@@ -167,7 +166,10 @@ async fn report_loop(
                         'active_subscribes', {active_subscribes}
                     )",
                 )).await?;
-                let row = rows.into_element();
+
+                let row = rows.next().expect("expected at least one row").to_owned();
+                assert!(rows.next().is_none(), "introspection query had more than one row?");
+
                 let jsonb = Jsonb::from_row(row);
                 Ok::<_, anyhow::Error>(jsonb.as_ref().to_serde_json())
             })

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -55,7 +55,7 @@ pub mod lex;
     nightly_doc_features,
     doc(cfg(all(feature = "bytes_", feature = "region")))
 )]
-#[cfg(all(feature = "bytes_", feature = "region"))]
+#[cfg(all(feature = "bytes_", feature = "region", feature = "tracing_"))]
 pub mod lgbytes;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "metrics")))]
 #[cfg(feature = "metrics")]

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -13,7 +13,7 @@ use std::io;
 use bytes::BytesMut;
 use csv::{ByteRecord, ReaderBuilder};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
-use mz_repr::{Datum, RelationType, Row, RowArena};
+use mz_repr::{Datum, RelationType, Row, RowArena, RowRef};
 use proptest::prelude::{any, Arbitrary, Just};
 use proptest::strategy::{BoxedStrategy, Strategy, Union};
 use serde::Deserialize;
@@ -24,7 +24,7 @@ static END_OF_COPY_MARKER: &[u8] = b"\\.";
 include!(concat!(env!("OUT_DIR"), "/mz_pgcopy.copy.rs"));
 
 fn encode_copy_row_binary(
-    row: &Row,
+    row: &RowRef,
     typ: &RelationType,
     out: &mut Vec<u8>,
 ) -> Result<(), io::Error> {
@@ -69,7 +69,7 @@ fn encode_copy_row_binary(
 
 fn encode_copy_row_text(
     CopyTextFormatParams { null, delimiter }: &CopyTextFormatParams,
-    row: &Row,
+    row: &RowRef,
     typ: &RelationType,
     out: &mut Vec<u8>,
 ) -> Result<(), io::Error> {
@@ -108,7 +108,7 @@ fn encode_copy_row_csv(
         header: _,
         null,
     }: &CopyCsvFormatParams,
-    row: &Row,
+    row: &RowRef,
     typ: &RelationType,
     out: &mut Vec<u8>,
 ) -> Result<(), io::Error> {
@@ -505,7 +505,7 @@ pub fn decode_copy_format<'a>(
 /// Encodes the given `Row` into bytes based on the given `CopyFormatParams`.
 pub fn encode_copy_format<'a>(
     params: &CopyFormatParams<'a>,
-    row: &Row,
+    row: &RowRef,
     typ: &RelationType,
     out: &mut Vec<u8>,
 ) -> Result<(), io::Error> {

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -24,7 +24,7 @@ use mz_repr::adt::pg_legacy_name::NAME_MAX_BYTES;
 use mz_repr::adt::range::{Range, RangeInner};
 use mz_repr::adt::timestamp::CheckedTimestamp;
 use mz_repr::strconv::{self, Nestable};
-use mz_repr::{Datum, RelationType, Row, RowArena, ScalarType};
+use mz_repr::{Datum, RelationType, RowArena, RowRef, ScalarType};
 use postgres_types::{FromSql, IsNull, ToSql, Type as PgType};
 use uuid::Uuid;
 
@@ -728,7 +728,7 @@ fn pg_len(what: &str, len: usize) -> Result<i32, io::Error> {
 ///
 /// Calling this function is equivalent to mapping [`Value::from_datum`] over
 /// every datum in `row`.
-pub fn values_from_row(row: &Row, typ: &RelationType) -> Vec<Option<Value>> {
+pub fn values_from_row(row: &RowRef, typ: &RelationType) -> Vec<Option<Value>> {
     row.iter()
         .zip(typ.column_types.iter())
         .map(|(col, typ)| Value::from_datum(col, &typ.scalar_type))

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -41,6 +41,7 @@ mz-ore = { path = "../ore", features = [
     "region",
     "stack",
     "test",
+    "tracing_",
 ], default-features = false }
 mz-persist-types = { path = "../persist-types", default-features = false }
 mz-pgtz = { path = "../pgtz", default-features = false }

--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -13,12 +13,13 @@ fn main() {
     prost_build::Config::new()
         .btree_map(["."])
         .extern_path(".mz_proto", "::mz_proto")
-        .bytes([".mz_repr.row.ProtoDatum.bytes"])
+        .bytes([".mz_repr.row.ProtoDatum.bytes", ".mz_repr.row.collection"])
         .compile_protos(
             &[
                 "repr/src/antichain.proto",
                 "repr/src/global_id.proto",
                 "repr/src/row.proto",
+                "repr/src/row/collection.proto",
                 "repr/src/strconv.proto",
                 "repr/src/relation_and_scalar.proto",
                 "repr/src/role_id.proto",

--- a/src/repr/src/datum_vec.rs
+++ b/src/repr/src/datum_vec.rs
@@ -19,7 +19,7 @@
 use crate::{Datum, RowRef};
 
 /// A re-useable vector of `Datum` with no particular lifetime.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct DatumVec {
     outer: Vec<Datum<'static>>,
 }

--- a/src/repr/src/datum_vec.rs
+++ b/src/repr/src/datum_vec.rs
@@ -16,7 +16,7 @@
 //! It uses `ore::vec::repurpose_allocation` to accomplish this, which contains
 //! unsafe code.
 
-use crate::{Datum, Row};
+use crate::{Datum, RowRef};
 
 /// A re-useable vector of `Datum` with no particular lifetime.
 #[derive(Debug, Default)]
@@ -39,8 +39,9 @@ impl DatumVec {
             inner,
         }
     }
+
     /// Borrow an instance with a specific lifetime, and pre-populate with a `Row`.
-    pub fn borrow_with<'a>(&'a mut self, row: &'a Row) -> DatumVecBorrow<'a> {
+    pub fn borrow_with<'a>(&'a mut self, row: &'a RowRef) -> DatumVecBorrow<'a> {
         let mut borrow = self.borrow();
         borrow.extend(row.iter());
         borrow
@@ -79,6 +80,7 @@ impl<'outer> std::ops::DerefMut for DatumVecBorrow<'outer> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::Row;
 
     #[mz_ore::test]
     fn miri_test_datum_vec() {

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -56,7 +56,7 @@ pub use crate::row::encoding::{
 };
 pub use crate::row::{
     datum_list_size, datum_size, datums_size, read_datum, row_size, DatumList, DatumMap, ProtoRow,
-    Row, RowArena, RowPacker, SharedRow,
+    Row, RowArena, RowPacker, RowRef, SharedRow,
 };
 pub use crate::scalar::{
     arb_datum, arb_range_type, ArrayRustType, AsColumnType, Datum, DatumType, PropArray, PropDatum,

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -51,9 +51,11 @@ pub use crate::relation::{
     ColumnName, ColumnType, NotNullViolation, ProtoColumnName, ProtoColumnType, ProtoRelationDesc,
     ProtoRelationType, RelationDesc, RelationType,
 };
+pub use crate::row::collection::{ProtoRowCollection, RowCollection, SortedRowCollectionIter};
 pub use crate::row::encoding::{
     DatumDecoderT, DatumEncoderT, DatumToPersist, DatumToPersistFn, RowDecoder, RowEncoder,
 };
+pub use crate::row::iter::{IntoRowIterator, RowIterator};
 pub use crate::row::{
     datum_list_size, datum_size, datums_size, read_datum, row_size, DatumList, DatumMap, ProtoRow,
     Row, RowArena, RowPacker, RowRef, SharedRow,

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -228,8 +228,7 @@ impl Row {
     /// Extracts a Row slice containing the entire [`Row`].
     #[inline]
     pub fn as_row_ref(&self) -> &RowRef {
-        // SAFETY: We're creating a RowRef from a Row, so we know the data is valid.
-        unsafe { RowRef::from_slice(self.data.as_slice()) }
+        RowRef::from_slice(self.data.as_slice())
     }
 }
 
@@ -393,13 +392,13 @@ pub struct RowRef([u8]);
 impl RowRef {
     /// Create a [`RowRef`] from a slice of data.
     ///
-    /// SAFETY:
-    ///
-    /// * The user must guarantee that the provided slice is actually from a [`Row`].
-    ///
-    pub unsafe fn from_slice(row: &[u8]) -> &RowRef {
+    /// We do not check that the provided slice is valid [`Row`] data, will panic on read
+    /// if the data is invalid.
+    pub fn from_slice(row: &[u8]) -> &RowRef {
         #[allow(clippy::as_conversions)]
-        &*(row as *const _ as *const RowRef)
+        let ptr = row as *const [u8] as *const RowRef;
+        // SAFETY: We know `ptr` is non-null and aligned because it came from a &[u8].
+        unsafe { &*ptr }
     }
 
     /// Unpack `self` into a `Vec<Datum>` for efficient random access.

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -385,7 +385,7 @@ mod columnation {
 
 /// A contiguous slice of bytes that are row data.
 ///
-/// A [`RowRef`] is to [`Row`] as [`str`] is to [`String`].
+/// A [`RowRef`] is to [`Row`] as [`prim@str`] is to [`String`].
 #[derive(PartialEq, Eq)]
 #[repr(transparent)]
 pub struct RowRef([u8]);

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -233,12 +233,14 @@ impl Row {
 }
 
 impl Borrow<RowRef> for Row {
+    #[inline]
     fn borrow(&self) -> &RowRef {
         self.as_row_ref()
     }
 }
 
 impl AsRef<RowRef> for Row {
+    #[inline]
     fn as_ref(&self) -> &RowRef {
         self.as_row_ref()
     }
@@ -247,6 +249,7 @@ impl AsRef<RowRef> for Row {
 impl Deref for Row {
     type Target = RowRef;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.as_row_ref()
     }

--- a/src/repr/src/row/collection.proto
+++ b/src/repr/src/row/collection.proto
@@ -1,0 +1,22 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package mz_repr.row.collection;
+
+message ProtoRowCollection {
+    bytes encoded = 1;
+    repeated ProtoEncodedRowMetadata metadata = 2;
+}
+
+message ProtoEncodedRowMetadata {
+    uint64 offset = 1;
+    uint64 diff = 2;
+}

--- a/src/repr/src/row/collection.rs
+++ b/src/repr/src/row/collection.rs
@@ -27,7 +27,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_repr.row.collection.rs"));
 ///
 /// Note: the encoding format we use to represent [`Row`]s in this struct is
 /// not stable, and thus should never be persisted durably.
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct RowCollection {
     /// Contiguous blob of encoded Rows.
     encoded: Bytes,
@@ -115,8 +115,7 @@ impl RowCollection {
         };
 
         let slice = &self.encoded[lower_offset..upper.offset];
-        // SAFETY: We know all of the data in a RowCollection are valid Rows.
-        let row = unsafe { RowRef::from_slice(slice) };
+        let row = RowRef::from_slice(slice);
 
         Some((row, upper))
     }

--- a/src/repr/src/row/collection.rs
+++ b/src/repr/src/row/collection.rs
@@ -37,7 +37,7 @@ pub struct RowCollection {
 
 impl RowCollection {
     /// Create a new [`RowCollection`] from a collection of [`Row`]s.
-    pub fn new(rows: Vec<(Row, NonZeroUsize)>) -> Self {
+    pub fn new(rows: &[(Row, NonZeroUsize)]) -> Self {
         // Pre-sizing our buffer should allow us to make just 1 allocation, and
         // use the perfect amount of memory.
         //
@@ -52,7 +52,7 @@ impl RowCollection {
             encoded.extend(row.data());
             metadata.push(EncodedRowMetadata {
                 offset: encoded.len(),
-                diff,
+                diff: *diff,
             });
         }
 
@@ -469,7 +469,7 @@ mod tests {
     fn test_sorted_iter() {
         let a = Row::pack_slice(&[Datum::String("hello world")]);
         let b = Row::pack_slice(&[Datum::UInt32(42)]);
-        let col = RowCollection::new(vec![
+        let col = RowCollection::new(&[
             (a.clone(), NonZeroUsize::new(3).unwrap()),
             (b.clone(), NonZeroUsize::new(2).unwrap()),
         ]);
@@ -495,7 +495,7 @@ mod tests {
     fn test_sorted_iter_offset() {
         let a = Row::pack_slice(&[Datum::String("hello world")]);
         let b = Row::pack_slice(&[Datum::UInt32(42)]);
-        let col = RowCollection::new(vec![
+        let col = RowCollection::new(&[
             (a.clone(), NonZeroUsize::new(3).unwrap()),
             (b.clone(), NonZeroUsize::new(2).unwrap()),
         ]);
@@ -536,7 +536,7 @@ mod tests {
     fn test_sorted_iter_limit() {
         let a = Row::pack_slice(&[Datum::String("hello world")]);
         let b = Row::pack_slice(&[Datum::UInt32(42)]);
-        let col = RowCollection::new(vec![
+        let col = RowCollection::new(&[
             (a.clone(), NonZeroUsize::new(3).unwrap()),
             (b.clone(), NonZeroUsize::new(2).unwrap()),
         ]);
@@ -587,7 +587,7 @@ mod tests {
     #[mz_ore::test]
     fn test_mapped_row_iterator() {
         let a = Row::pack_slice(&[Datum::String("hello world")]);
-        let col = RowCollection::new(vec![(a.clone(), NonZeroUsize::new(3).unwrap())]);
+        let col = RowCollection::new(&[(a.clone(), NonZeroUsize::new(3).unwrap())]);
         let col = col.sorted_view(|a, b| a.cmp(b));
 
         // Make sure we can call `.map` on a `dyn RowIterator`.
@@ -604,7 +604,7 @@ mod tests {
     #[mz_ore::test]
     fn test_projected_row_iterator() {
         let a = Row::pack_slice(&[Datum::String("hello world"), Datum::Int16(42)]);
-        let col = RowCollection::new(vec![(a.clone(), NonZeroUsize::new(2).unwrap())]);
+        let col = RowCollection::new(&[(a.clone(), NonZeroUsize::new(2).unwrap())]);
         let col = col.sorted_view(|a, b| a.cmp(b));
 
         // Project away the first column.

--- a/src/repr/src/row/collection.rs
+++ b/src/repr/src/row/collection.rs
@@ -411,6 +411,7 @@ mod tests {
     use std::borrow::Borrow;
 
     use proptest::prelude::*;
+    use proptest::test_runner::Config;
 
     use super::*;
     use crate::Datum;
@@ -660,10 +661,14 @@ mod tests {
             }
         }
 
-        proptest!(|(rows in any::<Vec<Row>>())| {
-            // The proptest! macro interferes with rustfmt.
-            row_collection_roundtrips(rows)
-        });
+        // This test is slow, so we limit the default number of test cases.
+        proptest!(
+            Config { cases: 10, ..Default::default() },
+            |(rows in any::<Vec<Row>>())| {
+                // The proptest! macro interferes with rustfmt.
+                row_collection_roundtrips(rows)
+            }
+        );
     }
 
     #[mz_ore::test]
@@ -681,10 +686,14 @@ mod tests {
             }
         }
 
-        proptest!(|(a in any::<Vec<Row>>(), b in any::<Vec<Row>>())| {
-            // The proptest! macro interferes with rustfmt.
-            row_collection_merge(a, b)
-        });
+        // This test is slow, so we limit the default number of test cases.
+        proptest!(
+            Config { cases: 5, ..Default::default() },
+            |(a in any::<Vec<Row>>(), b in any::<Vec<Row>>())| {
+                // The proptest! macro interferes with rustfmt.
+                row_collection_merge(a, b)
+            }
+        );
     }
 
     #[mz_ore::test]
@@ -703,9 +712,13 @@ mod tests {
             }
         }
 
-        proptest!(|(a in any::<Vec<Row>>())| {
-            // The proptest! macro interferes with rustfmt.
-            row_collection_sort(a)
-        });
+        // This test is slow, so we limit the default number of test cases.
+        proptest!(
+            Config { cases: 10, ..Default::default() },
+            |(a in any::<Vec<Row>>())| {
+                // The proptest! macro interferes with rustfmt.
+                row_collection_sort(a)
+            }
+        );
     }
 }

--- a/src/repr/src/row/collection.rs
+++ b/src/repr/src/row/collection.rs
@@ -649,6 +649,7 @@ mod tests {
     }
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow
     fn proptest_row_collection() {
         fn row_collection_roundtrips(rows: Vec<Row>) {
             let collection = RowCollection::from(&rows);
@@ -672,6 +673,7 @@ mod tests {
     }
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow
     fn proptest_merge() {
         fn row_collection_merge(a: Vec<Row>, b: Vec<Row>) {
             let mut a_col = RowCollection::from(&a);
@@ -697,6 +699,7 @@ mod tests {
     }
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // too slow
     fn proptest_sort() {
         fn row_collection_sort(mut a: Vec<Row>) {
             let a_col = RowCollection::from(&a);

--- a/src/repr/src/row/collection.rs
+++ b/src/repr/src/row/collection.rs
@@ -229,12 +229,6 @@ impl SortedRowCollection {
             .get(idx)
             .and_then(|inner_idx| self.collection.get(*inner_idx))
     }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&RowRef, &EncodedRowMetadata)> {
-        self.sorted_view
-            .iter()
-            .map(|idx| self.collection.get(*idx).expect("invalid view"))
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/repr/src/row/collection.rs
+++ b/src/repr/src/row/collection.rs
@@ -1,0 +1,731 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Defines types for working with collections of [`Row`].
+
+use std::num::NonZeroUsize;
+
+use bytes::Bytes;
+use mz_ore::cast::CastFrom;
+use mz_proto::RustType;
+use serde::{Deserialize, Serialize};
+
+use crate::row::iter::{IntoRowIterator, RowIterator};
+use crate::row::{Row, RowRef};
+use crate::DatumVec;
+
+include!(concat!(env!("OUT_DIR"), "/mz_repr.row.collection.rs"));
+
+/// Collection of [`Row`]s represented as a single blob.
+///
+/// Note: the encoding format we use to represent [`Row`]s in this struct is
+/// not stable, and thus should never be persisted durably.
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RowCollection {
+    /// Contiguous blob of encoded Rows.
+    encoded: Bytes,
+    /// Metadata about an individual Row in the blob.
+    metadata: Vec<EncodedRowMetadata>,
+}
+
+impl RowCollection {
+    /// Create a new [`RowCollection`] from a collection of [`Row`]s.
+    pub fn new(rows: Vec<(Row, NonZeroUsize)>) -> Self {
+        // Pre-sizing our buffer should allow us to make just 1 allocation, and
+        // use the perfect amount of memory.
+        //
+        // Note(parkmycar): I didn't do any benchmarking to determine if this
+        // is faster, so feel free to change this if you'd like.
+        let encoded_size = rows.iter().map(|(row, _diff)| row.data.len()).sum();
+
+        let mut encoded = Vec::<u8>::with_capacity(encoded_size);
+        let mut metadata = Vec::<EncodedRowMetadata>::with_capacity(rows.len());
+
+        for (row, diff) in rows {
+            encoded.extend(row.data());
+            metadata.push(EncodedRowMetadata {
+                offset: encoded.len(),
+                diff,
+            });
+        }
+
+        RowCollection {
+            encoded: Bytes::from(encoded),
+            metadata,
+        }
+    }
+
+    /// Merge another [`RowCollection`] into `self`.
+    pub fn merge(&mut self, other: &RowCollection) {
+        if other.count() == 0 {
+            return;
+        }
+
+        // TODO(parkmycar): Using SegmentedBytes here would be nice.
+        let mut new_bytes = vec![0; self.encoded.len() + other.encoded.len()];
+        new_bytes[..self.encoded.len()].copy_from_slice(&self.encoded[..]);
+        new_bytes[self.encoded.len()..].copy_from_slice(&other.encoded[..]);
+
+        let mapped_metas = other.metadata.iter().map(|meta| EncodedRowMetadata {
+            offset: meta.offset + self.encoded.len(),
+            diff: meta.diff,
+        });
+
+        self.metadata.extend(mapped_metas);
+        self.encoded = Bytes::from(new_bytes);
+    }
+
+    /// Total count of [`Row`]s represented by this collection.
+    pub fn count(&self) -> usize {
+        self.metadata.iter().map(|meta| meta.diff.get()).sum()
+    }
+
+    /// Total count of ([`Row`], [`EncodedRowMetadata`]) pairs in this collection.
+    pub fn entries(&self) -> usize {
+        self.metadata.len()
+    }
+
+    /// Returns the number of bytes this [`RowCollection`] uses.
+    pub fn byte_len(&self) -> usize {
+        let row_data_size = self.encoded.len();
+        let metadata_size = self
+            .metadata
+            .len()
+            .saturating_mul(std::mem::size_of::<EncodedRowMetadata>());
+
+        row_data_size.saturating_add(metadata_size)
+    }
+
+    /// Returns a [`RowRef`] for the entry at `idx`, if one exists.
+    pub fn get(&self, idx: usize) -> Option<(&RowRef, &EncodedRowMetadata)> {
+        let (lower_offset, upper) = match idx {
+            0 => (0, self.metadata.get(idx)?),
+            _ => {
+                let lower = self.metadata.get(idx - 1).map(|m| m.offset)?;
+                let upper = self.metadata.get(idx)?;
+                (lower, upper)
+            }
+        };
+
+        let slice = &self.encoded[lower_offset..upper.offset];
+        // SAFETY: We know all of the data in a RowCollection are valid Rows.
+        let row = unsafe { RowRef::from_slice(slice) };
+
+        Some((row, upper))
+    }
+
+    /// "Sorts" the [`RowCollection`] by returning a sorted view over the collection.
+    pub fn sorted_view<F>(self, mut f: F) -> SortedRowCollection
+    where
+        F: FnMut(&RowRef, &RowRef) -> std::cmp::Ordering,
+    {
+        let mut view: Vec<_> = (0..self.metadata.len()).collect();
+        view.sort_by(|a, b| {
+            let (a_row, _) = self.get(*a).expect("index invalid?");
+            let (b_row, _) = self.get(*b).expect("index invalid?");
+            f(a_row, b_row)
+        });
+
+        SortedRowCollection {
+            collection: self,
+            sorted_view: view,
+        }
+    }
+}
+
+impl<'a, T: IntoIterator<Item = &'a Row>> From<T> for RowCollection {
+    fn from(rows: T) -> Self {
+        let mut encoded = Vec::<u8>::new();
+        let mut metadata = Vec::<EncodedRowMetadata>::new();
+
+        for row in rows {
+            encoded.extend(row.data());
+            metadata.push(EncodedRowMetadata {
+                offset: encoded.len(),
+                diff: unsafe { NonZeroUsize::new_unchecked(1) },
+            });
+        }
+
+        RowCollection {
+            encoded: Bytes::from(encoded),
+            metadata,
+        }
+    }
+}
+
+impl RustType<ProtoRowCollection> for RowCollection {
+    fn into_proto(&self) -> ProtoRowCollection {
+        ProtoRowCollection {
+            encoded: Bytes::clone(&self.encoded),
+            metadata: self
+                .metadata
+                .iter()
+                .map(EncodedRowMetadata::into_proto)
+                .collect(),
+        }
+    }
+
+    fn from_proto(proto: ProtoRowCollection) -> Result<Self, mz_proto::TryFromProtoError> {
+        Ok(RowCollection {
+            encoded: proto.encoded,
+            metadata: proto
+                .metadata
+                .into_iter()
+                .map(EncodedRowMetadata::from_proto)
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
+/// Inner type of [`RowCollection`], describes a single Row.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct EncodedRowMetadata {
+    /// Offset into the binary blob of encoded rows.
+    ///
+    /// TODO(parkmycar): Consider making this a `u32`.
+    offset: usize,
+    /// Diff for the Row.
+    ///
+    /// TODO(parkmycar): Consider making this a `NonZeroU32`.
+    diff: NonZeroUsize,
+}
+
+impl RustType<ProtoEncodedRowMetadata> for EncodedRowMetadata {
+    fn into_proto(&self) -> ProtoEncodedRowMetadata {
+        ProtoEncodedRowMetadata {
+            offset: u64::cast_from(self.offset),
+            diff: self.diff.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoEncodedRowMetadata) -> Result<Self, mz_proto::TryFromProtoError> {
+        Ok(EncodedRowMetadata {
+            offset: usize::cast_from(proto.offset),
+            diff: NonZeroUsize::from_proto(proto.diff)?,
+        })
+    }
+}
+
+/// Provides a sorted view of a [`RowCollection`].
+#[derive(Debug, Clone)]
+pub struct SortedRowCollection {
+    /// The inner [`RowCollection`].
+    collection: RowCollection,
+    /// Indexes into the inner collection that represent the sorted order.
+    sorted_view: Vec<usize>,
+}
+
+impl SortedRowCollection {
+    pub fn get(&self, idx: usize) -> Option<(&RowRef, &EncodedRowMetadata)> {
+        self.sorted_view
+            .get(idx)
+            .and_then(|inner_idx| self.collection.get(*inner_idx))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&RowRef, &EncodedRowMetadata)> {
+        self.sorted_view
+            .iter()
+            .map(|idx| self.collection.get(*idx).expect("invalid view"))
+    }
+}
+
+#[derive(Debug)]
+pub struct SortedRowCollectionIter {
+    /// Collection we're iterating over.
+    collection: SortedRowCollection,
+
+    /// Index for the row we're currently referencing.
+    row_idx: usize,
+    /// Number of diffs we've emitted for the current row.
+    diff_idx: usize,
+
+    /// Start yielding rows after we've offset this many values into the iterator.
+    offset: Option<usize>,
+    /// Maximum number of rows this iterator will yield.
+    limit: Option<usize>,
+
+    /// Columns to underlying rows to include.
+    projection: Option<Vec<usize>>,
+    /// Allocations that we reuse for every iteration to project columns.
+    projection_buf: (DatumVec, Row),
+}
+
+impl SortedRowCollectionIter {
+    /// Returns the inner [`SortedRowCollection`].
+    pub fn into_inner(self) -> SortedRowCollection {
+        self.collection
+    }
+
+    /// Sets the offset for this iterator.
+    pub fn with_offset(mut self, offset: usize) -> SortedRowCollectionIter {
+        self.offset = Some(offset);
+        self
+    }
+
+    /// Sets the limit for this iterator.
+    pub fn with_limit(mut self, limit: usize) -> SortedRowCollectionIter {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Specify the columns that should be yielded.
+    pub fn with_projection(mut self, projection: Vec<usize>) -> SortedRowCollectionIter {
+        // Omit the projection if it would be a no-op to avoid a relatively expensive memcpy.
+        if let Some((row, _)) = self.collection.get(0) {
+            let cols = row.into_iter().enumerate().map(|(idx, _datum)| idx);
+            if projection.iter().copied().eq(cols) {
+                return self;
+            }
+        }
+
+        self.projection = Some(projection);
+        self
+    }
+
+    /// Helper method for implementing [`RowIterator`].
+    ///
+    /// Advances the internal pointers by the specified amount.
+    fn advance_by(
+        collection: &SortedRowCollection,
+        row_idx: &mut usize,
+        diff_idx: &mut usize,
+        mut count: usize,
+    ) {
+        while count > 0 {
+            let Some((_, row_meta)) = collection.get(*row_idx) else {
+                return;
+            };
+
+            let remaining_diff = row_meta.diff.get() - *diff_idx;
+            if remaining_diff <= count {
+                *diff_idx = 0;
+                *row_idx += 1;
+                count -= remaining_diff;
+            } else {
+                *diff_idx += count;
+                count = 0;
+            }
+        }
+    }
+
+    /// Helper method for implementing [`RowIterator`].
+    ///
+    /// Projects columns for the provided `row`.
+    fn project<'a>(
+        projection: Option<&'a Vec<usize>>,
+        row: &'a RowRef,
+        datum_buf: &'a mut DatumVec,
+        row_buf: &'a mut Row,
+    ) -> Option<&'a RowRef> {
+        if let Some(projection) = projection.as_ref() {
+            // Copy the required columns into our reusable buffer.
+            {
+                let datums = datum_buf.borrow_with(row);
+                row_buf
+                    .packer()
+                    .extend(projection.iter().map(|i| &datums[*i]));
+            }
+
+            Some(row_buf)
+        } else {
+            Some(row)
+        }
+    }
+}
+
+impl RowIterator for SortedRowCollectionIter {
+    fn next(&mut self) -> Option<&RowRef> {
+        // Advance past our offset.
+        if let Some(offset) = self.offset {
+            Self::advance_by(
+                &self.collection,
+                &mut self.row_idx,
+                &mut self.diff_idx,
+                offset,
+            );
+        }
+        self.offset = None;
+
+        // Bail if we've reached our limit.
+        if let Some(0) = self.limit {
+            return None;
+        }
+
+        let row = self.collection.get(self.row_idx).map(|(r, _)| r)?;
+
+        // If we're about to yield a row, then subtract from our limit.
+        if let Some(limit) = &mut self.limit {
+            *limit = limit.saturating_sub(1);
+        }
+
+        // Advance to the next row.
+        Self::advance_by(&self.collection, &mut self.row_idx, &mut self.diff_idx, 1);
+
+        // Project away and/or re-order any columns.
+        let (datum_buf, row_buf) = &mut self.projection_buf;
+        let row = Self::project(self.projection.as_ref(), row, datum_buf, row_buf)?;
+
+        Some(row)
+    }
+
+    fn peek(&mut self) -> Option<&RowRef> {
+        // Even for peek we still have to advance past any offset, otherwise we
+        // could return a Row that shouldn't have been yielded.
+        if let Some(offset) = self.offset {
+            Self::advance_by(
+                &self.collection,
+                &mut self.row_idx,
+                &mut self.diff_idx,
+                offset,
+            );
+        }
+        self.offset = None;
+
+        // Bail if we've reached our limit.
+        if let Some(0) = self.limit {
+            return None;
+        }
+
+        let row = self.collection.get(self.row_idx).map(|(r, _)| r)?;
+
+        // Note: Unlike `next()` we do not subtract from our limit, nor advance
+        // the internal pointers.
+
+        // Project away and/or re-order any columns.
+        let (datum_buf, row_buf) = &mut self.projection_buf;
+        let row = Self::project(self.projection.as_ref(), row, datum_buf, row_buf)?;
+
+        Some(row)
+    }
+
+    fn count(&self) -> usize {
+        self.collection.collection.count()
+    }
+}
+
+impl IntoRowIterator for SortedRowCollection {
+    type Iter = SortedRowCollectionIter;
+
+    fn into_row_iter(self) -> Self::Iter {
+        SortedRowCollectionIter {
+            collection: self,
+            row_idx: 0,
+            diff_idx: 0,
+            offset: None,
+            limit: None,
+            projection: None,
+            // Note: Neither of these types allocate until elements are pushed in.
+            projection_buf: (DatumVec::new(), Row::default()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Borrow;
+
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::Datum;
+
+    #[mz_ore::test]
+    fn test_row_collection() {
+        let a = Row::pack_slice(&[Datum::False, Datum::String("hello world"), Datum::Int16(42)]);
+        let b = Row::pack_slice(&[Datum::MzTimestamp(crate::Timestamp::new(10))]);
+
+        let collection = RowCollection::from([&a, &b]);
+
+        let (a_rnd, _) = collection.get(0).unwrap();
+        assert_eq!(a_rnd, a.borrow());
+
+        let (b_rnd, _) = collection.get(1).unwrap();
+        assert_eq!(b_rnd, b.borrow());
+    }
+
+    #[mz_ore::test]
+    fn test_merge() {
+        let a = Row::pack_slice(&[Datum::False, Datum::String("hello world"), Datum::Int16(42)]);
+        let b = Row::pack_slice(&[Datum::MzTimestamp(crate::Timestamp::new(10))]);
+
+        let mut a_col = RowCollection::from([&a]);
+        let b_col = RowCollection::from([&b]);
+
+        a_col.merge(&b_col);
+
+        assert_eq!(a_col.count(), 2);
+        assert_eq!(a_col.get(0).map(|(r, _)| r), Some(a.borrow()));
+        assert_eq!(a_col.get(1).map(|(r, _)| r), Some(b.borrow()));
+    }
+
+    #[mz_ore::test]
+    fn test_sort() {
+        let a = Row::pack_slice(&[Datum::False, Datum::String("hello world"), Datum::Int16(42)]);
+        let b = Row::pack_slice(&[Datum::MzTimestamp(crate::Timestamp::new(10))]);
+
+        let col = RowCollection::from([&a, &b]);
+        let mut rows = vec![a, b];
+
+        let sorted_view = col.sorted_view(|a, b| a.cmp(b));
+        rows.sort_by(|a, b| a.cmp(b));
+
+        for i in 0..rows.len() {
+            let (row_x, _) = sorted_view.get(i).unwrap();
+            let row_y = rows.get(i).unwrap();
+
+            assert_eq!(row_x, row_y.borrow());
+        }
+    }
+
+    #[mz_ore::test]
+    fn test_sorted_iter() {
+        let a = Row::pack_slice(&[Datum::String("hello world")]);
+        let b = Row::pack_slice(&[Datum::UInt32(42)]);
+        let col = RowCollection::new(vec![
+            (a.clone(), NonZeroUsize::new(3).unwrap()),
+            (b.clone(), NonZeroUsize::new(2).unwrap()),
+        ]);
+        let col = col.sorted_view(|a, b| a.cmp(b));
+        let mut iter = col.into_row_iter();
+
+        // Peek shouldn't advance the iterator.
+        assert_eq!(iter.peek(), Some(b.borrow()));
+
+        assert_eq!(iter.next(), Some(b.borrow()));
+        assert_eq!(iter.next(), Some(b.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), None);
+
+        // For good measure make sure we don't panic.
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.peek(), None);
+    }
+
+    #[mz_ore::test]
+    fn test_sorted_iter_offset() {
+        let a = Row::pack_slice(&[Datum::String("hello world")]);
+        let b = Row::pack_slice(&[Datum::UInt32(42)]);
+        let col = RowCollection::new(vec![
+            (a.clone(), NonZeroUsize::new(3).unwrap()),
+            (b.clone(), NonZeroUsize::new(2).unwrap()),
+        ]);
+        let col = col.sorted_view(|a, b| a.cmp(b));
+
+        // Test with a reasonable offset that does not span rows.
+        let mut iter = col.into_row_iter().with_offset(1);
+        assert_eq!(iter.next(), Some(b.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        let col = iter.into_inner();
+
+        // Test with an offset that spans the first row.
+        let mut iter = col.into_row_iter().with_offset(3);
+
+        assert_eq!(iter.peek(), Some(a.borrow()));
+
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        let col = iter.into_inner();
+
+        // Test with an offset that passes the entire collection.
+        let mut iter = col.into_row_iter().with_offset(100);
+        assert_eq!(iter.peek(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.peek(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[mz_ore::test]
+    fn test_sorted_iter_limit() {
+        let a = Row::pack_slice(&[Datum::String("hello world")]);
+        let b = Row::pack_slice(&[Datum::UInt32(42)]);
+        let col = RowCollection::new(vec![
+            (a.clone(), NonZeroUsize::new(3).unwrap()),
+            (b.clone(), NonZeroUsize::new(2).unwrap()),
+        ]);
+        let col = col.sorted_view(|a, b| a.cmp(b));
+
+        // Test with a limit that spans only the first row.
+        let mut iter = col.into_row_iter().with_limit(1);
+        assert_eq!(iter.next(), Some(b.borrow()));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        let col = iter.into_inner();
+
+        // Test with a limit that spans both rows.
+        let mut iter = col.into_row_iter().with_limit(4);
+        assert_eq!(iter.peek(), Some(b.borrow()));
+        assert_eq!(iter.next(), Some(b.borrow()));
+        assert_eq!(iter.next(), Some(b.borrow()));
+
+        assert_eq!(iter.peek(), Some(a.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        let col = iter.into_inner();
+
+        // Test with a limit that is more rows than we have.
+        let mut iter = col.into_row_iter().with_limit(1000);
+        assert_eq!(iter.next(), Some(b.borrow()));
+        assert_eq!(iter.next(), Some(b.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), Some(a.borrow()));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        let col = iter.into_inner();
+
+        // Test with a limit of 0.
+        let mut iter = col.into_row_iter().with_limit(0);
+        assert_eq!(iter.peek(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[mz_ore::test]
+    fn test_mapped_row_iterator() {
+        let a = Row::pack_slice(&[Datum::String("hello world")]);
+        let col = RowCollection::new(vec![(a.clone(), NonZeroUsize::new(3).unwrap())]);
+        let col = col.sorted_view(|a, b| a.cmp(b));
+
+        // Make sure we can call `.map` on a `dyn RowIterator`.
+        let iter: Box<dyn RowIterator> = Box::new(col.into_row_iter());
+
+        let mut mapped = iter.map(|f| f.to_owned());
+        assert!(mapped.next().is_some());
+        assert!(mapped.next().is_some());
+        assert!(mapped.next().is_some());
+        assert!(mapped.next().is_none());
+        assert!(mapped.next().is_none());
+    }
+
+    #[mz_ore::test]
+    fn test_projected_row_iterator() {
+        let a = Row::pack_slice(&[Datum::String("hello world"), Datum::Int16(42)]);
+        let col = RowCollection::new(vec![(a.clone(), NonZeroUsize::new(2).unwrap())]);
+        let col = col.sorted_view(|a, b| a.cmp(b));
+
+        // Project away the first column.
+        let mut iter = col.into_row_iter().with_projection(vec![1]);
+
+        let projected_a = Row::pack_slice(&[Datum::Int16(42)]);
+        assert_eq!(iter.next(), Some(projected_a.as_ref()));
+        assert_eq!(iter.next(), Some(projected_a.as_ref()));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        let col = iter.into_inner();
+
+        // Project away all columns.
+        let mut iter = col.into_row_iter().with_projection(vec![]);
+
+        let projected_a = Row::default();
+        assert_eq!(iter.next(), Some(projected_a.as_ref()));
+        assert_eq!(iter.next(), Some(projected_a.as_ref()));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        let col = iter.into_inner();
+
+        // Include all columns.
+        let mut iter = col.into_row_iter().with_projection(vec![0, 1]);
+
+        assert_eq!(iter.next(), Some(a.as_ref()));
+        assert_eq!(iter.next(), Some(a.as_ref()));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        let col = iter.into_inner();
+
+        // Swap the order of columns.
+        let mut iter = col.into_row_iter().with_projection(vec![1, 0]);
+
+        let projected_a = Row::pack_slice(&[Datum::Int16(42), Datum::String("hello world")]);
+        assert_eq!(iter.next(), Some(projected_a.as_ref()));
+        assert_eq!(iter.next(), Some(projected_a.as_ref()));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[mz_ore::test]
+    fn proptest_row_collection() {
+        fn row_collection_roundtrips(rows: Vec<Row>) {
+            let collection = RowCollection::from(&rows);
+
+            for i in 0..rows.len() {
+                let (a, _) = collection.get(i).unwrap();
+                let b = rows.get(i).unwrap().borrow();
+
+                assert_eq!(a, b);
+            }
+        }
+
+        proptest!(|(rows in any::<Vec<Row>>())| {
+            // The proptest! macro interferes with rustfmt.
+            row_collection_roundtrips(rows)
+        });
+    }
+
+    #[mz_ore::test]
+    fn proptest_merge() {
+        fn row_collection_merge(a: Vec<Row>, b: Vec<Row>) {
+            let mut a_col = RowCollection::from(&a);
+            let b_col = RowCollection::from(&b);
+
+            a_col.merge(&b_col);
+
+            let all_rows = a.iter().chain(b.iter());
+            for (idx, row) in all_rows.enumerate() {
+                let (col_row, _) = a_col.get(idx).unwrap();
+                assert_eq!(col_row, row.borrow());
+            }
+        }
+
+        proptest!(|(a in any::<Vec<Row>>(), b in any::<Vec<Row>>())| {
+            // The proptest! macro interferes with rustfmt.
+            row_collection_merge(a, b)
+        });
+    }
+
+    #[mz_ore::test]
+    fn proptest_sort() {
+        fn row_collection_sort(mut a: Vec<Row>) {
+            let a_col = RowCollection::from(&a);
+
+            let sorted_view = a_col.sorted_view(|a, b| a.cmp(b));
+            a.sort_by(|a, b| a.cmp(b));
+
+            for i in 0..a.len() {
+                let (row_x, _) = sorted_view.get(i).unwrap();
+                let row_y = a.get(i).unwrap();
+
+                assert_eq!(row_x, row_y.borrow());
+            }
+        }
+
+        proptest!(|(a in any::<Vec<Row>>())| {
+            // The proptest! macro interferes with rustfmt.
+            row_collection_sort(a)
+        });
+    }
+}

--- a/src/repr/src/row/collection.rs
+++ b/src/repr/src/row/collection.rs
@@ -192,7 +192,9 @@ pub struct EncodedRowMetadata {
     offset: usize,
     /// Diff for the Row.
     ///
-    /// TODO(parkmycar): Consider making this a `NonZeroU32`.
+    /// TODO(parkmycar): Consider making this a smaller type, note that some compute introspection
+    /// collections, e.g. `mz_scheduling_elapsed_raw`, encodes nano seconds in the diff field which
+    /// requires a u64.
     diff: NonZeroUsize,
 }
 

--- a/src/repr/src/row/iter.rs
+++ b/src/repr/src/row/iter.rs
@@ -26,8 +26,8 @@ use crate::row::{Row, RowRef};
 /// * [`streaming_iterator`](https://docs.rs/streaming-iterator/latest/streaming_iterator/)
 /// * [`lending-iterator`](https://docs.rs/lending-iterator/latest/lending_iterator/)
 ///
-/// Neither have an `IntoLendingIterator` trait that is useful for our interface, or do they don't
-/// work well with trait objects.
+/// Neither have an `IntoLendingIterator` trait that is useful for our interface, nor do they work
+/// well with trait objects.
 pub trait RowIterator: Debug {
     /// Returns the next [`RowRef`] advancing the iterator.
     fn next(&mut self) -> Option<&RowRef>;

--- a/src/repr/src/row/iter.rs
+++ b/src/repr/src/row/iter.rs
@@ -1,0 +1,190 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Defines a "lending iterator" for [`Row`]
+
+use std::fmt::Debug;
+
+use crate::row::{Row, RowRef};
+
+/// An iterator that can borrow from `self` and yield [`RowRef`]s.
+///
+/// This trait is a "lending iterator" for [`Row`]s, in other words, an iterator that borrows from
+/// self (e.g. an underlying memory buffer) to return a [`RowRef`]. The [`std::iter::Iterator`]
+/// trait does not currently support this pattern because there is no way to name the lifetime of
+/// the borrow on its associated `Item` type. Generic Associated Types (GATs) would allow this but
+/// so far no new trait has been introduced with this API.
+///
+/// There are a few open source crates that provide a trait:
+///
+/// * [`streaming_iterator`](https://docs.rs/streaming-iterator/latest/streaming_iterator/)
+/// * [`lending-iterator`](https://docs.rs/lending-iterator/latest/lending_iterator/)
+///
+/// Neither have an `IntoLendingIterator` trait that is useful for our interface, or do they don't
+/// work well with trait objects.
+pub trait RowIterator: Debug {
+    /// Returns the next [`RowRef`] advancing the iterator.
+    fn next(&mut self) -> Option<&RowRef>;
+
+    /// Returns the next [`RowRef`] without advancing the iterator.
+    fn peek(&mut self) -> Option<&RowRef>;
+
+    /// The total number of [`Row`]s this iterator could ever yield.
+    ///
+    /// Note: it _does not_ return the number of rows _remaining_, in otherwords calling `.next()`
+    /// will not change the value returned from this method.
+    fn count(&self) -> usize;
+
+    /// Maps the returned [`RowRef`]s from this [`RowIterator`].
+    fn map<T, F>(self, f: F) -> MappedRowIterator<Self, F>
+    where
+        Self: Sized,
+        F: FnMut(&RowRef) -> T,
+    {
+        MappedRowIterator {
+            inner: self,
+            func: f,
+        }
+    }
+}
+
+impl<I: RowIterator + ?Sized> RowIterator for Box<I> {
+    fn next(&mut self) -> Option<&RowRef> {
+        (**self).next()
+    }
+
+    fn peek(&mut self) -> Option<&RowRef> {
+        (**self).peek()
+    }
+
+    fn count(&self) -> usize {
+        (**self).count()
+    }
+}
+
+impl<I: RowIterator + ?Sized> RowIterator for &mut I {
+    fn next(&mut self) -> Option<&RowRef> {
+        (**self).next()
+    }
+
+    fn peek(&mut self) -> Option<&RowRef> {
+        (**self).peek()
+    }
+
+    fn count(&self) -> usize {
+        (**self).count()
+    }
+}
+
+#[derive(Debug)]
+pub struct MappedRowIterator<I: RowIterator, F> {
+    inner: I,
+    func: F,
+}
+
+impl<T, F, I: RowIterator> Iterator for MappedRowIterator<I, F>
+where
+    F: FnMut(&RowRef) -> T,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let row_ref = self.inner.next()?;
+        Some((self.func)(row_ref))
+    }
+}
+
+/// Convert a type into a [`RowIterator`].
+pub trait IntoRowIterator {
+    type Iter: RowIterator;
+    fn into_row_iter(self) -> Self::Iter;
+}
+
+impl<T: RowIterator> IntoRowIterator for T {
+    type Iter = Self;
+    fn into_row_iter(self) -> Self::Iter {
+        self
+    }
+}
+
+/// A [`RowIterator`] for a single [`Row`].
+#[derive(Debug)]
+pub struct SingleRowIter {
+    row: Row,
+    finished: bool,
+}
+
+impl RowIterator for SingleRowIter {
+    fn next(&mut self) -> Option<&RowRef> {
+        if self.finished {
+            None
+        } else {
+            self.finished = true;
+            Some(self.row.as_ref())
+        }
+    }
+
+    fn peek(&mut self) -> Option<&RowRef> {
+        if self.finished {
+            None
+        } else {
+            Some(self.row.as_ref())
+        }
+    }
+
+    fn count(&self) -> usize {
+        1
+    }
+}
+
+impl IntoRowIterator for Row {
+    type Iter = SingleRowIter;
+
+    fn into_row_iter(self) -> Self::Iter {
+        SingleRowIter {
+            row: self,
+            finished: false,
+        }
+    }
+}
+
+/// A [`RowIterator`] for a [`Vec`] of [`Row`]s.
+#[derive(Debug, Clone)]
+pub struct VecRowIter {
+    rows: Vec<Row>,
+    index: usize,
+}
+
+impl RowIterator for VecRowIter {
+    fn next(&mut self) -> Option<&RowRef> {
+        let row = self.rows.get(self.index).map(|r| r.as_ref())?;
+        self.index = self.index.saturating_add(1);
+
+        Some(row)
+    }
+
+    fn peek(&mut self) -> Option<&RowRef> {
+        self.rows.get(self.index).map(|r| r.as_ref())
+    }
+
+    fn count(&self) -> usize {
+        self.rows.len()
+    }
+}
+
+impl IntoRowIterator for Vec<Row> {
+    type Iter = VecRowIter;
+
+    fn into_row_iter(self) -> Self::Iter {
+        VecRowIter {
+            rows: self,
+            index: 0,
+        }
+    }
+}

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -432,7 +432,7 @@ SELECT generate_series(1, 2)
 2
 
 query error db error: ERROR: result exceeds max size of 100 B
-SELECT generate_series(1, 10)
+SELECT generate_series(1, 51)
 
 # Regression for #22724
 # Ensure duplicate rows don't overcount bytes in the presence of LIMIT.

--- a/test/testdrive/oom.td
+++ b/test/testdrive/oom.td
@@ -14,21 +14,27 @@ $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdri
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_result_size = 128
 
-# Each inline row takes 24 bytes of memory, 23 for the inline array and 1 for the length.
+# In environmentd each Row requires 24 bytes + number of bytes to encode. But we'll also de-dupe
+# repeated values by incrementing the diff.
 
-> SELECT 1::int4 FROM generate_series(1, 5);
+> SELECT 1::int4 FROM generate_series(1, 10);
+1
+1
+1
+1
+1
 1
 1
 1
 1
 1
 
-! SELECT 1::int4 FROM generate_series(1, 6);
+! SELECT * FROM generate_series(1, 6);
 contains:result exceeds max size of 128 B
 
 > CREATE TABLE t1 (a int4)
 
-> INSERT INTO t1 SELECT 1::int4 FROM generate_series(1, 5);
+> INSERT INTO t1 SELECT * FROM generate_series(1, 5);
 
 > INSERT INTO t1 VALUES (6);
 
@@ -65,8 +71,8 @@ ALTER SYSTEM SET max_result_size = 240000;
 ! SELECT generate_series::int4 FROM generate_series(1, 10001)
 contains:result exceeds max size of 240.0 KB
 
-! SELECT 1::int4 FROM generate_series(1, 10001)
-contains:result exceeds max size of 240.0 KB
+> SELECT 1::int4 FROM generate_series(1, 10001)
+10001 values hashing to 7e844fba503f0b3f02daa3de7c80938e
 
 > CREATE TABLE t2 (a int4)
 


### PR DESCRIPTION
This PR optimizes `PeekResponse`s by replacing `Vec<Row>` with a new `RowCollection` type which stores a collection of `Row`s in a contiguous blob. It makes the following changes:

1. `PeekResponse` generally requires less memory because we only allocate the exact amount needed to encode a row and only have 8 bytes of overhead for the offset. Opposed to 24 bytes for a `Row` which will store 23 bytes inline. For small rows (e.g. a single int) this leads to possibly wasted space, and for large rows that spill to the heap it requires 24 bytes of overhead.
2. `ProtoPeekResponse` now sends a blob of `bytes` (i.e. a Rust `bytes::Bytes`) which are a contiguous blob of `Row`s encoded in their own wire format. This makes handling decoding the rows from a `PeekResponse` zero-copy. Previously we were using `Vec<ProtoRow>` which resulted in multiple allocations per-Row.
3. `RowSetFinishing` no longer "explodes" `Vec<(Row, Diff)>` tuples into a `Vec<Row>`, we operate on the `(Row, Diff)` format.
4. `RowSetFinishing` creates a "sorted view" on top of the binary data from the network response, preventing the need to copy or move any of the row data itself.
5. pgwire and http protocol layers consume a newly defined `RowIterator` instead of `Vec<Row>`.

As far as I can tell, handling a `PeekResponse` now only requires 6 allocations:

1. Creating a `Vec<(usize, NonZeroUsize)>` for offsets and diffs when deserializing a `ProtoPeekResponse`
2. Creating a correctly sized `Vec<usize>` when creating a sorted view
3. Creating two `DatumVec`s, also for when we create our sorted view
4. Optionally creating a `Row` and `DatumVec` which are reusable buffers when projecting columns.

Previously the number of allocations was `O(n)` where `n` is the number of rows in a response

### Motivation

Reduce the amount of memory used by `environmentd` when handling a `PeekResponse`

Fixes https://github.com/MaterializeInc/materialize/issues/26712

### Tips for reviewer

This PR ended up being bigger than I thought it would be, so I split into 4 commits which can be reviewed independently:

1. Introduce a `RowRef` type, where `RowRef:Row::str:String`. I added a `RowRef` type because we needed an interface that would allow us to reference as slice of bytes (i.e. `&[u8]`) as row data.
2. Introduce the `RowCollection` type and `RowIterator` trait. `RowCollection` is the contiguous slice of bytes that we read `RowRef`s out of. Then `RowIterator` (as described in a doc comment) is a ["lending iterator"](https://blog.rust-lang.org/2022/10/28/gats-stabilization.html#what-are-gats) for Rows.
3. Changes to compute code to return a `RowCollection` in `PeekResponse`
4. Changes to adapter code to use a `Box<dyn RowIterator>` instead of `Vec<Row>`. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Performance improvements for handling query responses.
