### PR TITLE
tests: node recovery: fix

### DIFF
--- a/test/cloudtest/node_recovery/test_k8s_node_recovery.py
+++ b/test/cloudtest/node_recovery/test_k8s_node_recovery.py
@@ -168,6 +168,8 @@ def validate_state(
             # arbitrary error can occur if envd is not yet ready after restart
             if is_last_run:
                 print(f"Validation failed in try {try_info}, aborting!")
+                if last_error_message is not None:
+                    print(f"Last error message was: {last_error_message}")
             else:
                 print(f"Validation failed in try {try_info}, retrying.")
             last_error_message = str(e)
@@ -178,7 +180,6 @@ def validate_state(
         # do not raise an FailedTestExecutionError because we are not in mzcompose
         fail(
             f"Failed to achieve '{expected_state}' using '{isolation_level}' within {timeout_in_sec}s!",
-            msg=last_error_message,
         )
 
     duration = round(end_time - start_time, 1)


### PR DESCRIPTION
This fixes the error reporting observed in https://buildkite.com/materialize/nightly/builds/7638#annotation-018f4361-d5af-4a9e-a2c8-66a6b6267182-error.