### PR TITLE
adapter: remove cascade index retain history requirement

### DIFF
--- a/src/adapter-types/src/compaction.rs
+++ b/src/adapter-types/src/compaction.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::cmp::Ordering;
 use std::num::TryFromIntError;
 use std::time::Duration;
 
@@ -36,7 +35,7 @@ pub const SINCE_GRANULARITY: mz_repr::Timestamp = mz_repr::Timestamp::new(1000);
 
 // A common type (that is usable by the sql crate and also can implement various methods on types in
 // storage) to express compaction windows.
-#[derive(Clone, Default, Copy, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Default, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum CompactionWindow {
     /// Unspecified by the user, use a system-provided default.
     #[default]
@@ -45,19 +44,6 @@ pub enum CompactionWindow {
     DisableCompaction,
     /// Create a compaction window for a specified duration.
     Duration(Timestamp),
-}
-
-impl Ord for CompactionWindow {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.comparable_timestamp()
-            .cmp(&other.comparable_timestamp())
-    }
-}
-
-impl PartialOrd for CompactionWindow {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 impl CompactionWindow {

--- a/test/sqllogictest/retain_history.slt
+++ b/test/sqllogictest/retain_history.slt
@@ -26,9 +26,6 @@ CREATE INDEX idx_a ON view_a (a) WITH (RETAIN HISTORY FOR '1m')
 statement ok
 CREATE VIEW view_b AS SELECT a AS b FROM view_a
 
-statement error db error: ERROR: dependent index materialize\.public\.idx_a has a RETAIN HISTORY of 60s, but must be at least 120s
-CREATE INDEX idx_b ON view_b (b) WITH (RETAIN HISTORY FOR '2m')
-
 statement ok
 CREATE INDEX idx_b ON view_b (b)
 
@@ -42,18 +39,8 @@ DROP INDEX idx_a
 statement ok
 CREATE INDEX idx_a ON view_a (a)
 
-statement error db error: ERROR: dependent index materialize\.public\.idx_a has a RETAIN HISTORY of 1s, but must be at least 120s
-CREATE INDEX idx_b ON view_b (b) WITH (RETAIN HISTORY FOR '2m')
-
 statement ok
 CREATE INDEX idx_b ON view_b (b) WITH (RETAIN HISTORY FOR '1ms')
-
-# Unitless intervals are seconds.
-statement error db error: ERROR: dependent index materialize\.public\.idx_a has a RETAIN HISTORY of 1s, but must be at least 5s
-CREATE INDEX idx_c ON view_b (b) WITH (RETAIN HISTORY FOR 5)
-
-statement error db error: ERROR: dependent index materialize\.public\.idx_a has a RETAIN HISTORY of 1s, but must be at least 300s
-ALTER INDEX idx_b SET (RETAIN HISTORY FOR '5m')
 
 statement ok
 ALTER INDEX idx_a SET (RETAIN HISTORY FOR '5m')
@@ -79,12 +66,6 @@ ORDER BY o.name
 idx_a  FOR  300000
 idx_b  FOR  180000
 idx_c  FOR  60000
-
-statement error db error: ERROR: dependent index materialize\.public\.idx_a has a RETAIN HISTORY of 300s, but must be at least 360s
-ALTER INDEX idx_b SET (RETAIN HISTORY FOR '6m')
-
-statement error db error: ERROR: dependent index materialize\.public\.idx_b has a RETAIN HISTORY of 180s, but must be at least 240s
-ALTER INDEX idx_c SET (RETAIN HISTORY FOR '4m')
 
 statement ok
 ALTER INDEX idx_a SET (RETAIN HISTORY FOR '7m')
@@ -186,9 +167,6 @@ ALTER SOURCE counter RESET (RETAIN HISTORY)
 
 statement ok
 ALTER SOURCE auction_house RESET (RETAIN HISTORY)
-
-statement error db error: ERROR: dependent index materialize\.public\.idx_c has a RETAIN HISTORY of 1s, but must be at least 240s
-ALTER INDEX idx_b RESET (RETAIN HISTORY)
 
 statement ok
 ALTER INDEX idx_c RESET (RETAIN HISTORY)


### PR DESCRIPTION
We incorrectly understood an internal investigation and believed that indexes cause dependent indexes to also increase their compaction window. This is not the case: only the arrangement created by the index has its compaction increased. Thus we can remove this restriction since it was designed only to prevent silent memory increases by users.

Fixes #27017

Partial revert of commit 844fa219ec5d3522e6add5d4af8afd8d7ff1e3e4.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a