### PR TITLE
persist: speed up `select count(*) from persist`

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -902,6 +902,13 @@ class FlipFlagsAction(Action):
         self.flags_with_values: dict[str, list[str]] = dict()
         self.flags_with_values["persist_roundtrip_spine"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values[
+            "persist_optimize_ignored_data_fetch"
+        ] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values[
+            "persist_optimize_ignored_data_decode"
+        ] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["persist_write_diffs_sum"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values[
             "enable_variadic_left_join_lowering"
         ] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -32,9 +32,10 @@ use crate::internal::machine::{
 };
 use crate::internal::state::ROLLUP_THRESHOLD;
 use crate::operators::{
-    OPTIMIZE_IGNORED_DATA_DECODE, PERSIST_SINK_MINIMUM_BATCH_UPDATES,
-    STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES, STORAGE_SOURCE_DECODE_FUEL,
+    PERSIST_SINK_MINIMUM_BATCH_UPDATES, STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES,
+    STORAGE_SOURCE_DECODE_FUEL,
 };
+use crate::project::OPTIMIZE_IGNORED_DATA_DECODE;
 use crate::read::READER_LEASE_DURATION;
 
 /// The tunable knobs for persist.
@@ -335,10 +336,11 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::internal::state::WRITE_DIFFS_SUM)
         .add(&crate::internal::apply::ROUNDTRIP_SPINE)
         .add(&crate::iter::SPLIT_OLD_RUNS)
-        .add(&crate::operators::OPTIMIZE_IGNORED_DATA_DECODE)
         .add(&crate::operators::PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
         .add(&crate::operators::STORAGE_SOURCE_DECODE_FUEL)
+        .add(&crate::project::OPTIMIZE_IGNORED_DATA_DECODE)
+        .add(&crate::project::OPTIMIZE_IGNORED_DATA_FETCH)
         .add(&crate::read::READER_LEASE_DURATION)
         .add(&crate::rpc::PUBSUB_CLIENT_ENABLED)
         .add(&crate::rpc::PUBSUB_PUSH_DIFF_ENABLED)

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -2290,6 +2290,8 @@ pub struct PushdownMetrics {
     pub(crate) parts_audited_bytes: IntCounter,
     pub(crate) parts_inline_count: IntCounter,
     pub(crate) parts_inline_bytes: IntCounter,
+    pub(crate) parts_faked_count: IntCounter,
+    pub(crate) parts_faked_bytes: IntCounter,
     pub(crate) parts_stats_trimmed_count: IntCounter,
     pub(crate) parts_stats_trimmed_bytes: IntCounter,
     pub part_stats: PartStatsMetrics,
@@ -2329,6 +2331,14 @@ impl PushdownMetrics {
             parts_inline_bytes: registry.register(metric!(
                 name: "mz_persist_pushdown_parts_inline_bytes",
                 help: "total size of parts not fetched because they were inline",
+            )),
+            parts_faked_count: registry.register(metric!(
+                name: "mz_persist_pushdown_parts_faked_count",
+                help: "count of parts faked because of aggressive projection pushdown",
+            )),
+            parts_faked_bytes: registry.register(metric!(
+                name: "mz_persist_pushdown_parts_faked_bytes",
+                help: "total size of parts replaced with fakes by aggressive projection pushdown",
             )),
             parts_stats_trimmed_count: registry.register(metric!(
                 name: "mz_persist_pushdown_parts_stats_trimmed_count",

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -59,6 +59,7 @@ pub mod critical;
 pub mod error;
 pub mod fetch;
 pub mod internals_bench;
+pub mod iter;
 pub mod metrics {
     //! Utilities related to metrics.
     pub use crate::internal::metrics::{
@@ -103,15 +104,8 @@ pub mod operators {
         The maximum amount of work to do in the persist_source mfp_and_decode \
         operator before yielding.",
     );
-
-    // TODO(cfg): Move this next to the use.
-    pub(crate) const OPTIMIZE_IGNORED_DATA_DECODE: Config<bool> = Config::new(
-        "persist_optimize_ignored_data_decode",
-        true,
-        "CYA to allow opt-out of a performance optimization to skip decoding ignored data",
-    );
 }
-pub mod iter;
+pub mod project;
 pub mod read;
 pub mod rpc;
 pub mod stats;

--- a/src/persist-client/src/project.rs
+++ b/src/persist-client/src/project.rs
@@ -1,0 +1,183 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Projection pushdown
+
+use differential_dataflow::trace::Description;
+use mz_dyncfg::{Config, ConfigSet};
+use mz_ore::cast::CastFrom;
+use mz_persist::indexed::columnar::ColumnarRecordsBuilder;
+use mz_persist_types::stats::PartStats;
+use mz_persist_types::Codec64;
+use mz_proto::RustType;
+use timely::progress::{Antichain, Timestamp};
+use tracing::debug;
+
+use crate::internal::encoding::LazyInlineBatchPart;
+use crate::internal::metrics::Metrics;
+use crate::internal::state::{BatchPart, ProtoInlineBatchPart};
+
+pub(crate) const OPTIMIZE_IGNORED_DATA_FETCH: Config<bool> = Config::new(
+    "persist_optimize_ignored_data_fetch",
+    true,
+    "CYA to allow opt-out of a performance optimization to skip fetching ignored data",
+);
+
+pub(crate) const OPTIMIZE_IGNORED_DATA_DECODE: Config<bool> = Config::new(
+    "persist_optimize_ignored_data_decode",
+    true,
+    "CYA to allow opt-out of a performance optimization to skip decoding ignored data",
+);
+
+/// Information about which columns of persist-stored data may not be needed.
+///
+/// TODO: This is mostly a placeholder for real projection pushdown, but in the
+/// short-term it allows us a special case of projection pushdown: ignoring all
+/// non-`Err` data. See [ProjectionPushdown::try_optimize_ignored_data_fetch].
+#[derive(Debug, Clone)]
+#[allow(rustdoc::private_intra_doc_links)]
+pub enum ProjectionPushdown {
+    /// Fetch all columns.
+    FetchAll,
+    /// For data with a top-level error column in the structured representation,
+    /// ignore all columns except for data in parts that may contain an error.
+    /// This may seem like a peculiar set of requirements, but it enables the
+    /// aggressive [Self::try_optimize_ignored_data_fetch] optimization and it
+    /// corresponds to a common query shape: `SELECT count(*)`.
+    ///
+    /// This error bit is certainly a bit of an abstraction breakage in the
+    /// "persist is independent of mz" story, but it should go away when we
+    /// implement full projection pushdown.
+    IgnoreAllNonErr {
+        /// The name of the top-level error column.
+        err_col_name: &'static str,
+        /// The `Codec` encoded key corresponding to ignored data.
+        key_bytes: Vec<u8>,
+        /// The `Codec` encoded val corresponding to ignored data.
+        val_bytes: Vec<u8>,
+    },
+}
+
+impl Default for ProjectionPushdown {
+    fn default() -> Self {
+        ProjectionPushdown::FetchAll
+    }
+}
+
+impl ProjectionPushdown {
+    /// If relevant, applies the [Self::IgnoreAllNonErr] projection to a part
+    /// about to be fetched.
+    ///
+    /// If a part contains data from entirely before a snapshot `as_of`, and the
+    /// pushed-down MFP projects to an empty list of columns, and we can prove
+    /// that the part is error free, then we can use the diff sum from stats
+    /// instead of loading the data. In this case, we return a `Some` with a
+    /// replacement [BatchPart]. In all other cases, a None.
+    ///
+    /// - Summing the diffs in a part is equivalent to projecting the row in
+    ///   each tuple to an empty row and then consolidating. (Which is pretty
+    ///   much how `select count(*)` queries get compiled today.)
+    /// - If the as-of timestamp falls in the middle of a part, we can just
+    ///   fetch and process the part as normal. The optimization can still
+    ///   provide a speedup for other parts. TODO: We could improve this by
+    ///   keeping track in metadata of the largest timestamp(s) in a hollow
+    ///   part.
+    pub(crate) fn try_optimize_ignored_data_fetch<T: Timestamp + Codec64>(
+        &self,
+        cfg: &ConfigSet,
+        metrics: &Metrics,
+        as_of: &Antichain<T>,
+        desc: &Description<T>,
+        part: &BatchPart<T>,
+    ) -> Option<BatchPart<T>> {
+        if !OPTIMIZE_IGNORED_DATA_FETCH.get(cfg) {
+            return None;
+        }
+        let (err_col_name, key_bytes, val_bytes) = match self {
+            ProjectionPushdown::FetchAll => return None,
+            ProjectionPushdown::IgnoreAllNonErr {
+                err_col_name,
+                key_bytes,
+                val_bytes,
+            } => (*err_col_name, key_bytes.as_slice(), val_bytes.as_slice()),
+        };
+        let (diffs_sum, stats) = match &part {
+            BatchPart::Hollow(x) => (x.diffs_sum, x.stats.as_ref()),
+            BatchPart::Inline { .. } => return None,
+        };
+        debug!(
+            "try_optimize_ignored_data_fetch diffs_sum={:?} as_of={:?} lower={:?} upper={:?}",
+            // This is only used for debugging, so hack to assume that D is i64.
+            diffs_sum.map(i64::decode),
+            as_of.elements(),
+            desc.lower().elements(),
+            desc.upper().elements()
+        );
+        let as_of = match &as_of.elements() {
+            &[as_of] => as_of,
+            _ => return None,
+        };
+        let eligible = desc.upper().less_equal(as_of) && desc.since().less_equal(as_of);
+        if !eligible {
+            return None;
+        }
+        let Some(diffs_sum) = diffs_sum else {
+            return None;
+        };
+        let Some(true) = error_free(stats.map(|x| x.decode()), err_col_name) else {
+            return None;
+        };
+
+        debug!(
+            "try_optimize_ignored_data_fetch faked {:?} diffs at ts {:?} skipping fetch of {} bytes",
+            // This is only used for debugging, so hack to assume that D is i64.
+            i64::decode(diffs_sum),
+            as_of,
+            part.encoded_size_bytes(),
+        );
+        metrics.pushdown.parts_faked_count.inc();
+        metrics
+            .pushdown
+            .parts_faked_bytes
+            .inc_by(u64::cast_from(part.encoded_size_bytes()));
+
+        let mut faked_data = ColumnarRecordsBuilder::default();
+        assert!(faked_data.push(((key_bytes, val_bytes), T::encode(as_of), diffs_sum)));
+        let updates = faked_data.finish(&metrics.columnar).into_proto();
+        let faked_data = LazyInlineBatchPart::from(&ProtoInlineBatchPart {
+            desc: Some(desc.into_proto()),
+            index: 0,
+            updates: Some(updates),
+        });
+        Some(BatchPart::Inline {
+            updates: faked_data,
+            ts_rewrite: None,
+        })
+    }
+}
+
+/// Returns whether the part is provably free of `SourceData(Err(_))`s.
+///
+/// Will return false if the part is known to contain errors or None if it's
+/// unknown.
+pub fn error_free(part_stats: Option<PartStats>, err_col_name: &str) -> Option<bool> {
+    let part_stats = part_stats?;
+    // Counter-intuitive: We can easily calculate the number of errors that
+    // were None from the column stats, but not how many were Some. So, what
+    // we do is count the number of Nones, which is the number of Oks, and
+    // then subtract that from the total.
+    let num_results = part_stats.key.len;
+    // The number of OKs is the number of rows whose error is None.
+    let num_oks = part_stats
+        .key
+        .col::<Option<Vec<u8>>>(err_col_name)
+        .expect("err column should be a Option<Vec<u8>>")
+        .map(|x| x.none)?;
+    Some(num_results == num_oks)
+}

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -44,11 +44,11 @@ use crate::internal::metrics::Metrics;
 use crate::internal::state::{BatchPart, HollowBatch};
 use crate::internal::watch::StateWatch;
 use crate::iter::{Consolidator, SPLIT_OLD_RUNS};
+use crate::stats::{SnapshotPartStats, SnapshotPartsStats};
 use crate::{parse_id, GarbageCollector, PersistConfig, ShardId};
 
 pub use crate::internal::encoding::LazyPartStats;
 pub use crate::internal::state::Since;
-use crate::stats::{SnapshotPartStats, SnapshotPartsStats};
 
 /// An opaque identifier for a reader of a persist durable TVC (aka shard).
 #[derive(Arbitrary, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -23,6 +23,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::task::JoinHandleExt;
 use mz_persist_client::cfg::RetryParameters;
 use mz_persist_client::operators::shard_source::{shard_source, SnapshotMode};
+use mz_persist_client::project::ProjectionPushdown;
 use mz_persist_client::{Diagnostics, PersistClient, ShardId};
 use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
 use mz_persist_types::txn::TxnsCodec;
@@ -558,6 +559,7 @@ impl DataSubscribe {
                     |_, _| true,
                     false.then_some(|| unreachable!()),
                     async {},
+                    ProjectionPushdown::FetchAll,
                 );
                 (data_stream.leave(), token)
             });

--- a/test/sqllogictest/shard_errors.slt
+++ b/test/sqllogictest/shard_errors.slt
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Disable persist inline writes so we get hollow parts with diffs_sum below
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET persist_inline_writes_single_max_bytes = 0
+----
+COMPLETE 0
+
+# Create a one batch shard with a `SourceData(Err(_))` in it and an empty upper.
+# This guarantees that the query timestamp of the select is within our one
+# batch.
+statement ok
+CREATE MATERIALIZED VIEW foo AS (VALUES (1/0));
+
+# Make sure we get the error even if we project away all columns.
+query error division by zero
+SELECT count(*) FROM foo;
+
+# Create another shard with an error in it, and then some batch with no error
+# past it. This means we should have a batch with an error that is entirely
+# before the query timestamp of the select below.
+statement ok
+CREATE TABLE bar (a INT);
+
+statement ok
+INSERT INTO bar VALUES (0);
+
+statement ok
+CREATE MATERIALIZED VIEW baz AS SELECT 1/a FROM bar;
+
+statement ok
+INSERT INTO bar VALUES (1);
+
+# Make sure we get the error even if we project away all columns.
+query error division by zero
+SELECT count(*) FROM baz;


### PR DESCRIPTION
Motivation (h/t bkirwi): it's empirically very common for users to do
`select count(*) from x` queries to explore a brand new relation `x`.
These queries run in time proportional to the number of triples in `x`,
which can be slow when `x` is large. However, users prefer when their
queries are fast.

Persist recently started storing in metadata the sum of diffs for each
hollow part in a shard. In `persist_source`, if a part contains data
from entirely before the query `as_of`, and the pushed-down MFP projects
to an empty list of columns, and we can prove that the part is error
free, then we can use the count from stats instead of loading the data.

- Summing the diffs in a part is equivalent to projecting the row in
  each tuple to an empty row and then consolidating. (Which is pretty
  much how select count(*) queries get compiled today.)
- If the as-of timestamp falls in the middle of a part, we can just
  fetch and process the part as normal. The optimization can still
  provide a speedup for other parts.
- This is implemented entirely in persist/`persist_source`; the output
  looks precisely the same to Compute, just a bit more consolidated.

```
materialize=> select count(*) from lineitem;
  count
---------
 6003896
(1 row)

Time: 23906.461 ms (00:23.906)
materialize=> alter system set persist_optimize_ignored_data_fetch='true';
ALTER SYSTEM
Time: 229.953 ms
materialize=> select count(*) from lineitem;
  count
---------
 6003874 <- Not a bug, the answer did change in between the two queries
(1 row)

Time: 292.615 ms
```

Touches #20618

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
