### PR TITLE
storage: refactor storage controller API for ALTER SOURCE, ALTER CONNECTION

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3279,7 +3279,7 @@ impl Coordinator {
         if !sink_connections.is_empty() {
             self.controller
                 .storage
-                .update_export_connection(sink_connections)
+                .alter_export_connections(sink_connections)
                 .await
                 .unwrap_or_terminate("altering exports after txn must succeed");
         }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 use anyhow::anyhow;
 use futures::future::BoxFuture;
 use itertools::Itertools;
-use maplit::{btreemap, btreeset};
+use maplit::btreeset;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_cloud_resources::VpcEndpointConfig;
 use mz_controller_types::{ClusterId, ReplicaId};
@@ -3522,11 +3522,9 @@ impl Coordinator {
                     _ => unreachable!("already verified of type ingestion"),
                 };
 
-                let descs = btreemap! {id => desc};
-
                 self.controller
                     .storage
-                    .check_alter_ingestion_source_desc(&descs)
+                    .check_alter_ingestion_source_desc(id, &desc)
                     .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?;
 
                 // Redefine source. This must be done before we create any new
@@ -3556,7 +3554,7 @@ impl Coordinator {
 
                 self.controller
                     .storage
-                    .alter_ingestion_source_desc(descs)
+                    .alter_ingestion_source_desc(id, desc)
                     .await
                     .unwrap_or_terminate("cannot fail to alter source desc");
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3234,8 +3234,8 @@ impl Coordinator {
         let mut connections = VecDeque::new();
         connections.push_front(entry.id());
 
-        let mut source_descs = BTreeMap::new();
-        let mut sinks = BTreeMap::new();
+        let mut source_connections = BTreeMap::new();
+        let mut sink_connections = BTreeMap::new();
 
         while let Some(id) = connections.pop_front() {
             for id in self.catalog.get_entry(&id).used_by() {
@@ -3251,11 +3251,11 @@ impl Coordinator {
                             _ => unreachable!("only ingestions reference connections"),
                         };
 
-                        source_descs.insert(*id, desc);
+                        source_connections.insert(*id, desc.connection);
                     }
                     CatalogItemType::Sink => {
                         let export = entry.sink().expect("known to be sink");
-                        sinks.insert(
+                        sink_connections.insert(
                             *id,
                             export
                                 .connection
@@ -3268,20 +3268,18 @@ impl Coordinator {
             }
         }
 
-        if !source_descs.is_empty() {
-            // TODO(#26767): provide an API to modify the connection without
-            // modifying the entire source desc, just like we offer for sinks.
+        if !source_connections.is_empty() {
             self.controller
                 .storage
-                .alter_ingestion_source_desc(source_descs)
+                .alter_ingestion_connections(source_connections)
                 .await
                 .unwrap_or_terminate("cannot fail to alter source desc");
         }
 
-        if !sinks.is_empty() {
+        if !sink_connections.is_empty() {
             self.controller
                 .storage
-                .update_export_connection(sinks)
+                .update_export_connection(sink_connections)
                 .await
                 .unwrap_or_terminate("altering exports after txn must succeed");
         }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -429,8 +429,8 @@ pub trait StorageController: Debug {
         exports: Vec<(GlobalId, ExportDescription<Self::Timestamp>)>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
-    /// For each identified export, update its `StorageSinkConnection`.
-    async fn update_export_connection(
+    /// For each identified export, alter its [`StorageSinkConnection`].
+    async fn alter_export_connections(
         &mut self,
         exports: BTreeMap<GlobalId, StorageSinkConnection>,
     ) -> Result<(), StorageError<Self::Timestamp>>;

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -33,12 +33,15 @@ use mz_persist_types::{Codec64, ShardId};
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
 use mz_sql_parser::ast::UnresolvedItemName;
 use mz_storage_types::configuration::StorageConfiguration;
+use mz_storage_types::connections::inline::InlinedConnection;
 use mz_storage_types::controller::{CollectionMetadata, StorageError};
 use mz_storage_types::instances::StorageInstanceId;
 use mz_storage_types::parameters::StorageParameters;
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sinks::{MetadataUnfilled, StorageSinkConnection, StorageSinkDesc};
-use mz_storage_types::sources::{IngestionDescription, SourceData, SourceDesc};
+use mz_storage_types::sources::{
+    GenericSourceConnection, IngestionDescription, SourceData, SourceDesc,
+};
 use serde::{Deserialize, Serialize};
 use timely::progress::Timestamp as TimelyTimestamp;
 use timely::progress::{Antichain, ChangeBatch, Timestamp};
@@ -400,6 +403,12 @@ pub trait StorageController: Debug {
     async fn alter_ingestion_source_desc(
         &mut self,
         collections: BTreeMap<GlobalId, SourceDesc>,
+    ) -> Result<(), StorageError<Self::Timestamp>>;
+
+    /// Alters each identified collection to use the correlated [`GenericSourceConnection`].
+    async fn alter_ingestion_connections(
+        &mut self,
+        source_connections: BTreeMap<GlobalId, GenericSourceConnection<InlinedConnection>>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
     /// Acquire an immutable reference to the export state, should it exist.

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -384,25 +384,23 @@ pub trait StorageController: Debug {
         collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
-    /// Check that the ingestion associated with each `id` can use the
-    /// correlated [`SourceDesc`].
+    /// Check that the ingestion associated with `id` can use the provided
+    /// [`SourceDesc`].
     ///
     /// Note that this check is optimistic and its return of `Ok(())` does not
     /// guarantee that subsequent calls to `alter_ingestion_source_desc` are
     /// guaranteed to succeed.
-    ///
-    /// # Panics
-    /// - If `id` is not correlated to a collection with an
-    ///   [`IngestionDescription`].
     fn check_alter_ingestion_source_desc(
         &mut self,
-        collections: &BTreeMap<GlobalId, SourceDesc>,
+        ingestion_id: GlobalId,
+        source_desc: &SourceDesc,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
-    /// Alters each identified collection to use the correlated [`SourceDesc`].
+    /// Alters the identified collection to use the provided [`SourceDesc`].
     async fn alter_ingestion_source_desc(
         &mut self,
-        collections: BTreeMap<GlobalId, SourceDesc>,
+        ingestion_id: GlobalId,
+        source_desc: SourceDesc,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
     /// Alters each identified collection to use the correlated [`GenericSourceConnection`].

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1295,7 +1295,7 @@ where
     }
 
     /// Create the sinks described by the `ExportDescription`.
-    async fn update_export_connection(
+    async fn alter_export_connections(
         &mut self,
         exports: BTreeMap<GlobalId, StorageSinkConnection>,
     ) -> Result<(), StorageError<Self::Timestamp>> {


### PR DESCRIPTION
There were some unnecessary and noisy changes to the storage controller I wanted to make during the fix for subsource dependency inversion. Now that it's landed, we can tidy up the interface a bit.

### Motivation

- This PR adds a known-desirable feature. Closes #26767
- This PR refactors existing code.
  - The `alter_ingestion_source_desc` methods took collections but were only ever called with single elements.
  - The API to alter a sink's connection used a different verb than I think it should.

### Tips for reviewer

- Review commit by commit
- Reviewing without whitespace is probably easier

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
