### PR TITLE
persist: fix finalize_shard/tombstoning

### DIFF
--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1209,6 +1209,10 @@ where
         assert_eq!(self.trace.upper(), &Antichain::new());
         assert_eq!(self.trace.since(), &Antichain::new());
 
+        // Remember our current state, so we can decide whether we have to
+        // record a transition in durable state.
+        let was_tombstone = self.is_tombstone();
+
         // Enter the "tombstone" state, if we're not in it already.
         self.writers.clear();
         self.leased_readers.clear();
@@ -1260,6 +1264,10 @@ where
             let merge_reqs = new_trace.push_batch(Self::tombstone_batch());
             assert_eq!(merge_reqs, Vec::new());
             self.trace = new_trace;
+            Continue(())
+        } else if !was_tombstone {
+            // We were not tombstoned before, so have to make sure this state
+            // transition is recorded.
             Continue(())
         } else {
             // All our batches are empty, and there's only one... there's no shrinking this

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -1784,6 +1784,123 @@ mod tests {
         read.maybe_heartbeat_reader().await;
     }
 
+    /// Verify that shard finalization works with empty shards, shards that have
+    /// an empty write up to the empty upper Antichain.
+    #[mz_persist_proc::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
+    async fn finalize_empty_shard(dyncfgs: ConfigUpdates) {
+        const EMPTY: &[(((), ()), u64, i64)] = &[];
+        let persist_client = new_test_client(&dyncfgs).await;
+
+        let shard_id = ShardId::new();
+        pub const CRITICAL_SINCE: CriticalReaderId =
+            CriticalReaderId([0, 0, 0, 0, 17, 17, 34, 34, 51, 51, 68, 68, 68, 68, 68, 68]);
+
+        let (mut write, mut read) = persist_client
+            .expect_open::<(), (), u64, i64>(shard_id)
+            .await;
+
+        // Advance since and upper to empty, which is a pre-requisite for
+        // finalization/tombstoning.
+        let () = read.downgrade_since(&Antichain::new()).await;
+        let () = write
+            .compare_and_append(EMPTY, Antichain::from_elem(0), Antichain::new())
+            .await
+            .expect("usage should be valid")
+            .expect("upper should match");
+
+        let mut since_handle: SinceHandle<(), (), u64, i64, u64> = persist_client
+            .open_critical_since(shard_id, CRITICAL_SINCE, Diagnostics::for_tests())
+            .await
+            .expect("invalid persist usage");
+
+        let epoch = since_handle.opaque().clone();
+        let new_since = Antichain::new();
+        let downgrade = since_handle
+            .compare_and_downgrade_since(&epoch, (&epoch, &new_since))
+            .await;
+
+        assert!(
+            downgrade.is_ok(),
+            "downgrade of critical handle must succeed"
+        );
+
+        let finalize = persist_client
+            .finalize_shard::<(), (), u64, i64>(shard_id, Diagnostics::for_tests())
+            .await;
+
+        assert!(finalize.is_ok(), "finalization must succeed");
+
+        let is_finalized = persist_client
+            .is_finalized::<(), (), u64, i64>(shard_id, Diagnostics::for_tests())
+            .await
+            .expect("invalid persist usage");
+        assert!(is_finalized, "shard must still be finalized");
+    }
+
+    /// Verify that shard finalization works with shards that had some data
+    /// written to them, plus then an empty batch to bring their upper to the
+    /// empty Antichain.
+    #[mz_persist_proc::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
+    async fn finalize_shard(dyncfgs: ConfigUpdates) {
+        const EMPTY: &[(((), ()), u64, i64)] = &[];
+        const DATA: &[(((), ()), u64, i64)] = &[(((), ()), 0, 1)];
+        let persist_client = new_test_client(&dyncfgs).await;
+
+        let shard_id = ShardId::new();
+        pub const CRITICAL_SINCE: CriticalReaderId =
+            CriticalReaderId([0, 0, 0, 0, 17, 17, 34, 34, 51, 51, 68, 68, 68, 68, 68, 68]);
+
+        let (mut write, mut read) = persist_client
+            .expect_open::<(), (), u64, i64>(shard_id)
+            .await;
+
+        // Write some data.
+        let () = write
+            .compare_and_append(DATA, Antichain::from_elem(0), Antichain::from_elem(1))
+            .await
+            .expect("usage should be valid")
+            .expect("upper should match");
+
+        // Advance since and upper to empty, which is a pre-requisite for
+        // finalization/tombstoning.
+        let () = read.downgrade_since(&Antichain::new()).await;
+        let () = write
+            .compare_and_append(EMPTY, Antichain::from_elem(1), Antichain::new())
+            .await
+            .expect("usage should be valid")
+            .expect("upper should match");
+
+        let mut since_handle: SinceHandle<(), (), u64, i64, u64> = persist_client
+            .open_critical_since(shard_id, CRITICAL_SINCE, Diagnostics::for_tests())
+            .await
+            .expect("invalid persist usage");
+
+        let epoch = since_handle.opaque().clone();
+        let new_since = Antichain::new();
+        let downgrade = since_handle
+            .compare_and_downgrade_since(&epoch, (&epoch, &new_since))
+            .await;
+
+        assert!(
+            downgrade.is_ok(),
+            "downgrade of critical handle must succeed"
+        );
+
+        let finalize = persist_client
+            .finalize_shard::<(), (), u64, i64>(shard_id, Diagnostics::for_tests())
+            .await;
+
+        assert!(finalize.is_ok(), "finalization must succeed");
+
+        let is_finalized = persist_client
+            .is_finalized::<(), (), u64, i64>(shard_id, Diagnostics::for_tests())
+            .await
+            .expect("invalid persist usage");
+        assert!(is_finalized, "shard must still be finalized");
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(4096))]
 


### PR DESCRIPTION
Please see comments in code/tests. I noticed this while working on my PR that factors out a `StorageCollections` from the controller, which might do finalization with slightly different timing/at a different moment. But this might have been weird before.

The tests would fail without this fix, because `is_finalized` returns `false`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
