### PR TITLE
scalability framework: failure reporting

### DIFF
--- a/misc/python/materialize/scalability/comparison_outcome.py
+++ b/misc/python/materialize/scalability/comparison_outcome.py
@@ -98,3 +98,10 @@ class ComparisonOutcome:
         self.significant_improvement_df = concat_df_totals_extended(
             [self.significant_improvement_df, significant_improvements_data]
         )
+
+    def get_regressions_by_endpoint(self, endpoint: Endpoint) -> list[Regression]:
+        return [
+            regression
+            for regression in self.regressions
+            if regression.endpoint == endpoint
+        ]

--- a/misc/python/materialize/scalability/endpoints.py
+++ b/misc/python/materialize/scalability/endpoints.py
@@ -184,9 +184,7 @@ class MaterializeContainer(MaterializeNonRemote):
                 self._port = self.composition.default_port("materialized")
 
     def __str__(self) -> str:
-        return (
-            f"MaterializeContainer ({self.image} specified as {self.specified_target})"
-        )
+        return f"MaterializeContainer ({self.image} specified as {self.specified_target()})"
 
 
 def endpoint_name_to_description(endpoint_name: str) -> str:

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -20,6 +20,7 @@ from materialize.mzcompose.composition import Composition, WorkflowArgumentParse
 from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.postgres import Postgres
+from materialize.mzcompose.test_result import FailedTestExecutionError
 from materialize.scalability.benchmark_config import BenchmarkConfiguration
 from materialize.scalability.benchmark_executor import BenchmarkExecutor
 from materialize.scalability.benchmark_result import BenchmarkResult
@@ -253,7 +254,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     report_assessment(regression_assessment)
 
     if regression_assessment.has_unjustified_regressions():
-        sys.exit(1)
+        raise FailedTestExecutionError(
+            error_summary="At least one regression occurred",
+            errors=regression_assessment.to_failure_details(),
+        )
 
 
 def validate_and_adjust_targets(


### PR DESCRIPTION
This shows an annotation in CI when a regression occurs. Previously, nothing was shown and logs had to be searched.

### Demo

https://buildkite.com/materialize/nightly/builds/7722

<img width="1151" alt="Bildschirmfoto 2024-05-09 um 16 39 29" src="https://github.com/MaterializeInc/materialize/assets/129728240/60ecd9b0-6895-4842-9b88-d8eee8657047">


