### PR TITLE
storage: revert `IngestionExport`/cluster correlation from storage controller

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -949,9 +949,6 @@ fn humanize_sql_for_show_create(
                             // Dropping a subsource does not remove any `TEXT
                             // COLUMNS` values that refer to the table it
                             // ingests, which we'll handle below.
-                            //
-                            // TODO(#26774): is this better if this is an option
-                            // on the subsources?
                             PgConfigOptionName::TextColumns => {}
                             // Drop details, which does not rountrip.
                             PgConfigOptionName::Details => return false,
@@ -984,9 +981,6 @@ fn humanize_sql_for_show_create(
                             // Dropping a subsource does not remove any `TEXT
                             // COLUMNS` values that refer to the table it
                             // ingests, which we'll handle below.
-                            //
-                            // TODO(#26774): is this better if this is an option
-                            // on the subsources?
                             MySqlConfigOptionName::TextColumns
                             | MySqlConfigOptionName::IgnoreColumns => {}
                             // Drop details, which does not rountrip.

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -118,29 +118,6 @@ pub enum DataSource {
     Other(DataSourceOther),
 }
 
-impl DataSource {
-    /// If this data source depends on the frontier of another collection,
-    /// return it.
-    ///
-    /// Dependencies offer the ability to tie the frontiers of collections
-    /// together, e.g. we expect that you cannot drop a collection with any
-    /// dependents that have not been dropped yet.
-    pub fn collection_dependency(&self) -> Option<GlobalId> {
-        match self {
-            DataSource::Introspection(_)
-            | DataSource::Webhook
-            | DataSource::Other(DataSourceOther::TableWrites)
-            | DataSource::Progress
-            | DataSource::Other(DataSourceOther::Compute) => None,
-            // Exports depend on their ingestion. n.b. we expect this dependency
-            // to carry transitively to the ingestion's remap collection.
-            DataSource::IngestionExport { ingestion_id, .. } => Some(*ingestion_id),
-            // Ingestions depend on their remap collection.
-            DataSource::Ingestion(ingestion) => Some(ingestion.remap_collection_id),
-        }
-    }
-}
-
 /// Describes how data is written to a collection maintained outside of the
 /// storage controller.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2243,7 +2243,7 @@ where
                         // do not yet track the cluster on pending compaction
                         // commands.
                         //
-                        // TODO(#24235): place the cluster ID in the pending compaction
+                        // TODO(#8185): place the cluster ID in the pending compaction
                         // commands of IngestionExports.
                         pending_source_drops.push(id);
                         None
@@ -3820,9 +3820,9 @@ impl<T: Timestamp> CollectionState<T> {
             DataSource::Webhook
             | DataSource::Introspection(_)
             | DataSource::Other(_)
-            // TODO(#24235) This isn't quite right because a source export runs on the
-            // ingestion's cluster, but we don't have the ability to perform
-            // cross-referenced lookups here (at least not yet).
+            // TODO(#8185) This isn't quite right because a source export runs
+            // on the ingestion's cluster, but we don't yet support announcing
+            // that.
             | DataSource::IngestionExport { .. }
             | DataSource::Progress => None,
         }

--- a/src/storage-controller/src/rehydration.rs
+++ b/src/storage-controller/src/rehydration.rs
@@ -494,8 +494,7 @@ where
                         Some(export) => {
                             export.description.as_of.clone_from(frontier);
                         }
-                        // uppers contains both ingestions and their exports
-                        None if self.uppers.contains_key(id) => continue,
+                        None if self.sources.contains_key(id) => continue,
                         None => panic!("AllowCompaction command for non-existent {id}"),
                     }
                 }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -965,51 +965,16 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 }
                 StorageCommand::RunIngestions(ingestions) => {
                     ingestions.retain_mut(|ingestion| {
-                        // Subsources can be dropped independently of their
-                        // primary source, so we evaluate them in a separate
-                        // loop.
-                        for export_id in ingestion
-                            .description
-                            .source_exports
-                            .keys()
-                            .filter(|export_id| **export_id != ingestion.id)
-                        {
-                            if drop_commands.remove(export_id)
-                                || self.storage_state.dropped_ids.contains(&ingestion.id)
-                            {
-                                self.storage_state.dropped_ids.insert(*export_id);
-                            }
-                        }
-
                         if drop_commands.remove(&ingestion.id)
                             || self.storage_state.dropped_ids.contains(&ingestion.id)
                         {
-                            // If an ingestion is dropped, so too must all of
-                            // its subsources (i.e. ingestion exports, as well
-                            // as its progress subsource).
-                            for id in ingestion.description.subsource_ids() {
-                                drop_commands.remove(&id);
-                                self.storage_state.dropped_ids.insert(id);
-                            }
+                            // Make sure that we report back that the ID was
+                            // dropped.
+                            self.storage_state.dropped_ids.insert(ingestion.id);
 
                             false
                         } else {
-                            let most_recent_defintion =
-                                seen_most_recent_definition.insert(ingestion.id);
-
-                            if most_recent_defintion {
-                                // If this is the most recent definition, this
-                                // is what we will be running when
-                                // reconciliation completes. This definition
-                                // must not include any dropped subsources.
-                                ingestion.description.source_exports.retain(|export_id, _| {
-                                    !self.storage_state.dropped_ids.contains(export_id)
-                                });
-
-                                // After clearing any dropped subsources, we can
-                                // state that we expect all of these to exist.
-                                expected_objects.extend(ingestion.description.subsource_ids());
-                            }
+                            expected_objects.extend(ingestion.description.subsource_ids());
 
                             let running_ingestion =
                                 self.storage_state.ingestions.get(&ingestion.id);
@@ -1019,7 +984,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                             //   is why these commands are run in reverse.
                             // - Ingestions whose descriptions are not exactly
                             //   those that are currently running.
-                            most_recent_defintion
+                            seen_most_recent_definition.insert(ingestion.id)
                                 && running_ingestion != Some(&ingestion.description)
                         }
                     })
@@ -1072,14 +1037,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
         let stale_objects = self
             .storage_state
             .ingestions
-            .values()
-            .map(|i| i.subsource_ids())
-            .flatten()
-            .chain(self.storage_state.exports.keys().copied())
+            .keys()
+            .chain(self.storage_state.exports.keys())
             // Objects are considered stale if we did not see them re-created.
             .filter(|id| !expected_objects.contains(id))
             // Synthesize the drop command
-            .map(|id| (id, Antichain::new()))
+            .map(|id| (*id, Antichain::new()))
             .collect::<Vec<_>>();
 
         trace!(

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1192,9 +1192,7 @@ impl StorageState {
                             // restart a sink in the future.
                             export_description.as_of.clone_from(&frontier);
                         }
-                        // reported_frontiers contains both ingestions and their
-                        // exports
-                        None if self.reported_frontiers.contains_key(&id) => (),
+                        None if self.ingestions.contains_key(&id) => (),
                         None => panic!("AllowCompaction command for non-existent {id}"),
                     }
 


### PR DESCRIPTION
#26826 introduced an issue with frontier advancement that shows up in at least some nightly tests (https://buildkite.com/materialize/nightly/builds/7697#018f5565-d7e6-4d28-84e4-e83085ba29ec). I tried gracefully fixing the issue in #26983 but that approach introduced a different class of failure. I need some more time to fully resolve this, so I am tactically reverting the bits in #26826 that are most likely to have caused the regression.

Closes #26976
Unfixes #24773

### Motivation

This PR fixes a recognized bug. #26976

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
