### PR TITLE
storage: understand which cluster ingestion exports run on

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -424,7 +424,16 @@ impl CatalogState {
                     let source_type = source.source_type();
                     let connection_id = source.connection_id();
                     let envelope = source.envelope();
-                    let cluster_id = entry.item().cluster_id().map(|id| id.to_string());
+                    let cluster_entry = match source.data_source {
+                        // Ingestion exports don't have their own cluster, but
+                        // run on their ingestion's cluster.
+                        DataSourceDesc::IngestionExport { ingestion_id, .. } => {
+                            self.get_entry(&ingestion_id)
+                        }
+                        _ => entry,
+                    };
+
+                    let cluster_id = cluster_entry.item().cluster_id().map(|id| id.to_string());
 
                     let (key_format, value_format) = source.formats();
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -115,6 +115,29 @@ pub enum DataSource {
     Other(DataSourceOther),
 }
 
+impl DataSource {
+    /// If this data source depends on the frontier of another collection,
+    /// return it.
+    ///
+    /// Dependencies offer the ability to tie the frontiers of collections
+    /// together, e.g. we expect that you cannot drop a collection with any
+    /// dependents that have not been dropped yet.
+    pub fn collection_dependency(&self) -> Option<GlobalId> {
+        match self {
+            DataSource::Introspection(_)
+            | DataSource::Webhook
+            | DataSource::Other(DataSourceOther::TableWrites)
+            | DataSource::Progress
+            | DataSource::Other(DataSourceOther::Compute) => None,
+            // Exports depend on their ingestion. n.b. we expect this dependency
+            // to carry transitively to the ingestion's remap collection.
+            DataSource::IngestionExport { ingestion_id, .. } => Some(*ingestion_id),
+            // Ingestions depend on their remap collection.
+            DataSource::Ingestion(ingestion) => Some(ingestion.remap_collection_id),
+        }
+    }
+}
+
 /// Describes how data is written to a collection maintained outside of the
 /// storage controller.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1853,7 +1853,11 @@ where
         // Repeatedly extract the maximum id, and updates for it.
         while let Some(key) = updates.keys().rev().next().cloned() {
             let mut update = updates.remove(&key).unwrap();
-            if let Some(collection) = self.collections.get_mut(&key) {
+            if let Ok(collection) = self.collection(key) {
+                let cluster_id = self
+                    .determine_collection_cluster_id(&collection.description.data_source)
+                    .expect("collection is well structured");
+
                 let current_read_capabilities = collection.read_capabilities.frontier().to_owned();
                 for (time, diff) in update.iter() {
                     assert!(
@@ -1876,6 +1880,11 @@ where
                     }
                 }
 
+                let collection = self
+                    .collections
+                    .get_mut(&key)
+                    .expect("collection must still exists");
+
                 let changes = collection.read_capabilities.update_iter(update.drain());
                 update.extend(changes);
 
@@ -1886,14 +1895,9 @@ where
                         .extend(update.iter().cloned());
                 }
 
-                let (changes, frontier, _cluster_id) =
-                    collections_net.entry(key).or_insert_with(|| {
-                        (
-                            ChangeBatch::new(),
-                            Antichain::new(),
-                            collection.cluster_id(),
-                        )
-                    });
+                let (changes, frontier, _cluster_id) = collections_net
+                    .entry(key)
+                    .or_insert_with(|| (ChangeBatch::new(), Antichain::new(), cluster_id));
 
                 changes.extend(update.drain());
                 *frontier = collection.read_capabilities.frontier().to_owned();
@@ -2144,17 +2148,6 @@ where
                         };
                         Some(drop_fut.boxed())
                     }
-                    DataSource::IngestionExport { .. } if read_frontier.is_empty() => {
-                        // Dropping an ingestion is a form of dropping a source.
-                        // This won't be handled above because ingestion exports
-                        // do not yet track the cluster on pending compaction
-                        // commands.
-                        //
-                        // TODO(#24235): place the cluster ID in the pending compaction
-                        // commands of IngestionExports.
-                        pending_source_drops.push(id);
-                        None
-                    }
                     // These sources are manged by `clusterd`.
                     DataSource::Webhook
                     | DataSource::Introspection(_)
@@ -2332,10 +2325,12 @@ where
 
         // Enrich `frontiers` with storage frontiers.
         for (object_id, collection) in self.collections.iter().filter(|(_id, c)| !c.is_dropped()) {
-            let replica_id = collection
-                .cluster_id()
+            let replica_id = self
+                .determine_collection_cluster_id(&collection.description.data_source)
+                .expect("collection is well structured")
                 .and_then(|c| self.replicas.get(&c))
                 .copied();
+
             if let Some(replica_id) = replica_id {
                 let upper = collection.write_frontier.clone();
                 frontiers.insert((*object_id, replica_id), upper);
@@ -3459,6 +3454,34 @@ where
         Ok(dependency)
     }
 
+    /// Determine which, if any, cluster this `DataSource` runs on.
+    fn determine_collection_cluster_id(
+        &self,
+        data_source: &DataSource,
+    ) -> Result<Option<StorageInstanceId>, StorageError<T>> {
+        let instance_id = match data_source {
+            DataSource::Ingestion(ingestion) => Some(ingestion.instance_id),
+            DataSource::IngestionExport { ingestion_id, .. } => {
+                let ingestion_collection = self.collection(*ingestion_id)?;
+                match &ingestion_collection.description.data_source {
+                    DataSource::Ingestion(i) => Some(i.instance_id),
+                    _ => {
+                        tracing::error!(
+                            "IngestionExport relies on {ingestion_id}, which is not an ingestion"
+                        );
+                        Err(StorageError::IdentifierInvalid(*ingestion_id))?
+                    }
+                }
+            }
+            DataSource::Webhook
+            | DataSource::Introspection(_)
+            | DataSource::Other(_)
+            | DataSource::Progress => None,
+        };
+
+        Ok(instance_id)
+    }
+
     /// If this identified collection has a dependency, install a read hold on
     /// it.
     ///
@@ -3713,21 +3736,6 @@ impl<T: Timestamp> CollectionState<T> {
             storage_dependency,
             write_frontier,
             collection_metadata: metadata,
-        }
-    }
-
-    /// Returns the cluster to which the collection is bound, if applicable.
-    pub fn cluster_id(&self) -> Option<StorageInstanceId> {
-        match &self.description.data_source {
-            DataSource::Ingestion(ingestion) => Some(ingestion.instance_id),
-            DataSource::Webhook
-            | DataSource::Introspection(_)
-            | DataSource::Other(_)
-            // TODO(#24235) This isn't quite right because a source export runs on the
-            // ingestion's cluster, but we don't have the ability to perform
-            // cross-referenced lookups here (at least not yet).
-            | DataSource::IngestionExport { .. }
-            | DataSource::Progress => None,
         }
     }
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -628,8 +628,7 @@ where
             let data_shard_since = since_handle.since().clone();
 
             // Determine if this collection has another dependency.
-            let storage_dependency =
-                self.determine_collection_dependency(&description.data_source)?;
+            let storage_dependency = description.data_source.collection_dependency();
 
             // Determine the intial since of the collection.
             let initial_since = match storage_dependency {
@@ -3418,40 +3417,6 @@ where
             self.finalizable_shards.remove(&id);
             self.finalized_shards.insert(id);
         }
-    }
-
-    /// Determine if this collection has another dependency.
-    ///
-    /// Currently, collections have either 0 or 1 dependencies.
-    fn determine_collection_dependency(
-        &self,
-        data_source: &DataSource,
-    ) -> Result<Option<GlobalId>, StorageError<T>> {
-        let dependency = match &data_source {
-            DataSource::Introspection(_)
-            | DataSource::Webhook
-            | DataSource::Other(DataSourceOther::TableWrites)
-            | DataSource::Progress
-            | DataSource::Other(DataSourceOther::Compute) => None,
-            DataSource::IngestionExport { ingestion_id, .. } => {
-                // Ingestion exports depend on their primary source's remap
-                // collection.
-                let source_collection = self.collection(*ingestion_id)?;
-                match &source_collection.description {
-                    CollectionDescription {
-                        data_source: DataSource::Ingestion(ingestion_desc),
-                        ..
-                    } => Some(ingestion_desc.remap_collection_id),
-                    _ => unreachable!(
-                        "SourceExport must only refer to primary sources that already exist"
-                    ),
-                }
-            }
-            // Ingestions depend on their remap collection.
-            DataSource::Ingestion(ingestion) => Some(ingestion.remap_collection_id),
-        };
-
-        Ok(dependency)
     }
 
     /// Determine which, if any, cluster this `DataSource` runs on.

--- a/src/storage-controller/src/rehydration.rs
+++ b/src/storage-controller/src/rehydration.rs
@@ -494,7 +494,8 @@ where
                         Some(export) => {
                             export.description.as_of.clone_from(frontier);
                         }
-                        None if self.sources.contains_key(id) => continue,
+                        // uppers contains both ingestions and their exports
+                        None if self.uppers.contains_key(id) => continue,
                         None => panic!("AllowCompaction command for non-existent {id}"),
                     }
                 }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1192,7 +1192,9 @@ impl StorageState {
                             // restart a sink in the future.
                             export_description.as_of.clone_from(&frontier);
                         }
-                        None if self.ingestions.contains_key(&id) => (),
+                        // reported_frontiers contains both ingestions and their
+                        // exports
+                        None if self.reported_frontiers.contains_key(&id) => (),
                         None => panic!("AllowCompaction command for non-existent {id}"),
                     }
 

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -965,16 +965,51 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 }
                 StorageCommand::RunIngestions(ingestions) => {
                     ingestions.retain_mut(|ingestion| {
+                        // Subsources can be dropped independently of their
+                        // primary source, so we evaluate them in a separate
+                        // loop.
+                        for export_id in ingestion
+                            .description
+                            .source_exports
+                            .keys()
+                            .filter(|export_id| **export_id != ingestion.id)
+                        {
+                            if drop_commands.remove(export_id)
+                                || self.storage_state.dropped_ids.contains(&ingestion.id)
+                            {
+                                self.storage_state.dropped_ids.insert(*export_id);
+                            }
+                        }
+
                         if drop_commands.remove(&ingestion.id)
                             || self.storage_state.dropped_ids.contains(&ingestion.id)
                         {
-                            // Make sure that we report back that the ID was
-                            // dropped.
-                            self.storage_state.dropped_ids.insert(ingestion.id);
+                            // If an ingestion is dropped, so too must all of
+                            // its subsources (i.e. ingestion exports, as well
+                            // as its progress subsource).
+                            for id in ingestion.description.subsource_ids() {
+                                drop_commands.remove(&id);
+                                self.storage_state.dropped_ids.insert(id);
+                            }
 
                             false
                         } else {
-                            expected_objects.extend(ingestion.description.subsource_ids());
+                            let most_recent_defintion =
+                                seen_most_recent_definition.insert(ingestion.id);
+
+                            if most_recent_defintion {
+                                // If this is the most recent definition, this
+                                // is what we will be running when
+                                // reconciliation completes. This definition
+                                // must not include any dropped subsources.
+                                ingestion.description.source_exports.retain(|export_id, _| {
+                                    !self.storage_state.dropped_ids.contains(export_id)
+                                });
+
+                                // After clearing any dropped subsources, we can
+                                // state that we expect all of these to exist.
+                                expected_objects.extend(ingestion.description.subsource_ids());
+                            }
 
                             let running_ingestion =
                                 self.storage_state.ingestions.get(&ingestion.id);
@@ -984,7 +1019,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                             //   is why these commands are run in reverse.
                             // - Ingestions whose descriptions are not exactly
                             //   those that are currently running.
-                            seen_most_recent_definition.insert(ingestion.id)
+                            most_recent_defintion
                                 && running_ingestion != Some(&ingestion.description)
                         }
                     })
@@ -1037,12 +1072,14 @@ impl<'w, A: Allocate> Worker<'w, A> {
         let stale_objects = self
             .storage_state
             .ingestions
-            .keys()
-            .chain(self.storage_state.exports.keys())
+            .values()
+            .map(|i| i.subsource_ids())
+            .flatten()
+            .chain(self.storage_state.exports.keys().copied())
             // Objects are considered stale if we did not see them re-created.
             .filter(|id| !expected_objects.contains(id))
             // Synthesize the drop command
-            .map(|id| (*id, Antichain::new()))
+            .map(|id| (id, Antichain::new()))
             .collect::<Vec<_>>();
 
         trace!(

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -302,24 +302,24 @@ contains: CREATE SOURCE specifies DETAILS option
   );
 
 > SHOW SOURCES
-conflict_table        subsource <null>  <null>
-create                subsource <null>  <null>
-escaped_text_table    subsource <null>  <null>
-large_text            subsource <null>  <null>
-mixED_CAse            subsource <null>  <null>
-multipart_pk          subsource <null>  <null>
-mz_source             mysql  ${arg.default-replica-size}  cdc_cluster
-mz_source_progress    progress  <null>  <null>
-nonpk_table           subsource <null>  <null>
-nulls_table           subsource <null>  <null>
-pk_table              subsource <null>  <null>
-trailing_space_nopk   subsource <null>  <null>
-trailing_space_pk     subsource <null>  <null>
-types_table           subsource <null>  <null>
-utf8_table            subsource <null>  <null>
-"\"literal_quotes\""  subsource <null>  <null>
-"space table"         subsource <null>  <null>
-таблица               subsource <null>  <null>
+conflict_table        subsource  ${arg.default-replica-size}  cdc_cluster
+create                subsource  ${arg.default-replica-size}  cdc_cluster
+escaped_text_table    subsource  ${arg.default-replica-size}  cdc_cluster
+large_text            subsource  ${arg.default-replica-size}  cdc_cluster
+mixED_CAse            subsource  ${arg.default-replica-size}  cdc_cluster
+multipart_pk          subsource  ${arg.default-replica-size}  cdc_cluster
+mz_source             mysql      ${arg.default-replica-size}  cdc_cluster
+mz_source_progress    progress   <null> <null>
+nonpk_table           subsource  ${arg.default-replica-size}  cdc_cluster
+nulls_table           subsource  ${arg.default-replica-size}  cdc_cluster
+pk_table              subsource  ${arg.default-replica-size}  cdc_cluster
+trailing_space_nopk   subsource  ${arg.default-replica-size}  cdc_cluster
+trailing_space_pk     subsource  ${arg.default-replica-size}  cdc_cluster
+types_table           subsource  ${arg.default-replica-size}  cdc_cluster
+utf8_table            subsource  ${arg.default-replica-size}  cdc_cluster
+"\"literal_quotes\""  subsource  ${arg.default-replica-size}  cdc_cluster
+"space table"         subsource  ${arg.default-replica-size}  cdc_cluster
+таблица               subsource  ${arg.default-replica-size}  cdc_cluster
 
 > SELECT schema_name, table_name FROM mz_internal.mz_mysql_source_tables
 public          create
@@ -711,10 +711,10 @@ contains:TEXT COLUMNS refers to columns not currently being added
   );
 
 > SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
-another_enum_table      subsource <null> <null>
+another_enum_table      subsource ${arg.default-replica-size} cdc_cluster
 enum_source             mysql     ${arg.default-replica-size} cdc_cluster
 enum_source_progress    progress  <null> <null>
-enum_table              subsource <null> <null>
+enum_table              subsource ${arg.default-replica-size} cdc_cluster
 
 > SELECT * FROM enum_table
 var0
@@ -748,7 +748,7 @@ INSERT INTO pk_table VALUES (99999, 'abc');
 > SHOW SOURCES
 another_source          mysql  ${arg.default-replica-size} cdc_cluster
 another_source_progress progress  <null> <null>
-another_table           subsource <null> <null>
+another_table           subsource ${arg.default-replica-size} cdc_cluster
 
 > DROP SOURCE another_source CASCADE;
 

--- a/test/mysql-cdc/subsource-resolution-duplicates.td
+++ b/test/mysql-cdc/subsource-resolution-duplicates.td
@@ -54,7 +54,7 @@ detail: subsources referencing table: x, y
 > SHOW sources
  mz_source          mysql     ${arg.default-replica-size} quickstart
  mz_source_progress progress  <null> <null>
- t                  subsource <null> <null>
+ t                  subsource ${arg.default-replica-size} quickstart
 
 $ mysql-execute name=mysql
 DROP DATABASE other;

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -316,25 +316,25 @@ detail:referenced items: no_replica_identity
   );
 
 > SHOW SOURCES
-array_types_table     subsource <null>  <null>
-conflict_table        subsource <null>  <null>
-create                subsource <null>  <null>
-escaped_text_table    subsource <null>  <null>
-large_text            subsource <null>  <null>
-multipart_pk          subsource <null>  <null>
-mz_source             postgres  ${arg.default-replica-size}  cdc_cluster
-mz_source_progress    progress  <null>  <null>
-nonpk_table           subsource <null>  <null>
-nulls_table           subsource <null>  <null>
-pk_table              subsource <null>  <null>
-"space table"         subsource <null>  <null>
-trailing_space_nopk   subsource <null>  <null>
-trailing_space_pk     subsource <null>  <null>
-"\"literal_quotes\""  subsource <null>  <null>
-tstzrange_table       subsource <null>  <null>
-types_table           subsource <null>  <null>
-utf8_table            subsource <null>  <null>
-таблица               subsource <null>  <null>
+array_types_table     subsource  ${arg.default-replica-size}  cdc_cluster
+conflict_table        subsource  ${arg.default-replica-size}  cdc_cluster
+create                subsource  ${arg.default-replica-size}  cdc_cluster
+escaped_text_table    subsource  ${arg.default-replica-size}  cdc_cluster
+large_text            subsource  ${arg.default-replica-size}  cdc_cluster
+multipart_pk          subsource  ${arg.default-replica-size}  cdc_cluster
+mz_source             postgres   ${arg.default-replica-size}  cdc_cluster
+mz_source_progress    progress   <null> <null>
+nonpk_table           subsource  ${arg.default-replica-size}  cdc_cluster
+nulls_table           subsource  ${arg.default-replica-size}  cdc_cluster
+pk_table              subsource  ${arg.default-replica-size}  cdc_cluster
+"space table"         subsource  ${arg.default-replica-size}  cdc_cluster
+trailing_space_nopk   subsource  ${arg.default-replica-size}  cdc_cluster
+trailing_space_pk     subsource  ${arg.default-replica-size}  cdc_cluster
+"\"literal_quotes\""  subsource  ${arg.default-replica-size}  cdc_cluster
+tstzrange_table       subsource  ${arg.default-replica-size}  cdc_cluster
+types_table           subsource  ${arg.default-replica-size}  cdc_cluster
+utf8_table            subsource  ${arg.default-replica-size}  cdc_cluster
+таблица               subsource  ${arg.default-replica-size}  cdc_cluster
 
 > SELECT schema_name, table_name FROM mz_internal.mz_postgres_source_tables
 public          create
@@ -791,10 +791,10 @@ contains:TEXT COLUMNS refers to table not currently being added
   );
 
 > SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
-another_enum_table      subsource <null> <null>
+another_enum_table      subsource ${arg.default-replica-size} cdc_cluster
 enum_source             postgres  ${arg.default-replica-size} cdc_cluster
 enum_source_progress    progress  <null> <null>
-enum_table              subsource <null> <null>
+enum_table              subsource ${arg.default-replica-size} cdc_cluster
 
 > SELECT * FROM enum_table
 var0
@@ -854,7 +854,7 @@ true
 > SHOW SOURCES
 another_source          postgres  ${arg.default-replica-size} cdc_cluster
 another_source_progress progress  <null> <null>
-another_table           subsource <null> <null>
+another_table           subsource ${arg.default-replica-size} cdc_cluster
 
 > DROP SOURCE another_source CASCADE
 

--- a/test/pg-cdc/subsource-resolution-duplicates.td
+++ b/test/pg-cdc/subsource-resolution-duplicates.td
@@ -56,7 +56,7 @@ detail: subsources referencing table: x, y
 > SHOW sources
  mz_source          postgres  ${arg.default-replica-size} quickstart
  mz_source_progress progress  <null> <null>
- t                  subsource <null> <null>
+ t                  subsource ${arg.default-replica-size} quickstart
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP SCHEMA other CASCADE;

--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -20,13 +20,13 @@ $ set-arg-default single-replica-cluster=quickstart
 > SHOW SOURCES
 name          type           size                         cluster
 -----------------------------------------------------------------
-accounts      subsource      <null>                       <null>
-auctions      subsource      <null>                       <null>
-bids          subsource      <null>                       <null>
+accounts      subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
+auctions      subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
+bids          subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
 demo          load-generator ${arg.default-replica-size}  ${arg.single-replica-cluster}
-demo_progress progress       <null>                       <null>
-organizations subsource      <null>                       <null>
-users         subsource      <null>                       <null>
+demo_progress progress       <null> <null>
+organizations subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
+users         subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
 
 > SHOW COLUMNS FROM auctions
 end_time false "timestamp with time zone"

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -20,13 +20,13 @@ exact:COUNTER load generators do not support SCALE FACTOR values
   FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
 > SHOW SOURCES
-accounts                subsource      <null>                         <null>
+accounts                subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
 auction_house           load-generator ${arg.default-replica-size}    ${arg.single-replica-cluster}
-auction_house_progress  progress       <null>                         <null>
-auctions                subsource      <null>                         <null>
-bids                    subsource      <null>                         <null>
-organizations           subsource      <null>                         <null>
-users                   subsource      <null>                         <null>
+auction_house_progress  progress       <null> <null>
+auctions                subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
+bids                    subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
+organizations           subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
+users                   subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
 
 # FOR TABLES doesn't always work.
 # A previous test here checked bids, which worked.
@@ -44,13 +44,13 @@ contains:LOAD GENERATOR source validation: FOR TABLES (..) unsupported
   FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
 > SHOW SOURCES FROM another;
-accounts                subsource      <null>                       <null>
+accounts                subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
 auction_house           load-generator ${arg.default-replica-size}  ${arg.single-replica-cluster}
-auction_house_progress  progress       <null>                       <null>
-auctions                subsource      <null>                       <null>
-bids                    subsource      <null>                       <null>
-organizations           subsource      <null>                       <null>
-users                   subsource      <null>                       <null>
+auction_house_progress  progress       <null> <null>
+auctions                subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
+bids                    subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
+organizations           subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
+users                   subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 

--- a/test/testdrive/quickstart.td
+++ b/test/testdrive/quickstart.td
@@ -23,13 +23,13 @@
 > SHOW SOURCES
 name                   type           size                         cluster
 --------------------------------------------------------------------------
-accounts               subsource      <null>                       <null>
-bids                   subsource      <null>                       <null>
+accounts               subsource      <null>                       quickstart_tutorial
+bids                   subsource      <null>                       quickstart_tutorial
 auction_house          load-generator <null>                       quickstart_tutorial
 auction_house_progress progress       <null>                       <null>
-auctions               subsource      <null>                       <null>
-organizations          subsource      <null>                       <null>
-users                  subsource      <null>                       <null>
+auctions               subsource      <null>                       quickstart_tutorial
+organizations          subsource      <null>                       quickstart_tutorial
+users                  subsource      <null>                       quickstart_tutorial
 
 > SELECT id, seller, item FROM auctions WHERE id = 1
 1 1824 "Best Pizza in Town"

--- a/test/testdrive/tpch.td
+++ b/test/testdrive/tpch.td
@@ -40,16 +40,16 @@ SELECT size FROM (
 > SHOW SOURCES
 name           type            size             cluster
 -------------------------------------------------------
- customer      subsource       <null>           <null>
+ customer      subsource       ${source-size}   ${arg.single-replica-cluster}
  gen           load-generator  ${source-size}   ${arg.single-replica-cluster}
- gen_progress  progress        <null>           <null>
- lineitem      subsource       <null>           <null>
- nation        subsource       <null>           <null>
- orders        subsource       <null>           <null>
- part          subsource       <null>           <null>
- partsupp      subsource       <null>           <null>
- region        subsource       <null>           <null>
- supplier      subsource       <null>           <null>
+ gen_progress  progress        <null> <null>
+ lineitem      subsource       ${source-size}   ${arg.single-replica-cluster}
+ nation        subsource       ${source-size}   ${arg.single-replica-cluster}
+ orders        subsource       ${source-size}   ${arg.single-replica-cluster}
+ part          subsource       ${source-size}   ${arg.single-replica-cluster}
+ partsupp      subsource       ${source-size}   ${arg.single-replica-cluster}
+ region        subsource       ${source-size}   ${arg.single-replica-cluster}
+ supplier      subsource       ${source-size}   ${arg.single-replica-cluster}
 
 # SF * 150,000
 > SELECT count(*) FROM customer


### PR DESCRIPTION
Now that we understand which ingestion an ingestion export belongs to, we can:

- Announce the cluster that it's running on in introspection tables (#24235)
- Propagate drop commands for individual subsources down to the clusters on which they run. This, in turn, means that we will get `DroppedIds` responses from the cluster containing ingestion export `GlobalId`s and can then retire its data shard. (#8185)

### Motivation

This PR fixes a recognized bug.

Fixes #24235
Progresses #8185; not closing it because we should add a test.
Fixes #24773

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
