### PR TITLE
sql-parser: make `ident!` and `Ident::new` consistent

### DIFF
--- a/src/sql-parser/src/ident.rs
+++ b/src/sql-parser/src/ident.rs
@@ -61,14 +61,14 @@
 macro_rules! ident {
     ($val:expr) => {{
         let _x: &'static str = $val;
-        $crate::ident!(@internal_check_len 255, $val);
+        $crate::ident!(@internal_check 255, $val);
 
         $crate::ast::Ident::new_unchecked($val)
     }};
 
     // Internal helper macro to assert the length of the provided string literal is less than our
     // maximum.
-    (@internal_check_len $max_len:literal, $val:expr) => {{
+    (@internal_check $max_len:literal, $val:expr) => {{
         #[allow(dead_code)]
         const fn check_len<const MAX: usize, const LEN: usize>() {
             if LEN > MAX {
@@ -83,6 +83,8 @@ macro_rules! ident {
             }
         }
 
+        // `str` does not implement `const PartialEq`, which is why we need to
+        // hand roll this equals function.
         const fn equal(lhs: &str, rhs: &str) -> bool {
             let lhs = lhs.as_bytes();
             let rhs = rhs.as_bytes();

--- a/src/sql-parser/src/ident.rs
+++ b/src/sql-parser/src/ident.rs
@@ -43,6 +43,18 @@
 /// let _id = ident!(TOO_LONG);
 /// ```
 ///
+/// ```compile_fail
+/// use mz_sql_parser::ident;
+/// const FORBIDDEN: &str = ".";
+/// ident!(FORBIDDEN);
+/// ```
+///
+/// ```compile_fail
+/// use mz_sql_parser::ident;
+/// const FORBIDDEN: &str = "..";
+/// ident!(FORBIDDEN);
+/// ```
+///
 /// [`Ident`]: crate::ast::Ident
 ///
 #[macro_export]
@@ -64,8 +76,32 @@ macro_rules! ident {
             }
         }
 
+        #[allow(dead_code)]
+        const fn check_value(val: &str) {
+            if equal(val, ".") || equal(val, "..") {
+                panic!(stringify!(provided string literal, $val, is an invalid identifier));
+            }
+        }
+
+        const fn equal(lhs: &str, rhs: &str) -> bool {
+            let lhs = lhs.as_bytes();
+            let rhs = rhs.as_bytes();
+            if lhs.len() != rhs.len() {
+                return false;
+            }
+            let mut i = 0;
+            while i < lhs.len() {
+                if lhs[i] != rhs[i] {
+                    return false;
+                }
+                i += 1;
+            }
+            true
+        }
+
         const _X_VAL: &str = $val;
         const _X_LEN: usize = _X_VAL.len();
-        const _X_CHECK: () = check_len::<$max_len, _X_LEN>();
+        const _X_CHECK_LEN: () = check_len::<$max_len, _X_LEN>();
+        const _X_CHECK_VALUE: () = check_value(_X_VAL);
     }}
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

Closes #26904

This implements the "minimal solution" solution described in the issue.

### Tips for reviewer

- I'm using doctests with `compile_fail` to check for the failing compilation (they would pass, or rather fail, on `main`).
- The compile time error isn't perfect, because it would e.g. say `provided string literal FORBIDDEN is an invalid identifier` when not passing in a direct literal but rather a `const`. But it is the same for the other compile error, and probably good enough.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
