### PR TITLE
catalog: Add sub-operations to transactions

### DIFF
--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -2121,6 +2121,7 @@ impl Catalog {
                     state.entry_by_id.insert(id, new_entry);
                 }
             };
+            tx.commit_op();
         }
 
         if dry_run_ops.is_empty() {

--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -15,7 +15,6 @@
 
 //! Vector utilities.
 
-use std::cmp::Ordering;
 use std::mem::{align_of, size_of};
 
 #[cfg(feature = "smallvec")]
@@ -145,6 +144,11 @@ pub trait VecExt<T> {
     fn drain_filter_swapping<F>(&mut self, filter: F) -> DrainFilterSwapping<'_, T, F>
     where
         F: FnMut(&mut T) -> bool;
+
+    /// Returns whether the vector is sorted using the given comparator function.
+    fn is_sorted_by<F>(&self, compare: F) -> bool
+    where
+        F: FnMut(&T, &T) -> bool;
 }
 
 /// Extension methods for `Vec<T>` where `T: PartialOrd`
@@ -167,22 +171,27 @@ impl<T> VecExt<T> for Vec<T> {
             pred: filter,
         }
     }
+
+    // implementation is from Vec::is_sorted_by, but with `windows` instead of
+    // the unstable `array_windows`
+    fn is_sorted_by<F>(&self, mut compare: F) -> bool
+    where
+        F: FnMut(&T, &T) -> bool,
+    {
+        self.windows(2).all(|win| compare(&win[0], &win[1]))
+    }
 }
 
 impl<T> PartialOrdVecExt<T> for Vec<T>
 where
     T: PartialOrd,
 {
-    // implementation is from Vec::is_sorted_by, but with `windows` instead of
-    // the unstable `array_windows`
     fn is_sorted(&self) -> bool {
-        self.windows(2)
-            .all(|win| win[0].partial_cmp(&win[1]).map_or(false, Ordering::is_le))
+        self.is_sorted_by(|a, b| a <= b)
     }
 
     fn is_strictly_sorted(&self) -> bool {
-        self.windows(2)
-            .all(|win| win[0].partial_cmp(&win[1]).map_or(false, Ordering::is_lt))
+        self.is_sorted_by(|a, b| a < b)
     }
 }
 

--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -332,4 +332,35 @@ mod test {
         let v: Vec<Gus1> = vec![Default::default()];
         let _: Vec<Gus2> = repurpose_allocation(v);
     }
+
+    #[crate::test]
+    fn test_is_sorted_by() {
+        assert!(vec![0, 1, 2].is_sorted_by(|a, b| a < b));
+        assert!(vec![0, 1, 2].is_sorted_by(|a, b| a <= b));
+        assert!(!vec![0, 1, 2].is_sorted_by(|a, b| a > b));
+        assert!(!vec![0, 1, 2].is_sorted_by(|a, b| a >= b));
+        assert!(vec![0, 1, 2].is_sorted_by(|_a, _b| true));
+        assert!(!vec![0, 1, 2].is_sorted_by(|_a, _b| false));
+
+        assert!(!vec![0, 1, 1, 2].is_sorted_by(|a, b| a < b));
+        assert!(vec![0, 1, 1, 2].is_sorted_by(|a, b| a <= b));
+        assert!(!vec![0, 1, 1, 2].is_sorted_by(|a, b| a > b));
+        assert!(!vec![0, 1, 1, 2].is_sorted_by(|a, b| a >= b));
+        assert!(vec![0, 1, 1, 2].is_sorted_by(|_a, _b| true));
+        assert!(!vec![0, 1, 1, 2].is_sorted_by(|_a, _b| false));
+
+        assert!(!vec![2, 1, 0].is_sorted_by(|a, b| a < b));
+        assert!(!vec![2, 1, 0].is_sorted_by(|a, b| a <= b));
+        assert!(vec![2, 1, 0].is_sorted_by(|a, b| a > b));
+        assert!(vec![2, 1, 0].is_sorted_by(|a, b| a >= b));
+        assert!(vec![2, 1, 0].is_sorted_by(|_a, _b| true));
+        assert!(!vec![2, 1, 0].is_sorted_by(|_a, _b| false));
+
+        assert!(!vec![5, 1, 9, 42].is_sorted_by(|a, b| a < b));
+        assert!(!vec![5, 1, 9, 42].is_sorted_by(|a, b| a <= b));
+        assert!(!vec![5, 1, 9, 42].is_sorted_by(|a, b| a > b));
+        assert!(!vec![5, 1, 9, 42].is_sorted_by(|a, b| a >= b));
+        assert!(vec![5, 1, 9, 42].is_sorted_by(|_a, _b| true));
+        assert!(!vec![5, 1, 9, 42].is_sorted_by(|_a, _b| false));
+    }
 }


### PR DESCRIPTION
This commit adds sub-operations to catalog transactions. This allows callers to logically group operations within a catalog transaction. This feature will be useful when the catalog is structured to listen to durable changes, because it will allow the catalog to extract durable changes for a single logical operation and apply just those changes to it's in-memory state.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer

All of the interesting changes are in `TableTransaction` the rest is mostly plumbing.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
