### PR TITLE
storage/mysql: Support specifying date/datetime columns as text

### DIFF
--- a/src/mysql-util/src/desc.proto
+++ b/src/mysql-util/src/desc.proto
@@ -28,6 +28,12 @@ message ProtoMySqlColumnMetaJson {}
 
 message ProtoMySqlColumnMetaYear {}
 
+message ProtoMySqlColumnMetaDate {}
+
+message ProtoMySqlColumnMetaTimestamp {
+    uint32 precision = 1;
+}
+
 message ProtoMySqlColumnDesc {
     string name = 1;
     optional mz_repr.relation_and_scalar.ProtoColumnType column_type = 2;
@@ -36,6 +42,8 @@ message ProtoMySqlColumnDesc {
         ProtoMySqlColumnMetaEnum enum = 3;
         ProtoMySqlColumnMetaJson json = 4;
         ProtoMySqlColumnMetaYear year = 5;
+        ProtoMySqlColumnMetaDate date = 6;
+        ProtoMySqlColumnMetaTimestamp timestamp = 7;
     }
 }
 

--- a/src/mysql-util/src/schemas.rs
+++ b/src/mysql-util/src/schemas.rs
@@ -428,6 +428,22 @@ fn parse_as_text_column(
                 })?,
             })),
         )),
+        "date" => Ok((ScalarType::String, Some(MySqlColumnMeta::Date))),
+        "datetime" | "timestamp" => Ok((
+            ScalarType::String,
+            Some(MySqlColumnMeta::Timestamp(
+                info.datetime_precision
+                    // Default precision is 0 in MySQL if not specified
+                    .unwrap_or_default()
+                    .try_into()
+                    .map_err(|_| UnsupportedDataType {
+                        column_type: info.column_type.clone(),
+                        qualified_table_name: format!("{:?}.{:?}", schema_name, table_name),
+                        column_name: info.column_name.clone(),
+                        intended_type: Some("text".to_string()),
+                    })?,
+            )),
+        )),
         _ => Err(UnsupportedDataType {
             column_type: info.column_type.clone(),
             qualified_table_name: format!("{:?}.{:?}", schema_name, table_name),

--- a/test/mysql-cdc/30-text-columns.td
+++ b/test/mysql-cdc/30-text-columns.td
@@ -24,23 +24,29 @@ ALTER SYSTEM SET enable_mysql_source = true
 
 $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
 
+# Insert data into MySQL that can't be decoded using native types and must be decoded
+# as a TEXT COLUMN
+# NOTE: We need to use `sql_mode = ''` to have MySQL allow the 0000-00-00 dates which it
+# correctly disallows by default in newer versions, but used to allow in previous ones.
+
 $ mysql-execute name=mysql
 DROP DATABASE IF EXISTS public;
 CREATE DATABASE public;
 USE public;
-CREATE TABLE t1 (f1 JSON, f2 ENUM('small', 'medium', 'large'), f3 YEAR);
-
-INSERT INTO t1 VALUES (CAST('{"bar": "baz", "balance": 7.77, "active": false, "nest": {"birds": ["seagull", "robin"]}}' AS JSON), 'large', 2024);
+CREATE TABLE t1 (f1 JSON, f2 ENUM('small', 'medium', 'large'), f3 YEAR, f4 DATE, f5 DATE, f6 DATE, f7 DATETIME, f8 DATETIME, f9 DATETIME(4));
+SET SESSION sql_mode = '';
+INSERT INTO t1 VALUES (CAST('{"bar": "baz", "balance": 7.77, "active": false, "nest": {"birds": ["seagull", "robin"]}}' AS JSON), 'large', 2024, '0000-00-00', '2024-00-01', '2024-01-00', '0000-00-00 00:00:00',  '0000-00-00 00:00:00.000000',  '0000-00-00 00:00:00.000000');
 
 > CREATE SOURCE da
   FROM MYSQL CONNECTION mysqc (
-    TEXT COLUMNS (public.t1.f1, public.t1.f2, public.t1.f3)
+    TEXT COLUMNS (public.t1.f1, public.t1.f2, public.t1.f3, public.t1.f4, public.t1.f5, public.t1.f6, public.t1.f7, public.t1.f8, public.t1.f9)
   )
   FOR TABLES (public.t1);
 
 # Insert the same data post-snapshot
 $ mysql-execute name=mysql
 USE public;
+SET SESSION sql_mode = '';
 INSERT INTO t1 SELECT * FROM t1;
 
 > SELECT f1::jsonb->>'balance' FROM t1;
@@ -59,6 +65,30 @@ INSERT INTO t1 SELECT * FROM t1;
 > SELECT f1 FROM t1;
 "{\"bar\":\"baz\",\"nest\":{\"birds\":[\"seagull\",\"robin\"]},\"active\":false,\"balance\":7.77}"
 "{\"bar\":\"baz\",\"nest\":{\"birds\":[\"seagull\",\"robin\"]},\"active\":false,\"balance\":7.77}"
+
+> SELECT f4 FROM t1;
+0000-00-00
+0000-00-00
+
+> SELECT f5 FROM t1;
+2024-00-01
+2024-00-01
+
+> SELECT f6 FROM t1;
+2024-01-00
+2024-01-00
+
+> SELECT f7 FROM t1;
+"0000-00-00 00:00:00"
+"0000-00-00 00:00:00"
+
+> SELECT f8 FROM t1;
+"0000-00-00 00:00:00"
+"0000-00-00 00:00:00"
+
+> SELECT f9 FROM t1;
+"0000-00-00 00:00:00.0000"
+"0000-00-00 00:00:00.0000"
 
 > DROP SOURCE da CASCADE;
 


### PR DESCRIPTION
### Motivation

Supports a new MySQL Source trial whose upstream data includes invalid `0000-00-00` dates that are currently causing ingestion of those date columns to fail. This adds support for specifying the date and datetime columns containing invalid dates to be rendered as `TEXT COLUMNS` instead.

In the future we may add user-facing options to allow casting invalid dates to NULL or some other value, but that work needs scoping and more time to implement.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
