### PR TITLE
doc: deprecate ALTER SOURCE...DROP SUBSOURCE docs

### DIFF
--- a/doc/user/content/sql/alter-source.md
+++ b/doc/user/content/sql/alter-source.md
@@ -8,6 +8,10 @@ menu:
 
 `ALTER SOURCE` changes certain characteristics of a source.
 
+_Note:_ `ALTER SOURCE` previously supported a `DROP SUBSOURCE` subcommand.
+However, users can now use [`DROP SOURCE`](/sql/drop-source/) to drop
+subsources.
+
 ## Syntax
 
 {{< diagram "alter-source.svg" >}}
@@ -28,7 +32,6 @@ Field   | Use
 --------|-----
 _name_  | The identifier of the source you want to alter.
 **ADD SUBSOURCE** ... | PostgreSQL sources only: Add the identified tables from the upstream database (`table_name`) to the named source, with the option of choosing the name for the subsource in Materialize (`subsrc_name`). Supports [additional options](#add-subsource-with_options).
-**DROP SUBSOURCE** ... | PostgreSQL sources only: Drop the identified subsources from the source. Specifying **CASCADE** also drops all objects that depend on the subsource. **RESTRICT** (default) will not drop the subsource if it has any dependencies.
 
 ### **ADD SUBSOURCE** `with_options`
 
@@ -66,12 +69,6 @@ You cannot drop the "progress subsource".
 
 ```sql
 ALTER SOURCE pg_src ADD SUBSOURCE tbl_a, tbl_b AS b WITH (TEXT COLUMNS [tbl_a.col]);
-```
-
-### Dropping subsources
-
-```sql
-ALTER SOURCE pg_src DROP SUBSOURCE tbl_a, b CASCADE;
 ```
 
 ## Privileges

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -210,7 +210,8 @@ the table and, unfortunately, is wholly unaware that this occurred.
 
 To mitigate this issue, if you need to drop and re-add a table to a publication,
 ensure that you remove the table/subsource from the source _before_ re-adding it
-(i.e. [`ALTER SOURCE...DROP SUBSOURCE`](/sql/alter-source/#context)).
+(i.e. [`DROP SOURCE`](/sql/drop-source/) on the subsource [`ALTER SOURCE...ADD
+SUBSOURCE`](/sql/alter-source/#context)).
 
 ##### Supported types
 
@@ -428,17 +429,16 @@ CREATE SOURCE mz_source
 
 ### Adding/dropping tables to/from a source
 
-To handle upstream [schema changes](#schema-changes), use the
-[`ALTER SOURCE...DROP SUBSOURCE`](/sql/alter-source/#context) syntax to drop
-the affected subsource, and then `ALTER SOURCE...ADD SUBSOURCE` to add the
-subsource back to the source.
+To handle upstream [schema changes](#schema-changes), use the [`DROP
+SOURCE`](/sql/drop-source) syntax to drop the affected subsource, and then
+`ALTER SOURCE...ADD SUBSOURCE` to add the subsource back to the source.
 
 ```sql
 -- List all subsources in mz_source
 SHOW SUBSOURCES ON mz_source;
 
 -- Get rid of an outdated or errored subsource
-ALTER SOURCE mz_source DROP SUBSOURCE table_1;
+DROP SOURCE table_1;
 
 -- Start ingesting the table with the updated schema or fix
 ALTER SOURCE mz_source ADD SUBSOURCE table_1;

--- a/doc/user/layouts/shortcodes/postgres-direct/ingesting-data/allow-materialize-ips.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/ingesting-data/allow-materialize-ips.html
@@ -45,5 +45,5 @@ created [earlier](#step-2-create-a-publication):
     ALL TABLES`.
 
 1. After source creation, you can handle upstream [schema changes](/sql/create-source/postgres/#schema-changes)
-   for specific replicated tables using the [`ALTER SOURCE...{ADD | DROP SUBSOURCE`](/sql/alter-source/#context)
-   syntax.
+   for specific replicated tables by [dropping the table as a source](/sql/drop-source/)
+   and then using [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/#context).


### PR DESCRIPTION
rough sketch of docs for #26556

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
