### PR TITLE
jemalloc: add resident stat to profile page

### DIFF
--- a/src/prof-http/src/lib.rs
+++ b/src/prof-http/src/lib.rs
@@ -289,8 +289,10 @@ mod enabled {
                     "Allocated for allocator metadata",
                     ByteSize(u64::cast_from(stats.metadata)).to_string_as(true),
                 ),
-                // Don't print `stats.resident` since it is a bit hard to interpret;
-                // see `man jemalloc` for details.
+                (
+                    "Maximum number of bytes in physically resident data pages mapped by the allocator",
+                    ByteSize(u64::cast_from(stats.resident)).to_string_as(true),
+                ),
                 (
                     "Bytes unused, but retained by allocator",
                     ByteSize(u64::cast_from(stats.retained)).to_string_as(true),


### PR DESCRIPTION
`stats.resident` is actually the closest to physical memory, which is how ooms happen. Its nice to compare this to `stats.active`!

### Motivation


  * This PR adds a known-desirable feature.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
