### PR TITLE
ci: save docker stats as artifact

### DIFF
--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -34,6 +34,7 @@ netstat -ant > netstat-ant.log
 netstat -panelot > netstat-panelot.log
 ps aux > ps-aux.log
 docker ps -a --no-trunc > docker-ps-a.log
+docker stats --all --no-stream > docker-stats.log
 
 mv "$HOME"/cores .
 


### PR DESCRIPTION
Not sure yet if this is helpful as it is.

Future work:
* We should collect the stream (instead of the snapshot at the end) in a proper way.
* Furthermore, we might want to trigger this directly from the bounded-memory check to capture data per scenario.
* Moritz suggested to read the `max-rss` property.