### PR TITLE
build: Bump version of confluent-kafka

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -64,7 +64,7 @@ types-setuptools==67.6.0.0
 types-toml==0.10.8.1
 typing-extensions==4.7.0
 yamllint==1.33.0
-confluent-kafka==2.1.1
+confluent-kafka==2.3.0
 fastavro==1.8.2
 websocket-client==1.7.0
 pyarrow-stubs==10.0.1.7


### PR DESCRIPTION
This PR bumps the version of `confluent-kafka` that we use to `2.3.0`, which fixes the build. Currently `bin/environmentd` can fail on a fresh checkout because we fail to build the wheel for the `confluent-kafka` package. Bumping to `2.3.0` allows us to rely on the pre-built wheel.

### Motivation

Fixes the build

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
