### PR TITLE
Reduce metrics collection from 10 to 30 seconds

### DIFF
--- a/src/metrics/src/lgalloc.rs
+++ b/src/metrics/src/lgalloc.rs
@@ -160,7 +160,7 @@ pub async fn register_metrics_into(metrics_registry: &MetricsRegistry) {
     let mut lgmetrics = LgMetrics::new(metrics_registry);
 
     mz_ore::task::spawn(|| "lgalloc_stats_update", async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(10));
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;

--- a/src/metrics/src/rusage.rs
+++ b/src/metrics/src/rusage.rs
@@ -110,7 +110,7 @@ pub async fn register_metrics_into(metrics_registry: &MetricsRegistry) {
     let rusage = RuMetrics::new(metrics_registry);
 
     mz_ore::task::spawn(|| "rusage_stats_update", async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(10));
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;


### PR DESCRIPTION
Collecting the lgalloc file/memory statistics can take a significant amount of time for processes with large page tables. This change reduces the collection interval from 10s to 30s, which should still provide up-to-date data to prometheus as we're scraping only once a minute.

This fixes high CPU utilization in `lgalloc_stats`. Overall, this seems to be less than 2% of our CPU utilization, but in my staging account it was closer to 10%. https://pprof.me/78678452f12318493381a9cf6b213f34 shows the cost of walking the page tables.

This should really be a flag, but we're instantiating the metrics tasks before having access to any flags. In the long run, we can make the tasks configurable. Reducing the interval itself is a safe change and immediately removes the issue we're observing.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
