### PR TITLE
graceful reconfiguration v1 design doc

### DIFF
--- a/doc/developer/design/20240411_graceful_reconfiguration_of_managed_clusters_v1.md
+++ b/doc/developer/design/20240411_graceful_reconfiguration_of_managed_clusters_v1.md
@@ -24,7 +24,8 @@ hydrated.
 ### V2 Scope
  - Provide a Hydration-based reconfiguration cleanup scheduling.
  - The DDL will be able to run in the background.
- - The action will be cancelable or able to be preemptively finalized.
+ - Backgrounded reconfigurations will be cancelable or be able to be
+   preemptively finalized, by another connection issuing a SQL statement.
 
 ## Out of Scope
  - Interactions with proposed schedules, ex: auto-scaling/auto-quiescing
@@ -34,7 +35,7 @@ hydrated.
 ### Summary:
 This feature will introduce new SQL in `ALTER CLUSTER` which will create new
 replicas matching the alter statement; however, unlike existing alter mechanisms,
-we will delay the cleanup of old replicas until the provided conditions are met.
+it will delay the cleanup of old replicas until the provided `WAIT` condition is met.
 
 The SQL will need to define a type of check to be performed, parameters for that
 check, and whether or not to background the operation.
@@ -42,41 +43,43 @@ check, and whether or not to background the operation.
 Suggested syntax:
 
 ```sql
-ALTER CLUSTER c1 SET (SIZE 'small') WITH ( 
-  WAIT = FOR <interval>,
+ALTER CLUSTER c1 SET (SIZE 'small') WITH (
+  WAIT = <condition>,
   BACKGROUND = {true|false},
-)
 ```
 
-```sql
-ALTER CLUSTER c1 SET (SIZE 'small') WITH ( 
-  WAIT = UNTIL CAUGHT UP (
-    TIMEOUT = <interval>,
-    ON TIMEOUT = {CONTINUE | ABORT}
-  )
-  BACKGROUND = {true|false},
-)
-```
-
-The two types of checks, in agreement with the V1 and V2 scopes respectively, are: 
- - `FOR` which waits for a provided duration before failing and aborting.
- - `UNTIL CAUGHT UP` which will wait for a "catch up" mechanism to return true
+The two types of checks, in agreement with the V1 and V2 scopes respectively, are:
+ - `FOR`, which waits for a provided duration before proceeding with finalization.
+    ```sql
+    ALTER CLUSTER c1 SET (SIZE 'small') WITH (
+      WAIT = FOR <interval>,
+      BACKGROUND = {true|false},
+    )
+    ```
+ - `UNTIL CAUGHT UP`, which will wait for a "catch up" mechanism to return true
    or for a timeout to be met. It will roll back or forward depending on the value
    provided to `ON TIMEOUT`.
-
-The SQL will kick off some action in `sequence_alter_cluster_managed_to_managed`
-which will result in new reconfiguration replicas being created, new entries
-placed `mz_internal.mz_pending_cluster_replicas` and a `ReconfigureCluster`
-task being created which will ensure the reconfiguration finishes.
-
-To keep track of ongoing reconfigurations we will introduce a new
-`mz_internal.mz_pending_cluster_replicas` table which holds the state of
-reconfiguration replicas. This table will include all configuration parameters
-required to restart a reconfiguration task. It will be in charge of resuming or
-cleaning up a reconfiguration.
+    ```sql
+    ALTER CLUSTER c1 SET (SIZE 'small') WITH (
+      WAIT = UNTIL CAUGHT UP (
+        TIMEOUT = <interval>,
+        ON TIMEOUT = {CONTINUE | ABORT}
+      )
+      BACKGROUND = {true|false},
+    )
+    ```
 
 All replicas will be billed during reconfiguration (except explicitly unbilled replicas).
 
+__Cancelation__
+For v1, all `ALTER CLUSTER` statements will block, and graceful reconfiguration
+will only be cancelable by canceling the query from the connection that issued it.
+
+For v2, we will introduce backgrounded reconfiguration which will need some
+new semantics to cancel. Something like the following should suffice.
+```sql
+CANEL ALTER CLUSTER <cluster>
+```
 
 ### Definitions:
  - Active Replica: These replicas should be actively serving results and are
@@ -84,11 +87,14 @@ All replicas will be billed during reconfiguration (except explicitly unbilled r
    prior version of the configuration. If a reconfiguration is not ongoing they
    should be the only replicas.
  - Reconfiguration Replica: These replicas only exist during a reconfiguration,
-   their names will be suffixed with `reconfig-`. They will move to active
+   their names will be suffixed with `-pending`. They will move to active
    once the reconfiguration is finalized. These will be stored in the
    `mz_pending_cluster_replicas` table.
  - Reconfiguring Cluster: any cluster with one or more replicas in the
    `mz_pending_cluster_replicas` table
+ - Replica Promotion, during the finalization of an alter cluster, pending replicas will be "promoted".
+   This entails changing the pending value of the replica to false, and removing the '-pending'
+   suffix.
 
 ### Guard Rails
 - Only one reconfiguration will occur at a time for a given cluster. Alter statements
@@ -97,30 +103,185 @@ All replicas will be billed during reconfiguration (except explicitly unbilled r
   reconfiguring a cluster with sources/sinks. These clusters will need to use
   the non-scheduled mechanism (delete-before-create). This is due to a limitation
   where sources and sinks must only run on a single replica.
-- We must store all state required to restart a `ReconfigureCluster` task in the event that environmentd
-  crashes/restarts.
-- We may want to consider limiting timeout duration.
+- We will use a launch darkly flag to hardcap the max timeout and duration.
+- If we are not backgrounding the reconfiguration the expectation will be that
+  if the sql query does not successfully return, due to a crash or connection drop, the alter
+  will not finalize and all reconfiguration replicas will cleaned up.
 
-### Visibility
-Reconfiguration replicas should be identifiable for purposes of reporting and
-visibility in the UI. We may be able to do this by creating a prefix `reconfig-`
-for reconfiguration replicas, alternatively, we could set a bool status on the
-replica resource in the catalog.
-
-### Details
-
-#### Limitations:
-  - Cannot be used on clusters with sources, sources should not be created on
+### Limitations:
+  - Cannot be used on clusters with sources or sinks, sources should not be created on
     clusters with reconfiguration replicas.
   - Must be run on managed clusters, and cannot be used to alter a cluster from
     managed to unmanaged.
 
-#### Replica Naming
-Active replicas will continue with the same naming scheme (r1, r2, ...)
-Reconfiguration replicas will use the `reconfig` prefix; ex `reconfig-r3`,
-`reconfig-r4`, which will be removed once they are moved to active.
+### Visibility
+Reconfiguration replicas will be identifiable for purposes of reporting and
+visibility in the UI. They will both have a `-pending` suffix and will have a
+`pending` column in `mz_cluster_replicas` will be true.
 
-#### Interactions with other schedules:
+### Replica Naming
+Active replicas will continue with the same naming scheme (r1, r2, ...)
+Reconfiguration replicas will use the `-pending` suffix; ex `r1-pending`,
+`r2-pending`, which will be removed once they are moved to active.
+
+
+### Implementation Details
+We want to accomplish the following
+ - interpret SQL to identify when to use graceful vs disruptive alters
+ - selectively choose which mechanism is used to alter the cluster
+ - provide a mechanism to cancel the operation
+
+
+#### Catalog Changes
+A `pending: bool` field will be added to the `ClusterReplica` memory and durable
+catalog structs. This will be set to true for reconfiguration replicas and will
+help either recover or cleanup on environmentd crashes. `mz_cluster_replicas`
+will show the value of this `pending` field.
+
+#### Process
+Below broken this process broken down into four components
+1. Interpret the query to determine if we're doing graceful reconfiguration
+2. run `sequence_alter_cluster_managed_to_managed_graceful`
+3. wait and finalize
+4. return to the user
+
+*In v2, steps 3 and 4 may be swapped.
+
+__Interpreting the Query__
+This will use standard parsing/planning, the only notable
+callout here is that we'll want `mz_sql::plan::AlterClusterOptions`
+to contain an `alter_mechanaism` field which holds an optional
+`AlterClusterMechanism`:
+
+```rust
+enum AlterClusterMechanism {
+  Duration{
+    timeout: Duration
+    ...
+  },
+  UntilCaughtUp{
+    timeout: Duration,
+    continue_on_timeout: bool
+    ...
+  },
+}
+```
+
+__Cluster Sequencer__
+
+The following outlines the new logic for the cluster sequencer when
+performing an alter cluster on a managed cluster.
+
+Because this will need to be cancelable and will wait for a significant
+duration before responding, the current `sequence_cluster_alter` process cannot
+be used. This implementation will rely on migrating `sequence_cluster_alter` to
+use the `sequence_staged` flow, allowing us to kick off a thread/stage which
+performs waits/validations.
+
+The new `sequence_alter_cluster` function will need to perform
+the current validations, used in both `sequence_alter_cluster` and
+`sequence_alter_cluster_managed_to_managed`, but will kick off a new
+`StageResult::Handle` when an `alter_mechanism` is provided. The task in this
+handle will perform waits/validations and pass off the finalization to
+a `Finalize` stage.
+
+Additionally, we'll need to perform some extra validations to ensure the
+the `alter_mechanism` and `AlterClusterPlan` are compatible. These are:
+1. validate the cluster is managed
+2. validate that the cluster is not undergoing a reconfiguration
+3. validate the cluster has no sources and now sinks
+4. the cluster cannot have a refresh schedule (v1)
+
+The `sequence_alter_cluster_managed_to_managed` method will need
+to be updated to apply the correct name/pending status for new replicas
+and only remove existing replicas when no alter_mechanism is provided.
+
+
+For V2:
+We will need to implement a message strategy that kicks the work off
+off of the `sequence_staged` flow. In this scenario, we will still create new
+replicas in the foreground, but the wait/checks will be performed in a separate
+message handle by emitting a `ClusterReconfigureCheckReady` message.
+
+The state for the reconfiguration will be stored in a `PendingClusterReconfiguration`
+struct.
+
+
+```rust
+struct PendingClusterReconfiguration {
+ ctx: ExecuteContext,
+ // needed to determine timeouts
+ start_time: Instant,
+ // the plan will hold the cluster_id, config, mechanism, etc...
+ plan: AlterClusterPlan,
+ // idempotency key will need to be part of the  message and will need to be
+ // validated to ensure we're looking at the correct plan, in case we
+ // miss a cancel and a new entry was put in pending_cluster_reconfiguration.
+ idempotency_key: Uuid,
+}
+```
+
+In order to cancel we'll keep a map, `pending_cluster_reconfigurations`,  of
+session `ClusterIds` to `PendingClusterReconfigurations`.
+
+*Currently due to limitations in sources and sinks, we will need to maintain
+the disruptive alter mechanism. Once multiple replicas are allowed for sources
+and sinks we can remove the disruptive mechanism and default the wait to `WAIT=For 0 seconds`.
+
+
+#### Handling PendingClusterReconfigure Messages
+
+The responsibilities of this operation will be:
+1. checking for cancellations
+2. checking for the `WAIT` condition
+3. finalizaing the reconfiguration
+4. returning to the user
+
+__Checking the `WAIT` Condition__
+The message handler will perform all checks on every run. If the wait condition
+has not yet been met, we will reschedule the message to be resent. For each
+reschedule we'll spawn a task that waits some duration and sends a
+`ClusterReconfigureCheckReady` message with the connection_id.
+For `WAIT FOR` we can wait for the exact duration that would cause the next check to succeed.
+For `WAIT UNTIL CAUGHT UP` we can just wait for three seconds.
+
+__Finalize the Reconfiguration__
+Finalizing the reconfiguration will occur once the `wait` condition has been
+met. During this phase, the following steps will occur.
+- Drop any non-pending replicas that do not have a billed_as value.
+- Finalize the pending replicas:
+  - Rename to remove the `-pending` suffix.
+  - Alter config to set `pending` to true.
+- Update the cluster catalog to the new desired config.
+
+
+__Handling Dropped Connections__
+Dropped connections will be handled by storing a `clean_cluster_alters: BTreeSet<GlobalId>` in the `ConnMeta`.
+We will use this along with a `retire_cluster_alter` function which can be called during connection termination.
+`retire_compute_sync_for_conn` provides an example of this.
+
+__Handling Cancelation__
+The mechanism used for handling dropped connections can be used for cancelation.
+`cancel_compute_sync_for_conn` provides an example of this.
+
+__v2 coniderations__
+Reverting the reconfiguration
+On failure or timeout of the reconfiguration, this task will revert to the state
+prior to the `ALTER CLUSTER` DDL. It will remove reconfigure replicas, and ensure the
+cluster config matches the original version.
+
+
+#### Recover after Environmentd Restart
+For v1, environmentd restarts will remove `pending` replicas from the Catalog
+during Catalog initialization. This will cause the compute controller to remove
+any pending physical replicas during its initialization (this is already an
+existing feature).
+
+For v2, we will need to store the AlterClusterPlan durably for all backgrounded reconfigurations.
+We will then need the coordinator to attempt to continue an ongoing reconfiguration on restart.
+
+
+#### Interactions with Cluster Schedules:
 
 __V1__
 We will choose to initially disallow any reconfiguration of a cluster
@@ -137,85 +298,7 @@ Some proposed schedules, auto-scaling, for instance, may want to use graceful
 reconfiguration under the hood. These would need specific well-defined
 interactions with user-invoked graceful reconfiguration.
 
-
-#### Catalog Changes
-We will need to create a new table `mz_internal.mz_pending_cluster_replicas`
-
-| column     |  type |
-| ---------- | ----- |
-| replica_id | str   |
-| cluster_id | str   |
-| timeout    | int   |
-| wait_type  | str   |
-| background | bool  |
-| start_time | int   |
-| finished   | bool  |
-| continue_on_timeout | bool |
-
-This table will be responsible for holding the state of the graceful replication task.
-Each reconfiguration replica will have an entry in `mz_epnding_cluster_replicas`.
-
-
-#### Reconfiguration Task
-
-The reconfiguration task will perform the following actions:
-1. Monitor the `wait` condition
-The `wait` condition provided in the DDL will be polled by this task, once the
-condition is met the replicas will be marked as finished and the task will move
-on to finalization.
-
-2. Finalize the reconfiguration
-Finalizing the reconfiguration will occur once the `wait` condition has been
-met. During this phase, the following steps will occur.
-- reconfiguration replica promotion to active
-- cluster configuration update to the new desired state
-- replicas with the previous configuration will be removed
-- replicas for the cluster will be removed from the `mz_pending_cluster_replicas` table
-
-3. Reverting the reconfiguration
-On failure or timeout of the reconfiguration, this task will revert to the state
-prior to the `ALTER CLUSTER` DDL. It will remove reconfigure replicas, and ensure the
-cluster config matches the original version.
-
-
-#### Cluster Sequencer
-
-The following roughly defines the new logic for the cluster sequencer when
-performing an alter cluster on a managed cluster.
-
-`mz_sql::plan::AlterClusterOptions` will have additional fields added to keep track of
-the mechanism being used to perform the alter `AlterClusterMechanism::{Default|Duration|UntilCaughtUp}`.
-
-If we see a non-default mechanism we'll ensure that the cluster is managed
-and pass the mechanism to `sequence_alter_cluster_managed_to_managed`.
-This function will need to be updated to either perform a
-`sequence_alter_cluster_managed_to_managed_disruptive` or
-`sequence_alter_cluster_managed_to_managed_graceful` operation.
-
-The `disruptive` version will perform the current delete-before-create mechanism.
-The `graceful` version will perform the following actions:
-1. Validations
-  1. validate that the cluster is not undergoing a reconfiguration
-  2. validate the cluster is managed
-  3. validate the cluster has no sources and now sinks
-  4. the cluster cannot have a refresh schedule (v1)
-2. Creating the reconfiguration replicas
-3. Transactionally creating reconfiguration replicas and inserting the replicas into
-   the `mz_pending_cluster_replicas` table.
-4. Starting a blocking (or backgrounded) reconfiguration task 
-
-
-#### Recoviner from Environmentd Crash
-Initially, we will recover from an environmentd crash by removing all
-reconfiguration replicas and clearing the `mz_pending_cluster_replicas` table,
-to ensure no active reconfigures are occurring. This is because
-we will treat any disruption in connection as a failed DDL which will need to
-be aborted.
-
-For V2, for each cluster, we will want to inspect whether an active
-reconfiguration is ongoing and continue it. To do this we'll likely need calls
-to `sequence_alter_cluster_managed_to_managed` to be idempotent w.r.t pending
-cluster replicas. 
+### Related Tasks
 
 
 ## Alternatives
@@ -231,7 +314,7 @@ in `handle_schedule_decision`
 
 
 ### Syntax
-The current proposal uses the `WITH (...)` syntax, it may be more straightforward to add this to the 
+The current proposal uses the `WITH (...)` syntax, it may be more straightforward to add this to the
 cluster as a config attribute though:
 ```SQL
 ALTER CLUSTER SET (CLEANUP TIMEOUT 5 minutes)
@@ -283,20 +366,17 @@ replicas for a cluster undergoing reconfiguration are restarted.
 
 For hydration-based scheduling the `until caught up` syntax will be used.
 
+There is also a question on the mechanism for tracking hydration or frontiers.
+We could check at a regular interval if the frontiers between original
+and reconfiguration replicas match. Another possible alternative is spinning up a thread that
+subscribes to the frontiers and kicks off finalization once the chosen condition is met.
 
-### Reconfiguration replica naming:
-Is it still useful to have reconfiguration replica naming differences if we also have a table tracking those
-replicas? It seems like we could get the list just as easily with a join and skip a step in the reconfiguration task.
-
-### Should the reconfiguration task create the replicas
-Currently, I have the reconfiguration task set to be in charge of the wait check and the finalization, but not
-the reconfiguration replica creation nor the insertion into `mz_cluster_pending_replicas`. This seems like a reasonable
-separation, as if we cannot do these two things we should fail and not background a task.
-
-
-### Do we want a more generic jobs table?
-The proposed mechanism is for a sort of one-off very specific job engine. Assuming we
-want a more robust job engine in the future it may make sense to take baby steps towards that here.
-For instance, we could introduce an `mz_job` table that stores all information about a ReconfiguratTask. This
-could be used on environmentd restart to re-initialize the task or perform cleanup for the task if the envd restart
-would've caused the task to fail. I haven't thought this through much.
+### Handling Sources / Sinks
+Currently we are opting not to allow graceful reconfiguration of clusters with
+sources and sinks, due to a single replica limit for these clusters. However,
+it may be possible to allow some graceful reconfiguration on these clusters, if
+we postpone installing the sources or sinks on the pending replicas until the
+replica is promoted. This will ensure that it is the only replica running. We
+would also have to ensure the new replication factor is greater than or equal to
+one in the new config. Multi-replica sources and sinks will implicitly resolve
+this issue, so, for now, it seems reasonable to wait for that.

--- a/doc/developer/design/20240411_graceful_reconfiguration_of_managed_clusters_v1.md
+++ b/doc/developer/design/20240411_graceful_reconfiguration_of_managed_clusters_v1.md
@@ -1,0 +1,331 @@
+# Graceful Reconfiguration of Managed Clusters
+
+Associated issues/prs:
+[#20010](https://github.com/MaterializeInc/materialize/issues/20010)
+[#26401](https://github.com/MaterializeInc/materialize/pull/26401)
+
+## The Problem
+Reconfiguring a managed cluster via `ALTER CLUSTER...` leads to downtime. This
+is due to our cluster sequencer first removing the old replicas and then adding new
+replicas that match the new configuration. The duration of downtime can be seen
+as extending through the full period it takes to rehydrate the new replicas.
+
+## Success Criteria
+A mechanism should be provided that allows users to delay the deletion of old
+replicas while new replicas are spun up
+
+## Scope
+### V1 Scope
+ - Timeout-based reconfiguration cleanup scheduling
+
+### V2 Scope
+ - Hydration-based reconfiguration cleanup scheduling
+
+### Out of scope
+ - Issues arising from multi-subscriber message handling are out of scope.
+
+## Solution Proposal
+
+### Summary:
+This feature will introduce new SQL in `ALTER CLUSTER` which will delay the
+cleanup of replicas until a specified timeout, or until a hydration check
+is triggered. 
+
+Ex:
+```sql
+ALTER CLUSTER c1 SET (SIZE 'small') WITH ( CLEANUP TIMEOUT 5 minutes );
+```
+
+Additionally, it will be possible to preempt the cleanup by specifying the
+statement with a TIMEOUT of 0, as long as no other changes are made to the
+cluster.
+
+Ex:
+```sql
+ALTER CLUSTER c1 SET (SIZE 'small') WITH ( CLEANUP TIMEOUT 0 minutes );
+```
+
+
+The new syntax and mechanisms will be built to work with auto-cleanup mechanisms
+built around cluster hydration but the syntax for that and the mechanism are not
+in scope for this document.
+
+All replicas will be billed during reconfiguration (except explicitly unbilled replicas).
+
+
+### Definitions:
+ -  Active Replica: These replicas should be actively serving results and are
+    named r1, r2, r3, etc. If a reconfiguration is ongoing, they will match the
+    prior version of the configuration. If a reconfiguration is not ongoing they
+    should be the only replicas.
+ - Reconfiguration Replica: These replicas only exist during a reconfiguration,
+   their names will be suffixed with `reconfig-`. They will move to active once
+   the reconfiguration is finalized.
+
+
+### Guard Rails
+- Only one reconfiguration will occur at a time for a given cluster If a
+  cluster undergoing reconfiguration is modified we should drop reconfiguration
+  replicas and overwrite the reconfigure value. If the alter changes no fields
+  we should just modify the reconfigure value without dropping the replicas. We
+  will issue a notice when overwriting an existing reconfigure.
+- We must protect against creating a source/sink on a reconfiguring cluster and
+  reconfiguring a cluster with sources/sinks. These clusters will need to use
+  the non-scheduled mechanism (delete-before-create). This is due to a limitation
+  where sources and sinks must only run on a single replica.
+- Optionally, we may want to consider limiting timeout duration.
+
+### Visibility
+Reconfiguration replicas should be identifiable for purposes of reporting and
+visibility in the UI. We may be able to do this by creating a prefix `reconfig-`
+for reconfiguration replicas, alternatively, we could set a bool status on the
+replica resource in the catalog.
+
+### Details
+
+#### Invariants:
+  - Only one reconfiguration will be allowed at a time for a cluster. 
+  - Unbilled replicas do not count towards reconfiguration and are not affected
+    by reconfiguration.
+
+#### Limitations:
+  - Cannot be used on clusters with sources, sources should not be created on
+    clusters with reconfigure replicas.
+
+#### Replica Naming
+Active replicas will continue with the same naming scheme (r1, r2, ...)
+Reconfiguration replicas will use the `reconfig` prefix; ex `reconfig-r3`,
+`reconfig-r4`, which will be removed once they are moved to active.
+
+#### SQL
+Introduce new SQL to define a delay duration for alter cluster.
+
+`ALTER CLUSTER c1 SET (SIZE 'small') WITH ( CLEANUP TIMEOUT  5 minutes );`
+
+This will alter the cluster and create new cluster replicas, but will not
+remove existing replicas. Instead, it will set the schedule for the cluster
+to `ClusterSchedule::Reconfigure` and set the deadline to `now + the provided
+duration`. When CLEANUP TIMEOUT is not provided the cluster will behave as it
+previously did, immediately tearing down and then creating the new replicas.
+
+Initially, all reconfigurations will wait for the full timeout; however, when we
+move to a hydration/parity cleanup detection mechanism, the reconfiguration may
+finish before the timeout. The same SQL can be used in both cases.
+
+#### Interactions with other schedules:
+
+In introducing a second `ClusterScehdule` variant, we now have to account for
+the interaction between these variants. To do so, `ClusterSchedule::Manual`
+will be special-cased. We will allow multiple `ClusterSchedules` to be set
+concurrently on a given cluster, however, when `ClusterSchedule::Reconfigure`
+is one of them, it will be the only schedule that will cause a decision to be
+emitted.
+
+Benefits of this approach:
+ - No other `ClusterSchedule` could interact with a cluster being reconfigured,
+   which may reduce the complexity of behavior between interacting schedules.
+ - Interactions with refresh. A resize on an active refresh to a smaller cluster
+   size would complete (or timeout) rather than be quiesced by the refresh
+   schedule decision. This should give a better indication of whether the new
+   size would work on subsequent refreshes.
+
+Downsides of this approach:
+ - Replicas may be alive for the entire delay period rather than just the period
+   it takes to perform the refresh, this could lead to additional/unexpected
+   billing.
+
+#### Catalog Changes
+__Cluster__
+Add a new ClusterSchedule Enum along with a `Reconfigure`  variant which would
+be applied temporarily during reconfigure.
+```rust
+ClusterSchedule::Reconfigure {
+  // timestamp for user-provided timeout
+  timeout: Option<u64>,
+  // V2 hydration config may end up here when we determine how it should be
+  // used to determine reconfiguration is complete This could also want to be
+  // a detection_mechanism: enum if we want different detection mechanisms that
+  // the user can specify 
+  // auto_detect: bool
+}
+```
+
+#### Scheduling
+`cluster_scheduling`'s `check_schedule_policies`, will be updated
+to additionally check `check_reconfiguration_policy`, which sends
+`ScheduleDecisions` with the decision `FinalizeReconfigure`, when the reconfigure timeout deadline has passed.
+
+`check_reconfiguration_policy`, for V1, will trigger a `FinalizeReconfiguration` `ScheduingDecision` for clusters that
+have a `Reconfigure` `ClusterSchedule` with a timeout value greater than the current time. In V2, we will add logic to this to also check for parity/hydration. At this point, it may need to be backgrounded as it's likely a much more costly check.
+
+`Message::SchedulingDecisions` will be adjusted from 
+`SchedulingDecisions(Vec<(&'static str, Vec<(ClusterId, bool)>)>)` to be
+`SchedulingDecisions(Vec<SchedulingPolicyDecision>)`
+```rust
+enum SchedulingPolicyDecision {
+  Refresh(Vec<(ClusterId, bool)>),
+  FinalizeReconfigure(Vec<(ClusterId)>),
+}
+```
+
+The logic for `handle_schedule_decision` will be directed to the correct
+function based on the  variant of decision `handle_refresh_decision` or
+`handle_finalize_reconfigure_decision`.
+
+For each cluster `handle_finalize_reconfigure_decisions` will check the current
+catalog to avoid conflicts with catalog updates since the `FinalizeDecision`
+was sent. If there's a collision that should prevent the finalization, such as a
+new size adjustment, then break; Otherwise, remove the active replicas and move
+the reconfiguration replicas to be active. Finally, remove the `Reconfigure`
+schedule from the cluster.
+
+
+#### Cluster Sequencer
+The following roughly defines the new logic for the cluster sequencer when
+performing an alter cluster on a managed cluster.
+
+There are two states to look at
+1. the newly provided config
+2. the reconfigue config (what is in the catalog)
+
+First scenario, the cluster being altered has no `Reconfigure` `cluster_schedule`:
+If cleanup_timeout is None:
+ - use the old mechanism ( drop and replace )
+If the new alter statement provides a `cleanup_timeout`: 
+ - check for sources/sinks,
+ - update the catalog with the changes and add a `Reconfigure` cluster schedule
+ - deploy new reconfigure replicas
+
+Second scenario, the cluster being altered is undergoing a reconfigure:
+If cleanup_timeout is None,
+ - Use the old mechanism - Drop and replace including all reconfigure replicas and remove the schedule.
+If the new alter statement provides a `cleanup_timeout`:
+ - If the new config matches the current config
+   - bump the timeout
+ - If the new config doesn't match the current config
+   - check for sources/sinks
+   - update cluster catalog with new schedule and config
+   - drop reconfigure replicas
+   - launch new reconfigure replicas
+
+Note:
+An `ALTER CLUSTER` statement that is run twice (double shot), either needs to
+push out the timeout of an ongoing reconfiguration or needs to entirely replace
+the existing reconfigure schedule dropping and recreating any reconfigure
+replicas. I believe the former is the more useful behavior.
+
+## Alternatives
+### Multiple Schedule Interactions
+We may choose to not special-case the `Reonconfigure` `ClusterSchedule`. In
+doing so both Schedules can create `ScheduleDecision` messages in their handle
+scheduling calls, the handler for each decision may happen in any order one
+after the other with no delay. Importantly, handling decisions is a serial
+process so no two decision handlers will be taking action at the same time. This
+may lead to a replica  that was recently spinning up from an `ALTER CLUSTER`
+statement being immediately shut down due to a refresh finalizing. Notably, if
+the cluster was sized down the following refresh may fail due to OOD or OOM as
+it never succeeded with the new size.
+
+Benefits
+  - Should be relatively easy to write this, as the expectation for any schedule
+    adjustment should be idempotent, ensure the cluster/replicas are in the
+    correct state after the decision action has finished.
+Downsides
+  - The interaction with `REFRESH EVERY` here is still weird. One might downsize
+    during the active period of `REFRESH EVERY`, but refresh finishes before the
+    reconfiguration finishing and the user will not know that the smaller size
+    will OOM or OOD(out of disk) on the next run because the reconfigure size
+    never had to finish.
+
+### Allow cancelation?
+We could additionally add a prior config field in `ClusterSchedule::Reconfigure`
+that stores the `prior_config`. This would be the pre-reconfigure configuration
+and could be used to cancel an upgrade. This would be done by running an
+`ALTER CLUSTER` statement that does not provide a `CLEANUP TIMEOUT`, and whose
+configuration matches the `prior_config`. This seems somewhat convoluted and
+I don't know that allowing for cancellation is necessary as long as we allow for
+adjustment of the current reconfigure timeout, and we allow for overwriting the
+current reconfiguration entirely.
+
+
+### Syntax
+The current proposal uses the `WITH (...)` syntax, it may be more straightforward to add this to the 
+cluster as a config attribute though:
+```SQL
+ALTER CLUSTER SET (CLEANUP TIMEOUT 5 minutes)
+```
+
+The above syntax would add a permanent reconfiguration timeout to the cluster that would
+be applied on every reconfigure. For this to work we'd need to update
+the cluster to know when a reconfigure event started, then we could compare the
+event + the duration to now and send a `ReconfigureFinalization` decision.
+
+To me the reconfigure schedule exists only to interact with actions taken from
+`ALTER CLUSTER` statements and is not really a property of the cluster, so I'm
+not very bullish on this syntax. I could be convinced that this is more ergonimic.
+
+## Open Questions
+
+### How do we handle multiple schedules?
+If this feature is introducing multiple schedules we'll need some rules
+governing the interaction between schedules. There's a world where each schedule
+needs to consider its interaction with all other schedules and that seems kind
+of scary.
+
+### How do we handle clusters with sinks and sources?
+There is a current limitation around clusters with sources where the replication
+factor must be 1 or 0 This being said we must disallow any reconfiguration
+schedules for clusters with sources (and sinks?). This is a new annoying issue
+as we now allow clusters to perform both compute and source roles. We should
+consider some ways to handle this, one potential is to keep source activity to
+a single replica in a multi-replica cluster. Alternatively, we just don't allow
+this, and we add some big disclaimers to clusters with sources.
+
+### How does a multi-subscriber coord work with schedules?
+We don't want two schedule decisions to be acting at the same time. Currently,
+this isn't an issue, but it seems a bit scary. Is this a concern?
+
+### How will this impact coord delays?
+Particularly when we look at hydration-based, this may add a reasonable
+complexity/time to the `coord` loop, which could lead to stalls. We may need to
+consider spinning off cluster scheduling decisions to a task.
+
+### Should ClusterSchedule::Reconfigure be a schedule?
+Since reconfiguration is only a temporary action it's somewhat reasonable that
+we wouldn't want to count it as a "schedule" option. If we're not doing this,
+we'd still have to define and persist some field to alert us of the timeout
+deadline, which likely means adding `reconfiugration_deadline: option<u64>`
+and `reconfiguration_mechanism` to the durable cluster object. I don't think
+this plays well with other types of scheduling and doesn't properly encapsulate
+the reconfiguration behavior, it's also less extensible when we think about
+different configurations for reconfiguration we may want in the future.
+
+### Hydration-Based Scheduling
+There is currently the beginning of the mechanism to look at hydration
+based metrics for scheduling in `compute-client/src/controller/
+instance:update_hydration_status`, this works very well for a single data flow,
+but can't gauge the hydration status of a replica as a whole.
+
+What we likely want is a mechanism [discussed here](https://github.com/MaterializeInc/materialize/issues/20010#issuecomment-2058563052), where we
+compare the data-flow frontiers between reconfiguration and active replicas,
+and when the reconfiguration replicas have all data flows within some threshold
+of the active, we send a message which invokes a `RecofigurationFinalize`
+scheduling decision. This decision may have to be a different decision policy
+then the standard `ReconfigurationFinalize` as we may want to perform some
+additional checks of the hydration status to ensure new data flows between when
+the message got sent and when the action is being taken have hydrated.
+
+__Potential challenges with using hydration status__:
+It is difficult to know when "hydration" has finished because:
+  - New data coming in may change the timestamp and lead to hydration status inaccuracies
+  - New data-flows can be created ad-hock which will need to be "hydrated"
+  - hydration_status errors related to `evnironmentd` restart?
+    (https://materializeinc.slack.com/archives/CTESPM7FU/p1712227236046369?thread_ts=1712224682.263469&cid=CTESPM7FU)
+Some of these can be resolved by only looking at data flows that were installed
+when the replica was created. It seems like comparing active and reconfiguration
+replicas will likely work better than attempting to gauge when hydration has
+finished for a given replica. It also may allow us to shorten the timeout if all
+replicas for a cluster undergoing reconfiguration are restarted.
+
+Ideally, no extra syntax is needed for hydration. We can implement it directly using the
+current syntax and it will just finalize the reconfiguration before we hit the timeout.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Design doc for graceful reconfiguration of managed clusters.
Currently limited to timeout based reconfiguration delay (v1).

https://github.com/MaterializeInc/materialize/issues/20010

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
