### PR TITLE
adapter: simplify acquire_read_holds, remove time/precise arguments

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2263,9 +2263,7 @@ impl Coordinator {
         // We're putting in place read holds, to prevent the since of
         // dependencies moving along concurrently, pulling the rug from under
         // us!
-        let read_holds = self
-            .acquire_read_holds(mz_repr::Timestamp::minimum(), &direct_dependencies, false)
-            .expect("can acquire un-precise read holds");
+        let read_holds = self.acquire_read_holds(&direct_dependencies);
 
         let min_as_of = self.least_valid_read(&read_holds);
 

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -870,9 +870,7 @@ impl Coordinator {
             // It's important that we acquire read holds _before_ we determine the least valid read.
             // Otherwise, we're not guaranteed that the since frontier doesn't
             // advance forward from underneath us.
-            let read_holds = self
-                .acquire_read_holds(Timestamp::MIN, &ids, false)
-                .expect("precise==false, so acquiring read holds always succeeds");
+            let read_holds = self.acquire_read_holds(&ids);
 
             // Does `mz_now()` occur?
             let mz_now_ts = if cmvs

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1040,9 +1040,7 @@ impl Coordinator {
         //
         // TODO: Maybe in the future, pass those holds on to storage, to hold on
         // to them and downgrade when possible?
-        let read_holds = self
-            .acquire_read_holds(mz_repr::Timestamp::MIN, &id_bundle, false)
-            .expect("can acquire read holds");
+        let read_holds = self.acquire_read_holds(&id_bundle);
         let as_of = self.least_valid_read(&read_holds);
 
         let storage_sink_from_entry = self.catalog().get_entry(&sink.from);

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -20,7 +20,6 @@ use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan;
 use mz_sql::session::metadata::SessionMetadata;
-use timely::progress::Timestamp as _;
 use tracing::Span;
 
 use crate::command::ExecuteResponse;
@@ -462,9 +461,7 @@ impl Coordinator {
                 //
                 // TODO: Maybe in the future, pass those holds on to compute, to
                 // hold on to them and downgrade when possible?
-                let read_holds = coord
-                    .acquire_read_holds(mz_repr::Timestamp::minimum(), &id_bundle, false)
-                    .expect("can acquire read holds");
+                let read_holds = coord.acquire_read_holds(&id_bundle);
                 let since = coord.least_valid_read(&read_holds);
                 df_desc.set_as_of(since);
 

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -566,9 +566,7 @@ impl Coordinator {
         } else {
             // No one has acquired holds, make sure we can determine an as_of
             // and render our dataflow below.
-            read_holds_owned = self
-                .acquire_read_holds(mz_repr::Timestamp::MIN, &id_bundle, false)
-                .expect("can always acquire non-precise read holds");
+            read_holds_owned = self.acquire_read_holds(&id_bundle);
             &read_holds_owned
         };
 

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -187,11 +187,7 @@ impl TimestampProvider for Coordinator {
     }
 
     fn acquire_read_holds(&mut self, id_bundle: &CollectionIdBundle) -> ReadHolds<Timestamp> {
-        let read_holds = self
-            .acquire_read_holds(mz_repr::Timestamp::minimum(), id_bundle, false)
-            .expect("can acquire read holds");
-
-        read_holds
+        self.acquire_read_holds(id_bundle)
     }
 
     fn catalog_state(&self) -> &CatalogState {


### PR DESCRIPTION
Previous refactorings removed the need for acquiring read holds at a specific time or with a guarantee of acquiring a "precise" read hold. We can now remove this recently-introduced change again.

All remaining usage of the method has `time = MIN` and `precise = false`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
