### PR TITLE
storage/{pg,mysql}: serialize snapshot and replication phases

### DIFF
--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -117,14 +117,14 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
 
     let repl_reader_id = u64::cast_from(config.responsible_worker(REPL_READER));
     let (mut data_output, data_stream) = builder.new_output::<CapacityContainerBuilder<_>>();
-    let (upper_output, upper_stream) = builder.new_output::<CapacityContainerBuilder<_>>();
+    let (_upper_output, upper_stream) = builder.new_output::<CapacityContainerBuilder<_>>();
     // Captures DefiniteErrors that affect the entire source, including all subsources
     let (mut definite_error_handle, definite_errors) =
         builder.new_output::<CapacityContainerBuilder<_>>();
-    let mut rewind_input = builder.new_input_for_many(
+    let mut rewind_input = builder.new_input_for(
         rewind_stream,
         Exchange::new(move |_| repl_reader_id),
-        [&data_output, &upper_output],
+        &data_output,
     );
 
     let output_indexes = table_info

--- a/src/storage/src/source/mysql/replication/context.rs
+++ b/src/storage/src/source/mysql/replication/context.rs
@@ -44,7 +44,7 @@ pub(super) struct ReplContext<'a> {
     pub(super) data_cap_set: &'a mut CapabilitySet<GtidPartition>,
     pub(super) upper_cap_set: &'a mut CapabilitySet<GtidPartition>,
     // Owned values:
-    pub(super) rewinds: BTreeMap<MySqlTableName, ([Capability<GtidPartition>; 2], RewindRequest)>,
+    pub(super) rewinds: BTreeMap<MySqlTableName, (Capability<GtidPartition>, RewindRequest)>,
     pub(super) errored_tables: BTreeSet<MySqlTableName>,
 }
 
@@ -66,7 +66,7 @@ impl<'a> ReplContext<'a> {
         >,
         data_cap_set: &'a mut CapabilitySet<GtidPartition>,
         upper_cap_set: &'a mut CapabilitySet<GtidPartition>,
-        rewinds: BTreeMap<MySqlTableName, ([Capability<GtidPartition>; 2], RewindRequest)>,
+        rewinds: BTreeMap<MySqlTableName, (Capability<GtidPartition>, RewindRequest)>,
     ) -> Self {
         Self {
             config,

--- a/src/storage/src/source/mysql/replication/events.rs
+++ b/src/storage/src/source/mysql/replication/events.rs
@@ -275,7 +275,7 @@ pub(super) async fn handle_rows_event(
             let data = (*output_index, event);
 
             // Rewind this update if it was already present in the snapshot
-            if let Some(([_rewind_data_cap, _upper_cap], rewind_req)) = ctx.rewinds.get(&table) {
+            if let Some((_rewind_data_cap, rewind_req)) = ctx.rewinds.get(&table) {
                 if !rewind_req.snapshot_upper.less_equal(new_gtid) {
                     rewind_count += 1;
                     event_buffer.push((data.clone(), GtidPartition::minimum(), -diff));
@@ -299,7 +299,7 @@ pub(super) async fn handle_rows_event(
     // Instead, we buffer rewind events into a reusable buffer, and emit all at once here at the end.
 
     if !event_buffer.is_empty() {
-        let ([rewind_data_cap, _], _) = ctx.rewinds.get(&table).unwrap();
+        let (rewind_data_cap, _) = ctx.rewinds.get(&table).unwrap();
         for d in event_buffer.drain(..) {
             ctx.data_output.give(rewind_data_cap, d).await;
         }

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -419,22 +419,11 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                     return Ok(());
                 }
 
-                // We have established a snapshot frontier so we can broadcast the rewind requests
-                for table in reader_snapshot_table_info.keys() {
-                    trace!(%id, "timely-{worker_id} producing rewind request for {table}");
-                    let req = RewindRequest {
-                        table: table.clone(),
-                        snapshot_upper: snapshot_gtid_frontier.clone(),
-                    };
-                    rewinds_handle.give(&rewind_cap_set[0], req).await;
-                }
-                *rewind_cap_set = CapabilitySet::new();
-
                 // Read the snapshot data from the tables
                 let mut final_row = Row::default();
 
                 let mut snapshot_staged = 0;
-                for (table, (output_index, table_desc)) in reader_snapshot_table_info {
+                for (table, (output_index, table_desc)) in &reader_snapshot_table_info {
                     let query = format!("SELECT * FROM {}", table);
                     trace!(%id, "timely-{worker_id} reading snapshot from \
                                  table '{table}':\n{table_desc:?}");
@@ -442,7 +431,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                     let mut count = 0;
                     while let Some(row) = results.try_next().await? {
                         let row: MySqlRow = row;
-                        let event = match pack_mysql_row(&mut final_row, row, &table_desc) {
+                        let event = match pack_mysql_row(&mut final_row, row, table_desc) {
                             Ok(row) => Ok(row),
                             // Produce a DefiniteError in the stream for any rows that fail to decode
                             Err(err @ MySqlError::ValueDecodeError { .. }) => {
@@ -453,7 +442,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                         raw_handle
                             .give(
                                 &data_cap_set[0],
-                                ((output_index, event), GtidPartition::minimum(), 1),
+                                ((*output_index, event), GtidPartition::minimum(), 1),
                             )
                             .await;
                         count += 1;
@@ -474,6 +463,23 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                     trace!(%id, "timely-{worker_id} snapshotted {count} records from \
                                  table '{table}'");
                 }
+
+                // We are done with the snapshot so now we will emit rewind requests. It is
+                // important that this happens after the snapshot has finished because this is what
+                // unblocks the replication operator and we want this to happen serially. It might
+                // seem like a good idea to read the replication stream concurrently with the
+                // snapshot but it actually leads to a lot of data being staged for the future,
+                // which needlesly consumed memory in the cluster.
+                for table in reader_snapshot_table_info.keys() {
+                    trace!(%id, "timely-{worker_id} producing rewind request for {table}");
+                    let req = RewindRequest {
+                        table: table.clone(),
+                        snapshot_upper: snapshot_gtid_frontier.clone(),
+                    };
+                    rewinds_handle.give(&rewind_cap_set[0], req).await;
+                }
+                *rewind_cap_set = CapabilitySet::new();
+
                 if snapshot_staged < snapshot_total {
                     error!(%id, "timely-{worker_id} snapshot size {snapshot_total} is somehow
                                  bigger than records staged {snapshot_staged}");

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -349,14 +349,6 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 use_snapshot(&client, &snapshot).await?;
             }
 
-            // We have established a snapshot LSN so we can broadcast the rewind requests
-            for &oid in reader_snapshot_table_info.keys() {
-                trace!(%id, "timely-{worker_id} producing rewind request for {oid}");
-                let req = RewindRequest { oid, snapshot_lsn };
-                rewinds_handle.give(&rewind_cap_set[0], req).await;
-            }
-            *rewind_cap_set = CapabilitySet::new();
-
             let upstream_info = match mz_postgres_util::publication_info(
                 &config.config.connection_context.ssh_tunnel_manager,
                 &connection_config,
@@ -467,6 +459,19 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                     }
                 }
             }
+
+            // We are done with the snapshot so now we will emit rewind requests. It is important
+            // that this happens after the snapshot has finished because this is what unblocks the
+            // replication operator and we want this to happen serially. It might seem like a good
+            // idea to read the replication stream concurrently with the snapshot but it actually
+            // leads to a lot of data being staged for the future, which needlesly consumed memory
+            // in the cluster.
+            for &oid in reader_snapshot_table_info.keys() {
+                trace!(%id, "timely-{worker_id} producing rewind request for {oid}");
+                let req = RewindRequest { oid, snapshot_lsn };
+                rewinds_handle.give(&rewind_cap_set[0], req).await;
+            }
+            *rewind_cap_set = CapabilitySet::new();
 
             if snapshot_staged < snapshot_total {
                 error!(%id, "timely-{worker_id} snapshot size {snapshot_total} is somehow


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This is the same PR as #26691 but with an additional fix for the issue observed in #26725 which is included as a separate commit on top of the original work, which is unchanged in the first commit.

The problem was that the rewind input was declared as being connected to both the data and the upper output when in fact it only affected the data output. When #26691 delayed the production of rewinds to a later point it unintentionally caused the upper output frontier to get stuck, which blocked reclock binding production, which caused data to be buffered. The fix is to simply not connect it to the upper output.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
