### PR TITLE
compute: hydration status based on output frontiers

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1804,12 +1804,11 @@ where
 
             let old_global_frontier = coll.write_frontier.clone();
 
-            self.update_hydration_status(id, replica_id, &new_frontier);
             self.collection_mut(id)
                 .expect("we know about the collection")
                 .collection_introspection
                 .frontier_update(&new_frontier);
-            self.update_write_frontiers(replica_id, &[(id, new_frontier.clone())].into());
+            self.update_write_frontiers(replica_id, &[(id, new_frontier)].into());
 
             if let Ok(coll) = self.collection(id) {
                 if coll.write_frontier != old_global_frontier {
@@ -1823,7 +1822,12 @@ where
 
         // Apply an input frontier advancement.
         if let Some(new_frontier) = frontiers.input_frontier {
-            self.update_replica_input_frontiers(replica_id, &[(id, new_frontier.clone())].into());
+            self.update_replica_input_frontiers(replica_id, &[(id, new_frontier)].into());
+        }
+
+        // Apply an output frontier advancement.
+        if let Some(new_frontier) = frontiers.output_frontier {
+            self.update_hydration_status(id, replica_id, &new_frontier);
         }
     }
 

--- a/src/compute-client/src/protocol/response.proto
+++ b/src/compute-client/src/protocol/response.proto
@@ -55,6 +55,7 @@ message ProtoComputeResponse {
 message ProtoFrontiersResponse {
     mz_repr.antichain.ProtoU64Antichain write_frontier = 1;
     mz_repr.antichain.ProtoU64Antichain input_frontier = 2;
+    mz_repr.antichain.ProtoU64Antichain output_frontier = 3;
 }
 
 message ProtoPeekResponse {

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -459,7 +459,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
 
             // Report frontier information back the coordinator.
             if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {
-                compute_state.report_compute_frontiers();
+                compute_state.report_frontiers();
                 compute_state.report_dropped_collections();
                 compute_state.report_operator_hydration();
             }

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -369,10 +369,9 @@ r2 true
 > CREATE MATERIALIZED VIEW mv9 WITH (REFRESH AT mz_now()::text::int8 + 1000000) AS
   SELECT x*x FROM t3;
 
-# Check that all operators have hydrated. Ideally, we'd want to check `mz_hydration_statuses`, but that is
-# currently wrong for REFRESH MVs, see https://github.com/MaterializeInc/materialize/issues/25518
+# Check that all operators have hydrated.
 > SELECT DISTINCT hydrated
-  FROM mz_internal.mz_compute_operator_hydration_statuses h JOIN mz_objects o ON (h.object_id = o.id)
+  FROM mz_internal.mz_hydration_statuses h JOIN mz_objects o ON (h.object_id = o.id)
   WHERE name = 'mv9';
 true
 
@@ -382,7 +381,7 @@ true
   SELECT DISTINCT x, y FROM t2, t3;
 
 > SELECT DISTINCT hydrated
-  FROM mz_internal.mz_compute_operator_hydration_statuses h JOIN mz_objects o ON (h.object_id = o.id)
+  FROM mz_internal.mz_hydration_statuses h JOIN mz_objects o ON (h.object_id = o.id)
   WHERE name = 'mv10';
 true
 

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -9,9 +9,8 @@
 
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_refresh_every_mvs = true
-
-$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 ALTER SYSTEM SET enable_cluster_schedule_refresh = true
+ALTER SYSTEM SET enable_unstable_dependencies = true
 
 > CREATE DATABASE materialized_view_refresh_options;
 > SET DATABASE = materialized_view_refresh_options;
@@ -621,6 +620,48 @@ true <null>
   WHERE mv.id = mvr.materialized_view_id AND name = 'mv1';
 8000
 
+# Negative test for `mz_hydration_statuses`, a regression test for #25518.
+#
+# It's hard to observe the bug before the first hydration, so we make the first
+# hydration quick to just get it over with, and then we make the next hydration
+# slow, and try to catch the bug there.
+
+> CREATE CLUSTER cluster_to_be_bricked SIZE = '1', REPLICATION FACTOR = 1;
+> CREATE TABLE t6 (a int);
+> INSERT INTO t6 VALUES (1);
+> CREATE MATERIALIZED VIEW mv_long_hydration
+  IN CLUSTER cluster_to_be_bricked
+  WITH (REFRESH EVERY '1 day') AS
+  SELECT mz_unsafe.mz_sleep(a)
+  FROM t6;
+
+# Wait for the first rehydration to complete
+> SELECT * FROM mv_long_hydration;
+<null>
+
+> SELECT hydrated
+  FROM mz_internal.mz_hydration_statuses JOIN mz_materialized_views ON (object_id = id)
+  WHERE name = 'mv_long_hydration';
+true
+
+# Make the next rehydration take 1000000 ms.
+> INSERT INTO t6 VALUES (1000000);
+
+# Restart the cluster to force a rehydration.
+> ALTER CLUSTER cluster_to_be_bricked SET (REPLICATION FACTOR 0);
+> ALTER CLUSTER cluster_to_be_bricked SET (REPLICATION FACTOR 1);
+
+# Give the following hydration status query some time to wrongly turn to true if there is a bug.
+> SELECT mz_unsafe.mz_sleep(3);
+<null>
+
+> SELECT hydrated
+  FROM mz_internal.mz_hydration_statuses JOIN mz_materialized_views ON (object_id = id)
+  WHERE name = 'mv_long_hydration';
+false
+
+> DROP MATERIALIZED VIEW mv_long_hydration;
+
 # ----------------------------------------
 # Cleanup
 # ----------------------------------------
@@ -632,3 +673,4 @@ true <null>
 > DROP CLUSTER c_schedule_6;
 > DROP CLUSTER c_schedule_7;
 > DROP CLUSTER cluster_no_replica;
+> DROP CLUSTER cluster_to_be_bricked;


### PR DESCRIPTION
This PR adds a new `output_frontier` to `ComputeResponse::Frontiers`, which is used to report a frontier of times the dataflow has fully processed. This frontier is usable for tracking dataflow progress even for dataflows that jump their write frontier into the future. The new output frontier is then used instead of the write frontier in the hydration status tracking, resolving existing defects we have with `REFRESH` MVs.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/25518

### Tips for reviewer

Can we find a better term than "output frontier"? I chose it because it is consistent with the use of "input frontier" as the frontier of times we have finished at the inputs. But perhaps it is too ambiguous?

I think medium-term we want to report the hydration status through replica introspection, which would also allow us to report a hydration time. That's currently blocked by #26730 though, and fixing the existing controller-based tracking is easy. Plus there are other motivations for reporting an output frontier to the controller, like shutting down replicas automatically when they fall behind, or exposing replica progress to users.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A