### PR TITLE
storage/copy-to-s3: Implement parquet decimal/numeric, jsonb, uuid types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,6 +4032,8 @@ dependencies = [
  "chrono",
  "mz-ore",
  "mz-repr",
+ "serde",
+ "serde_json",
  "workspace-hack",
 ]
 

--- a/src/arrow-util/Cargo.toml
+++ b/src/arrow-util/Cargo.toml
@@ -15,6 +15,8 @@ arrow = { version = "51.0.0", default-features = false }
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 mz-repr = { path = "../repr" }
 mz-ore = { path = "../ore" }
+serde = { version = "1.0.152" }
+serde_json = "1.0.89"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -182,15 +182,7 @@ $ s3-verify-keys bucket=copytos3 prefix-path=test/5 key-pattern=INCOMPLETE
     FORMAT = 'parquet'
   );
 
-# TODO: Uncomment when parquet supports complex types
-# > COPY (SELECT array[1,2]::int[], false::bool, 'Inf'::double, '{"s": "abc"}'::jsonb, 1::mz_timestamp, 32767::smallint, 2147483647::integer, 9223372036854775807::bigint, 12345678901234567890123.4567890123456789::numeric(39,16), '2010-10-10'::date, '10:10:10'::time, '2010-10-10 10:10:10+00'::timestamp, '0 day'::interval, 'aaaa'::text, '\\xAAAA'::bytea, 'това е'::text, 'текст'::bytea) TO 's3://copytos3/parquet_test/3'
-#   WITH (
-#     AWS CONNECTION = aws_conn,
-#     MAX FILE SIZE = "100MB",
-#     FORMAT = 'parquet'
-#   );
-
-> COPY (SELECT false::bool, 'Inf'::double, 1::mz_timestamp, 32767::smallint, 2147483647::integer, 9223372036854775807::bigint, 1234567890123456789012.4567890123456789::numeric(38,16), '2010-10-10'::date, '10:10:10'::time, '2010-10-10 10:10:10+00'::timestamp, 'aaaa'::text, '\\xAAAA'::bytea, 'това е'::text, 'текст'::bytea) TO 's3://copytos3/parquet_test/3'
+> COPY (SELECT false::bool, 'Inf'::double, '{"s": "abc"}'::jsonb, '85907cb9-ac9b-4e35-84b8-60dc69368aca'::uuid, 1::mz_timestamp, 32767::smallint, 2147483647::integer, 9223372036854775807::bigint, 1234567890123456789012.4567890123456789::numeric(38,16), '2010-10-10'::date, '10:10:10'::time, '2010-10-10 10:10:10+00'::timestamp, 'aaaa'::text, '\\xAAAA'::bytea, 'това е'::text, 'текст'::bytea) TO 's3://copytos3/parquet_test/3'
   WITH (
     AWS CONNECTION = aws_conn,
     MAX FILE SIZE = "100MB",
@@ -206,7 +198,7 @@ $ s3-verify-data bucket=copytos3 key=parquet_test/2
 2
 
 $ s3-verify-data bucket=copytos3 key=parquet_test/3
-false inf 1970-01-01T00:00:00.001 32767 2147483647 9223372036854775807 1234567890123456789012.4567890123456789 2010-10-10 10:10:10 2010-10-10T10:10:10 aaaa 5c7841414141 това е d182d0b5d0bad181d182
+false inf {"s":"abc"} 85907cb9ac9b4e3584b860dc69368aca 1 32767 2147483647 9223372036854775807 1234567890123456789012.4567890123456789 2010-10-10 10:10:10 2010-10-10T10:10:10 aaaa 5c7841414141 това е d182d0b5d0bad181d182
 
 # Confirm that unimplemented types will early exit before writing to s3
 ! COPY (SELECT '0 day'::interval)  TO 's3://copytos3/parquet_test/5'
@@ -230,21 +222,21 @@ $ s3-verify-data bucket=copytos3 key=parquet_test/5
 
 # Tests for decimal / numeric type
 
-! COPY (SELECT .123456789012345678901234567890123456789::numeric(39,39)) TO 's3://copytos3/parquet_test/4'
+! COPY (SELECT .123456789012345678901234567890123456789::numeric(39,39)) TO 's3://copytos3/parquet_test/6'
   WITH (AWS CONNECTION = aws_conn, FORMAT = 'parquet');
-contains:Numeric max scale 39 out of range
+contains:Cannot encode the following columns/types: ["numeric: Numeric { max_scale: Some(NumericMaxScale(39)) }"]
 
-! COPY (SELECT 12345678901234567890123.4567890123456789::numeric(38,16)) TO 's3://copytos3/parquet_test/5'
+! COPY (SELECT 12345678901234567890123.4567890123456789::numeric(38,16)) TO 's3://copytos3/parquet_test/6'
   WITH (AWS CONNECTION = aws_conn, FORMAT = 'parquet');
 contains:out of range for column with precision
 
-! COPY (SELECT 'NaN'::numeric(10,5)) TO 's3://copytos3/parquet_test/5'
+! COPY (SELECT 'NaN'::numeric(10,5)) TO 's3://copytos3/parquet_test/7'
   WITH (AWS CONNECTION = aws_conn, FORMAT = 'parquet');
 contains:Cannot represent special numeric value
 
 # the default column scale will be set to 10 so if we see a value with more than 10 digits after the
 # decimal it cannot be represented in this column
-! COPY (SELECT 5.4567890123456789::numeric) TO 's3://copytos3/parquet_test/6'
+! COPY (SELECT 5.4567890123456789::numeric) TO 's3://copytos3/parquet_test/8'
   WITH (AWS CONNECTION = aws_conn, FORMAT = 'parquet');
 contains:cannot represent decimal value
 
@@ -258,12 +250,12 @@ contains:cannot represent decimal value
 123456789.123456789 -123456789.12345678912345 1234567890000 123456789.12345
 10000000000000000001 100000000000000.0000001 -100000000 100000000000000000000000000000000.00001
 
-> COPY t2 TO 's3://copytos3/parquet_test/7'
+> COPY t2 TO 's3://copytos3/parquet_test/9'
   WITH (AWS CONNECTION = aws_conn, FORMAT = 'parquet');
 
 # each column will use scale 10 or the defined max-scale of the input column, so many values will
 # be padded with 0s after the decimal point to fit the column scale but are still the same number
-$ s3-verify-data bucket=copytos3 key=parquet_test/7 sort-rows=true
+$ s3-verify-data bucket=copytos3 key=parquet_test/9 sort-rows=true
 1234.0000000000 -1234.000000000000000 1234 1234.00000
 123456789.1234567890 -123456789.123456789123450 1234567890000 123456789.12345
 10000000000000000001.0000000000 100000000000000.000000100000000 -100000000 100000000000000000000000000000000.00001

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -190,13 +190,12 @@ $ s3-verify-keys bucket=copytos3 prefix-path=test/5 key-pattern=INCOMPLETE
 #     FORMAT = 'parquet'
 #   );
 
-> COPY (SELECT false::bool, 'Inf'::double, 1::mz_timestamp, 32767::smallint, 2147483647::integer, 9223372036854775807::bigint, '2010-10-10'::date, '10:10:10'::time, '2010-10-10 10:10:10+00'::timestamp, 'aaaa'::text, '\\xAAAA'::bytea, 'това е'::text, 'текст'::bytea) TO 's3://copytos3/parquet_test/3'
+> COPY (SELECT false::bool, 'Inf'::double, 1::mz_timestamp, 32767::smallint, 2147483647::integer, 9223372036854775807::bigint, 1234567890123456789012.4567890123456789::numeric(38,16), '2010-10-10'::date, '10:10:10'::time, '2010-10-10 10:10:10+00'::timestamp, 'aaaa'::text, '\\xAAAA'::bytea, 'това е'::text, 'текст'::bytea) TO 's3://copytos3/parquet_test/3'
   WITH (
     AWS CONNECTION = aws_conn,
     MAX FILE SIZE = "100MB",
     FORMAT = 'parquet'
   );
-
 
 $ s3-verify-data bucket=copytos3 key=parquet_test/1/${key-1}
 1
@@ -207,7 +206,7 @@ $ s3-verify-data bucket=copytos3 key=parquet_test/2
 2
 
 $ s3-verify-data bucket=copytos3 key=parquet_test/3
-false inf 1970-01-01T00:00:00.001 32767 2147483647 9223372036854775807 2010-10-10 10:10:10 2010-10-10T10:10:10 aaaa 5c7841414141 това е d182d0b5d0bad181d182
+false inf 1970-01-01T00:00:00.001 32767 2147483647 9223372036854775807 1234567890123456789012.4567890123456789 2010-10-10 10:10:10 2010-10-10T10:10:10 aaaa 5c7841414141 това е d182d0b5d0bad181d182
 
 # Confirm that unimplemented types will early exit before writing to s3
 ! COPY (SELECT '0 day'::interval)  TO 's3://copytos3/parquet_test/5'
@@ -228,3 +227,43 @@ contains:Cannot encode the following columns/types: ["interval: Interval"]
 
 $ s3-verify-data bucket=copytos3 key=parquet_test/5
 1
+
+# Tests for decimal / numeric type
+
+! COPY (SELECT .123456789012345678901234567890123456789::numeric(39,39)) TO 's3://copytos3/parquet_test/4'
+  WITH (AWS CONNECTION = aws_conn, FORMAT = 'parquet');
+contains:Numeric max scale 39 out of range
+
+! COPY (SELECT 12345678901234567890123.4567890123456789::numeric(38,16)) TO 's3://copytos3/parquet_test/5'
+  WITH (AWS CONNECTION = aws_conn, FORMAT = 'parquet');
+contains:out of range for column with precision
+
+! COPY (SELECT 'NaN'::numeric(10,5)) TO 's3://copytos3/parquet_test/5'
+  WITH (AWS CONNECTION = aws_conn, FORMAT = 'parquet');
+contains:Cannot represent special numeric value
+
+# the default column scale will be set to 10 so if we see a value with more than 10 digits after the
+# decimal it cannot be represented in this column
+! COPY (SELECT 5.4567890123456789::numeric) TO 's3://copytos3/parquet_test/6'
+  WITH (AWS CONNECTION = aws_conn, FORMAT = 'parquet');
+contains:cannot represent decimal value
+
+> CREATE TABLE t2 (a NUMERIC, b NUMERIC(38, 15), c NUMERIC(38, 0), d NUMERIC(38, 5));
+> INSERT INTO t2 VALUES (1234, -1234, 1234, 1234);
+> INSERT INTO t2 VALUES (123456789.123456789, -123456789.12345678912345, 1234567890000, 123456789.12345);
+> INSERT INTO t2 VALUES (10000000000000000001, 100000000000000.0000001, -100000000, 100000000000000000000000000000000.00001)
+
+> SELECT a, b, c, d FROM t2
+1234 -1234 1234 1234
+123456789.123456789 -123456789.12345678912345 1234567890000 123456789.12345
+10000000000000000001 100000000000000.0000001 -100000000 100000000000000000000000000000000.00001
+
+> COPY t2 TO 's3://copytos3/parquet_test/7'
+  WITH (AWS CONNECTION = aws_conn, FORMAT = 'parquet');
+
+# each column will use scale 10 or the defined max-scale of the input column, so many values will
+# be padded with 0s after the decimal point to fit the column scale but are still the same number
+$ s3-verify-data bucket=copytos3 key=parquet_test/7 sort-rows=true
+1234.0000000000 -1234.000000000000000 1234 1234.00000
+123456789.1234567890 -123456789.123456789123450 1234567890000 123456789.12345
+10000000000000000001.0000000000 100000000000000.000000100000000 -100000000 100000000000000000000000000000000.00001


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Part of the work towards private-preview for copy-to-s3: https://github.com/MaterializeInc/materialize/issues/7256

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

See the code-comments for an explanation of handling related to numeric values that that cannot fit in the arrow/parquet representation.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
