### PR TITLE
adapter: error for slow coord messages

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2383,10 +2383,10 @@ impl Coordinator {
                     let duration = tokio::time::Duration::from_secs(30);
                     let timeout = tokio::time::timeout(duration, idle_tx.reserve()).await;
                     let Ok(maybe_permit) = timeout else {
-                        // Only log the error if we're newly stuck, to prevent logging repeatedly.
+                        // Only log if we're newly stuck, to prevent logging repeatedly.
                         if !coord_stuck {
                             let last_message = last_message_watchdog.lock().expect("poisoned");
-                            tracing::error!(
+                            tracing::warn!(
                                 last_message_kind = %last_message.kind,
                                 last_message_sql = %last_message.stmt_to_string(),
                                 "coordinator stuck for {duration:?}",
@@ -2569,7 +2569,7 @@ impl Coordinator {
                 // If something is _really_ slow, print a trace id for debugging, if OTEL is enabled.
                 if duration > warn_threshold {
                     let trace_id = otel_context.is_valid().then(|| otel_context.trace_id());
-                    tracing::warn!(
+                    tracing::error!(
                         ?msg_kind,
                         ?trace_id,
                         ?duration,

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -899,9 +899,8 @@ pub static WEBHOOKS_SECRETS_CACHING_TTL_SECS: VarDefinition = VarDefinition::new
 
 pub static COORD_SLOW_MESSAGE_WARN_THRESHOLD: VarDefinition = VarDefinition::new(
     "coord_slow_message_warn_threshold",
-    // Note(parkmycar): This value was chosen arbitrarily.
-    value!(Duration; Duration::from_secs(5)),
-    "Sets the threshold at which we will warn! for a coordinator message being slow.",
+    value!(Duration; Duration::from_secs(30)),
+    "Sets the threshold at which we will error! for a coordinator message being slow.",
     true,
 );
 


### PR DESCRIPTION
We decided to move to caring about individual slow messages because we largely have control over how long they take to execute. We want to have an SLO/SLI around these. Decide on 30s as the initial starting goal and send to entry when they occur.

Demote the busy log to a warning. We care less about this because many messages is workload dependent and thus can vary a lot by user. We initially will have a lower importance to this metric until the slow individual messages metric is improved.

Fixes #26861

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a