### PR TITLE
test: adjust existing tests w/ correct semantics discovered by RTR

### DIFF
--- a/test/mysql-cdc/25-schema-changes.td
+++ b/test/mysql-cdc/25-schema-changes.td
@@ -45,6 +45,7 @@ INSERT INTO add_columns VALUES (2, 'ab');
 
 > SELECT * FROM add_columns;
 1
+2
 
 #
 # Now remove that added column
@@ -55,6 +56,7 @@ ALTER TABLE add_columns DROP COLUMN f2;
 
 > SELECT * FROM add_columns;
 1
+2
 
 > DROP SOURCE mz_source CASCADE;
 

--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -55,9 +55,8 @@ INSERT INTO table_a VALUES (9, 'nine');
 
 # Current table_a is not new table_a. Note that this only works right now
 # because we are bad at detecting dropped tables.
-> SELECT * FROM table_a;
-1 one
-2 two
+! SELECT * FROM table_a;
+contains:table was dropped
 
 # We are not aware that the new table_a is different
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_a;

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -296,6 +296,7 @@ INSERT INTO table_a VALUES (4, 'four');
 1
 2
 3
+4
 
 > DROP SOURCE table_a;
 > ALTER SOURCE mz_source ADD SUBSOURCE table_a;

--- a/test/pg-cdc/alter-table-after-source.td
+++ b/test/pg-cdc/alter-table-after-source.td
@@ -389,11 +389,10 @@ contains:altered
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 TRUNCATE truncate_table;
+INSERT INTO truncate_table VALUES (1, 1);
 
-# This should error but we use PG 10 in these tests, which doesn't
-# put truncate messages in the replication stream. #18518
-> SELECT * FROM truncate_table;
-1 1
+! SELECT * FROM truncate_table;
+contains:table was truncated
 
 #
 # Drop table

--- a/test/pg-cdc/truncate-table.td
+++ b/test/pg-cdc/truncate-table.td
@@ -48,5 +48,5 @@ TRUNCATE TABLE t1;
 #
 # See the Postgres docs for more information:
 # https://www.postgresql.org/docs/10/logical-replication-restrictions.html
-> SELECT * FROM t1;
-1
+! SELECT * FROM t1;
+contains:table was truncated


### PR DESCRIPTION
#25195 discovered some problems with the current tests––however, the problems were that the tests expected less-than-ideal/wrong results, rather than RTR introducing bugs in tests. 👌

Sending this as a separate commit both to prove that the uncovered issues are not with RTR, as well as fixing buggy tests now because I don't have a clear sense of when RTR will get merged.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
