### PR TITLE
storage: Fix for runtime invalid-socket-address error

### DIFF
--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -46,7 +46,10 @@ pub enum PostgresError {
     Ssh(#[source] anyhow::Error),
     /// Error doing io to setup an ssh connection.
     #[error("error communicating with ssh tunnel: {0}")]
-    SshIo(#[from] std::io::Error),
+    SshIo(std::io::Error),
+    /// Error doing io to setup a connection.
+    #[error("IO error in connection: {0}")]
+    Io(#[from] std::io::Error),
     /// A postgres error.
     #[error(transparent)]
     Postgres(#[from] tokio_postgres::Error),

--- a/src/postgres-util/src/tunnel.rs
+++ b/src/postgres-util/src/tunnel.rs
@@ -303,7 +303,9 @@ impl Config {
                 // the singular host in place.
 
                 let privatelink_host = mz_cloud_resources::vpc_endpoint_name(*connection_id);
-                let privatelink_addrs = tokio::net::lookup_host(privatelink_host).await?;
+                // `net::lookup_host` requires a port to be specified, but the port has no effect
+                // on the lookup so use a dummy one
+                let privatelink_addrs = tokio::net::lookup_host((privatelink_host, 11111)).await?;
 
                 // Override the actual IPs to connect to for the TCP connection, leaving the original host in-place
                 // for TLS verification


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Postgres connections over AWS PrivateLink were broken by https://github.com/MaterializeInc/materialize/pull/26186/ which introduced a runtime error because `tokio::net::lookup_host` here requires a port provided:
https://github.com/MaterializeInc/materialize/blob/80e3fe9561c8d6849b16cbb7bfa4a6305a278916/src/postgres-util/src/tunnel.rs#L305-L306

We unfortunately did not have a PrivateLink + Postgres Source test in CI. This work is tracked here https://github.com/MaterializeInc/cloud/issues/8238 and will be prioritized for implementation during the next 2 weeks (cc @jubrad @pH14 @benesch )

I [reproduced](https://materializeinc.sentry.io/issues/5255681995/?environment=staging&project=6780145&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=0) this error on my staging environment using a debug build (from https://github.com/MaterializeInc/materialize/pull/26804) and then verified this fix with a second debug build (from https://github.com/MaterializeInc/materialize/pull/26805)

This also fixes the `thiserror` conversion for `PostgresError` that caused us to originally attribute the error to something related to ssh-connections.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
