### PR TITLE
output consistency: support for maps

### DIFF
--- a/misc/python/materialize/output_consistency/data_type/data_type_category.py
+++ b/misc/python/materialize/output_consistency/data_type/data_type_category.py
@@ -28,5 +28,6 @@ class DataTypeCategory(Enum):
     ENUM = 200
 
     ARRAY = 300
+    MAP = 301
 
     OTHER_UNSUPPORTED = 400

--- a/misc/python/materialize/output_consistency/expression/expression_characteristics.py
+++ b/misc/python/materialize/output_consistency/expression/expression_characteristics.py
@@ -41,3 +41,6 @@ class ExpressionCharacteristics(Enum):
 
     JSON_EMPTY = 150
     JSON_ARRAY = 151
+
+    MAP_EMPTY = 160
+    MAP_WITH_DUP_KEYS = 161

--- a/misc/python/materialize/output_consistency/input_data/operations/all_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/all_operations_provider.py
@@ -33,6 +33,9 @@ from materialize.output_consistency.input_data.operations.generic_operations_pro
 from materialize.output_consistency.input_data.operations.jsonb_operations_provider import (
     JSONB_OPERATION_TYPES,
 )
+from materialize.output_consistency.input_data.operations.map_operations_provider import (
+    MAP_OPERATION_TYPES,
+)
 from materialize.output_consistency.input_data.operations.number_operations_provider import (
     NUMERIC_OPERATION_TYPES,
 )
@@ -61,5 +64,6 @@ ALL_OPERATION_TYPES: list[DbOperationOrFunction] = list(
         BYTEA_OPERATION_TYPES,
         CRYPTO_OPERATION_TYPES,
         JSONB_OPERATION_TYPES,
+        MAP_OPERATION_TYPES,
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
@@ -38,6 +38,7 @@ from materialize.output_consistency.operation.operation import (
     DbOperationOrFunction,
 )
 
+# all operations will be disabled for Postgres at the bottom
 MAP_OPERATION_TYPES: list[DbOperationOrFunction] = []
 
 MAP_OPERATION_TYPES.append(
@@ -121,3 +122,7 @@ MAP_OPERATION_TYPES.append(
 # )
 
 # TODO: map_build operates on records
+
+for operation in MAP_OPERATION_TYPES:
+    # Postgres does not support the map type
+    operation.is_pg_compatible = False

--- a/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-
+from materialize.mz_version import MzVersion
 from materialize.output_consistency.input_data.params.any_operation_param import (
     AnyOperationParam,
 )
@@ -69,6 +69,24 @@ MAP_OPERATION_TYPES.append(
     )
 )
 
+# with specified keys
+MAP_OPERATION_TYPES.append(
+    DbOperation(
+        "MAP[$ => $]",
+        [MAP_FIELD_NAME_PARAM, AnyOperationParam()],
+        MapReturnTypeSpec(),
+        since_mz_version=MzVersion.parse_mz("v0.100.0"),
+    )
+)
+# with arbitrary text values
+MAP_OPERATION_TYPES.append(
+    DbOperation(
+        "MAP[$ => $]",
+        [TextOperationParam(), AnyOperationParam()],
+        MapReturnTypeSpec(),
+        since_mz_version=MzVersion.parse_mz("v0.100.0"),
+    )
+)
 
 MAP_OPERATION_TYPES.append(
     DbFunction(

--- a/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
@@ -1,0 +1,105 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.output_consistency.input_data.params.any_operation_param import (
+    AnyOperationParam,
+)
+from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
+    MAP_FIELD_NAME_PARAM,
+)
+from materialize.output_consistency.input_data.params.map_operation_param import (
+    MapOperationParam,
+)
+from materialize.output_consistency.input_data.params.text_operation_param import (
+    TextOperationParam,
+)
+from materialize.output_consistency.input_data.return_specs.boolean_return_spec import (
+    BooleanReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.map_return_spec import (
+    MapReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.map_value_return_spec import (
+    DynamicMapValueReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.number_return_spec import (
+    NumericReturnTypeSpec,
+)
+from materialize.output_consistency.operation.operation import (
+    DbFunction,
+    DbOperation,
+    DbOperationOrFunction,
+)
+
+MAP_OPERATION_TYPES: list[DbOperationOrFunction] = []
+
+MAP_OPERATION_TYPES.append(
+    DbOperation(
+        "$ -> $",
+        [MapOperationParam(), MAP_FIELD_NAME_PARAM],
+        DynamicMapValueReturnTypeSpec(),
+    )
+)
+MAP_OPERATION_TYPES.append(
+    DbOperation(
+        "$ @> $",
+        [MapOperationParam(), AnyOperationParam()],
+        BooleanReturnTypeSpec(),
+    )
+)
+MAP_OPERATION_TYPES.append(
+    DbOperation(
+        "$ <@ $",
+        [MapOperationParam(), AnyOperationParam()],
+        BooleanReturnTypeSpec(),
+    )
+)
+MAP_OPERATION_TYPES.append(
+    DbOperation(
+        "$ ? $",
+        [MapOperationParam(), MAP_FIELD_NAME_PARAM],
+        BooleanReturnTypeSpec(),
+    )
+)
+
+
+MAP_OPERATION_TYPES.append(
+    DbFunction(
+        "map_length",
+        [MapOperationParam()],
+        NumericReturnTypeSpec(only_integer=True),
+    )
+)
+# TODO: use with multiple keys and values
+MAP_OPERATION_TYPES.append(
+    DbFunction(
+        "map_agg",
+        [TextOperationParam(), AnyOperationParam()],
+        MapReturnTypeSpec(),
+    )
+)
+
+# TODO: array type required
+# MAP_OPERATION_TYPES.append(
+#     DbOperation(
+#         "$ ?& $",
+#         [MapOperationParam(), <str array>],
+#         BooleanReturnTypeSpec(),
+#     )
+# )
+# MAP_OPERATION_TYPES.append(
+#     DbOperation(
+#         "$ ?| $",
+#         [MapOperationParam(), <str array>],
+#         BooleanReturnTypeSpec(),
+#     )
+# )
+
+# TODO: map_build operates on records

--- a/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
+++ b/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
@@ -102,6 +102,10 @@ HASH_ALGORITHM_PARAM = EnumConstantOperationParam(
     ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"], add_quotes=True
 )
 
+MAP_FIELD_NAME_PARAM = EnumConstantOperationParam(
+    ["", "n", "a", "A", "b"], add_quotes=True, add_invalid_value=True
+)
+
 
 def all_data_types_enum_constant_operation_param(
     must_be_pg_compatible: bool,

--- a/misc/python/materialize/output_consistency/input_data/params/map_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/map_operation_param.py
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.output_consistency.data_type.data_type import DataType
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.expression.expression import Expression
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.types.map_type_provider import (
+    MapDataType,
+)
+from materialize.output_consistency.operation.operation_param import OperationParam
+
+
+class MapOperationParam(OperationParam):
+    def __init__(
+        self,
+        optional: bool = False,
+        incompatibilities: set[ExpressionCharacteristics] | None = None,
+    ):
+        super().__init__(
+            DataTypeCategory.MAP,
+            optional,
+            incompatibilities,
+            incompatibility_combinations=None,
+        )
+
+    def supports_type(
+        self, data_type: DataType, previous_args: list[Expression]
+    ) -> bool:
+        return isinstance(data_type, MapDataType)

--- a/misc/python/materialize/output_consistency/input_data/return_specs/map_return_spec.py
+++ b/misc/python/materialize/output_consistency/input_data/return_specs/map_return_spec.py
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.operation.return_type_spec import (
+    InputArgTypeHints,
+    ReturnTypeSpec,
+)
+
+
+class MapReturnTypeSpec(ReturnTypeSpec):
+    def __init__(
+        self,
+        param_index_of_map_value_type: int = 0,
+        map_value_type_category: DataTypeCategory = DataTypeCategory.DYNAMIC,
+    ):
+        super().__init__(DataTypeCategory.MAP, [param_index_of_map_value_type])
+        self._map_value_type_category = map_value_type_category
+
+    def resolve_type_category(
+        self, input_arg_type_hints: InputArgTypeHints
+    ) -> DataTypeCategory:
+        # update the value type of the map
+        if self._map_value_type_category == DataTypeCategory.DYNAMIC:
+            self._update_map_value_type(input_arg_type_hints)
+
+        # provide the actual return value
+        return super().resolve_type_category(input_arg_type_hints)
+
+    def _update_map_value_type(self, input_arg_type_hints: InputArgTypeHints) -> None:
+        assert (
+            input_arg_type_hints is not None
+            and self.indices_of_required_input_type_hints is not None
+            and not input_arg_type_hints.is_empty()
+        ), "Invalid state"
+        self._map_value_type_category = (
+            input_arg_type_hints.type_category_of_requested_args[
+                self.indices_of_required_input_type_hints[0]
+            ]
+        )
+
+    def get_map_value_type(self) -> DataTypeCategory:
+        assert (
+            self._map_value_type_category != DataTypeCategory.DYNAMIC
+        ), "map value type not resolved"
+        return self._map_value_type_category

--- a/misc/python/materialize/output_consistency/input_data/return_specs/map_value_return_spec.py
+++ b/misc/python/materialize/output_consistency/input_data/return_specs/map_value_return_spec.py
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.input_data.return_specs.dynamic_return_spec import (
+    DynamicReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.map_return_spec import (
+    MapReturnTypeSpec,
+)
+from materialize.output_consistency.operation.return_type_spec import InputArgTypeHints
+
+
+class DynamicMapValueReturnTypeSpec(DynamicReturnTypeSpec):
+    def __init__(self, param_index_to_take_type: int = 0):
+        super().__init__(param_index_to_take_type)
+        self.requires_return_type_spec_hints = True
+
+    def resolve_type_category(
+        self, input_arg_type_hints: InputArgTypeHints
+    ) -> DataTypeCategory:
+        assert (
+            input_arg_type_hints is not None
+            and self.indices_of_required_input_type_hints is not None
+            and not input_arg_type_hints.is_empty()
+        ), "Invalid state"
+        input_arg_return_type_spec = (
+            input_arg_type_hints.return_type_spec_of_requested_args[
+                self.indices_of_required_input_type_hints[0]
+            ]
+        )
+
+        assert isinstance(input_arg_return_type_spec, MapReturnTypeSpec)
+        return input_arg_return_type_spec.get_map_value_type()

--- a/misc/python/materialize/output_consistency/input_data/types/all_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/all_types_provider.py
@@ -21,6 +21,9 @@ from materialize.output_consistency.input_data.types.date_time_types_provider im
 from materialize.output_consistency.input_data.types.jsonb_type_provider import (
     JSONB_DATA_TYPE,
 )
+from materialize.output_consistency.input_data.types.map_type_provider import (
+    MAP_DATA_TYPES,
+)
 from materialize.output_consistency.input_data.types.number_types_provider import (
     NUMERIC_DATA_TYPES,
 )
@@ -36,5 +39,6 @@ DATA_TYPES: list[DataType] = list(
         [TEXT_DATA_TYPE],
         [BYTEA_DATA_TYPE],
         [JSONB_DATA_TYPE],
+        MAP_DATA_TYPES,
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/types/map_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/map_type_provider.py
@@ -35,6 +35,7 @@ class MapDataType(DataType):
             internal_identifier,
             type_name,
             DataTypeCategory.MAP,
+            is_pg_compatible=False,
         )
         self.map_value_1 = map_value_1
         self.map_value_2 = map_value_2

--- a/misc/python/materialize/output_consistency/input_data/types/map_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/map_type_provider.py
@@ -1,0 +1,96 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type import DataType
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.return_specs.map_return_spec import (
+    MapReturnTypeSpec,
+)
+from materialize.output_consistency.operation.return_type_spec import ReturnTypeSpec
+
+MAP_TEXT_TO_DOUBLE_TYPE_IDENTIFIER = "MAP_TEXT_TO_DOUBLE"
+MAP_TEXT_TO_TIMESTAMPTZ_TYPE_IDENTIFIER = "MAP_TEXT_TO_TIMESTAMPTZ"
+MAP_TEXT_TO_TEXT_MAP_TYPE_IDENTIFIER = "MAP_TEXT_TO_TEXT_MAP"
+
+
+class MapDataType(DataType):
+    def __init__(
+        self,
+        internal_identifier: str,
+        type_name: str,
+        map_value_1: str,
+        map_value_2: str,
+        value_type_category: DataTypeCategory,
+    ):
+        super().__init__(
+            internal_identifier,
+            type_name,
+            DataTypeCategory.MAP,
+        )
+        self.map_value_1 = map_value_1
+        self.map_value_2 = map_value_2
+        self.value_type_category = value_type_category
+
+    def resolve_return_type_spec(
+        self, characteristics: set[ExpressionCharacteristics]
+    ) -> ReturnTypeSpec:
+        return MapReturnTypeSpec(map_value_type_category=self.value_type_category)
+
+
+def _map_entry(
+    key: str,
+    sql_value: str,
+) -> str:
+    return f"{key}=>{sql_value}"
+
+
+def as_sql_map_string(
+    sql_value_by_key: dict[str, str], omit_quotes: bool = False
+) -> str:
+    entries = []
+    for key, sql_value in sql_value_by_key.items():
+        entries.append(_map_entry(key, sql_value))
+    entries_str = ", ".join(entries)
+    entries_str = f"{{{entries_str}}}"
+
+    if not omit_quotes:
+        entries_str = f"'{entries_str}'"
+
+    return entries_str
+
+
+MAP_TEXT_TO_DOUBLE_TYPE = MapDataType(
+    MAP_TEXT_TO_DOUBLE_TYPE_IDENTIFIER,
+    "MAP[TEXT=>DOUBLE]",
+    map_value_1="0.0",
+    map_value_2="4.7",
+    value_type_category=DataTypeCategory.NUMERIC,
+)
+MAP_TEXT_TO_TIMESTAMPTZ_TYPE = MapDataType(
+    MAP_TEXT_TO_TIMESTAMPTZ_TYPE_IDENTIFIER,
+    "MAP[TEXT=>TIMESTAMPTZ]",
+    map_value_1="''2024-02-29 11:50:00 EST''",
+    map_value_2="''2024-03-31 01:20:00 Europe/Vienna''",
+    value_type_category=DataTypeCategory.DATE_TIME,
+)
+NESTED_MAP_TEXT_TO_TEXT_TEXT_TYPE = MapDataType(
+    MAP_TEXT_TO_TEXT_MAP_TYPE_IDENTIFIER,
+    "MAP[TEXT=>MAP[TEXT=>TEXT]]",
+    map_value_1=as_sql_map_string({"a": "10", "b": "20"}, omit_quotes=True),
+    map_value_2=as_sql_map_string({"a": "11", "b": "22"}, omit_quotes=True),
+    value_type_category=DataTypeCategory.MAP,
+)
+MAP_DATA_TYPES = [
+    MAP_TEXT_TO_DOUBLE_TYPE,
+    MAP_TEXT_TO_TIMESTAMPTZ_TYPE,
+    NESTED_MAP_TEXT_TO_TEXT_TEXT_TYPE,
+]

--- a/misc/python/materialize/output_consistency/input_data/values/all_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/all_values_provider.py
@@ -23,6 +23,9 @@ from materialize.output_consistency.input_data.values.date_time_values_provider 
 from materialize.output_consistency.input_data.values.jsonb_values_provider import (
     JSONB_DATA_TYPE_WITH_VALUES,
 )
+from materialize.output_consistency.input_data.values.map_values_provider import (
+    VALUES_PER_MAP_DATA_TYPE,
+)
 from materialize.output_consistency.input_data.values.number_values_provider import (
     VALUES_PER_NUMERIC_DATA_TYPE,
 )
@@ -38,5 +41,6 @@ ALL_DATA_TYPES_WITH_VALUES: list[DataTypeWithValues] = list(
         [BYTEA_DATA_TYPE_WITH_VALUES],
         [TEXT_DATA_TYPE_WITH_VALUES],
         [JSONB_DATA_TYPE_WITH_VALUES],
+        list(VALUES_PER_MAP_DATA_TYPE.values()),
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/values/map_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/map_values_provider.py
@@ -1,0 +1,61 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type_with_values import (
+    DataTypeWithValues,
+)
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.types.map_type_provider import (
+    MAP_DATA_TYPES,
+    MapDataType,
+    as_sql_map_string,
+)
+
+VALUES_PER_MAP_DATA_TYPE: dict[MapDataType, DataTypeWithValues] = dict()
+
+for map_data_type in MAP_DATA_TYPES:
+    values_of_type = DataTypeWithValues(map_data_type)
+    VALUES_PER_MAP_DATA_TYPE[map_data_type] = values_of_type
+
+    values_of_type.add_raw_value(
+        as_sql_map_string(
+            sql_value_by_key=dict(),
+        ),
+        "EMPTY",
+        {ExpressionCharacteristics.MAP_EMPTY},
+    )
+
+    # key values should be specified in MAP_FIELD_NAME_PARAM in misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
+    MAP_1_CONTENT = dict()
+    MAP_1_CONTENT["n"] = "NULL"
+    MAP_1_CONTENT["a"] = map_data_type.map_value_1
+    MAP_1_CONTENT["A"] = map_data_type.map_value_2
+    MAP_1_CONTENT["b"] = map_data_type.map_value_2
+
+    values_of_type.add_raw_value(
+        as_sql_map_string(
+            sql_value_by_key=MAP_1_CONTENT,
+        ),
+        "VAL",
+        set(),
+    )
+
+    MAP_W_DUP_KEYS_CONTENT = dict()
+    MAP_W_DUP_KEYS_CONTENT["a"] = map_data_type.map_value_1
+    MAP_W_DUP_KEYS_CONTENT["a"] = map_data_type.map_value_2
+
+    values_of_type.add_raw_value(
+        as_sql_map_string(
+            sql_value_by_key=MAP_W_DUP_KEYS_CONTENT,
+        ),
+        "DUP_KEYS",
+        {ExpressionCharacteristics.MAP_WITH_DUP_KEYS},
+    )

--- a/misc/python/materialize/output_consistency/operation/operation.py
+++ b/misc/python/materialize/output_consistency/operation/operation.py
@@ -130,6 +130,7 @@ class DbOperation(DbOperationOrFunction):
         is_enabled: bool = True,
         is_pg_compatible: bool = True,
         tags: set[str] | None = None,
+        since_mz_version: MzVersion | None = None,
     ):
         param_count = len(params)
         super().__init__(
@@ -143,6 +144,7 @@ class DbOperation(DbOperationOrFunction):
             is_enabled=is_enabled,
             is_pg_compatible=is_pg_compatible,
             tags=tags,
+            since_mz_version=since_mz_version,
         )
         self.pattern = pattern
 


### PR DESCRIPTION
Support maps in the output-consistency test framework and test the new map constructor (https://github.com/MaterializeInc/materialize/pull/27006) amongst other things.
This is based on https://github.com/MaterializeInc/materialize/pull/27082.

### Commits
014cac903a output consistency: support map type
d88426d2bd output consistency: add map operations
507f8f3bef output consistency: add new map constructor as operation
631ae9c859 postgres consistency: disable map type for Postgres (does not support maps)

### Nightly
https://buildkite.com/materialize/nightly/builds?branch=nrainer-materialize%3Aoutput-consistency%2Fmaps