### PR TITLE
persist-cli: check if values roundtrip though `arrow-rs`

### DIFF
--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -15,19 +15,25 @@ use std::fmt;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use bytes::BufMut;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
-use mz_ore::cast::CastFrom;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use mz_ore::bytes::SegmentedBytes;
+use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
+use mz_persist::indexed::columnar::parquet::{decode_trace_parquet, encode_trace_parquet};
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
+use mz_persist::location::Blob;
 use mz_persist_types::codec_impls::TodoSchema;
 use mz_persist_types::{Codec, Codec64};
 use mz_proto::RustType;
 use prost::Message;
+use serde::Serialize;
 use serde_json::json;
 
 use crate::async_runtime::IsolatedRuntime;
@@ -80,6 +86,9 @@ pub(crate) enum Command {
 
     /// Prints information about blob usage for a shard
     BlobUsage(StateArgs),
+
+    /// Checks if the shard roundtrips through arrow-rs
+    ArrowRsRoundtrip(BlobArgs),
 
     /// Prints each consensus state change as JSON. Output includes the full consensus state
     /// before and after each state transitions:
@@ -159,6 +168,10 @@ pub async fn run(command: InspectArgs) -> Result<(), anyhow::Error> {
         Command::UnreferencedBlobs(args) => {
             let unreferenced_blobs = unreferenced_blobs(&args).await?;
             println!("{}", json!(unreferenced_blobs));
+        }
+        Command::ArrowRsRoundtrip(args) => {
+            let report = arrow_rs_roundtrip(&args.blob_uri).await?;
+            println!("{}", json!(report));
         }
         Command::BlobUsage(args) => {
             let () = blob_usage(&args).await?;
@@ -628,6 +641,204 @@ pub async fn unreferenced_blobs(args: &StateArgs) -> Result<impl serde::Serializ
     }
 
     Ok(unreferenced_blobs)
+}
+
+/// Roundtrips all blobs through arrow-rs and ensures they match what is currently in S3.
+pub async fn arrow_rs_roundtrip(blob_uri: &str) -> Result<impl Serialize, anyhow::Error> {
+    let cfg = PersistConfig::new_default_configs(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
+
+    let metrics_registry = MetricsRegistry::new();
+    let metrics = Arc::new(Metrics::new(&cfg, &metrics_registry));
+
+    #[derive(Debug, Default, Serialize)]
+    struct BlobReport {
+        num_shards: usize,
+        num_blobs: usize,
+        missing_blobs: usize,
+        num_rows: usize,
+        num_bytes: usize,
+    }
+
+    /// Helper method that lists all shards in a Blob store.
+    async fn list_shards(
+        blob: Arc<dyn Blob + Send + Sync>,
+    ) -> Result<BTreeMap<ShardId, Vec<PartialBatchKey>>, anyhow::Error> {
+        let mut shards = BTreeMap::new();
+        blob.list_keys_and_metadata(&BlobKeyPrefix::All.to_string(), &mut |metadata| {
+            match BlobKey::parse_ids(metadata.key) {
+                Ok((shard, PartialBlobKey::Batch(writer_key, part_id))) => {
+                    let partial_keys = shards.entry(shard).or_insert_with(Vec::new);
+                    partial_keys.push(PartialBatchKey::new(&writer_key, &part_id));
+                }
+                Err(err) => {
+                    eprintln!("error parsing blob: {}", err);
+                }
+                _ => (),
+            }
+        })
+        .await?;
+
+        Ok(shards)
+    }
+
+    // Open a handle to S3.
+    let blob = make_blob(&cfg, blob_uri, NO_COMMIT, Arc::clone(&metrics))
+        .await
+        .context("making blob")?;
+    tracing::info!(?blob_uri, "opened blob");
+
+    // List all shards.
+    let shards = mz_ore::retry::Retry::default()
+        .max_tries(5)
+        .retry_async(|_| {
+            let blob = Arc::clone(&blob);
+            async move { list_shards(Arc::clone(&blob)).await }
+        })
+        .await?;
+
+    let num_parts: usize = shards.values().map(|parts| parts.len()).sum();
+    tracing::info!(
+        ?blob_uri,
+        num_shards = shards.len(),
+        num_parts,
+        "listed blob"
+    );
+
+    let mut report = BlobReport::default();
+    for (shard_id, partial_keys) in shards {
+        // Drives all of the GET futures concurrently.
+        //
+        // Note(parkmycar): We should limit the number of blobs we fetch in parallel to reduce
+        // memory usage.
+        let mut blob_stream: FuturesUnordered<_> = partial_keys
+            .iter()
+            .map(|partial_key| {
+                let blob = Arc::clone(&blob);
+                let key = partial_key.complete(&shard_id);
+                mz_ore::retry::Retry::default().retry_async(move |_| {
+                    let blob = Arc::clone(&blob);
+                    let key = key.clone();
+                    async move { blob.get(&key).await }
+                })
+            })
+            .collect();
+
+        // Updates the 'persist_use_arrow_rs_library' feature flag.
+        let update_feature_flag = |val: &str| {
+            let mut updates = mz_dyncfg::ConfigUpdates::default();
+            let val = mz_dyncfg::ConfigVal::String(val.to_string());
+            updates.add_dynamic("persist_use_arrow_rs_library", val);
+            updates.apply(metrics.columnar.cfg());
+        };
+
+        while let Some(blob_result) = blob_stream.next().await {
+            let Some(blob) = blob_result? else {
+                report.missing_blobs += 1;
+                continue;
+            };
+
+            // Decode with both `arrow2` and `arrow-rs`.
+            let arrow2_records: BlobTraceBatchPart<i64> = {
+                update_feature_flag("off");
+                decode_trace_parquet(blob.clone(), &metrics.columnar)?
+            };
+            let arrow_rs_records: BlobTraceBatchPart<i64> = {
+                update_feature_flag("read_and_write");
+                decode_trace_parquet(blob.clone(), &metrics.columnar)?
+            };
+
+            // Make sure the records match.
+            if arrow2_records != arrow_rs_records {
+                anyhow::bail!("arrow2 and arrow-rs return different values, {blob_uri:?}");
+            }
+
+            report.num_rows += arrow2_records
+                .updates
+                .iter()
+                .map(|r| r.len())
+                .sum::<usize>();
+            report.num_bytes += arrow2_records
+                .updates
+                .iter()
+                .map(|r| r.goodbytes())
+                .sum::<usize>();
+
+            // Now roundtrip through arrow-rs.
+            let mut buf = Vec::new();
+            {
+                update_feature_flag("read_and_write");
+                encode_trace_parquet(&mut buf, &arrow2_records, &metrics.columnar)?;
+            }
+            let buf = SegmentedBytes::from(buf);
+
+            // Read back the arrow-rs encoded blob and make sure they also match.
+            let arrow2_records_rnd: BlobTraceBatchPart<i64> = {
+                update_feature_flag("off");
+                decode_trace_parquet(buf.clone(), &metrics.columnar)?
+            };
+            let arrow_rs_records_rnd: BlobTraceBatchPart<i64> = {
+                update_feature_flag("read_and_write");
+                decode_trace_parquet(buf.clone(), &metrics.columnar)?
+            };
+
+            if arrow2_records_rnd != arrow_rs_records_rnd {
+                anyhow::bail!("failed to roundtrip through arrow-rs, {blob_uri:?}");
+            }
+        }
+
+        report.num_shards += 1;
+        report.num_blobs += partial_keys.len();
+        tracing::info!(
+            ?blob_uri,
+            ?shard_id,
+            num_parts = partial_keys.len(),
+            "completed one check"
+        );
+    }
+
+    // Make sure our metrics indicated we did the right things.
+    let metrics = metrics_registry.gather();
+    let arrow_metrics = metrics
+        .into_iter()
+        .find(|family| family.get_name() == "mz_persist_arrow_operations")
+        .expect("failed to get metrics");
+    let get_arrow_metric = |library: &str, op: &str| {
+        arrow_metrics
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                let library = metric
+                    .get_label()
+                    .iter()
+                    .find(|label| label.get_name() == "library" && label.get_value() == library)
+                    .is_some();
+                let op = metric
+                    .get_label()
+                    .iter()
+                    .find(|label| label.get_name() == "op" && label.get_value() == op)
+                    .is_some();
+
+                library && op
+            })
+            .map(|metric| {
+                let val = metric.get_counter().get_value();
+                u64::cast_lossy(val)
+            })
+            .expect("failed to find metric")
+    };
+
+    let arrow2_encode = get_arrow_metric("arrow2", "encode");
+    let arrow2_decode = get_arrow_metric("arrow2", "decode");
+    let arrow_rs_encode = get_arrow_metric("arrow_rs", "encode");
+    let arrow_rs_decode = get_arrow_metric("arrow_rs", "decode");
+
+    assert_eq!(arrow2_decode, arrow_rs_decode);
+    assert_eq!(arrow2_encode, 0);
+    assert!(arrow_rs_encode > 0);
+
+    tracing::info!(?blob_uri, "completed");
+
+    Ok(report)
 }
 
 /// Returns information about blob usage for a shard

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -84,7 +84,7 @@ pub struct TraceBatchMeta {
 ///
 /// TODO: disallow empty trace batch parts in the future so there is one unique
 /// way to represent an empty trace batch.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BlobTraceBatchPart<T> {
     /// Which updates are included in this batch.
     ///

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -141,7 +141,7 @@ impl ColumnarMetrics {
     }
 
     /// Returns a reference to the inner [`ConfigSet`].
-    /// 
+    ///
     /// Exposed to allow updating the inner [`ConfigSet`] during testing.
     pub fn cfg(&self) -> &ConfigSet {
         &self.cfg

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -139,4 +139,11 @@ impl ColumnarMetrics {
 
         Self::new(&registry, &lgbytes, cfg, false)
     }
+
+    /// Returns a reference to the inner [`ConfigSet`].
+    /// 
+    /// Exposed to allow updating the inner [`ConfigSet`] during testing.
+    pub fn cfg(&self) -> &ConfigSet {
+        &self.cfg
+    }
 }

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -139,11 +139,4 @@ impl ColumnarMetrics {
 
         Self::new(&registry, &lgbytes, cfg, false)
     }
-
-    /// Returns a reference to the inner [`ConfigSet`].
-    ///
-    /// Exposed to allow updating the inner [`ConfigSet`] during testing.
-    pub fn cfg(&self) -> &ConfigSet {
-        &self.cfg
-    }
 }


### PR DESCRIPTION
New command for `persist-cli` that checks if all blobs for an environment return the same values when deserialized by `arrow2` and `arrow-rs`. Then we re-encode with `arrow-rs` and check again.

### Motivation

We recently merged https://github.com/MaterializeInc/materialize/pull/26968 which allows us to encode and decode blobs with the new arrow-rs library.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
