### PR TITLE
Refactor delta joins to demote demuxing

### DIFF
--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -1255,16 +1255,22 @@ impl DeltaPathPlan {
             writeln!(f, "{}initial_closure", ctx.indent)?;
             ctx.indented(|ctx| plan.initial_closure.fmt_text(f, ctx))?;
         }
-        {
-            let source_relation = &plan.source_relation;
-            let source_key = mode.seq(&plan.source_key, None);
-            let source_key = CompactScalars(source_key);
-            writeln!(
+        match &plan.source_key {
+            Some(source_key) => {
+                let source_key = mode.seq(source_key, None);
+                let source_key = CompactScalars(source_key);
+                writeln!(
+                    f,
+                    "{}source={{ relation={}, key=[{}] }}",
+                    ctx.indent, &plan.source_relation, source_key
+                )?
+            }
+            None => writeln!(
                 f,
-                "{}source={{ relation={}, key=[{}] }}",
-                ctx.indent, source_relation, source_key
-            )?;
-        }
+                "{}source={{ relation={}, key=[] }}",
+                ctx.indent, &plan.source_relation
+            )?,
+        };
         Ok(())
     }
 }

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -519,6 +519,98 @@ impl<T: timely::progress::Timestamp> Plan<T> {
 
             let config = TransformConfig { monotonic_ids };
             Self::refine_single_time_consolidation(&mut dataflow, &config)?;
+
+            // For delta join plans, not in WMR blocks, remove all but the first join path.
+            // In addition, remove any arrangement on the first input, as it no longer needs
+            // to support the other paths. In removing the arrangement, we'll need to unset
+            // the source key (to `None`, indicating a streamed collection), and also update
+            // the initial join closure, as the column layout will now be different.
+            for build_desc in dataflow.objects_to_build.iter_mut() {
+                // Worklist, populated by non-WMR children.
+                let mut todo = vec![&mut build_desc.plan];
+                while let Some(expr) = todo.pop() {
+                    match &mut expr.node {
+                        // TODO: also handle binary differential joins, as they too
+                        // have the potential to remove bespoke arrangements.
+                        PlanNode::Join {
+                            inputs,
+                            plan: JoinPlan::Delta(plan),
+                            ..
+                        } => {
+                            // Always truncate the paths that we will not hydrate.
+                            plan.path_plans.truncate(1);
+                            // We now have fewer obligations to arrange the first input.
+                            // Only `source_key` of the first plan, which we can helpfully
+                            // remove if the arrangement by that key is bespoke.
+                            if let Some(source_key) = &plan.path_plans[0].source_key {
+                                if let PlanNode::ArrangeBy { forms, .. } = &mut inputs[0].node {
+                                    // Discard arrangement forms other than the source key.
+                                    forms.arranged.retain(|af| &af.0 == source_key);
+                                    // We do not need to retain the remaining forms, but the
+                                    // presence of a form does signal (though not guarantee)
+                                    // that `Input` is not yet arranged by `source_key`, and
+                                    // we might improve things by making a collection of it.
+                                    // If there *is* a pre-existing form, ideally we already
+                                    // use it, and won't fix that here.
+                                    if let Some((key, map, thin)) = forms.arranged.pop() {
+                                        forms.raw = true;
+                                        plan.path_plans[0].source_key = None;
+                                        // TODO: Update `initial_closure` to reference columns
+                                        // of the raw collection, rather than arranged columns.
+                                        // The initial closure expects access to key columns,
+                                        // which are arbitrary expressions, and to "thinned"
+                                        // columns that are base columns.
+                                        // Step 1: Update ready equivalences.
+                                        for class in plan.path_plans[0]
+                                            .initial_closure
+                                            .ready_equivalences
+                                            .iter_mut()
+                                        {
+                                            for expr in class.iter_mut() {
+                                                let mut todo = vec![expr];
+                                                while let Some(expr) = todo.pop() {
+                                                    if let MirScalarExpr::Column(c, _) = expr {
+                                                        if let Some(e) = key.get(*c) {
+                                                            *expr = e.clone()
+                                                        } else {
+                                                            *c = thin[*c - key.len()];
+                                                        }
+                                                    } else {
+                                                        todo.extend(expr.children_mut());
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        // Step 2: Update before MFP.
+                                        let (m, f, p) = plan.path_plans[0]
+                                            .initial_closure
+                                            .before
+                                            .as_map_filter_project();
+                                        let mfp = MapFilterProject::new(map.len())
+                                            .map(key)
+                                            .project((0..map.len()).chain(thin))
+                                            .map(m)
+                                            .filter(f)
+                                            .project(p);
+                                        let safe_mfp =
+                                            mfp.into_plan().unwrap().into_nontemporal().unwrap();
+                                        plan.path_plans[0].initial_closure.before = safe_mfp;
+
+                                        forms.arranged.clear();
+                                    }
+                                }
+                            }
+                            todo.extend(inputs.iter_mut());
+                        }
+                        PlanNode::LetRec { body, .. } => {
+                            todo.push(body);
+                        }
+                        x => {
+                            todo.extend(x.children_mut());
+                        }
+                    }
+                }
+            }
         }
 
         soft_assert_eq_no_log!(dataflow.check_invariants(), Ok(()));

--- a/src/compute-types/src/plan/join/delta_join.rs
+++ b/src/compute-types/src/plan/join/delta_join.rs
@@ -47,7 +47,7 @@ pub struct DeltaPathPlan {
     /// The relation whose updates seed the dataflow path.
     pub source_relation: usize,
     /// The key we expect the source relation to be arranged by.
-    pub source_key: Vec<MirScalarExpr>,
+    pub source_key: Option<Vec<MirScalarExpr>>,
     /// An initial closure to apply before any stages.
     pub initial_closure: JoinClosure,
     /// A *sequence* of stages to apply one after the other.
@@ -236,7 +236,7 @@ impl DeltaJoinPlan {
                 initial_closure,
                 stage_plans,
                 final_closure,
-                source_key: source_key.to_vec(),
+                source_key: Some(source_key.to_vec()),
             });
         }
 

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -13,8 +13,6 @@
 
 #![allow(clippy::op_ref)]
 
-use std::collections::{BTreeMap, BTreeSet};
-
 use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
@@ -58,56 +56,17 @@ where
             // Collects error streams for the ambient scope.
             let mut inner_errs = Vec::new();
 
-            // Deduplicate the error streams of multiply used arrangements.
-            let mut err_dedup = BTreeSet::new();
-
             // Our plan is to iterate through each input relation, and attempt
             // to find a plan that maximally uses existing keys (better: uses
             // existing arrangements, to which we have access).
             let mut join_results = Vec::new();
 
-            // First let's prepare the input arrangements we will need.
-            // This reduces redundant imports, and simplifies the dataflow structure.
-            // As the arrangements are all shared, it should not dramatically improve
-            // the efficiency, but the dataflow simplification is worth doing.
-            let mut arrangements = BTreeMap::new();
-            for path_plan in join_plan.path_plans.iter() {
-                for stage_plan in path_plan.stage_plans.iter() {
-                    let lookup_idx = stage_plan.lookup_relation;
-                    let lookup_key = stage_plan.lookup_key.clone();
-                    arrangements
-                        .entry((lookup_idx, lookup_key.clone()))
-                        .or_insert_with(|| {
-                            match inputs[lookup_idx]
-                                .arrangement(&lookup_key)
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "Arrangement alarmingly absent!: {}, {:?}",
-                                        lookup_idx, lookup_key,
-                                    )
-                                }) {
-                                ArrangementFlavor::Local(oks, errs) => {
-                                    if err_dedup.insert((lookup_idx, lookup_key)) {
-                                        inner_errs.push(
-                                            errs.enter_region(inner)
-                                                .as_collection(|k, _v| k.clone()),
-                                        );
-                                    }
-                                    Ok(oks.enter_region(inner))
-                                }
-                                ArrangementFlavor::Trace(_gid, oks, errs) => {
-                                    if err_dedup.insert((lookup_idx, lookup_key)) {
-                                        inner_errs.push(
-                                            errs.enter_region(inner)
-                                                .as_collection(|k, _v| k.clone()),
-                                        );
-                                    }
-                                    Err(oks.enter_region(inner))
-                                }
-                            }
-                        });
-                }
-            }
+            // Bring all collection bundles into the `inner` region.
+            // TODO: Prune unused collections and arrangements, for clarity.
+            let inputs = inputs
+                .into_iter()
+                .map(|cb| cb.enter_region(inner))
+                .collect::<Vec<_>>();
 
             for path_plan in join_plan.path_plans {
                 // Deconstruct the stages of the path plan.
@@ -137,40 +96,25 @@ where
                     // available information to determine the filtering and logic that we can apply, and
                     // introduce that in to the `lookup` logic to cause it to happen in that operator.
 
+                    let bundles = inputs
+                        .iter()
+                        .map(|cb| cb.enter_region(region))
+                        .collect::<Vec<_>>();
+
                     // Collects error streams for the region scope. Concats before leaving.
                     let mut region_errs = Vec::with_capacity(inputs.len());
 
-                    // Ensure this input is rendered, and extract its update stream.
-                    let val = arrangements
-                        .get(&(source_relation, source_key))
-                        .expect("Arrangement promised by the planner is absent!");
-                    let as_of = self.as_of_frontier.clone();
-                    let update_stream = match val {
-                        Ok(local) => {
-                            let arranged = local.clone().enter_region(region);
-                            let (update_stream, err_stream) =
-                                build_update_stream::<_, RowRowAgent<_, _>>(
-                                    arranged,
-                                    as_of,
-                                    source_relation,
-                                    initial_closure,
-                                );
-                            region_errs.push(err_stream);
-                            update_stream
-                        }
-                        Err(trace) => {
-                            let arranged = trace.clone().enter_region(region);
-                            let (update_stream, err_stream) =
-                                build_update_stream::<_, RowRowEnter<_, _, _>>(
-                                    arranged,
-                                    as_of,
-                                    source_relation,
-                                    initial_closure,
-                                );
-                            region_errs.push(err_stream);
-                            update_stream
-                        }
-                    };
+                    // Form the initial stream of updates that will hydrate the delta path.
+                    let (update_stream, err_stream) = build_update_stream(
+                        &bundles[source_relation],
+                        self.as_of_frontier.clone(),
+                        Some(source_key),
+                        source_relation,
+                        initial_closure,
+                    );
+
+                    region_errs.push(err_stream);
+
                     // Promote `time` to a datum element.
                     //
                     // The `half_join` operator manipulates as "data" a pair `(data, time)`,
@@ -199,51 +143,29 @@ where
                         //
                         // We need to write the logic twice, as there are two types of arrangement
                         // we might have: either dataflow-local or an imported trace.
-                        let (oks, errs) =
-                            match arrangements.get(&(lookup_relation, lookup_key)).unwrap() {
-                                Ok(local) => {
-                                    if source_relation < lookup_relation {
-                                        build_halfjoin::<_, RowRowAgent<_, _>, _>(
-                                            update_stream,
-                                            local.clone().enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.le(t2),
-                                            closure,
-                                        )
-                                    } else {
-                                        build_halfjoin::<_, RowRowAgent<_, _>, _>(
-                                            update_stream,
-                                            local.clone().enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.lt(t2),
-                                            closure,
-                                        )
-                                    }
-                                }
-                                Err(trace) => {
-                                    if source_relation < lookup_relation {
-                                        build_halfjoin::<_, RowRowEnter<_, _, _>, _>(
-                                            update_stream,
-                                            trace.clone().enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.le(t2),
-                                            closure,
-                                        )
-                                    } else {
-                                        build_halfjoin::<_, RowRowEnter<_, _, _>, _>(
-                                            update_stream,
-                                            trace.clone().enter_region(region),
-                                            stream_key,
-                                            stream_thinning,
-                                            |t1, t2| t1.lt(t2),
-                                            closure,
-                                        )
-                                    }
-                                }
-                            };
+                        let (oks, errs) = {
+                            if source_relation < lookup_relation {
+                                build_halfjoin(
+                                    update_stream,
+                                    stream_key,
+                                    stream_thinning,
+                                    &bundles[lookup_relation],
+                                    lookup_key,
+                                    |t1, t2| t1.le(t2),
+                                    closure,
+                                )
+                            } else {
+                                build_halfjoin(
+                                    update_stream,
+                                    stream_key,
+                                    stream_thinning,
+                                    &bundles[lookup_relation],
+                                    lookup_key,
+                                    |t1, t2| t1.lt(t2),
+                                    closure,
+                                )
+                            }
+                        };
                         update_stream = oks;
                         region_errs.push(errs);
                     }
@@ -306,6 +228,53 @@ where
     }
 }
 
+/// Constructs a halfjoin from an update stream and collection bundle.
+fn build_halfjoin<G, CF>(
+    updates: VecCollection<G, (Row, G::Timestamp), Diff>,
+    prev_key: Vec<MirScalarExpr>,
+    prev_thinning: Vec<usize>,
+    bundle: &CollectionBundle<G>,
+    lookup_key: Vec<MirScalarExpr>,
+    comparison: CF,
+    closure: JoinClosure,
+) -> (
+    VecCollection<G, (Row, G::Timestamp), Diff>,
+    VecCollection<G, DataflowError, Diff>,
+)
+where
+    G: Scope,
+    G::Timestamp: RenderTimestamp,
+    CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
+{
+    match bundle.arrangement(&lookup_key[..]) {
+        Some(ArrangementFlavor::Local(inner, errs)) => {
+            let (ok, err) = build_halfjoin_trace::<_, RowRowAgent<_, _>, _>(
+                updates,
+                inner,
+                prev_key,
+                prev_thinning,
+                comparison,
+                closure,
+            );
+            (ok, err.concat(&errs.as_collection(|k, _v| k.clone())))
+        }
+        Some(ArrangementFlavor::Trace(_, inner, errs)) => {
+            let (ok, err) = build_halfjoin_trace::<_, RowRowEnter<_, _, _>, _>(
+                updates,
+                inner,
+                prev_key,
+                prev_thinning,
+                comparison,
+                closure,
+            );
+            (ok, err.concat(&errs.as_collection(|k, _v| k.clone())))
+        }
+        None => {
+            panic!("Missing promised arrangement")
+        }
+    }
+}
+
 /// Constructs a `half_join` from supplied arguments.
 ///
 /// This method exists to factor common logic from four code paths that are generic over the type of trace.
@@ -316,7 +285,7 @@ where
 /// the time of the update. This operator may manipulate `time` as part of this pair, but will not manipulate
 /// the time of the update. This is crucial for correctness, as the total order on times of updates is used
 /// to ensure that any two updates are matched at most once.
-fn build_halfjoin<G, Tr, CF>(
+fn build_halfjoin_trace<G, Tr, CF>(
     updates: VecCollection<G, (Row, G::Timestamp), Diff>,
     trace: Arranged<G, Tr>,
     prev_key: Vec<MirScalarExpr>,
@@ -455,12 +424,60 @@ where
     }
 }
 
+/// Builds an initial update stream from a collection bundle.
+fn build_update_stream<G>(
+    bundle: &CollectionBundle<G>,
+    as_of: Antichain<mz_repr::Timestamp>,
+    source_key: Option<Vec<MirScalarExpr>>,
+    source_relation: usize,
+    initial_closure: JoinClosure,
+) -> (
+    VecCollection<G, Row, Diff>,
+    VecCollection<G, DataflowError, Diff>,
+)
+where
+    G: Scope,
+    G::Timestamp: RenderTimestamp,
+{
+    if let Some(source_key) = source_key {
+        match bundle.arrangement(&source_key[..]) {
+            Some(ArrangementFlavor::Local(inner, errs)) => {
+                let (ok, err) = build_update_stream_trace::<_, RowRowAgent<_, _>>(
+                    inner,
+                    as_of,
+                    source_relation,
+                    initial_closure,
+                );
+                (ok, err.concat(&errs.as_collection(|k, _v| k.clone())))
+            }
+            Some(ArrangementFlavor::Trace(_, inner, errs)) => {
+                let (ok, err) = build_update_stream_trace::<_, RowRowEnter<_, _, _>>(
+                    inner,
+                    as_of,
+                    source_relation,
+                    initial_closure,
+                );
+                (ok, err.concat(&errs.as_collection(|k, _v| k.clone())))
+            }
+            None => {
+                panic!(
+                    "Missing promised arrangement: {:?}, relation: {:?}",
+                    source_key, source_relation
+                )
+            }
+        }
+    } else {
+        // Build an update stream based on a `Collection` input.
+        unimplemented!();
+    }
+}
+
 /// Builds the beginning of the update stream of a delta path.
 ///
 /// At start-up time only the delta path for the first relation sees updates, since any updates fed to the
 /// other delta paths would be discarded anyway due to the tie-breaking logic that avoids double-counting
 /// updates happening at the same time on different relations.
-fn build_update_stream<G, Tr>(
+fn build_update_stream_trace<G, Tr>(
     trace: Arranged<G, Tr>,
     as_of: Antichain<mz_repr::Timestamp>,
     source_relation: usize,

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -108,7 +108,7 @@ where
                     let (update_stream, err_stream) = build_update_stream(
                         &bundles[source_relation],
                         self.as_of_frontier.clone(),
-                        Some(source_key),
+                        source_key,
                         source_relation,
                         initial_closure,
                     );
@@ -256,7 +256,7 @@ where
                 comparison,
                 closure,
             );
-            (ok, err.concat(&errs.as_collection(|k, _v| k.clone())))
+            (ok, err.concat(errs.as_collection(|k, _v| k.clone())))
         }
         Some(ArrangementFlavor::Trace(_, inner, errs)) => {
             let (ok, err) = build_halfjoin_trace::<_, RowRowEnter<_, _, _>, _>(
@@ -267,7 +267,7 @@ where
                 comparison,
                 closure,
             );
-            (ok, err.concat(&errs.as_collection(|k, _v| k.clone())))
+            (ok, err.concat(errs.as_collection(|k, _v| k.clone())))
         }
         None => {
             panic!("Missing promised arrangement")
@@ -448,7 +448,7 @@ where
                     source_relation,
                     initial_closure,
                 );
-                (ok, err.concat(&errs.as_collection(|k, _v| k.clone())))
+                (ok, err.concat(errs.as_collection(|k, _v| k.clone())))
             }
             Some(ArrangementFlavor::Trace(_, inner, errs)) => {
                 let (ok, err) = build_update_stream_trace::<_, RowRowEnter<_, _, _>>(
@@ -457,7 +457,7 @@ where
                     source_relation,
                     initial_closure,
                 );
-                (ok, err.concat(&errs.as_collection(|k, _v| k.clone())))
+                (ok, err.concat(errs.as_collection(|k, _v| k.clone())))
             }
             None => {
                 panic!(
@@ -468,7 +468,17 @@ where
         }
     } else {
         // Build an update stream based on a `Collection` input.
-        unimplemented!();
+        let (oks, errs) = bundle
+            .collection
+            .clone()
+            .expect("The unarranged collection doesn't exist.");
+        let (ok, err) = build_update_stream_stream(
+            oks,
+            as_of,
+            source_relation,
+            initial_closure,
+        );
+        (ok, err.concat(errs))
     }
 }
 
@@ -585,4 +595,47 @@ where
         ok_stream.as_collection(),
         err_stream.as_collection().map(DataflowError::from),
     )
+}
+
+/// Builds the beginning of the update stream of a delta path.
+///
+/// At start-up time only the delta path for the first relation sees updates, since any updates fed to the
+/// other delta paths would be discarded anyway due to the tie-breaking logic that avoids double-counting
+/// updates happening at the same time on different relations.
+fn build_update_stream_stream<G>(
+    stream: VecCollection<G, Row, Diff>,
+    as_of: Antichain<mz_repr::Timestamp>,
+    source_relation: usize,
+    initial_closure: JoinClosure,
+) -> (
+    VecCollection<G, Row, Diff>,
+    VecCollection<G, DataflowError, Diff>,
+)
+where
+    G: Scope,
+    G::Timestamp: RenderTimestamp,
+{
+    // We should only be calling this with the 0th source relation, for the moment.
+    assert_eq!(source_relation, 0);
+
+    let mut inner_as_of = Antichain::new();
+    for event_time in as_of.elements().iter() {
+        inner_as_of.insert(<G::Timestamp>::to_inner(event_time.clone()));
+    }
+
+    let mut datums = DatumVec::new();
+    type CB<C> = ConsolidatingContainerBuilder<C>;
+    let (oks, err) =
+        stream.flat_map_fallible::<CB<_>, CB<_>, _, _, _, _>("UpdateStream", move |row| {
+            let temp_storage = RowArena::new();
+            let mut row_builder = SharedRow::get();
+            let mut datums_local = datums.borrow_with(&row);
+
+            initial_closure
+                .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                .map(|row| row.cloned())
+                .transpose()
+        });
+
+    (oks, err.map(DataflowError::from))
 }


### PR DESCRIPTION
Re-organize the rendering of delta joins to consolidate "demuxing" outside of the main body of delta join rendering. This is in anticipation of supporting `Collection` hydration for delta join paths, which our existing code is overly specific about (and prevents).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
