### PR TITLE
adapter: instrument cluster readiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5909,9 +5909,11 @@ dependencies = [
 name = "mz-segment"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "mz-ore",
  "segment",
  "serde_json",
+ "time",
  "tokio",
  "tracing",
  "uuid",

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -41,7 +41,7 @@ use mz_controller::clusters::{
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_expr::refresh_schedule::RefreshEvery;
 use mz_expr::MirScalarExpr;
-use mz_orchestrator::{CpuLimit, DiskLimit, MemoryLimit, NotReadyReason, ServiceProcessMetrics};
+use mz_orchestrator::{CpuLimit, DiskLimit, MemoryLimit, ServiceProcessMetrics};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_repr::adt::array::ArrayDimension;
@@ -376,7 +376,7 @@ impl CatalogState {
         let not_ready_reason = match event.status {
             ClusterStatus::Ready => None,
             ClusterStatus::NotReady(None) => None,
-            ClusterStatus::NotReady(Some(NotReadyReason::OomKilled)) => Some("oom-killed"),
+            ClusterStatus::NotReady(Some(reason)) => Some(reason.to_string()),
         };
 
         BuiltinTableUpdate {
@@ -385,7 +385,7 @@ impl CatalogState {
                 Datum::String(&replica_id.to_string()),
                 Datum::UInt64(process_id),
                 Datum::String(status),
-                not_ready_reason.into(),
+                Datum::from(not_ready_reason.as_deref()),
                 Datum::TimestampTz(event.time.try_into().expect("must fit")),
             ]),
             diff,

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -56,7 +56,7 @@ use crate::session::{
     EndTransactionAction, PreparedStatement, Session, SessionConfig, TransactionId,
 };
 use crate::statement_logging::StatementEndedExecutionReason;
-use crate::telemetry::{self, SegmentClientExt, StatementFailureType};
+use crate::telemetry::{self, EventDetails, SegmentClientExt, StatementFailureType};
 use crate::webhook::AppendWebhookResponse;
 use crate::{AdapterNotice, AppendWebhookError, PeekResponseUnary, StartupResponse};
 
@@ -475,13 +475,16 @@ impl SessionClient {
         );
         segment_client.environment_track(
             &self.environment_id,
-            session.application_name(),
-            user_id,
             event_name,
             json!({
                 "statement_kind": statement_kind,
                 "error": &parse_error.error,
             }),
+            EventDetails {
+                user_id: Some(user_id),
+                application_name: Some(session.application_name()),
+                ..Default::default()
+            },
         );
     }
 

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -101,6 +101,14 @@ pub enum NotReadyReason {
     OomKilled,
 }
 
+impl fmt::Display for NotReadyReason {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NotReadyReason::OomKilled => f.write_str("oom-killed"),
+        }
+    }
+}
+
 /// Describes the status of an orchestrated service.
 #[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq)]
 pub enum ServiceStatus {

--- a/src/segment/Cargo.toml
+++ b/src/segment/Cargo.toml
@@ -10,9 +10,11 @@ publish = false
 workspace = true
 
 [dependencies]
+chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 mz-ore = { path = "../ore", features = ["async"], default-features = false }
 segment = { version = "0.2.1", features = ["native-tls-vendored"], default-features = false }
 serde_json = "1.0.89"
+time = "0.3.17"
 tokio = { version = "1.32.0", features = ["sync"] }
 tracing = "0.1.37"
 uuid = "1.2.2"


### PR DESCRIPTION
One of the cloud team's SLIs this quarter is the amount of time between the commit of a `CREATE CLUSTER` or `ALTER CLUSTER` command and when the cluster becomes ready. So, add a Segment event every time a cluster becomes ready or becomes not ready.

It will then be straightforward to write an analytics query that joins these new events against the existing "Cluster Replica Created" events to determine the cluster startup delay. (Under the hood, an `ALTER CLUSTER` is converted into a sequence of replica drop/creation events.)

Touches MaterializeInc/cloud#9311.

Following is an example of the Segment events that get issued when creating a new cluster. Since I was running this off my local machine, clusters become ready nearly instantly. 

```json
{
  "context": {
    "group_id": "6ab91d1a-f4bf-45b7-8682-079cf077e350",
    "library": {
      "name": "unknown",
      "version": "unknown"
    }
  },
  "event": "Cluster Replica Created",
  "integrations": {},
  "messageId": "api-2fzGIiHu07MgUvp9RHBm4rHPtYC",
  "originalTimestamp": "2024-05-04T04:20:11.462306Z",
  "properties": {
    "application_name": "psql",
    "cloud_provider": "local",
    "cloud_provider_region": "az1",
    "details": {
      "billed_as": null,
      "cluster_id": "u2",
      "cluster_name": "nikhil",
      "disk": false,
      "internal": false,
      "logical_size": "1",
      "replica_id": "u2",
      "replica_name": "r1"
    },
    "event_source": "environment"
  },
  "receivedAt": "2024-05-04T04:20:13.047Z",
  "sentAt": null,
  "timestamp": "2024-05-04T04:20:11.462Z",
  "type": "track",
  "userId": "6ab91d1a-f4bf-45b7-8682-079cf077e350",
  "writeKey": "REDACTED"
}

{
  "context": {
    "group_id": "6ab91d1a-f4bf-45b7-8682-079cf077e350",
    "library": {
      "name": "unknown",
      "version": "unknown"
    }
  },
  "event": "Cluster Changed Status",
  "integrations": {},
  "messageId": "api-2fzGIibkzVSdLamYJrvT7TpqJOq",
  "originalTimestamp": "2024-05-04T04:20:11.666765Z",
  "properties": {
    "cloud_provider": "local",
    "cloud_provider_region": "az1",
    "cluster_id": "u2",
    "event_source": "environment",
    "process_id": 0,
    "replica_id": "u2",
    "status": "ready"
  },
  "receivedAt": "2024-05-04T04:20:13.902Z",
  "sentAt": null,
  "timestamp": "2024-05-04T04:20:11.666Z",
  "type": "track",
  "userId": "6ab91d1a-f4bf-45b7-8682-079cf077e350",
  "writeKey": "REDACTED"
}
```

And here's how it looks when a cluster becomes not ready:

```json
{
  "context": {
    "group_id": "6ab91d1a-f4bf-45b7-8682-079cf077e350",
    "library": {
      "name": "unknown",
      "version": "unknown"
    }
  },
  "event": "Cluster Changed Status",
  "integrations": {},
  "messageId": "api-2fzGZNKO4x4Z3kjFK4vywJT0A7Q",
  "originalTimestamp": "2024-05-04T04:22:24.838029Z",
  "properties": {
    "cloud_provider": "local",
    "cloud_provider_region": "az1",
    "cluster_id": "u2",
    "event_source": "environment",
    "process_id": 0,
    "reason": "unknown",
    "replica_id": "u3",
    "status": "not-ready"
  },
  "receivedAt": "2024-05-04T04:22:26.328Z",
  "sentAt": null,
  "timestamp": "2024-05-04T04:22:24.838Z",
  "type": "track",
  "userId": "6ab91d1a-f4bf-45b7-8682-079cf077e350",
  "writeKey": "REDACTED"
}
```

Events for clusters that become not ready aren't helpful for measuring the cluster provisioning time, but I thought the event might be interesting in the future.


### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Go commit by commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
