### PR TITLE
persist: use semaphore-based physical flow control in cc replica fetches

### DIFF
--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -260,6 +260,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let mut persist_cfg =
         PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone(), mz_dyncfgs::all_dyncfgs());
     persist_cfg.is_cc_active = args.is_cluster_size_v2;
+    persist_cfg.announce_memory_limit = args.announce_memory_limit;
     let persist_clients = Arc::new(PersistClientCache::new(
         persist_cfg,
         &metrics_registry,

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -566,7 +566,7 @@ impl DataSubscribe {
             let (mut data, mut txns) = (ProbeHandle::new(), ProbeHandle::new());
             let data_stream = data_stream.flat_map(|part| {
                 let part = part.parse();
-                part.map(|((k, v), t, d)| {
+                part.part.map(|((k, v), t, d)| {
                     let (k, ()) = (k.unwrap(), v.unwrap());
                     (k, t, d)
                 })

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -26,8 +26,8 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::{PersistConfig, RetryParameters};
-use mz_persist_client::fetch::SerdeLeasedBatchPart;
 use mz_persist_client::fetch::{FetchedBlob, FetchedPart};
+use mz_persist_client::fetch::{SerdeLeasedBatchPart, ShardSourcePart};
 use mz_persist_client::operators::shard_source::{shard_source, SnapshotMode};
 use mz_persist_txn::operator::txns_progress;
 use mz_persist_types::codec_impls::UnitSchema;
@@ -493,7 +493,7 @@ struct PendingWork {
 enum PendingPart {
     Unparsed(FetchedBlob<SourceData, (), Timestamp, Diff>),
     Parsed {
-        part: FetchedPart<SourceData, (), Timestamp, Diff>,
+        part: ShardSourcePart<SourceData, (), Timestamp, Diff>,
         error_free: bool,
     },
 }
@@ -516,7 +516,7 @@ impl PendingPart {
                 // Won't recurse any further.
                 self.part_mut()
             }
-            PendingPart::Parsed { part, error_free } => (part, *error_free),
+            PendingPart::Parsed { part, error_free } => (&mut part.part, *error_free),
         }
     }
 }


### PR DESCRIPTION
Unblock the transition to cc replicas by reintroducing physical
persist_source flow control. We introduce a new mechanism to improve a
couple deficiencies in the previous one:

- (1) Our product principle of any dataflow that works in the steady
  state should be able to rehydrate (see below).
- (2) More directly model the constrained resource.

Thought experiment for (1): A single dataflow has N inputs, each a
unique shard. One by one, a 128 MiB part is written to each of them. If
we want this to rehydrate, the unavoidable conclusion is that we need
cross-persist_source flow control.

- This has historically been stressful because the old mechanism worked
  on granular timely timestamps, which could easily lead to deadlocks if
  used across multiple inputs (thus each was totally isolated).
- We work around this here by passing a release-on-drop permit token to
  the decode operator, which is run-to-completion.

For (2), we directly model the per-process constrained resource
(mem/disk) with a per-process semaphore having `mem_limit_bytes`
permits.

- Persist fetch data is put in lgalloc, so disk is the real limiting
  resource.
- This targets 50% disk utilization (with the standard cc 1:2 ratio)
  from persist, which seems like a reasonable place to start.
- This is also enough that stalls of the fetch pipeline seem unlikely in
  practice, so there's probably not much benefit to targeting more than
  100% of memory.
- Initial experiments have shown impressive results:
  - Flat usage for constrained scenarios (25cc rehydrating tpch indexes)
  - No slowdown for unconstrained scenarios (50cc rehydrating tpch
    indexes)
  - Notably, the previous mechanism achieved _neither_ of these.
  - This may allow us to default the new mechanism to on!

Notes:
- This also unblocks logical persist_source flow control once we've
  moved off cc replicas with the old physical flow control on.
- NB: Having multiple mechanisms in mz for flow control is unfortunate,
  but it seems possible to model this logic using the frontiers
  technique (which Gus's new flow control is also), so it should be
  possible to unify them later. The translation seems tricky though, and
  unblocking cc replicas now is easily worth it if we rip this out.
- This could also easily be made data parallel (adjusting permits
  accordingly). Initially leaning per-process because per-worker could
  result in less efficient resource usage and the cross-worker
  coordination is a rounding error compared to the network requests it
  would accompany.
- I initially tried using one permit per blob, but this led to some
  slowdown of what should have been unconstrained scenarios.
- Uses other than persist_source have the potential for deadlock with
  this new mechanism, so are initially left out. Compaction is already
  bounded memory, so possible we could model that one as acquiring all
  permits upfront? Even if so, leaving this until/when it becomes an
  issue in practice.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
