### PR TITLE
persist: in range-based stats interpretation, make jsonb_get_string infallible

### DIFF
--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -151,6 +151,15 @@ impl<'a> ResultSpec<'a> {
         }
     }
 
+    /// Every result matches this spec.
+    pub fn any_infallible() -> Self {
+        ResultSpec {
+            nullable: true,
+            fallible: false,
+            values: Values::All,
+        }
+    }
+
     /// A spec that only matches null.
     pub fn null() -> Self {
         ResultSpec {
@@ -576,7 +585,7 @@ impl SpecialUnary {
                             }
                             // Otherwise, assume the worst: this function may return either a valid
                             // value or null.
-                            _ => ResultSpec::value_all().union(ResultSpec::null()),
+                            _ => ResultSpec::any_infallible(),
                         }
                     })
                 },
@@ -650,8 +659,11 @@ impl SpecialBinary {
                         field_spec
                     }
                 } else {
-                    // TODO: it should be possible to narrow this further...
-                    ResultSpec::anything()
+                    // The implementation of `jsonb_get_string` always returns
+                    // `Ok(...)`. Morally, everything has a string
+                    // representation, and the worst you can get is a NULL,
+                    // which maps to a NULL.
+                    ResultSpec::any_infallible()
                 }
             })
         }

--- a/test/sqllogictest/explain-pushdown.slt
+++ b/test/sqllogictest/explain-pushdown.slt
@@ -70,6 +70,31 @@ EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value < 10;
 ----
 materialize.public.numbers  1039  1039  1  1
 
+# Verify that pushdown of jsonb_get_string is infallible. Before this was
+# fixed, a filter expression on a jsonb field that is not present in all parts
+# would cause those parts to be fetched, even when AND'ed together with an
+# expression that would definitely filter out the part otherwise.
+
+statement ok
+CREATE TABLE jsonb_fields (
+    timestamp int,
+    payload jsonb
+);
+
+statement ok
+INSERT INTO jsonb_fields VALUES (1, '{ "field": "value" }');
+
+statement ok
+INSERT INTO jsonb_fields VALUES (2, '{ "other-field": "value" }');
+
+# The `timestamp > 1000` part filters out everything, regardless of whether the
+# referenced field exists in the payload or not.
+
+query TIIII
+EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM jsonb_fields where timestamp > 1000 AND payload->>'field' = 'not-value';
+----
+materialize.public.jsonb_fields  2011  0  2  0
+
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_explain_pushdown = false
 ----


### PR DESCRIPTION
WIP, to see what CI has to say. But: why _was_ it fallible before. The worst you can get is a `NULL`, is Parker and mine's naive (and likely wrong!) understanding.

The logging is not meant to stay in, this PR is not meant to be merged like this in general.

cc @ParkMyCar 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
