### PR TITLE
sql,optimizer: remove `enable_equivalence_propagation` feature flag

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -69,7 +69,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_disk_cluster_replicas": "true",
     "enable_eager_delta_joins": "true",
     "enable_envelope_debezium_in_subscribe": "true",
-    "enable_equivalence_propagation": "true",
     "enable_expressions_in_limit_syntax": "true",
     "enable_logical_compaction_window": "true",
     "enable_multi_worker_storage_persist_sink": "true",

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -97,8 +97,6 @@ optimizer_feature_flags!({
     enable_consolidate_after_union_negate: bool,
     // Bound from `SystemVars::enable_eager_delta_joins`.
     enable_eager_delta_joins: bool,
-    // Enable the `EquivalencePropagation` transform in the optimizer.
-    enable_equivalence_propagation: bool,
     // Enable Lattice-based fixpoint iteration on LetRec nodes in the
     // Analysis framework.
     enable_letrec_fixpoint_analysis: bool,

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -139,7 +139,6 @@ End
 Endpoint
 Enforced
 Envelope
-Equivalence
 Error
 Escape
 Estimate
@@ -316,7 +315,6 @@ Primary
 Privatelink
 Privileges
 Progress
-Propagation
 Protobuf
 Protocol
 Publication

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1788,7 +1788,6 @@ pub enum ClusterFeatureName {
     ReoptimizeImportedViews,
     EnableNewOuterJoinLowering,
     EnableEagerDeltaJoins,
-    EnableEquivalencePropagation,
     EnableVariadicLeftJoinLowering,
     EnableLetrecFixpointAnalysis,
 }
@@ -1804,7 +1803,6 @@ impl WithOptionName for ClusterFeatureName {
             Self::ReoptimizeImportedViews
             | Self::EnableNewOuterJoinLowering
             | Self::EnableEagerDeltaJoins
-            | Self::EnableEquivalencePropagation
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis => false,
         }
@@ -3225,7 +3223,6 @@ pub enum ExplainPlanOptionName {
     ReoptimizeImportedViews,
     EnableNewOuterJoinLowering,
     EnableEagerDeltaJoins,
-    EnableEquivalencePropagation,
     EnableVariadicLeftJoinLowering,
     EnableLetrecFixpointAnalysis,
 }
@@ -3260,7 +3257,6 @@ impl WithOptionName for ExplainPlanOptionName {
             | Self::ReoptimizeImportedViews
             | Self::EnableNewOuterJoinLowering
             | Self::EnableEagerDeltaJoins
-            | Self::EnableEquivalencePropagation
             | Self::EnableVariadicLeftJoinLowering
             | Self::EnableLetrecFixpointAnalysis => false,
         }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3514,7 +3514,6 @@ generate_extracted_config!(
     (ReoptimizeImportedViews, Option<bool>, Default(None)),
     (EnableEagerDeltaJoins, Option<bool>, Default(None)),
     (EnableNewOuterJoinLowering, Option<bool>, Default(None)),
-    (EnableEquivalencePropagation, Option<bool>, Default(None)),
     (EnableVariadicLeftJoinLowering, Option<bool>, Default(None)),
     (EnableLetrecFixpointAnalysis, Option<bool>, Default(None))
 );
@@ -3605,7 +3604,6 @@ pub fn plan_create_cluster(
             reoptimize_imported_views,
             enable_eager_delta_joins,
             enable_new_outer_join_lowering,
-            enable_equivalence_propagation,
             enable_variadic_left_join_lowering,
             enable_letrec_fixpoint_analysis,
             seen: _,
@@ -3614,7 +3612,6 @@ pub fn plan_create_cluster(
             reoptimize_imported_views,
             enable_eager_delta_joins,
             enable_new_outer_join_lowering,
-            enable_equivalence_propagation,
             enable_variadic_left_join_lowering,
             enable_letrec_fixpoint_analysis,
             ..Default::default()

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -361,7 +361,6 @@ generate_extracted_config!(
     (ReoptimizeImportedViews, Option<bool>, Default(None)),
     (EnableNewOuterJoinLowering, Option<bool>, Default(None)),
     (EnableEagerDeltaJoins, Option<bool>, Default(None)),
-    (EnableEquivalencePropagation, Option<bool>, Default(None)),
     (EnableVariadicLeftJoinLowering, Option<bool>, Default(None)),
     (EnableLetrecFixpointAnalysis, Option<bool>, Default(None))
 );
@@ -405,7 +404,6 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
             types: v.types,
             features: OptimizerFeatureOverrides {
                 enable_eager_delta_joins: v.enable_eager_delta_joins,
-                enable_equivalence_propagation: v.enable_equivalence_propagation,
                 enable_new_outer_join_lowering: v.enable_new_outer_join_lowering,
                 enable_variadic_left_join_lowering: v.enable_variadic_left_join_lowering,
                 enable_letrec_fixpoint_analysis: v.enable_letrec_fixpoint_analysis,

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2050,13 +2050,6 @@ feature_flags!(
         enable_for_item_parsing: false,
     },
     {
-        name: enable_equivalence_propagation,
-        desc: "Enable the EquivalencePropagation transform in the optimizer",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
         name: enable_variadic_left_join_lowering,
         desc: "Enable joint HIR ⇒ MIR lowering of stacks of left joins",
         default: false,
@@ -2084,7 +2077,6 @@ impl From<&super::SystemVars> for OptimizerFeatures {
         Self {
             enable_consolidate_after_union_negate: vars.enable_consolidate_after_union_negate(),
             enable_eager_delta_joins: vars.enable_eager_delta_joins(),
-            enable_equivalence_propagation: vars.enable_equivalence_propagation(),
             enable_new_outer_join_lowering: vars.enable_new_outer_join_lowering(),
             enable_reduce_mfp_fusion: vars.enable_reduce_mfp_fusion(),
             enable_variadic_left_join_lowering: vars.enable_variadic_left_join_lowering(),

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -477,29 +477,21 @@ impl Optimizer {
             Box::new(crate::Fixpoint {
                 name: "fixpoint01",
                 limit: 100,
-                transforms: {
-                    let mut buf: Vec<Box<dyn Transform>> = Vec::new();
-
+                transforms: vec![
                     // Predicate pushdown sets the equivalence classes of joins.
-                    buf.push(Box::new(predicate_pushdown::PredicatePushdown::default()));
-                    if ctx.features.enable_equivalence_propagation {
-                        buf.push(Box::new(
-                            equivalence_propagation::EquivalencePropagation::default(),
-                        ));
-                    }
+                    Box::new(predicate_pushdown::PredicatePushdown::default()),
+                    Box::new(equivalence_propagation::EquivalencePropagation::default()),
                     // Lifts the information `!isnull(col)`
-                    buf.push(Box::new(nonnullable::NonNullable));
+                    Box::new(nonnullable::NonNullable),
                     // Lifts the information `col = literal`
                     // TODO (#6613): this also tries to lift `!isnull(col)` but
                     // less well than the previous transform. Eliminate
                     // redundancy between the two transforms.
-                    buf.push(Box::new(column_knowledge::ColumnKnowledge::default()));
+                    Box::new(column_knowledge::ColumnKnowledge::default()),
                     // Lifts the information `col1 = col2`
-                    buf.push(Box::new(demand::Demand::default()));
-                    buf.push(Box::new(FuseAndCollapse::default()));
-
-                    buf
-                },
+                    Box::new(demand::Demand::default()),
+                    Box::new(FuseAndCollapse::default()),
+                ],
             }),
             // 5. Reduce/Join simplifications.
             Box::new(crate::Fixpoint {


### PR DESCRIPTION
Remove the `enable_equivalence_propagation` feature flag from the optimizer and SQL-level integrations (`EXPLAIN`, `CREATE CLUSTER`).

### Motivation

  * This PR adds a known-desirable feature.

Removes the feature flag introduced for the rollout of #24155.

### Tips for reviewer

Should be easy to review, as this is just removing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
