### PR TITLE
ci: align timeout for rqg-left-join-stacks

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1270,7 +1270,7 @@ steps:
       - id: rqg-left-join-stacks
         label: "RQG left join stacks workload"
         depends_on: build-aarch64
-        timeout_in_minutes: 35
+        timeout_in_minutes: 45
         agents:
           queue: linux-aarch64-small
         plugins:


### PR DESCRIPTION
rqg-left-join-stacks still failed with the slightly increased timeout. Adjusting it to the same value as most other RQG steps use.