### PR TITLE
buildkite insights: optionally include commit hash in step analysis

### DIFF
--- a/misc/python/materialize/buildkite_insights/step_analysis/README.md
+++ b/misc/python/materialize/buildkite_insights/step_analysis/README.md
@@ -13,6 +13,7 @@ usage: buildkite-step-durations [-h]
                                 [--branch BRANCH]
                                 [--build-state {running,scheduled,passed,failing,failed,blocked,canceled,canceling,skipped,not_run,finished}]
                                 [--build-step-state {assigned,broken,canceled,failed,passed,running,scheduled,skipped,timed_out,unblocked,waiting,waiting_failed}]
+                                [--include-commit-hash]
                                 [--output-type {txt,txt-short,csv}]
                                 {cleanup,coverage,deploy,deploy-mz-lsp-server,deploy-mz,deploy-website,license,nightly,release-qualification,security,slt,test,www}
 ```

--- a/misc/python/materialize/buildkite_insights/steps/build_step.py
+++ b/misc/python/materialize/buildkite_insights/steps/build_step.py
@@ -22,6 +22,7 @@ from materialize.buildkite_insights.buildkite_api.buildkite_constants import (
 class BuildItemOutcomeBase:
     step_key: str
     build_number: int
+    commit_hash: str
     created_at: datetime
     duration_in_min: float | None
     passed: bool
@@ -108,6 +109,7 @@ def _extract_build_step_data_from_build(
 
         id = build_data["id"]
         build_number = build_data["number"]
+        commit_hash = build_data["commit"]
         created_at = datetime.fromisoformat(job["created_at"])
         build_step_key = job["step_key"]
         parallel_job_index = job.get("parallel_group_index")
@@ -133,6 +135,7 @@ def _extract_build_step_data_from_build(
             step_key=build_step_key,
             parallel_job_index=parallel_job_index,
             build_number=build_number,
+            commit_hash=commit_hash,
             created_at=created_at,
             duration_in_min=duration_in_min,
             passed=job_passed,
@@ -248,6 +251,7 @@ def _step_outcomes_to_job_outcome(
         ids=ids,
         step_key=any_execution.step_key,
         build_number=any_execution.build_number,
+        commit_hash=any_execution.commit_hash,
         created_at=min_created_at,
         duration_in_min=sum_duration_in_min,
         passed=all_passed,


### PR DESCRIPTION
Introducing the parameter `--include-commit-hash`, which is helpful when bisecting.

```
nrainer@mz-nrainer mz-repo % bin/buildkite-step-insights nightly --build-step-key persist-txn-fencing --include-commit-hash
Using existing data: /Users/nrainer/Workspaces/mz-repo/temp/builds-nightly-params-3a3630f2.json
Loaded data from /Users/nrainer/Workspaces/mz-repo/temp/builds-nightly-params-3a3630f2.json
persist-txn-fencing, #7639, 2024-05-05 11:33:54 +0000, 42.13 min, https://buildkite.com/materialize/nightly/builds/7639, 83b7a87ac5ab480f3d1fde4b5d867e66e2c97b4a, SUCCESS
persist-txn-fencing, #7638, 2024-05-04 11:33:56 +0000, 121.14 min, https://buildkite.com/materialize/nightly/builds/7638, eec4e9ac8ef68ffce6c8fafa10f18e9d3503608c, FAIL
persist-txn-fencing, #7636, 2024-05-03 23:33:56 +0000, 42.77 min, https://buildkite.com/materialize/nightly/builds/7636, 73d368796eb9df422089bfd789ac3317cdc25f3d, SUCCESS
persist-txn-fencing, #7635, 2024-05-03 17:31:11 +0000, 42.66 min, https://buildkite.com/materialize/nightly/builds/7635, d9dbf3018b803256d38329cedfd6d6c0b3d9c788, SUCCESS
persist-txn-fencing, #7620, 2024-05-03 11:33:58 +0000, 41.79 min, https://buildkite.com/materialize/nightly/builds/7620, 743b6d85b338102d4e50185217a9765d97f140ce, SUCCESS
persist-txn-fencing, #7618, 2024-05-02 23:31:22 +0000, 38.48 min, https://buildkite.com/materialize/nightly/builds/7618, 86b8ba52df741637768a44194739467bfd146974, SUCCESS
persist-txn-fencing, #7616, 2024-05-02 17:31:12 +0000, 45.38 min, https://buildkite.com/materialize/nightly/builds/7616, 7fd607c461cddbc00476800ec2b002195ad55b75, SUCCESS
persist-txn-fencing, #7612, 2024-05-02 11:33:59 +0000, 39.37 min, https://buildkite.com/materialize/nightly/builds/7612, 71255efe20c827836c2e091cec69a8259dd26f52, SUCCESS
persist-txn-fencing, #7611, 2024-05-01 23:33:14 +0000, 41.12 min, https://buildkite.com/materialize/nightly/builds/7611, 613aa2a0dd1f078a35ede07cdb7c34bf5d807c54, SUCCESS
persist-txn-fencing, #7607, 2024-05-01 17:33:51 +0000, 44.18 min, https://buildkite.com/materialize/nightly/builds/7607, 2519890de64611bcd74b2c0fa40cc4ba07d78cc6, SUCCESS
```