### PR TITLE
tests: mark 0.99.1 as broken

### DIFF
--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -47,6 +47,7 @@ INVALID_VERSIONS = {
     MzVersion.parse_mz("v0.89.7"),
     MzVersion.parse_mz("v0.92.0"),  # incompatible for upgrades
     MzVersion.parse_mz("v0.93.0"),  # accidental release
+    MzVersion.parse_mz("v0.99.1"),  # incompatible for upgrades
 }
 
 _SKIP_IMAGE_CHECK_BELOW_THIS_VERSION = MzVersion.parse_mz("v0.77.0")


### PR DESCRIPTION
See https://materializeinc.slack.com/archives/CTESPM7FU/p1715556223518329

This should fix (at least some) upgrade checks.