### PR TITLE
sql + storage: cleanup subsource dependency inversion code

### DIFF
--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -356,7 +356,7 @@ class MySqlExecutor(Executor):
                 f"""CREATE SOURCE {identifier(self.database)}.{identifier(self.schema)}.{identifier(self.source)}
                     {f"IN CLUSTER {identifier(self.cluster)}" if self.cluster else ""}
                     FROM MYSQL CONNECTION mysql{self.num}
-                    FOR TABLES (mysql.{identifier(self.table)} AS {identifier(self.table)})""",
+                    FOR TABLES ({identifier(self.table)} AS {identifier(self.table)})""",
             )
         self.mz_conn.autocommit = False
 

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -10,9 +10,8 @@
 //! Logic related to applying updates from a [`mz_catalog::durable::DurableCatalogState`] to a
 //! [`CatalogState`].
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
-use std::str::FromStr;
 
 use mz_catalog::builtin::{Builtin, BUILTIN_LOG_LOOKUP, BUILTIN_LOOKUP};
 use mz_catalog::memory::error::{Error, ErrorKind};
@@ -33,9 +32,9 @@ use mz_sql::names::{
     ItemQualifiers, QualifiedItemName, QualifiedSchemaName, ResolvedDatabaseSpecifier, ResolvedIds,
     SchemaSpecifier,
 };
+use mz_sql::rbac;
 use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
 use mz_sql::session::vars::{VarError, VarInput};
-use mz_sql::{plan, rbac};
 use mz_sql_parser::ast::Expr;
 use mz_storage_types::sources::Timeline;
 use once_cell::sync::Lazy;
@@ -47,8 +46,6 @@ use crate::AdapterError;
 
 enum ApplyUpdateError {
     Error(Error),
-    AwaitingIdDependency((GlobalId, mz_catalog::durable::Item, Diff)),
-    AwaitingNameDependency((String, mz_catalog::durable::Item, Diff)),
 }
 
 impl CatalogState {
@@ -69,126 +66,13 @@ impl CatalogState {
         &mut self,
         updates: Vec<StateUpdate>,
     ) -> Result<(), Error> {
-        // TODO(#26764): we can refactor this to assume that items are
-        // topologically sorted by their `GlobalId`.
-        let mut awaiting_id_dependencies: BTreeMap<GlobalId, Vec<_>> = BTreeMap::new();
-        let mut awaiting_name_dependencies: BTreeMap<String, Vec<_>> = BTreeMap::new();
-        let mut updates: VecDeque<_> = updates.into_iter().collect();
-        while let Some(StateUpdate { kind, diff }) = updates.pop_front() {
+        for StateUpdate { kind, diff } in updates {
             assert_eq!(
                 diff, 1,
                 "initial catalog updates should be consolidated: ({kind:?}, {diff:?})"
             );
-            match self.apply_update(kind, diff) {
-                Ok(None) => {}
-                Ok(Some(id)) => {
-                    // Enqueue any items waiting on this dependency.
-                    let mut resolved_dependent_items = Vec::new();
-                    if let Some(dependent_items) = awaiting_id_dependencies.remove(&id) {
-                        resolved_dependent_items.extend(dependent_items);
-                    }
-                    let entry = self.get_entry(&id);
-                    let full_name = self.resolve_full_name(entry.name(), None);
-                    if let Some(dependent_items) =
-                        awaiting_name_dependencies.remove(&full_name.to_string())
-                    {
-                        resolved_dependent_items.extend(dependent_items);
-                    }
-                    let resolved_dependent_items =
-                        resolved_dependent_items
-                            .into_iter()
-                            .map(|(item, diff)| StateUpdate {
-                                kind: StateUpdateKind::Item(item),
-                                diff,
-                            });
-                    updates.extend(resolved_dependent_items);
-                }
-                Err(ApplyUpdateError::Error(err)) => return Err(err),
-                Err(ApplyUpdateError::AwaitingIdDependency((id, item, diff))) => {
-                    awaiting_id_dependencies
-                        .entry(id)
-                        .or_default()
-                        .push((item, diff));
-                }
-                Err(ApplyUpdateError::AwaitingNameDependency((name, item, diff))) => {
-                    awaiting_name_dependencies
-                        .entry(name)
-                        .or_default()
-                        .push((item, diff));
-                }
-            }
-        }
-
-        // Error on any unsatisfied dependencies.
-        if let Some((missing_dep, mut dependents)) = awaiting_id_dependencies.into_iter().next() {
-            let (
-                mz_catalog::durable::Item {
-                    id,
-                    oid: _,
-                    schema_id,
-                    name,
-                    create_sql: _,
-                    owner_id: _,
-                    privileges: _,
-                },
-                diff,
-            ) = dependents.remove(0);
-            let schema = self.find_non_temp_schema(&schema_id);
-            let name = QualifiedItemName {
-                qualifiers: ItemQualifiers {
-                    database_spec: schema.database().clone(),
-                    schema_spec: schema.id().clone(),
-                },
-                item: name,
-            };
-            let name = self.resolve_full_name(&name, None);
-            let action = if diff == 1 { "deserialize" } else { "remove" };
-
-            return Err(Error::new(ErrorKind::Corruption {
-                detail: format!(
-                    "failed to {} item {} ({}): {}",
-                    action,
-                    id,
-                    name,
-                    plan::PlanError::InvalidId(missing_dep)
-                ),
-            }));
-        }
-
-        if let Some((missing_dep, mut dependents)) = awaiting_name_dependencies.into_iter().next() {
-            let (
-                mz_catalog::durable::Item {
-                    id,
-                    oid: _,
-                    schema_id,
-                    name,
-                    create_sql: _,
-                    owner_id: _,
-                    privileges: _,
-                },
-                diff,
-            ) = dependents.remove(0);
-            let schema = self.find_non_temp_schema(&schema_id);
-            let name = QualifiedItemName {
-                qualifiers: ItemQualifiers {
-                    database_spec: schema.database().clone(),
-                    schema_spec: schema.id().clone(),
-                },
-                item: name,
-            };
-            let name = self.resolve_full_name(&name, None);
-            let action = if diff == 1 { "deserialize" } else { "remove" };
-            return Err(Error::new(ErrorKind::Corruption {
-                detail: format!(
-                    "failed to {} item {} ({}): {}",
-                    action,
-                    id,
-                    name,
-                    Error {
-                        kind: ErrorKind::Sql(SqlCatalogError::UnknownItem(missing_dep))
-                    }
-                ),
-            }));
+            self.apply_update(kind, diff)
+                .map_err(|ApplyUpdateError::Error(err)| err)?;
         }
 
         Ok(())
@@ -732,18 +616,12 @@ impl CatalogState {
     /// Applies an item update to `self`.
     ///
     /// Returns a `GlobalId` on success, if the applied update added a new `GlobalID` to `self`.
-    /// Returns a dependency on failure, if the update could not be applied due to a missing
-    /// dependency.
     #[instrument(level = "debug")]
     fn apply_item_update(
         &mut self,
         item: mz_catalog::durable::Item,
         diff: Diff,
     ) -> Result<Option<GlobalId>, ApplyUpdateError> {
-        // If we knew beforehand that the items were being applied in dependency
-        // order, then we could fully delegate to `self.insert_item(...)` and`self.drop_item(...)`.
-        // However, we don't know that items are applied in dependency order, so we must handle the
-        // case that the item is valid, but we haven't applied all of its dependencies yet.
         match diff {
             1 => {
                 // TODO(benesch): a better way of detecting when a view has depended
@@ -763,27 +641,6 @@ impl CatalogState {
                                 depender_name: name,
                             },
                         )));
-                    }
-                    // If we were missing a dependency, wait for it to be added.
-                    Err(AdapterError::PlanError(plan::PlanError::InvalidId(missing_dep))) => {
-                        return Err(ApplyUpdateError::AwaitingIdDependency((
-                            missing_dep,
-                            item,
-                            diff,
-                        )));
-                    }
-                    // If we were missing a dependency, wait for it to be added.
-                    Err(AdapterError::PlanError(plan::PlanError::Catalog(
-                        SqlCatalogError::UnknownItem(missing_dep),
-                    ))) => {
-                        return match GlobalId::from_str(&missing_dep) {
-                            Ok(id) => Err(ApplyUpdateError::AwaitingIdDependency((id, item, diff))),
-                            Err(_) => Err(ApplyUpdateError::AwaitingNameDependency((
-                                missing_dep,
-                                item,
-                                diff,
-                            ))),
-                        }
                     }
                     Err(e) => {
                         let schema = self.find_non_temp_schema(&item.schema_id);
@@ -822,13 +679,6 @@ impl CatalogState {
                 Ok(Some(item.id))
             }
             -1 => {
-                let entry = self.get_entry(&item.id);
-                if let Some(id) = entry.referenced_by().first() {
-                    return Err(ApplyUpdateError::AwaitingIdDependency((*id, item, diff)));
-                }
-                if let Some(id) = entry.used_by().first() {
-                    return Err(ApplyUpdateError::AwaitingIdDependency((*id, item, diff)));
-                }
                 self.drop_item(item.id);
                 Ok(None)
             }

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -487,7 +487,6 @@ impl CatalogState {
             Builtin::Index(index) => {
                 let mut item = self
                     .parse_item(
-                        id,
                         &index.create_sql(),
                         None,
                         index.is_retained_metrics_object,
@@ -631,7 +630,7 @@ impl CatalogState {
                 static LOGGING_ERROR: Lazy<Regex> =
                     Lazy::new(|| Regex::new("mz_catalog.[^']*").expect("valid regex"));
 
-                let catalog_item = match self.deserialize_item(item.id, &item.create_sql) {
+                let catalog_item = match self.deserialize_item(&item.create_sql) {
                     Ok(item) => item,
                     Err(AdapterError::Catalog(Error {
                         kind: ErrorKind::Sql(SqlCatalogError::UnknownItem(name)),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -446,15 +446,17 @@ impl CatalogState {
                     );
 
                     updates.extend(match &source.data_source {
-                        DataSourceDesc::Ingestion(ingestion) => match &ingestion.desc.connection {
-                            GenericSourceConnection::Postgres(postgres) => {
-                                self.pack_postgres_source_update(id, postgres, diff)
+                        DataSourceDesc::Ingestion { ingestion_desc, .. } => {
+                            match &ingestion_desc.desc.connection {
+                                GenericSourceConnection::Postgres(postgres) => {
+                                    self.pack_postgres_source_update(id, postgres, diff)
+                                }
+                                GenericSourceConnection::Kafka(kafka) => {
+                                    self.pack_kafka_source_update(id, kafka, diff)
+                                }
+                                _ => vec![],
                             }
-                            GenericSourceConnection::Kafka(kafka) => {
-                                self.pack_kafka_source_update(id, kafka, diff)
-                            }
-                            _ => vec![],
-                        },
+                        }
                         DataSourceDesc::IngestionExport {
                             ingestion_id,
                             external_reference: UnresolvedItemName(external_reference),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -486,13 +486,9 @@ impl CatalogState {
                                     )
                                 }
                                 "mysql" => {
-                                    mz_ore::soft_assert_eq_no_log!(external_reference.len(), 3);
-                                    // The left-most qualification of MySQL
-                                    // tables is contrived to be "mysql", but
-                                    // has no correlation to the actual
-                                    // database.
-                                    let schema_name = external_reference[1].to_ast_string();
-                                    let table_name = external_reference[2].to_ast_string();
+                                    mz_ore::soft_assert_eq_no_log!(external_reference.len(), 2);
+                                    let schema_name = external_reference[0].to_ast_string();
+                                    let table_name = external_reference[1].to_ast_string();
 
                                     self.pack_mysql_source_tables_update(
                                         id,

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 
 use futures::future::BoxFuture;
@@ -18,7 +18,6 @@ use mz_ore::now::{EpochMillis, NowFn};
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::visit_mut::VisitMut;
-use mz_sql::ast::{CreateSubsourceOption, CreateSubsourceOptionName, Ident};
 use mz_sql::catalog::SessionCatalog;
 use mz_sql_parser::ast::{Raw, Statement};
 use mz_storage_types::connections::ConnectionContext;
@@ -82,7 +81,7 @@ where
 pub(crate) async fn migrate(
     state: &CatalogState,
     tx: &mut Transaction<'_>,
-    now: NowFn,
+    _now: NowFn,
     _boot_ts: Timestamp,
     _connection_context: &ConnectionContext,
 ) -> Result<(), anyhow::Error> {
@@ -156,247 +155,12 @@ pub(crate) async fn migrate(
     //
     // Each migration should be a function that takes `tx` and `conn_cat` as
     // input and stages arbitrary transformations to the catalog on `tx`.
-    subsource_rewrite_v0_98(tx, &conn_cat, now)?;
 
     info!(
         "migration from catalog version {:?} complete",
         catalog_version
     );
     Ok(())
-}
-
-/// Inverts the dependency structure of subsources.
-///
-/// In previous versions of MZ, a primary source depended on its subsources.
-/// This migration inverts that relationship so that subsources depend on their
-/// primary source.
-///
-/// This function also adjusts items' `GlobalId`s such that the dependency graph
-/// can be inferred using the ordering of `GlobalId`s, i.e. all of an item's
-/// dependents have `GlobalId`s greater than its own.
-fn subsource_rewrite_v0_98(
-    tx: &mut Transaction<'_>,
-    conn_catalog: &ConnCatalog,
-    now: NowFn,
-) -> Result<(), anyhow::Error> {
-    use mz_sql::ast::UnresolvedItemName;
-    use mz_sql::catalog::CatalogItemType;
-    use mz_sql_parser::ast::RawItemName;
-    use mz_storage_types::connections::Connection;
-    use mz_storage_types::sources::GenericSourceConnection;
-
-    // A vector in the _new_ dependency order. Because the `vec` doesn't have
-    // any built-in de-duplication, we will need to deduplicate these values
-    // elsewhere.
-    let mut needs_new_id = vec![];
-
-    // The IDs of the sources whose subsources we are updating. We need to
-    // ensure we keep their IDs static.
-    let mut source_ids_of_updated_subsources = BTreeSet::new();
-
-    // Collect all items that we need to update in the txn; do this en masse
-    // because individually updating items can perform poorly.
-    let mut updated_items = BTreeMap::new();
-
-    // Get all sources in this TXN.
-    let mut source_map: BTreeMap<_, _> = tx
-        .get_items()
-        .into_iter()
-        .filter(|item| conn_catalog.get_item(&item.id).item_type() == CatalogItemType::Source)
-        .map(|item| (item.id, item))
-        .collect();
-
-    // Iterate over all sources in the catalog.
-    for source in conn_catalog
-        .get_items()
-        .iter()
-        .filter(|item| item.item_type() == CatalogItemType::Source)
-    {
-        // Get all of the source exports.
-        let mut exports = source.source_exports();
-
-        // Drop the self-referencing export.
-        exports.retain(|id, _| *id != source.id());
-
-        // If no exports, this is not a multi-output source.
-        if exports.is_empty() {
-            continue;
-        }
-
-        let desc = source
-            .source_desc()
-            .expect("item is source with desc")
-            .expect("item is source with desc");
-
-        // The new `IngestionExport` structure uses `UnresolvedItemName`s to
-        // refer to items in the publication, so collect those for all
-        // mult-output sources.
-        let external_reference_tables: Vec<_> = match &desc.connection {
-            GenericSourceConnection::Postgres(pg) => {
-                let connection = conn_catalog.get_item(&pg.connection_id);
-                let conn = connection
-                    .connection()
-                    .expect("generic source connection has connection details");
-                let database = match conn {
-                    Connection::Postgres(p) => p.database.clone(),
-                    _ => unreachable!("PG sources must have PG connections"),
-                };
-
-                pg.publication_details
-                    .tables
-                    .iter()
-                    .map(|t| {
-                        UnresolvedItemName(vec![
-                            Ident::new_unchecked(database.clone()),
-                            Ident::new_unchecked(t.namespace.clone()),
-                            Ident::new_unchecked(t.name.clone()),
-                        ])
-                    })
-                    .collect()
-            }
-            GenericSourceConnection::MySql(mysql) => mysql
-                .details
-                .tables
-                .iter()
-                .map(|t| {
-                    UnresolvedItemName(vec![
-                        Ident::new_unchecked("mysql"),
-                        Ident::new_unchecked(t.schema_name.clone()),
-                        Ident::new_unchecked(t.name.clone()),
-                    ])
-                })
-                .collect(),
-            GenericSourceConnection::LoadGenerator(load_generator) => {
-                let prefix = UnresolvedItemName(vec![
-                    Ident::new_unchecked(
-                        mz_storage_types::sources::load_generator::LOAD_GENERATOR_DATABASE_NAME,
-                    ),
-                    Ident::new_unchecked(load_generator.load_generator.schema_name()),
-                ]);
-
-                load_generator
-                    .load_generator
-                    .views()
-                    .into_iter()
-                    .map(|(view_name, _desc)| {
-                        let mut name = prefix.clone();
-                        name.0.push(Ident::new_unchecked(view_name.to_string()));
-                        name
-                    })
-                    .collect()
-            }
-            GenericSourceConnection::Kafka(_) => {
-                unreachable!("Kafka sources have non-self source exports")
-            }
-        };
-
-        let primary_source_full_name = conn_catalog.resolve_full_name(source.name());
-        let primary_source_name = mz_sql::normalize::unresolve(primary_source_full_name);
-
-        for (export_id, output_idx) in exports {
-            let subsource_item = conn_catalog.get_item(&export_id);
-            let mut subsource_stmt =
-                mz_sql_parser::parser::parse_statements(subsource_item.create_sql())
-                    .expect("parsing persisted create_sql must succeed")
-                    .into_element()
-                    .ast;
-
-            match &mut subsource_stmt {
-                Statement::CreateSubsource(create_subsource_stmt) => {
-                    create_subsource_stmt.of_source =
-                        Some(RawItemName::Name(primary_source_name.clone()));
-
-                    create_subsource_stmt
-                        .with_options
-                        .retain(|o| o.name != CreateSubsourceOptionName::References);
-
-                    create_subsource_stmt
-                        .with_options
-                        .push(CreateSubsourceOption {
-                            name: CreateSubsourceOptionName::ExternalReference,
-                            value: Some(mz_sql::ast::WithOptionValue::UnresolvedItemName(
-                                // output indices are 1 greater than their table
-                                // index to account for the idiom of using 0 for
-                                // the primary source output.
-                                external_reference_tables[output_idx - 1].clone(),
-                            )),
-                        })
-                }
-                _ => unreachable!("subsource items must correlate to subsources"),
-            }
-
-            let mut subsource_item = source_map.remove(&export_id).expect("item exists");
-            subsource_item.create_sql = subsource_stmt.to_ast_string_stable();
-
-            let present = updated_items.insert(export_id, subsource_item);
-            assert_eq!(present, None, "each export only updated a single time");
-
-            if export_id < source.id() {
-                tracing::info!(
-                    "subsource {} has a GlobalId less than its primary source ({})",
-                    export_id,
-                    source.id()
-                );
-                needs_new_id.push(export_id);
-                source_ids_of_updated_subsources.insert(source.id());
-            }
-        }
-
-        // Update source definition to no longer include list of referenced
-        // subsources.
-        let primary_source_id = source.id();
-        let mut primary_source_item = source_map
-            .remove(&primary_source_id)
-            .expect("source exists");
-        let mut primary_source_stmt =
-            mz_sql_parser::parser::parse_statements(&primary_source_item.create_sql)
-                .expect("parsing persisted create_sql must succeed")
-                .into_element()
-                .ast;
-
-        match &mut primary_source_stmt {
-            Statement::CreateSource(create_source_stmt) => {
-                create_source_stmt.referenced_subsources = None;
-            }
-            _ => unreachable!("subsource items must correlate to subsources"),
-        }
-
-        primary_source_item.create_sql = primary_source_stmt.to_ast_string_stable();
-        let present = updated_items.insert(primary_source_id, primary_source_item);
-        assert_eq!(present, None, "each source only updated a single time");
-    }
-
-    tx.update_items(updated_items)?;
-
-    let mut remaining_updates = VecDeque::from_iter(needs_new_id.drain(..));
-
-    // If this item's ID must be moved forward, so too must every item that
-    // depends on it except for its primary source ID.
-    while let Some(id) = remaining_updates.pop_front() {
-        needs_new_id.push(id);
-        remaining_updates.extend(
-            conn_catalog
-                .state()
-                .get_entry(&id)
-                .used_by()
-                .iter()
-                .filter(|id| !source_ids_of_updated_subsources.contains(id))
-                .cloned(),
-        );
-    }
-
-    // Ensure that each ID is present only once and that it is in the greatest
-    // position.
-    let mut id_dedup = BTreeSet::new();
-    needs_new_id = needs_new_id
-        .into_iter()
-        .rev()
-        .filter(|id| id_dedup.insert(*id))
-        // Flip this back around in the right order.
-        .rev()
-        .collect();
-
-    assign_new_user_global_ids(tx, conn_catalog, now, needs_new_id)
 }
 
 /// Assigns new `GlobalId`s to the items in `needs_new_id`.
@@ -411,7 +175,7 @@ fn subsource_rewrite_v0_98(
 ///   `GlobalId`s they wish to reassign to `needs_new_id`.
 /// - Assumes all items in `needs_new_id` are present in `conn_catalog` and that
 ///   their types do not change.
-fn assign_new_user_global_ids(
+fn _assign_new_user_global_ids(
     tx: &mut Transaction<'_>,
     conn_catalog: &ConnCatalog,
     now: NowFn,
@@ -488,7 +252,7 @@ fn assign_new_user_global_ids(
 
         let object_type = entry.item_type().into();
 
-        add_to_audit_log(
+        _add_to_audit_log(
             tx,
             mz_audit_log::EventType::Create,
             object_type,
@@ -499,7 +263,7 @@ fn assign_new_user_global_ids(
             occurred_at,
         )?;
 
-        add_to_audit_log(
+        _add_to_audit_log(
             tx,
             mz_audit_log::EventType::Drop,
             object_type,
@@ -644,7 +408,7 @@ fn assign_new_user_global_ids(
 // Please include the adapter team on any code reviews that add or edit
 // migrations.
 
-fn add_to_audit_log(
+fn _add_to_audit_log(
     tx: &mut Transaction,
     event_type: mz_audit_log::EventType,
     object_type: mz_audit_log::ObjectType,

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -148,13 +148,12 @@ impl CatalogItemRebuilder {
         match self {
             Self::SystemSource(item) => item,
             Self::Object {
-                id,
+                id: _,
                 sql,
                 is_retained_metrics_object,
                 custom_logical_compaction_window,
             } => state
                 .parse_item(
-                    id,
                     &sql,
                     None,
                     is_retained_metrics_object,
@@ -490,7 +489,7 @@ impl Catalog {
                     let handle = mz_ore::task::spawn(
                         || "parse view",
                         async move {
-                            let res = task_state.parse_item(id, &create_sql, None, false, None);
+                            let res = task_state.parse_item(&create_sql, None, false, None);
                             (id, res)
                         }
                         .instrument(span),

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -911,7 +911,6 @@ impl CatalogState {
                         external_reference,
                     },
                     mz_sql::plan::DataSourceDesc::Progress => DataSourceDesc::Progress,
-                    mz_sql::plan::DataSourceDesc::Source => DataSourceDesc::Source,
                     mz_sql::plan::DataSourceDesc::Webhook {
                         validate_using,
                         body_format,
@@ -2422,7 +2421,6 @@ impl CatalogState {
                         .unwrap_or(source_cw);
                     cws.entry(cw).or_default().insert(id);
                 }
-                DataSourceDesc::Source => unreachable!(),
                 DataSourceDesc::Introspection(_)
                 | DataSourceDesc::Progress
                 | DataSourceDesc::Webhook { .. } => {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1886,8 +1886,6 @@ impl Coordinator {
                     },
                     Some(source_status_collection_id),
                 ),
-                // Subsources use source statuses.
-                DataSourceDesc::Source => unreachable!("cannot render legacy-style subsources"),
                 DataSourceDesc::Webhook { .. } => {
                     (DataSource::Webhook, Some(source_status_collection_id))
                 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1868,8 +1868,20 @@ impl Coordinator {
         let source_desc = |source: &Source| {
             let (data_source, status_collection_id) = match source.data_source.clone() {
                 // Re-announce the source description.
-                DataSourceDesc::Ingestion(ingestion) => {
-                    let ingestion = ingestion.into_inline_connection(catalog.state());
+                DataSourceDesc::Ingestion {
+                    ingestion_desc:
+                        mz_sql::plan::Ingestion {
+                            desc,
+                            progress_subsource,
+                        },
+                    cluster_id,
+                } => {
+                    let desc = desc.into_inline_connection(catalog.state());
+                    let ingestion = mz_storage_types::sources::IngestionDescription::new(
+                        desc,
+                        cluster_id,
+                        progress_subsource,
+                    );
 
                     (
                         DataSource::Ingestion(ingestion.clone()),

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -219,8 +219,10 @@ impl Coordinator {
                         }
                         CatalogItem::Source(source) => {
                             sources_to_drop.push(*id);
-                            if let DataSourceDesc::Ingestion(ingestion) = &source.data_source {
-                                match &ingestion.desc.connection {
+                            if let DataSourceDesc::Ingestion { ingestion_desc, .. } =
+                                &source.data_source
+                            {
+                                match &ingestion_desc.desc.connection {
                                     GenericSourceConnection::Postgres(conn) => {
                                         let conn = conn
                                             .clone()

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -452,9 +452,6 @@ impl Coordinator {
                             },
                             source_status_collection_id,
                         ),
-                        DataSourceDesc::Source => {
-                            unreachable!("cannot render legacy-style sources")
-                        }
                         DataSourceDesc::Progress => (DataSource::Progress, None),
                         DataSourceDesc::Webhook { .. } => {
                             if let Some(url) =

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -244,7 +244,7 @@ impl Coordinator {
                 }
             }
 
-            let source = Source::new(source_id, plan, resolved_ids, None, false);
+            let source = Source::new(plan, resolved_ids, None, false);
             ops.push(catalog::Op::CreateItem {
                 id: source_id,
                 name,
@@ -434,9 +434,21 @@ impl Coordinator {
                         ));
 
                     let (data_source, status_collection_id) = match source.data_source {
-                        DataSourceDesc::Ingestion(ingestion) => {
-                            let ingestion =
-                                ingestion.into_inline_connection(coord.catalog().state());
+                        DataSourceDesc::Ingestion {
+                            ingestion_desc:
+                                mz_sql::plan::Ingestion {
+                                    desc,
+                                    progress_subsource,
+                                },
+                            cluster_id,
+                        } => {
+                            let desc = desc.into_inline_connection(coord.catalog().state());
+                            let ingestion = mz_storage_types::sources::IngestionDescription::new(
+                                desc,
+                                cluster_id,
+                                progress_subsource,
+                            );
+
                             (
                                 DataSource::Ingestion(ingestion),
                                 source_status_collection_id,
@@ -3241,7 +3253,7 @@ impl Coordinator {
                     CatalogItemType::Connection => connections.push_back(*id),
                     CatalogItemType::Source => {
                         let desc = match &entry.source().expect("known to be source").data_source {
-                            DataSourceDesc::Ingestion(ingestion) => ingestion
+                            DataSourceDesc::Ingestion { ingestion_desc, .. } => ingestion_desc
                                 .desc
                                 .clone()
                                 .into_inline_connection(self.catalog().state()),
@@ -3501,7 +3513,6 @@ impl Coordinator {
                 // here requires mocking out objects in the catalog, which is a
                 // large task for an operation we have to cover in tests anyway.
                 let source = Source::new(
-                    id,
                     plan,
                     resolved_ids,
                     cur_source.custom_logical_compaction_window,
@@ -3512,7 +3523,7 @@ impl Coordinator {
 
                 // Get new ingestion description for storage.
                 let desc = match &source.data_source {
-                    DataSourceDesc::Ingestion(ingestion) => ingestion
+                    DataSourceDesc::Ingestion { ingestion_desc, .. } => ingestion_desc
                         .desc
                         .clone()
                         .into_inline_connection(self.catalog().state()),

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -295,7 +295,7 @@ impl<'a> DataflowBuilder<'a> {
         // TODO(petrosagg): store an inverse mapping of subsource -> source in the catalog so that
         // we can retrieve monotonicity information from the parent source.
         match &source.data_source {
-            DataSourceDesc::Ingestion(ingestion) => ingestion.desc.monotonic(),
+            DataSourceDesc::Ingestion { ingestion_desc, .. } => ingestion_desc.desc.monotonic(),
             DataSourceDesc::IngestionExport { .. }
             | DataSourceDesc::Introspection(_)
             | DataSourceDesc::Progress

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -299,8 +299,7 @@ impl<'a> DataflowBuilder<'a> {
             DataSourceDesc::IngestionExport { .. }
             | DataSourceDesc::Introspection(_)
             | DataSourceDesc::Progress
-            | DataSourceDesc::Webhook { .. }
-            | DataSourceDesc::Source => false,
+            | DataSourceDesc::Webhook { .. } => false,
         }
     }
 

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -404,7 +404,6 @@ pub struct Ingestion {
     pub remap_collection_id: GlobalId,
 }
 
-// TODO(#26768): do we need all of these `DataSourceDesc`s?
 #[derive(Debug, Clone, Serialize)]
 pub enum DataSourceDesc {
     /// Receives data from an external system

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1480,22 +1480,6 @@ impl CatalogEntry {
         }
     }
 
-    /// Returns the mapping of `GloablIds` to output indices for this source.
-    // TODO(#26764, #26769): this should no longer be used.
-    pub fn source_exports(&self) -> BTreeMap<GlobalId, usize> {
-        match &self.item() {
-            CatalogItem::Source(source) => match &source.data_source {
-                DataSourceDesc::Ingestion(ingestion) => ingestion
-                    .source_exports
-                    .iter()
-                    .map(|(id, export)| (*id, export.output_index))
-                    .collect(),
-                _ => BTreeMap::new(),
-            },
-            _ => BTreeMap::new(),
-        }
-    }
-
     /// Reports whether this catalog entry is a progress source.
     pub fn is_progress_source(&self) -> bool {
         self.item().is_progress_source()
@@ -2251,10 +2235,6 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
 
     fn subsource_details(&self) -> Option<(GlobalId, &UnresolvedItemName)> {
         self.subsource_details()
-    }
-
-    fn source_exports(&self) -> BTreeMap<GlobalId, usize> {
-        self.source_exports()
     }
 
     fn is_progress_source(&self) -> bool {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1086,6 +1086,7 @@ impl_display_t!(ReferencedSubsources);
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CreateSubsourceOptionName {
     Progress,
+    // TODO(delte)
     References,
     // Tracks which item this subsource references in the primary source.
     ExternalReference,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -973,7 +973,7 @@ pub struct CreateSourceStatement<T: AstInfo> {
     pub if_not_exists: bool,
     pub key_constraint: Option<KeyConstraint>,
     pub with_options: Vec<CreateSourceOption<T>>,
-    pub referenced_subsources: Option<ReferencedSubsources<T>>,
+    pub referenced_subsources: Option<ReferencedSubsources>,
     pub progress_subsource: Option<DeferredItemName<T>>,
 }
 
@@ -1037,12 +1037,12 @@ impl_display_t!(CreateSourceStatement);
 
 /// A selected subsource in a FOR TABLES (..) statement
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct CreateSourceSubsource<T: AstInfo> {
+pub struct CreateSourceSubsource {
     pub reference: UnresolvedItemName,
-    pub subsource: Option<DeferredItemName<T>>,
+    pub subsource: Option<UnresolvedItemName>,
 }
 
-impl<T: AstInfo> AstDisplay for CreateSourceSubsource<T> {
+impl AstDisplay for CreateSourceSubsource {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_node(&self.reference);
         if let Some(subsource) = &self.subsource {
@@ -1051,19 +1051,19 @@ impl<T: AstInfo> AstDisplay for CreateSourceSubsource<T> {
         }
     }
 }
-impl_display_t!(CreateSourceSubsource);
+impl_display!(CreateSourceSubsource);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum ReferencedSubsources<T: AstInfo> {
+pub enum ReferencedSubsources {
     /// A subset defined with FOR TABLES (...)
-    SubsetTables(Vec<CreateSourceSubsource<T>>),
+    SubsetTables(Vec<CreateSourceSubsource>),
     /// A subset defined with FOR SCHEMAS (...)
     SubsetSchemas(Vec<Ident>),
     /// FOR ALL TABLES
     All,
 }
 
-impl<T: AstInfo> AstDisplay for ReferencedSubsources<T> {
+impl AstDisplay for ReferencedSubsources {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Self::SubsetTables(subsources) => {
@@ -1080,7 +1080,7 @@ impl<T: AstInfo> AstDisplay for ReferencedSubsources<T> {
         }
     }
 }
-impl_display_t!(ReferencedSubsources);
+impl_display!(ReferencedSubsources);
 
 /// An option in a `CREATE SUBSOURCE` statement.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -2335,7 +2335,7 @@ pub enum AlterSourceAction<T: AstInfo> {
     SetOptions(Vec<CreateSourceOption<T>>),
     ResetOptions(Vec<CreateSourceOptionName>),
     AddSubsources {
-        subsources: Vec<CreateSourceSubsource<T>>,
+        subsources: Vec<CreateSourceSubsource>,
         options: Vec<AlterSourceAddSubsourceOption<T>>,
     },
     DropSubsources {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1086,8 +1086,6 @@ impl_display_t!(ReferencedSubsources);
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CreateSubsourceOptionName {
     Progress,
-    // TODO(delte)
-    References,
     // Tracks which item this subsource references in the primary source.
     ExternalReference,
 }
@@ -1097,9 +1095,6 @@ impl AstDisplay for CreateSubsourceOptionName {
         match self {
             CreateSubsourceOptionName::Progress => {
                 f.write_str("PROGRESS");
-            }
-            CreateSubsourceOptionName::References => {
-                f.write_str("REFERENCES");
             }
             CreateSubsourceOptionName::ExternalReference => {
                 f.write_str("EXTERNAL REFERENCE");
@@ -1116,9 +1111,9 @@ impl WithOptionName for CreateSubsourceOptionName {
     /// on the conservative side and return `true`.
     fn redact_value(&self) -> bool {
         match self {
-            CreateSubsourceOptionName::Progress
-            | CreateSubsourceOptionName::References
-            | CreateSubsourceOptionName::ExternalReference => false,
+            CreateSubsourceOptionName::Progress | CreateSubsourceOptionName::ExternalReference => {
+                false
+            }
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2618,7 +2618,7 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    /// Parse the name of a CREATE SINK optional parameter
+    /// Parse the name of a CREATE SUBSOURCE optional parameter
     fn parse_create_subsource_option_name(
         &mut self,
     ) -> Result<CreateSubsourceOptionName, ParserError> {
@@ -2633,7 +2633,7 @@ impl<'a> Parser<'a> {
         Ok(name)
     }
 
-    /// Parse a NAME = VALUE parameter for CREATE SINK
+    /// Parse a NAME = VALUE parameter for CREATE SUBSOURCE
     fn parse_create_subsource_option(&mut self) -> Result<CreateSubsourceOption<Raw>, ParserError> {
         Ok(CreateSubsourceOption {
             name: self.parse_create_subsource_option_name()?,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2622,13 +2622,12 @@ impl<'a> Parser<'a> {
     fn parse_create_subsource_option_name(
         &mut self,
     ) -> Result<CreateSubsourceOptionName, ParserError> {
-        let name = match self.expect_one_of_keywords(&[EXTERNAL, PROGRESS, REFERENCES])? {
+        let name = match self.expect_one_of_keywords(&[EXTERNAL, PROGRESS])? {
             EXTERNAL => {
                 self.expect_keyword(REFERENCE)?;
                 CreateSubsourceOptionName::ExternalReference
             }
             PROGRESS => CreateSubsourceOptionName::Progress,
-            REFERENCES => CreateSubsourceOptionName::References,
             _ => unreachable!(),
         };
         Ok(name)

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2725,10 +2725,10 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    fn parse_subsource_references(&mut self) -> Result<CreateSourceSubsource<Raw>, ParserError> {
+    fn parse_subsource_references(&mut self) -> Result<CreateSourceSubsource, ParserError> {
         let reference = self.parse_item_name()?;
         let subsource = if self.parse_one_of_keywords(&[AS, INTO]).is_some() {
-            Some(self.parse_deferred_item_name()?)
+            Some(self.parse_item_name()?)
         } else {
             None
         };

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -651,15 +651,15 @@ CREATE DATABASE IF NOT EXISTS db
 CreateDatabase(CreateDatabaseStatement { name: UnresolvedDatabaseName(Ident("db")), if_not_exists: true })
 
 parse-statement
-CREATE SUBSOURCE IF NOT EXISTS source.sub (a int, b text) WITH (PROGRESS, REFERENCES)
+CREATE SUBSOURCE IF NOT EXISTS source.sub (a int, b text) WITH (PROGRESS)
 ----
-CREATE SUBSOURCE IF NOT EXISTS source.sub (a int4, b text) WITH (PROGRESS, REFERENCES)
+CREATE SUBSOURCE IF NOT EXISTS source.sub (a int4, b text) WITH (PROGRESS)
 =>
-CreateSubsource(CreateSubsourceStatement { name: UnresolvedItemName([Ident("source"), Ident("sub")]), columns: [ColumnDef { name: Ident("a"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("b"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }], of_source: None, constraints: [], if_not_exists: true, with_options: [CreateSubsourceOption { name: Progress, value: None }, CreateSubsourceOption { name: References, value: None }] })
+CreateSubsource(CreateSubsourceStatement { name: UnresolvedItemName([Ident("source"), Ident("sub")]), columns: [ColumnDef { name: Ident("a"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("b"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }], of_source: None, constraints: [], if_not_exists: true, with_options: [CreateSubsourceOption { name: Progress, value: None }] })
 
 parse-statement
-CREATE SUBSOURCE IF NOT EXISTS source.sub (a int, b text) OF SOURCE primary WITH (PROGRESS, REFERENCES, EXTERNAL REFERENCE = "a"."b"."c")
+CREATE SUBSOURCE IF NOT EXISTS source.sub (a int, b text) OF SOURCE primary WITH (PROGRESS, EXTERNAL REFERENCE = "a"."b"."c")
 ----
-CREATE SUBSOURCE IF NOT EXISTS source.sub (a int4, b text) OF SOURCE primary WITH (PROGRESS, REFERENCES, EXTERNAL REFERENCE = a.b.c)
+CREATE SUBSOURCE IF NOT EXISTS source.sub (a int4, b text) OF SOURCE primary WITH (PROGRESS, EXTERNAL REFERENCE = a.b.c)
 =>
-CreateSubsource(CreateSubsourceStatement { name: UnresolvedItemName([Ident("source"), Ident("sub")]), columns: [ColumnDef { name: Ident("a"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("b"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }], of_source: Some(Name(UnresolvedItemName([Ident("primary")]))), constraints: [], if_not_exists: true, with_options: [CreateSubsourceOption { name: Progress, value: None }, CreateSubsourceOption { name: References, value: None }, CreateSubsourceOption { name: ExternalReference, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]))) }] })
+CreateSubsource(CreateSubsourceStatement { name: UnresolvedItemName([Ident("source"), Ident("sub")]), columns: [ColumnDef { name: Ident("a"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("b"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }], of_source: Some(Name(UnresolvedItemName([Ident("primary")]))), constraints: [], if_not_exists: true, with_options: [CreateSubsourceOption { name: Progress, value: None }, CreateSubsourceOption { name: ExternalReference, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]))) }] })

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -496,7 +496,7 @@ CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES (foo, bar as 
 ----
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES (foo, bar AS qux, baz AS zop)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(SubsetTables([CreateSourceSubsource { reference: UnresolvedItemName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("bar")]), subsource: Some(Deferred(UnresolvedItemName([Ident("qux")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(Deferred(UnresolvedItemName([Ident("zop")]))) }])), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(SubsetTables([CreateSourceSubsource { reference: UnresolvedItemName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("bar")]), subsource: Some(UnresolvedItemName([Ident("qux")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(UnresolvedItemName([Ident("zop")])) }])), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES ([s1 AS foo.bar]);
@@ -1327,35 +1327,35 @@ ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(Deferred(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")]))) }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(Deferred(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a, b.c, c, d.e
@@ -1377,35 +1377,35 @@ ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(Deferred(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")]))) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(Deferred(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(Deferred(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")]))) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a, b.c, c, d.e WITH (TEXT COLUMNS [a.b, c.d])
@@ -1433,7 +1433,7 @@ ALTER SOURCE IF EXISTS n ADD TABLE a, b.c AS d
 ----
 ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c AS d
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("b"), Ident("c")]), subsource: Some(Deferred(UnresolvedItemName([Ident("d")]))) }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("b"), Ident("c")]), subsource: Some(UnresolvedItemName([Ident("d")])) }], options: [] } })
 
 parse-statement
 ALTER SOURCE IF EXISTS n ADD SOURCE a, b.c AS d
@@ -2597,7 +2597,7 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FO
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR TABLES (foo, bar AS qux, baz AS zop)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(SubsetTables([CreateSourceSubsource { reference: UnresolvedItemName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("bar")]), subsource: Some(Deferred(UnresolvedItemName([Ident("qux")]))) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(Deferred(UnresolvedItemName([Ident("zop")]))) }])), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(SubsetTables([CreateSourceSubsource { reference: UnresolvedItemName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("bar")]), subsource: Some(UnresolvedItemName([Ident("qux")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(UnresolvedItemName([Ident("zop")])) }])), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar]);
@@ -2609,9 +2609,9 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FO
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES (baz AS [s1 AS foo.bar]);
 ----
-CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR TABLES (baz AS [s1 AS foo.bar])
-=>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(SubsetTables([CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(Named(Id("s1", UnresolvedItemName([Ident("foo"), Ident("bar")])))) }])), progress_subsource: None })
+error: Expected identifier, found left square bracket
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES (baz AS [s1 AS foo.bar]);
+                                                                                                 ^
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar] AS baz);

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -618,10 +618,6 @@ pub trait CatalogItem {
     /// ingestion it is a subsource of, as well as the item it exports.
     fn subsource_details(&self) -> Option<(GlobalId, &UnresolvedItemName)>;
 
-    /// Returns the mapping of `GloablIds` to output indices for this source.
-    // TODO(#26764, #26769): this should no longer be used.
-    fn source_exports(&self) -> BTreeMap<GlobalId, usize>;
-
     /// Reports whether this catalog item is a progress source.
     fn is_progress_source(&self) -> bool;
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1271,9 +1271,6 @@ pub enum DataSourceDesc {
         ingestion_id: GlobalId,
         external_reference: UnresolvedItemName,
     },
-    /// Receives data from some other source.
-    // TODO(#26764): delete
-    Source,
     /// Receives data from the source's reclocking/remapping operations.
     Progress,
     /// Receives data from HTTP post requests.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1281,10 +1281,9 @@ pub enum DataSourceDesc {
     },
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Ingestion {
     pub desc: SourceDesc<ReferencedConnection>,
-    pub subsource_exports: BTreeMap<GlobalId, usize>,
     pub progress_subsource: GlobalId,
 }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1260,7 +1260,6 @@ pub struct Source {
     pub compaction_window: Option<CompactionWindow>,
 }
 
-// TODO(#26768): do we need all of these `DataSourceDesc`s?
 #[derive(Debug, Clone)]
 pub enum DataSourceDesc {
     /// Receives data from an external system.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1493,7 +1493,6 @@ pub fn plan_create_source(
 generate_extracted_config!(
     CreateSubsourceOption,
     (Progress, bool, Default(false)),
-    (References, bool, Default(false)),
     (ExternalReference, UnresolvedItemName)
 );
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1373,7 +1373,6 @@ pub fn plan_create_source(
         create_sql,
         data_source: DataSourceDesc::Ingestion(Ingestion {
             desc: source_desc,
-            subsource_exports: BTreeMap::new(),
             progress_subsource,
         }),
         desc,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -64,9 +64,9 @@ use mz_sql_parser::ast::{
     IfExistsBehavior, IndexOption, IndexOptionName, KafkaSinkConfigOption, KeyConstraint,
     LoadGeneratorOption, LoadGeneratorOptionName, MaterializedViewOption,
     MaterializedViewOptionName, MySqlConfigOption, MySqlConfigOptionName, PgConfigOption,
-    PgConfigOptionName, ProtobufSchema, QualifiedReplica, ReferencedSubsources,
-    RefreshAtOptionValue, RefreshEveryOptionValue, RefreshOptionValue, ReplicaDefinition,
-    ReplicaOption, ReplicaOptionName, RoleAttribute, SetRoleVar, SourceIncludeMetadata, Statement,
+    PgConfigOptionName, ProtobufSchema, QualifiedReplica, RefreshAtOptionValue,
+    RefreshEveryOptionValue, RefreshOptionValue, ReplicaDefinition, ReplicaOption,
+    ReplicaOptionName, RoleAttribute, SetRoleVar, SourceIncludeMetadata, Statement,
     TableConstraint, TableOption, TableOptionName, UnresolvedDatabaseName, UnresolvedItemName,
     UnresolvedObjectName, UnresolvedSchemaName, Value, ViewDefinition, WithOptionValue,
 };
@@ -614,6 +614,11 @@ pub fn plan_create_source(
         progress_subsource,
     } = &stmt;
 
+    mz_ore::soft_assert_or_log!(
+        referenced_subsources.is_none(),
+        "referenced subsources must be cleared in purification"
+    );
+
     let envelope = envelope.clone().unwrap_or(ast::SourceEnvelope::None);
 
     let allowed_with_options = vec![
@@ -650,7 +655,7 @@ pub fn plan_create_source(
         bail_unsupported!("INCLUDE metadata with non-Kafka sources");
     }
 
-    let (external_connection, available_subsources) = match connection {
+    let external_connection = match connection {
         CreateSourceConnection::Kafka {
             connection: connection_name,
             options,
@@ -765,9 +770,7 @@ pub fn plan_create_source(
                 metadata_columns,
             };
 
-            let connection = GenericSourceConnection::Kafka(connection);
-
-            (connection, None)
+            GenericSourceConnection::Kafka(connection)
         }
         CreateSourceConnection::Postgres {
             connection,
@@ -836,9 +839,6 @@ pub fn plan_create_source(
                     .or_default()
                     .insert(col);
             }
-
-            // Register the available subsources
-            let mut available_subsources = BTreeMap::new();
 
             // Here we will generate the cast expressions required to convert the text encoded
             // columns into the appropriate target types, creating a Vec<MirScalarExpr> per table.
@@ -995,17 +995,6 @@ pub fn plan_create_source(
                 }
                 let r = table_casts.insert(i + 1, column_casts);
                 assert!(r.is_none(), "cannot have table defined multiple times");
-
-                let name = FullItemName {
-                    database: RawDatabaseSpecifier::Name(connection.database.clone()),
-                    schema: table.namespace.clone(),
-                    item: table.name.clone(),
-                };
-
-                // The zero-th output is the main output
-                // TODO(petrosagg): these plus ones are an accident waiting to happen. Find a way
-                // to handle the main source and the subsources uniformly
-                available_subsources.insert(name, i + 1);
             }
 
             let publication_details = PostgresSourcePublicationDetails::from_proto(details)
@@ -1020,7 +1009,7 @@ pub fn plan_create_source(
                     publication_details,
                 });
 
-            (connection, Some(available_subsources))
+            connection
         }
         CreateSourceConnection::MySql {
             connection,
@@ -1049,25 +1038,6 @@ pub fn plan_create_source(
                 ProtoMySqlSourceDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
             let details = MySqlSourceDetails::from_proto(details).map_err(|e| sql_err!("{}", e))?;
 
-            let mut available_subsources = BTreeMap::new();
-
-            for (index, table) in details.tables.iter().enumerate() {
-                let name = FullItemName {
-                    // In MySQL we use 'mysql' as the default database name
-                    // since there is no concept of a 'database' in MySQL
-                    // (schemas and databases are the same thing)
-                    //
-                    //TODO(#26764, #26772): remove this.
-                    database: RawDatabaseSpecifier::Name("mysql".to_string()),
-                    schema: table.schema_name.clone(),
-                    item: table.name.clone(),
-                };
-                // The zero-th output is the main output
-                // TODO(petrosagg): these plus ones are an accident waiting to happen. Find a way
-                // to handle the main source and the subsources uniformly
-                available_subsources.insert(name, index + 1);
-            }
-
             let text_columns = text_columns
                 .into_iter()
                 .map(|name| name.try_into().map_err(|e| sql_err!("{}", e)))
@@ -1086,13 +1056,11 @@ pub fn plan_create_source(
                     ignore_columns,
                 });
 
-            (connection, Some(available_subsources))
+            connection
         }
         CreateSourceConnection::LoadGenerator { generator, options } => {
-            let (load_generator, available_subsources) =
+            let (load_generator, _available_subsources) =
                 load_generator_ast_to_generator(scx, generator, options, include_metadata)?;
-            let available_subsources = available_subsources
-                .map(|a| BTreeMap::from_iter(a.into_iter().map(|(k, v)| (k, v.0))));
 
             let LoadGeneratorOptionExtracted { tick_interval, .. } = options.clone().try_into()?;
             let tick_micros = match tick_interval {
@@ -1105,78 +1073,9 @@ pub fn plan_create_source(
                 tick_micros,
             });
 
-            (connection, available_subsources)
+            connection
         }
     };
-
-    // TODO(#26764): enable this assert
-    //
-    // mz_ore::soft_assert_or_log!( referenced_subsources.is_none(), "referenced
-    //     subsources must be cleared in purification" );
-    //
-    // TODO(#26764): remove available_subsources, requested_subsources--this
-    // will be handled in purification only.
-    let (available_subsources, requested_subsources) = match (available_subsources, referenced_subsources) {
-            (Some(available_subsources), Some(ReferencedSubsources::SubsetTables(subsources))) => {
-                let mut requested_subsources = vec![];
-                for subsource in subsources {
-                    let name = subsource.reference.clone();
-
-                    let target = match &subsource.subsource {
-                        // migration: this only needs to be supported for one
-                        // version to allow booting old-style subsources.
-                        None => continue,
-                        Some(DeferredItemName::Named(target)) => target.clone(),
-                        _ => {
-                            sql_bail!(
-                                "[internal error] subsources must be named during purification"
-                            )
-                        }
-                    };
-
-                    requested_subsources.push((name, target));
-                }
-                (available_subsources, requested_subsources)
-            }
-            // Some(_), None indicates that this is a new-style source that
-            // doesn't track its subsources directly.
-            (Some(_), None)
-            // `(None, None)` indicates that this a non-subsource bearing
-            // source.
-            | (None, None) => (BTreeMap::new(), vec![]),
-            (None, Some(_))
-            | (Some(_), Some(ReferencedSubsources::All | ReferencedSubsources::SubsetSchemas(_))) =>
-            {
-                sql_bail!("[internal error] subsources should be resolved during purification")
-            }
-        };
-
-    // TODO(#26764): remove this code; subsource exports will no longer be
-    // tracked by planning.
-    let mut subsource_exports = BTreeMap::new();
-    for (name, target) in requested_subsources {
-        let name = normalize::full_name(name)?;
-        let idx = match available_subsources.get(&name) {
-            Some(idx) => idx,
-            None => sql_bail!("Requested non-existent subtable: {name}"),
-        };
-
-        let target_id = match target {
-            ResolvedItemName::Item { id, .. } => id,
-            ResolvedItemName::Cte { .. } | ResolvedItemName::Error => {
-                sql_bail!("[internal error] invalid target id")
-            }
-        };
-
-        // TODO(petrosagg): This is the point where we would normally look into the catalog for the
-        // item with ID `target` and verify that its RelationDesc is identical to the type of the
-        // dataflow output. We can't do that here however because the subsources are created in the
-        // same transaction as this source and they are not yet in the catalog. In the future, when
-        // provisional catalogs are made available to the planner we could do the check. For now
-        // we don't allow users to manually target subsources and rely on purification generating
-        // correct definitions.
-        subsource_exports.insert(target_id, *idx);
-    }
 
     let CreateSourceOptionExtracted {
         timeline,
@@ -1474,7 +1373,7 @@ pub fn plan_create_source(
         create_sql,
         data_source: DataSourceDesc::Ingestion(Ingestion {
             desc: source_desc,
-            subsource_exports,
+            subsource_exports: BTreeMap::new(),
             progress_subsource,
         }),
         desc,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1512,7 +1512,6 @@ pub fn plan_create_subsource(
 
     let CreateSubsourceOptionExtracted {
         progress,
-        references,
         external_reference,
         ..
     } = with_options.clone().try_into()?;
@@ -1522,7 +1521,7 @@ pub fn plan_create_subsource(
     // statements, so this would fire in integration testing if we failed to
     // uphold it.
     assert!(
-        (progress ^ references) ^ (external_reference.is_some() && of_source.is_some()),
+        progress ^ (external_reference.is_some() && of_source.is_some()),
         "CREATE SUBSOURCE statement must specify either PROGRESS or REFERENCES option"
     );
 
@@ -1636,9 +1635,6 @@ pub fn plan_create_subsource(
         }
     } else if progress {
         DataSourceDesc::Progress
-    } else if references {
-        // This is a legacy subsource with the inverted dependency structure.
-        DataSourceDesc::Source
     } else {
         panic!("subsources must specify one of `external_reference`, `progress`, or `references`")
     };

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -88,7 +88,7 @@ pub(crate) struct RequestedSubsource<'a, T> {
 }
 
 fn subsource_gen<'a, T>(
-    selected_subsources: &mut Vec<CreateSourceSubsource<Aug>>,
+    selected_subsources: &mut Vec<CreateSourceSubsource>,
     catalog: &SubsourceCatalog<&'a T>,
     source_name: &UnresolvedItemName,
 ) -> Result<Vec<RequestedSubsource<'a, T>>, PlanError> {
@@ -96,20 +96,15 @@ fn subsource_gen<'a, T>(
 
     for subsource in selected_subsources {
         let subsource_name = match &subsource.subsource {
-            Some(name) => match name {
-                DeferredItemName::Deferred(name) => {
-                    let partial = normalize::unresolved_item_name(name.clone())?;
-                    match partial.schema {
-                        Some(_) => name.clone(),
-                        // In cases when a prefix is not provided for the deferred name
-                        // fallback to using the schema of the source with the given name
-                        None => subsource_name_gen(source_name, &partial.item)?,
-                    }
+            Some(name) => {
+                let partial = normalize::unresolved_item_name(name.clone())?;
+                match partial.schema {
+                    Some(_) => name.clone(),
+                    // In cases when a prefix is not provided for the deferred name
+                    // fallback to using the schema of the source with the given name
+                    None => subsource_name_gen(source_name, &partial.item)?,
                 }
-                DeferredItemName::Named(..) => {
-                    unreachable!("already errored on this condition")
-                }
-            },
+            }
             None => {
                 // Use the entered name as the upstream reference, and then use
                 // the item as the subsource name to ensure it's created in the
@@ -132,16 +127,6 @@ fn subsource_gen<'a, T>(
     }
 
     Ok(validated_requested_subsources)
-}
-
-// Convenience function to ensure subsources are not named.
-fn named_subsource_err(name: &Option<DeferredItemName<Aug>>) -> Result<(), PlanError> {
-    match name {
-        Some(DeferredItemName::Named(_)) => {
-            sql_bail!("Cannot manually ID qualify subsources")
-        }
-        _ => Ok(()),
-    }
 }
 
 /// Generates a subsource name by prepending source schema name if present
@@ -512,17 +497,8 @@ async fn purify_create_source(
         ..
     } = &mut create_source_stmt;
 
-    // Disallow manually targetting subsources, this syntax is reserved for purification only
-    named_subsource_err(progress_subsource)?;
-
-    if let Some(ReferencedSubsources::SubsetTables(subsources)) = referenced_subsources {
-        for CreateSourceSubsource {
-            subsource,
-            reference: _,
-        } in subsources
-        {
-            named_subsource_err(subsource)?;
-        }
+    if let Some(DeferredItemName::Named(_)) = progress_subsource {
+        sql_bail!("Cannot manually ID qualify progress subsource")
     }
 
     let mut create_subsource_stmts = vec![];
@@ -1367,14 +1343,6 @@ async fn purify_alter_source(
         ..
     } = options.clone().try_into()?;
     assert!(details.is_none(), "details cannot be explicitly set");
-
-    for CreateSourceSubsource {
-        subsource,
-        reference: _,
-    } in targeted_subsources.iter()
-    {
-        named_subsource_err(subsource)?;
-    }
 
     // Get PostgresConnection for generating subsources.
     let pg_connection = &pg_source_connection.connection;

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -16,7 +16,6 @@ use mz_sql_parser::ast::{ReferencedSubsources, UnresolvedItemName};
 use mz_storage_types::errors::{ContextCreationError, CsrConnectError};
 
 use crate::names::{FullItemName, PartialItemName};
-use crate::pure::Aug;
 
 /// Logical errors detectable during purification for a POSTGRES SOURCE.
 #[derive(Debug, Clone, thiserror::Error)]
@@ -129,7 +128,7 @@ impl PgSourcePurificationError {
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum KafkaSourcePurificationError {
     #[error("{} is only valid for multi-output sources", .0.to_ast_string())]
-    ReferencedSubsources(ReferencedSubsources<Aug>),
+    ReferencedSubsources(ReferencedSubsources),
     #[error("KAFKA CONNECTION without TOPIC")]
     ConnectionMissingTopic,
     #[error("{0} is not a KAFKA CONNECTION")]

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -100,12 +100,6 @@ pub struct IngestionDescription<S: 'static = (), C: ConnectionAccess = InlinedCo
     ///   in its own field.
     /// - This field should not be populated by the storage controller in
     ///   response to collections being created.
-    // TODO(#26764, #26769): after implementing subsource dependency inversion,
-    // we should consider creating a version of this struct in planning without
-    // `source_exports`; right now that field is always empty in the catalog's
-    // version of the source and it misleadingly looks like it might have the
-    // actual exports in it. However, this cannot be removed until after the
-    // migration.
     #[proptest(
         strategy = "proptest::collection::btree_map(any::<GlobalId>(), any::<SourceExport<S>>(), 0..4)"
     )]
@@ -114,6 +108,22 @@ pub struct IngestionDescription<S: 'static = (), C: ConnectionAccess = InlinedCo
     pub instance_id: StorageInstanceId,
     /// The ID of this ingestion's remap/progress collection.
     pub remap_collection_id: GlobalId,
+}
+
+impl IngestionDescription {
+    pub fn new(
+        desc: SourceDesc,
+        instance_id: StorageInstanceId,
+        remap_collection_id: GlobalId,
+    ) -> Self {
+        Self {
+            desc,
+            ingestion_metadata: (),
+            source_exports: BTreeMap::new(),
+            instance_id,
+            remap_collection_id,
+        }
+    }
 }
 
 impl<S> IngestionDescription<S> {

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -256,11 +256,7 @@ pub struct MySqlSourceDetails {
 impl MySqlSourceDetails {
     pub fn output_idx_for_name(&self, name: &UnresolvedItemName) -> Option<usize> {
         let (schema_name, name) = match &name.0[..] {
-            // TODO(#26772): remove this inserted database name that doesn't refer to
-            // anything meaningful.
-            [database, schema_name, name] if database.as_str() == "mysql" => {
-                (schema_name.as_str(), name.as_str())
-            }
+            [schema_name, name] => (schema_name.as_str(), name.as_str()),
             _ => return None,
         };
 

--- a/test/mysql-cdc/subsource-resolution-duplicates.td
+++ b/test/mysql-cdc/subsource-resolution-duplicates.td
@@ -39,12 +39,12 @@ INSERT INTO other.t VALUES (1);
   FROM MYSQL CONNECTION mysql_conn
   FOR ALL TABLES;
 contains:multiple subsources would be named t
-detail:referenced tables with duplicate name: mysql.other.t, mysql.public.t
+detail:referenced tables with duplicate name: other.t, public.t
 
 ! CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_conn
   FOR TABLES (public.t AS x, public.t as Y);
-contains:multiple subsources refer to table mysql.public.t
+contains:multiple subsources refer to table public.t
 detail: subsources referencing table: x, y
 
 > CREATE SOURCE mz_source


### PR DESCRIPTION
Fixes #26764, #26769, #26772, #26768

### Motivation

 This PR refactors existing code.

### Tips for reviewer

The code touched is very disparate, probably go commit-by-commit and look for the crates that interest you.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
