### PR TITLE
adapter: cascading indexes must share retain history

### DIFF
--- a/src/adapter-types/src/compaction.rs
+++ b/src/adapter-types/src/compaction.rs
@@ -7,10 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::cmp::Ordering;
 use std::num::TryFromIntError;
 use std::time::Duration;
 
-use mz_repr::Timestamp;
+use mz_repr::{Timestamp, TimestampManipulation};
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::Serialize;
 use timely::progress::frontier::MutableAntichain;
@@ -20,7 +21,7 @@ use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 /// The default is set to a second to track the default timestamp frequency for sources.
 const DEFAULT_LOGICAL_COMPACTION_WINDOW_MILLIS: u64 = 1000;
 
-/// `DEFAULT_LOGICAL_COMPACTION_WINDOW` as an `EpochMillis` timestamp
+/// `DEFAULT_LOGICAL_COMPACTION_WINDOW` as an `EpochMillis` timestamp.
 const DEFAULT_LOGICAL_COMPACTION_WINDOW_TS: Timestamp =
     Timestamp::new(DEFAULT_LOGICAL_COMPACTION_WINDOW_MILLIS);
 
@@ -32,7 +33,7 @@ pub const SINCE_GRANULARITY: mz_repr::Timestamp = mz_repr::Timestamp::new(1000);
 
 // A common type (that is usable by the sql crate and also can implement various methods on types in
 // storage) to express compaction windows.
-#[derive(Clone, Default, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Default, Copy, Debug, PartialEq, Eq, Serialize)]
 pub enum CompactionWindow {
     /// Unspecified by the user, use a system-provided default.
     #[default]
@@ -43,6 +44,19 @@ pub enum CompactionWindow {
     Duration(Timestamp),
 }
 
+impl Ord for CompactionWindow {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.comparable_timestamp()
+            .cmp(&other.comparable_timestamp())
+    }
+}
+
+impl PartialOrd for CompactionWindow {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl CompactionWindow {
     pub fn lag_from(&self, from: Timestamp) -> Timestamp {
         let lag = match self {
@@ -51,6 +65,15 @@ impl CompactionWindow {
             CompactionWindow::Duration(d) => *d,
         };
         from.saturating_sub(lag)
+    }
+
+    /// Returns self as a Timestamp that can be used for comparisons.
+    pub fn comparable_timestamp(&self) -> Timestamp {
+        match self {
+            CompactionWindow::Default => DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
+            CompactionWindow::DisableCompaction => Timestamp::maximum(),
+            CompactionWindow::Duration(d) => *d,
+        }
     }
 }
 

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -31,8 +31,8 @@ use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
 use mz_sql::catalog::{
     CatalogCluster, CatalogDatabase, CatalogError as SqlCatalogError,
-    CatalogItem as SqlCatalogItem, CatalogRole, CatalogSchema, DefaultPrivilegeAclItem,
-    DefaultPrivilegeObject, RoleAttributes, RoleMembership, RoleVars,
+    CatalogItem as SqlCatalogItem, CatalogItemType, CatalogRole, CatalogSchema,
+    DefaultPrivilegeAclItem, DefaultPrivilegeObject, RoleAttributes, RoleMembership, RoleVars,
 };
 use mz_sql::names::{
     CommentObjectId, DatabaseId, FullItemName, ObjectId, QualifiedItemName, QualifiedSchemaName,
@@ -43,7 +43,8 @@ use mz_sql::session::vars::{OwnedVarInput, Var, VarInput, PERSIST_TXN_TABLES};
 use mz_sql::{rbac, DEFAULT_SCHEMA};
 use mz_sql_parser::ast::{QualifiedReplica, Value};
 use mz_storage_client::controller::StorageController;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::time::Duration;
 use tracing::{info, trace};
 
 use crate::catalog::{
@@ -429,6 +430,7 @@ impl Catalog {
                         new_entry.item().clone(),
                     )?;
                     tx.update_item(id, new_entry.into())?;
+                    Self::check_index_retain_histories(state, &id)?;
                 }
                 Op::AlterRole {
                     id,
@@ -938,6 +940,7 @@ impl Catalog {
                             details,
                         )?;
                     }
+                    let typ = item.typ();
                     state.insert_item(
                         id,
                         oid,
@@ -947,6 +950,9 @@ impl Catalog {
                         PrivilegeMap::from_mz_acl_items(privileges),
                     );
                     builtin_table_updates.extend(state.pack_item_update(id, 1));
+                    if matches!(typ, CatalogItemType::Index) {
+                        Self::check_index_retain_histories(state, &id)?;
+                    }
                 }
                 Op::Comment {
                     object_id,
@@ -2260,6 +2266,137 @@ impl Catalog {
             tx.set_persist_txn_tables(state.system_configuration.persist_txn_tables())?;
         }
         Ok(())
+    }
+
+    /// Verify retain history requirements of `id` (an index on a view must have a retain history >=
+    /// the retain history of any view index that uses it). If `id` is not an Index on a View,
+    /// returns Ok.
+    ///
+    /// The intention of this function is to prevent unexpected downstream memory growth. When the
+    /// retain history is increased on an index that is on a view, any indexes that are used by that
+    /// index have their compaction window implicitly increased. This could greatly and unexpectedly
+    /// increase memory use of those downstream indexes. To prevent this surprise to users, require
+    /// that users first increase all downstream indexes so that they are aware of and opting in to
+    /// the increased memory usage. If a persist object (table, materialized view, source) is used
+    /// by the index, we do not need to check further because the increased retain history of the
+    /// index will only result in a longer persist compaction window resulting in more disk use, but
+    /// not more memory use. Because disk is cheap and can't run out, it is ok for this increase to
+    /// not be explicit by the user.
+    fn check_index_retain_histories(
+        catalog: &CatalogState,
+        id: &GlobalId,
+    ) -> Result<(), AdapterError> {
+        let entry = catalog.get_entry(id);
+        let Some(index) = entry.index() else {
+            return Ok(());
+        };
+        let on = catalog.get_entry(&index.on);
+        if !on.is_view() {
+            // Non-views don't have this cascade requirement.
+            return Ok(());
+        }
+        let index_rh = index.custom_logical_compaction_window.unwrap_or_default();
+        for uses_index_id in Self::get_view_index_uses(catalog, id) {
+            // `id` uses these indexes, id must have the lower retain history.
+            let uses_index = catalog.get_entry(&uses_index_id);
+            let uses_rh = uses_index
+                .index()
+                .expect("must be an index")
+                .custom_logical_compaction_window
+                .unwrap_or_default();
+            if uses_rh < index_rh {
+                return Err(AdapterError::RequiredRetainHistory {
+                    required: Duration::from_millis(index_rh.comparable_timestamp().into()),
+                    found: Duration::from_millis(uses_rh.comparable_timestamp().into()),
+                    name: catalog
+                        .resolve_full_name(uses_index.name(), None)
+                        .to_string(),
+                });
+            }
+        }
+        for used_index_id in Self::get_view_index_used_by(catalog, id) {
+            // `id` is used by these indexes, id must have the higher retain history.
+            let used_by_index = catalog.get_entry(&used_index_id);
+            let used_rh = used_by_index
+                .index()
+                .expect("must be an index")
+                .custom_logical_compaction_window
+                .unwrap_or_default();
+            if index_rh < used_rh {
+                return Err(AdapterError::RequiredRetainHistory {
+                    required: Duration::from_millis(used_rh.comparable_timestamp().into()),
+                    found: Duration::from_millis(index_rh.comparable_timestamp().into()),
+                    name: catalog
+                        .resolve_full_name(used_by_index.name(), None)
+                        .to_string(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// For the Index at `id` that is on a View, return the index ids it directly depends on.
+    ///
+    /// # Panics
+    /// Panics if `id` is not an Index on a View.
+    fn get_view_index_uses(catalog: &CatalogState, id: &GlobalId) -> BTreeSet<GlobalId> {
+        let entry = catalog.get_entry(id);
+        let index = entry.index().expect("must be an index");
+        let mut index_ids = BTreeSet::new();
+        let mut views_to_check = VecDeque::from([index.on]);
+        while let Some(view_id) = views_to_check.pop_front() {
+            let view = catalog.get_entry(&view_id);
+            assert!(view.is_view());
+            // Views can use other views, need to check those too.
+            for uses_id in view.uses() {
+                match catalog.get_entry(&uses_id).item().typ() {
+                    CatalogItemType::View => {
+                        views_to_check.push_back(uses_id);
+                    }
+                    _ => {}
+                }
+            }
+            // Indexes are used by views: add those to the result set.
+            for used_by_id in view.used_by() {
+                match catalog.get_entry(used_by_id).item().typ() {
+                    CatalogItemType::Index => {
+                        index_ids.insert(*used_by_id);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        index_ids.remove(id);
+        index_ids
+    }
+
+    /// For the Index at `id` that is on a View, return the index ids that use it.
+    ///
+    /// # Panics
+    /// Panics if `id` is not an Index on a View.
+    fn get_view_index_used_by(catalog: &CatalogState, id: &GlobalId) -> BTreeSet<GlobalId> {
+        let entry = catalog.get_entry(id);
+        let index = entry.index().expect("must be an index");
+        let mut index_ids = BTreeSet::new();
+        let mut views_to_check = VecDeque::from([index.on]);
+        while let Some(view_id) = views_to_check.pop_front() {
+            let view = catalog.get_entry(&view_id);
+            assert!(view.is_view());
+            for used_by_id in view.used_by() {
+                match catalog.get_entry(used_by_id).item().typ() {
+                    CatalogItemType::View => {
+                        views_to_check.push_back(*used_by_id);
+                    }
+                    CatalogItemType::Index => {
+                        index_ids.insert(*used_by_id);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        index_ids.remove(id);
+        index_ids
     }
 
     fn create_schema(

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt;
 use std::num::TryFromIntError;
+use std::time::Duration;
 
 use dec::TryFromDecimalError;
 use itertools::Itertools;
@@ -213,6 +214,12 @@ pub enum AdapterError {
     /// A CREATE MATERIALIZED VIEW statement tried to acquire a read hold at a REFRESH AT time,
     /// but was unable to get a precise read hold.
     InputNotReadableAtRefreshAtTime(Timestamp, Antichain<Timestamp>),
+    /// A dependent index did not have a high enough retained history.
+    RequiredRetainHistory {
+        required: Duration,
+        found: Duration,
+        name: String,
+    },
 }
 
 impl AdapterError {
@@ -380,6 +387,9 @@ impl AdapterError {
             AdapterError::InvalidAlter(_, e) => e.hint(),
             AdapterError::Optimizer(e) => e.hint(),
             AdapterError::ConnectionValidation(e) => e.hint(),
+            AdapterError::RequiredRetainHistory { .. } => Some(format!(
+                "Use `ALTER INDEX <index-name> SET (RETAIN HISTORY FOR <duration>)` to change your index and re-run the statement."
+            )),
             AdapterError::InputNotReadableAtRefreshAtTime(_, _) => Some(
                 "You can use `REFRESH AT greatest(mz_now(), <explicit timestamp>)` to refresh \
                  either at the explicitly specified timestamp, or now if the given timestamp would \
@@ -506,6 +516,7 @@ impl AdapterError {
             // `DATA_EXCEPTION`, similarly to `AbsurdSubscribeBounds`.
             AdapterError::MaterializedViewWouldNeverRefresh(_, _) => SqlState::DATA_EXCEPTION,
             AdapterError::InputNotReadableAtRefreshAtTime(_, _) => SqlState::DATA_EXCEPTION,
+            AdapterError::RequiredRetainHistory { .. } => SqlState::INTERNAL_ERROR,
         }
     }
 
@@ -719,6 +730,16 @@ impl fmt::Display for AdapterError {
                 write!(
                     f,
                     "REFRESH AT requested for a time where not all the inputs are readable"
+                )
+            }
+            AdapterError::RequiredRetainHistory {
+                required,
+                found,
+                name,
+            } => {
+                write!(
+                    f,
+                    "dependent index {name} has a RETAIN HISTORY of {found:?}, but must be at least {required:?}"
                 )
             }
         }

--- a/test/sqllogictest/retain_history.slt
+++ b/test/sqllogictest/retain_history.slt
@@ -1,0 +1,94 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_index_options = on;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE tab_a (a INT)
+
+statement ok
+CREATE VIEW view_a AS SELECT a FROM tab_a
+
+statement ok
+CREATE INDEX idx_a ON view_a (a) WITH (RETAIN HISTORY FOR '1m')
+
+statement ok
+CREATE VIEW view_b AS SELECT a AS b FROM view_a
+
+statement error db error: ERROR: dependent index materialize\.public\.idx_a has a RETAIN HISTORY of 60s, but must be at least 120s
+CREATE INDEX idx_b ON view_b (b) WITH (RETAIN HISTORY FOR '2m')
+
+statement ok
+CREATE INDEX idx_b ON view_b (b)
+
+statement ok
+DROP INDEX idx_b
+
+statement ok
+DROP INDEX idx_a
+
+# Default retain history.
+statement ok
+CREATE INDEX idx_a ON view_a (a)
+
+statement error db error: ERROR: dependent index materialize\.public\.idx_a has a RETAIN HISTORY of 1s, but must be at least 120s
+CREATE INDEX idx_b ON view_b (b) WITH (RETAIN HISTORY FOR '2m')
+
+statement ok
+CREATE INDEX idx_b ON view_b (b) WITH (RETAIN HISTORY FOR '1ms')
+
+# Unitless intervals are seconds.
+statement error db error: ERROR: dependent index materialize\.public\.idx_a has a RETAIN HISTORY of 1s, but must be at least 5s
+CREATE INDEX idx_c ON view_b (b) WITH (RETAIN HISTORY FOR 5)
+
+statement error db error: ERROR: dependent index materialize\.public\.idx_a has a RETAIN HISTORY of 1s, but must be at least 300s
+ALTER INDEX idx_b SET (RETAIN HISTORY FOR '5m')
+
+statement ok
+ALTER INDEX idx_a SET (RETAIN HISTORY FOR '5m')
+
+statement ok
+ALTER INDEX idx_b SET (RETAIN HISTORY FOR '3m')
+
+statement ok
+CREATE VIEW view_c AS SELECT * FROM view_b
+
+statement ok
+CREATE INDEX idx_c ON view_c (b)
+
+statement ok
+ALTER INDEX idx_c SET (RETAIN HISTORY FOR '1m')
+
+# a 5m, b 3m, c 1m
+
+statement error db error: ERROR: dependent index materialize\.public\.idx_a has a RETAIN HISTORY of 300s, but must be at least 360s
+ALTER INDEX idx_b SET (RETAIN HISTORY FOR '6m')
+
+statement error db error: ERROR: dependent index materialize\.public\.idx_b has a RETAIN HISTORY of 180s, but must be at least 240s
+ALTER INDEX idx_c SET (RETAIN HISTORY FOR '4m')
+
+# a 6m, b 3m, c 1m
+
+statement ok
+ALTER INDEX idx_a SET (RETAIN HISTORY FOR '7m')
+
+# a 7m, b 3m, c 1m
+
+statement ok
+ALTER INDEX idx_b SET (RETAIN HISTORY FOR '6m')
+
+# a 7m, b 6m, c 1m
+
+statement ok
+ALTER INDEX idx_b SET (RETAIN HISTORY FOR '4m')


### PR DESCRIPTION
When creating or altering the retain history of an index, check for an invariant that downstream indexes have a retain history at least that of any upstream index.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a