### PR TITLE
persist: Add `arrow-rs` methods behind a dyncfg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,7 +136,10 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
+ "arrow-csv",
  "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
  "arrow-ord",
  "arrow-row",
  "arrow-schema",
@@ -192,6 +210,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-csv"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95cbcba196b862270bf2a5edb75927380a7f3a163622c61d40cbba416a6305f2"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
 name = "arrow-data"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +262,26 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaafb5714d4e59feae964714d724f880511500e3569cc2a94d02456b403a2a49"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half 2.4.1",
+ "indexmap 2.0.0",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1081,6 +1138,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -3636,6 +3714,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5277,6 +5364,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "parquet",
  "paste",
  "pin-project",
  "prometheus",
@@ -5319,6 +5407,7 @@ name = "mz-persist"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arrow",
  "arrow2",
  "async-stream",
  "async-trait",
@@ -5343,6 +5432,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "openssl-sys",
+ "parquet",
  "postgres-openssl",
  "prometheus",
  "proptest",
@@ -7180,10 +7270,13 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64 0.22.0",
+ "brotli",
  "bytes",
  "chrono",
+ "flate2",
  "half 2.4.1",
  "hashbrown 0.14.0",
+ "lz4_flex",
  "num",
  "num-bigint",
  "paste",
@@ -7191,6 +7284,7 @@ dependencies = [
  "snap",
  "thrift",
  "twox-hash",
+ "zstd",
 ]
 
 [[package]]
@@ -9928,9 +10022,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "rand",
@@ -10515,6 +10609,7 @@ version = "0.0.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "arrow",
  "async-compression",
  "aws-config",
  "aws-credential-types",
@@ -10581,7 +10676,6 @@ dependencies = [
  "openssl-sys",
  "ordered-float 4.2.0",
  "parking_lot",
- "parquet",
  "phf",
  "phf_shared",
  "postgres",
@@ -10630,6 +10724,7 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
  "tungstenite",
+ "twox-hash",
  "uncased",
  "unicode-bidi",
  "unicode-normalization",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,21 +58,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,10 +121,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-csv",
  "arrow-data",
- "arrow-ipc",
- "arrow-json",
  "arrow-ord",
  "arrow-row",
  "arrow-schema",
@@ -210,25 +192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-csv"
-version = "51.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cbcba196b862270bf2a5edb75927380a7f3a163622c61d40cbba416a6305f2"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "lexical-core",
- "regex",
-]
-
-[[package]]
 name = "arrow-data"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,26 +225,6 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "flatbuffers",
-]
-
-[[package]]
-name = "arrow-json"
-version = "51.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaafb5714d4e59feae964714d724f880511500e3569cc2a94d02456b403a2a49"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half 2.4.1",
- "indexmap 2.0.0",
- "lexical-core",
- "num",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1138,27 +1081,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "brotli"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -3711,15 +3633,6 @@ checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "lz4_flex"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
-dependencies = [
- "twox-hash",
 ]
 
 [[package]]
@@ -7270,13 +7183,10 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64 0.22.0",
- "brotli",
  "bytes",
  "chrono",
- "flate2",
  "half 2.4.1",
  "hashbrown 0.14.0",
- "lz4_flex",
  "num",
  "num-bigint",
  "paste",
@@ -7284,7 +7194,6 @@ dependencies = [
  "snap",
  "thrift",
  "twox-hash",
- "zstd",
 ]
 
 [[package]]
@@ -10609,7 +10518,6 @@ version = "0.0.0"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow",
  "async-compression",
  "aws-config",
  "aws-credential-types",
@@ -10676,6 +10584,7 @@ dependencies = [
  "openssl-sys",
  "ordered-float 4.2.0",
  "parking_lot",
+ "parquet",
  "phf",
  "phf_shared",
  "postgres",

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -811,6 +811,17 @@ steps:
               composition: platform-checks
               args: [--scenario=TogglePersistRoundtripSpine, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-toggle-persist-use-arrow-rs-library
+        label: "Checks toggling persist use arrow_rs library"
+        depends_on: build-aarch64
+        timeout_in_minutes: 45
+        agents:
+          queue: linux-aarch64-large
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=TogglePersistUseArrowRsLibrary, "--seed=$BUILDKITE_JOB_ID"]
+
       - id: checks-migrate-aarch64-x86-64
         label: "Checks migrate from aarch64 to x86-64"
         depends_on: [build-x86_64, build-aarch64]

--- a/deny.toml
+++ b/deny.toml
@@ -146,6 +146,7 @@ name = "rustls"
 [[bans.deny]]
 name = "lazy_static"
 wrappers = [
+  "arrow-csv",
   "bindgen",
   "bstr",
   "console",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -1326,6 +1326,12 @@ user-id = 359 # Sean McArthur (seanmonstar)
 start = "2020-07-10"
 end = "2024-12-17"
 
+[[trusted.twox-hash]]
+criteria = "safe-to-deploy"
+user-id = 1060 # Jake Goulding (shepmaster)
+start = "2019-04-12"
+end = "2025-05-07"
+
 [[trusted.unicode-ident]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -1578,10 +1578,6 @@ criteria = "safe-to-deploy"
 version = "0.20.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.twox-hash]]
-version = "1.6.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.typed-arena]]
 version = "2.0.2"
 criteria = "safe-to-deploy"

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -749,6 +749,13 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.twox-hash]]
+version = "1.6.3"
+when = "2022-05-04"
+user-id = 1060
+user-login = "shepmaster"
+user-name = "Jake Goulding"
+
 [[publisher.unicode-ident]]
 version = "1.0.0"
 when = "2022-05-16"

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -294,3 +294,15 @@ class TogglePersistRoundtripSpine(SystemVarChange):
             value_1="FALSE",
             value_2="TRUE",
         )
+
+
+class TogglePersistUseArrowRsLibrary(SystemVarChange):
+    def __init__(self, checks: list[type[Check]], executor: Executor, seed: str | None):
+        super().__init__(
+            checks,
+            executor,
+            seed,
+            name="persist_use_arrow_rs_library",
+            value_1="FALSE",
+            value_2="TRUE",
+        )

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -303,6 +303,6 @@ class TogglePersistUseArrowRsLibrary(SystemVarChange):
             executor,
             seed,
             name="persist_use_arrow_rs_library",
-            value_1="FALSE",
-            value_2="TRUE",
+            value_1="read",
+            value_2="read_and_write",
         )

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -905,6 +905,11 @@ class FlipFlagsAction(Action):
             "enable_variadic_left_join_lowering"
         ] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["persist_use_arrow_rs_library"] = [
+            "off",
+            "read",
+            "read_and_write",
+        ]
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -36,6 +36,7 @@ num = "0.4.0"
 once_cell = "1.16.0"
 # The vendored feature is transitively depended upon by tokio-openssl.
 openssl = { version = "0.10.48", features = ["vendored"], optional = true }
+parquet = { version = "51.0.0", optional = true }
 paste = "1.0.11"
 pin-project = "1.0.12"
 prometheus = { version = "0.13.3", default-features = false, optional = true }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -36,7 +36,7 @@ num = "0.4.0"
 once_cell = "1.16.0"
 # The vendored feature is transitively depended upon by tokio-openssl.
 openssl = { version = "0.10.48", features = ["vendored"], optional = true }
-parquet = { version = "51.0.0", optional = true }
+parquet = { version = "51.0.0", optional = true, default-features = false }
 paste = "1.0.11"
 pin-project = "1.0.12"
 prometheus = { version = "0.13.3", default-features = false, optional = true }

--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -20,6 +20,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use mz_ore::task::RuntimeExt;
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
 use mz_persist::location::{Blob, CaSResult, Consensus, ExternalError, SeqNo, VersionedData};
+use mz_persist::metrics::ColumnarMetrics;
 use mz_persist::workload::{self, DataGenerator};
 use mz_persist_client::internals_bench::trace_push_batch_one_iter;
 use mz_persist_client::ShardId;
@@ -189,6 +190,7 @@ pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data:
         g.throughput(Throughput::Bytes(data.goodput_bytes()));
     }
 
+    let metrics = ColumnarMetrics::disconnected();
     let trace = BlobTraceBatchPart {
         desc: Description::new(
             Antichain::from_elem(0u64),
@@ -203,7 +205,7 @@ pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data:
         b.iter(|| {
             // Intentionally alloc a new buf each iter.
             let mut buf = Vec::new();
-            trace.encode(&mut buf);
+            trace.encode(&mut buf, &metrics);
         })
     });
 }

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1012,6 +1012,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         let partial_key = PartialBatchKey::new(&cfg.writer_key, &PartId::new());
         let key = partial_key.complete(&shard_metrics.shard_id);
         let goodbytes = updates.updates.iter().map(|x| x.goodbytes()).sum::<usize>();
+        let metrics_ = Arc::clone(&metrics);
 
         let (stats, (buf, encode_time)) = isolated_runtime
             .spawn_named(|| "batch::encode_part", async move {
@@ -1038,7 +1039,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
 
                 let encode_start = Instant::now();
                 let mut buf = Vec::new();
-                updates.encode(&mut buf);
+                updates.encode(&mut buf, &metrics_.columnar);
 
                 // Drop batch as soon as we can to reclaim its memory.
                 drop(updates);

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -131,8 +131,12 @@ impl Metrics {
             move || start.elapsed().as_secs_f64(),
         );
         let s3_blob = S3BlobMetrics::new(registry);
-        let columnar =
-            ColumnarMetrics::new(&s3_blob.lgbytes, cfg.configs.clone(), cfg.is_cc_active);
+        let columnar = ColumnarMetrics::new(
+            registry,
+            &s3_blob.lgbytes,
+            cfg.configs.clone(),
+            cfg.is_cc_active,
+        );
         Metrics {
             blob: vecs.blob_metrics(),
             consensus: vecs.consensus_metrics(),

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -88,6 +88,18 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                     x.add_dynamic("persist_inline_writes_total_max_bytes", ::mz_dyncfg::ConfigVal::Usize(0));
                     x
                 },
+                {
+                    // Exercises reading with arrow-rs
+                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
+                    x.add_dynamic("persist_use_arrow_rs_library", ::mz_dyncfg::ConfigVal::String("read".to_string()));
+                    x
+                },
+                {
+                    // Exercises reading and writing with arrow-rs
+                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
+                    x.add_dynamic("persist_use_arrow_rs_library", ::mz_dyncfg::ConfigVal::String("read_and_write".to_string()));
+                    x
+                },
             ];
 
             for (idx, dyncfgs) in dyncfgs.into_iter().enumerate() {

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -23,7 +23,7 @@ bench = false
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-arrow = "51.0.0"
+arrow = { version = "51.0.0", default-features = false }
 arrow2 = { version = "0.16.0", features = ["io_ipc", "io_parquet"] }
 async-trait = "0.1.68"
 async-stream = "0.3.3"
@@ -47,7 +47,7 @@ mz-postgres-client = { path = "../postgres-client" }
 mz-proto = { path = "../proto" }
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
-parquet = "51.0.0"
+parquet = { version = "51.0.0", default-features = false, features = ["arrow"] }
 postgres-openssl = { version = "0.5.0" }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -23,6 +23,7 @@ bench = false
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
+arrow = "51.0.0"
 arrow2 = { version = "0.16.0", features = ["io_ipc", "io_parquet"] }
 async-trait = "0.1.68"
 async-stream = "0.3.3"
@@ -40,12 +41,13 @@ once_cell = "1.16.0"
 md-5 = "0.10.5"
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-dyncfg = { path = "../dyncfg" }
-mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes_", "region"] }
+mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes_", "region", "parquet"] }
 mz-persist-types = { path = "../persist-types" }
 mz-postgres-client = { path = "../postgres-client" }
 mz-proto = { path = "../proto" }
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
+parquet = "51.0.0"
 postgres-openssl = { version = "0.5.0" }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -33,6 +33,7 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_CC_SIZES)
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_NONCC_SIZES)
+        .add(&crate::indexed::columnar::parquet::USE_ARROW_RS_LIBRARY)
         .add(&crate::s3::ENABLE_S3_LGALLOC_CC_SIZES)
         .add(&crate::s3::ENABLE_S3_LGALLOC_NONCC_SIZES)
 }

--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -98,6 +98,18 @@ impl From<arrow2::error::Error> for Error {
     }
 }
 
+impl From<parquet::errors::ParquetError> for Error {
+    fn from(e: parquet::errors::ParquetError) -> Self {
+        Error::String(e.to_string())
+    }
+}
+
+impl From<arrow::error::ArrowError> for Error {
+    fn from(e: arrow::error::ArrowError) -> Self {
+        Error::String(e.to_string())
+    }
+}
+
 impl<T> From<sync::PoisonError<T>> for Error {
     fn from(e: sync::PoisonError<T>) -> Self {
         Error::String(format!("poison: {}", e))

--- a/src/persist/src/indexed/columnar/arrow.rs
+++ b/src/persist/src/indexed/columnar/arrow.rs
@@ -13,6 +13,9 @@ use std::collections::BTreeMap;
 use std::convert;
 use std::sync::Arc;
 
+use arrow::datatypes::{
+    DataType as ArrowRsDataType, Field as ArrowRsField, Schema as ArrowRsSchema,
+};
 use arrow2::array::{Array, BinaryArray, PrimitiveArray};
 use arrow2::chunk::Chunk;
 use arrow2::datatypes::{DataType, Field, Schema};
@@ -39,7 +42,7 @@ use crate::metrics::ColumnarMetrics;
 /// time after year 2200). Using a i64 might be a pessimization for a
 /// non-realtime mz source with u64 timestamps in the range `(i64::MAX,
 /// u64::MAX]`, but realtime sources are overwhelmingly the common case.
-pub static SCHEMA_ARROW_KVTD: Lazy<Arc<Schema>> = Lazy::new(|| {
+pub static SCHEMA_ARROW2_KVTD: Lazy<Arc<Schema>> = Lazy::new(|| {
     Arc::new(Schema::from(vec![
         Field {
             name: "k".into(),
@@ -66,6 +69,17 @@ pub static SCHEMA_ARROW_KVTD: Lazy<Arc<Schema>> = Lazy::new(|| {
             metadata: BTreeMap::new(),
         },
     ]))
+});
+
+/// Duplicate of [`SCHEMA_ARROW2_KVTD`] but with [`arrow`] types.
+pub static SCHEMA_ARROW_RS_KVTD: Lazy<Arc<ArrowRsSchema>> = Lazy::new(|| {
+    let schema = ArrowRsSchema::new(vec![
+        ArrowRsField::new("k", ArrowRsDataType::Binary, false),
+        ArrowRsField::new("v", ArrowRsDataType::Binary, false),
+        ArrowRsField::new("t", ArrowRsDataType::Int64, false),
+        ArrowRsField::new("d", ArrowRsDataType::Int64, false),
+    ]);
+    Arc::new(schema)
 });
 
 /// Converts a ColumnarRecords into an arrow [(K, V, T, D)] Chunk.
@@ -105,6 +119,37 @@ pub fn encode_arrow_batch_kvtd(x: &ColumnarRecords) -> Chunk<Box<dyn Array>> {
     .expect("schema matches fields")
 }
 
+/// Converts a [`ColumnarRecords`] into `(K, V, T, D)` [`arrow`] columns.
+pub fn encode_arrow_batch_kvtd_arrow_rs(x: &ColumnarRecords) -> Vec<arrow::array::ArrayRef> {
+    use arrow::array::{BinaryArray, PrimitiveArray};
+    use arrow::buffer::{Buffer, OffsetBuffer, ScalarBuffer};
+
+    let key = BinaryArray::try_new(
+        OffsetBuffer::new(ScalarBuffer::from((*x.key_offsets).as_ref().to_vec())),
+        Buffer::from_vec(x.key_data.as_ref().to_vec()),
+        None,
+    )
+    .expect("valid key array");
+    let val = BinaryArray::try_new(
+        OffsetBuffer::new(ScalarBuffer::from((*x.val_offsets).as_ref().to_vec())),
+        Buffer::from_vec(x.val_data.as_ref().to_vec()),
+        None,
+    )
+    .expect("valid val array");
+    let ts = PrimitiveArray::<arrow::datatypes::Int64Type>::try_new(
+        (*x.timestamps).as_ref().to_vec().into(),
+        None,
+    )
+    .expect("valid ts array");
+    let diff = PrimitiveArray::<arrow::datatypes::Int64Type>::try_new(
+        (*x.diffs).as_ref().to_vec().into(),
+        None,
+    )
+    .expect("valid diff array");
+
+    vec![Arc::new(key), Arc::new(val), Arc::new(ts), Arc::new(diff)]
+}
+
 pub(crate) const ENABLE_ARROW_LGALLOC_CC_SIZES: Config<bool> = Config::new(
     "persist_enable_arrow_lgalloc_cc_sizes",
     true,
@@ -117,23 +162,11 @@ pub(crate) const ENABLE_ARROW_LGALLOC_NONCC_SIZES: Config<bool> = Config::new(
     "A feature flag to enable copying decoded arrow data into lgalloc on non-cc sized clusters.",
 );
 
-/// Converts an arrow [(K, V, T, D)] Chunk into a ColumnarRecords.
+/// Converts an [`arrow2`] [(K, V, T, D)] Chunk into a ColumnarRecords.
 pub fn decode_arrow_batch_kvtd(
     x: &Chunk<Box<dyn Array>>,
     metrics: &ColumnarMetrics,
 ) -> Result<ColumnarRecords, String> {
-    fn to_region<T: Copy>(buf: &[T], metrics: &ColumnarMetrics) -> Arc<MetricsRegion<T>> {
-        let use_lgbytes_mmap = if metrics.is_cc_active {
-            ENABLE_ARROW_LGALLOC_CC_SIZES.get(&metrics.cfg)
-        } else {
-            ENABLE_ARROW_LGALLOC_NONCC_SIZES.get(&metrics.cfg)
-        };
-        if use_lgbytes_mmap {
-            Arc::new(metrics.lgbytes_arrow.try_mmap_region(buf))
-        } else {
-            Arc::new(metrics.lgbytes_arrow.heap_region(buf.to_owned()))
-        }
-    }
     let columns = x.columns();
     if columns.len() != 4 {
         return Err(format!("expected 4 fields got {}", columns.len()));
@@ -182,4 +215,78 @@ pub fn decode_arrow_batch_kvtd(
     };
     ret.borrow().validate()?;
     Ok(ret)
+}
+
+/// Converts an [`arrow`] [(K, V, T, D)] [`RecordBatch`] into a [`ColumnarRecords`].
+///
+/// [`RecordBatch`]: `arrow::array::RecordBatch`
+pub fn decode_arrow_batch_kvtd_arrow_rs(
+    batch: &arrow::array::RecordBatch,
+    metrics: &ColumnarMetrics,
+) -> Result<ColumnarRecords, String> {
+    use arrow::array::{Array as ArrowRsArray, AsArray};
+
+    if batch.columns().len() != 4 {
+        return Err(format!(
+            "got wrong number of columns! {}",
+            batch.columns().len()
+        ));
+    }
+
+    let columns = batch.columns();
+
+    let key = &columns[0];
+    let val = &columns[1];
+    let time = &columns[2];
+    let diff = &columns[3];
+
+    let key = key
+        .as_binary_opt::<i32>()
+        .ok_or_else(|| "key column is wrong type".to_string())?;
+    let val = val
+        .as_binary_opt::<i32>()
+        .ok_or_else(|| "val column is wrong type".to_string())?;
+    let time = time
+        .as_primitive_opt::<arrow::datatypes::Int64Type>()
+        .ok_or_else(|| "time column is wrong type".to_string())?;
+    let diff = diff
+        .as_primitive_opt::<arrow::datatypes::Int64Type>()
+        .ok_or_else(|| "diff column is wrong type".to_string())?;
+
+    let key_offsets = to_region(&key.offsets()[..], metrics);
+    let key_data = to_region(key.value_data(), metrics);
+
+    let val_offsets = to_region(&val.offsets()[..], metrics);
+    let val_data = to_region(val.value_data(), metrics);
+
+    let timestamps = to_region(&time.values()[..], metrics);
+    let diffs = to_region(&diff.values()[..], metrics);
+
+    let len = key.len();
+    let ret = ColumnarRecords {
+        len,
+        key_data: MaybeLgBytes::LgBytes(LgBytes::from(key_data)),
+        key_offsets,
+        val_data: MaybeLgBytes::LgBytes(LgBytes::from(val_data)),
+        val_offsets,
+        timestamps,
+        diffs,
+    };
+    ret.borrow().validate()?;
+
+    Ok(ret)
+}
+
+/// Copies a slice of data into a possibly disk-backed lgalloc region.
+fn to_region<T: Copy>(buf: &[T], metrics: &ColumnarMetrics) -> Arc<MetricsRegion<T>> {
+    let use_lgbytes_mmap = if metrics.is_cc_active {
+        ENABLE_ARROW_LGALLOC_CC_SIZES.get(&metrics.cfg)
+    } else {
+        ENABLE_ARROW_LGALLOC_NONCC_SIZES.get(&metrics.cfg)
+    };
+    if use_lgbytes_mmap {
+        Arc::new(metrics.lgbytes_arrow.try_mmap_region(buf))
+    } else {
+        Arc::new(metrics.lgbytes_arrow.heap_region(buf.to_owned()))
+    }
 }

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -10,19 +10,23 @@
 //! Apache Parquet encodings and utils for persist data
 
 use std::io::{Read, Seek, Write};
+use std::sync::Arc;
 
 use arrow2::io::parquet::read::{infer_schema, read_metadata, FileReader};
 use arrow2::io::parquet::write::{
     CompressionOptions, Encoding, FileWriter, KeyValue, RowGroupIterator, Version, WriteOptions,
 };
 use differential_dataflow::trace::Description;
+use mz_dyncfg::Config;
+use mz_ore::bytes::SegmentedBytes;
 use mz_persist_types::Codec64;
 use timely::progress::{Antichain, Timestamp};
 
 use crate::error::Error;
 use crate::gen::persist::ProtoBatchFormat;
 use crate::indexed::columnar::arrow::{
-    decode_arrow_batch_kvtd, encode_arrow_batch_kvtd, SCHEMA_ARROW_KVTD,
+    decode_arrow_batch_kvtd, decode_arrow_batch_kvtd_arrow_rs, encode_arrow_batch_kvtd,
+    encode_arrow_batch_kvtd_arrow_rs, SCHEMA_ARROW2_KVTD, SCHEMA_ARROW_RS_KVTD,
 };
 use crate::indexed::columnar::ColumnarRecords;
 use crate::indexed::encoding::{
@@ -30,44 +34,82 @@ use crate::indexed::encoding::{
 };
 use crate::metrics::ColumnarMetrics;
 
+pub(crate) const USE_ARROW_RS_LIBRARY: Config<bool> = Config::new(
+    "persist_use_arrow_rs_library",
+    false,
+    "When `true` uses the newer arrow-rs library for writing data, `false` uses the existing arrow2 library.",
+);
+
 const INLINE_METADATA_KEY: &str = "MZ:inline";
 
 /// Encodes an BlobTraceBatchPart into the Parquet format.
-pub fn encode_trace_parquet<W: Write, T: Timestamp + Codec64>(
+pub fn encode_trace_parquet<W: Write + Send, T: Timestamp + Codec64>(
     w: &mut W,
     batch: &BlobTraceBatchPart<T>,
+    metrics: &ColumnarMetrics,
 ) -> Result<(), Error> {
     // Better to error now than write out an invalid batch.
     batch.validate()?;
-    encode_parquet_kvtd(
-        w,
-        encode_trace_inline_meta(batch, ProtoBatchFormat::ParquetKvtd),
-        &batch.updates,
-    )
+    let inline_meta = encode_trace_inline_meta(batch, ProtoBatchFormat::ParquetKvtd);
+
+    if USE_ARROW_RS_LIBRARY.get(&metrics.cfg) {
+        metrics.arrow_metrics.encode_arrow_rs.inc();
+        encode_parquet_kvtd_arrow_rs(w, inline_meta, &batch.updates)
+    } else {
+        metrics.arrow_metrics.encode_arrow2.inc();
+        encode_parquet_kvtd(w, inline_meta, &batch.updates)
+    }
 }
 
 /// Decodes a BlobTraceBatchPart from the Parquet format.
-pub fn decode_trace_parquet<R: Read + Seek, T: Timestamp + Codec64>(
-    r: &mut R,
+pub fn decode_trace_parquet<T: Timestamp + Codec64>(
+    buf: SegmentedBytes,
     metrics: &ColumnarMetrics,
 ) -> Result<BlobTraceBatchPart<T>, Error> {
-    let metadata = read_metadata(r).map_err(|err| err.to_string())?;
-    let metadata = metadata
-        .key_value_metadata()
-        .as_ref()
-        .and_then(|x| x.iter().find(|x| x.key == INLINE_METADATA_KEY));
-    let (format, meta) = decode_trace_inline_meta(metadata.and_then(|x| x.value.as_ref()))?;
+    let (metadata, updates) = if USE_ARROW_RS_LIBRARY.get(&metrics.cfg) {
+        let metadata =
+            parquet::arrow::arrow_reader::ArrowReaderMetadata::load(&buf, Default::default())?;
+        let metadata = metadata
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .as_ref()
+            .and_then(|x| x.iter().find(|x| x.key == INLINE_METADATA_KEY));
 
-    let updates = match format {
-        ProtoBatchFormat::Unknown => return Err("unknown format".into()),
-        ProtoBatchFormat::ArrowKvtd => {
-            return Err("ArrowKVTD format not supported in parquet".into())
-        }
-        ProtoBatchFormat::ParquetKvtd => decode_parquet_file_kvtd(r, metrics)?,
+        let (format, meta) = decode_trace_inline_meta(metadata.and_then(|x| x.value.as_ref()))?;
+        let updates = match format {
+            ProtoBatchFormat::Unknown => return Err("unknown format".into()),
+            ProtoBatchFormat::ArrowKvtd => {
+                return Err("ArrowKVTD format not supported in parquet".into())
+            }
+            ProtoBatchFormat::ParquetKvtd => decode_parquet_file_kvtd_parquet_rs(buf, metrics)?,
+        };
+        metrics.arrow_metrics.decode_arrow_rs.inc();
+
+        (meta, updates)
+    } else {
+        let mut reader = buf.reader();
+        let metadata = read_metadata(&mut reader).map_err(|err| err.to_string())?;
+        let metadata = metadata
+            .key_value_metadata()
+            .as_ref()
+            .and_then(|x| x.iter().find(|x| x.key == INLINE_METADATA_KEY));
+
+        let (format, meta) = decode_trace_inline_meta(metadata.and_then(|x| x.value.as_ref()))?;
+        let updates = match format {
+            ProtoBatchFormat::Unknown => return Err("unknown format".into()),
+            ProtoBatchFormat::ArrowKvtd => {
+                return Err("ArrowKVTD format not supported in parquet".into())
+            }
+            ProtoBatchFormat::ParquetKvtd => decode_parquet_file_kvtd(&mut reader, metrics)?,
+        };
+        metrics.arrow_metrics.decode_arrow2.inc();
+
+        (meta, updates)
     };
 
     let ret = BlobTraceBatchPart {
-        desc: meta.desc.map_or_else(
+        desc: metadata.desc.map_or_else(
             || {
                 Description::new(
                     Antichain::from_elem(T::minimum()),
@@ -77,7 +119,7 @@ pub fn decode_trace_parquet<R: Read + Seek, T: Timestamp + Codec64>(
             },
             |x| x.into(),
         ),
-        index: meta.index,
+        index: metadata.index,
         updates,
     };
     ret.validate()?;
@@ -99,7 +141,7 @@ fn encode_parquet_kvtd<W: Write>(
     };
     let row_groups = RowGroupIterator::try_new(
         iter,
-        &SCHEMA_ARROW_KVTD,
+        &SCHEMA_ARROW2_KVTD,
         options,
         vec![
             vec![Encoding::Plain],
@@ -113,7 +155,7 @@ fn encode_parquet_kvtd<W: Write>(
         key: INLINE_METADATA_KEY.into(),
         value: Some(inline_base64),
     }];
-    let mut writer = FileWriter::try_new(w, (**SCHEMA_ARROW_KVTD).clone(), options)?;
+    let mut writer = FileWriter::try_new(w, (**SCHEMA_ARROW2_KVTD).clone(), options)?;
     for group in row_groups {
         writer.write(group?).map_err(|err| err.to_string())?;
     }
@@ -122,7 +164,51 @@ fn encode_parquet_kvtd<W: Write>(
     Ok(())
 }
 
-fn decode_parquet_file_kvtd<R: Read + Seek>(
+/// Encodes [`ColumnarRecords`] to Parquet using the [`parquet`] crate.
+pub fn encode_parquet_kvtd_arrow_rs<W: Write + Send>(
+    w: &mut W,
+    inline_base64: String,
+    iter: &[ColumnarRecords],
+) -> Result<(), Error> {
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+    use parquet::basic::{Compression, Encoding};
+    use parquet::file::properties::{EnabledStatistics, WriterProperties, WriterVersion};
+
+    let metadata =
+        parquet::file::metadata::KeyValue::new(INLINE_METADATA_KEY.to_string(), inline_base64);
+
+    // Configure our writer to match arrow2 so the blobs can roundtrip.
+    let properties = WriterProperties::builder()
+        .set_dictionary_enabled(false)
+        .set_encoding(Encoding::PLAIN)
+        .set_statistics_enabled(EnabledStatistics::None)
+        .set_compression(Compression::UNCOMPRESSED)
+        .set_writer_version(WriterVersion::PARQUET_2_0)
+        .set_data_page_size_limit(1024 * 1024)
+        .set_max_row_group_size(usize::MAX)
+        .set_key_value_metadata(Some(vec![metadata]))
+        .build();
+
+    let mut writer = ArrowWriter::try_new(w, Arc::clone(&*SCHEMA_ARROW_RS_KVTD), Some(properties))?;
+
+    let batches = iter.into_iter().map(|c| {
+        let cols = encode_arrow_batch_kvtd_arrow_rs(c);
+        RecordBatch::try_new(Arc::clone(&*SCHEMA_ARROW_RS_KVTD), cols)
+    });
+
+    for batch in batches {
+        writer.write(&batch?)?
+    }
+
+    writer.flush()?;
+    writer.close()?;
+
+    Ok(())
+}
+
+/// Decodes [`ColumnarRecords`] from a reader, using [`arrow2`].
+pub fn decode_parquet_file_kvtd<R: Read + Seek>(
     r: &mut R,
     metrics: &ColumnarMetrics,
 ) -> Result<Vec<ColumnarRecords>, Error> {
@@ -132,10 +218,10 @@ fn decode_parquet_file_kvtd<R: Read + Seek>(
 
     let file_schema = reader.schema().fields.as_slice();
     // We're not trying to accept any sort of user created data, so be strict.
-    if file_schema != SCHEMA_ARROW_KVTD.fields {
+    if file_schema != SCHEMA_ARROW2_KVTD.fields {
         return Err(format!(
             "expected arrow schema {:?} got: {:?}",
-            SCHEMA_ARROW_KVTD.fields, file_schema
+            SCHEMA_ARROW2_KVTD.fields, file_schema
         )
         .into());
     }
@@ -143,6 +229,39 @@ fn decode_parquet_file_kvtd<R: Read + Seek>(
     let mut ret = Vec::new();
     for batch in reader {
         ret.push(decode_arrow_batch_kvtd(&batch?, metrics)?);
+    }
+    Ok(ret)
+}
+
+/// Decodes [`ColumnarRecords`] from a reader, using [`arrow`].
+pub fn decode_parquet_file_kvtd_parquet_rs(
+    r: impl parquet::file::reader::ChunkReader + 'static,
+    metrics: &ColumnarMetrics,
+) -> Result<Vec<ColumnarRecords>, Error> {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+    let builder = ParquetRecordBatchReaderBuilder::try_new(r)?;
+
+    // To match arrow2, we default the batch size to the number of rows in the RowGroup.
+    let row_groups = builder.metadata().row_groups();
+    if row_groups.len() > 1 {
+        return Err(Error::String("found more than 1 RowGroup".to_string()));
+    }
+    let num_rows = usize::try_from(row_groups[0].num_rows())
+        .map_err(|_| Error::String("found negative rows".to_string()))?;
+    let builder = builder.with_batch_size(num_rows);
+
+    // Make sure we have all of the expected columns.
+    if SCHEMA_ARROW_RS_KVTD.fields() != builder.schema().fields() {
+        return Err(format!("found invalid schema {:?}", builder.schema()).into());
+    }
+
+    let reader = builder.build()?;
+
+    let mut ret = Vec::new();
+    for batch in reader {
+        let batch = batch.map_err(|e| Error::String(e.to_string()))?;
+        ret.push(decode_arrow_batch_kvtd_arrow_rs(&batch, metrics)?);
     }
     Ok(ret)
 }

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -220,16 +220,16 @@ impl<T: Timestamp + Codec64> BlobTraceBatchPart<T> {
     }
 
     /// Encodes an BlobTraceBatchPart into the Parquet format.
-    pub fn encode<B>(&self, buf: &mut B)
+    pub fn encode<B>(&self, buf: &mut B, metrics: &ColumnarMetrics)
     where
-        B: BufMut,
+        B: BufMut + Send,
     {
-        encode_trace_parquet(&mut buf.writer(), self).expect("batch was invalid");
+        encode_trace_parquet(&mut buf.writer(), self, metrics).expect("batch was invalid");
     }
 
     /// Decodes a BlobTraceBatchPart from the Parquet format.
     pub fn decode(buf: &SegmentedBytes, metrics: &ColumnarMetrics) -> Result<Self, Error> {
-        decode_trace_parquet(&mut buf.clone().reader(), metrics)
+        decode_trace_parquet(buf.clone(), metrics)
     }
 
     /// Scans the part and returns a lower bound on the contained keys.
@@ -527,7 +527,8 @@ mod tests {
         batch: &BlobTraceBatchPart<T>,
     ) -> u64 {
         let mut val = Vec::new();
-        batch.encode(&mut val);
+        let metrics = ColumnarMetrics::disconnected();
+        batch.encode(&mut val, &metrics);
         let val = Bytes::from(val);
         let val_len = u64::cast_from(val.len());
         blob.set(key, val).await.expect("failed to set trace batch");
@@ -619,6 +620,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] // too slow
     fn encoded_batch_sizes() {
         fn sizes(data: DataGenerator) -> usize {
+            let metrics = ColumnarMetrics::disconnected();
             let trace = BlobTraceBatchPart {
                 desc: Description::new(
                     Antichain::from_elem(0u64),
@@ -629,7 +631,7 @@ mod tests {
                 updates: data.batches().collect(),
             };
             let mut trace_buf = Vec::new();
-            trace.encode(&mut trace_buf);
+            trace.encode(&mut trace_buf, &metrics);
             trace_buf.len()
         }
 

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 [dependencies]
 ahash = { version = "0.8.11" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
+arrow = { version = "51.0.0" }
 async-compression = { version = "0.4.5", default-features = false, features = ["gzip", "tokio", "zstd"] }
 aws-config = { version = "1.2.0", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.0", default-features = false, features = ["hardcoded-credentials", "test-util"] }
@@ -79,7 +80,6 @@ num-traits = { version = "0.2.15", features = ["i128", "libm"] }
 openssl = { version = "0.10.55", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
@@ -124,6 +124,7 @@ tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tungstenite = { version = "0.20.1" }
+twox-hash = { version = "1.6.3" }
 uncased = { version = "0.9.7" }
 unicode-bidi = { version = "0.3.15" }
 unicode-normalization = { version = "0.1.23" }
@@ -137,6 +138,7 @@ zstd-sys = { version = "2.0.9", features = ["std"] }
 [build-dependencies]
 ahash = { version = "0.8.11" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
+arrow = { version = "51.0.0" }
 async-compression = { version = "0.4.5", default-features = false, features = ["gzip", "tokio", "zstd"] }
 aws-config = { version = "1.2.0", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.0", default-features = false, features = ["hardcoded-credentials", "test-util"] }
@@ -201,7 +203,6 @@ num-traits = { version = "0.2.15", features = ["i128", "libm"] }
 openssl = { version = "0.10.55", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
@@ -247,6 +248,7 @@ tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tungstenite = { version = "0.20.1" }
+twox-hash = { version = "1.6.3" }
 uncased = { version = "0.9.7" }
 unicode-bidi = { version = "0.3.15" }
 unicode-normalization = { version = "0.1.23" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -16,7 +16,6 @@ publish = false
 [dependencies]
 ahash = { version = "0.8.11" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-arrow = { version = "51.0.0" }
 async-compression = { version = "0.4.5", default-features = false, features = ["gzip", "tokio", "zstd"] }
 aws-config = { version = "1.2.0", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.0", default-features = false, features = ["hardcoded-credentials", "test-util"] }
@@ -80,6 +79,7 @@ num-traits = { version = "0.2.15", features = ["i128", "libm"] }
 openssl = { version = "0.10.55", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
+parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
@@ -138,7 +138,6 @@ zstd-sys = { version = "2.0.9", features = ["std"] }
 [build-dependencies]
 ahash = { version = "0.8.11" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-arrow = { version = "51.0.0" }
 async-compression = { version = "0.4.5", default-features = false, features = ["gzip", "tokio", "zstd"] }
 aws-config = { version = "1.2.0", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.2.0", default-features = false, features = ["hardcoded-credentials", "test-util"] }
@@ -203,6 +202,7 @@ num-traits = { version = "0.2.15", features = ["i128", "libm"] }
 openssl = { version = "0.10.55", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
+parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }


### PR DESCRIPTION
This PR adds new encoding and decoding methods for our existing `ColumnarRecords` type that uses the newer `arrow-rs` and `parquet-rs` crates. These methods are behind a dyncfg "persist_use_arrow_rs_library" and we add a new Prometheus metric "mz_persist_arrow_operations" to track how often we're using one library over the other.

### Motivation

While working on writing structured Row data into S3 (https://github.com/MaterializeInc/materialize/issues/24830) I hit a bug related to `arrow2`/`parquet2` and nested struct fields. If there is a nested struct column and one of the inner most child columns is marked as not nullable, but its parent struct is nullable, then `parquet2` loses data on encoded and fails to decode.

For example, the following schema is similar to what we'd use in production:
```
{
  "k": {
    "ok": {
        "foo": i32,
    },
    "err": string,
  }
}
```

We model `SourceData` as a struct with two fields `ok` and `err`. When the inner `foo` column is marked as non-null, but the source has encountered an error so we get `ok: None err: Some(...)`, `parquet2` hits the bug described above.

If we dump the encoded Parquet, it can successfully be read by `parquet-cli` and the `arrow-rs` crate.

Minimal repro with `arrow2`: https://gist.github.com/ParkMyCar/c8ed98b79ae1ecc989bad3b40db8008b
Encoded parquet: [arrow2_bad_parquet_dump.txt](https://github.com/MaterializeInc/materialize/files/15237941/arrow2_bad_parquet_dump.txt)

Repro in `arrow-rs` that succeeds: https://gist.github.com/ParkMyCar/d69510f96ccb65c2fe9125c6a31cbf1f

### Tips for reviewer

This PR is split into separate commits which could be reviewed independently:

1. Implement the `parquet::ChunkReader` trait on `SegmentedBytes`
2. Add new metrics
3. Add `arrow-rs` and `parquet-rs` impls for the existing encode and decode methods, behind a dyncfg.
4. Cargo toml related changes and lints
5. Adds a new nightly testing slug that toggles the "persist_use_arrow_rs_library" dyncfg

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
