### PR TITLE
misc: remove vars that have been removed

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -42,7 +42,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     # -----
     # Unsafe functions
     "enable_unsafe_functions": "true",
-    "enable_dangerous_functions": "true",  # former name of 'enable_unsafe_functions'
     # -----
     # To reduce CRDB load as we are struggling with it in CI (values based on load test environment):
     "persist_next_listen_batch_retryer_clamp": "16s",
@@ -59,7 +58,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "compute_hydration_concurrency": 2,
     "disk_cluster_replicas_default": "true",
     "enable_alter_swap": "true",
-    "enable_assert_not_null": "true",
     "enable_aws_connection": "true",
     "enable_columnation_lgalloc": "true",
     "enable_comment": "true",
@@ -77,7 +75,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_reduce_mfp_fusion": "true",
     "enable_refresh_every_mvs": "true",
     "enable_cluster_schedule_refresh": "true",
-    "enable_sink_doc_on_option": "true",
     "enable_statement_lifecycle_logging": "true",
     "enable_table_keys": "true",
     "enable_variadic_left_join_lowering": "true",
@@ -96,7 +93,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "statement_logging_max_sample_rate": "0.01",
     "storage_persist_sink_minimum_batch_updates": "100",
     "storage_source_decode_fuel": "100000",
-    "timestamp_oracle": "postgres",
     "wait_catalog_consolidation_on_startup": "true",
 }
 


### PR DESCRIPTION
These were complaining on startup about not being present. They no longer exist in envd.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a