### PR TITLE
storage: permit demuxing the same source output to multiple persist shards

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3563,7 +3563,7 @@ impl Coordinator {
                                 column_name
                                     .0
                                     .push(Ident::new_unchecked(curr_col.name.clone()));
-                                let subsource = curr_subsources_by_reference[&name].clone();
+                                let subsource = curr_subsources_by_reference[&table_name].clone();
                                 return Err(AdapterError::SubsourceSchemaTextColumnsMismatch {
                                     column_name,
                                     subsource,

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -441,6 +441,9 @@ impl DataSourceDesc {
             .chain(std::iter::once((&id, &0)))
             .map(|(id, output_index)| {
                 let export = SourceExport {
+                    // This value will never be observed by a running ingestion,
+                    // and will be removed as part of #26769.
+                    arity: 0,
                     output_index: *output_index,
                     storage_metadata: (),
                 };

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -54,7 +54,8 @@ pub struct PostgresTableDesc {
 
 impl PostgresTableDesc {
     /// Determines if two `PostgresTableDesc` are compatible with one another in
-    /// a way that Materialize can handle.
+    /// a way that Materialize can handle in its PostgreSQL source's logical
+    /// replication.
     ///
     /// Currently this means that the values are equal except for the following
     /// exceptions:
@@ -62,7 +63,7 @@ impl PostgresTableDesc {
     ///   Compatibility is defined as returning `true` for
     ///   `PostgresColumnDesc::is_compatible`.
     /// - `self`'s keys are all present in `other`
-    pub fn determine_compatibility(
+    pub fn determine_logical_replication_compatibility(
         &self,
         other: &PostgresTableDesc,
         allow_type_to_change_by_col_num: &BTreeSet<u16>,
@@ -82,7 +83,7 @@ impl PostgresTableDesc {
         // Table columns cannot change position, so only need to ensure that
         // `self.columns` is a prefix of `other_cols`.
         if self.columns.len() <= other_cols.len()
-            && self.columns.iter().zip(other_cols.iter()).all(|(s, o)| s.is_compatible(o, allow_type_to_change_by_col_num))
+            && self.columns.iter().zip(other_cols.iter()).all(|(s, o)| s.is_logical_replication_compatible(o, allow_type_to_change_by_col_num))
             && &self.name == other_name
             && &self.oid == other_oid
             && &self.namespace == other_namespace
@@ -157,7 +158,7 @@ impl PostgresColumnDesc {
     /// Note that this function somewhat unnecessarily errors if the names
     /// differ; this is negotiable but we want users to understand the fixedness
     /// of names in our schemas.
-    fn is_compatible(
+    pub fn is_logical_replication_compatible(
         &self,
         other: &PostgresColumnDesc,
         allow_type_to_change_by_col_num: &BTreeSet<u16>,

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -1037,8 +1037,16 @@ fn humanize_sql_for_show_create(
                         }
                     });
                 }
-                CreateSourceConnection::Kafka { .. }
-                | CreateSourceConnection::LoadGenerator { .. } => {}
+
+                CreateSourceConnection::LoadGenerator { .. } => {
+                    // Multi-output load generator sources only support `FOR ALL
+                    // TABLES`.
+                    if !curr_references.is_empty() {
+                        curr_references.clear();
+                        stmt.referenced_subsources = Some(ReferencedSubsources::All);
+                    }
+                }
+                CreateSourceConnection::Kafka { .. } => {}
             }
 
             // If this source has any references, reconstruct them.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -619,6 +619,7 @@ where
                     id,
                     SourceExport {
                         output_index: 0,
+                        arity: description.desc.typ().arity(),
                         storage_metadata: (),
                     },
                 );
@@ -733,6 +734,7 @@ where
                                 id,
                                 SourceExport {
                                     output_index,
+                                    arity: collection_state.description.desc.typ().arity(),
                                     storage_metadata: (),
                                 },
                             )
@@ -1078,6 +1080,7 @@ where
             ingestion_id,
             SourceExport {
                 output_index: 0,
+                arity: collection.description.desc.typ().arity(),
                 storage_metadata: (),
             },
         );
@@ -1095,10 +1098,12 @@ where
                 continue;
             }
 
+            let export_collection = self.collection(*export_id)?;
+
             let DataSource::IngestionExport {
                 ingestion_id,
                 external_reference,
-            } = &self.collection(*export_id)?.description.data_source
+            } = &export_collection.description.data_source
             else {
                 panic!("source exports must be DataSource::IngestionExport")
             };
@@ -1115,6 +1120,7 @@ where
                 *export_id,
                 SourceExport {
                     output_index,
+                    arity: export_collection.description.desc.typ().arity(),
                     storage_metadata: (),
                 },
             );
@@ -3622,6 +3628,7 @@ where
             export_id,
             SourceExport {
                 output_index,
+                arity,
                 storage_metadata: (),
             },
         ) in ingestion_description.source_exports
@@ -3631,6 +3638,7 @@ where
                 export_id,
                 SourceExport {
                     storage_metadata: export_storage_metadata,
+                    arity,
                     output_index,
                 },
             );

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -79,6 +79,7 @@ message ProtoIngestionDescription {
         mz_repr.global_id.ProtoGlobalId id = 1;
         uint64 output_index = 2;
         mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 3;
+        uint64 arity = 4;
     }
 
     reserved 1;

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -407,7 +407,9 @@ fn verify_schema(
         })
         .collect();
 
-    match expected_desc.determine_compatibility(current_desc, &allow_oids_to_change_by_col_num) {
+    match expected_desc
+        .determine_logical_replication_compatibility(current_desc, &allow_oids_to_change_by_col_num)
+    {
         Ok(()) => Ok(()),
         Err(err) => Err(DefiniteError::IncompatibleSchema(err.to_string())),
     }

--- a/test/pg-cdc/alter-source-demux.td
+++ b/test/pg-cdc/alter-source-demux.td
@@ -57,6 +57,9 @@ INSERT INTO table_a VALUES (3, 'three', 'd');
 2 two
 3 three
 
+> SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"postgres\".\"public\".\"table_a\" AS \"materialize\".\"public\".\"table_a\""
+
 # New schema, same name
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_a;
 contains:catalog item 'table_a' already exists
@@ -72,6 +75,10 @@ contains:catalog item 'table_a' already exists
 1 one
 2 two
 3 three
+
+# Now only shows `table_a_3` in `SHOW CREATE SOURCE`
+> SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"postgres\".\"public\".\"table_a\" AS \"materialize\".\"public\".\"table_a_3\""
 
 # Multiple new columns
 
@@ -97,6 +104,10 @@ INSERT INTO table_a VALUES (4, 'four', 'e', 1);
 2 two
 3 three
 4 four
+
+# Now only shows `table_a_4` in `SHOW CREATE SOURCE`
+> SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"postgres\".\"public\".\"table_a\" AS \"materialize\".\"public\".\"table_a_4\""
 
 > SHOW SUBSOURCES ON mz_source
 mz_source_progress    progress

--- a/test/pg-cdc/alter-source-demux.td
+++ b/test/pg-cdc/alter-source-demux.td
@@ -1,0 +1,292 @@
+
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# IMPORTANT: The Postgres server has a custom pg_hba.conf that only
+# accepts connections from specific users. You will have to update
+# pg_hba.conf if you modify the existing user names or add new ones.
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_a VALUES (1, 'one');
+ALTER TABLE table_a REPLICA IDENTITY FULL;
+INSERT INTO table_a VALUES (2, 'two');
+
+> CREATE SOURCE "mz_source"
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source'
+  )
+  FOR SCHEMAS (public);
+
+> SHOW SUBSOURCES ON mz_source
+mz_source_progress    progress
+table_a               subsource
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a ADD COLUMN c TEXT DEFAULT 'c';
+INSERT INTO table_a VALUES (3, 'three', 'd');
+
+# Current strategy of ignoring uningested columns works.
+> SELECT * FROM table_a;
+1 one
+2 two
+3 three
+
+# New schema, same name
+! ALTER SOURCE mz_source ADD SUBSOURCE table_a;
+contains:catalog item 'table_a' already exists
+
+# New schema, new name
+> ALTER SOURCE mz_source ADD SUBSOURCE table_a AS table_a_3;
+> SELECT * FROM table_a_3;
+1 one c
+2 two c
+3 three d
+
+> SELECT * FROM table_a;
+1 one
+2 two
+3 three
+
+# Multiple new columns
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a ADD COLUMN d INT DEFAULT 0;
+INSERT INTO table_a VALUES (4, 'four', 'e', 1);
+
+> ALTER SOURCE mz_source ADD SUBSOURCE table_a AS table_a_4;
+> SELECT * FROM table_a_4;
+1 one c 0
+2 two c 0
+3 three d 0
+4 four e 1
+
+> SELECT * FROM table_a_3;
+1 one c
+2 two c
+3 three d
+4 four e
+
+> SELECT * FROM table_a;
+1 one
+2 two
+3 three
+4 four
+
+> SHOW SUBSOURCES ON mz_source
+mz_source_progress    progress
+table_a               subsource
+table_a_3             subsource
+table_a_4             subsource
+
+> SELECT schema_name, table_name FROM mz_internal.mz_postgres_source_tables;
+public table_a
+public table_a
+public table_a
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a ADD COLUMN e INT DEFAULT 0;
+INSERT INTO table_a VALUES (5, 'five', 'f', 2, 1);
+
+> ALTER SOURCE mz_source
+    ADD SUBSOURCE table_a AS table_a_5_text_col
+    WITH (
+        TEXT COLUMNS = [table_a.e]
+    );
+
+> SELECT * FROM table_a_5_text_col;
+1 one   c   0   0
+2 two   c   0   0
+3 three d   0   0
+4 four  e   1   0
+5 five  f   2   1
+
+> SELECT DISTINCT pg_typeof(e) FROM table_a_5_text_col;
+text
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a ADD COLUMN f INT DEFAULT 0;
+
+# Missing TEXT COLUMNS
+! ALTER SOURCE mz_source ADD SUBSOURCE table_a AS table_a_6;
+contains:new subsource schema incompatible with existing subsource referring to same table
+detail:current ingestion ("materialize.public.table_a_5_text_col") specifies TEXT COLUMNS on "postgres.public.table_a.e", but new subsource does not
+
+# Too many TEXT COLUMNS
+! ALTER SOURCE mz_source
+    ADD SUBSOURCE table_a AS table_a_6_text_cols
+    WITH (
+        TEXT COLUMNS = [table_a.d, table_a.e]
+    );
+contains:new subsource schema incompatible with existing subsource referring to same table
+detail:new subsource specifies TEXT COLUMNS on "postgres.public.table_a.d", but current ingestion ("materialize.public.table_a_5_text_col") does not
+
+# Just right
+> ALTER SOURCE mz_source
+    ADD SUBSOURCE table_a AS table_a_6_text_cols
+    WITH (
+        TEXT COLUMNS = [table_a.e]
+    );
+
+# If we drop a column, we cannot update the definition
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a DROP COLUMN f;
+
+! ALTER SOURCE mz_source
+    ADD SUBSOURCE table_a AS table_a_5_2
+    WITH (
+        TEXT COLUMNS = [table_a.e]
+    );
+contains:new subsource schema incompatible with existing subsource referring to same table
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a ADD COLUMN f INT DEFAULT 0;
+ALTER TABLE table_a ADD COLUMN g INT DEFAULT 0;
+
+# These schemas will never line up now that we've dropped one of the columns.
+! ALTER SOURCE mz_source
+    ADD SUBSOURCE table_a AS table_a_7
+    WITH (
+        TEXT COLUMNS = [table_a.e]
+    );
+contains:new subsource schema incompatible with existing subsource referring to same table
+
+# Test creating a subsource with the same resulting schema
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP TABLE table_a;
+CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_a VALUES (1, 'one');
+ALTER TABLE table_a REPLICA IDENTITY FULL;
+INSERT INTO table_a VALUES (2, 'two');
+
+> DROP SOURCE mz_source CASCADE;
+
+> CREATE SOURCE "mz_source"
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS = (table_a.f2)
+  )
+  FOR SCHEMAS (public);
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a DROP COLUMN f2;
+ALTER TABLE table_a ADD COLUMN f2 INT;
+
+# This would generate a subsource with the same schema, so we disallow it.
+! ALTER SOURCE mz_source
+    ADD SUBSOURCE table_a AS table_a_2
+    WITH (
+        TEXT COLUMNS = (table_a.f2)
+    );
+contains:new subsource schema incompatible with existing subsource referring to same table
+
+# Test changing a TEXT COLUMN type and ingesting another additional column
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TYPE an_enum AS ENUM ('var0', 'var1');
+CREATE TABLE enum_table (a an_enum);
+INSERT INTO enum_table VALUES ('var1'), ('var0');
+ALTER TABLE enum_table REPLICA IDENTITY FULL;
+
+> DROP SOURCE mz_source CASCADE;
+
+> CREATE SOURCE "mz_source"
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS = (enum_table.a)
+  )
+  FOR TABLES (enum_table);
+
+> SELECT * FROM enum_table
+var0
+var1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+BEGIN;
+ALTER TYPE an_enum RENAME TO an_enum_old;
+CREATE TYPE an_enum AS ENUM ('var0', 'var1', 'var2');
+ALTER TABLE enum_table ALTER COLUMN a TYPE an_enum USING a::text::an_enum;
+DROP TYPE an_enum_old;
+COMMIT;
+
+INSERT INTO enum_table VALUES ('var2');
+
+> SELECT * FROM enum_table
+var0
+var1
+var2
+
+# This subsource isn't differentiated
+! ALTER SOURCE mz_source
+    ADD SUBSOURCE enum_table AS enum_table_2
+    WITH (
+        TEXT COLUMNS = (enum_table.a)
+    );
+contains:new subsource schema incompatible with existing subsource referring to same table
+
+# Adding a column will sufficiently differentiate it
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE enum_table ADD COLUMN b INT DEFAULT 0;
+
+> ALTER SOURCE mz_source
+    ADD SUBSOURCE enum_table AS enum_table_2
+    WITH (
+        TEXT COLUMNS = (enum_table.a)
+    );
+
+> SELECT * FROM enum_table
+var0
+var1
+var2
+
+> SELECT * FROM enum_table_2
+var0 0
+var1 0
+var2 0
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+BEGIN;
+ALTER TYPE an_enum RENAME TO an_enum_old;
+CREATE TYPE an_enum AS ENUM ('var0', 'var1', 'var2', 'var3');
+ALTER TABLE enum_table ALTER COLUMN a TYPE an_enum USING a::text::an_enum;
+DROP TYPE an_enum_old;
+COMMIT;
+
+INSERT INTO enum_table VALUES ('var3', 1);
+
+> SELECT * FROM enum_table
+var0
+var1
+var2
+var3
+
+> SELECT * FROM enum_table_2
+var0 0
+var1 0
+var2 0
+var3 1

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -50,26 +50,8 @@ INSERT INTO table_a VALUES (2, 'two');
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP TABLE table_a CASCADE;
 
-!ALTER SOURCE mz_source ADD SUBSOURCE table_b;
+! ALTER SOURCE mz_source ADD SUBSOURCE table_b;
 contains:PUBLICATION mz_source is empty
-
-# Adding a table with the same name as a running table does not allow you to add
-# the new table, even though its OID is the different.
-
-$ postgres-execute connection=postgres://postgres:postgres@postgres
-CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
-ALTER TABLE table_a REPLICA IDENTITY FULL;
-INSERT INTO table_a VALUES (9, 'nine');
-
-# Current table_a is not new table_a. Note that this only works right now
-# because we are bad at detecting dropped tables.
-> SELECT * FROM table_a;
-1 one
-2 two
-
-# We are not aware that the new table_a is different
-!ALTER SOURCE mz_source ADD SUBSOURCE table_a;
-contains:another subsource already refers to postgres.public.table_a
 
 > DROP SOURCE mz_source CASCADE;
 
@@ -77,8 +59,9 @@ contains:another subsource already refers to postgres.public.table_a
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 
-DELETE FROM table_a;
+CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
 INSERT INTO table_a VALUES (1, 'one');
+ALTER TABLE table_a REPLICA IDENTITY FULL;
 INSERT INTO table_a VALUES (2, 'two');
 
 CREATE TABLE table_b (pk INTEGER PRIMARY KEY, f2 TEXT);
@@ -222,7 +205,7 @@ mz_source_progress    progress
 > ALTER SOURCE mz_source ADD SUBSOURCE table_g;
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_g;
-contains:another subsource already refers to postgres.public.table_g
+contains:new subsource schema incompatible with existing subsource referring to same table
 
 > ALTER SOURCE mz_source ADD SUBSOURCE table_a, table_b AS tb;
 
@@ -230,8 +213,23 @@ contains:another subsource already refers to postgres.public.table_g
 1 one
 2 two
 
-! ALTER SOURCE mz_source ADD SUBSOURCE table_a;
-contains:another subsource already refers to postgres.public.table_a
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE table_a RENAME TO table_z;
+
+! ALTER SOURCE mz_source ADD SUBSOURCE table_z;
+contains:ambiguous subsource references
+detail:"postgres.public.table_z" is currently ingested by "materialize.public.table_a", but is referred to as "postgres.public.table_a"
+
+> DROP SOURCE table_a;
+> ALTER SOURCE mz_source ADD SUBSOURCE table_z;
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP TABLE table_z CASCADE;
+CREATE TABLE table_z (a int);
+ALTER TABLE table_z REPLICA IDENTITY FULL;
+
+! ALTER SOURCE mz_source ADD SUBSOURCE table_z;
+contains:new subsource schema incompatible with existing subsource referring to same table
 
 > SELECT * FROM tb;
 1 one
@@ -256,13 +254,25 @@ INSERT INTO table_h VALUES (2, 'two');
 
 > SHOW SUBSOURCES ON mz_source
 mz_source_progress progress
-table_a            subsource
 table_g            subsource
 table_h            subsource
+table_z            subsource
 tb                 subsource
 
 #
 # Complex subsource operations
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_a VALUES (1, 'one');
+ALTER TABLE table_a REPLICA IDENTITY FULL;
+INSERT INTO table_a VALUES (2, 'two');
+
+> ALTER SOURCE mz_source ADD SUBSOURCE table_a;
+
+> SELECT * FROM table_a;
+1 one
+2 two
 
 # If your schema change breaks the subsource, you can fix it.
 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -367,8 +377,8 @@ INSERT INTO table_f VALUES (3, 'var1');
 > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 <null>
 
-! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS (table_z.a));
-contains:invalid TEXT COLUMNS option value: table table_z not found in source
+! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS (table_y.a));
+contains:invalid TEXT COLUMNS option value: table table_y not found in source
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS [table_f.f2]);
 contains:TEXT COLUMNS refers to table not currently being added


### PR DESCRIPTION
This was originally proposed in #25045, where @petrosagg suggested [a design similar to this one](https://github.com/MaterializeInc/materialize/pull/25045#pullrequestreview-1877787332).

#### Miniature design doc

Users often want to ingest new columns they've added to their PG tables. Our current strategy is to drop added columns on the floor (i.e. rows output from the dataflow are truncated to the arity of the `PostgresTableDesc`'s schema).

However, we could instead output rows at their maximum expected arity, and _then_ truncate those rows further if there are other `SourceExport`s that want the row at a lesser arity (i.e. hoist the same truncation logic from the dataflow itself to the bit that writes to the persist shard).

This design only supports arity-based truncation and doesn't provide more complex projections and re-orderings for two reasons:
- The expected use case of this feature is only to ingest new columns added to PostgreSQL tables. PostgreSQL doesn't support reordering columns, so this feature wouldn't do anything for the intended use case.
- Complex projections require unpacking and repacking the output `Row`, which is expensive.

If it turns out that we need more complex projections in the future, then we can add them.

### Motivation

This PR adds a known-desirable feature. Closes #24843

### Tips for reviewer

@MaterializeInc/storage please review the storage-related changes

Anyone can review the adapter changes, though I think @MaterializeInc/surfaces were the last folks to pay close attention to the shape of this code. I think that this is basically planning code, and that it just lives in the adapter is a little gross. Maybe we should file a refactor issue to work on tidying this up?

@MaterializeInc/testing PTAL if you have time. The tests here cover the contortions I could think of but also very glad to talk through anything.

There are also documentation changes that I need to make and link in here; will do those separately iff these changes get approved. #26872

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
