### PR TITLE
dyncfg: add support for f64 configs

### DIFF
--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -368,7 +368,7 @@ impl RustType<ProtoInstanceConfig> for InstanceConfig {
 ///
 /// Parameters can be set (`Some`) or unset (`None`).
 /// Unset parameters should be interpreted to mean "use the previous value".
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Arbitrary)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct ComputeParameters {
     /// The maximum allowed size in bytes for results of peeks and subscribes.
     ///

--- a/src/dyncfg/build.rs
+++ b/src/dyncfg/build.rs
@@ -16,7 +16,7 @@ fn main() {
         .btree_map(["."])
         .type_attribute(
             ".",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize, proptest_derive::Arbitrary)]",
+            "#[derive(serde::Serialize, serde::Deserialize, proptest_derive::Arbitrary)]",
         )
         .extern_path(".mz_proto", "::mz_proto")
         .compile_protos(&["dyncfg/src/dyncfg.proto"], &[".."])

--- a/src/dyncfg/src/dyncfg.proto
+++ b/src/dyncfg/src/dyncfg.proto
@@ -35,6 +35,7 @@ message ProtoConfigVal {
         uint32 u32 = 6;
         uint64 usize = 3;
         ProtoOptionU64 opt_usize = 7;
+        double f64 = 9;
         string string = 4;
         mz_proto.ProtoDuration duration = 5;
         // Switch to Protobuf's native JSON representation,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1232,6 +1232,9 @@ impl SystemVars {
                 ConfigVal::OptUsize(default) => {
                     VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), true)
                 }
+                ConfigVal::F64(default) => {
+                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), true)
+                }
                 ConfigVal::String(default) => {
                     VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), true)
                 }
@@ -1865,6 +1868,7 @@ impl SystemVars {
                 ConfigVal::OptUsize(_) => {
                     ConfigVal::from(*self.expect_config_value::<Option<usize>>(name))
                 }
+                ConfigVal::F64(_) => ConfigVal::from(*self.expect_config_value::<f64>(name)),
                 ConfigVal::String(_) => {
                     ConfigVal::from(self.expect_config_value::<String>(name).clone())
                 }


### PR DESCRIPTION
Shared via to_bits/from_bits so we can use atomics instead of Arc+Mutex.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
