### PR TITLE
 dbt-materialize: correct several issues with permission copying

### DIFF
--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -49,6 +49,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument(
         "-k", nargs="?", default=None, help="limit tests by keyword expressions"
     )
+    parser.add_argument("-s", action="store_true", help="don't suppress output")
     args = parser.parse_args()
 
     for test_case in test_cases:
@@ -62,6 +63,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             test_args = ["dbt-materialize/tests"]
             if args.k:
                 test_args.append(f"-k {args.k}")
+            if args.s:
+                test_args.append("-s")
 
             with c.test_case(test_case.name):
                 with c.override(materialized):

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -58,12 +58,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 options=test_case.materialized_options,
                 image=test_case.materialized_image,
                 volumes_extra=["secrets:/secrets"],
-                # Disable RBAC checks because of error on "DROP CLUSTER quickstart CASCADE":
-                # InsufficientPrivilege: must be owner of CLUSTER quickstart
-                # TODO: Can dbt connect using mz_system user instead of materialize?
-                additional_system_parameter_defaults={
-                    "enable_rbac_checks": "false",
-                },
             )
             test_args = ["dbt-materialize/tests"]
             if args.k:
@@ -84,6 +78,20 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                                 """
                         )
                     )
+
+                    # Give the test harness permission to modify the built-in
+                    # objects as necessary.
+                    for what in [
+                        "DATABASE materialize",
+                        "SCHEMA materialize.public",
+                        "CLUSTER quickstart",
+                    ]:
+                        c.sql(
+                            service="materialized",
+                            user="mz_system",
+                            port=6877,
+                            sql=f"ALTER {what} OWNER TO materialize",
+                        )
 
                     c.run(
                         "dbt",


### PR DESCRIPTION
In no particular order:

  * `internal_copy_schema_default_privs` was not escaping object names
    in its `ALTER DEFAULT PRIVILEGES` query.

  * The same query was missing a space after the role name (in the case
    that the privilege was granted to a specific role, rather than all
    roles).

  * `internal_copy_schema_default_privs` was not accounting for the
    return value of `run_query` to be a row containing a single column.
    (It was expecting the column directly.)

  * `internal_copy_cluster_grants` was determining what grants to revoke
    by looking at the grants on the `from` cluster when it needs to look
    at the `to` cluster.

  * `deploy_init` was invoking `internal_copy_cluster_grants` with
    variables referencing schemas rather than clusters (likely due to a
    copy/paste error).

  * `TestApplyGrantsAndPrivileges` had test methods whose names did not
    start with `test_`, so they were not being invoked. Once corrected,
    this exposed several other issues with the test, like the
    `materialize` user needing to be a member of `my_role` in order to
    grant default privileges to `my_role`.

### Motivation

  * This PR fixes a bug reported by a customer on Slack today.

### Tips for reviewer

I've taken this as far as I can take it. Given the number of lurking issues here, I'm not confident that the automated test suite has shaken everything out. @morsapaes @sjwiesman if one of you has time I think we'd be well served if you could point the adapter at a semi-real dbt project, add several users and several permissions on the project's cluster/schema, and ensure that everything works smoothly during the blue/green process and that all permissions are correctly copied over. 

One of the reasons we didn't catch the bug in the `deploy_init` macro sooner is because `schema` in a test returns an autogenerated test schema like `test31252531251235...`, which doesn't have permissions attached, and so the cluster permission copying code harmlessly does nothing. In a real environment, `schema` returns the schema for the project (e.g., `public`), which almost certainly _does_ have permissions attached, and so the cluster permission copying code actually activated, and then failed because `to` was incorrectly set to the nonexistent `deploy_schema` variable.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
