### PR TITLE
[persist] Replace the lease returner with an Arc-based count

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -356,6 +356,23 @@ where
     Ok(part)
 }
 
+/// This represents the lease of a seqno. It's generally paired with some external state,
+/// like a hollow part: holding this lease indicates that we may still want to fetch that part,
+/// and should hold back GC to keep it around.
+///
+/// Generally the state and lease are bundled together, as in [LeasedBatchPart]... but sometimes
+/// it's necessary to handle them separately, so this struct is exposed as well. Handle with care.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Lease(Arc<()>);
+
+impl Lease {
+    /// Returns the number of live copies of this lease... aside from this one.
+    pub fn copies(&self) -> usize {
+        // NB: the strong count is always > 0 for a live arc.
+        Arc::strong_count(&self.0) - 1
+    }
+}
+
 /// A token representing one fetch-able batch part.
 ///
 /// It is tradeable via `crate::fetch::fetch_batch` for the resulting data
@@ -390,9 +407,12 @@ pub struct LeasedBatchPart<T> {
     pub(crate) desc: Description<T>,
     pub(crate) part: BatchPart<T>,
     /// The `SeqNo` from which this part originated; we track this value as
-    /// long as necessary to ensure the `SeqNo` isn't garbage collected while a
+    /// to ensure the `SeqNo` isn't garbage collected while a
     /// read still depends on it.
-    pub(crate) leased_seqno: Option<SeqNo>,
+    pub(crate) leased_seqno: SeqNo,
+    /// The lease that prevents this part from being GCed. Code should ensure that this lease
+    /// lives as long as the part is needed.
+    pub(crate) lease: Lease,
     pub(crate) filter_pushdown_audit: bool,
 }
 
@@ -405,36 +425,19 @@ where
     ///
     /// !!!WARNING!!!
     ///
-    /// This semantically transfers the lease to the returned
-    /// SerdeLeasedBatchPart. If `self` has a `leased_seqno`, failing to take
-    /// the returned `SerdeLeasedBatchPart` back into a `LeasedBatchPart` will
-    /// leak `SeqNo`s and prevent persist GC.
-    pub fn into_exchangeable_part(mut self) -> SerdeLeasedBatchPart {
+    /// This method also returns the [Lease] associated with the given part, since
+    /// that can't travel across process boundaries. The caller is responsible for
+    /// ensuring that the lease is held for as long as the batch part may be in use:
+    /// dropping it too early may cause a fetch to fail.
+    pub fn into_exchangeable_part(mut self) -> (SerdeLeasedBatchPart, Lease) {
         let (proto, _metrics) = self.into_proto();
         // If `x` has a lease, we've effectively transferred it to `r`.
-        let _ = self.leased_seqno.take();
-        SerdeLeasedBatchPart {
+        let lease = std::mem::take(&mut self.lease);
+        let part = SerdeLeasedBatchPart {
             encoded_size_bytes: self.part.encoded_size_bytes(),
             proto: LazyProto::from(&proto),
-        }
-    }
-
-    /// Because sources get dropped without notice, we need to permit another
-    /// operator to safely expire leases.
-    ///
-    /// The part's `reader_id` is intentionally inaccessible, and should
-    /// be obtained from the issuing [`crate::ReadHandle`], or one of its derived
-    /// structures, e.g. [`crate::read::Subscribe`].
-    ///
-    /// # Panics
-    /// - If `reader_id` is different than the [`LeasedReaderId`] from
-    ///   the part issuer.
-    pub(crate) fn return_lease(&mut self, reader_id: &LeasedReaderId) -> Option<SeqNo> {
-        assert!(
-            &self.reader_id == reader_id,
-            "only issuing reader can authorize lease expiration"
-        );
-        self.leased_seqno.take()
+        };
+        (part, lease)
     }
 
     /// The encoded size of this part in bytes
@@ -1016,7 +1019,7 @@ impl<T: Timestamp + Codec64> RustType<(ProtoLeasedBatchPart, Arc<Metrics>)> for 
             part: Some(self.part.into_proto()),
             lease: Some(ProtoLease {
                 reader_id: self.reader_id.into_proto(),
-                seqno: self.leased_seqno.map(|x| x.into_proto()),
+                seqno: Some(self.leased_seqno.into_proto()),
             }),
             filter_pushdown_audit: self.filter_pushdown_audit,
         };
@@ -1037,7 +1040,8 @@ impl<T: Timestamp + Codec64> RustType<(ProtoLeasedBatchPart, Arc<Metrics>)> for 
             desc: proto.desc.into_rust_if_some("ProtoLeasedBatchPart::desc")?,
             part: proto.part.into_rust_if_some("ProtoLeasedBatchPart::part")?,
             reader_id: lease.reader_id.into_rust()?,
-            leased_seqno: lease.seqno.map(|x| x.into_rust()).transpose()?,
+            leased_seqno: lease.seqno.into_rust_if_some("ProtoLease::seqno")?,
+            lease: Lease::default(),
             filter_pushdown_audit: proto.filter_pushdown_audit,
         })
     }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -37,7 +37,6 @@ use crate::internal::metrics::{BatchPartReadMetrics, ReadMetrics, ShardMetrics};
 use crate::internal::paths::WriterKey;
 use crate::internal::state::{BatchPart, HollowBatchPart};
 use crate::metrics::Metrics;
-use crate::read::SubscriptionLeaseReturner;
 use crate::ShardId;
 
 /// Versions prior to this had bugs in consolidation, or used a different sort. However,
@@ -73,7 +72,6 @@ pub(crate) enum FetchData<T> {
         blob: Arc<dyn Blob + Send + Sync>,
         read_metrics: fn(&BatchPartReadMetrics) -> &ReadMetrics,
         shard_metrics: Arc<ShardMetrics>,
-        lease_returner: SubscriptionLeaseReturner,
         part: LeasedBatchPart<T>,
     },
     AlreadyFetched,
@@ -132,7 +130,6 @@ impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
                 blob,
                 read_metrics,
                 shard_metrics,
-                mut lease_returner,
                 part,
             } => {
                 // We do not use fetch_leased_part, since that requires more type info
@@ -148,7 +145,6 @@ impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
                 )
                 .await
                 .map_err(|blob_key| anyhow!("missing unleased key {blob_key}"));
-                lease_returner.return_leased_part(part);
                 fetched
             }
             FetchData::AlreadyFetched => Err(anyhow!("attempt to fetch an already-fetched part")),
@@ -350,7 +346,6 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
         blob: &Arc<dyn Blob + Send + Sync>,
         read_metrics: fn(&BatchPartReadMetrics) -> &ReadMetrics,
         shard_metrics: &Arc<ShardMetrics>,
-        lease_returner: &SubscriptionLeaseReturner,
         parts: impl IntoIterator<Item = LeasedBatchPart<T>>,
     ) {
         let run = parts
@@ -362,7 +357,6 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                         blob: Arc::clone(blob),
                         read_metrics,
                         shard_metrics: Arc::clone(shard_metrics),
-                        lease_returner: lease_returner.clone(),
                         part,
                     },
                 };

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -1018,7 +1018,6 @@ mod tests {
                 .await;
             for batch in snap {
                 let res = fetcher1.fetch_leased_part(&batch).await;
-                read0.process_returned_leased_part(batch);
                 assert_eq!(
                     res.unwrap_err(),
                     InvalidUsage::BatchNotFromThisShard {

--- a/src/persist-txn/src/txn_cache.rs
+++ b/src/persist-txn/src/txn_cache.rs
@@ -932,7 +932,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
                 part.stats()
             );
             if !should_fetch_part {
-                txns_subscribe.return_leased_part(part);
+                drop(part);
                 continue;
             }
             let part_updates = txns_subscribe.fetch_batch_part(part).await;


### PR DESCRIPTION
This swaps out Persist's leasing mechanism: instead of explicitly returning leases to the reader that issued them, we generate a lease token that keeps the lease alive as long as it's held.

This works transparently for most `LeasedBatchPart` usage... the only difference is that there's no need to return the part explicitly. However, we need some other way to do lease management in the shard source, since we still can't send leases across process boundaries. This code makes serializing a part also spit out the lease, and makes the source hold on to the lease until a frontier advances.

### Motivation

This is useful for #26939 - eg. it would be convenient if I could turn a single `LeasedBatchPart` (which actually represents a list of hollow parts stored elsewhere) into a bunch of `LeasedBatchPart`s representing the individual sub-parts, potentially in code like the `Consolidator` which doesn't have direct access to the handle, and being able to explicitly manipulate and clone leases helps with that.

(OTOH, I think this may be worthwhile even without #26939 on deck -- especially in the common case of leased parts, it seems to make things easier to manage. Happy to break that down if you don't immediately agree however!)

### Tips for reviewer

There are a bunch of possible followups one might imagine, but I've tried to keep this to just the core change and leave everything else alone.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
