### PR TITLE
sql: manually visit item name in ID migration

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -345,6 +345,13 @@ fn _assign_new_user_global_ids(
     };
 
     impl<'a> VisitMut<'_, Raw> for IdUpdater<'a> {
+        fn visit_column_name_mut(
+            &mut self,
+            node: &'_ mut <Raw as mz_sql::ast::AstInfo>::ColumnName,
+        ) {
+            self.visit_item_name_mut(&mut node.relation);
+        }
+
         fn visit_item_name_mut(&mut self, node: &'_ mut <Raw as mz_sql::ast::AstInfo>::ItemName) {
             if let RawItemName::Id(id, _) = node {
                 match GlobalId::from_str(id.as_str()) {


### PR DESCRIPTION
For some reason (I am sure it's good!), `Visit` doesn't recurse into `AstInfo::ColumnName`, which is treacherous because that means we don't visit all `GlobalId`s when traversing the AST and it requires manual intercession. We should fix the root issue (#26945) but I think this is fine to unblock the release.

### Motivation

This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
