### PR TITLE
[expr] Tag some binary / variadic functions as infallible

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -7950,6 +7950,12 @@ impl VariadicFunc {
     pub fn could_error(&self) -> bool {
         match self {
             VariadicFunc::And | VariadicFunc::Or => false,
+            VariadicFunc::Coalesce => false,
+            VariadicFunc::Concat | VariadicFunc::ConcatWs => false,
+            VariadicFunc::Replace => false,
+            VariadicFunc::Translate => false,
+            VariadicFunc::ArrayIndex { .. } => false,
+            VariadicFunc::ListCreate { .. } | VariadicFunc::RecordCreate { .. } => false,
             // All other cases are unknown
             _ => true,
         }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3221,6 +3221,49 @@ impl BinaryFunc {
             | BinaryFunc::Gte
             | BinaryFunc::Gt
             | BinaryFunc::Lte => false,
+            BinaryFunc::BitAndInt16
+            | BinaryFunc::BitAndInt32
+            | BinaryFunc::BitAndInt64
+            | BinaryFunc::BitAndUInt16
+            | BinaryFunc::BitAndUInt32
+            | BinaryFunc::BitAndUInt64
+            | BinaryFunc::BitOrInt16
+            | BinaryFunc::BitOrInt32
+            | BinaryFunc::BitOrInt64
+            | BinaryFunc::BitOrUInt16
+            | BinaryFunc::BitOrUInt32
+            | BinaryFunc::BitOrUInt64
+            | BinaryFunc::BitXorInt16
+            | BinaryFunc::BitXorInt32
+            | BinaryFunc::BitXorInt64
+            | BinaryFunc::BitXorUInt16
+            | BinaryFunc::BitXorUInt32
+            | BinaryFunc::BitXorUInt64
+            | BinaryFunc::BitShiftLeftInt16
+            | BinaryFunc::BitShiftLeftInt32
+            | BinaryFunc::BitShiftLeftInt64
+            | BinaryFunc::BitShiftLeftUInt16
+            | BinaryFunc::BitShiftLeftUInt32
+            | BinaryFunc::BitShiftLeftUInt64
+            | BinaryFunc::BitShiftRightInt16
+            | BinaryFunc::BitShiftRightInt32
+            | BinaryFunc::BitShiftRightInt64
+            | BinaryFunc::BitShiftRightUInt16
+            | BinaryFunc::BitShiftRightUInt32
+            | BinaryFunc::BitShiftRightUInt64 => false,
+            BinaryFunc::JsonbGetInt64 { .. }
+            | BinaryFunc::JsonbGetString { .. }
+            | BinaryFunc::JsonbGetPath { .. }
+            | BinaryFunc::JsonbContainsString
+            | BinaryFunc::JsonbConcat
+            | BinaryFunc::JsonbContainsJsonb
+            | BinaryFunc::JsonbDeleteInt64
+            | BinaryFunc::JsonbDeleteString => false,
+            BinaryFunc::MapContainsKey
+            | BinaryFunc::MapGetValue
+            | BinaryFunc::MapContainsAllKeys
+            | BinaryFunc::MapContainsAnyKeys
+            | BinaryFunc::MapContainsMap => false,
             _ => true,
         }
     }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -7951,6 +7951,7 @@ impl VariadicFunc {
         match self {
             VariadicFunc::And | VariadicFunc::Or => false,
             VariadicFunc::Coalesce => false,
+            VariadicFunc::Greatest | VariadicFunc::Least => false,
             VariadicFunc::Concat | VariadicFunc::ConcatWs => false,
             VariadicFunc::Replace => false,
             VariadicFunc::Translate => false,


### PR DESCRIPTION
### Motivation

Should address: https://github.com/MaterializeInc/cloud/issues/9251

In particular, if we can assume that these functions will never raise errors, then the abstract interpreter can reason more precisely about whether a filter expression might throw. (This is important since we always need to fetch parts with rows that may error during evaluation.)

While I was here, I tagged a number of other functions as infallible. I chose a subset that were both:
- structurally unable to return errors in the code: `eval` was implemented as `Ok(impl_fn(...))`.
- "clearly" infallible: there were easy-to-explain reasons why those functions _ought_ to be infallible.

### Tips for reviewer

I haven't attempted to investigate literally every function, so many functions that never throw in practice will still return `true` here.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
