### PR TITLE
storage/copy-to-s3: Document parquet format type conversions and fix extension type names

### DIFF
--- a/doc/user/content/sql/copy-to.md
+++ b/doc/user/content/sql/copy-to.md
@@ -49,3 +49,63 @@ The privileges required to execute this statement are:
       granted the necessary privileges.
 - `USAGE` privileges on all types used in the query.
 - `USAGE` privileges on the active cluster.
+
+
+<!--
+
+## Parquet Format
+
+### Parquet Compatibility
+
+Materialize writes Parquet files that aim for maximum compatibility with downstream systems.
+
+By default the following Parquet writer settings are used:
+
+Option | Setting
+-------|--------
+Writer Version | 1.0
+Compression | snappy
+Default Column Encoding | Dictionary
+Fallback Column Encoding | Plain
+Dictionary Page Encoding | Plain
+Dictionary Data Page Encoding | RLE_DICTIONARY
+
+### Data Types
+
+Materialize converts the values in the result set to [Apache Arrow](https://arrow.apache.org/docs/index.html), and then serializes
+this Arrow representation to Parquet.
+The Arrow schema is embedded in the Parquet file metadata and allows reconstruction of the Arrow representation using a compatible reader.
+
+Materialize will also include [Parquet Logical Type](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md) annotations where possible, however
+many newer Logical Type annotations are not supported in Parquet Writer Version 1.0.
+
+Materialize also embeds its own type information into the Apache Arrow schema. The field metadata in the schema contains an `ARROW:extension:name` annotation to indicate the Materialize native type the field came from.
+
+Materialize Type | Arrow Extension Name | [Arrow Type](https://github.com/apache/arrow/blob/main/format/Schema.fbs) | [Parquet Primitive Type](https://parquet.apache.org/docs/file-format/types/) | [Parquet Logical Type](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md)
+-----------------|----------------|------------|-------------------|--------------
+[`bigint`](types/integer) | `materialize.v1.bigint` | `int64` | `INT64`
+[`boolean`](types/boolean) | `materialize.v1.boolean` | `bool` | `BOOLEAN`
+[`bytea`](types/bytea) | `materialize.v1.bytea` | `large_binary` | `BYTE_ARRAY`
+[`date`](types/date) | `materialize.v1.date` | `date32` | `INT32` | `DATE`
+[`double precision`](types/float) | `materialize.v1.double` | `float64` | `DOUBLE`
+[`integer`](types/integer) | `materialize.v1.integer` | `int32` | `INT32`
+[`jsonb`](types/jsonb) | `materialize.v1.jsonb` | `large_utf8` | `BYTE_ARRAY`
+[`map`](types/map) | `materialize.v1.map` | `map` (`struct` with fields `keys` and `values`) | Nested | `MAP`
+[`list`](types/list) | `materialize.v1.list` | `list` | Nested
+[`numeric`](types/numeric) | `materialize.v1.numeric` | `decimal128[38, 10 or max-scale]` | `FIXED_LEN_BYTE_ARRAY` | `DECIMAL`
+[`real`](types/float) | `materialize.v1.real` | `float32` | `FLOAT`
+[`smallint`](types/integer) | `materialize.v1.smallint` | `int16` | `INT32` | `INT(16, true)`
+[`text`](types/text) | `materialize.v1.text` | `utf8` or `large_utf8` | `BYTE_ARRAY` | `STRING`
+[`time`](types/time) | `materialize.v1.time` | `time64[nanosecond]` | `INT64` | `TIME[isAdjustedToUTC = false, unit = NANOS]`
+[`uint2`](types/uint) | `materialize.v1.uint2` | `uint16` | `INT32` | `INT(16, false)`
+[`uint4`](types/uint) | `materialize.v1.uint4` | `uint32` | `INT32` | `INT(32, false)`
+[`uint8`](types/uint) | `materialize.v1.uint8` | `uint64` | `INT64` | `INT(64, false)`
+[`timestamp`](types/timestamp) | `materialize.v1.timestamp` | `time64[microsecond]` | `INT64` | `TIMESTAMP[isAdjustedToUTC = false, unit = MICROS]`
+[`timestamp with time zone`](types/timestamp) | `materialize.v1.timestampz` | `time64[microsecond]` | `INT64` | `TIMESTAMP[isAdjustedToUTC = true, unit = MICROS]`
+[Arrays](types/array) (`[]`) | `materialize.v1.array` | `struct` with `list` field `items` and `uint8` field `dimensions` | Nested
+[`uuid`](types/uuid) | `materialize.v1.uuid` | `fixed_size_binary(16)` | `FIXED_LEN_BYTE_ARRAY`
+[`oid`](oid) | Unsupported
+[`interval`](interval) | Unsupported
+[`record`](record) | Unsupported
+
+-->

--- a/doc/user/content/sql/types/_index.md
+++ b/doc/user/content/sql/types/_index.md
@@ -42,6 +42,7 @@ Type | Aliases | Use | Size (bytes) | Catalog name | Syntax
 [`timestamp`](timestamp) | | Date and time | 8 | Named | `TIMESTAMP '2007-02-01 15:04:05'`
 [`timestamp with time zone`](timestamp) | `timestamp with time zone` | Date and time with timezone | 8 | Named | `TIMESTAMPTZ '2007-02-01 15:04:05+06'`
 [Arrays](array) (`[]`) | | Multidimensional array | Variable | Named | `ARRAY[...]`
+[`uuid`](uuid) | | UUID | 16 | Named | `UUID 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'`
 
 #### Catalog name
 

--- a/src/arrow-util/src/builder.rs
+++ b/src/arrow-util/src/builder.rs
@@ -140,15 +140,15 @@ impl ArrowBuilder {
 /// this type: https://arrow.apache.org/docs/format/Columnar.html#extension-types
 fn scalar_to_arrow_datatype(scalar_type: &ScalarType) -> Result<(DataType, String), anyhow::Error> {
     let (data_type, extension_name) = match scalar_type {
-        ScalarType::Bool => (DataType::Boolean, "bool"),
-        ScalarType::Int16 => (DataType::Int16, "int16"),
-        ScalarType::Int32 => (DataType::Int32, "int32"),
-        ScalarType::Int64 => (DataType::Int64, "int64"),
-        ScalarType::UInt16 => (DataType::UInt16, "uint16"),
-        ScalarType::UInt32 => (DataType::UInt32, "uint32"),
-        ScalarType::UInt64 => (DataType::UInt64, "uint64"),
-        ScalarType::Float32 => (DataType::Float32, "float32"),
-        ScalarType::Float64 => (DataType::Float64, "float64"),
+        ScalarType::Bool => (DataType::Boolean, "boolean"),
+        ScalarType::Int16 => (DataType::Int16, "smallint"),
+        ScalarType::Int32 => (DataType::Int32, "integer"),
+        ScalarType::Int64 => (DataType::Int64, "bigint"),
+        ScalarType::UInt16 => (DataType::UInt16, "uint2"),
+        ScalarType::UInt32 => (DataType::UInt32, "uint4"),
+        ScalarType::UInt64 => (DataType::UInt64, "uint8"),
+        ScalarType::Float32 => (DataType::Float32, "real"),
+        ScalarType::Float64 => (DataType::Float64, "double"),
         ScalarType::Date => (DataType::Date32, "date"),
         // The resolution of our time and timestamp types is microseconds, which is lucky
         // since the original parquet 'ConvertedType's support microsecond resolution but not
@@ -171,22 +171,22 @@ fn scalar_to_arrow_datatype(scalar_type: &ScalarType) -> Result<(DataType, Strin
             ),
             "timestamptz",
         ),
-        ScalarType::Bytes => (DataType::LargeBinary, "bytes"),
+        ScalarType::Bytes => (DataType::LargeBinary, "bytea"),
         ScalarType::Char { length } => {
             if length.map_or(false, |l| l.into_u32() < i32::MAX.unsigned_abs()) {
-                (DataType::Utf8, "char")
+                (DataType::Utf8, "text")
             } else {
-                (DataType::LargeUtf8, "char")
+                (DataType::LargeUtf8, "text")
             }
         }
         ScalarType::VarChar { max_length } => {
             if max_length.map_or(false, |l| l.into_u32() < i32::MAX.unsigned_abs()) {
-                (DataType::Utf8, "varchar")
+                (DataType::Utf8, "text")
             } else {
-                (DataType::LargeUtf8, "varchar")
+                (DataType::LargeUtf8, "text")
             }
         }
-        ScalarType::String => (DataType::LargeUtf8, "string"),
+        ScalarType::String => (DataType::LargeUtf8, "text"),
         // Parquet does have a UUID 'Logical Type' in parquet format 2.4+, but there is no arrow
         // UUID type, so we match the format (a 16-byte fixed-length binary array) ourselves.
         ScalarType::Uuid => (DataType::FixedSizeBinary(16), "uuid"),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/materialize/issues/26884

I've added a section to the `copy-to` doc page that explains how materialize types are converted during copy-to-s3 with `FORMAT = 'parquet'`. Since the main copy-to-s3 docs are being worked on by @morsapaes this is all commented out so it's not yet rendered in the html output, and Marta can uncomment when putting up a PR for the full documentation.

This also adds the missing `uuid` type to the materialize top-level `types` doc page : https://materialize.com/docs/sql/types/

And it fixes the names of the 'extension types' we put into the arrow metadata to correspond more closely to external-facing materialize type-names.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
