### PR TITLE
python: update `pydantic` and `typing_extensions`

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -38,7 +38,7 @@ prettytable==3.10.0
 psutil==5.9.4
 psycopg==3.1.12
 psycopg-binary==3.1.12
-pydantic==1.10.4
+pydantic==2.7.1
 pyelftools==0.29
 pyjwt==2.8.0
 PyMySQL==1.0.2
@@ -62,7 +62,7 @@ types-PyYAML==6.0.12.2
 types-requests==2.28.11.7
 types-setuptools==67.6.0.0
 types-toml==0.10.8.1
-typing-extensions==4.7.0
+typing-extensions==4.11.0
 yamllint==1.33.0
 confluent-kafka==2.3.0
 fastavro==1.8.2

--- a/misc/python/materialize/cli/scratch/create.py
+++ b/misc/python/materialize/cli/scratch/create.py
@@ -125,10 +125,12 @@ def run(args: argparse.Namespace) -> None:
         with open(MZ_ROOT / "misc" / "scratch" / f"{args.machine}.json") as f:
 
             print(f"Reading machine configs from {f.name}")
-            descs = [MachineDesc.parse_obj(obj) for obj in multi_json(f.read())]
+            descs = [MachineDesc.model_validate(obj) for obj in multi_json(f.read())]
     else:
         print("Reading machine configs from stdin...")
-        descs = [MachineDesc.parse_obj(obj) for obj in multi_json(sys.stdin.read())]
+        descs = [
+            MachineDesc.model_validate(obj) for obj in multi_json(sys.stdin.read())
+        ]
 
     if args.ssh and len(descs) != 1:
         raise RuntimeError(f"Cannot use `--ssh` with {len(descs)} instances")


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR brings some dependencies up-to-date.

I noticed that a few of the Python dependencies are a little bit outdated. In particular pydantic is still on the old major version ([`1.10.4` from 2022](https://pypi.org/project/pydantic/#history)). This PR updates it to the latest version, including tiny adaptations for the major version bump.

The currently pinned version of `typing_extensions==4.7.0` is blacklisted by `pydantic-core` due to an issue in that version. Thus, I had to bump its version as well to unblock the pydantic update. Keeping `typing_extensions` up-to-date is typically a good idea anyway.


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
