### PR TITLE
[dnm] adapter/persist: add `PackedInterval` type

### DIFF
--- a/src/repr/proptest-regressions/adt/interval.txt
+++ b/src/repr/proptest-regressions/adt/interval.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc fc14a99244f5c679b0ca8dbc1ef1ff052c530d37ffc112f680625cc3cb5ffee1 # shrinks to interval = [Interval { months: 0, days: 0, micros: 0 }, Interval { months: -1, days: 0, micros: 0 }]

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -808,7 +808,12 @@ impl Arbitrary for Interval {
     type Parameters = ();
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (any::<i32>(), any::<i32>(), any::<i64>())
+        (
+            any::<i32>(),
+            any::<i32>(),
+            ((((i64::from(i32::MIN) * 60) - 59) * 60) * 1_000_000 - 59_999_999
+                ..(((i64::from(i32::MAX) * 60) + 59) * 60) * 1_000_000 + 59_999_999),
+        )
             .prop_map(|(months, days, micros)| Interval {
                 months,
                 days,
@@ -818,8 +823,87 @@ impl Arbitrary for Interval {
     }
 }
 
+/// An encoded packed variant of [`Interval`].
+///
+/// We uphold the variant that [`PackedInterval`] sorts the same as [`Interval`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PackedInterval([u8; Self::SIZE]);
+
+impl PackedInterval {
+    const SIZE: usize = 16;
+
+    /// Returns the encoded bytes of the [`PackedInterval`].
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0[..]
+    }
+
+    /// Creates a [`PackedInterval`] from a slice of bytes, returns an error if the size is
+    /// incorrect.
+    pub fn from_bytes(slice: &[u8]) -> Result<Self, String> {
+        if slice.len() != Self::SIZE {
+            return Err(format!(
+                "size for PackedInterval is incorrect, {}",
+                slice.len()
+            ));
+        }
+
+        let mut buf = [0u8; 16];
+        buf.copy_from_slice(&slice[..16]);
+
+        Ok(PackedInterval(buf))
+    }
+}
+
+// `as` conversions are okay here because we're doing bit level logic to make
+// sure the sort order of the packed binary is correct. This is implementation
+// is proptest-ed below.
+#[allow(clippy::as_conversions)]
+impl PackedInterval {
+    #[inline]
+    pub fn from_interval(value: Interval) -> Self {
+        let mut buf = [0u8; 16];
+
+        // Note: We XOR the values to get correct sorting of negative values.
+
+        let months = (value.months as u32) ^ (0x8000_0000u32);
+        let days = (value.days as u32) ^ (0x8000_0000u32);
+        let micros = (value.micros as u64) ^ (0x8000_0000_0000_0000u64);
+
+        buf[..4].copy_from_slice(&months.to_be_bytes());
+        buf[4..8].copy_from_slice(&days.to_be_bytes());
+        buf[8..].copy_from_slice(&micros.to_be_bytes());
+
+        PackedInterval(buf)
+    }
+
+    #[inline]
+    pub fn into_interval(self) -> Interval {
+        // Note: We XOR the values to get correct sorting of negative values.
+
+        let mut months = [0; 4];
+        months.copy_from_slice(&self.0[..4]);
+        let months = u32::from_be_bytes(months) ^ 0x8000_0000u32;
+
+        let mut days = [0; 4];
+        days.copy_from_slice(&self.0[4..8]);
+        let days = u32::from_be_bytes(days) ^ 0x8000_0000u32;
+
+        let mut micros = [0; 8];
+        micros.copy_from_slice(&self.0[8..]);
+        let micros = u64::from_be_bytes(micros) ^ 0x8000_0000_0000_0000u64;
+
+        Interval {
+            months: months as i32,
+            days: days as i32,
+            micros: micros as i64,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use proptest::prelude::*;
+
     use super::*;
 
     #[mz_ore::test]
@@ -1314,5 +1398,44 @@ mod test {
             Some(360),
             Interval::convert_date_time_unit(DateTimeField::Year, DateTimeField::Day, 1)
         );
+    }
+
+    #[mz_ore::test]
+    fn proptest_packed_interval_roundtrips() {
+        fn roundtrip_interval(og: Interval) {
+            let packed = PackedInterval::from_interval(og);
+            let rnd = packed.into_interval();
+
+            assert_eq!(og, rnd);
+        }
+
+        proptest!(|(interval in any::<Interval>())| {
+            roundtrip_interval(interval);
+        });
+    }
+
+    #[mz_ore::test]
+    fn proptest_packed_interval_sorts() {
+        fn sort_intervals(mut og: Vec<Interval>) {
+            let mut packed: Vec<_> = og
+                .iter()
+                .copied()
+                .map(PackedInterval::from_interval)
+                .collect();
+
+            og.sort();
+            packed.sort();
+
+            let rnd: Vec<_> = packed
+                .into_iter()
+                .map(PackedInterval::into_interval)
+                .collect();
+
+            assert_eq!(og, rnd);
+        }
+
+        proptest!(|(interval in any::<Vec<Interval>>())| {
+            sort_intervals(interval);
+        });
     }
 }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -3735,7 +3735,7 @@ pub fn arb_datum() -> BoxedStrategy<PropDatum> {
         arb_utc_date_time()
             .prop_map(|t| PropDatum::TimestampTz(CheckedTimestamp::from_timestamplike(t).unwrap()))
             .boxed(),
-        arb_interval().prop_map(PropDatum::Interval).boxed(),
+        any::<Interval>().prop_map(PropDatum::Interval).boxed(),
         arb_numeric().prop_map(PropDatum::Numeric).boxed(),
         prop::collection::vec(any::<u8>(), 1024)
             .prop_map(PropDatum::Bytes)
@@ -3967,21 +3967,6 @@ fn arb_dict(element_strategy: BoxedStrategy<PropDatum>) -> BoxedStrategy<PropDic
 fn arb_date() -> BoxedStrategy<Date> {
     (Date::LOW_DAYS..Date::HIGH_DAYS)
         .prop_map(move |days| Date::from_pg_epoch(days).unwrap())
-        .boxed()
-}
-
-fn arb_interval() -> BoxedStrategy<Interval> {
-    (
-        any::<i32>(),
-        any::<i32>(),
-        ((((i64::from(i32::MIN) * 60) - 59) * 60) * 1_000_000 - 59_999_999
-            ..(((i64::from(i32::MAX) * 60) + 59) * 60) * 1_000_000 + 59_999_999),
-    )
-        .prop_map(|(months, days, micros)| Interval {
-            months,
-            days,
-            micros,
-        })
         .boxed()
 }
 


### PR DESCRIPTION
This PR adds a `PackedInterval` type which would be used for Persist columnar encoding of `Interval`s. It upholds the invariant the that sort order of a `PackedInterval` is the same as an `Interval`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
