### PR TITLE
rqg: evolve `left-join-stacks` workload grammar (v3)

### DIFF
--- a/test/rqg/datasets/star_schema.sql
+++ b/test/rqg/datasets/star_schema.sql
@@ -42,15 +42,19 @@ CREATE TABLE d1 (pk1 INT, pk2 INT NOT NULL, v INT NOT NULL);
 CREATE INDEX d1_i1 ON d1(pk1, pk2);
 
 INSERT INTO d1 VALUES
+  -- pk1 != pk2 rows
   (NULL, 0, 0),
   (0, 0, 1),
   -- 1 not present in d1
   (2, 3, 0), (3, 2, 1),
   (3, 4, 0),
   -- 4 has no rows in d1
-  (5, 6, 0),
-  (6, 7, 0)
-  -- 7 is not present in either table
+  (5, 6, 0), (6, 5, 1),
+  (6, 7, 0),
+
+  -- pk1 = pk2 rows
+  (3, 3, 0),
+  (5, 5, 0), (5, 5, 1)
   ;
 
 -- Dimension table and data (d2)
@@ -60,31 +64,41 @@ CREATE TABLE d2 (pk1 INT, pk2 INT NOT NULL, v INT NOT NULL);
 CREATE INDEX d2_i1 ON d2(pk1, pk2);
 
 INSERT INTO d2 VALUES
+  -- pk1 != pk2 rows
   (NULL, 0, 0),
-  -- 1 not present in d2
+  (1, 2, 0), (2, 1, 0),
   (2, 3, 0),
   (3, 4, 0), (4, 3, 1),
   (4, 5, 0),
-  (NULL, 5, 0)
+  (NULL, 5, 0),
   -- 6 has no rows in d2
-  -- 7 is not present in either table
+
+  -- pk1 = pk2 rows
+  (3, 3, 0), (3, 3, 1),
+  (4, 4, 0)
   ;
 
 -- Dimension table and data (d3)
 -- -----------------------------
 
-CREATE TABLE d3 (pk1 INT, pk2 INT NOT NULL, v INT NOT NULL);
+CREATE TABLE d3 (pk1 INT, pk2 INT, v INT NOT NULL);
 CREATE INDEX d3_i1 ON d3(pk1, pk2);
 
 INSERT INTO d3 VALUES
+  -- pk1 != pk2 rows
   (0, 0, 1),
   -- 1 not present in d3
   (NULL, 2, 0),
   (3, 4, 0), (4, 3, 1),
   -- 4 has no rows in d3
   (5, 6, 0),
-  (6, 7, 0), (7, 6, 1)
-  -- 7 is not present in either table
+  (6, 7, 0), (7, 6, 1),
+
+  -- pk1 = pk2 rows
+  (NULL, NULL, 0),
+  (3, 3, 0),
+  (4, 4, 1),
+  (5, 5, 0), (5, 5, 1)
   ;
 
 -- PK materialized views

--- a/test/rqg/grammars/left_join_stacks.yy
+++ b/test/rqg/grammars/left_join_stacks.yy
@@ -12,10 +12,6 @@ explain:
 ;
 
 query:
-  select
-;
-
-select:
   SELECT
     ft.ft_col AS c01,
     ft.ft_col AS c02,
@@ -35,8 +31,22 @@ select:
     left_join4
     left_join5
     left_join6
+  WHERE
+    where_clause
   ORDER BY
     c01, c02, c03, c04, c05, c06, c07, c08, c09, c10
+;
+
+where_clause:
+    true | true | true | true | true
+  | ft.ft_col IS NOT NULL bool_op where_clause
+  | ft.ft_col > 1 bool_op where_clause
+  | dim_alias.dx_col < 7 bool_op where_clause
+;
+
+bool_op:
+    AND | AND | AND | AND | AND
+  | OR
 ;
 
 dim_alias:


### PR DESCRIPTION
- Add a `WHERE` clause to the `query` rule in `left_join_stacks.yy`.
- Tweak the `star_schema.sql` sample data so filtered rows have more non-NULL results.

### Motivation

  * This PR adds a feature that has not yet been specified.

Something that I was planning to add to #26709, but I merged the PR before that.

### Tips for reviewer

I tested with 1000 queries and inspected the (still identical) results sets to ensure that we don't get a lot of empty rows.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
