### PR TITLE
bazel: Add `bazel` to ci-builder, add Nightly test target

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -111,9 +111,15 @@ maybe(
 #    See: <https://github.com/bazelbuild/rules_foreign_cc/pull/1023>
 #    See: <https://github.com/MaterializeInc/rules_foreign_cc/commit/2199b1c304140fa959c3703b0b7e9cbf7d39c4c2>
 #
+# 3. Specify the AR tool to use when bootstrapping `make`. On macOS explicitly set the path to
+#    be llvm-ar which we know exists in our toolchain.
+#    See: <https://github.com/MaterializeInc/rules_foreign_cc/commit/e94986f05edf95fff025b6aeb995e09be8889b89>
+#
+# 4. `make` 4.2 fails to compile on Linux because of unrecognized symbols so we patch the source.
+#    See: <https://github.com/MaterializeInc/rules_foreign_cc/commit/de4a79280f54d8796e86b7ab0b631939b7b44d05>
 
-RULES_FOREIGN_CC_VERSION = "2199b1c304140fa959c3703b0b7e9cbf7d39c4c2"
-RULES_FOREIGN_CC_INTEGRITY = "sha256-Prb2q/bhVCocjT427OPVpzHuEnJmqcf1WPK4Ev7KlEI="
+RULES_FOREIGN_CC_VERSION = "de4a79280f54d8796e86b7ab0b631939b7b44d05"
+RULES_FOREIGN_CC_INTEGRITY = "sha256-WwRg/GJuUjT3SMJEagTni2ZH+g3szIkHaqGgbYCN1u0="
 maybe(
     http_archive,
     name = "rules_foreign_cc",

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-ge
     libncurses-dev \
     libstdc++6 \
     libstdc++-13-dev \
+    libtinfo5 \
     libtool-bin \
     llvm \
     make \
@@ -102,6 +103,7 @@ RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-ge
     libclang-common-15-dev \
     libclang-dev \
     libclang-rt-15-dev \
+    libtinfo5 \
     libpq-dev \
     lld \
     llvm \
@@ -271,6 +273,20 @@ RUN curl -fsSL https://dl.k8s.io/release/v1.24.3/bin/linux/$ARCH_GO/kubectl > /u
 
 RUN if [ $ARCH_GO = amd64 ]; then echo '8a45348bdaf81d46caf1706c8bf95b3f431150554f47d444ffde89e8cdd712c1 /usr/local/bin/kubectl' | sha256sum --check; fi
 RUN if [ $ARCH_GO = arm64 ]; then echo 'bdad4d3063ddb7bfa5ecf17fb8b029d5d81d7d4ea1650e4369aafa13ed97149a /usr/local/bin/kubectl' | sha256sum --check; fi
+
+# Install Bazel.
+#
+# TODO(parkmycar): Run Bazel in Docker image that does not have access to clang/gcc or any other tools.
+
+ARG BAZEL_VERSION="7.1.1"
+
+# Download the bazel binary from the official GitHub releases since the apt repositories do not
+# contain arm64 releases.
+RUN arch_bazel=$(echo "$ARCH_GCC" | sed "s/aarch64/arm64/") bazel_version=$(echo "$BAZEL_VERSION") \
+    && curl -fsSL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazel/releases/download/$bazel_version/bazel-$bazel_version-linux-$arch_bazel \
+    && if [ "$arch_bazel" = arm64 ]; then echo '37c2d1c8ff917eba88fc68a9fc7ac0b96014f1bed653f1621de0eabc79ed0d2b /usr/local/bin/bazel' | sha256sum --check; fi \
+    && if [ "$arch_bazel" = amd64 ]; then echo 'd93508529d41136065c7b1e5ff555fbfb9d18fd00e768886f2fc7dfb53b05b43 /usr/local/bin/bazel' | sha256sum --check; fi \
+    && chmod +x /usr/local/bin/bazel
 
 # Hardcode some known SSH hosts, or else SSH will ask whether the host is
 # trustworthy on the first connection.

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1588,3 +1588,22 @@ steps:
               composition: ruby
         agents:
           queue: linux-aarch64-small
+
+  - group: Bazel
+    key: bazel
+    steps:
+      - id: bazel-test-x86_64
+        label: ":bazel: Test x86_64"
+        command: bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
+        depends_on: []
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+
+      - id: bazel-test-aarch64
+        label: ":bazel: Test aarch64"
+        command: bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
+        depends_on: []
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-aarch64

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1594,7 +1594,7 @@ steps:
     steps:
       - id: bazel-test-x86_64
         label: ":bazel: Test x86_64"
-        command: bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
+        command: bin/ci-builder run stable bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
         depends_on: []
         timeout_in_minutes: 60
         agents:
@@ -1602,7 +1602,7 @@ steps:
 
       - id: bazel-test-aarch64
         label: ":bazel: Test aarch64"
-        command: bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
+        command: bin/ci-builder run stable bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
         depends_on: []
         timeout_in_minutes: 60
         agents:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1589,11 +1589,11 @@ steps:
         agents:
           queue: linux-aarch64-small
 
-  - group: Bazel
+  - group: ":bazel: Bazel"
     key: bazel
     steps:
       - id: bazel-test-x86_64
-        label: ":bazel: Test x86_64"
+        label: ":bazel: Test (x86_64)"
         command: bin/ci-builder run stable bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
         depends_on: []
         timeout_in_minutes: 60
@@ -1601,7 +1601,7 @@ steps:
           queue: builder-linux-x86_64
 
       - id: bazel-test-aarch64
-        label: ":bazel: Test aarch64"
+        label: ":bazel: Test (aarch64)"
         command: bin/ci-builder run stable bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
         depends_on: []
         timeout_in_minutes: 60


### PR DESCRIPTION
This PR gets Bazel running in CI. Specifically it does the following:

1. Adds `bazel` to the `ci-builder` image
2. Tweaks `rules_foreign_cc` so we can bootstrap `make` on Linux
3. Adds a new test group to the Nightly pipeline that invokes `bazel test //...` and uses the remote cache introduced in https://github.com/MaterializeInc/i2/pull/1847
    * The only tests we have right now are a `build_test` to make sure our C dependencies successfully build.

[Nightly run](https://buildkite.com/materialize/nightly/builds/7739#018f64f9-8e46-467c-bd1a-cb4ef2a964f8), if you look at the retries you'll see the tests weren't actually run, Bazel returned cached results!

### Hermetic Builds

This isn't yet testing hermeticy of our builds, to do that we need to [add a sysroot](https://steven.casagrande.io/articles/sysroot-generation-toolchains-llvm) to our toolchain so Bazel can find system headers, and ideally we don't even use `ci-builder` but instead have a separate bazel-only image. But I figured this was a good first step!

### Motivation

Related to https://github.com/MaterializeInc/materialize/issues/26796

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
