### PR TITLE
ci: cloudtests execution

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -827,6 +827,20 @@ steps:
               args: [-m=long, test/cloudtest/test_upgrade.py]
         sanitizer: skip
 
+      - id: cloudtest-slow
+        label: "Slow Cloudtest"
+        depends_on: build-aarch64
+        timeout_in_minutes: 30
+        env:
+          CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
+        agents:
+          queue: linux-aarch64
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/cloudtest:
+              args: [-m=long, test/cloudtest/test_storage_shared_fate.py]
+        sanitizer: skip
+
   - group: "K8s node recovery cloudtest"
     key: k8s-node-recovery
     steps:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -253,6 +253,8 @@ steps:
         label: Full Testdrive in Cloudtest (K8s)
         depends_on: build-aarch64
         timeout_in_minutes: 300
+        env:
+          CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
           queue: linux-aarch64-large
         plugins:
@@ -815,6 +817,8 @@ steps:
         label: "Platform checks upgrade in Cloudtest/K8s"
         depends_on: build-aarch64
         timeout_in_minutes: 60
+        env:
+          CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
           queue: linux-aarch64-large
         plugins:

--- a/test/cloudtest/test_storage_shared_fate.py
+++ b/test/cloudtest/test_storage_shared_fate.py
@@ -12,6 +12,8 @@ import subprocess
 import time
 from textwrap import dedent
 
+import pytest
+
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 from materialize.cloudtest.util.cluster import cluster_pod_name
 
@@ -147,6 +149,7 @@ def kill_clusterd(
         pass
 
 
+@pytest.mark.long
 def test_kill_all_storage_clusterds(mz: MaterializeApplication) -> None:
     """Kill all clusterds"""
     populate(mz, 1)
@@ -157,6 +160,7 @@ def test_kill_all_storage_clusterds(mz: MaterializeApplication) -> None:
     validate(mz, 1)
 
 
+@pytest.mark.long
 def test_kill_one_storage_clusterd(mz: MaterializeApplication) -> None:
     """Kill one clusterd out of $CLUSTER_SIZE"""
     populate(mz, 2)
@@ -164,6 +168,7 @@ def test_kill_one_storage_clusterd(mz: MaterializeApplication) -> None:
     validate(mz, 2)
 
 
+@pytest.mark.long
 def test_kill_first_storage_clusterd(mz: MaterializeApplication) -> None:
     """Kill the first clusterd out of $CLUSTER_SIZE"""
     populate(mz, 3)
@@ -171,6 +176,7 @@ def test_kill_first_storage_clusterd(mz: MaterializeApplication) -> None:
     validate(mz, 3)
 
 
+@pytest.mark.long
 def test_kill_all_but_one_storage_clusterd(mz: MaterializeApplication) -> None:
     """Kill all clusterds except one"""
     populate(mz, 4)
@@ -180,6 +186,7 @@ def test_kill_all_but_one_storage_clusterd(mz: MaterializeApplication) -> None:
     validate(mz, 4)
 
 
+@pytest.mark.long
 def test_kill_storage_while_suspended(mz: MaterializeApplication) -> None:
     """Suspend a clusterd and resume it after the rest of the cluster went down."""
     populate(mz, 5)
@@ -191,6 +198,7 @@ def test_kill_storage_while_suspended(mz: MaterializeApplication) -> None:
     validate(mz, 5)
 
 
+@pytest.mark.long
 def test_suspend_while_killing_storage(mz: MaterializeApplication) -> None:
     """Suspend a clusterd while the cluster is going down and resume it after."""
     populate(mz, 6)
@@ -201,6 +209,7 @@ def test_suspend_while_killing_storage(mz: MaterializeApplication) -> None:
     validate(mz, 6)
 
 
+@pytest.mark.long
 def test_suspend_all_but_one_storage(mz: MaterializeApplication) -> None:
     """Suspend all clusterds while killing one."""
     populate(mz, 7)


### PR DESCRIPTION
### Contents
* Move long running cloudtest to nightly.
* <s>Reduce number of shards for cloudtests in tests pipeline since the setup takes most of their time.</s>

### Some notes about durations
Duration of moved cloudtests (the first testcase includes the setup):
```
<testcase classname="test.cloudtest.test_storage_shared_fate" name="test_kill_all_storage_clusterds" time="884.014"/>
<testcase classname="test.cloudtest.test_storage_shared_fate" name="test_kill_one_storage_clusterd" time="99.838"/>
<testcase classname="test.cloudtest.test_storage_shared_fate" name="test_kill_first_storage_clusterd" time="97.356"/>
<testcase classname="test.cloudtest.test_storage_shared_fate" name="test_kill_all_but_one_storage_clusterd" time="107.586"/>
<testcase classname="test.cloudtest.test_storage_shared_fate" name="test_kill_storage_while_suspended" time="107.185"/>
<testcase classname="test.cloudtest.test_storage_shared_fate" name="test_suspend_while_killing_storage" time="90.715"/>
<testcase classname="test.cloudtest.test_storage_shared_fate" name="test_suspend_all_but_one_storage" time="108.012"/>
```

Duration of cloudtests of some other shard (first test case includes the setup):
```
<testcase classname="test.cloudtest.test_antiaffinity" name="test_create_cluster_antiaffinity" time="787.398"/>
<testcase classname="test.cloudtest.test_antiaffinity" name="test_create_cluster_replica_antiaffinity" time="12.027"/>
<testcase classname="test.cloudtest.test_antiaffinity" name="test_create_cluster_replica_zone_specified" time="11.965"/>
<testcase classname="test.cloudtest.test_antiaffinity" name="test_create_cluster_replica_zone_mixed" time="12.039"/>
<testcase classname="test.cloudtest.test_antiaffinity" name="test_managed_set_azs" time="11.985"/>
<testcase classname="test.cloudtest.test_antiaffinity" name="test_create_clusters_antiaffinity" time="0.000">
<skipped type="pytest.skip" message="Not currently guaranteed by implementation.">
/var/lib/buildkite-agent/builds/buildkite-aarch64-b9f4a11-i-0647a28266e5194d9-1/materialize/test/test/cloudtest/test_antiaffinity.py:161: Not currently guaranteed by implementation.
</skipped>
</testcase>
<testcase classname="test.cloudtest.test_cluster_rehydration" name="test_create_drop_source" time="14.989"/>
```

### Duration per shard

#### Before changes

<img width="1149" alt="Bildschirmfoto 2024-05-01 um 12 31 04" src="https://github.com/MaterializeInc/materialize/assets/129728240/58dee05f-2020-4e28-8aae-e274bee45248">

### Nightly

Triggered nightly for verification: https://buildkite.com/materialize/nightly/builds/7605 ✅ 