### PR TITLE
storage/rocksdb: Add support for specifying merge operator fn and merge commands

### DIFF
--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -11,7 +11,7 @@ use mz_ore::metrics::{CounterVecExt, HistogramVecExt};
 use mz_rocksdb::config::SharedWriteBufferManager;
 use mz_rocksdb::{
     InstanceOptions, KeyUpdate, RocksDBConfig, RocksDBInstance, RocksDBInstanceMetrics,
-    RocksDBSharedMetrics, ValueIterator,
+    RocksDBSharedMetrics, StubMergeOperator, ValueIterator,
 };
 use mz_rocksdb_types::RocksDBTuningParameters;
 use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, Opts};
@@ -51,7 +51,7 @@ async fn basic() -> Result<(), anyhow::Error> {
 
     let mut instance = RocksDBInstance::<String, String>::new(
         t.path(),
-        InstanceOptions::new(
+        InstanceOptions::<bincode::DefaultOptions, String, StubMergeOperator<String>>::new(
             rocksdb::Env::new()?,
             2,
             None,
@@ -267,7 +267,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
 
     let instance1 = RocksDBInstance::<String, String>::new(
         t.path().join("1").as_path(),
-        InstanceOptions::new(
+        InstanceOptions::<bincode::DefaultOptions, String, StubMergeOperator<String>>::new(
             rocksdb::Env::new()?,
             2,
             None,
@@ -293,7 +293,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
 
     let instance2 = RocksDBInstance::<String, String>::new(
         t.path().join("2").as_path(),
-        InstanceOptions::new(
+        InstanceOptions::<bincode::DefaultOptions, String, StubMergeOperator<String>>::new(
             rocksdb::Env::new()?,
             2,
             None,
@@ -322,7 +322,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
 
     let instance3 = RocksDBInstance::<String, String>::new(
         t.path().join("3").as_path(),
-        InstanceOptions::new(
+        InstanceOptions::<bincode::DefaultOptions, String, StubMergeOperator<String>>::new(
             rocksdb::Env::new()?,
             2,
             None,

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -309,16 +309,17 @@ where
                     rocksdb::RocksDB::new(
                         mz_rocksdb::RocksDBInstance::new(
                             &rocksdb_dir,
-                            mz_rocksdb::InstanceOptions::defaults_with_env(
+                            mz_rocksdb::InstanceOptions::new(
                                 env,
                                 rocksdb_cleanup_tries,
+                                None,
+                                // For now, just use the same config as the one used for
+                                // merging snapshots.
+                                upsert_bincode_opts(),
                             ),
                             tuning,
                             rocksdb_shared_metrics,
                             rocksdb_instance_metrics,
-                            // For now, just use the same config as the one used for
-                            // merging snapshots.
-                            upsert_bincode_opts(),
                         )
                         .await
                         .unwrap(),

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -309,7 +309,7 @@ where
                     rocksdb::RocksDB::new(
                         mz_rocksdb::RocksDBInstance::new(
                             &rocksdb_dir,
-                            mz_rocksdb::InstanceOptions::new(
+                            mz_rocksdb::InstanceOptions::<_, _, mz_rocksdb::StubMergeOperator<_>>::new(
                                 env,
                                 rocksdb_cleanup_tries,
                                 None,

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -80,7 +80,7 @@ where
         RocksDB::new(
             mz_rocksdb::RocksDBInstance::new(
                 instance_path,
-                mz_rocksdb::InstanceOptions::new(
+                mz_rocksdb::InstanceOptions::<_, _, mz_rocksdb::StubMergeOperator<_>>::new(
                     env.clone(),
                     *cleanup_tries,
                     None,

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -80,11 +80,15 @@ where
         RocksDB::new(
             mz_rocksdb::RocksDBInstance::new(
                 instance_path,
-                mz_rocksdb::InstanceOptions::defaults_with_env(env.clone(), *cleanup_tries),
+                mz_rocksdb::InstanceOptions::new(
+                    env.clone(),
+                    *cleanup_tries,
+                    None,
+                    upsert_bincode_opts(),
+                ),
                 tuning_config.clone(),
                 Arc::clone(shared_metrics),
                 Arc::clone(instance_metrics),
-                upsert_bincode_opts(),
             )
             .await
             .unwrap(),

--- a/src/storage/src/upsert/rocksdb.rs
+++ b/src/storage/src/upsert/rocksdb.rs
@@ -59,7 +59,7 @@ where
                 },
             ))
             .await?;
-        p_stats.processed_puts += stats.processed_puts;
+        p_stats.processed_puts += stats.processed_updates;
         let size: i64 = stats.size_written.try_into().expect("less than i64 size");
         p_stats.size_diff += size;
 

--- a/src/storage/src/upsert/rocksdb.rs
+++ b/src/storage/src/upsert/rocksdb.rs
@@ -9,7 +9,7 @@
 
 //! An `UpsertStateBackend` that stores values in RocksDB.
 
-use mz_rocksdb::RocksDBInstance;
+use mz_rocksdb::{KeyUpdate, RocksDBInstance};
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::types::{
@@ -34,6 +34,7 @@ impl<O> UpsertStateBackend<O> for RocksDB<O>
 where
     O: Send + Sync + Serialize + DeserializeOwned + 'static,
 {
+    // TODO: Refactor this to allow using using Merge instead of Put for updates.
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
         P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,
@@ -41,7 +42,7 @@ where
         let mut p_stats = PutStats::default();
         let stats = self
             .rocksdb
-            .multi_put(puts.into_iter().map(
+            .multi_update(puts.into_iter().map(
                 |(
                     k,
                     PutValue {
@@ -50,6 +51,10 @@ where
                     },
                 )| {
                     p_stats.adjust(value.as_ref(), None, &previous_value_metadata);
+                    let value = match value {
+                        Some(v) => KeyUpdate::Put(v),
+                        None => KeyUpdate::Delete,
+                    };
                     (k, value)
                 },
             ))


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Initial work towards enabling https://github.com/MaterializeInc/materialize/issues/26003

This adds support for the "merge" operation in rocksdb (https://github.com/facebook/rocksdb/wiki/Merge-Operator) by allowing a user of `mz-rocksdb-util` to provide an 'associative merge function' and to provide 'merge' updates for a key in addition to 'put' and 'delete' updates to a key.

There are 4 semantic changes done to the rocksdb util:
- `bincode::Options` are now part of `InstanceOptions` since they are necessary for use in the merge function
- `InstanceOptions` optionally accepts a `merge_operator` function that can be treated as an 'associative merge operator'
- the `multi_put` command has been renamed `multi_update`, and rather than using an `Option` to demarcate whether the operation should be a Put or a Delete, a new `KeyUpdate` enum has been introduced that also adds support for the `Merge` operation
- there is a `manual_compaction` command added to allow forcing compaction during unit tests


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
