### PR TITLE
sql: improve coercion of record literals

### DIFF
--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -562,6 +562,10 @@ impl<T: AstInfo> Expr<T> {
         self.binop(Op::bare("="), right)
     }
 
+    pub fn not_equals(self, right: Expr<T>) -> Expr<T> {
+        self.binop(Op::bare("<>"), right)
+    }
+
     pub fn minus(self, right: Expr<T>) -> Expr<T> {
         self.binop(Op::bare("-"), right)
     }

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -22,7 +22,10 @@ use once_cell::sync::Lazy;
 
 use crate::catalog::TypeCategory;
 use crate::plan::error::PlanError;
-use crate::plan::expr::{CoercibleScalarExpr, ColumnRef, HirScalarExpr, UnaryFunc};
+use crate::plan::expr::{
+    AbstractColumnType, CoercibleScalarExpr, CoercibleScalarType, ColumnRef, HirScalarExpr,
+    UnaryFunc,
+};
 use crate::plan::query::{ExprContext, QueryContext};
 use crate::plan::scope::Scope;
 
@@ -986,15 +989,48 @@ pub fn to_jsonb(ecx: &ExprContext, expr: HirScalarExpr) -> HirScalarExpr {
 /// [union-type-conv]: https://www.postgresql.org/docs/12/typeconv-union-case.html
 pub fn guess_best_common_type(
     ecx: &ExprContext,
-    types: &[Option<ScalarType>],
+    types: &[CoercibleScalarType],
 ) -> Result<ScalarType, PlanError> {
     // This function is a translation of `select_common_type` in PostgreSQL with
     // the addition of our near match logic, which supports Materialize
     // non-linear type promotions.
     // https://github.com/postgres/postgres/blob/d1b307eef/src/backend/parser/parse_coerce.c#L1288-L1308
 
+    // If every type is a literal record with the same number of fields, the
+    // best common type is a record with that number of fields. We recursively
+    // guess the best type for each field.
+    if let Some(CoercibleScalarType::Record(field_tys)) = types.first() {
+        if types
+            .iter()
+            .all(|t| matches!(t, CoercibleScalarType::Record(fts) if field_tys.len() == fts.len()))
+        {
+            let mut fields = vec![];
+            for i in 0..field_tys.len() {
+                let name = ColumnName::from(format!("f{}", fields.len() + 1));
+                let mut guesses = vec![];
+                let mut nullable = false;
+                for ty in types {
+                    let field_ty = match ty {
+                        CoercibleScalarType::Record(fts) => fts[i].clone(),
+                        _ => unreachable!(),
+                    };
+                    if field_ty.nullable() {
+                        nullable = true;
+                    }
+                    guesses.push(field_ty.scalar_type());
+                }
+                let guess = guess_best_common_type(ecx, &guesses)?;
+                fields.push((name, guess.nullable(nullable)));
+            }
+            return Ok(ScalarType::Record {
+                fields,
+                custom_id: None,
+            });
+        }
+    }
+
     // Remove unknown types, and collect them.
-    let mut types: Vec<_> = types.into_iter().filter_map(|v| v.as_ref()).collect();
+    let mut types: Vec<_> = types.into_iter().filter_map(|v| v.as_coerced()).collect();
 
     // In the case of mixed ints and uints, replace uints with their near match
     let contains_int = types

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -483,8 +483,10 @@ SELECT coalesce(row(1, 2), row(3), row(4, 5));
 statement ok
 CREATE TYPE custom_composite AS (i int);
 
-query error coalesce types record
+query T
 SELECT coalesce(row(1), row(1)::custom_composite)
+----
+(1)
 
 statement ok
 CREATE VIEW v AS SELECT 1 AS a
@@ -565,10 +567,12 @@ SELECT greatest(row(row(2, 4), 5), row(row(0, 10), 10), row(row(4, 3), 4));
 query error greatest could not convert type record
 SELECT greatest(row(1, 2), row(3), row(4, 5));
 
-query error greatest types record
+query T
 SELECT greatest(row(1), row(1)::custom_composite)
+----
+(1)
 
-query error greatest does not support casting from text to record
+query error greatest could not convert type record\(f1: integer,f2: integer\) to text
 SELECT greatest(row(1, 2), 'hello');
 
 query error greatest types integer and text cannot be matched
@@ -624,11 +628,13 @@ SELECT least(row(row(2, 4), 5), row(row(0, 10), 10), row(row(4, 3), 4));
 query error least could not convert type record
 SELECT least(row(1, 2), row(3), row(4, 5));
 
-query error least does not support casting from text to record
+query error least could not convert type record\(f1: integer,f2: integer\) to text
 SELECT least(row(1, 2), 'hello');
 
-query error least types record
+query T
 SELECT least(row(1), row(1)::custom_composite)
+----
+(1)
 
 query error least types integer and text cannot be matched
 SELECT least(1::int, 2::text)

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -756,8 +756,24 @@ NULL
 
 # map_build
 
+query T
+SELECT map_build(LIST[ROW('a', 1), ROW('b', 2)])::TEXT;
+----
+{a=>1,b=>2}
+
+query error LIST could not convert type record\(f1: text,f2: integer\) to text
+SELECT map_build(LIST[ROW('a', 1), ROW('b')])::TEXT;
+
+query error function map_build\(record\(f1: integer,f2: integer\) list\) does not exist
+SELECT map_build(LIST[ROW(1, 1), ROW(2, 2)])::TEXT;
+
 statement ok
 CREATE TYPE r AS (f1 TEXT, f2 INT);
+
+query T
+SELECT map_build(LIST[ROW('a', 1), ROW('b', 2)::r])::TEXT;
+----
+{a=>1,b=>2}
 
 query T
 SELECT map_build(LIST[ROW('a', 1), ROW('b', 2)]::r list)::TEXT;


### PR DESCRIPTION
Previously, the following query would fail to plan in Materialize:

    SELECT LIST[('a', 1), ('b', 2)]

The issue was in our selection of a best common type for the list elements. `guess_best_common_type` would assess that there were no list elements with a known (i.e., coerced) type and fall back to using `text`. The query would then fail to plan, since the record literals are not coercible to `text`.

If all list elements are uncoerced record literals, the best common type is some sort of record type. This commit adjusts
`guess_best_common_type` accordingly. The new implementation detects this situation and constructs a record type as the best common type, where the type of each field is the result of guessing the best common type for that field.

The specific motivation for this change is to make it possible to call `map_build` with anonymous record types. The following query now plans correctly:

    SELECT map_build(LIST[('a', 1), ('b', 2)])

Previously, calling `map_build` required constructing a custom record type of the appropriate shape and explicitly casting the list elements to that type:

    CREATE TYPE header AS (k text, v int);
    SELECT map_build(LIST[('a', 1), ('b', 2)]::header list)

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
