### PR TITLE
sql: add support for map constructors

### DIFF
--- a/doc/user/content/releases/v0.100.md
+++ b/doc/user/content/releases/v0.100.md
@@ -1,0 +1,11 @@
+---
+title: "Materialize v0.100"
+date: 2024-05-22
+released: false
+---
+
+## v0.100
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}

--- a/doc/user/content/sql/types/map.md
+++ b/doc/user/content/sql/types/map.md
@@ -75,6 +75,17 @@ SELECT MAP['a' => ['b' => 'c']];
  {a=>{b=>c}}
 ```
 
+`MAP` expressions evalute expressions for both keys and values:
+
+```sql
+SELECT MAP['a' || 'b' => 1 + 2];
+```
+```nofmt
+     map
+-------------
+ {ab=>3}
+```
+
 Alternatively, you can construct a map from the results of a subquery. The
 subquery must return two columns: a key column of type `text` and a value column
 of any type, in that order. Note that, in this form of the `MAP` expression,

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -3664,9 +3664,16 @@ static EMPTY_ARRAY_ROW: Lazy<Row> = Lazy::new(|| {
         .expect("array known to be valid");
     row
 });
+
 static EMPTY_LIST_ROW: Lazy<Row> = Lazy::new(|| {
     let mut row = Row::default();
     row.packer().push_list(iter::empty::<Datum>());
+    row
+});
+
+static EMPTY_MAP_ROW: Lazy<Row> = Lazy::new(|| {
+    let mut row = Row::default();
+    row.packer().push_dict(iter::empty::<(_, Datum)>());
     row
 });
 
@@ -3677,6 +3684,10 @@ impl Datum<'_> {
 
     pub fn empty_list() -> Datum<'static> {
         EMPTY_LIST_ROW.unpack_first()
+    }
+
+    pub fn empty_map() -> Datum<'static> {
+        EMPTY_MAP_ROW.unpack_first()
     }
 }
 

--- a/src/sql-lexer/src/lexer.rs
+++ b/src/sql-lexer/src/lexer.rs
@@ -98,6 +98,7 @@ pub enum Token {
     Colon,
     DoubleColon,
     Semicolon,
+    Arrow,
 }
 
 impl fmt::Display for Token {
@@ -121,6 +122,7 @@ impl fmt::Display for Token {
             Token::Colon => f.write_str("colon"),
             Token::DoubleColon => f.write_str("double colon"),
             Token::Semicolon => f.write_str("semicolon"),
+            Token::Arrow => f.write_str("arrow"),
         }
     }
 }
@@ -397,6 +399,13 @@ fn lex_number(buf: &mut LexBuf) -> Result<Token, LexerError> {
 
 fn lex_op(buf: &mut LexBuf) -> Token {
     buf.prev();
+
+    // Materialize special case: `=>` is lexed as an arrow token, rather than
+    // an operator.
+    if buf.consume_str("=>") {
+        return Token::Arrow;
+    }
+
     let mut s = String::new();
 
     // In PostgreSQL, operators might be composed of any of the characters in

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -188,6 +188,9 @@ pub enum Expr<T: AstInfo> {
     /// `LIST[<expr>*]`
     List(Vec<Expr<T>>),
     ListSubquery(Box<Query<T>>),
+    /// `MAP[<expr>*]`
+    Map(Vec<MapEntry<T>>),
+    MapSubquery(Box<Query<T>>),
     /// `<expr>([<expr>(:<expr>)?])+`
     Subscript {
         expr: Box<Expr<T>>,
@@ -448,14 +451,8 @@ impl<T: AstInfo> AstDisplay for Expr<T> {
                 f.write_str(")");
             }
             Expr::Array(exprs) => {
-                let mut exprs = exprs.iter().peekable();
                 f.write_str("ARRAY[");
-                while let Some(expr) = exprs.next() {
-                    f.write_node(expr);
-                    if exprs.peek().is_some() {
-                        f.write_str(", ");
-                    }
-                }
+                f.write_node(&display::comma_separated(exprs));
                 f.write_str("]");
             }
             Expr::ArraySubquery(s) => {
@@ -464,18 +461,22 @@ impl<T: AstInfo> AstDisplay for Expr<T> {
                 f.write_str(")");
             }
             Expr::List(exprs) => {
-                let mut exprs = exprs.iter().peekable();
                 f.write_str("LIST[");
-                while let Some(expr) = exprs.next() {
-                    f.write_node(expr);
-                    if exprs.peek().is_some() {
-                        f.write_str(", ");
-                    }
-                }
+                f.write_node(&display::comma_separated(exprs));
                 f.write_str("]");
             }
             Expr::ListSubquery(s) => {
                 f.write_str("LIST(");
+                f.write_node(&s);
+                f.write_str(")");
+            }
+            Expr::Map(exprs) => {
+                f.write_str("MAP[");
+                f.write_node(&display::comma_separated(exprs));
+                f.write_str("]");
+            }
+            Expr::MapSubquery(s) => {
+                f.write_str("MAP(");
                 f.write_node(&s);
                 f.write_str(")");
             }
@@ -663,6 +664,21 @@ impl AstDisplay for HomogenizingFunction {
     }
 }
 impl_display!(HomogenizingFunction);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct MapEntry<T: AstInfo> {
+    pub key: Expr<T>,
+    pub value: Expr<T>,
+}
+
+impl<T: AstInfo> AstDisplay for MapEntry<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.key);
+        f.write_str(" => ");
+        f.write_node(&self.value);
+    }
+}
+impl_display_t!(MapEntry);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SubscriptPosition<T: AstInfo> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -571,6 +571,7 @@ impl<'a> Parser<'a> {
             }
             Token::Keyword(ARRAY) => self.parse_array(),
             Token::Keyword(LIST) => self.parse_list(),
+            Token::Keyword(MAP) => self.parse_map(),
             Token::Keyword(CASE) => self.parse_case_expr(),
             Token::Keyword(CAST) => self.parse_cast_expr(),
             Token::Keyword(COALESCE) => {
@@ -5532,6 +5533,35 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn parse_map(&mut self) -> Result<Expr<Raw>, ParserError> {
+        if self.consume_token(&Token::LParen) {
+            let subquery = self.parse_query()?;
+            self.expect_token(&Token::RParen)?;
+            return Ok(Expr::MapSubquery(Box::new(subquery)));
+        }
+
+        self.expect_token(&Token::LBracket)?;
+        let mut exprs = vec![];
+        loop {
+            if let Some(Token::RBracket) = self.peek_token() {
+                break;
+            }
+            let key = self.parse_expr()?;
+            self.expect_token(&Token::Arrow)?;
+            let value = if let Some(Token::LBracket) = self.peek_token() {
+                self.parse_map()?
+            } else {
+                self.parse_expr()?
+            };
+            exprs.push(MapEntry { key, value });
+            if !self.consume_token(&Token::Comma) {
+                break;
+            }
+        }
+        self.expect_token(&Token::RBracket)?;
+        Ok(Expr::Map(exprs))
+    }
+
     fn parse_sequence<F>(&mut self, mut f: F) -> Result<Vec<Expr<Raw>>, ParserError>
     where
         F: FnMut(&mut Self) -> Result<Expr<Raw>, ParserError>,
@@ -5714,7 +5744,7 @@ impl<'a> Parser<'a> {
 
                 // MZ "proprietary" types
                 MAP => {
-                    return self.parse_map();
+                    return self.parse_map_type();
                 }
 
                 // Misc.
@@ -6046,10 +6076,10 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_map(&mut self) -> Result<RawDataType, ParserError> {
+    fn parse_map_type(&mut self) -> Result<RawDataType, ParserError> {
         self.expect_token(&Token::LBracket)?;
         let key_type = Box::new(self.parse_data_type()?);
-        self.expect_token(&Token::Op("=>".to_owned()))?;
+        self.expect_token(&Token::Arrow)?;
         let value_type = Box::new(self.parse_data_type()?);
         self.expect_token(&Token::RBracket)?;
         Ok(RawDataType::Map {

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1438,6 +1438,50 @@ SELECT LIST(WITH usps AS (SELECT 42) SELECT * FROM usps)
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: ListSubquery(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("usps"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("42")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("usps")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
+# Map subqueries
+parse-statement
+SELECT MAP[1 => a, b => 1 + 2, a || 'b' => (SELECT 1), c => LIST[4, 5]]
+----
+SELECT MAP[1 => a, b => 1 + 2, a || 'b' => (SELECT 1), c => LIST[4, 5]]
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Map([MapEntry { key: Value(Number("1")), value: Identifier([Ident("a")]) }, MapEntry { key: Identifier([Ident("b")]), value: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) } }, MapEntry { key: Op { op: Op { namespace: None, op: "||" }, expr1: Identifier([Ident("a")]), expr2: Some(Value(String("b"))) }, value: Subquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) }, MapEntry { key: Identifier([Ident("c")]), value: List([Value(Number("4")), Value(Number("5"))]) }]), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+# Map subqueries
+parse-statement
+SELECT MAP[]
+----
+SELECT MAP[]
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Map([]), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT MAP['a' => MAP['b' => MAP['c' => 'd', 'e' => 'f'], 'g' => h], 'i' => MAP['j' => 'k']]
+----
+SELECT MAP['a' => MAP['b' => MAP['c' => 'd', 'e' => 'f'], 'g' => h], 'i' => MAP['j' => 'k']]
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Map([MapEntry { key: Value(String("a")), value: Map([MapEntry { key: Value(String("b")), value: Map([MapEntry { key: Value(String("c")), value: Value(String("d")) }, MapEntry { key: Value(String("e")), value: Value(String("f")) }]) }, MapEntry { key: Value(String("g")), value: Identifier([Ident("h")]) }]) }, MapEntry { key: Value(String("i")), value: Map([MapEntry { key: Value(String("j")), value: Value(String("k")) }]) }]), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT MAP[1, 2]
+----
+error: Expected arrow, found comma
+SELECT MAP[1, 2]
+            ^
+
+parse-statement
+SELECT MAP[1]
+----
+error: Expected arrow, found right square bracket
+SELECT MAP[1]
+            ^
+
+parse-statement
+SELECT MAP(SELECT 2 * 10)
+----
+SELECT MAP(SELECT 2 * 10)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: MapSubquery(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "*" }, expr1: Value(Number("2")), expr2: Some(Value(Number("10"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
 # Array subqueries
 parse-statement
 SELECT ARRAY[1, 2, 3]

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -60,10 +60,11 @@ use mz_sql_parser::ast::{
     visit, AsOf, Assignment, AstInfo, CreateWebhookSourceBody, CreateWebhookSourceCheck,
     CreateWebhookSourceHeader, CreateWebhookSourceSecret, CteBlock, DeleteStatement, Distinct,
     Expr, Function, FunctionArgs, HomogenizingFunction, Ident, InsertSource, IsExprConstruct, Join,
-    JoinConstraint, JoinOperator, Limit, MutRecBlock, MutRecBlockOption, MutRecBlockOptionName,
-    OrderByExpr, Query, Select, SelectItem, SelectOption, SelectOptionName, SetExpr, SetOperator,
-    ShowStatement, SubscriptPosition, TableAlias, TableFactor, TableWithJoins, UnresolvedItemName,
-    UpdateStatement, Value, Values, WindowFrame, WindowFrameBound, WindowFrameUnits, WindowSpec,
+    JoinConstraint, JoinOperator, Limit, MapEntry, MutRecBlock, MutRecBlockOption,
+    MutRecBlockOptionName, OrderByExpr, Query, Select, SelectItem, SelectOption, SelectOptionName,
+    SetExpr, SetOperator, ShowStatement, SubscriptPosition, TableAlias, TableFactor,
+    TableWithJoins, UnresolvedItemName, UpdateStatement, Value, Values, WindowFrame,
+    WindowFrameBound, WindowFrameUnits, WindowSpec,
 };
 use mz_sql_parser::ident;
 use uuid::Uuid;
@@ -3216,6 +3217,7 @@ fn invent_column_name(
             Expr::NullIf { .. } => Some(("nullif".into(), NameQuality::High)),
             Expr::Array { .. } => Some(("array".into(), NameQuality::High)),
             Expr::List { .. } => Some(("list".into(), NameQuality::High)),
+            Expr::Map { .. } | Expr::MapSubquery(_) => Some(("map".into(), NameQuality::High)),
             Expr::Cast { expr, data_type } => match invent(ecx, expr, table_func_names) {
                 Some((name, NameQuality::High)) => Some((name, NameQuality::High)),
                 _ => Some((data_type.unqualified_item_name().into(), NameQuality::Low)),
@@ -3679,6 +3681,7 @@ fn plan_expr_inner<'a>(
         Expr::Parameter(n) => plan_parameter(ecx, *n),
         Expr::Array(exprs) => plan_array(ecx, exprs, None),
         Expr::List(exprs) => plan_list(ecx, exprs, None),
+        Expr::Map(exprs) => plan_map(ecx, exprs, None),
         Expr::Row { exprs } => plan_row(ecx, exprs),
 
         // Generalized functions, operators, and casts.
@@ -3743,6 +3746,7 @@ fn plan_expr_inner<'a>(
         Expr::Exists(query) => plan_exists(ecx, query),
         Expr::Subquery(query) => plan_subquery(ecx, query),
         Expr::ListSubquery(query) => plan_list_subquery(ecx, query),
+        Expr::MapSubquery(query) => plan_map_subquery(ecx, query),
         Expr::ArraySubquery(query) => plan_array_subquery(ecx, query),
         Expr::Collate { expr, collation } => plan_collate(ecx, expr, collation),
         Expr::Nested(_) => unreachable!("Expr::Nested not desugared"),
@@ -3787,16 +3791,17 @@ fn plan_cast(
 ) -> Result<CoercibleScalarExpr, PlanError> {
     let to_scalar_type = scalar_type_from_sql(ecx.qcx.scx, data_type)?;
     let expr = match expr {
-        // Special case a direct cast of an ARRAY or LIST expression so
+        // Special case a direct cast of an ARRAY, LIST, or MAP expression so
         // we can pass in the target type as a type hint. This is
         // a limited form of the coercion that we do for string literals
         // via CoercibleScalarExpr. We used to let CoercibleScalarExpr
-        // handle ARRAY/LIST coercion too, but doing so causes
+        // handle ARRAY/LIST/MAP coercion too, but doing so causes
         // PostgreSQL compatibility trouble.
         //
         // See: https://github.com/postgres/postgres/blob/31f403e95/src/backend/parser/parse_expr.c#L2762-L2768
         Expr::Array(exprs) => plan_array(ecx, exprs, Some(&to_scalar_type))?,
         Expr::List(exprs) => plan_list(ecx, exprs, Some(&to_scalar_type))?,
+        Expr::Map(exprs) => plan_map(ecx, exprs, Some(&to_scalar_type))?,
         _ => plan_expr(ecx, expr)?,
     };
     let ecx = &ecx.with_name("CAST");
@@ -4373,6 +4378,106 @@ where
     .into())
 }
 
+fn plan_map_subquery(
+    ecx: &ExprContext,
+    query: &Query<Aug>,
+) -> Result<CoercibleScalarExpr, PlanError> {
+    if !ecx.allow_subqueries {
+        sql_bail!("{} does not allow subqueries", ecx.name)
+    }
+
+    let mut qcx = ecx.derived_query_context();
+    let mut query = plan_query(&mut qcx, query)?;
+    if query.limit.is_some() || query.offset > 0 {
+        query.expr = HirRelationExpr::top_k(
+            query.expr,
+            vec![],
+            query.order_by.clone(),
+            query.limit,
+            query.offset,
+            query.group_size_hints.limit_input_group_size,
+        );
+    }
+    if query.project.len() != 2 {
+        sql_bail!(
+            "expected map subquery to return 2 columns, got {} columns",
+            query.project.len()
+        );
+    }
+
+    let query_types = qcx.relation_type(&query.expr).column_types;
+    let key_column = query.project[0];
+    let key_type = query_types[key_column].clone().scalar_type();
+    let value_column = query.project[1];
+    let value_type = query_types[value_column].clone().scalar_type();
+
+    if key_type != ScalarType::String {
+        sql_bail!("cannot build map from subquery because first column is not of type text");
+    }
+
+    let aggregation_exprs: Vec<_> = iter::once(HirScalarExpr::CallVariadic {
+        func: VariadicFunc::RecordCreate {
+            field_names: vec![ColumnName::from("key"), ColumnName::from("value")],
+        },
+        exprs: vec![
+            HirScalarExpr::column(key_column),
+            HirScalarExpr::column(value_column),
+        ],
+    })
+    .chain(
+        query
+            .order_by
+            .iter()
+            .map(|co| HirScalarExpr::column(co.column)),
+    )
+    .collect();
+
+    let expr = query
+        .expr
+        .reduce(
+            vec![],
+            vec![AggregateExpr {
+                func: AggregateFunc::MapAgg {
+                    order_by: query
+                        .order_by
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, order)| ColumnOrder { column: i, ..order })
+                        .collect(),
+                    value_type: value_type.clone(),
+                },
+                expr: Box::new(HirScalarExpr::CallVariadic {
+                    func: VariadicFunc::RecordCreate {
+                        field_names: iter::repeat(ColumnName::from(""))
+                            .take(aggregation_exprs.len())
+                            .collect(),
+                    },
+                    exprs: aggregation_exprs,
+                }),
+                distinct: false,
+            }],
+            None,
+        )
+        .project(vec![0]);
+
+    // If `expr` has no rows, return an empty map rather than NULL.
+    let expr = HirScalarExpr::CallVariadic {
+        func: VariadicFunc::Coalesce,
+        exprs: vec![
+            HirScalarExpr::Select(Box::new(expr)),
+            HirScalarExpr::literal(
+                Datum::empty_map(),
+                ScalarType::Map {
+                    value_type: Box::new(value_type),
+                    custom_id: None,
+                },
+            ),
+        ],
+    };
+
+    Ok(expr.into())
+}
+
 fn plan_collate(
     ecx: &ExprContext,
     expr: &Expr<Aug>,
@@ -4516,6 +4621,53 @@ fn plan_list(
         exprs,
     }
     .into())
+}
+
+fn plan_map(
+    ecx: &ExprContext,
+    entries: &[MapEntry<Aug>],
+    type_hint: Option<&ScalarType>,
+) -> Result<CoercibleScalarExpr, PlanError> {
+    let (value_type, exprs) = if entries.is_empty() {
+        if let Some(ScalarType::Map { value_type, .. }) = type_hint {
+            (value_type.without_modifiers(), vec![])
+        } else {
+            sql_bail!("cannot determine type of empty map");
+        }
+    } else {
+        let type_hint = match type_hint {
+            Some(ScalarType::Map { value_type, .. }) => Some(&**value_type),
+            _ => None,
+        };
+
+        let mut keys = vec![];
+        let mut values = vec![];
+        for MapEntry { key, value } in entries {
+            let key = plan_expr(ecx, key)?.type_as(ecx, &ScalarType::String)?;
+            let value = match value {
+                // Special case nested MAP expressions so we can plumb
+                // the type hint through.
+                Expr::Map(entries) => plan_map(ecx, entries, type_hint)?,
+                _ => plan_expr(ecx, value)?,
+            };
+            keys.push(key);
+            values.push(value);
+        }
+        let values = coerce_homogeneous_exprs(&ecx.with_name("MAP"), values, type_hint)?;
+        let value_type = ecx.scalar_type(&values[0]).without_modifiers();
+        let out = itertools::interleave(keys, values).collect();
+        (value_type, out)
+    };
+
+    if matches!(value_type, ScalarType::Char { .. }) {
+        bail_unsupported!("char map");
+    }
+
+    let expr = HirScalarExpr::CallVariadic {
+        func: VariadicFunc::MapBuild { value_type },
+        exprs,
+    };
+    Ok(expr.into())
 }
 
 /// Coerces a list of expressions such that all input expressions will be cast

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -142,6 +142,118 @@ SELECT ('{hello=>{\{\}=>\"\"}}'::map[text=>map[text=>text]])::text
 ----
 {hello=>{"{}"=>"\"\""}}
 
+# Test MAP literals.
+
+query T
+SELECT MAP['a' => 1]::text
+----
+{a=>1}
+
+query T
+SELECT MAP['a' => 1, 'a' => 2]::text
+----
+{a=>2}
+
+query T
+SELECT MAP['a' => 1, 'b' => 2, 'a' => 3]::text
+----
+{a=>3,b=>2}
+
+query T
+SELECT MAP['a' => MAP['b' => 'c']]::text
+----
+{a=>{b=>c}}
+
+query T
+SELECT MAP['a' => ['b' => 'c']]::text
+----
+{a=>{b=>c}}
+
+query T
+SELECT MAP['a' => list[[1], [2]]]::text
+----
+{a=>{{1},{2}}}
+
+query T
+SELECT MAP['a' => ['b' => list[[1], [2]]]]::text
+----
+{a=>{b=>{{1},{2}}}}
+
+query T
+SELECT MAP[column1 => column2]::text FROM (VALUES ('a', 1), ('b', 2), ('c', 3))
+----
+{a=>1}
+{b=>2}
+{c=>3}
+
+query error cannot determine type of empty map
+SELECT MAP[]::text
+
+query T
+SELECT MAP[]::map[text => text]::text
+----
+{}
+
+statement ok
+CREATE TABLE mlt(t text, y int)
+
+statement ok
+INSERT INTO mlt VALUES ('a', 6), ('b', 8), ('c', 10), ('c', 11)
+
+query T
+SELECT MAP(SELECT * FROM mlt WHERE t > 'a' ORDER BY y DESC)::text;
+----
+{b=>8,c=>10}
+
+query T
+SELECT MAP(SELECT * FROM mlt WHERE mlt.t > mlt_outer.t)::text
+FROM mlt AS mlt_outer;
+----
+{}
+{}
+{c=>11}
+{b=>8,c=>11}
+
+query TII
+SELECT list_agg(t)::text, min(y), max(y)
+FROM mlt AS mlt_outer
+GROUP BY MAP(SELECT * FROM mlt WHERE mlt.t < mlt_outer.t);
+----
+{a}  6  6
+{b}  8  8
+{c,c}  10  11
+
+query T
+SELECT MAP(SELECT * FROM mlt WHERE t < 'a')::text
+----
+{}
+
+# Test MAP subqueries.
+
+query T
+SELECT MAP(VALUES ('a', 1), ('b', 2), ('c', 3))::text
+----
+{a=>1,b=>2,c=>3}
+
+query T
+SELECT MAP(VALUES ('a', 1), ('a', 2) ORDER BY 2)::text
+----
+{a=>2}
+
+query T
+SELECT MAP(VALUES ('a', 1), ('a', 2) ORDER BY 2 DESC)::text
+----
+{a=>1}
+
+query error cannot build map from subquery because first column is not of type text
+SELECT MAP(VALUES (1, 1))
+
+query error expected map subquery to return 2 columns, got 1 columns
+SELECT MAP(VALUES (1))
+
+query error expected map subquery to return 2 columns, got 3 columns
+SELECT MAP(VALUES (1, 2, 3))
+
 # Test map operators.
 
 ## ?

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -150,6 +150,36 @@ SELECT MAP['a' => 1]::text
 {a=>1}
 
 query T
+SELECT MAP['a' => 1 + 1]::text
+----
+{a=>2}
+
+query T
+SELECT MAP['a' => 2 * 1 + 1]::text
+----
+{a=>3}
+
+query T
+SELECT MAP['a' => 2 * 1 + 2 / 2]::text
+----
+{a=>3}
+
+query T
+SELECT MAP['a' => 2 * (1 + 1) / 2]::text
+----
+{a=>2}
+
+query T
+SELECT MAP['a' || 'b' => 1]::text
+----
+{ab=>1}
+
+query T
+SELECT MAP['a' || 'b' => 1 + 1]::text
+----
+{ab=>2}
+
+query T
 SELECT MAP['a' => 1, 'a' => 2]::text
 ----
 {a=>2}


### PR DESCRIPTION
Add support for long desired map constructors, akin to list and array constructors. Maps can now be constructed with the `MAP` literal:

    MAP['a' => 1, 'b' => 2]

Or from a subquery:

    MAP(VALUES ('a', 1), ('b', 2))

See the documentation within for details.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add a `MAP` expression that can construct a map from a list of key–value pairs or a subquery.
