### PR TITLE
sql: impl FoldNode for RawColumnName

### DIFF
--- a/src/sql-parser/src/ast/metadata.rs
+++ b/src/sql-parser/src/ast/metadata.rs
@@ -143,6 +143,20 @@ impl AstDisplay for RawColumnName {
 }
 impl_display!(RawColumnName);
 
+impl<T> FoldNode<Raw, T> for RawColumnName
+where
+    T: AstInfo,
+{
+    type Folded = T::ColumnName;
+
+    fn fold<F>(self, f: &mut F) -> Self::Folded
+    where
+        F: Fold<Raw, T>,
+    {
+        f.fold_column_name(self)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
 pub enum RawClusterName {
     Unresolved(Ident),


### PR DESCRIPTION
This impl was missing, which meant that visitors would not visit column names in ASTs. This leads to a bug in a GlobalId migration, where the GlobalId referred to in a column name is changed.

### Motivation

This PR fixes a recognized bug. https://materializeinc.slack.com/archives/CTESPM7FU/p1714784793099809

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
