### PR TITLE
adapter: subsource retain history propagation

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -379,11 +379,8 @@ impl Catalog {
     }
 
     /// For the Sources ids in `ids`, return the read policies for all `ids` and additional ids that
-    /// propagate from them. Specifically, `ids` contains a source, all of its subsources will be
-    /// added to the result.
-    ///
-    /// # Panics
-    /// Panics if any of `ids` is not a `Source` item type.
+    /// propagate from them. Specifically, `ids` contains a source, it and all of its subsources
+    /// will be added to the result.
     pub fn source_read_policies(
         &self,
         id: GlobalId,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -66,6 +66,7 @@ use mz_storage_client::controller::StorageController;
 use mz_storage_types::connections::inline::{ConnectionResolver, InlinedConnection};
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::controller::PersistTxnTablesImpl;
+use mz_storage_types::read_policy::ReadPolicy;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::notice::OptimizerNotice;
 use smallvec::SmallVec;
@@ -375,6 +376,26 @@ impl Catalog {
         }
 
         return dropped_notices;
+    }
+
+    /// For the Sources ids in `ids`, return the read policies for all `ids` and additional ids that
+    /// propagate from them. Specifically, `ids` contains a source, all of its subsources will be
+    /// added to the result.
+    ///
+    /// # Panics
+    /// Panics if any of `ids` is not a `Source` item type.
+    pub fn source_read_policies(
+        &self,
+        id: GlobalId,
+    ) -> Vec<(GlobalId, ReadPolicy<mz_repr::Timestamp>)> {
+        let mut policies = Vec::new();
+        let cws = self.state.source_compaction_windows([id]);
+        for (cw, ids) in cws {
+            for id in ids {
+                policies.push((id, cw.into()));
+            }
+        }
+        policies
     }
 }
 

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -327,12 +327,12 @@ impl crate::coord::Coordinator {
     /// with a read policy that allows no compaction.
     pub(crate) async fn initialize_storage_read_policies(
         &mut self,
-        ids: Vec<GlobalId>,
+        ids: BTreeSet<GlobalId>,
         compaction_window: CompactionWindow,
     ) {
         self.initialize_read_policies(
             &CollectionIdBundle {
-                storage_ids: ids.into_iter().collect(),
+                storage_ids: ids,
                 compute_ids: BTreeMap::new(),
             },
             compaction_window,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -9,6 +9,7 @@
 
 use differential_dataflow::lattice::Lattice;
 use maplit::btreemap;
+use maplit::btreeset;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_catalog::memory::objects::{CatalogItem, MaterializedView};
 use mz_expr::refresh_schedule::RefreshSchedule;
@@ -676,7 +677,7 @@ impl Coordinator {
 
                 coord
                     .initialize_storage_read_policies(
-                        vec![sink_id],
+                        btreeset![sink_id],
                         compaction_window.unwrap_or(CompactionWindow::Default),
                     )
                     .await;

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1245,7 +1245,8 @@ impl CatalogItem {
         }
     }
 
-    /// The custom compaction window, if any has been set.
+    /// The custom compaction window, if any has been set. This does not reflect any propagated
+    /// compaction window (i.e., source -> subsource).
     pub fn custom_logical_compaction_window(&self) -> Option<CompactionWindow> {
         match self {
             CatalogItem::Table(table) => table.custom_logical_compaction_window,
@@ -1263,7 +1264,8 @@ impl CatalogItem {
     }
 
     /// Mutable access to the custom compaction window, or None if this type does not support custom
-    /// compaction windows.
+    /// compaction windows. This does not reflect any propagated compaction window (i.e., source ->
+    /// subsource).
     pub fn custom_logical_compaction_window_mut(
         &mut self,
     ) -> Option<&mut Option<CompactionWindow>> {
@@ -1283,14 +1285,13 @@ impl CatalogItem {
         Some(cw)
     }
 
-    /// The initial compaction window, for objects that have one; that is,
-    /// tables, sources, indexes, and MVs.
+    /// The initial compaction window, for objects that have one; that is, tables, sources, indexes,
+    /// and MVs. This does not reflect any propagated compaction window (i.e., source -> subsource).
     ///
-    /// If `custom_logical_compaction_window()` returns something, use
-    /// that.  Otherwise, use a sensible default (currently 1s).
+    /// If `custom_logical_compaction_window()` returns something, use that.  Otherwise, use a
+    /// sensible default (currently 1s).
     ///
-    /// For objects that do not have the concept of compaction window,
-    /// return None.
+    /// For objects that do not have the concept of compaction window, return None.
     pub fn initial_logical_compaction_window(&self) -> Option<CompactionWindow> {
         let custom_logical_compaction_window = match self {
             CatalogItem::Table(_)

--- a/test/sqllogictest/retain_history.slt
+++ b/test/sqllogictest/retain_history.slt
@@ -93,11 +93,28 @@ ALTER INDEX idx_b SET (RETAIN HISTORY FOR '6m')
 statement ok
 ALTER INDEX idx_b SET (RETAIN HISTORY FOR '4m')
 
-# Test subsource propagation.
+# Test subsource propagation. Test sources with and without subsources and view dependencies to
+# ensure the alter code correctly ignores the views.
 statement ok
 CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES
 ----
 
 statement ok
+CREATE VIEW auction_house_view AS SELECT * FROM users
+----
+
+statement ok
 ALTER SOURCE auction_house SET (RETAIN HISTORY FOR '1m')
+----
+
+statement ok
+CREATE SOURCE counter FROM LOAD GENERATOR COUNTER
+----
+
+statement ok
+CREATE VIEW counter_view AS SELECT * FROM counter
+----
+
+statement ok
+ALTER SOURCE counter SET (RETAIN HISTORY FOR '1m')
 ----

--- a/test/sqllogictest/retain_history.slt
+++ b/test/sqllogictest/retain_history.slt
@@ -92,3 +92,12 @@ ALTER INDEX idx_b SET (RETAIN HISTORY FOR '6m')
 
 statement ok
 ALTER INDEX idx_b SET (RETAIN HISTORY FOR '4m')
+
+# Test subsource propagation.
+statement ok
+CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES
+----
+
+statement ok
+ALTER SOURCE auction_house SET (RETAIN HISTORY FOR '1m')
+----


### PR DESCRIPTION
If a subsource has not set its retain history but the parent source has, use the parent source's retain history.

Fixes #26650

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a