### PR TITLE
[persist/txn] Use the "critical" since when creating new read leases in the txns code

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -487,6 +487,7 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
                     shard_name: CATALOG_SHARD_NAME.to_string(),
                     handle_purpose: "openable durable catalog state temporary reader".to_string(),
                 },
+                false,
             )
             .await
             .expect("invalid usage")

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -945,6 +945,7 @@ impl PersistPeek {
                 Arc::new(metadata.relation_desc.clone()),
                 Arc::new(UnitSchema),
                 Diagnostics::from_purpose("persist::peek"),
+                false,
             )
             .await
             .map_err(|e| e.to_string())?;

--- a/src/dyncfg/src/lib.rs
+++ b/src/dyncfg/src/lib.rs
@@ -148,7 +148,7 @@ impl<D: ConfigDefault> Config<D> {
     fn shared<'a>(&self, set: &'a ConfigSet) -> &'a ConfigValAtomic {
         &set.configs
             .get(self.name)
-            .expect("config should be registered to set")
+            .unwrap_or_else(|| panic!("config {} should be registered to set", self.name))
             .val
     }
 }

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -247,6 +247,7 @@ impl Transactor {
                 Arc::new(StringSchema),
                 Arc::new(UnitSchema),
                 Diagnostics::from_purpose("txn data"),
+                false,
             )
             .await
             .expect("data schema shouldn't change");

--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -267,6 +267,7 @@ impl Transactor {
                     Arc::new(MaelstromKeySchema),
                     Arc::new(MaelstromValSchema),
                     Diagnostics::from_purpose("maelstrom short-lived"),
+                    false,
                 )
                 .await
                 .expect("codecs should match");

--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -240,6 +240,7 @@ async fn bench_snapshot_one_iter(
             Arc::new(VecU8Schema),
             Arc::new(VecU8Schema),
             Diagnostics::from_purpose("bench"),
+            false,
         )
         .await?;
 

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -318,6 +318,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL)
         .add(&crate::cfg::CRDB_CONNECT_TIMEOUT)
         .add(&crate::cfg::CRDB_TCP_USER_TIMEOUT)
+        .add(&crate::cfg::TXN_USE_CRITICAL_SINCE)
         .add(&crate::internal::cache::BLOB_CACHE_MEM_LIMIT_BYTES)
         .add(&crate::internal::compact::COMPACTION_MINIMUM_TIMEOUT)
         .add(&crate::internal::machine::NEXT_LISTEN_BATCH_RETRYER_CLAMP)
@@ -396,6 +397,13 @@ pub const CRDB_TCP_USER_TIMEOUT: Config<Duration> = Config::new(
     The TCP timeout for connections to CockroachDB. Specifies the amount of \
     time that transmitted data may remain unacknowledged before the TCP \
     connection is forcibly closed.",
+);
+
+/// Migrate the txns code to use the critical since when opening a new read handle.
+pub const TXN_USE_CRITICAL_SINCE: Config<bool> = Config::new(
+    "persist_txn_use_critical_since",
+    true,
+    "Use the critical since (instead of the overall since) when initializing a subscribe.",
 );
 
 impl PostgresClientKnobs for PersistConfig {

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -83,10 +83,10 @@ impl CriticalReaderId {
 /// shard.
 ///
 /// In contrast to [crate::read::ReadHandle], which is time-leased, this handle
-/// and its associated capability are not leased. A SinceHandle only releases
-/// its since capability when [Self::expire] is called. Also unlike
-/// `ReadHandle`, expire is not called on drop. This is less ergonomic, but
-/// useful for "critical" since holds which must survive even lease timeouts.
+/// and its associated capability are not leased.
+/// A SinceHandle does not release its capability when dropped.
+/// This is less ergonomic,
+/// but useful for "critical" since holds which must survive even lease timeouts.
 ///
 /// **IMPORTANT**: The above means that if a SinceHandle is registered and then
 /// lost, the shard's since will be permanently "stuck", forever preventing
@@ -331,12 +331,11 @@ where
         }
     }
 
-    /// Politely expires this reader, releasing its since capability.
-    #[instrument(level = "debug", fields(shard = %self.machine.shard_id()))]
-    pub async fn expire(mut self) {
-        let (_, maintenance) = self.machine.expire_critical_reader(&self.reader_id).await;
-        maintenance.start_performing(&self.machine, &self.gc);
-    }
+    // Expiry temporarily removed.
+    // If you'd like to stop this handle from holding back the since of the shard,
+    // downgrade it to [].
+    // TODO(bkirwi): revert this when since behaviour on expiry has settled,
+    // or all readers are associated with a critical handle.
 }
 
 #[cfg(test)]

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -171,6 +171,7 @@ where
         purpose: &str,
         lease_duration: Duration,
         heartbeat_timestamp_ms: u64,
+        use_critical_since: bool,
     ) -> (LeasedReaderState<T>, RoutineMaintenance) {
         let metrics = Arc::clone(&self.applier.metrics);
         let (_seqno, (reader_state, seqno_since), maintenance) = self
@@ -182,6 +183,7 @@ where
                     seqno,
                     lease_duration,
                     heartbeat_timestamp_ms,
+                    use_critical_since,
                 )
             })
             .await;
@@ -2002,6 +2004,7 @@ pub mod datadriven {
                 Arc::new(StringSchema),
                 Arc::new(UnitSchema),
                 Diagnostics::for_tests(),
+                false,
             )
             .await
             .expect("invalid shard types");
@@ -2070,6 +2073,7 @@ pub mod datadriven {
                 "tests",
                 READER_LEASE_DURATION.get(&datadriven.client.cfg),
                 (datadriven.client.cfg.now)(),
+                false,
             )
             .await;
         datadriven.routine.push(maintenance);

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -648,6 +648,7 @@ where
         (seqno, maintenance)
     }
 
+    #[allow(dead_code)] // TODO(bkirwi): remove this when since behaviour on expiry has settled
     pub async fn expire_critical_reader(
         &mut self,
         reader_id: &CriticalReaderId,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -451,9 +451,10 @@ impl PersistClient {
     ///
     /// In contrast to the time-leased [ReadHandle] returned by [Self::open] and
     /// [Self::open_leased_reader], this handle and its associated capability
-    /// are not leased. A [SinceHandle] only releases its since capability when
-    /// [SinceHandle::expire] is called. Also unlike `ReadHandle`, expire is not
-    /// called on drop. This is less ergonomic, but useful for "critical" since
+    /// are not leased. A [SinceHandle] does not release its since capability;
+    /// downgrade to the empty antichain to hold back the since.
+    /// Also unlike `ReadHandle`, the handle is not expired on drop.
+    /// This is less ergonomic, but useful for "critical" since
     /// holds which must survive even lease timeouts.
     ///
     /// **IMPORTANT**: The above means that if a SinceHandle is registered and

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -311,7 +311,7 @@ impl PersistClient {
                 diagnostics.clone(),
             )
             .await?,
-            self.open_leased_reader(shard_id, key_schema, val_schema, diagnostics)
+            self.open_leased_reader(shard_id, key_schema, val_schema, diagnostics, false)
                 .await?,
         ))
     }
@@ -331,6 +331,7 @@ impl PersistClient {
         key_schema: Arc<K::Schema>,
         val_schema: Arc<V::Schema>,
         diagnostics: Diagnostics,
+        use_critical_since: bool,
     ) -> Result<ReadHandle<K, V, T, D>, InvalidUsage<T>>
     where
         K: Debug + Codec,
@@ -349,6 +350,7 @@ impl PersistClient {
                 &diagnostics.handle_purpose,
                 READER_LEASE_DURATION.get(&self.cfg),
                 heartbeat_ts,
+                use_critical_since,
             )
             .await;
         maintenance.start_performing(&machine, &gc);
@@ -897,6 +899,7 @@ mod tests {
                 Arc::new(StringSchema),
                 Arc::new(StringSchema),
                 Diagnostics::for_tests(),
+                false,
             )
             .await
             .expect("codec mismatch");
@@ -906,6 +909,7 @@ mod tests {
                 Arc::new(StringSchema),
                 Arc::new(StringSchema),
                 Diagnostics::for_tests(),
+                false,
             )
             .await
             .expect("codec mismatch");
@@ -1031,6 +1035,7 @@ mod tests {
                         Arc::new(VecU8Schema),
                         Arc::new(StringSchema),
                         Diagnostics::for_tests(),
+                        false,
                     )
                     .await
                     .unwrap_err(),

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -281,6 +281,7 @@ where
                         key_schema,
                         val_schema,
                         diagnostics,
+                        false,
                     )
                     .await
             }
@@ -690,6 +691,7 @@ mod tests {
                 Arc::new(<std::string::String as mz_persist_types::Codec>::Schema::default()),
                 Arc::new(<std::string::String as mz_persist_types::Codec>::Schema::default()),
                 Diagnostics::for_tests(),
+                false,
             )
             .await
             .expect("invalid usage");

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -864,11 +864,13 @@ where
                 purpose,
                 READER_LEASE_DURATION.get(&self.cfg),
                 heartbeat_ts,
+                false,
             )
             .await;
         maintenance.start_performing(&machine, &gc);
         // The point of clone is that you're guaranteed to have the same (or
         // greater) since capability, verify that.
+        // TODO: better if it's the same since capability exactly.
         assert!(PartialOrder::less_equal(&reader_state.since, &self.since));
         let new_reader = ReadHandle::new(
             self.cfg.clone(),

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -21,9 +21,9 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use futures::Stream;
 use mz_dyncfg::Config;
-use mz_ore::instrument;
 use mz_ore::now::EpochMillis;
 use mz_ore::task::{AbortOnDropHandle, JoinHandle, RuntimeExt};
+use mz_ore::{instrument, soft_assert_or_log};
 use mz_persist::location::{Blob, SeqNo};
 use mz_persist_types::{Codec, Codec64};
 use proptest_derive::Arbitrary;
@@ -751,6 +751,14 @@ where
         as_of: Antichain<T>,
     ) -> Result<Vec<LeasedBatchPart<T>>, Since<T>> {
         let batches = self.machine.snapshot(&as_of).await?;
+
+        soft_assert_or_log!(
+            PartialOrder::less_equal(self.since(), &as_of),
+            "ReadHandle::snapshot called with as_of {:?} not past the handle's since {:?}, \
+            though the read has succeeded. This implies the since is not being held back correctly.",
+            &as_of,
+            self.since()
+        );
 
         let filter = FetchBatchFilter::Snapshot { as_of };
         let mut leased_parts = Vec::new();

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -696,6 +696,7 @@ pub mod tests {
                 Arc::new(StringSchema),
                 Arc::new(UnitSchema),
                 Diagnostics::for_tests(),
+                true,
             )
             .await
             .expect("codecs should not change")

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::HashMap;
 use mz_ore::instrument;
+use mz_persist_client::cfg::TXN_USE_CRITICAL_SINCE;
 use mz_persist_client::fetch::LeasedBatchPart;
 use mz_persist_client::metrics::encode_ts_metric;
 use mz_persist_client::read::{ListenEvent, ReadHandle, Subscribe};
@@ -720,7 +721,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
                     shard_name: "txns".to_owned(),
                     handle_purpose: "read txns".to_owned(),
                 },
-                false,
+                TXN_USE_CRITICAL_SINCE.get(client.dyncfgs()),
             )
             .await
             .expect("txns schema shouldn't change");

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -720,6 +720,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
                     shard_name: "txns".to_owned(),
                     handle_purpose: "read txns".to_owned(),
                 },
+                false,
             )
             .await
             .expect("txns schema shouldn't change");
@@ -1280,6 +1281,7 @@ mod tests {
                 Arc::new(ShardIdSchema),
                 Arc::new(VecU8Schema),
                 Diagnostics::for_tests(),
+                true,
             )
             .await
             .expect("txns schema shouldn't change");

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -20,6 +20,7 @@ use differential_dataflow::lattice::Lattice;
 use futures::Stream;
 use mz_ore::instrument;
 use mz_ore::task::AbortOnDropHandle;
+use mz_persist_client::cfg::TXN_USE_CRITICAL_SINCE;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::read::{Cursor, LazyPartStats, ListenEvent, ReadHandle, Since, Subscribe};
 use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
@@ -679,7 +680,7 @@ where
                     shard_name: "txns".to_owned(),
                     handle_purpose: "read txns".to_owned(),
                 },
-                false,
+                TXN_USE_CRITICAL_SINCE.get(client.dyncfgs()),
             )
             .await
             .expect("txns schema shouldn't change");

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -679,6 +679,7 @@ where
                     shard_name: "txns".to_owned(),
                     handle_purpose: "read txns".to_owned(),
                 },
+                false,
             )
             .await
             .expect("txns schema shouldn't change");

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -3393,6 +3393,7 @@ where
                     shard_name: id.to_string(),
                     handle_purpose: format!("snapshot {}", id),
                 },
+                false,
             )
             .await
             .expect("invalid persist usage");

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -851,6 +851,7 @@ mod tests {
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
                 Diagnostics::from_purpose("test_since_hold"),
+                false,
             )
             .await
             .expect("error opening persist shard");
@@ -1212,6 +1213,7 @@ mod tests {
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
                 Diagnostics::from_purpose("test_since_hold"),
+                false,
             )
             .await
             .expect("error opening persist shard");
@@ -1489,6 +1491,7 @@ mod tests {
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
                 Diagnostics::from_purpose("test_since_hold"),
+                false,
             )
             .await
             .expect("error opening persist shard");
@@ -1699,6 +1702,7 @@ mod tests {
                 Arc::new(PROGRESS_DESC.clone()),
                 Arc::new(UnitSchema),
                 Diagnostics::from_purpose("test_since_hold"),
+                false,
             )
             .await
             .expect("error opening persist shard");

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -404,6 +404,7 @@ impl SinkHandle {
                         shard_name: sink_id.to_string(),
                         handle_purpose: format!("sink::since {}", sink_id),
                     },
+                    false,
                 )
                 .await
                 .expect("opening reader for shard");

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -138,6 +138,7 @@ where
                                 shard_name: ingestion_description.remap_collection_id.to_string(),
                                 handle_purpose: format!("reclock for {}", id),
                             },
+                            false,
                         )
                         .await
                         .expect("shard unavailable");
@@ -298,6 +299,7 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                                                         id
                                                     ),
                                                 },
+                                                false,
                                             )
                                             .await
                                             .unwrap();


### PR DESCRIPTION
- Allow read-lease-creators to opt in to having their initial since set to the least critical handle, instead of the shards overall since.
- Opt the txns code into this feature, behind a default-on flag.

### Motivation

Previously-unreported bug. (While the general risk was known, this new instance of it is I think new?)

Briefly: every new source that reads a txns shard subscribes with an as-of of the global since. Since we throttle since downgrades, this will prevent the global since from advancing for a few minutes. If the rate at which we create new txn-backed dataflows is faster than the rate at which these downgrades go through, we can hold back the since indefinitely.

A way around is to have the initial since of the handle based on the shard's critical handle. Since that doesn't depend on the since hold of any leased handle, the holds of our leases should stay more or less in sync with our critical handle and everything should be fine.

### Tips for reviewer

Everything but the last commit ought to be a noop!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
