### PR TITLE
persist: Remove stale comments

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -214,6 +214,13 @@ where
     }
 
     /// Politely expires this subscribe, releasing its lease.
+    ///
+    /// There is a best-effort impl in Drop for [`ReadHandle`] to expire the
+    /// [`ReadHandle`] held by the subscribe that wasn't explicitly expired
+    /// with this method. When possible, explicit expiry is still preferred
+    /// because the Drop one is best effort and is dependant on a tokio
+    /// [Handle] being available in the TLC at the time of drop (which is a bit
+    /// subtle). Also, explicit expiry allows for control over when it happens.
     pub async fn expire(mut self) {
         if let Some(parts) = self.snapshot.take() {
             for part in parts {
@@ -481,6 +488,13 @@ where
     }
 
     /// Politely expires this listen, releasing its lease.
+    ///
+    /// There is a best-effort impl in Drop for [`ReadHandle`] to expire the
+    /// [`ReadHandle`] held by the listen that wasn't explicitly expired with
+    /// this method. When possible, explicit expiry is still preferred because
+    /// the Drop one is best effort and is dependant on a tokio [Handle] being
+    /// available in the TLC at the time of drop (which is a bit subtle). Also,
+    /// explicit expiry allows for control over when it happens.
     pub async fn expire(self) {
         self.handle.expire().await
     }

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -103,7 +103,6 @@ impl LeasedReaderId {
 pub struct Subscribe<K, V, T, D>
 where
     T: Timestamp + Lattice + Codec64,
-    // These are only here so we can use them in the auto-expiring `Drop` impl.
     K: Debug + Codec,
     V: Debug + Codec,
     D: Semigroup + Codec64 + Send + Sync,
@@ -215,13 +214,6 @@ where
     }
 
     /// Politely expires this subscribe, releasing its lease.
-    ///
-    /// There is a best-effort impl in Drop to expire a listen that wasn't
-    /// explicitly expired with this method. When possible, explicit expiry is
-    /// still preferred because the Drop one is best effort and is dependant on
-    /// a tokio [Handle] being available in the TLC at the time of drop (which
-    /// is a bit subtle). Also, explicit expiry allows for control over when it
-    /// happens.
     pub async fn expire(mut self) {
         if let Some(parts) = self.snapshot.take() {
             for part in parts {
@@ -248,7 +240,6 @@ pub enum ListenEvent<T, D> {
 pub struct Listen<K, V, T, D>
 where
     T: Timestamp + Lattice + Codec64,
-    // These are only here so we can use them in the auto-expiring `Drop` impl.
     K: Debug + Codec,
     V: Debug + Codec,
     D: Semigroup + Codec64 + Send + Sync,
@@ -490,13 +481,6 @@ where
     }
 
     /// Politely expires this listen, releasing its lease.
-    ///
-    /// There is a best-effort impl in Drop to expire a listen that wasn't
-    /// explicitly expired with this method. When possible, explicit expiry is
-    /// still preferred because the Drop one is best effort and is dependant on
-    /// a tokio [Handle] being available in the TLC at the time of drop (which
-    /// is a bit subtle). Also, explicit expiry allows for control over when it
-    /// happens.
     pub async fn expire(self) {
         self.handle.expire().await
     }


### PR DESCRIPTION
### Motivation
Update comments.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
