### PR TITLE
persist-txn: Fix since_ts invariant

### DIFF
--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -685,16 +685,7 @@ where
             )
             .await
             .expect("txns schema shouldn't change");
-        let as_of = txns_read.since().clone();
-        let txns_id = txns_read.shard_id();
-        let since_ts = as_of.as_option().expect("txns shard is not closed").clone();
-        let txns_subscribe = txns_read
-            .subscribe(as_of)
-            .await
-            .expect("handle holds a capability");
-
-        let state = TxnsCacheState::new(txns_id, since_ts, only_data_id);
-
+        let (state, txns_subscribe) = TxnsCacheState::init::<C>(only_data_id, txns_read).await;
         let subscribe_task = TxnsSubscribeTask {
             txns_subscribe,
             buf: Vec::new(),


### PR DESCRIPTION
The `TxnsCacheState` has an invariant, that is written in the `compact_to()` method but not the struct definition, that states `self.since_ts <= self.progress_exclusive`. Previously, when initializing the cache, `progress_exclusive` was always initialized to `T::minimum()` while `since_ts` was always initialized to the since of the txns shard. As a result, almost all caches were initialized in a broken state. This led to the confusing scenario where the cache may be learning about new entries that should have already been compacted.

This commit fixes the issue by always initializing the cache s.t. both the initial `since_ts` and the initial progress_exclusive` are advanced to the since of the txn shard.

Touches #26893

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
