### PR TITLE
Reorganize controller timestamp trait bounds

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -35,7 +35,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use differential_dataflow::consolidation::consolidate;
-use differential_dataflow::lattice::Lattice;
 use futures::{future, Future, FutureExt};
 use mz_build_info::BuildInfo;
 use mz_cluster_client::client::ClusterReplicaLocation;
@@ -46,12 +45,12 @@ use mz_dyncfg::ConfigSet;
 use mz_expr::RowSetFinishing;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::{Diff, GlobalId, Row, TimestampManipulation};
+use mz_repr::{Datum, Diff, GlobalId, Row, TimestampManipulation};
 use mz_storage_client::controller::{IntrospectionType, StorageController};
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::{AntichainRef, MutableAntichain};
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use tokio::time::{self, MissedTickBehavior};
 use tracing::warn;
 use uuid::Uuid;
@@ -76,6 +75,12 @@ mod sequential_hydration;
 pub mod error;
 
 type IntrospectionUpdates = (IntrospectionType, Vec<(Row, Diff)>);
+
+/// A composite trait for types that serve as timestamps in the Compute Controller.
+/// `Into<Datum<'a>>` is needed for writing timestamps to introspection collections.
+pub trait ComputeControllerTimestamp: TimestampManipulation + for<'a> Into<Datum<'a>> {}
+
+impl ComputeControllerTimestamp for mz_repr::Timestamp {}
 
 /// Responses from the compute controller.
 #[derive(Debug)]
@@ -168,7 +173,7 @@ pub struct ComputeController<T> {
     maintenance_scheduled: bool,
 }
 
-impl<T: Timestamp> ComputeController<T> {
+impl<T: ComputeControllerTimestamp> ComputeController<T> {
     /// Construct a new [`ComputeController`].
     pub fn new(
         build_info: &'static BuildInfo,
@@ -360,7 +365,7 @@ impl<T: Timestamp> ComputeController<T> {
 
 impl<T> ComputeController<T>
 where
-    T: Timestamp + Lattice,
+    T: ComputeControllerTimestamp,
     ComputeGrpcClient: ComputeClient<T>,
 {
     /// Create a compute instance.
@@ -508,7 +513,7 @@ pub struct ActiveComputeController<'a, T> {
     storage: &'a mut dyn StorageController<Timestamp = T>,
 }
 
-impl<T: Timestamp> ActiveComputeController<'_, T> {
+impl<T: ComputeControllerTimestamp> ActiveComputeController<'_, T> {
     /// TODO(#25239): Add documentation.
     pub fn instance_exists(&self, id: ComputeInstanceId) -> bool {
         self.compute.instance_exists(id)
@@ -533,7 +538,7 @@ impl<T: Timestamp> ActiveComputeController<'_, T> {
 
 impl<T> ActiveComputeController<'_, T>
 where
-    T: Timestamp + Lattice,
+    T: ComputeControllerTimestamp,
     ComputeGrpcClient: ComputeClient<T>,
 {
     /// Adds replicas of an instance.
@@ -692,13 +697,7 @@ where
             }
         }
     }
-}
 
-impl<T> ActiveComputeController<'_, T>
-where
-    T: TimestampManipulation,
-    ComputeGrpcClient: ComputeClient<T>,
-{
     /// Processes the work queued by [`ComputeController::ready`].
     #[mz_ore::instrument(level = "debug")]
     pub async fn process(&mut self) -> Option<ComputeControllerResponse<T>> {
@@ -761,7 +760,7 @@ pub struct ComputeInstanceRef<'a, T> {
     instance: &'a Instance<T>,
 }
 
-impl<T: Timestamp> ComputeInstanceRef<'_, T> {
+impl<T: ComputeControllerTimestamp> ComputeInstanceRef<'_, T> {
     /// Return the ID of this compute instance.
     pub fn instance_id(&self) -> ComputeInstanceId {
         self.instance_id
@@ -855,7 +854,7 @@ impl<T> CollectionState<T> {
     }
 }
 
-impl<T: Timestamp> CollectionState<T> {
+impl<T: ComputeControllerTimestamp> CollectionState<T> {
     /// Creates a new collection state, with an initial read policy valid from `since`.
     pub fn new(
         as_of: Antichain<T>,
@@ -892,7 +891,7 @@ impl<T: Timestamp> CollectionState<T> {
 
     /// Creates a new collection state for a log collection.
     pub fn new_log_collection() -> Self {
-        let since = Antichain::from_elem(Timestamp::minimum());
+        let since = Antichain::from_elem(timely::progress::Timestamp::minimum());
         let mut state = Self::new(since, Vec::new(), Vec::new());
         state.log_collection = true;
         // Log collections are created and scheduled implicitly as part of replica initialization.

--- a/src/compute-client/src/controller/sequential_hydration.rs
+++ b/src/compute-client/src/controller/sequential_hydration.rs
@@ -49,10 +49,11 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::soft_assert_eq_or_log;
 use mz_repr::GlobalId;
 use mz_service::client::GenericClient;
-use timely::progress::{Antichain, Timestamp};
+use timely::progress::Antichain;
 use timely::PartialOrder;
 use tracing::debug;
 
+use crate::controller::ComputeControllerTimestamp;
 use crate::metrics::ReplicaMetrics;
 use crate::protocol::command::ComputeCommand;
 use crate::protocol::response::ComputeResponse;
@@ -88,7 +89,7 @@ pub(super) struct SequentialHydration<C, T> {
 impl<C, T> SequentialHydration<C, T>
 where
     C: ComputeClient<T>,
-    T: Timestamp,
+    T: ComputeControllerTimestamp,
 {
     /// Create a new `SequentialHydration` client.
     pub fn new(client: C, dyncfg: Arc<ConfigSet>, metrics: ReplicaMetrics) -> Self {
@@ -230,7 +231,7 @@ where
 impl<C, T> GenericClient<ComputeCommand<T>, ComputeResponse<T>> for SequentialHydration<C, T>
 where
     C: ComputeClient<T>,
-    T: Timestamp,
+    T: ComputeControllerTimestamp,
 {
     async fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
         self.absorb_command(cmd).await

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -30,6 +30,7 @@ use timely::PartialOrder;
 use tonic::{Request, Status, Streaming};
 use uuid::Uuid;
 
+use crate::controller::ComputeControllerTimestamp;
 use crate::metrics::ReplicaMetrics;
 use crate::protocol::command::{ComputeCommand, ProtoComputeCommand};
 use crate::protocol::response::{
@@ -181,7 +182,7 @@ pub struct PartitionedComputeState<T> {
 impl<T> Partitionable<ComputeCommand<T>, ComputeResponse<T>>
     for (ComputeCommand<T>, ComputeResponse<T>)
 where
-    T: timely::progress::Timestamp + Lattice,
+    T: ComputeControllerTimestamp,
 {
     type PartitionedState = PartitionedComputeState<T>;
 
@@ -199,7 +200,7 @@ where
 
 impl<T> PartitionedComputeState<T>
 where
-    T: timely::progress::Timestamp,
+    T: ComputeControllerTimestamp,
 {
     fn reset(&mut self) {
         let PartitionedComputeState {
@@ -256,7 +257,7 @@ where
 
 impl<T> PartitionedState<ComputeCommand<T>, ComputeResponse<T>> for PartitionedComputeState<T>
 where
-    T: timely::progress::Timestamp + Lattice,
+    T: ComputeControllerTimestamp,
 {
     fn split_command(&mut self, command: ComputeCommand<T>) -> Vec<Option<ComputeCommand<T>>> {
         self.observe_command(&command);
@@ -520,7 +521,7 @@ struct PendingSubscribe<T> {
     dropped: bool,
 }
 
-impl<T: timely::progress::Timestamp> PendingSubscribe<T> {
+impl<T: ComputeControllerTimestamp> PendingSubscribe<T> {
     fn new(parts: usize) -> Self {
         let mut frontiers = MutableAntichain::new();
         // TODO(benesch): fix this dangerous use of `as`.

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -15,10 +15,11 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
-use differential_dataflow::lattice::Lattice;
 use futures::stream::{BoxStream, StreamExt};
 use mz_cluster_client::client::ClusterReplicaLocation;
-use mz_compute_client::controller::{ComputeReplicaConfig, ComputeReplicaLogging};
+use mz_compute_client::controller::{
+    ComputeControllerTimestamp, ComputeReplicaConfig, ComputeReplicaLogging,
+};
 use mz_compute_client::logging::LogVariant;
 use mz_compute_client::service::{ComputeClient, ComputeGrpcClient};
 use mz_compute_types::ComputeInstanceId;
@@ -35,7 +36,6 @@ use mz_repr::GlobalId;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use timely::progress::Timestamp;
 use tracing::{error, warn};
 
 use crate::Controller;
@@ -319,7 +319,7 @@ pub struct CreateReplicaConfig {
 
 impl<T> Controller<T>
 where
-    T: Timestamp + Lattice,
+    T: ComputeControllerTimestamp,
     ComputeGrpcClient: ComputeClient<T>,
 {
     /// Creates a cluster with the specified identifier and configuration.

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -35,6 +35,7 @@ use mz_build_info::BuildInfo;
 use mz_cluster_client::ReplicaId;
 use mz_compute_client::controller::{
     ActiveComputeController, ComputeController, ComputeControllerResponse,
+    ComputeControllerTimestamp,
 };
 use mz_compute_client::protocol::response::{PeekResponse, SubscribeBatch};
 use mz_compute_client::service::{ComputeClient, ComputeGrpcClient};
@@ -192,7 +193,7 @@ pub struct Controller<T = mz_repr::Timestamp> {
     immediate_watch_sets: Vec<Box<dyn Any>>,
 }
 
-impl<T: Timestamp> Controller<T> {
+impl<T: ComputeControllerTimestamp> Controller<T> {
     pub fn active_compute(&mut self) -> ActiveComputeController<T> {
         self.compute.activate(&mut *self.storage)
     }
@@ -275,7 +276,7 @@ impl<T: Timestamp> Controller<T> {
 
 impl<T> Controller<T>
 where
-    T: TimestampManipulation,
+    T: ComputeControllerTimestamp,
     ComputeGrpcClient: ComputeClient<T>,
 {
     pub fn update_orchestrator_scheduling_config(
@@ -550,6 +551,7 @@ where
     StorageCommand<T>: RustType<ProtoStorageCommand>,
     StorageResponse<T>: RustType<ProtoStorageResponse>,
     for<'a> T: Into<Datum<'a>>,
+    T: ComputeControllerTimestamp,
 {
     /// Creates a new controller.
     ///


### PR DESCRIPTION
1. commit:
  - Encapsulates trait bounds needed by the Compute Controller in a new composite trait `ComputeControllerTimestamp` (as suggested by @antiguru and @aalexandrov). This makes life easier if we ever need to add or remove trait bounds in the Compute Controller, because we'd need to do it at only one place.
    - Note that I also removed `: Lattice` from a bunch of places, because `Lattice` is included through `TimestampManipulation`.
    - Note that I changed the trait bounds also in `service.rs`, but those changes wouldn't be strictly needed.
- Removes a few `timely::progress::Timestamp` imports, to make it more explicit which `Timestamp` are we referring to.
- Makes `TimestampManipulation` and `Into<Datum>` uniformly accessible throughout the Compute Controller by including them in `ComputeControllerTimestamp`.
    - Note that `TimestampManipulation` was already accessible at a couple of places in the Compute Controller, but now it's accessible everywhere.
    - `Into<Datum>` is not yet used, but I'm planning to use it for a REFRESH introspection table, where I'll need to write timestamps as Datums.

2. commit: This just removes some unneeded trait bounds from the top-level `impl Controller` that either doesn't seem to be used anymore or are also included in `TimestampManipulation` (these are `TotalOrder` and `Lattice`). Note that I didn't remove `TimestampManipulation` and `Into<Datum<'a>>`; even though they are also included in `ComputeControllerTimestamp`, I wanted to be explicit about these being needed also by the Storage Controller.

@benesch, I tagged you as a representative of the Storage team. Please look at the 2. commit, which is just a tiny change.

### Motivation

   * This PR refactors existing code. Inspired by [this Slack discussion](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1713774612023769) and the discussion in the Compute hangout.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
