### PR TITLE
Rationalize type of `(key, val)` to `row` mapping

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1700,11 +1700,11 @@ impl ExprHumanizer for ConnCatalog<'_> {
                 // Init ix_names with unknown column names. Unknown columns are
                 // represented as an empty String and rendered as `#c` by the
                 // Display::fmt implementation for HumanizedExpr<'a, usize, M>.
-                let ix_arity = p.values().cloned().max().map(|m| m + 1).unwrap_or(0);
+                let ix_arity = p.iter().map(|x| *x + 1).max().unwrap_or(0);
                 let mut ix_names = vec![String::new(); ix_arity];
 
                 // Apply the permutation by swapping on_names with ix_names.
-                for (on_pos, ix_pos) in p.into_iter() {
+                for (on_pos, ix_pos) in p.into_iter().enumerate() {
                     let on_name = on_names.get_mut(on_pos).expect("on_name");
                     let ix_name = ix_names.get_mut(ix_pos).expect("ix_name");
                     std::mem::swap(on_name, ix_name);

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -292,10 +292,7 @@ fn permute_oneshot_mfp_around_index(
     let input_arity = mfp.input_arity;
     let mut safe_mfp = mfp_to_safe_plan(mfp)?;
     let (permute, thinning) = mz_expr::permutation_for_arrangement(key, input_arity);
-    safe_mfp.permute(
-        permute.into_iter().enumerate().collect(),
-        key.len() + thinning.len(),
-    );
+    safe_mfp.permute_fn(|c| permute[c], key.len() + thinning.len());
     Ok(safe_mfp)
 }
 
@@ -585,8 +582,8 @@ impl crate::coord::Coordinator {
 
                 // Create an identity MFP operator.
                 let mut map_filter_project = mz_expr::MapFilterProject::new(source_arity);
-                map_filter_project.permute(
-                    index_permutation.into_iter().enumerate().collect(),
+                map_filter_project.permute_fn(
+                    |c| index_permutation[c],
                     index_key.len() + index_thinned_arity,
                 );
                 let map_filter_project = mfp_to_safe_plan(map_filter_project)?;

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -81,7 +81,7 @@ pub struct PeekDataflowPlan<T = mz_repr::Timestamp> {
     pub(crate) desc: DataflowDescription<mz_compute_types::plan::Plan<T>, (), T>,
     pub(crate) id: GlobalId,
     key: Vec<MirScalarExpr>,
-    permutation: BTreeMap<usize, usize>,
+    permutation: Vec<usize>,
     thinned_arity: usize,
 }
 
@@ -292,7 +292,10 @@ fn permute_oneshot_mfp_around_index(
     let input_arity = mfp.input_arity;
     let mut safe_mfp = mfp_to_safe_plan(mfp)?;
     let (permute, thinning) = mz_expr::permutation_for_arrangement(key, input_arity);
-    safe_mfp.permute(permute, key.len() + thinning.len());
+    safe_mfp.permute(
+        permute.into_iter().enumerate().collect(),
+        key.len() + thinning.len(),
+    );
     Ok(safe_mfp)
 }
 
@@ -582,8 +585,10 @@ impl crate::coord::Coordinator {
 
                 // Create an identity MFP operator.
                 let mut map_filter_project = mz_expr::MapFilterProject::new(source_arity);
-                map_filter_project
-                    .permute(index_permutation, index_key.len() + index_thinned_arity);
+                map_filter_project.permute(
+                    index_permutation.into_iter().enumerate().collect(),
+                    index_key.len() + index_thinned_arity,
+                );
                 let map_filter_project = mfp_to_safe_plan(map_filter_project)?;
                 (
                     (None, timestamp, map_filter_project),

--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -49,6 +49,8 @@ breaking:
     - compute-types/src/plan/reduce.proto
     # reason: does not currently require backward-compatibility
     - compute-types/src/plan/render_plan.proto
+    # reason: does currently not require backward-compatibility
+    - compute-types/src/plan/threshold.proto
     # reason: does not currently require backward-compatibility
     - compute-types/src/sinks.proto
     # reason: Ignore because plans are currently not persisted.

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -20,7 +20,6 @@
 //!    pairs on the same line or as lowercase `$key` fields on indented lines.
 //! 5. A single non-recursive parameter can be written just as `$val`.
 
-use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::Deref;
 
@@ -798,9 +797,9 @@ struct Arrangement<'a> {
     thinning: &'a Vec<usize>,
 }
 
-impl<'a> From<&'a (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>)> for Arrangement<'a> {
+impl<'a> From<&'a (Vec<MirScalarExpr>, Vec<usize>, Vec<usize>)> for Arrangement<'a> {
     fn from(
-        (key, permutation, thinning): &'a (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>),
+        (key, permutation, thinning): &'a (Vec<MirScalarExpr>, Vec<usize>, Vec<usize>),
     ) -> Self {
         Arrangement {
             key,
@@ -834,12 +833,12 @@ impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Arrangement<'a> {
 }
 
 /// Helper struct for rendering a permutation.
-struct Permutation<'a>(&'a BTreeMap<usize, usize>);
+struct Permutation<'a>(&'a Vec<usize>);
 
 impl<'a> fmt::Display for Permutation<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut pairs = vec![];
-        for (x, y) in self.0.iter().filter(|(x, y)| x != y) {
+        for (x, y) in self.0.iter().enumerate().filter(|(x, y)| x != *y) {
             pairs.push(format!("#{}: #{}", x, y));
         }
 

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -97,7 +97,7 @@ pub struct AvailableCollections {
     /// The set of arrangements of the collection, along with a
     /// column permutation mapping
     #[proptest(strategy = "prop::collection::vec(any_arranged_thin(), 0..3)")]
-    pub arranged: Vec<(Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>)>,
+    pub arranged: Vec<(Vec<MirScalarExpr>, Vec<usize>, Vec<usize>)>,
     /// The types of the columns in the raw form of the collection, if known. We
     /// only capture types when necessary to support arrangement specialization,
     /// so this only done for specific LIR operators during lowering.
@@ -107,10 +107,10 @@ pub struct AvailableCollections {
 /// A strategy that produces arrangements that are thinner than the default. That is
 /// the number of direct children is limited to a maximum of 3.
 pub(crate) fn any_arranged_thin(
-) -> impl Strategy<Value = (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>)> {
+) -> impl Strategy<Value = (Vec<MirScalarExpr>, Vec<usize>, Vec<usize>)> {
     (
         prop::collection::vec(MirScalarExpr::arbitrary(), 0..3),
-        BTreeMap::<usize, usize>::arbitrary(),
+        Vec::<usize>::arbitrary(),
         Vec::<usize>::arbitrary(),
     )
 }
@@ -161,7 +161,7 @@ impl AvailableCollections {
     /// specified ways, with optionally given types describing
     /// the rows that would be in the raw form of the collection.
     pub fn new_arranged(
-        arranged: Vec<(Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>)>,
+        arranged: Vec<(Vec<MirScalarExpr>, Vec<usize>, Vec<usize>)>,
         types: Option<Vec<ColumnType>>,
     ) -> Self {
         assert!(
@@ -176,9 +176,7 @@ impl AvailableCollections {
     }
 
     /// Get some arrangement, if one exists.
-    pub fn arbitrary_arrangement(
-        &self,
-    ) -> Option<&(Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>)> {
+    pub fn arbitrary_arrangement(&self) -> Option<&(Vec<MirScalarExpr>, Vec<usize>, Vec<usize>)> {
         assert!(
             self.raw || !self.arranged.is_empty(),
             "Invariant violated: at least one collection must exist"

--- a/src/compute-types/src/plan/join.rs
+++ b/src/compute-types/src/plan/join.rs
@@ -260,7 +260,7 @@ impl JoinClosure {
             }
         }
 
-        before.permute(permutation, thinned_arity_with_key);
+        before.permute_fn(|c| permutation[&c], thinned_arity_with_key);
 
         // `before` should not be modified after this point.
         before.optimize();
@@ -385,7 +385,7 @@ impl JoinBuildState {
             }
         }
         let column_map_len = column_map.len();
-        mfp.permute(column_map, column_map_len);
+        mfp.permute_fn(|c| column_map[&c], column_map_len);
         mfp.optimize();
 
         JoinClosure {

--- a/src/compute-types/src/plan/join/delta_join.rs
+++ b/src/compute-types/src/plan/join/delta_join.rs
@@ -261,7 +261,7 @@ impl DeltaJoinPlan {
             let (initial_permutation, initial_thinning) =
                 permutation_for_arrangement(source_key, input_mapper.input_arity(source_relation));
             let initial_closure = join_build_state.extract_closure(
-                initial_permutation,
+                initial_permutation.into_iter().enumerate().collect(),
                 source_key.len() + initial_thinning.len(),
             );
 

--- a/src/compute-types/src/plan/join/linear_join.rs
+++ b/src/compute-types/src/plan/join/linear_join.rs
@@ -9,8 +9,6 @@
 
 //! Planning of linear joins.
 
-use std::collections::BTreeMap;
-
 use mz_expr::{
     join_permutations, permutation_for_arrangement, JoinInputCharacteristics, MapFilterProject,
     MirScalarExpr,
@@ -160,7 +158,7 @@ impl LinearJoinPlan {
     pub fn create_from(
         source_relation: usize,
         // When specified, a key and its corresponding permutation and thinning.
-        source_arrangement: Option<&(Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>)>,
+        source_arrangement: Option<&(Vec<MirScalarExpr>, Vec<usize>, Vec<usize>)>,
         equivalences: &[Vec<MirScalarExpr>],
         join_order: &[(usize, Vec<MirScalarExpr>, Option<JoinInputCharacteristics>)],
         input_mapper: mz_expr::JoinInputMapper,

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -473,10 +473,9 @@ impl Context {
                                 // to check this here for robustness against future code changes.
                                 break 'fusion None;
                             }
-                            mfp.permute(
-                                (1..mfp.input_arity).map(|col| (col, col - 1)).collect(),
-                                mfp.input_arity - 1,
-                            );
+                            let permutation: BTreeMap<_, _> =
+                                (1..mfp.input_arity).map(|col| (col, col - 1)).collect();
+                            mfp.permute_fn(|c| permutation[&c], mfp.input_arity - 1);
                             mfp
                         };
                         // We now put together the project that was before the FlatMap, and the

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -235,10 +235,7 @@ impl Context {
                     //   `LiteralConstraints` has already run.
                     // (Also note that a similar literal constraint handling machinery is also
                     // present when handling the leftover MFP after this big match.)
-                    mfp.permute(
-                        permutation.iter().cloned().enumerate().collect(),
-                        thinning.len() + key.len(),
-                    );
+                    mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
                     in_keys.arranged = vec![(key.clone(), permutation.clone(), thinning.clone())];
                     GetPlan::Arrangement(key.clone(), Some(val.clone()), mfp)
                 } else if !mfp.is_identity() {
@@ -246,10 +243,7 @@ impl Context {
                     if let Some((key, permutation, thinning)) =
                         in_keys.arbitrary_arrangement().cloned()
                     {
-                        mfp.permute(
-                            permutation.iter().cloned().enumerate().collect(),
-                            thinning.len() + key.len(),
-                        );
+                        mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
                         in_keys.arranged = vec![(key.clone(), permutation, thinning)];
                         GetPlan::Arrangement(key, None, mfp)
                     } else {
@@ -322,10 +316,7 @@ impl Context {
                         let (input_key, permutation, thinning) =
                             v_keys.arbitrary_arrangement().unwrap();
                         let mut input_mfp = MapFilterProject::new(value.arity());
-                        input_mfp.permute(
-                            permutation.iter().cloned().enumerate().collect(),
-                            thinning.len() + input_key.len(),
-                        );
+                        input_mfp.permute_fn(|c| permutation[c], thinning.len() + input_key.len());
                         let input_key = Some(input_key.clone());
 
                         let forms = AvailableCollections::new_raw();
@@ -869,10 +860,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         input_keys.arbitrary_arrangement()
                     {
                         let mut mfp = MapFilterProject::new(arity);
-                        mfp.permute(
-                            permutation.iter().cloned().enumerate().collect(),
-                            thinning.len() + input_key.len(),
-                        );
+                        mfp.permute_fn(|c| permutation[c], thinning.len() + input_key.len());
                         (Some(input_key.clone()), mfp)
                     } else {
                         (None, MapFilterProject::new(arity))
@@ -905,10 +893,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 .iter()
                 .filter_map(|(key, permutation, thinning)| {
                     let mut mfp = mfp.clone();
-                    mfp.permute(
-                        permutation.iter().cloned().enumerate().collect(),
-                        thinning.len() + key.len(),
-                    );
+                    mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
                     mfp.literal_constraints(key)
                         .map(|val| (key.clone(), permutation, thinning, val))
                 })
@@ -921,32 +906,20 @@ This is not expected to cause incorrect results, but could indicate a performanc
             // (3) Otherwise, if there is _some_ key, use that,
             // (4) Otherwise just read the raw collection.
             let input_key_val = if let Some((key, permutation, thinning, val)) = key_val {
-                mfp.permute(
-                    permutation.iter().cloned().enumerate().collect(),
-                    thinning.len() + key.len(),
-                );
+                mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
 
                 Some((key, Some(val)))
             } else if let Some((key, permutation, thinning)) =
                 keys.arranged.iter().find(|(key, permutation, thinning)| {
                     let mut mfp = mfp.clone();
-                    mfp.permute(
-                        permutation.iter().cloned().enumerate().collect(),
-                        thinning.len() + key.len(),
-                    );
+                    mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
                     mfp.is_identity()
                 })
             {
-                mfp.permute(
-                    permutation.iter().cloned().enumerate().collect(),
-                    thinning.len() + key.len(),
-                );
+                mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
                 Some((key.clone(), None))
             } else if let Some((key, permutation, thinning)) = keys.arbitrary_arrangement() {
-                mfp.permute(
-                    permutation.iter().cloned().enumerate().collect(),
-                    thinning.len() + key.len(),
-                );
+                mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
                 Some((key.clone(), None))
             } else {
                 None
@@ -1110,10 +1083,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 old_collections.arbitrary_arrangement()
             {
                 let mut mfp = MapFilterProject::new(arity);
-                mfp.permute(
-                    permutation.iter().cloned().enumerate().collect(),
-                    thinning.len() + input_key.len(),
-                );
+                mfp.permute_fn(|c| permutation[c], thinning.len() + input_key.len());
                 (Some(input_key.clone()), mfp)
             } else {
                 (None, MapFilterProject::new(arity))

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -920,10 +920,7 @@ impl KeyValPlan {
             .map(group_key.iter().cloned())
             .project(input_arity..(input_arity + group_key.len()));
         if let Some((input_permutation, new_arity)) = input_permutation_and_new_arity.clone() {
-            key_mfp.permute(
-                input_permutation.into_iter().enumerate().collect(),
-                new_arity,
-            );
+            key_mfp.permute_fn(|c| input_permutation[c], new_arity);
         }
 
         // Form an operator for evaluating value expressions.
@@ -931,10 +928,7 @@ impl KeyValPlan {
             .map(aggregates.iter().map(|a| a.expr.clone()))
             .project(input_arity..(input_arity + aggregates.len()));
         if let Some((input_permutation, new_arity)) = input_permutation_and_new_arity {
-            val_mfp.permute(
-                input_permutation.into_iter().enumerate().collect(),
-                new_arity,
-            );
+            val_mfp.permute_fn(|c| input_permutation[c], new_arity);
         }
 
         key_mfp.optimize();

--- a/src/compute-types/src/plan/threshold.proto
+++ b/src/compute-types/src/plan/threshold.proto
@@ -23,12 +23,7 @@ message ProtoThresholdPlan {
 }
 
 message ProtoArrangement {
-  message ProtoArrangementPermutation {
-    uint64 key = 1;
-    uint64 val = 2;
-  }
-
   repeated mz_expr.scalar.ProtoMirScalarExpr all_columns = 1;
-  repeated ProtoArrangementPermutation permutation = 2;
+  repeated uint64 permutation = 2;
   repeated uint64 thinning = 3;
-}
+};

--- a/src/compute-types/src/plan/threshold.proto
+++ b/src/compute-types/src/plan/threshold.proto
@@ -9,6 +9,8 @@
 
 // See https://developers.google.com/protocol-buffers for what's going on here.
 
+// buf breaking: ignore (does currently not require backward-compatibility)
+
 syntax = "proto3";
 
 package mz_compute_types.plan.threshold;
@@ -26,4 +28,4 @@ message ProtoArrangement {
   repeated mz_expr.scalar.ProtoMirScalarExpr all_columns = 1;
   repeated uint64 permutation = 2;
   repeated uint64 thinning = 3;
-};
+}

--- a/src/compute-types/src/plan/threshold.rs
+++ b/src/compute-types/src/plan/threshold.rs
@@ -23,8 +23,6 @@
 //!     is beneficial to use this operator if the number of retractions is expected to be small, and
 //!     if a potential downstream operator does not expect its input to be arranged.
 
-use std::collections::BTreeMap;
-
 use mz_expr::{permutation_for_arrangement, MirScalarExpr};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::ColumnType;
@@ -68,36 +66,19 @@ impl RustType<ProtoThresholdPlan> for ThresholdPlan {
     }
 }
 
-impl RustType<ProtoArrangement> for (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>) {
+impl RustType<ProtoArrangement> for (Vec<MirScalarExpr>, Vec<usize>, Vec<usize>) {
     fn into_proto(&self) -> ProtoArrangement {
-        use proto_arrangement::ProtoArrangementPermutation;
         ProtoArrangement {
             all_columns: self.0.into_proto(),
-            permutation: self
-                .1
-                .iter()
-                .map(|x| ProtoArrangementPermutation {
-                    key: x.0.into_proto(),
-                    val: x.1.into_proto(),
-                })
-                .collect(),
+            permutation: self.1.iter().map(|x| x.into_proto()).collect(),
             thinning: self.2.iter().map(|x| x.into_proto()).collect(),
         }
     }
 
     fn from_proto(proto: ProtoArrangement) -> Result<Self, TryFromProtoError> {
-        let perm: Result<BTreeMap<usize, usize>, TryFromProtoError> = proto
-            .permutation
-            .iter()
-            .map(|x| {
-                let key = usize::from_proto(x.key);
-                let val = usize::from_proto(x.val);
-                Ok((key?, val?))
-            })
-            .collect();
         Ok((
             proto.all_columns.into_rust()?,
-            perm?,
+            proto.permutation.into_rust()?,
             proto.thinning.into_rust()?,
         ))
     }
@@ -125,7 +106,7 @@ impl ThresholdPlan {
 pub struct BasicThresholdPlan {
     /// Description of how the input has been arranged, and how to arrange the output
     #[proptest(strategy = "any_arranged_thin()")]
-    pub ensure_arrangement: (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>),
+    pub ensure_arrangement: (Vec<MirScalarExpr>, Vec<usize>, Vec<usize>),
 }
 
 /// A plan to maintain all inputs with negative counts, which are subtracted from the output
@@ -134,19 +115,14 @@ pub struct BasicThresholdPlan {
 pub struct RetractionsThresholdPlan {
     /// Description of how the input has been arranged
     #[proptest(strategy = "any_arranged_thin()")]
-    pub ensure_arrangement: (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>),
+    pub ensure_arrangement: (Vec<MirScalarExpr>, Vec<usize>, Vec<usize>),
 }
 
 impl ThresholdPlan {
     /// Construct the plan from the number of columns (`arity`).
     ///
     /// Also returns the arrangement and thinning required for the input.
-    pub fn create_from(
-        arity: usize,
-    ) -> (
-        Self,
-        (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>),
-    ) {
+    pub fn create_from(arity: usize) -> (Self, (Vec<MirScalarExpr>, Vec<usize>, Vec<usize>)) {
         // Arrange the input by all columns in order.
         let mut all_columns = Vec::new();
         for column in 0..arity {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -105,8 +105,8 @@ where
                         demand_map.insert(*column, demand_map.len());
                     }
                     let demand_map_len = demand_map.len();
-                    key_plan.permute(demand_map.clone(), demand_map_len);
-                    val_plan.permute(demand_map, demand_map_len);
+                    key_plan.permute_fn(|c| demand_map[&c], demand_map_len);
+                    val_plan.permute_fn(|c| demand_map[&c], demand_map_len);
                     let skips = mz_compute_types::plan::reduce::convert_indexes_to_skips(demand);
                     move |row_datums, time, diff| {
                         let binding = SharedRow::get();

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -80,7 +80,10 @@ where
             let unthinned_arity = sink.from_desc.arity();
             let (permutation, thinning) = permutation_for_arrangement(key, unthinned_arity);
             let mut mfp = MapFilterProject::new(unthinned_arity);
-            mfp.permute(permutation, thinning.len() + key.len());
+            mfp.permute(
+                permutation.into_iter().enumerate().collect(),
+                thinning.len() + key.len(),
+            );
             bundle.as_collection_core(mfp, Some((key.clone(), None)), self.until.clone())
         };
 

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -80,10 +80,7 @@ where
             let unthinned_arity = sink.from_desc.arity();
             let (permutation, thinning) = permutation_for_arrangement(key, unthinned_arity);
             let mut mfp = MapFilterProject::new(unthinned_arity);
-            mfp.permute(
-                permutation.into_iter().enumerate().collect(),
-                thinning.len() + key.len(),
-            );
+            mfp.permute_fn(|c| permutation[c], thinning.len() + key.len());
             bundle.as_collection_core(mfp, Some((key.clone(), None)), self.until.clone())
         };
 

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -882,12 +882,13 @@ fn implement_arrangements<'a>(
     let mut combined_project = Vec::new();
     for (index, lifted_mfp) in lifted_mfps.into_iter().enumerate() {
         if let Some(mut lifted_mfp) = lifted_mfp {
-            lifted_mfp.permute(
+            let column_map = new_join_mapper
+                .local_columns(index)
+                .zip(new_join_mapper.global_columns(index))
+                .collect::<BTreeMap<_, _>>();
+            lifted_mfp.permute_fn(
                 // globalize all input column references
-                new_join_mapper
-                    .local_columns(index)
-                    .zip(new_join_mapper.global_columns(index))
-                    .collect(),
+                |c| column_map[&c],
                 // shift the position of scalars to be after the last input
                 // column
                 arity,

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -3700,10 +3700,10 @@ FROM t
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
+                        [
+                          0,
+                          1
+                        ],
                         [
                           1
                         ]
@@ -7055,10 +7055,10 @@ MATERIALIZED VIEW collated_global_mv
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
+                        [
+                          0,
+                          1
+                        ],
                         [
                           1
                         ]
@@ -8397,10 +8397,10 @@ SELECT * FROM collated_global
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
+                        [
+                          0,
+                          1
+                        ],
                         [
                           1
                         ]

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -204,10 +204,10 @@ SELECT * FROM t
                       "Column": 0
                     }
                   ],
-                  {
-                    "0": 0,
-                    "1": 1
-                  },
+                  [
+                    0,
+                    1
+                  ],
                   [
                     1
                   ]
@@ -301,10 +301,10 @@ SELECT a + b, 1 FROM t
                       "Column": 0
                     }
                   ],
-                  {
-                    "0": 0,
-                    "1": 1
-                  },
+                  [
+                    0,
+                    1
+                  ],
                   [
                     1
                   ]
@@ -498,10 +498,10 @@ SELECT * FROM ov
                                   "Column": 0
                                 }
                               ],
-                              {
-                                "0": 0,
-                                "1": 1
-                              },
+                              [
+                                0,
+                                1
+                              ],
                               [
                                 1
                               ]
@@ -628,10 +628,10 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                                           "Column": 0
                                         }
                                       ],
-                                      {
-                                        "0": 0,
-                                        "1": 1
-                                      },
+                                      [
+                                        0,
+                                        1
+                                      ],
                                       [
                                         1
                                       ]
@@ -717,9 +717,9 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0
-                        },
+                        [
+                          0
+                        ],
                         []
                       ]
                     ],
@@ -750,9 +750,9 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                       "Column": 0
                     }
                   ],
-                  {
-                    "0": 0
-                  },
+                  [
+                    0
+                  ],
                   []
                 ]
               }
@@ -814,10 +814,10 @@ SELECT * FROM ov
                                   "Column": 0
                                 }
                               ],
-                              {
-                                "0": 0,
-                                "1": 1
-                              },
+                              [
+                                0,
+                                1
+                              ],
                               [
                                 1
                               ]
@@ -950,10 +950,10 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                                 "Column": 0
                                               }
                                             ],
-                                            {
-                                              "0": 0,
-                                              "1": 1
-                                            },
+                                            [
+                                              0,
+                                              1
+                                            ],
                                             [
                                               1
                                             ]
@@ -1039,9 +1039,9 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                   "Column": 0
                                 }
                               ],
-                              {
-                                "0": 0
-                              },
+                              [
+                                0
+                              ],
                               []
                             ]
                           ],
@@ -1072,9 +1072,9 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0
-                        },
+                        [
+                          0
+                        ],
                         []
                       ]
                     }
@@ -1103,9 +1103,9 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0
-                                },
+                                [
+                                  0
+                                ],
                                 []
                               ]
                             ],
@@ -1178,9 +1178,9 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0
-                                },
+                                [
+                                  0
+                                ],
                                 []
                               ]
                             ],
@@ -1315,10 +1315,10 @@ SELECT x * 5 FROM cte WHERE x = 5
                                                         "Column": 0
                                                       }
                                                     ],
-                                                    {
-                                                      "0": 0,
-                                                      "1": 1
-                                                    },
+                                                    [
+                                                      0,
+                                                      1
+                                                    ],
                                                     [
                                                       1
                                                     ]
@@ -1373,9 +1373,9 @@ SELECT x * 5 FROM cte WHERE x = 5
                                                         "Column": 0
                                                       }
                                                     ],
-                                                    {
-                                                      "0": 0
-                                                    },
+                                                    [
+                                                      0
+                                                    ],
                                                     []
                                                   ]
                                                 ],
@@ -1491,9 +1491,9 @@ SELECT x * 5 FROM cte WHERE x = 5
                                   "Column": 0
                                 }
                               ],
-                              {
-                                "0": 0
-                              },
+                              [
+                                0
+                              ],
                               []
                             ]
                           ],
@@ -1524,9 +1524,9 @@ SELECT x * 5 FROM cte WHERE x = 5
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0
-                        },
+                        [
+                          0
+                        ],
                         []
                       ]
                     }
@@ -1649,10 +1649,10 @@ SELECT generate_series(a, b) from t
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
+                        [
+                          0,
+                          1
+                        ],
                         [
                           1
                         ]
@@ -1751,10 +1751,10 @@ SELECT DISTINCT a, b FROM t
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
+                        [
+                          0,
+                          1
+                        ],
                         [
                           1
                         ]
@@ -1856,10 +1856,10 @@ GROUP BY a
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
+                        [
+                          0,
+                          1
+                        ],
                         [
                           1
                         ]
@@ -2012,10 +2012,10 @@ FROM t
                                   "Column": 0
                                 }
                               ],
-                              {
-                                "0": 0,
-                                "1": 1
-                              },
+                              [
+                                0,
+                                1
+                              ],
                               [
                                 1
                               ]
@@ -2154,10 +2154,10 @@ FROM t
                                   "arranged": [
                                     [
                                       [],
-                                      {
-                                        "0": 0,
-                                        "1": 1
-                                      },
+                                      [
+                                        0,
+                                        1
+                                      ],
                                       [
                                         0,
                                         1
@@ -2213,10 +2213,10 @@ FROM t
                                                 "arranged": [
                                                   [
                                                     [],
-                                                    {
-                                                      "0": 0,
-                                                      "1": 1
-                                                    },
+                                                    [
+                                                      0,
+                                                      1
+                                                    ],
                                                     [
                                                       0,
                                                       1
@@ -2355,10 +2355,10 @@ SELECT * FROM hierarchical_group_by
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
+                        [
+                          0,
+                          1
+                        ],
                         [
                           1
                         ]
@@ -2477,10 +2477,10 @@ MATERIALIZED VIEW hierarchical_global_mv
                                   "Column": 0
                                 }
                               ],
-                              {
-                                "0": 0,
-                                "1": 1
-                              },
+                              [
+                                0,
+                                1
+                              ],
                               [
                                 1
                               ]
@@ -2596,10 +2596,10 @@ MATERIALIZED VIEW hierarchical_global_mv
                                   "arranged": [
                                     [
                                       [],
-                                      {
-                                        "0": 0,
-                                        "1": 1
-                                      },
+                                      [
+                                        0,
+                                        1
+                                      ],
                                       [
                                         0,
                                         1
@@ -2655,10 +2655,10 @@ MATERIALIZED VIEW hierarchical_global_mv
                                                 "arranged": [
                                                   [
                                                     [],
-                                                    {
-                                                      "0": 0,
-                                                      "1": 1
-                                                    },
+                                                    [
+                                                      0,
+                                                      1
+                                                    ],
                                                     [
                                                       0,
                                                       1
@@ -2802,10 +2802,10 @@ SELECT * FROM hierarchical_global
                                   "Column": 0
                                 }
                               ],
-                              {
-                                "0": 0,
-                                "1": 1
-                              },
+                              [
+                                0,
+                                1
+                              ],
                               [
                                 1
                               ]
@@ -2913,10 +2913,10 @@ SELECT * FROM hierarchical_global
                                   "arranged": [
                                     [
                                       [],
-                                      {
-                                        "0": 0,
-                                        "1": 1
-                                      },
+                                      [
+                                        0,
+                                        1
+                                      ],
                                       [
                                         0,
                                         1
@@ -2972,10 +2972,10 @@ SELECT * FROM hierarchical_global
                                                 "arranged": [
                                                   [
                                                     [],
-                                                    {
-                                                      "0": 0,
-                                                      "1": 1
-                                                    },
+                                                    [
+                                                      0,
+                                                      1
+                                                    ],
                                                     [
                                                       0,
                                                       1
@@ -3124,10 +3124,10 @@ GROUP BY a
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -3378,10 +3378,10 @@ GROUP BY a
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -4409,10 +4409,10 @@ MATERIALIZED VIEW collated_group_by_mv
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -4519,10 +4519,10 @@ MATERIALIZED VIEW collated_group_by_mv
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -4652,10 +4652,10 @@ MATERIALIZED VIEW collated_group_by_mv
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -4906,10 +4906,10 @@ MATERIALIZED VIEW collated_group_by_mv
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -5738,10 +5738,10 @@ SELECT * FROM collated_group_by
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -5840,10 +5840,10 @@ SELECT * FROM collated_group_by
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -5973,10 +5973,10 @@ SELECT * FROM collated_group_by
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -6227,10 +6227,10 @@ SELECT * FROM collated_group_by
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -9733,10 +9733,10 @@ WHERE a = c AND d = e AND b + d > 42
                               "Column": 0
                             }
                           ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
+                          [
+                            0,
+                            1
+                          ],
                           [
                             1
                           ]
@@ -9798,10 +9798,10 @@ WHERE a = c AND d = e AND b + d > 42
                               "Column": 0
                             }
                           ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
+                          [
+                            0,
+                            1
+                          ],
                           [
                             1
                           ]
@@ -9812,10 +9812,10 @@ WHERE a = c AND d = e AND b + d > 42
                               "Column": 1
                             }
                           ],
-                          {
-                            "0": 1,
-                            "1": 0
-                          },
+                          [
+                            1,
+                            0
+                          ],
                           [
                             0
                           ]
@@ -9885,9 +9885,9 @@ WHERE a = c AND d = e AND b + d > 42
                               "Column": 0
                             }
                           ],
-                          {
-                            "0": 0
-                          },
+                          [
+                            0
+                          ],
                           []
                         ]
                       ],
@@ -10512,10 +10512,10 @@ WHERE a = c AND d = e AND f = a
                               "Column": 0
                             }
                           ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
+                          [
+                            0,
+                            1
+                          ],
                           [
                             1
                           ]
@@ -10558,10 +10558,10 @@ WHERE a = c AND d = e AND f = a
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -10650,10 +10650,10 @@ WHERE a = c AND d = e AND f = a
                               "Column": 0
                             }
                           ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
+                          [
+                            0,
+                            1
+                          ],
                           [
                             1
                           ]
@@ -10667,10 +10667,10 @@ WHERE a = c AND d = e AND f = a
                               "Column": 1
                             }
                           ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
+                          [
+                            0,
+                            1
+                          ],
                           []
                         ]
                       ],
@@ -10720,10 +10720,10 @@ WHERE a = c AND d = e AND f = a
                                     "Column": 0
                                   }
                                 ],
-                                {
-                                  "0": 0,
-                                  "1": 1
-                                },
+                                [
+                                  0,
+                                  1
+                                ],
                                 [
                                   1
                                 ]
@@ -10815,10 +10815,10 @@ WHERE a = c AND d = e AND f = a
                               "Column": 1
                             }
                           ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
+                          [
+                            0,
+                            1
+                          ],
                           []
                         ]
                       ],
@@ -11223,10 +11223,10 @@ WHERE a = c and a = e
                               "Column": 0
                             }
                           ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
+                          [
+                            0,
+                            1
+                          ],
                           [
                             1
                           ]
@@ -11265,10 +11265,10 @@ WHERE a = c and a = e
                               "Column": 0
                             }
                           ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
+                          [
+                            0,
+                            1
+                          ],
                           [
                             1
                           ]
@@ -11307,10 +11307,10 @@ WHERE a = c and a = e
                               "Column": 0
                             }
                           ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
+                          [
+                            0,
+                            1
+                          ],
                           [
                             1
                           ]


### PR DESCRIPTION
We use a `BTreeMap<usize, usize>` for the "permutation" from concatenated `[key, val]` columns, when it appears it can always be a `Vec<usize>`: each output column must identify an input column. This also hints that this isn't really a permutation as much as a projection. More generally both of these could be `Vec<MirScalarExpr>` if we ever plan to be so bold (and perhaps this is an opportunity to abstract the specifics away, so that everyone's signatures don't change in the future). For example, various `permute` functions could/should be `pre-mfp` where you hand over perhaps a `Vec<MirScalarExpr>` that *could* be column references, or more general expressions. E.g. if we form a key using a cast, we cannot represent the operation that just un-casts it (in some cases) and that would be good enough vs keeping the un-cast column around as a value.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
