### PR TITLE
storage: make suspend and restart delay configurable, drop to 5s from 30s

### DIFF
--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -10,9 +10,8 @@
 //! Dyncfgs used by the storage layer. Despite their name, these can be used
 //! "statically" during rendering, or dynamically within timely operators.
 
-use std::time::Duration;
-
 use mz_dyncfg::{Config, ConfigSet};
+use std::time::Duration;
 
 /// When dataflows observe an invariant violation it is either due to a bug or due to the cluster
 /// being shut down. This configuration defines the amount of time to wait before panicking the
@@ -167,6 +166,13 @@ pub const STORAGE_ROCKSDB_CLEANUP_TRIES: Config<usize> = Config::new(
     "How many times to try to cleanup old RocksDB DB's on disk before giving up.",
 );
 
+/// Delay interval when reconnecting to a source / sink after halt.
+pub const STORAGE_SUSPEND_AND_RESTART_DELAY: Config<Duration> = Config::new(
+    "storage_suspend_and_restart_delay",
+    Duration::from_secs(5),
+    "Delay interval when reconnecting to a source / sink after halt.",
+);
+
 /// Adds the full set of all storage `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -184,4 +190,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_ROCKSDB_USE_MERGE_OPERATOR)
         .add(&STORAGE_UPSERT_MAX_SNAPSHOT_BATCH_BUFFERING)
         .add(&STORAGE_ROCKSDB_CLEANUP_TRIES)
+        .add(&STORAGE_SUSPEND_AND_RESTART_DELAY)
 }

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -203,6 +203,7 @@ use std::rc::Rc;
 use mz_ore::error::ErrorExt;
 use mz_repr::{GlobalId, Row};
 use mz_storage_types::controller::CollectionMetadata;
+use mz_storage_types::dyncfgs;
 use mz_storage_types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_types::sources::{GenericSourceConnection, IngestionDescription};
 use timely::communication::Allocate;
@@ -375,6 +376,8 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     .storage_configuration
                     .parameters
                     .record_namespaced_errors,
+                dyncfgs::STORAGE_SUSPEND_AND_RESTART_DELAY
+                    .get(storage_state.storage_configuration.config_set()),
             );
             tokens.push(health_token);
 
@@ -436,6 +439,8 @@ pub fn build_export_dataflow<A: Allocate>(
                     .storage_configuration
                     .parameters
                     .record_namespaced_errors,
+                dyncfgs::STORAGE_SUSPEND_AND_RESTART_DELAY
+                    .get(storage_state.storage_configuration.config_set()),
             );
             tokens.push(health_token);
 

--- a/test/kafka-auth/test-schema-registry-ssl-basic.td
+++ b/test/kafka-auth/test-schema-registry-ssl-basic.td
@@ -126,8 +126,8 @@ $ kafka-ingest topic=avro-data format=avro schema=${schema} timestamp=2
 1
 2
 
-> SELECT status FROM mz_internal.mz_sink_statuses WHERE name = 'snk_backup';
-stalled
+> SELECT count(status) > 0 FROM mz_internal.mz_sink_status_history JOIN mz_sinks ON sink_id = id WHERE name = 'snk_backup' AND status = 'stalled';
+true
 
 > ALTER CONNECTION kafka_backup SET (BROKER 'kafka:9092');
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->


https://github.com/MaterializeInc/materialize/issues/26139 + https://github.com/MaterializeInc/cloud/issues/8965 have the full context, but the tl;dr is that sources can take a long time reconnect after momentary network blips. This means <1s of network downtime can turn into >60s of actual source/sink unavailability. One of the primary sources of downtime is the fixed 30s `SUSPEND_AND_RESTART_DELAY`.

This PR makes two small changes to this knob:
1. Makes it configurable
2. Drops the default to 5s, down from 30s

A more advanced solution would be using exponential backoff, but it's not quite clear to me how to make that work within the healthcheck operator. Tossing this up as a proposal, and will let a member of @MaterializeInc/storage determine whether it's sufficient 😄 

### Motivation

In part addresses https://github.com/MaterializeInc/materialize/issues/26139, though it'd be nice to move to exponential backoff eventually.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
