### PR TITLE
tests: parallel workload: add ignore

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -374,6 +374,7 @@ class CopyToS3Action(Action):
                 'is not allowed from the "mz_introspection" cluster',
                 "copy has been terminated because underlying relation",
                 "Relation contains unimplemented arrow types",
+                "Cannot encode the following columns/types",
             ]
         )
         if exe.db.complexity == Complexity.DDL:


### PR DESCRIPTION
This addresses failures in the parallel workload tests like, for example, in https://buildkite.com/materialize/nightly/builds/7572#018f29a2-0c37-43c4-887e-d711b629f08a.

Nightly: https://buildkite.com/materialize/nightly/builds/7573