### PR TITLE
metric coverage for # of pgwire TLS connections with and without SNI

### DIFF
--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -496,11 +496,8 @@ impl PgwireBalancer {
         // per tenant. In the future we may want to remove non-SNI connections.
         if let Conn::Ssl(ssl_stream) = conn.inner() {
             let tenant = resolved.tenant.as_deref().unwrap_or_else(|| "unknown");
-            if ssl_stream.ssl().servername(NameType::HOST_NAME).is_some() {
-                metrics.tenant_pgwire_sni_count(tenant, true).inc();
-            } else {
-                metrics.tenant_pgwire_sni_count(tenant, false).inc();
-            }
+            let has_sni = ssl_stream.ssl().servername(NameType::HOST_NAME).is_some();
+            metrics.tenant_pgwire_sni_count(tenant, has_sni).inc();
         }
 
         let _active_guard = resolved


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Counts the # of pgwire TLS connections that do / do not send along SNI. Long term there are a number of benefits in exclusively relying on SNI / connection options, rather than using Frontegg resolution, so I'm curious where we stand today.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
