### PR TITLE
compute: persist_sink: fix size metrics reporting

### DIFF
--- a/src/compute/src/sink/correction.rs
+++ b/src/compute/src/sink/correction.rs
@@ -125,12 +125,18 @@ impl<D: Data> Correction<D> {
             None => Bound::Unbounded,
         };
 
+        let mut new_size = self.total_size;
+
         // Consolidate relevant times and compute the total number of updates.
         let range = self.updates.range_mut((start, end));
         let update_count = range.fold(0, |acc, (_, data)| {
+            new_size -= (data.len(), data.capacity());
             data.consolidate();
+            new_size += (data.len(), data.capacity());
             acc + data.len()
         });
+
+        self.update_metrics(new_size);
 
         let range = self.updates.range((start, end));
         range


### PR DESCRIPTION
This PR fixes the reporting of `Correction` size metrics. Previously we'd forget updating the reported sizes when the `Correction` data was consolidated, which was an oversight.

### Motivation

  * This PR fixes a previously unreported bug.

The reported `Correction` size metrics are wrong because they don't take into account consolidation that happens when collection updates for a given time range.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A