### PR TITLE
ci: slow cloudtests: increase timeout

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -841,7 +841,7 @@ steps:
       - id: cloudtest-slow
         label: "Slow Cloudtest"
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 35
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:


### PR DESCRIPTION
[Timed out yesterday](https://buildkite.com/materialize/nightly/builds/7616#018f3a5c-3787-437d-9463-1a6fa3792dbc) once, average duration is probably close to 30 minutes.