### PR TITLE
tests: fix deprecation warnings and unused imports

### DIFF
--- a/src/adapter/benches/catalog.rs
+++ b/src/adapter/benches/catalog.rs
@@ -7,12 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::str::FromStr;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 use mz_adapter::catalog::{Catalog, Op};
 use mz_ore::now::SYSTEM_TIME;
-use mz_ore::task::spawn;
 use mz_persist_client::PersistClient;
 use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
 use tokio::runtime::Runtime;

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -756,12 +756,11 @@ fn test_format_timestamptz() {
         sec: u32,
         nano: u32,
     ) -> DateTime<Utc> {
-        DateTime::from_utc(
-            NaiveDate::from_ymd_opt(year, month, day)
+        Utc.from_utc_datetime(
+            &NaiveDate::from_ymd_opt(year, month, day)
                 .unwrap()
                 .and_hms_nano_opt(hour, min, sec, nano)
                 .unwrap(),
-            Utc,
         )
     }
 


### PR DESCRIPTION
These keep popping up in my editor.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
