### PR TITLE
persist-txn: use TxnsRead worker task in operator

### DIFF
--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -61,9 +61,6 @@ pub struct PersistClientCache {
     pub(crate) state_cache: Arc<StateCache>,
     pubsub_sender: Arc<dyn PubSubSender>,
     _pubsub_receiver_task: JoinHandle<()>,
-
-    // WIP hack plumb this around instead (What does this mean? Why not have this be `std::sync::OnceLock<Arc<TxnRead>>`?)
-    // This is the `TxnRead` for the `clusterd` process.
     txn_ctx: std::sync::OnceLock<Arc<dyn Any + Send + Sync>>,
 }
 
@@ -103,14 +100,14 @@ impl PersistClientCache {
         }
     }
 
-    /// WIP
+    /// TODO(jkosh44/danh) Remove this.
     pub fn txn_ctx<T: Default + Send + Sync + 'static>(&self) -> Arc<T> {
         Arc::clone(self.txn_ctx.get_or_init(|| {
             let txn_ctx: Arc<dyn Any + Send + Sync> = Arc::new(T::default());
             txn_ctx
         }))
         .downcast::<T>()
-        .expect("WIP")
+        .unwrap()
     }
 
     /// A test helper that returns a [PersistClientCache] disconnected from

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -19,7 +19,6 @@ use std::time::{Duration, Instant};
 
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
-use mz_dyncfg::ConfigSet;
 use mz_ore::instrument;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::task::{AbortOnDropHandle, JoinHandle};
@@ -127,11 +126,6 @@ impl PersistClientCache {
     /// Returns the [PersistConfig] being used by this cache.
     pub fn cfg(&self) -> &PersistConfig {
         &self.cfg
-    }
-
-    /// Returns persist's [ConfigSet].
-    pub fn dyncfgs(&self) -> &ConfigSet {
-        &self.cfg.configs
     }
 
     /// Returns persist `Metrics`.

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, Instant};
 
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
+use mz_dyncfg::ConfigSet;
 use mz_ore::instrument;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::task::{AbortOnDropHandle, JoinHandle};
@@ -62,7 +63,8 @@ pub struct PersistClientCache {
     pubsub_sender: Arc<dyn PubSubSender>,
     _pubsub_receiver_task: JoinHandle<()>,
 
-    // WIP hack plumb this around instead
+    // WIP hack plumb this around instead (What does this mean? Why not have this be `std::sync::OnceLock<Arc<TxnRead>>`?)
+    // This is the `TxnRead` for the `clusterd` process.
     txn_ctx: std::sync::OnceLock<Arc<dyn Any + Send + Sync>>,
 }
 
@@ -125,6 +127,11 @@ impl PersistClientCache {
     /// Returns the [PersistConfig] being used by this cache.
     pub fn cfg(&self) -> &PersistConfig {
         &self.cfg
+    }
+
+    /// Returns persist's [ConfigSet].
+    pub fn dyncfgs(&self) -> &ConfigSet {
+        &self.cfg.configs
     }
 
     /// Returns persist `Metrics`.

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -334,6 +334,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::cfg::USE_CRITICAL_SINCE_CATALOG)
         .add(&crate::cfg::USE_CRITICAL_SINCE_SOURCE)
         .add(&crate::cfg::USE_CRITICAL_SINCE_SNAPSHOT)
+        .add(&crate::cfg::USE_GLOBAL_TXN_CACHE_SOURCE)
         .add(&crate::fetch::FETCH_SEMAPHORE_COST_ADJUSTMENT)
         .add(&crate::fetch::FETCH_SEMAPHORE_PERMIT_ADJUSTMENT)
         .add(&crate::internal::cache::BLOB_CACHE_MEM_LIMIT_BYTES)
@@ -445,6 +446,13 @@ pub const USE_CRITICAL_SINCE_SNAPSHOT: Config<bool> = Config::new(
     "persist_use_critical_since_snapshot",
     false,
     "Use the critical since (instead of the overall since) when taking snapshots in the controller or in fast-path peeks.",
+);
+
+/// Migrate the persist source to use a process global txn cache.
+pub const USE_GLOBAL_TXN_CACHE_SOURCE: Config<bool> = Config::new(
+    "use_global_txn_cache_source",
+    true,
+    "Use the process global txn cache (instead of an operator local one) in the Persist source.",
 );
 
 impl PostgresClientKnobs for PersistConfig {

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -164,7 +164,7 @@
 //!     .apply(&mut txns).await;
 //!
 //! // Read data shard(s) at some `read_ts`.
-//! let mut subscribe = DataSubscribe::new("example", client, txns_id, d1, 4, Antichain::new());
+//! let mut subscribe = DataSubscribe::new("example", client, txns_id, d1, 4, Antichain::new(), true);
 //! while subscribe.progress() <= 4 {
 //!     subscribe.step();
 //! #   tokio::task::yield_now().await;
@@ -753,6 +753,7 @@ pub mod tests {
                 data_id,
                 as_of,
                 Antichain::new(),
+                true,
             );
             data_subscribe.step_past(until - 1).await;
             self.assert_eq(data_id, as_of, until, data_subscribe.output().clone());

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -202,9 +202,7 @@ where
             )
             .await
             .expect("schema shouldn't change");
-        let (Some(mut subscribe), fut) = subscribe.unblock_subscribe(data_write) else {
-            return;
-        };
+        let (mut subscribe, fut) = subscribe.unblock_subscribe(data_write);
         fut.await;
 
         debug!("{} emitting {:?}", name, subscribe.remap);

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -525,7 +525,7 @@ where
     None
 }
 
-/// The process global [`TxnRead`] that any operator can communicate with.
+/// The process global [`TxnsRead`] that any operator can communicate with.
 #[derive(Default, Debug, Clone)]
 pub struct TxnsContext<T: Clone> {
     read: Arc<tokio::sync::OnceCell<TxnsRead<T>>>,

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -365,11 +365,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> TxnsCacheState
     ///
     /// Callers must first wait for [`TxnsCache::update_gt`] with the same or
     /// later timestamp to return. Panics otherwise.
-    pub(crate) fn data_subscribe<K, V, D>(
-        &self,
-        data_id: ShardId,
-        as_of: T,
-    ) -> DataSubscribeBlocked<T> {
+    pub(crate) fn data_subscribe(&self, data_id: ShardId, as_of: T) -> DataSubscribeBlocked<T> {
         self.assert_only_data_id(&data_id);
         assert!(self.progress_exclusive > as_of);
         let snapshot = self.data_snapshot(data_id, as_of);

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -1170,6 +1170,7 @@ mod tests {
                 data_id,
                 as_of,
                 Antichain::new(),
+                true,
             )
         }
     }

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -370,8 +370,8 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> TxnsCacheState
         assert!(self.progress_exclusive > as_of);
         let snapshot = self.data_snapshot(data_id, as_of);
         let remap = DataRemapEntry {
-            physical_upper: snapshot.empty_to.step_forward(),
-            logical_upper: snapshot.empty_to.step_forward(),
+            physical_upper: snapshot.empty_to.clone(),
+            logical_upper: snapshot.empty_to.clone(),
         };
         DataSubscribe {
             data_id,

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -17,8 +17,7 @@ use std::sync::Arc;
 
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
-use futures::future::BoxFuture;
-use futures::{FutureExt, Stream};
+use futures::Stream;
 use mz_ore::instrument;
 use mz_ore::task::AbortOnDropHandle;
 use mz_ore::vec::VecExt;

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -297,7 +297,8 @@ pub struct DataRemapEntry<T> {
 pub(crate) struct DataSubscribe<T> {
     /// The id of the data shard.
     pub(crate) data_id: ShardId,
-    /// WIP
+    /// The initial snapshot, used to unblock the reading of the initial
+    /// snapshot.
     pub(crate) snapshot: Option<DataSnapshot<T>>,
     /// The physical and logical upper of `data_id`.
     pub(crate) remap: DataRemapEntry<T>,

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -347,7 +347,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> DataSubscribeB
 
 /// A shared [TxnsCache] running in a task and communicated with over a channel.
 #[derive(Debug, Clone)]
-pub struct TxnsRead<T> {
+pub struct TxnsRead<T: Clone> {
     txns_id: ShardId,
     tx: mpsc::UnboundedSender<TxnsReadCmd<T>>,
     _read_task: Arc<AbortOnDropHandle<()>>,
@@ -371,6 +371,7 @@ impl<T: Timestamp + Lattice + Codec64> TxnsRead<T> {
             rx,
             pending_waits_by_ts: BTreeSet::new(),
             pending_waits_by_id: BTreeMap::new(),
+            caps_by_ts: BTreeSet::new(),
         };
 
         let read_task =
@@ -397,6 +398,22 @@ impl<T: Timestamp + Lattice + Codec64> TxnsRead<T> {
     pub async fn data_snapshot(&self, data_id: ShardId, as_of: T) -> DataSnapshot<T> {
         self.send(|tx| TxnsReadCmd::DataSnapshot { data_id, as_of, tx })
             .await
+    }
+
+    /// See [crate::txn_cache::TxnsCacheState::data_snapshot] and
+    /// [crate::txn_cache::TxnsCacheState::data_listen_next].
+    pub async fn data_subscribe(
+        &self,
+        data_id: ShardId,
+        as_of: T,
+    ) -> (DataSnapshot<T>, TxnsReadCapability<T>) {
+        self.send(|tx| TxnsReadCmd::DataSubscribe {
+            txns_read_tx: self.tx.clone(),
+            data_id,
+            as_of,
+            tx,
+        })
+        .await
     }
 
     /// See [TxnsCache::update_ge].
@@ -445,14 +462,54 @@ impl<T: Timestamp + Lattice + Codec64> TxnsRead<T> {
     }
 }
 
+/// WIP
+#[derive(Debug)]
+pub struct TxnsReadCapability<T: Clone> {
+    cap_id: Uuid,
+    /// A capability to query a TxnsRead at times >= this one.
+    cap_ts: T,
+    txns_read_tx: mpsc::UnboundedSender<TxnsReadCmd<T>>,
+}
+
+impl<T: Timestamp + Lattice + Codec64> TxnsReadCapability<T> {
+    /// See [crate::txn_cache::TxnsCacheState::data_listen_next].
+    pub async fn data_listen_next(
+        self,
+        data_id: ShardId,
+        ts: T,
+    ) -> (DataListenNext<T>, TxnsReadCapability<T>) {
+        assert!(ts >= self.cap_ts);
+        let (tx, rx) = oneshot::channel();
+        self.txns_read_tx
+            .clone()
+            .send(TxnsReadCmd::DataListenNext {
+                cap: self,
+                data_id,
+                ts,
+                tx,
+            })
+            .expect("task unexpectedly shut down");
+        rx.await.expect("task unexpectedly shut down")
+    }
+}
+
+impl<T: Clone> Drop for TxnsReadCapability<T> {
+    fn drop(&mut self) {
+        let _ = self.txns_read_tx.send(TxnsReadCmd::DropCap {
+            id: self.cap_id,
+            ts: self.cap_ts.clone(),
+        });
+    }
+}
+
 /// Cancels an in-flight wait command when dropped, unless the given `tx` is
 /// yanked before that.
-struct CancelWaitOnDrop<T> {
+struct CancelWaitOnDrop<T: Clone> {
     id: Uuid,
     tx: Option<mpsc::UnboundedSender<TxnsReadCmd<T>>>,
 }
 
-impl<T> CancelWaitOnDrop<T> {
+impl<T: Clone> CancelWaitOnDrop<T> {
     /// Marks the wait command as complete. This guard will no longer send a
     /// cancel command when dropped.
     pub fn complete(&mut self) {
@@ -460,7 +517,7 @@ impl<T> CancelWaitOnDrop<T> {
     }
 }
 
-impl<T> Drop for CancelWaitOnDrop<T> {
+impl<T: Clone> Drop for CancelWaitOnDrop<T> {
     fn drop(&mut self) {
         let tx = match self.tx.take() {
             Some(tx) => tx,
@@ -477,7 +534,7 @@ impl<T> Drop for CancelWaitOnDrop<T> {
 }
 
 #[derive(Debug)]
-enum TxnsReadCmd<T> {
+enum TxnsReadCmd<T: Clone> {
     Updates {
         entries: Vec<(TxnsEntry, T, i64)>,
         frontier: T,
@@ -487,6 +544,18 @@ enum TxnsReadCmd<T> {
         as_of: T,
         tx: oneshot::Sender<DataSnapshot<T>>,
     },
+    DataSubscribe {
+        txns_read_tx: mpsc::UnboundedSender<TxnsReadCmd<T>>,
+        data_id: ShardId,
+        as_of: T,
+        tx: oneshot::Sender<(DataSnapshot<T>, TxnsReadCapability<T>)>,
+    },
+    DataListenNext {
+        cap: TxnsReadCapability<T>,
+        data_id: ShardId,
+        ts: T,
+        tx: oneshot::Sender<(DataListenNext<T>, TxnsReadCapability<T>)>,
+    },
     Wait {
         id: Uuid,
         ts: WaitTs<T>,
@@ -494,6 +563,10 @@ enum TxnsReadCmd<T> {
     },
     CancelWait {
         id: Uuid,
+    },
+    DropCap {
+        id: Uuid,
+        ts: T,
     },
 }
 
@@ -569,6 +642,7 @@ struct TxnsReadTask<T: Timestamp + Lattice + Codec64> {
     cache: TxnsCacheState<T>,
     pending_waits_by_ts: BTreeSet<(WaitTs<T>, Uuid)>,
     pending_waits_by_id: BTreeMap<Uuid, PendingWait<T>>,
+    caps_by_ts: BTreeSet<(T, Uuid)>,
 }
 
 /// A pending "wait" notification that we will complete once the frontier
@@ -664,6 +738,40 @@ where
                     let res = self.cache.data_snapshot(data_id, as_of.clone());
                     let _ = tx.send(res);
                 }
+                TxnsReadCmd::DataSubscribe {
+                    txns_read_tx,
+                    data_id,
+                    as_of,
+                    tx,
+                } => {
+                    let snap = self.cache.data_snapshot(data_id, as_of.clone());
+                    let cap_ts = snap.empty_to.clone();
+                    let cap_id = Uuid::new_v4();
+                    self.caps_by_ts.insert((cap_ts.clone(), cap_id));
+                    let cap = TxnsReadCapability {
+                        cap_ts,
+                        cap_id,
+                        txns_read_tx,
+                    };
+                    let _ = tx.send((snap, cap));
+                }
+                TxnsReadCmd::DataListenNext {
+                    mut cap,
+                    data_id,
+                    ts,
+                    tx,
+                } => {
+                    assert!(self.caps_by_ts.remove(&(cap.cap_ts.clone(), cap.cap_id)));
+                    let res = self.cache.data_listen_next(&data_id, ts);
+                    match &res {
+                        DataListenNext::ReadDataTo(x) | DataListenNext::EmitLogicalProgress(x) => {
+                            cap.cap_ts.clone_from(x)
+                        }
+                        DataListenNext::CompactedTo(_) | DataListenNext::WaitForTxnsProgress => {}
+                    };
+                    assert!(self.caps_by_ts.insert((cap.cap_ts.clone(), cap.cap_id)));
+                    let _ = tx.send((res, cap));
+                }
                 TxnsReadCmd::Wait { id, ts, tx } => {
                     let mut pending_wait = PendingWait { ts, tx: Some(tx) };
                     let completed = pending_wait.maybe_complete(&self.cache.progress_exclusive);
@@ -677,6 +785,9 @@ where
                     let pending_wait = self.pending_waits_by_id.remove(&id).expect("missing wait");
                     let wait_ts = pending_wait.ts.clone();
                     self.pending_waits_by_ts.remove(&(wait_ts, id));
+                }
+                TxnsReadCmd::DropCap { id, ts } => {
+                    assert!(self.caps_by_ts.remove(&(ts, id)));
                 }
             }
         }

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -17,9 +17,11 @@ use std::sync::Arc;
 
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
-use futures::Stream;
+use futures::future::BoxFuture;
+use futures::{FutureExt, Stream};
 use mz_ore::instrument;
 use mz_ore::task::AbortOnDropHandle;
+use mz_ore::vec::VecExt;
 use mz_persist_client::cfg::USE_CRITICAL_SINCE_TXN;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::read::{Cursor, LazyPartStats, ListenEvent, ReadHandle, Since, Subscribe};
@@ -61,16 +63,8 @@ pub struct DataSnapshot<T> {
 impl<T: Timestamp + Lattice + TotalOrder + Codec64> DataSnapshot<T> {
     /// Unblocks reading a snapshot at `self.as_of` by waiting for the latest
     /// write before that time and then running an empty CaA if necessary.
-    ///
-    /// Returns a frontier that is greater than the as_of and less_equal the
-    /// physical upper of the data shard. This is suitable for use as an initial
-    /// input to `TxnsCache::data_listen_next` (after reading up to it, of
-    /// course).
     #[instrument(level = "debug", fields(shard = %self.data_id, ts = ?self.as_of, empty_to = ?self.empty_to))]
-    pub(crate) async fn unblock_read<K, V, D>(
-        &self,
-        mut data_write: WriteHandle<K, V, T, D>,
-    ) -> Antichain<T>
+    pub(crate) async fn unblock_read<K, V, D>(&self, mut data_write: WriteHandle<K, V, T, D>)
     where
         K: Debug + Codec,
         V: Debug + Codec,
@@ -107,7 +101,7 @@ impl<T: Timestamp + Lattice + TotalOrder + Codec64> DataSnapshot<T> {
                 "CaA data snapshot {:.9} shard finalized",
                 self.data_id.to_string(),
             );
-            return Antichain::new();
+            return;
         };
 
         // TODO(jkosh44) We should not be writing to unregistered shards, but
@@ -143,7 +137,6 @@ impl<T: Timestamp + Lattice + TotalOrder + Codec64> DataSnapshot<T> {
                 }
             }
         }
-        Antichain::from_elem(self.empty_to.clone())
     }
 
     /// See [ReadHandle::snapshot_and_fetch].
@@ -300,13 +293,14 @@ pub struct DataRemapEntry<T> {
     pub logical_upper: T,
 }
 
-/// A token exchangeable for a [`DataSubscribe`].
+/// A token exchangeable for a subscription to physical and logical uppers
+/// of a data shard.
 ///
 /// Must be unblocked via [`DataSubscribeBlocked::unblock_subscribe`].
 #[derive(Debug)]
 pub(crate) struct DataSubscribeBlocked<T>(pub(crate) DataSnapshot<T>);
 
-/// A token that keeps track of a [`DataRemapEntry`] for shard `data_id`.
+/// Keeps track of a [`DataRemapEntry`] for shard `data_id`.
 #[derive(Debug)]
 pub(crate) struct DataSubscribe<T> {
     /// The id of the data shard.
@@ -315,39 +309,84 @@ pub(crate) struct DataSubscribe<T> {
     pub(crate) remap: DataRemapEntry<T>,
 }
 
+/// An active subscription of [`DataRemapEntry`]s for a data shard.
+#[derive(Debug)]
+pub struct DataSubscription<T: Timestamp + Lattice + Codec64> {
+    /// Metadata and current [`DataRemapEntry`] for the data shard.
+    subscribe: DataSubscribe<T>,
+    /// Channel to send [`DataRemapEntry`]s.
+    tx: mpsc::UnboundedSender<DataRemapEntry<T>>,
+}
+
 impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64> DataSubscribeBlocked<T> {
     /// Unblocks the snapshot portion of this subscribe. See
     /// [`DataSnapshot::unblock_read`].
     ///
-    /// Returns `None` if the upper of the data shard is the empty antichain.
+    /// Returns a [`DataSubscribe`] and a future that must be awaited to
+    /// unblock that snapshot. The returned subscribe is `None` if the upper
+    /// of the data shard is the empty antichain.
+    #[must_use]
     #[instrument(level = "debug", fields(shard = %self.0.data_id, ts = ?self.0.as_of, empty_to = ?self.0.empty_to))]
-    pub(crate) async fn unblock_subscribe<K, V, D>(
+    pub(crate) fn unblock_subscribe<'a, K, V, D>(
         self,
         data_write: WriteHandle<K, V, T, D>,
-    ) -> Option<DataSubscribe<T>>
+    ) -> (Option<DataSubscribe<T>>, BoxFuture<'a, ()>)
     where
-        K: Debug + Codec,
-        V: Debug + Codec,
+        K: Debug + Codec + Send + Sync,
+        V: Debug + Codec + Send + Sync,
         D: Semigroup + Codec64 + Send + Sync,
     {
-        let snapshot = self.0;
-        let empty_to = snapshot.unblock_read(data_write).await;
-        let Some(empty_to) = empty_to.into_option() else {
-            return None;
-        };
-        Some(DataSubscribe {
-            data_id: snapshot.data_id,
+        debug!(
+            "unblock_subscribe latest_write={:?} as_of={:?} for {:.9}",
+            self.0.latest_write,
+            self.0.as_of,
+            self.0.data_id.to_string()
+        );
+
+        if data_write.shared_upper().is_empty() {
+            return (None, async {}.boxed());
+        }
+
+        let subscribe = DataSubscribe {
+            data_id: self.0.data_id.clone(),
             remap: DataRemapEntry {
-                physical_upper: empty_to.clone(),
-                logical_upper: empty_to,
+                physical_upper: self.0.empty_to.clone(),
+                logical_upper: self.0.empty_to.clone(),
             },
-        })
+        };
+        let fut = async move {
+            self.0.unblock_read(data_write).await;
+        }
+        .boxed();
+        (Some(subscribe), fut)
+    }
+}
+
+pub(crate) trait UnblockSubscribe<T>: Debug + Send {
+    fn unblock_subscribe<'a>(
+        self: Box<Self>,
+        subscribe: DataSubscribeBlocked<T>,
+    ) -> (Option<DataSubscribe<T>>, BoxFuture<'a, ()>);
+}
+
+impl<K, V, T, D> UnblockSubscribe<T> for WriteHandle<K, V, T, D>
+where
+    K: Debug + Codec + Send + Sync,
+    V: Debug + Codec + Send + Sync,
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
+{
+    fn unblock_subscribe<'a>(
+        self: Box<Self>,
+        subscribe: DataSubscribeBlocked<T>,
+    ) -> (Option<DataSubscribe<T>>, BoxFuture<'a, ()>) {
+        subscribe.unblock_subscribe(*self)
     }
 }
 
 /// A shared [TxnsCache] running in a task and communicated with over a channel.
 #[derive(Debug, Clone)]
-pub struct TxnsRead<T: Clone> {
+pub struct TxnsRead<T> {
     txns_id: ShardId,
     tx: mpsc::UnboundedSender<TxnsReadCmd<T>>,
     _read_task: Arc<AbortOnDropHandle<()>>,
@@ -367,11 +406,11 @@ impl<T: Timestamp + Lattice + Codec64> TxnsRead<T> {
             TxnsSubscribeTask::<T, C>::open(&client, txns_id, None, tx.clone()).await;
 
         let mut task = TxnsReadTask {
-            cache,
             rx,
+            cache,
             pending_waits_by_ts: BTreeSet::new(),
             pending_waits_by_id: BTreeMap::new(),
-            caps_by_ts: BTreeSet::new(),
+            data_subscriptions: Vec::new(),
         };
 
         let read_task =
@@ -400,17 +439,19 @@ impl<T: Timestamp + Lattice + Codec64> TxnsRead<T> {
             .await
     }
 
-    /// See [crate::txn_cache::TxnsCacheState::data_snapshot] and
-    /// [crate::txn_cache::TxnsCacheState::data_listen_next].
-    pub async fn data_subscribe(
+    /// Initiate a subscription to `data_id`.
+    ///
+    /// Returns a channel that [`DataRemapEntry`]s are sent over.
+    pub(crate) async fn data_subscribe(
         &self,
         data_id: ShardId,
         as_of: T,
-    ) -> (DataSnapshot<T>, TxnsReadCapability<T>) {
+        unblock: Box<dyn UnblockSubscribe<T>>,
+    ) -> mpsc::UnboundedReceiver<DataRemapEntry<T>> {
         self.send(|tx| TxnsReadCmd::DataSubscribe {
-            txns_read_tx: self.tx.clone(),
             data_id,
             as_of,
+            unblock,
             tx,
         })
         .await
@@ -462,54 +503,14 @@ impl<T: Timestamp + Lattice + Codec64> TxnsRead<T> {
     }
 }
 
-/// WIP
-#[derive(Debug)]
-pub struct TxnsReadCapability<T: Clone> {
-    cap_id: Uuid,
-    /// A capability to query a TxnsRead at times >= this one.
-    cap_ts: T,
-    txns_read_tx: mpsc::UnboundedSender<TxnsReadCmd<T>>,
-}
-
-impl<T: Timestamp + Lattice + Codec64> TxnsReadCapability<T> {
-    /// See [crate::txn_cache::TxnsCacheState::data_listen_next].
-    pub async fn data_listen_next(
-        self,
-        data_id: ShardId,
-        ts: T,
-    ) -> (DataListenNext<T>, TxnsReadCapability<T>) {
-        assert!(ts >= self.cap_ts);
-        let (tx, rx) = oneshot::channel();
-        self.txns_read_tx
-            .clone()
-            .send(TxnsReadCmd::DataListenNext {
-                cap: self,
-                data_id,
-                ts,
-                tx,
-            })
-            .expect("task unexpectedly shut down");
-        rx.await.expect("task unexpectedly shut down")
-    }
-}
-
-impl<T: Clone> Drop for TxnsReadCapability<T> {
-    fn drop(&mut self) {
-        let _ = self.txns_read_tx.send(TxnsReadCmd::DropCap {
-            id: self.cap_id,
-            ts: self.cap_ts.clone(),
-        });
-    }
-}
-
 /// Cancels an in-flight wait command when dropped, unless the given `tx` is
 /// yanked before that.
-struct CancelWaitOnDrop<T: Clone> {
+struct CancelWaitOnDrop<T> {
     id: Uuid,
     tx: Option<mpsc::UnboundedSender<TxnsReadCmd<T>>>,
 }
 
-impl<T: Clone> CancelWaitOnDrop<T> {
+impl<T> CancelWaitOnDrop<T> {
     /// Marks the wait command as complete. This guard will no longer send a
     /// cancel command when dropped.
     pub fn complete(&mut self) {
@@ -517,7 +518,7 @@ impl<T: Clone> CancelWaitOnDrop<T> {
     }
 }
 
-impl<T: Clone> Drop for CancelWaitOnDrop<T> {
+impl<T> Drop for CancelWaitOnDrop<T> {
     fn drop(&mut self) {
         let tx = match self.tx.take() {
             Some(tx) => tx,
@@ -534,7 +535,7 @@ impl<T: Clone> Drop for CancelWaitOnDrop<T> {
 }
 
 #[derive(Debug)]
-enum TxnsReadCmd<T: Clone> {
+enum TxnsReadCmd<T> {
     Updates {
         entries: Vec<(TxnsEntry, T, i64)>,
         frontier: T,
@@ -545,16 +546,10 @@ enum TxnsReadCmd<T: Clone> {
         tx: oneshot::Sender<DataSnapshot<T>>,
     },
     DataSubscribe {
-        txns_read_tx: mpsc::UnboundedSender<TxnsReadCmd<T>>,
         data_id: ShardId,
         as_of: T,
-        tx: oneshot::Sender<(DataSnapshot<T>, TxnsReadCapability<T>)>,
-    },
-    DataListenNext {
-        cap: TxnsReadCapability<T>,
-        data_id: ShardId,
-        ts: T,
-        tx: oneshot::Sender<(DataListenNext<T>, TxnsReadCapability<T>)>,
+        unblock: Box<dyn UnblockSubscribe<T>>,
+        tx: oneshot::Sender<mpsc::UnboundedReceiver<DataRemapEntry<T>>>,
     },
     Wait {
         id: Uuid,
@@ -563,10 +558,6 @@ enum TxnsReadCmd<T: Clone> {
     },
     CancelWait {
         id: Uuid,
-    },
-    DropCap {
-        id: Uuid,
-        ts: T,
     },
 }
 
@@ -642,7 +633,7 @@ struct TxnsReadTask<T: Timestamp + Lattice + Codec64> {
     cache: TxnsCacheState<T>,
     pending_waits_by_ts: BTreeSet<(WaitTs<T>, Uuid)>,
     pending_waits_by_id: BTreeMap<Uuid, PendingWait<T>>,
-    caps_by_ts: BTreeSet<(T, Uuid)>,
+    data_subscriptions: Vec<DataSubscription<T>>,
 }
 
 /// A pending "wait" notification that we will complete once the frontier
@@ -695,14 +686,13 @@ where
                         entries
                     );
 
-                    let prev_frontier = self.cache.progress_exclusive.clone();
-                    self.cache.push_entries(entries, frontier.clone());
-                    if prev_frontier < self.cache.progress_exclusive {
-                        debug!(
-                            "compacting TxnsRead cache to {:?} progress={:?}",
-                            prev_frontier, self.cache.progress_exclusive
-                        );
+                    self.cache.push_entries(entries.clone(), frontier.clone());
+
+                    for subscription in &mut self.data_subscriptions {
+                        Self::update_subscription(subscription, &self.cache);
                     }
+                    self.data_subscriptions
+                        .drain_filter_swapping(|subscription| !subscription.tx.is_closed());
 
                     // The frontier has advanced, so respond to waits and retain
                     // those that still have to wait.
@@ -739,38 +729,32 @@ where
                     let _ = tx.send(res);
                 }
                 TxnsReadCmd::DataSubscribe {
-                    txns_read_tx,
                     data_id,
                     as_of,
+                    unblock,
                     tx,
                 } => {
-                    let snap = self.cache.data_snapshot(data_id, as_of.clone());
-                    let cap_ts = snap.empty_to.clone();
-                    let cap_id = Uuid::new_v4();
-                    self.caps_by_ts.insert((cap_ts.clone(), cap_id));
-                    let cap = TxnsReadCapability {
-                        cap_ts,
-                        cap_id,
-                        txns_read_tx,
+                    let subscribe = self.cache.data_subscribe(data_id, as_of.clone());
+                    let (sub_tx, sub_rx) = mpsc::unbounded_channel();
+                    let (Some(subscribe), fut) = unblock.unblock_subscribe(subscribe) else {
+                        // Data shard upper is the empty antichain, so we can
+                        // return earler and drop the sender.
+                        let _ = tx.send(sub_rx);
+                        return;
                     };
-                    let _ = tx.send((snap, cap));
-                }
-                TxnsReadCmd::DataListenNext {
-                    mut cap,
-                    data_id,
-                    ts,
-                    tx,
-                } => {
-                    assert!(self.caps_by_ts.remove(&(cap.cap_ts.clone(), cap.cap_id)));
-                    let res = self.cache.data_listen_next(&data_id, ts);
-                    match &res {
-                        DataListenNext::ReadDataTo(x) | DataListenNext::EmitLogicalProgress(x) => {
-                            cap.cap_ts.clone_from(x)
-                        }
-                        DataListenNext::CompactedTo(_) | DataListenNext::WaitForTxnsProgress => {}
+                    mz_ore::task::spawn(|| "persist-txn::unblock_subscribe", fut);
+                    // Send the initial remap entry.
+                    sub_tx
+                        .send(subscribe.remap.clone())
+                        .expect("receiver still in scope");
+                    let mut subscription = DataSubscription {
+                        subscribe,
+                        tx: sub_tx,
                     };
-                    assert!(self.caps_by_ts.insert((cap.cap_ts.clone(), cap.cap_id)));
-                    let _ = tx.send((res, cap));
+                    // Fill the subscriber in on the updates from as_of to the current progress.
+                    Self::update_subscription(&mut subscription, &self.cache);
+                    self.data_subscriptions.push(subscription);
+                    let _ = tx.send(sub_rx);
                 }
                 TxnsReadCmd::Wait { id, ts, tx } => {
                     let mut pending_wait = PendingWait { ts, tx: Some(tx) };
@@ -782,16 +766,50 @@ where
                     }
                 }
                 TxnsReadCmd::CancelWait { id } => {
-                    let pending_wait = self.pending_waits_by_id.remove(&id).expect("missing wait");
-                    let wait_ts = pending_wait.ts.clone();
-                    self.pending_waits_by_ts.remove(&(wait_ts, id));
-                }
-                TxnsReadCmd::DropCap { id, ts } => {
-                    assert!(self.caps_by_ts.remove(&(ts, id)));
+                    // A waiter may have been dropped after a wait completed,
+                    // but before hearing about the completion. In that case
+                    // they will have tried to cancel an already cleaned up
+                    // wait.
+                    if let Some(pending_wait) = self.pending_waits_by_id.remove(&id) {
+                        self.pending_waits_by_ts.remove(&(pending_wait.ts, id));
+                    }
                 }
             }
         }
         warn!("TxnsReadTask shutting down");
+    }
+
+    fn update_subscription(subscription: &mut DataSubscription<T>, cache: &TxnsCacheState<T>) {
+        loop {
+            match cache.data_listen_next(
+                &subscription.subscribe.data_id,
+                &subscription.subscribe.remap.logical_upper,
+            ) {
+                // The data shard got a write!
+                DataListenNext::ReadDataTo(new_upper) => {
+                    // A write means both the physical and logical upper advance.
+                    subscription.subscribe.remap.physical_upper = new_upper.clone();
+                    subscription.subscribe.remap.logical_upper = new_upper.clone();
+                }
+                // We know there are no writes in `[logical_upper,
+                // new_progress)`, so advance our output frontier.
+                DataListenNext::EmitLogicalProgress(new_progress) => {
+                    assert!(subscription.subscribe.remap.physical_upper < new_progress);
+                    assert!(subscription.subscribe.remap.logical_upper < new_progress);
+
+                    subscription.subscribe.remap.logical_upper = new_progress.clone();
+                }
+                // We've caught up to the txns upper, and we have to wait for
+                // more before updates before sending more pairs.
+                DataListenNext::WaitForTxnsProgress => break,
+            };
+            // Not an error if the receiver hung up, they just need be cleaned up at some point.
+            let _ = subscription.tx.send(subscription.subscribe.remap.clone());
+        }
+        assert_eq!(
+            cache.progress_exclusive, subscription.subscribe.remap.logical_upper,
+            "we should update the subscription up to the current progress_exclusive"
+        );
     }
 }
 

--- a/src/persist-txn/src/txns.rs
+++ b/src/persist-txn/src/txns.rs
@@ -1179,7 +1179,7 @@ mod tests {
             );
             let data_id =
                 self.data_ids[usize::cast_from(self.rng.next_u64()) % self.data_ids.len()];
-            match self.rng.next_u64() % 5 {
+            match self.rng.next_u64() % 6 {
                 0 => self.write(data_id).await,
                 // The register and forget impls intentionally don't switch on
                 // whether it's already registered to stress idempotence.
@@ -1189,7 +1189,8 @@ mod tests {
                     debug!("stress update {:.9} to {}", data_id.to_string(), self.ts);
                     let _ = self.txns.txns_cache.update_ge(&self.ts).await;
                 }
-                4 => self.start_read(data_id),
+                4 => self.start_read(data_id, true),
+                5 => self.start_read(data_id, false),
                 _ => unreachable!(""),
             }
             debug!("stress {} step {} DONE ts={}", self.idx, self.step, self.ts);
@@ -1305,7 +1306,7 @@ mod tests {
             .await
         }
 
-        fn start_read(&mut self, data_id: ShardId) {
+        fn start_read(&mut self, data_id: ShardId, use_global_txn_cache: bool) {
             debug!(
                 "stress start_read {:.9} at {}",
                 data_id.to_string(),
@@ -1326,6 +1327,7 @@ mod tests {
                         data_id,
                         as_of,
                         Antichain::new(),
+                        use_global_txn_cache,
                     );
                     let data_id = format!("{:.9}", data_id.to_string());
                     let _guard = info_span!("read_worker", %data_id, as_of).entered();

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -96,7 +96,7 @@ mod rehydration;
 mod statistics;
 
 #[derive(Debug)]
-enum PersistTxns<T> {
+enum PersistTxns<T: Clone> {
     EnabledEager {
         txns_id: ShardId,
         txns_client: PersistClient,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -96,7 +96,7 @@ mod rehydration;
 mod statistics;
 
 #[derive(Debug)]
-enum PersistTxns<T: Clone> {
+enum PersistTxns<T> {
     EnabledEager {
         txns_id: ShardId,
         txns_client: PersistClient,

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -29,7 +29,7 @@ use mz_persist_client::cfg::{PersistConfig, RetryParameters};
 use mz_persist_client::fetch::{FetchedBlob, FetchedPart};
 use mz_persist_client::fetch::{SerdeLeasedBatchPart, ShardSourcePart};
 use mz_persist_client::operators::shard_source::{shard_source, SnapshotMode};
-use mz_persist_txn::operator::txns_progress;
+use mz_persist_txn::operator::{txns_progress, TxnsContext};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::{Codec, Codec64};
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, RelationType, Row, RowArena, Timestamp};
@@ -219,10 +219,12 @@ where
     // system. This means the "logical" upper may be ahead of the "physical"
     // upper. Render a dataflow operator that passes through the input and
     // translates the progress frontiers as necessary.
+    let persist_txn_ctx = persist_clients.txn_ctx::<TxnsContext<G::Timestamp>>();
     let (stream, txns_tokens) = match metadata.txns_shard {
         Some(txns_shard) => txns_progress::<SourceData, (), Timestamp, i64, _, TxnsCodecRow, _, _>(
             stream,
             &source_id.to_string(),
+            (*persist_txn_ctx).clone(),
             move || {
                 let (c, l) = (
                     Arc::clone(&persist_clients),

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -225,6 +225,7 @@ where
             stream,
             &source_id.to_string(),
             (*persist_txn_ctx).clone(),
+            Arc::clone(&persist_clients).dyncfgs(),
             move || {
                 let (c, l) = (
                     Arc::clone(&persist_clients),

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -225,7 +225,7 @@ where
             stream,
             &source_id.to_string(),
             (*persist_txn_ctx).clone(),
-            Arc::clone(&persist_clients).dyncfgs(),
+            Arc::clone(&persist_clients).cfg(),
             move || {
                 let (c, l) = (
                     Arc::clone(&persist_clients),


### PR DESCRIPTION
Previously, each time the persist-txn operator was rendered, we'd crate
a (filtered) subscribe to the txns shard. This replaces it with a
process-singleton (unfiltered) subscribe.

There is a notable tradeoff here between N filtered vs 1 unfiltered
subscriptions. However, in staging envs when there was a bug that held
back the txns since, it caused a _very_ :nervous-laughter: and linearly
increasing amount of cpu, memory, and network use. Because of this, I
believe it's worth selecting the option that bounds the worst case over
the option that optimizes the case of a few tables.

We could later get the "optimizes the case of a few tables" back, if
necessary, with a decent amount of elbow grease: making TxnsRead more
sophisticated about quiescing as well as dynamically changing the set of
data_ids that it watches.

Touches #22173

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
