### PR TITLE
adapter: Update application names we log in Prometheus, warn for some adapter errors

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -866,11 +866,13 @@ impl SessionClient {
                     drop(guarded_rx);
 
                     let res = res.expect("sender dropped");
-                    let status = if res.result.is_ok() {
-                        "success"
-                    } else {
-                        "error"
-                    };
+                    let status = res.result.is_ok().then_some("success").unwrap_or("error");
+                    if let Err(err) = res.result.as_ref() {
+                        if name_hint.should_trace_errors() {
+                            tracing::warn!(?err, ?name_hint, "adapter response error");
+                        }
+                    }
+
                     if let Some(typ) = typ {
                         inner_client
                             .metrics


### PR DESCRIPTION
Was chatting with @materializekatrina about our SLOs and we want to alert on adapter errors from the web console and ideally we'd be able to figure out what the error was. To solve for this we `tracing::warn` adapter errors if the application name is `web_console`. I confirmed with console folks this is internal only queries and `web_console_shell` are user queries from the shell.

At the same time Katrina queried our segment data (which contains all application names) and this PR adds a few of the most common ones we see.

### Motivation

Metrics and SLO

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improves some internal metrics
