### PR TITLE
tests: fix kafka-sink-headers.td by always using a single-replica cluster

### DIFF
--- a/test/testdrive/kafka-sink-headers.td
+++ b/test/testdrive/kafka-sink-headers.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-arg-default single-replica-cluster=quickstart
+
 # Test the HEADER option for Kafka sinks, which allows attaching user-specified
 # headers to each Kafka message emitted by the sink.
 
@@ -21,6 +23,7 @@ ALTER SYSTEM SET enable_kafka_sink_headers = true
 > CREATE TABLE wrong_name_tbl (k int);
 
 ! CREATE SINK snk
+  IN CLUSTER ${arg.single-replica-cluster}
   FROM wrong_name_tbl
   INTO KAFKA CONNECTION k (TOPIC 'testdrive-bad-${testdrive.seed}')
   KEY (k) NOT ENFORCED
@@ -33,6 +36,7 @@ contains:HEADERS column (h) is unknown
 > CREATE TABLE wrong_type_tbl (k int, h1 int, h2 map[text => int]);
 
 ! CREATE SINK snk
+  IN CLUSTER ${arg.single-replica-cluster}
   FROM wrong_type_tbl
   INTO KAFKA CONNECTION k (TOPIC 'testdrive-bad-${testdrive.seed}')
   KEY (k) NOT ENFORCED
@@ -41,6 +45,7 @@ contains:HEADERS column (h) is unknown
 contains:HEADERS column must have type map[text => text] or map[text => bytea]
 
 ! CREATE SINK snk
+  IN CLUSTER ${arg.single-replica-cluster}
   FROM wrong_type_tbl
   INTO KAFKA CONNECTION k (TOPIC 'testdrive-bad-${testdrive.seed}')
   KEY (k) NOT ENFORCED
@@ -59,6 +64,7 @@ contains:HEADERS column must have type map[text => text] or map[text => bytea]
     (5, '{"a" => "b", "c" => "d"}')
 
 > CREATE SINK text_snk
+  IN CLUSTER ${arg.single-replica-cluster}
   FROM text_tbl
   INTO KAFKA CONNECTION k (TOPIC 'testdrive-text-${testdrive.seed}')
   KEY (k) NOT ENFORCED
@@ -88,6 +94,7 @@ b         <null>    {"k": 6, "h": {"a": "b", "c": null}}
     (5, '{"a" => "b", "c" => "d"}')
 
 > CREATE SINK bytea_snk
+  IN CLUSTER ${arg.single-replica-cluster}
   FROM bytea_tbl
   INTO KAFKA CONNECTION k (TOPIC 'testdrive-bytea-${testdrive.seed}')
   KEY (k) NOT ENFORCED


### PR DESCRIPTION
Without this, nightly testdrive tests that run on clusters with more
than one replica are failing.

It's the fix for
```
kafka-sink-headers.td:61:1: error: executing query failed: db error: ERROR: cannot create sink in cluster with more than one replica: ERROR: cannot create sink in cluster with more than one replica
```


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
