### PR TITLE
optimize: track `StatementKind` for each `Optimizer`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,6 +96,7 @@
 /src/prof                           @teskje
 /src/proto                          @aalexandrov
 /src/repr                           @MaterializeInc/storage @MaterializeInc/compute
+/src/repr/src/optimize.rs           @MaterializeInc/compute
 /src/repr/src/row                   @MaterializeInc/persist
 /src/repr-test-util                 @MaterializeInc/compute
 /src/rocksdb                        @MaterializeInc/storage

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -164,8 +164,12 @@ impl Optimize<HirRelationExpr> for Optimizer {
 
         // MIR ⇒ MIR optimization (local)
         let mut df_meta = DataflowMetainfo::default();
-        let mut transform_ctx =
-            TransformCtx::local(&self.config.features, &self.typecheck_ctx, &mut df_meta);
+        let mut transform_ctx = TransformCtx::local(
+            STATEMENT_KIND,
+            &self.config.features,
+            &self.typecheck_ctx,
+            &mut df_meta,
+        );
         let expr = optimize_mir_local(expr, &mut transform_ctx)?.into_inner();
 
         self.duration += time.elapsed();
@@ -311,6 +315,7 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
 
         // Construct TransformCtx for global optimization.
         let mut transform_ctx = TransformCtx::global(
+            STATEMENT_KIND,
             &df_builder,
             &*stats,
             &self.config.features,

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -185,6 +185,7 @@ impl Optimize<Index> for Optimizer {
         // Construct TransformCtx for global optimization.
         let mut df_meta = DataflowMetainfo::default();
         let mut transform_ctx = TransformCtx::global(
+            STATEMENT_KIND,
             &df_builder,
             &mz_transform::EmptyStatisticsOracle, // TODO: wire proper stats
             &self.config.features,

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -176,8 +176,12 @@ impl Optimize<HirRelationExpr> for Optimizer {
 
         // MIR ⇒ MIR optimization (local)
         let mut df_meta = DataflowMetainfo::default();
-        let mut transform_ctx =
-            TransformCtx::local(&self.config.features, &self.typecheck_ctx, &mut df_meta);
+        let mut transform_ctx = TransformCtx::local(
+            STATEMENT_KIND,
+            &self.config.features,
+            &self.typecheck_ctx,
+            &mut df_meta,
+        );
         let expr = optimize_mir_local(expr, &mut transform_ctx)?.into_inner();
 
         self.duration += time.elapsed();
@@ -253,6 +257,7 @@ impl Optimize<LocalMirPlan> for Optimizer {
 
         // Construct TransformCtx for global optimization.
         let mut transform_ctx = TransformCtx::global(
+            STATEMENT_KIND,
             &df_builder,
             &mz_transform::EmptyStatisticsOracle, // TODO: wire proper stats
             &self.config.features,

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -176,8 +176,12 @@ impl Optimize<HirRelationExpr> for Optimizer {
 
         // MIR ⇒ MIR optimization (local)
         let mut df_meta = DataflowMetainfo::default();
-        let mut transform_ctx =
-            TransformCtx::local(&self.config.features, &self.typecheck_ctx, &mut df_meta);
+        let mut transform_ctx = TransformCtx::local(
+            STATEMENT_KIND,
+            &self.config.features,
+            &self.typecheck_ctx,
+            &mut df_meta,
+        );
         let expr = optimize_mir_local(expr, &mut transform_ctx)?.into_inner();
 
         self.duration += time.elapsed();
@@ -300,6 +304,7 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
 
         // Construct TransformCtx for global optimization.
         let mut transform_ctx = TransformCtx::global(
+            STATEMENT_KIND,
             &df_builder,
             &*stats,
             &self.config.features,

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -233,8 +233,12 @@ impl Optimize<SubscribeFrom> for Optimizer {
                 // let expr = expr.lower(&self.config)?;
 
                 // MIR ⇒ MIR optimization (local)
-                let mut transform_ctx =
-                    TransformCtx::local(&self.config.features, &self.typecheck_ctx, &mut df_meta);
+                let mut transform_ctx = TransformCtx::local(
+                    STATEMENT_KIND,
+                    &self.config.features,
+                    &self.typecheck_ctx,
+                    &mut df_meta,
+                );
                 let expr = optimize_mir_local(expr, &mut transform_ctx)?;
 
                 df_builder.import_view_into_dataflow(&self.view_id, &expr, &mut df_desc)?;
@@ -265,6 +269,7 @@ impl Optimize<SubscribeFrom> for Optimizer {
 
         // Construct TransformCtx for global optimization.
         let mut transform_ctx = TransformCtx::global(
+            STATEMENT_KIND,
             &df_builder,
             &mz_transform::EmptyStatisticsOracle, // TODO: wire proper stats
             &self.config.features,

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -60,8 +60,12 @@ impl Optimize<HirRelationExpr> for Optimizer {
 
         // MIR ⇒ MIR optimization (local)
         let mut df_meta = DataflowMetainfo::default();
-        let mut transform_ctx =
-            TransformCtx::local(&self.config.features, &self.typecheck_ctx, &mut df_meta);
+        let mut transform_ctx = TransformCtx::local(
+            STATEMENT_KIND,
+            &self.config.features,
+            &self.typecheck_ctx,
+            &mut df_meta,
+        );
         let expr = optimize_mir_local(expr, &mut transform_ctx)?;
 
         if let Some(metrics) = &self.metrics {

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -28,7 +28,7 @@ use std::{fmt, iter};
 use mz_expr::{MirRelationExpr, MirScalarExpr};
 use mz_ore::id_gen::IdGen;
 use mz_ore::stack::RecursionLimitError;
-use mz_repr::optimize::OptimizerFeatures;
+use mz_repr::optimize::{OptimizerFeatures, StatementKind};
 use mz_repr::GlobalId;
 use tracing::error;
 
@@ -90,6 +90,8 @@ macro_rules! any {
 pub struct TransformCtx<'a> {
     /// The global ID for this query (if it exists).
     pub global_id: Option<GlobalId>,
+    /// The kind of the optimized statement.
+    pub kind: StatementKind,
     /// The indexes accessible.
     pub indexes: &'a dyn IndexOracle,
     /// Statistical estimates.
@@ -110,11 +112,13 @@ impl<'a> TransformCtx<'a> {
     /// [`Optimizer::logical_optimizer`] in order to transform a stand-alone
     /// [`MirRelationExpr`].
     pub fn local(
+        kind: StatementKind,
         features: &'a OptimizerFeatures,
         typecheck_ctx: &'a typecheck::SharedContext,
         df_meta: &'a mut DataflowMetainfo,
     ) -> Self {
         Self {
+            kind,
             indexes: &EmptyIndexOracle,
             stats: &EmptyStatisticsOracle,
             global_id: None,
@@ -129,6 +133,7 @@ impl<'a> TransformCtx<'a> {
     ///
     /// Used to call [`dataflow::optimize_dataflow`].
     pub fn global(
+        kind: StatementKind,
         indexes: &'a dyn IndexOracle,
         stats: &'a dyn StatisticsOracle,
         features: &'a OptimizerFeatures,
@@ -136,6 +141,7 @@ impl<'a> TransformCtx<'a> {
         df_meta: &'a mut DataflowMetainfo,
     ) -> Self {
         Self {
+            kind,
             indexes,
             stats,
             global_id: None,

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -29,7 +29,7 @@ mod tests {
     use mz_ore::collections::HashMap;
     use mz_ore::str::separated;
     use mz_repr::explain::{Explain, ExplainConfig, ExplainFormat};
-    use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
+    use mz_repr::optimize::{OptimizerFeatures, OverrideFrom, StatementKind};
     use mz_repr::GlobalId;
     use mz_transform::dataflow::{
         optimize_dataflow_demand_inner, optimize_dataflow_filters_inner, DataflowMetainfo,
@@ -51,7 +51,7 @@ mod tests {
             let features = OptimizerFeatures::default();
             let typecheck_ctx = typecheck::empty_context();
             let mut df_meta = DataflowMetainfo::default();
-            let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
+            let mut transform_ctx = TransformCtx::local(StatementKind::Peek, &features, &typecheck_ctx, &mut df_meta);
 
             #[allow(deprecated)]
             Optimizer::logical_optimizer(&mut transform_ctx)
@@ -177,7 +177,8 @@ mod tests {
         let features = OptimizerFeatures::default();
         let typecheck_ctx = typecheck::empty_context();
         let mut df_meta = DataflowMetainfo::default();
-        let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
+        let mut transform_ctx =
+            TransformCtx::local(StatementKind::Peek, &features, &typecheck_ctx, &mut df_meta);
         let mut rel = parse_relation(s, cat, args)?;
         for t in args.get("apply").cloned().unwrap_or_else(Vec::new).iter() {
             get_transform(t)?.transform(&mut rel, &mut transform_ctx)?;
@@ -354,7 +355,8 @@ mod tests {
             let features = OptimizerFeatures::default();
             let typecheck_ctx = typecheck::empty_context();
             let mut df_meta = DataflowMetainfo::default();
-            let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
+            let mut transform_ctx =
+                TransformCtx::local(StatementKind::Peek, &features, &typecheck_ctx, &mut df_meta);
 
             #[allow(deprecated)]
             let optimizer = Optimizer::logical_optimizer(&mut transform_ctx);
@@ -388,7 +390,8 @@ mod tests {
             let features = OptimizerFeatures::default();
             let typecheck_ctx = typecheck::empty_context();
             let mut df_meta = DataflowMetainfo::default();
-            let mut transform_ctx = TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
+            let mut transform_ctx =
+                TransformCtx::local(StatementKind::Peek, &features, &typecheck_ctx, &mut df_meta);
 
             let log_optimizer = Optimizer::logical_cleanup_pass(&mut transform_ctx, true);
             let phys_optimizer = Optimizer::physical_optimizer(&mut transform_ctx);

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -14,7 +14,7 @@ use mz_expr_parser::{handle_define, try_parse_mir, TestCatalog};
 use mz_ore::str::Indent;
 use mz_repr::explain::text::text_string_at;
 use mz_repr::explain::{ExplainConfig, PlanRenderingContext};
-use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
+use mz_repr::optimize::{OptimizerFeatures, OverrideFrom, StatementKind};
 use mz_transform::attribute::annotate_plan;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::typecheck::TypeErrorHumanizer;
@@ -259,8 +259,12 @@ fn apply_transform<T: mz_transform::Transform>(
     let features = mz_repr::optimize::OptimizerFeatures::default();
     let typecheck_ctx = mz_transform::typecheck::empty_context();
     let mut df_meta = DataflowMetainfo::default();
-    let mut transform_ctx =
-        mz_transform::TransformCtx::local(&features, &typecheck_ctx, &mut df_meta);
+    let mut transform_ctx = mz_transform::TransformCtx::local(
+        StatementKind::Peek,
+        &features,
+        &typecheck_ctx,
+        &mut df_meta,
+    );
 
     // Apply the transformation, returning early on TransformError.
     transform


### PR DESCRIPTION
This can be handy if we want to condition code in `mz_transform` depending on the optimized statement kind.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

This is mostly trivial plumbing.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
