### PR TITLE
python: fix handling of COCKROACH_URL in run.py

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -267,7 +267,7 @@ def main() -> int:
             command += ["--test", test]
         command += args.args
         command += ["--", "--nocapture"]
-        os.environ["COCKROACH_URL"] = args.postgres
+        env["COCKROACH_URL"] = args.postgres
     else:
         raise UIError(f"unknown program {args.program}")
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

Running the unit test suite via `bin/cargo-test` without an externally set `COCKROACH_URL` currently fails with:

```
COCKROACH_URL environment variable is not set
```
This is unexpected, because it actually [tries to set it here](https://github.com/MaterializeInc/materialize/blob/83b7a87ac5ab480f3d1fde4b5d867e66e2c97b4a/misc/python/materialize/cli/run.py#L270).

The reason why it doesn't work is a small inconsistency: The environment variable is set on `os.environ` but the subprocess is executed with `os.execvpe` passing in an explicit `env`. For the [`exec*e` variants](https://docs.python.org/3/library/os.html#os.execvpe), only the passed-in `env` is relevant, i.e., the modification to `os.environ` (and `putenv`) is not visible in the subprocess.

This PR fixes the issue simply by making the modification in the explicitly passed `env` instance instead.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
