### PR TITLE
compute: remove unneeded feature flags

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -52,23 +52,6 @@ pub const ENABLE_CHUNKED_STACK: Config<bool> = Config::new(
     "Enable the chunked stack implementation in compute.",
 );
 
-/// Enable operator hydration status logging.
-pub const ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING: Config<bool> = Config::new(
-    "enable_compute_operator_hydration_status_logging",
-    true,
-    "Enable logging of the hydration status of compute operators.",
-);
-
-/// Enable controller-controlled dataflow scheduling.
-///
-/// Introduced to derisk the rollout of the `Schedule` compute command.
-/// TODO(teskje): remove after successful validation in prod
-pub const ENABLE_CONTROLLER_DATAFLOW_SCHEDULING: Config<bool> = Config::new(
-    "enable_compute_controller_dataflow_scheduling",
-    true,
-    "Enable compute controller-controlled dataflow scheduling.",
-);
-
 /// Maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
 pub const DATAFLOW_MAX_INFLIGHT_BYTES: Config<Option<usize>> = Config::new(
     "compute_dataflow_max_inflight_bytes",
@@ -105,7 +88,7 @@ pub const LGALLOC_SLOW_CLEAR_BYTES: Config<usize> = Config::new(
 /// The number of dataflows that may hydrate concurrently.
 pub const HYDRATION_CONCURRENCY: Config<usize> = Config::new(
     "compute_hydration_concurrency",
-    usize::MAX,
+    4,
     "Controls how many compute dataflows may hydrate concurrently.",
 );
 
@@ -140,8 +123,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_COLUMNATION_LGALLOC)
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
         .add(&ENABLE_CHUNKED_STACK)
-        .add(&ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING)
-        .add(&ENABLE_CONTROLLER_DATAFLOW_SCHEDULING)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
         .add(&LGALLOC_BACKGROUND_INTERVAL)

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -117,7 +117,6 @@ use differential_dataflow::{AsCollection, Collection, Data, ExchangeData, Hashab
 use futures::channel::oneshot;
 use futures::FutureExt;
 use mz_compute_types::dataflows::{BuildDesc, DataflowDescription, IndexDesc};
-use mz_compute_types::dyncfgs::ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING;
 use mz_compute_types::plan::flat_plan::{FlatPlan, FlatPlanNode};
 use mz_compute_types::plan::LirId;
 use mz_expr::{EvalError, Id};
@@ -759,9 +758,7 @@ where
             let node = nodes.remove(&id).unwrap();
             let mut bundle = self.render_plan_node(node, &collections);
 
-            if ENABLE_OPERATOR_HYDRATION_STATUS_LOGGING.get(&self.worker_config) {
-                self.log_operator_hydration(&mut bundle, id);
-            }
+            self.log_operator_hydration(&mut bundle, id);
 
             collections.insert(id, bundle);
         }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -20,7 +20,6 @@ use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
 use differential_dataflow::{Collection, Data};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::AvailableCollections;
-use mz_dyncfg::ConfigSet;
 use mz_expr::{Id, MapFilterProject, MirScalarExpr};
 use mz_repr::fixed_length::{FromDatumIter, ToDatumIter};
 use mz_repr::{DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowArena, SharedRow};
@@ -85,8 +84,6 @@ where
     pub(super) hydration_logger: Option<HydrationLogger>,
     /// Specification for rendering linear joins.
     pub(super) linear_join_spec: LinearJoinSpec,
-    /// Per-worker dynamic configuration.
-    pub(super) worker_config: ConfigSet,
 }
 
 impl<S: Scope> Context<S>
@@ -128,7 +125,6 @@ where
             shutdown_token: Default::default(),
             hydration_logger,
             linear_join_spec: compute_state.linear_join_spec,
-            worker_config: compute_state.worker_config.clone(),
         }
     }
 }


### PR DESCRIPTION
This PR removes two feature flags that were introduced to reduce the risk of rolling out their respective features, which have been successfully rolled out in the meantime:

* `enable_compute_operator_hydration_status_logging`
* `enable_compute_controller_dataflow_scheduling`

Also adjusts the default value of `compute_hydration_concurrency` to the same value that's configured in all cloud environments.

### Motivation

   * This PR cleans up feature flags.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A