### PR TITLE
rust: Upgrade to v1.78.0, add guide detailing steps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.77.0"
+rust-version = "1.78.0"
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/bin/lint-versions
+++ b/bin/lint-versions
@@ -11,5 +11,5 @@
 #
 # lint-versions - Check rust version
 
-grep "rust-version = " Cargo.toml | grep -q "1\.77\.0" || \
+grep "rust-version = " Cargo.toml | grep -q "1\.78\.0" || \
 (echo "Please validate new Rust versions for compilation time performance regressions or ask Team Testing to do so. Afterwards change the tested version in bin/lint-versions" && exit 1)

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -47,6 +47,8 @@ We recommend that you do _not_ install Rust via your system's package manager.
 We closely track the most recent version of Rust. The version of Rust in your
 package manager is likely too old to build Materialize.
 
+For details on how we upgrade Rust see [here](/doc/developer/upgrade-rust.md).
+
 ### CockroachDB
 
 Running Materialize locally requires a running CockroachDB server.

--- a/doc/developer/upgrade-rust.md
+++ b/doc/developer/upgrade-rust.md
@@ -1,0 +1,23 @@
+# Upgrading Rust
+
+Materialize builds with the [stable](https://rust-lang.github.io/rustup/concepts/channels.html)
+release of Rust, which gets [updated every 6 weeks](https://releases.rs/). We try to pretty
+aggressively track the latest version to get the newest features and make upgrades as easy as
+possible.
+
+Anyone is welcome to upgrade the version of Rust! Below is the list of things you need to do:
+
+1. Bump the `rust-version` field in our [Workspace `Cargo.toml`](/Cargo.toml).
+2. Bump the `NIGHTLY_RUST_DATE` value in the [`ci-builder`](/bin/ci-builder) script.
+    * Note: CI has a nightly version of Rust so we can run [Miri](https://github.com/rust-lang/miri).
+3. Locally run `rustup upgrade stable` to pull the latest version of the Rust toolchain, or
+   whatever version you're upgrading to.
+4. From the root of the repository run `cargo clippy --workspace --tests`, fix any new clippy lints
+   that were introduced.
+5. Check if Rust's unicode version has changed. If it has make sure to include in the release notes
+   what version it previously was, and what version it got bumped to.
+    * The [Releases](https://github.com/rust-lang/rust/releases) page for the Rust repository
+      should mention if it's been changed. But the only way to know for sure it to
+      [git blame the `UNICODE_VERSION` const](https://github.com/rust-lang/rust/blame/master/library/core/src/unicode/unicode_data.rs).
+6. When the upgrade PR finally merges, post in `#eng-general` to give everyone a heads up and let
+   them know they can upgrade by running `rustup upgrade stable`.

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1412,7 +1412,7 @@ impl ExprHumanizer for ConnCatalog<'_> {
     }
 
     fn id_exists(&self, id: GlobalId) -> bool {
-        self.state.entry_by_id.get(&id).is_some()
+        self.state.entry_by_id.contains_key(&id)
     }
 }
 

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -87,12 +87,12 @@ impl CatalogState {
     fn check_internal_fields(&self) -> Result<(), Vec<InternalFieldsInconsistency>> {
         let mut inconsistencies = Vec::new();
         for (name, id) in &self.database_by_name {
-            if self.database_by_id.get(id).is_none() {
+            if !self.database_by_id.contains_key(id) {
                 inconsistencies.push(InternalFieldsInconsistency::Database(name.clone(), *id));
             }
         }
         for (name, id) in &self.ambient_schemas_by_name {
-            if self.ambient_schemas_by_id.get(id).is_none() {
+            if !self.ambient_schemas_by_id.contains_key(id) {
                 inconsistencies.push(InternalFieldsInconsistency::AmbientSchema(
                     name.clone(),
                     *id,
@@ -100,12 +100,12 @@ impl CatalogState {
             }
         }
         for (name, id) in &self.clusters_by_name {
-            if self.clusters_by_id.get(id).is_none() {
+            if !self.clusters_by_id.contains_key(id) {
                 inconsistencies.push(InternalFieldsInconsistency::Cluster(name.clone(), *id));
             }
         }
         for (name, role_id) in &self.roles_by_name {
-            if self.roles_by_id.get(role_id).is_none() {
+            if self.roles_by_id.contains_key(role_id) {
                 inconsistencies.push(InternalFieldsInconsistency::Role(name.clone(), *role_id))
             }
         }
@@ -124,17 +124,17 @@ impl CatalogState {
     fn check_roles(&self) -> Result<(), Vec<RoleInconsistency>> {
         let mut inconsistencies = Vec::new();
         for (database_id, database) in &self.database_by_id {
-            if self.roles_by_id.get(&database.owner_id).is_none() {
+            if !self.roles_by_id.contains_key(&database.owner_id) {
                 inconsistencies.push(RoleInconsistency::Database(*database_id, database.owner_id));
             }
             for (schema_id, schema) in &database.schemas_by_id {
-                if self.roles_by_id.get(&schema.owner_id).is_none() {
+                if !self.roles_by_id.contains_key(&schema.owner_id) {
                     inconsistencies.push(RoleInconsistency::Schema(*schema_id, schema.owner_id));
                 }
             }
         }
         for (global_id, entry) in &self.entry_by_id {
-            if self.roles_by_id.get(entry.owner_id()).is_none() {
+            if !self.roles_by_id.contains_key(entry.owner_id()) {
                 inconsistencies.push(RoleInconsistency::Entry(
                     *global_id,
                     entry.owner_id().clone(),
@@ -142,11 +142,11 @@ impl CatalogState {
             }
         }
         for (cluster_id, cluster) in &self.clusters_by_id {
-            if self.roles_by_id.get(&cluster.owner_id).is_none() {
+            if !self.roles_by_id.contains_key(&cluster.owner_id) {
                 inconsistencies.push(RoleInconsistency::Cluster(*cluster_id, cluster.owner_id));
             }
             for replica in cluster.replicas() {
-                if self.roles_by_id.get(&replica.owner_id).is_none() {
+                if !self.roles_by_id.contains_key(&replica.owner_id) {
                     inconsistencies.push(RoleInconsistency::ClusterReplica(
                         *cluster_id,
                         replica.replica_id,
@@ -156,11 +156,11 @@ impl CatalogState {
             }
         }
         for (default_priv, privileges) in self.default_privileges.iter() {
-            if self.roles_by_id.get(&default_priv.role_id).is_none() {
+            if !self.roles_by_id.contains_key(&default_priv.role_id) {
                 inconsistencies.push(RoleInconsistency::DefaultPrivilege(default_priv.clone()));
             }
             for acl_item in privileges {
-                if self.roles_by_id.get(&acl_item.grantee).is_none() {
+                if !self.roles_by_id.contains_key(&acl_item.grantee) {
                     inconsistencies.push(RoleInconsistency::DefaultPrivilegeItem {
                         grantor: default_priv.role_id,
                         grantee: acl_item.grantee,
@@ -256,13 +256,13 @@ impl CatalogState {
                     }
                 }
                 CommentObjectId::Role(role_id) => {
-                    if self.roles_by_id.get(&role_id).is_none() {
+                    if !self.roles_by_id.contains_key(&role_id) {
                         comment_inconsistencies
                             .push(CommentInconsistency::Dangling(comment_object_id));
                     }
                 }
                 CommentObjectId::Database(database_id) => {
-                    if self.database_by_id.get(&database_id).is_none() {
+                    if !self.database_by_id.contains_key(&database_id) {
                         comment_inconsistencies
                             .push(CommentInconsistency::Dangling(comment_object_id));
                     }
@@ -283,7 +283,7 @@ impl CatalogState {
                             }
                         }
                         (ResolvedDatabaseSpecifier::Ambient, SchemaSpecifier::Id(schema_id)) => {
-                            if self.ambient_schemas_by_id.get(&schema_id).is_none() {
+                            if !self.ambient_schemas_by_id.contains_key(&schema_id) {
                                 comment_inconsistencies
                                     .push(CommentInconsistency::Dangling(comment_object_id));
                             }
@@ -295,7 +295,7 @@ impl CatalogState {
                     }
                 }
                 CommentObjectId::Cluster(cluster_id) => {
-                    if self.clusters_by_id.get(&cluster_id).is_none() {
+                    if !self.clusters_by_id.contains_key(&cluster_id) {
                         comment_inconsistencies
                             .push(CommentInconsistency::Dangling(comment_object_id));
                     }

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -105,7 +105,7 @@ impl CatalogState {
             }
         }
         for (name, role_id) in &self.roles_by_name {
-            if self.roles_by_id.contains_key(role_id) {
+            if !self.roles_by_id.contains_key(role_id) {
                 inconsistencies.push(InternalFieldsInconsistency::Role(name.clone(), *role_id))
             }
         }

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -541,7 +541,7 @@ fn ast_rewrite_create_source_pg_database_details(
                     match &conn {
                         mz_storage_types::connections::Connection::Postgres(pg) => {
                             // Store the connection's database in the details.
-                            details.database = pg.database.clone();
+                            details.database.clone_from(&pg.database);
                         }
                         _ => unreachable!("PG sources must use PG connections"),
                     };

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1301,7 +1301,7 @@ impl CatalogState {
     pub(super) fn rename_cluster(&mut self, id: ClusterId, to_name: String) {
         let cluster = self.get_cluster_mut(id);
         let old_name = std::mem::take(&mut cluster.name);
-        cluster.name = to_name.clone();
+        cluster.name.clone_from(&to_name);
 
         assert!(self.clusters_by_name.remove(&old_name).is_some());
         assert!(self.clusters_by_name.insert(to_name, id).is_none());

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -1592,10 +1592,10 @@ impl Catalog {
                     }
 
                     let mut to_full_name = current_full_name.clone();
-                    to_full_name.item = to_name.clone();
+                    to_full_name.item.clone_from(&to_name);
 
                     let mut to_qualified_name = entry.name().clone();
-                    to_qualified_name.item = to_name.clone();
+                    to_qualified_name.item.clone_from(&to_name);
 
                     let details = EventDetails::RenameItemV1(mz_audit_log::RenameItemV1 {
                         id: id.to_string(),
@@ -1617,7 +1617,7 @@ impl Catalog {
 
                     // Rename item itself.
                     let mut new_entry = entry.clone();
-                    new_entry.name.item = to_name.clone();
+                    new_entry.name.item.clone_from(&to_name);
                     new_entry.item = entry
                         .item()
                         .rename_item_refs(
@@ -1792,7 +1792,7 @@ impl Catalog {
                     // Update the schema itself.
                     let schema = state.get_schema_mut(&database_spec, &schema_spec, conn_id);
                     let old_name = schema.name().schema.clone();
-                    schema.name.schema = new_name.clone();
+                    schema.name.schema.clone_from(&new_name);
                     let new_schema = schema.clone().into_durable_schema(database_spec.id());
                     tx.update_schema(schema_id, new_schema)?;
 

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1015,7 +1015,7 @@ impl Coordinator {
     /// This cleans up any state in the coordinator associated with the session.
     #[mz_ore::instrument(level = "debug")]
     async fn handle_terminate(&mut self, conn_id: ConnectionId) {
-        if self.active_conns.get(&conn_id).is_none() {
+        if self.active_conns.contains_key(&conn_id) {
             // If the session doesn't exist in `active_conns`, then this method will panic later on.
             // Instead we explicitly panic here while dumping the entire Coord to the logs to help
             // debug. This panic is very infrequent so we want as much information as possible.

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1015,7 +1015,7 @@ impl Coordinator {
     /// This cleans up any state in the coordinator associated with the session.
     #[mz_ore::instrument(level = "debug")]
     async fn handle_terminate(&mut self, conn_id: ConnectionId) {
-        if self.active_conns.contains_key(&conn_id) {
+        if !self.active_conns.contains_key(&conn_id) {
             // If the session doesn't exist in `active_conns`, then this method will panic later on.
             // Instead we explicitly panic here while dumping the entire Coord to the logs to help
             // debug. This panic is very infrequent so we want as much information as possible.

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -588,7 +588,7 @@ impl Coordinator {
             }) => {
                 use AlterOptionParameter::*;
                 match &options.size {
-                    Set(s) => *size = s.clone(),
+                    Set(s) => size.clone_from(s),
                     Reset => coord_bail!("SIZE has no default value"),
                     Unchanged => {}
                 }
@@ -598,7 +598,7 @@ impl Coordinator {
                     Unchanged => {}
                 }
                 match &options.availability_zones {
-                    Set(az) => *availability_zones = az.clone(),
+                    Set(az) => availability_zones.clone_from(az),
                     Reset => *availability_zones = Default::default(),
                     Unchanged => {}
                 }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3202,7 +3202,7 @@ impl Coordinator {
                     _ => unreachable!(),
                 };
 
-                ssh.public_keys = current_ssh.public_keys.clone();
+                ssh.public_keys.clone_from(&current_ssh.public_keys);
             }
             _ => {}
         };

--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -141,6 +141,7 @@ where
     /// Execute the optimization stage and panic if an error occurs.
     ///
     /// See [`Optimize::optimize`].
+    #[allow(dead_code)] // This function is never used, but it's useful to keep around.
     fn must_optimize(&mut self, expr: From) -> Self::To {
         match self.optimize(expr) {
             Ok(ok) => ok,

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -298,7 +298,7 @@ impl<'s> Optimize<LocalMirPlan<Resolved<'s>>> for Optimizer {
                 df_desc.until = Antichain::from_elem(until);
                 // Also updating the sink up_to
                 for (_, sink) in &mut df_desc.sink_exports {
-                    sink.up_to = df_desc.until.clone();
+                    sink.up_to.clone_from(&df_desc.until);
                 }
             } else {
                 warn!(as_of = %as_of, "as_of + 1 overflow");

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -223,7 +223,7 @@ impl Optimize<LocalMirPlan> for Optimizer {
         };
         let mut df_desc = MirDataflowDescription::new(self.debug_name.clone());
 
-        df_desc.refresh_schedule = self.refresh_schedule.clone();
+        df_desc.refresh_schedule.clone_from(&self.refresh_schedule);
 
         df_builder.import_view_into_dataflow(&self.view_id, &expr, &mut df_desc)?;
         df_builder.maybe_reoptimize_imported_views(&mut df_desc, &self.config)?;

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -1010,7 +1010,7 @@ mod tests {
         record2.put("a", 42i64);
         record2.put("b", "bar");
 
-        let expected = vec![record1.avro(), record2.avro()];
+        let expected = [record1.avro(), record2.avro()];
 
         for (i, value) in reader.enumerate() {
             assert_eq!(value.unwrap(), expected[i]);

--- a/src/balancerd/src/codec.rs
+++ b/src/balancerd/src/codec.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::str;
-
 use async_trait::async_trait;
 use bytes::{Buf, BufMut, BytesMut};
 use bytesize::ByteSize;
@@ -17,7 +15,8 @@ use mz_ore::cast::CastFrom;
 use mz_ore::future::OreSinkExt;
 use mz_ore::netio::AsyncReady;
 use mz_pgwire_common::{
-    parse_frame_len, Conn, Cursor, DecodeState, ErrorResponse, FrontendMessage, MAX_REQUEST_SIZE,
+    parse_frame_len, Conn, Cursor, DecodeState, ErrorResponse, FrontendMessage, Pgbuf,
+    MAX_REQUEST_SIZE,
 };
 use tokio::io::{self, AsyncRead, AsyncWrite, Interest, Ready};
 use tokio_util::codec::{Decoder, Encoder, Framed};
@@ -209,39 +208,6 @@ impl Encoder<BackendMessage> for Codec {
         dst[base..base + 4].copy_from_slice(&len.to_be_bytes());
 
         Ok(())
-    }
-}
-
-trait Pgbuf: BufMut {
-    fn put_string(&mut self, s: &str);
-    fn put_length_i16(&mut self, len: usize) -> Result<(), io::Error>;
-    fn put_format_i8(&mut self, format: mz_pgwire_common::Format);
-    fn put_format_i16(&mut self, format: mz_pgwire_common::Format);
-}
-
-impl<B: BufMut> Pgbuf for B {
-    fn put_string(&mut self, s: &str) {
-        self.put(s.as_bytes());
-        self.put_u8(b'\0');
-    }
-
-    fn put_length_i16(&mut self, len: usize) -> Result<(), io::Error> {
-        let len = i16::try_from(len)
-            .map_err(|_| io::Error::new(io::ErrorKind::Other, "length does not fit in an i16"))?;
-        self.put_i16(len);
-        Ok(())
-    }
-
-    fn put_format_i8(&mut self, format: mz_pgwire_common::Format) {
-        self.put_i8(match format {
-            mz_pgwire_common::Format::Text => 0,
-            mz_pgwire_common::Format::Binary => 1,
-        })
-    }
-
-    fn put_format_i16(&mut self, format: mz_pgwire_common::Format) {
-        self.put_i8(0);
-        self.put_format_i8(format);
     }
 }
 

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -242,7 +242,7 @@ impl Cluster {
     pub fn rename_replica(&mut self, replica_id: ReplicaId, to_name: String) {
         let replica = self.replica_mut(replica_id).expect("Must exist");
         let old_name = std::mem::take(&mut replica.name);
-        replica.name = to_name.clone();
+        replica.name.clone_from(&to_name);
 
         assert!(self.replica_id_by_name_.remove(&old_name).is_some());
         assert!(self

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1661,7 +1661,7 @@ where
                 continue; // frontier has not advanced
             }
 
-            collection.write_frontier = new_upper.clone();
+            collection.write_frontier.clone_from(new_upper);
 
             let old_since = &collection.implied_capability;
             let new_since = match &collection.read_policy {

--- a/src/compute-types/src/plan/flat_plan.rs
+++ b/src/compute-types/src/plan/flat_plan.rs
@@ -754,7 +754,7 @@ impl<T> FlatPlanNode<T> {
         match self {
             Constant { .. } | Get { .. } => (),
             LetRec { values, body, .. } => {
-                list = values.clone();
+                list.clone_from(values);
                 last = Some(*body);
             }
             Mfp { input, .. }
@@ -767,7 +767,7 @@ impl<T> FlatPlanNode<T> {
                 last = Some(*input);
             }
             Join { inputs, .. } | Union { inputs, .. } => {
-                list = inputs.clone();
+                list.clone_from(inputs);
             }
         }
 

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -61,10 +61,7 @@ impl Context {
     pub fn lower<T: Timestamp>(
         mut self,
         desc: DataflowDescription<OptimizedMirRelationExpr>,
-    ) -> Result<DataflowDescription<Plan<T>>, String>
-    where
-        T: Timestamp,
-    {
+    ) -> Result<DataflowDescription<Plan<T>>, String> {
         // Sources might provide arranged forms of their data, in the future.
         // Indexes provide arranged forms of their data.
         for IndexImport {

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -1049,6 +1049,7 @@ where
     }
 }
 
+#[allow(dead_code)] // Some of the methods on this trait are unused, but useful to have.
 /// A timestamp type that can be used for operations within MZ's dataflow layer.
 pub trait RenderTimestamp: Timestamp + Lattice + Refines<mz_repr::Timestamp> + Columnation {
     /// The system timestamp component of the timestamp.

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -767,7 +767,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             // If it were broken out by `GlobalId` then we could drop only those of dataflows we drop.
             compute_state.subscribe_response_buffer = Rc::new(RefCell::new(Vec::new()));
         } else {
-            todo_commands = new_commands.clone();
+            todo_commands.clone_from(&new_commands);
         }
 
         // Execute the commands to bring us to `new_commands`.

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -113,11 +113,6 @@ pub async fn handle_sql(
     }
 }
 
-#[derive(Serialize)]
-struct ErrorResponse {
-    error: String,
-}
-
 pub async fn handle_sql_ws(
     State(state): State<WsState>,
     existing_user: Option<Extension<AuthedUser>>,

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -483,7 +483,7 @@ mod tests {
             ("baz".to_string(), "3".to_string()),
         ]);
         let mut filters = WebhookHeaderFilters::default();
-        filters.block = block.clone();
+        filters.block.clone_from(&block);
 
         let mut h = filter_headers(&headers, &filters);
         assert_eq!(h.next().unwrap().0, "bar");
@@ -491,7 +491,7 @@ mod tests {
         assert!(h.next().is_none());
 
         let mut filters = WebhookHeaderFilters::default();
-        filters.allow = allow.clone();
+        filters.allow.clone_from(&allow);
 
         let mut h = filter_headers(&headers, &filters);
         assert_eq!(h.next().unwrap().0, "bar");

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -844,7 +844,7 @@ fn test_http_sql() {
                 .get("rows")
                 .map(|rows| rows.get(0).map(|row| row.parse::<usize>().unwrap()))
                 .flatten();
-            let fixtimestamp = tc.args.get("fixtimestamp").is_some();
+            let fixtimestamp = tc.args.contains_key("fixtimestamp");
             ws.send(msg).unwrap();
             let mut responses = String::new();
             loop {

--- a/src/expr-parser/src/catalog.rs
+++ b/src/expr-parser/src/catalog.rs
@@ -93,6 +93,6 @@ impl ExprHumanizer for TestCatalog {
     }
 
     fn id_exists(&self, id: GlobalId) -> bool {
-        self.names.get(&id).is_some()
+        self.names.contains_key(&id)
     }
 }

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -191,7 +191,7 @@ impl ExprHumanizer for TestCatalog {
     }
 
     fn id_exists(&self, id: GlobalId) -> bool {
-        self.names.get(&id).is_some()
+        self.names.contains_key(&id)
     }
 }
 

--- a/src/fivetran-destination/src/utils.rs
+++ b/src/fivetran-destination/src/utils.rs
@@ -268,7 +268,7 @@ impl<'a> tokio::io::AsyncWrite for CopyIntoAsyncWrite<'a> {
             .inner
             .as_mut()
             .poll_ready(cx)
-            .map_err(|e| std::io::Error::other(e)))?;
+            .map_err(std::io::Error::other))?;
 
         let len = buf.len();
         let buf = bytes::Bytes::from(buf.to_vec());
@@ -285,7 +285,7 @@ impl<'a> tokio::io::AsyncWrite for CopyIntoAsyncWrite<'a> {
         self.inner
             .as_mut()
             .poll_flush(cx)
-            .map_err(|e| std::io::Error::other(e))
+            .map_err(std::io::Error::other)
     }
 
     fn poll_shutdown(
@@ -295,7 +295,7 @@ impl<'a> tokio::io::AsyncWrite for CopyIntoAsyncWrite<'a> {
         self.inner
             .as_mut()
             .poll_close(cx)
-            .map_err(|e| std::io::Error::other(e))
+            .map_err(std::io::Error::other)
     }
 }
 

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -161,6 +161,8 @@ impl<'a> AvroDecode for AvroStringDecoder<'a> {
     }
 }
 
+// TODO(parkmycar): Should we just delete this?
+#[allow(dead_code)]
 pub(super) struct OptionalRecordDecoder<'a, 'row> {
     pub packer: &'a mut RowPacker<'row>,
     pub buf: &'a mut Vec<u8>,

--- a/src/ore/src/collections/hash.rs
+++ b/src/ore/src/collections/hash.rs
@@ -134,40 +134,40 @@ where
 
     /// See [`std::collections::HashMap::get`].
     #[inline]
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.0.get(k)
     }
 
     /// See [`std::collections::HashMap::get_key_value`].
     #[inline]
-    pub fn get_key_value<Q: ?Sized>(&self, k: &Q) -> Option<(&K, &V)>
+    pub fn get_key_value<Q>(&self, k: &Q) -> Option<(&K, &V)>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.0.get_key_value(k)
     }
 
     /// See [`std::collections::HashMap::contains_key`].
     #[inline]
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.0.contains_key(k)
     }
 
     /// See [`std::collections::HashMap::get_mut`].
     #[inline]
-    pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut V>
+    pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.0.get_mut(k)
     }
@@ -180,20 +180,20 @@ where
 
     /// See [`std::collections::HashMap::remove`].
     #[inline]
-    pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
+    pub fn remove<Q>(&mut self, k: &Q) -> Option<V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.0.remove(k)
     }
 
     /// See [`std::collections::HashMap::remove_entry`].
     #[inline]
-    pub fn remove_entry<Q: ?Sized>(&mut self, k: &Q) -> Option<(K, V)>
+    pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(K, V)>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.0.remove_entry(k)
     }
@@ -353,20 +353,20 @@ where
 
     /// See [`std::collections::HashSet::contains`].
     #[inline]
-    pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
+    pub fn contains<Q>(&self, value: &Q) -> bool
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.0.contains(value)
     }
 
     /// See [`std::collections::HashSet::get`].
     #[inline]
-    pub fn get<Q: ?Sized>(&self, value: &Q) -> Option<&T>
+    pub fn get<Q>(&self, value: &Q) -> Option<&T>
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.0.get(value)
     }
@@ -403,20 +403,20 @@ where
 
     /// See [`std::collections::HashSet::remove`].
     #[inline]
-    pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
+    pub fn remove<Q>(&mut self, value: &Q) -> bool
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.0.remove(value)
     }
 
     /// See [`std::collections::HashSet::take`].
     #[inline]
-    pub fn take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
+    pub fn take<Q>(&mut self, value: &Q) -> Option<T>
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.0.take(value)
     }

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -290,13 +290,13 @@ where
         maintenance.start_performing(&self.machine, &self.gc);
         match res {
             Ok(Since(since)) => {
-                self.since = since.clone();
-                self.opaque = new.0.clone();
+                self.since.clone_from(&since);
+                self.opaque.clone_from(new.0);
                 Ok(since)
             }
             Err((actual_opaque, since)) => {
                 self.since = since.0;
-                self.opaque = actual_opaque.clone();
+                self.opaque.clone_from(&actual_opaque);
                 Err(actual_opaque)
             }
         }

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -565,9 +565,6 @@ impl MetricsVecs {
 }
 
 #[derive(Debug)]
-pub struct CmdCasMismatchMetric(#[allow(dead_code)] pub(crate) IntCounter);
-
-#[derive(Debug)]
 pub struct CmdMetrics {
     pub(crate) name: String,
     pub(crate) started: IntCounter,

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -892,7 +892,9 @@ where
             &writer_state.most_recent_write_upper,
             batch.desc.upper()
         );
-        writer_state.most_recent_write_upper = batch.desc.upper().clone();
+        writer_state
+            .most_recent_write_upper
+            .clone_from(batch.desc.upper());
 
         // Heartbeat the writer state to keep our idempotency token alive.
         writer_state.last_heartbeat_timestamp_ms = std::cmp::max(
@@ -1006,7 +1008,7 @@ where
         }
 
         if PartialOrder::less_equal(&reader_state.since, new_since) {
-            reader_state.since = new_since.clone();
+            reader_state.since.clone_from(new_since);
             reader_state.opaque = OpaqueState(Codec64::encode(new_opaque));
             self.update_since();
             Continue(Ok(Since(new_since.clone())))

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -1351,10 +1351,10 @@ mod tests {
                 // Validate that the diff applies to both the previous state (also checked in
                 // debug asserts) and our follower that's only synchronized via diffs.
                 old_leader
-                    .apply_diff(&metrics, diff.clone())
+                    .apply_diff(metrics, diff.clone())
                     .expect("diff applies to the old version of the leader state");
                 follower
-                    .apply_diff(&metrics, diff.clone())
+                    .apply_diff(metrics, diff.clone())
                     .expect("diff applies to the synced version of the follower state");
 
                 // TODO: once spine structure is roundtripped through diffs, assert that the follower

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -299,7 +299,7 @@ impl<T: Timestamp + Lattice> Trace<T> {
                             break;
                         };
                         if next_batch.is_empty() {
-                            new_upper = next_batch.desc.upper().clone();
+                            new_upper.clone_from(next_batch.desc.upper());
                         } else {
                             legacy_batches.push(next_batch);
                             break;
@@ -314,7 +314,7 @@ impl<T: Timestamp + Lattice> Trace<T> {
                             new_upper.clone(),
                             batch.desc.since().clone(),
                         ))));
-                        new_upper = expected_desc.upper().clone();
+                        new_upper.clone_from(expected_desc.upper());
                     }
                     batch = Arc::new(HollowBatch::empty(Description::new(
                         batch.desc.lower().clone(),
@@ -1743,7 +1743,7 @@ pub(crate) mod tests {
                         batch.desc.upper().clone(),
                         batch.desc.since().clone(),
                     );
-                    lower = batch.desc.upper().clone();
+                    lower.clone_from(batch.desc.upper());
                     let _merge_req = trace.push_batch(batch);
                 }
                 trace.roundtrip_structure = roundtrip_structure;

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -392,7 +392,7 @@ where
                 Err(mismatch) => {
                     // We tried to to a non-contiguous append, that won't work.
                     if PartialOrder::less_than(&mismatch.current, &lower) {
-                        self.upper = mismatch.current.clone();
+                        self.upper.clone_from(&mismatch.current);
 
                         batch.delete().await;
 
@@ -512,7 +512,7 @@ where
 
             match res {
                 CompareAndAppendRes::Success(_seqno, maintenance) => {
-                    self.upper = desc.upper().clone();
+                    self.upper.clone_from(desc.upper());
                     for batch in batches.iter_mut() {
                         batch.mark_consumed();
                     }
@@ -522,7 +522,7 @@ where
                 CompareAndAppendRes::UpperMismatch(_seqno, current_upper) => {
                     // We tried to to a compare_and_append with the wrong expected upper, that
                     // won't work. Update the cached upper to the current upper.
-                    self.upper = current_upper.clone();
+                    self.upper.clone_from(&current_upper);
                     return Ok(Err(UpperMismatch {
                         current: current_upper,
                         expected: expected_upper,

--- a/src/persist-txn/src/txns.rs
+++ b/src/persist-txn/src/txns.rs
@@ -551,7 +551,7 @@ where
 
             let mut unapplied_by_data = BTreeMap::<_, Vec<_>>::new();
             for (data_id, unapplied, unapplied_ts) in self.txns_cache.unapplied() {
-                if ts < &unapplied_ts {
+                if ts < unapplied_ts {
                     break;
                 }
                 unapplied_by_data

--- a/src/pgwire-common/src/codec.rs
+++ b/src/pgwire-common/src/codec.rs
@@ -49,7 +49,7 @@ impl fmt::Display for CodecError {
     }
 }
 
-trait Pgbuf: BufMut {
+pub trait Pgbuf: BufMut {
     fn put_string(&mut self, s: &str);
     fn put_length_i16(&mut self, len: usize) -> Result<(), io::Error>;
     fn put_format_i8(&mut self, format: Format);

--- a/src/pgwire-common/src/lib.rs
+++ b/src/pgwire-common/src/lib.rs
@@ -19,7 +19,7 @@ mod message;
 mod severity;
 
 pub use codec::{
-    decode_startup, input_err, parse_frame_len, CodecError, Cursor, DecodeState,
+    decode_startup, input_err, parse_frame_len, CodecError, Cursor, DecodeState, Pgbuf,
     ACCEPT_SSL_ENCRYPTION, MAX_REQUEST_SIZE, REJECT_ENCRYPTION,
 };
 pub use conn::Conn;

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1203,7 +1203,7 @@ fn fill_pdt_date(
                 return Ok(());
             }
             Err(_) => {
-                *actual = original_actual.clone();
+                actual.clone_from(&original_actual);
                 pdt.clear_date();
             }
         }

--- a/src/repr/src/row/collection.rs
+++ b/src/repr/src/row/collection.rs
@@ -446,7 +446,7 @@ mod tests {
         let b = Row::pack_slice(&[Datum::MzTimestamp(crate::Timestamp::new(10))]);
 
         let col = RowCollection::from([&a, &b]);
-        let mut rows = vec![a, b];
+        let mut rows = [a, b];
 
         let sorted_view = col.sorted_view(|a, b| a.cmp(b));
         rows.sort_by(|a, b| a.cmp(b));

--- a/src/sql-parser/src/lib.rs
+++ b/src/sql-parser/src/lib.rs
@@ -86,7 +86,7 @@ pub fn datadriven_testcase(tc: &datadriven::TestCase) -> String {
                         // still compare that the resulting ASTs are identical, and it's valid for
                         // those to come from different original strings.
                         (Statement::Declare(parsed), Statement::Declare(stmt)) => {
-                            parsed.sql = stmt.sql.clone();
+                            parsed.sql.clone_from(&stmt.sql);
                         }
                         _ => {}
                     }
@@ -97,7 +97,7 @@ pub fn datadriven_testcase(tc: &datadriven::TestCase) -> String {
                         );
                     }
                 }
-                if tc.args.get("roundtrip").is_some() {
+                if tc.args.contains_key("roundtrip") {
                     format!("{}\n", stmt)
                 } else {
                     // TODO(justin): it would be nice to have a middle-ground between this
@@ -136,7 +136,7 @@ pub fn datadriven_testcase(tc: &datadriven::TestCase) -> String {
                     }
                 }
 
-                if tc.args.get("roundtrip").is_some() {
+                if tc.args.contains_key("roundtrip") {
                     format!("{}\n", s)
                 } else {
                     // TODO(justin): it would be nice to have a middle-ground between this

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1847,7 +1847,7 @@ where
         for (id, new_upper) in updates.iter() {
             if let Some(collection) = self.collections.get_mut(id) {
                 if PartialOrder::less_than(&collection.write_frontier, new_upper) {
-                    collection.write_frontier = new_upper.clone();
+                    collection.write_frontier.clone_from(new_upper);
                 }
 
                 let mut new_read_capability = collection
@@ -1866,7 +1866,7 @@ where
                 }
             } else if let Ok(export) = self.export_mut(*id) {
                 if PartialOrder::less_than(&export.write_frontier, new_upper) {
-                    export.write_frontier = new_upper.clone();
+                    export.write_frontier.clone_from(new_upper);
                 }
 
                 // Ignore read policy for sinks whose write frontiers are closed, which identifies
@@ -1978,7 +1978,7 @@ where
                     });
 
                 changes.extend(update.drain());
-                *frontier = export.read_capability.clone();
+                frontier.clone_from(&export.read_capability);
             } else {
                 // This is confusing and we should probably error.
                 panic!("Unknown collection identifier {}", key);
@@ -2200,9 +2200,9 @@ where
             let client = cluster_id.and_then(|cluster_id| self.clients.get_mut(&cluster_id));
 
             if cluster_id.is_some() && read_frontier.is_empty() {
-                if self.collections.get(&id).is_some() {
+                if self.collections.contains_key(&id) {
                     pending_source_drops.push(id);
-                } else if self.exports.get(&id).is_some() {
+                } else if self.exports.contains_key(&id) {
                     pending_sink_drops.push(id);
                 } else {
                     panic!("Reference to absent collection {id}");
@@ -2282,7 +2282,7 @@ where
             // Sources can have subsources, which don't have associated clusters, which
             // is why this operates differently than sinks.
             if read_frontier.is_empty() {
-                if self.collections.get(&id).is_some() {
+                if self.collections.contains_key(&id) {
                     source_statistics_to_drop.push(id);
                 }
             }

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -940,7 +940,7 @@ where
                 };
 
                 // Update the `flow_control_frontier` if its advanced.
-                flow_control_frontier = new_flow_control_frontier.clone();
+                flow_control_frontier.clone_from(&new_flow_control_frontier);
 
                 // Retire parts that are processed downstream.
                 let retired_parts = inflight_parts

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -542,7 +542,7 @@ where
 
                 // After successfully emitting a new description, we can update the upper for the
                 // operator.
-                current_upper = desired_frontier.to_owned();
+                current_upper.clone_from(&desired_frontier);
             }
         }
     });
@@ -878,8 +878,8 @@ where
 
                     output.give_container(&cap, &mut batch_tokens).await;
 
-                    processed_desired_frontier = desired_frontier.clone();
-                    processed_descriptions_frontier = batch_descriptions_frontier.clone();
+                    processed_desired_frontier.clone_from(&desired_frontier);
+                    processed_descriptions_frontier.clone_from(&batch_descriptions_frontier);
                 }
             } else {
                 trace!(

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -59,7 +59,7 @@ pub(crate) type OutputIndex = usize;
 ///
 /// This function is intended to implement the recipe described here:
 /// <https://github.com/MaterializeInc/materialize/blob/main/doc/developer/platform/architecture-storage.md#source-ingestion>
-pub fn render_source<'g, G: Scope<Timestamp = ()>, C>(
+pub fn render_source<'g, G, C>(
     scope: &mut Child<'g, G, mz_repr::Timestamp>,
     dataflow_debug_name: &String,
     id: GlobalId,

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -729,7 +729,7 @@ fn sink_collection<G: Scope<Timestamp = Timestamp>>(
                         info!("{name}: committing transaction for {}", progress.pretty());
                         producer.commit_transaction(progress.clone()).await?;
                         transaction_begun = false;
-                        *write_frontier.borrow_mut() = progress.clone();
+                        write_frontier.borrow_mut().clone_from(&progress);
                         match progress.into_option() {
                             Some(new_upper) => upper = new_upper,
                             None => break,

--- a/src/storage/src/source/mysql/replication/partitions.rs
+++ b/src/storage/src/source/mysql/replication/partitions.rs
@@ -91,7 +91,7 @@ impl GtidReplicationPartitions {
                 // Since we start replication at a specific upper, we
                 // should only see GTID transaction-ids
                 // in a monotonic order for each source, starting at that upper.
-                if active_part.timestamp() > &new_part.timestamp() {
+                if active_part.timestamp() > new_part.timestamp() {
                     let err = DefiniteError::BinlogGtidMonotonicityViolation(
                         source_id.to_string(),
                         new_part.timestamp().clone(),

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -303,7 +303,7 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                                             )
                                             .await
                                             .unwrap();
-                                        as_of = read_handle.since().clone();
+                                        as_of.clone_from(read_handle.since());
                                         mz_ore::task::spawn(
                                             move || "deferred_expire",
                                             async move {

--- a/src/timely-util/src/progress.rs
+++ b/src/timely-util/src/progress.rs
@@ -21,9 +21,9 @@ use timely::progress::Antichain;
 use timely::PartialOrder;
 
 /// An out-of-crate [`Arbitrary`] implementation for [`Antichain`].
-pub fn any_antichain<T: PartialOrder>() -> impl Strategy<Value = Antichain<T>>
+pub fn any_antichain<T>() -> impl Strategy<Value = Antichain<T>>
 where
-    T: Arbitrary + Ord,
+    T: Arbitrary + Ord + PartialOrder,
 {
     proptest::collection::vec(any::<T>(), 0..11).prop_map(Into::into)
 }

--- a/src/transform/src/attribute/column_names.rs
+++ b/src/transform/src/attribute/column_names.rs
@@ -191,7 +191,7 @@ impl<'c> ColumnNames<'c> {
                 for (i, mut column_name) in base_results.iter().cloned().enumerate() {
                     for input_results in inputs_results.iter() {
                         if column_name.is_empty() && !input_results[i].is_empty() {
-                            column_name = input_results[i].clone();
+                            column_name.clone_from(&input_results[i]);
                             break;
                         }
                     }

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -608,7 +608,7 @@ id: {}, key: {:?}",
                     IndexUsageType::FullScan => {
                         full_scan_changes.insert(get_id, picked_idx);
                         *idx_id = picked_idx;
-                        *key = picked_idx_key.clone();
+                        key.clone_from(&picked_idx_key);
                     }
                     _ => {}
                 }

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -287,8 +287,8 @@ impl RedundantJoin {
                                 for (local_col, global_col) in
                                     old_input_mapper.global_columns(input).enumerate()
                                 {
-                                    projection[global_col] =
-                                        prov.dereferenced_projection[local_col].clone();
+                                    projection[global_col]
+                                        .clone_from(&prov.dereferenced_projection[local_col]);
                                 }
                                 prov.dereferenced_projection = projection;
                                 results.push(prov);


### PR DESCRIPTION
This PR adds a guide in our developer docs outlining the steps necessary to upgrade the version of Rust that we depend on. It also upgrades the version of Rust we use from 1.77.0 to 1.78.0

### Motivation

1. Upgrade Rust
2. We realized recently that the version of the Unicode Standard Rust uses can change across releases and we wanted to formalize a process for indicating when that occurred.

### Tips for reviewer

The PR is broken up into three commits which can be reviewed independently:

1. The ugprade Rust guide
2. A few non-trivial changes required by clippy
3. Trivial clippy changes.

The vast majority of the trivial changes are using `.contains_key(...)` instead of `.get(..).is_some(..)` and using `foo.clone_from(&bar)` instead of `foo = bar.clone()`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - The version of Unicode that Materialize depends on has been bumped from [15.0.0](https://www.unicode.org/versions/Unicode15.0.0/) to [15.1.0](https://www.unicode.org/versions/Unicode15.1.0/)
