### PR TITLE
storage/upsert: Use RocksDB merge operator during snapshot rehydration

### DIFF
--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -308,6 +308,10 @@ pub struct RocksDBInstance<K, V> {
 
     // Configuration that can change dynamically.
     dynamic_config: config::RocksDBDynamicConfig,
+
+    /// Whether this instance supports merge operations (whether a
+    /// merge operator was set at creation time)
+    pub supports_merges: bool,
 }
 
 impl<K, V> RocksDBInstance<K, V>
@@ -340,6 +344,7 @@ where
             + 'static,
     {
         let dynamic_config = tuning_config.dynamic.clone();
+        let supports_merges = options.merge_operator.is_some();
         if options.cleanup_on_new && instance_path.exists() {
             let instance_path_owned = instance_path.to_owned();
 
@@ -411,6 +416,7 @@ where
             multi_get_results_scratch: Vec::new(),
             multi_update_scratch: Vec::new(),
             dynamic_config,
+            supports_merges,
         })
     }
 

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -816,17 +816,8 @@ fn rocksdb_core_loop<K, V, M, O, IM, F>(
                                     ret.size_written += u64::cast_from(encode_buf.len());
                                     // calculate the diff size if the diff multiplier is present
                                     if let Some(diff) = diff {
-                                        let encoded_len = match i64::try_from(encode_buf.len()) {
-                                            Ok(len) => len,
-                                            Err(_) => {
-                                                let _ =
-                                                    response_sender.send(Err(Error::ValueError(
-                                                        "encoded value length too large"
-                                                            .to_string(),
-                                                    )));
-                                                return;
-                                            }
-                                        };
+                                        let encoded_len = i64::try_from(encode_buf.len())
+                                            .expect("less than i64 size");
                                         ret.size_diff =
                                             Some(ret.size_diff.unwrap_or(0) + (diff * encoded_len));
                                     }

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -77,9 +77,9 @@ async fn basic() -> Result<(), anyhow::Error> {
 
     instance
         .multi_update(vec![
-            ("one".to_string(), KeyUpdate::Put("onev".to_string())),
+            ("one".to_string(), KeyUpdate::Put("onev".to_string()), None),
             // Deleting a non-existent key shouldn't do anything
-            ("two".to_string(), KeyUpdate::Delete),
+            ("two".to_string(), KeyUpdate::Delete, None),
         ])
         .await?;
 
@@ -102,8 +102,8 @@ async fn basic() -> Result<(), anyhow::Error> {
     instance
         .multi_update(vec![
             // Double-writing a key should keep the last one.
-            ("two".to_string(), KeyUpdate::Put("twov1".to_string())),
-            ("two".to_string(), KeyUpdate::Put("twov2".to_string())),
+            ("two".to_string(), KeyUpdate::Put("twov1".to_string()), None),
+            ("two".to_string(), KeyUpdate::Put("twov2".to_string()), None),
         ])
         .await?;
 
@@ -174,7 +174,7 @@ async fn associative_merge_operator_test() -> Result<(), anyhow::Error> {
             .multi_update(
                 merges
                     .into_iter()
-                    .map(|v| (key.clone(), KeyUpdate::Merge(v))),
+                    .map(|v| (key.clone(), KeyUpdate::Merge(v), Some(1))),
             )
             .await?;
     }
@@ -201,14 +201,14 @@ async fn associative_merge_operator_test() -> Result<(), anyhow::Error> {
             .multi_update(
                 merges
                     .into_iter()
-                    .map(|v| (key.clone(), KeyUpdate::Merge(v))),
+                    .map(|v| (key.clone(), KeyUpdate::Merge(v), Some(1))),
             )
             .await?;
 
         if i % 7 == 0 {
             rolling_sum += 3;
             instance
-                .multi_update(vec![(key.clone(), KeyUpdate::Put(rolling_sum))])
+                .multi_update(vec![(key.clone(), KeyUpdate::Put(rolling_sum), None)])
                 .await?;
         }
     }
@@ -234,7 +234,7 @@ async fn associative_merge_operator_test() -> Result<(), anyhow::Error> {
             .multi_update(
                 merges
                     .into_iter()
-                    .map(|v| (key.clone(), KeyUpdate::Merge(v))),
+                    .map(|v| (key.clone(), KeyUpdate::Merge(v), Some(1))),
             )
             .await?;
 
@@ -251,6 +251,56 @@ async fn associative_merge_operator_test() -> Result<(), anyhow::Error> {
             .map(|v| v.map(|v| v.value))
             .collect::<Vec<_>>(),
         vec![Some(rolling_sum)]
+    );
+
+    instance.close().await?;
+
+    Ok(())
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `rocksdb_create_default_env` on OS `linux`
+async fn update_operation_stats_test() -> Result<(), anyhow::Error> {
+    // If the test aborts, this may not be cleaned up.
+    let t = tempfile::tempdir()?;
+
+    let mut instance = RocksDBInstance::<String, String>::new(
+        t.path().join("5").as_path(),
+        InstanceOptions::<bincode::DefaultOptions, String, StubMergeOperator<String>>::new(
+            rocksdb::Env::new()?,
+            2,
+            None,
+            bincode::DefaultOptions::new(),
+        ),
+        RocksDBConfig::new(Default::default(), None),
+        shared_metrics_for_tests()?,
+        instance_metrics_for_tests()?,
+    )
+    .await?;
+
+    let stats = instance
+        .multi_update(vec![
+            (
+                "two".to_string(),
+                KeyUpdate::Put("twov1".to_string()),
+                Some(1),
+            ),
+            (
+                "two".to_string(),
+                KeyUpdate::Put("twov1".to_string()),
+                Some(-1),
+            ),
+            (
+                "two".to_string(),
+                KeyUpdate::Put("twov2".to_string()),
+                Some(1),
+            ),
+        ])
+        .await?;
+    assert_eq!(stats.processed_updates, 3);
+    assert_eq!(
+        i64::try_from(stats.size_written).unwrap(),
+        3 * stats.size_diff.unwrap()
     );
 
     instance.close().await?;

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -136,13 +136,13 @@ async fn associative_merge_operator_test() -> Result<(), anyhow::Error> {
 
     // A simple merge operator that adds all merge values to the existing key
     // value, if any.
-    fn merge(_key: &[u8], operands: ValueIterator<bincode::DefaultOptions, u32>) -> Option<u32> {
+    fn merge(_key: &[u8], operands: ValueIterator<bincode::DefaultOptions, u32>) -> u32 {
         let mut val = 0;
 
         for op in operands {
             val += op;
         }
-        Some(val)
+        val
     }
 
     let static_options = InstanceOptions::new(

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -77,6 +77,13 @@ pub const STORAGE_UPSERT_PREVENT_SNAPSHOT_BUFFERING: Config<bool> = Config::new(
     "Prevent snapshot buffering in upsert.",
 );
 
+/// Whether to enable the merge operator in upsert for the RocksDB backend.
+pub const STORAGE_ROCKSDB_USE_MERGE_OPERATOR: Config<bool> = Config::new(
+    "storage_rocksdb_use_merge_operator",
+    false,
+    "Use the native rocksdb merge operator where possible.",
+);
+
 /// If `storage_upsert_prevent_snapshot_buffering` is true, this prevents the upsert
 /// operator from buffering too many events from the upstream snapshot. In the absence
 /// of hydration flow control, this could prevent certain workloads from causing egregiously
@@ -102,6 +109,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&KAFKA_CLIENT_ID_ENRICHMENT_RULES)
         .add(&ENFORCE_EXTERNAL_ADDRESSES)
         .add(&STORAGE_UPSERT_PREVENT_SNAPSHOT_BUFFERING)
+        .add(&STORAGE_ROCKSDB_USE_MERGE_OPERATOR)
         .add(&STORAGE_UPSERT_MAX_SNAPSHOT_BATCH_BUFFERING)
         .add(&STORAGE_ROCKSDB_CLEANUP_TRIES)
 }

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -538,7 +538,7 @@ async fn drain_staged_input<S, G, T, FromTime, E>(
     // implementations, and reduces the number of reads and write we need to do.
     //
     // This "mini-upsert" technique is actually useful in `UpsertState`'s
-    // `consolidate_snapshot_chunk` implementation, minimizing gets and puts on
+    // `consolidate_snapshot_read_write_inner` implementation, minimizing gets and puts on
     // the `UpsertStateBackend` implementations. In some sense, its "upsert all the way down".
     while let Some((ts, key, from_time, value)) = commands.next() {
         let mut command_state = if let Entry::Occupied(command_state) = commands_state.entry(key) {

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -268,6 +268,7 @@ where
         tracing::info!(
             ?tuning,
             ?storage_configuration.parameters.upsert_auto_spill_config,
+            ?rocksdb_use_native_merge_operator,
             "timely-{} rendering {} with rocksdb-backed upsert state",
             source_config.worker_id,
             source_config.id

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -19,7 +19,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use super::memory::InMemoryHashMap;
 use super::rocksdb::RocksDB;
 use super::types::{
-    GetStats, MergeStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
+    GetStats, MergeStats, MergeValue, PutStats, PutValue, StateValue, UpsertStateBackend,
+    UpsertValueAndSize,
 };
 use super::UpsertKey;
 
@@ -122,7 +123,7 @@ where
 
     async fn multi_merge<M>(&mut self, merges: M) -> Result<MergeStats, anyhow::Error>
     where
-        M: IntoIterator<Item = (UpsertKey, StateValue<O>)>,
+        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<O>>)>,
     {
         match &mut self.backend_type {
             BackendType::InMemory(_) => {

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -10,11 +10,9 @@
 //! An `UpsertStateBackend` that starts in memory and spills to RocksDB
 //! when the total size passes some threshold.
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use mz_ore::metrics::DeleteOnDropGauge;
-use mz_rocksdb::RocksDBConfig;
 use prometheus::core::AtomicU64;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -23,36 +21,28 @@ use super::rocksdb::RocksDB;
 use super::types::{
     GetStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
 };
-use super::upsert_bincode_opts;
 use super::UpsertKey;
 
 pub enum BackendType<O> {
     InMemory(InMemoryHashMap<O>),
     RocksDb(RocksDB<O>),
 }
-/// Params required to create rocksdb instance
-pub(crate) struct RocksDBParams {
-    pub(crate) instance_path: PathBuf,
-    pub(crate) env: rocksdb::Env,
-    pub(crate) tuning_config: RocksDBConfig,
-    pub(crate) shared_metrics: Arc<mz_rocksdb::RocksDBSharedMetrics>,
-    pub(crate) instance_metrics: Arc<mz_rocksdb::RocksDBInstanceMetrics>,
-    pub(crate) cleanup_tries: usize,
-}
 
-pub struct AutoSpillBackend<O> {
+pub struct AutoSpillBackend<O, F> {
     backend_type: BackendType<O>,
-    rockdsdb_params: RocksDBParams,
     auto_spill_threshold_bytes: usize,
     rocksdb_autospill_in_use: Arc<DeleteOnDropGauge<'static, AtomicU64, Vec<String>>>,
+    rocksdb_init_fn: Option<F>,
 }
 
-impl<O> AutoSpillBackend<O>
+impl<O, F, Fut> AutoSpillBackend<O, F>
 where
     O: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
+    F: FnOnce() -> Fut + 'static,
+    Fut: std::future::Future<Output = RocksDB<O>>,
 {
     pub(crate) fn new(
-        rockdsdb_params: RocksDBParams,
+        rocksdb_init_fn: F,
         auto_spill_threshold_bytes: usize,
         rocksdb_autospill_in_use: Arc<DeleteOnDropGauge<'static, AtomicU64, Vec<String>>>,
     ) -> Self {
@@ -60,46 +50,19 @@ where
         rocksdb_autospill_in_use.set(0);
         Self {
             backend_type: BackendType::InMemory(InMemoryHashMap::default()),
-            rockdsdb_params,
+            rocksdb_init_fn: Some(rocksdb_init_fn),
             auto_spill_threshold_bytes,
             rocksdb_autospill_in_use,
         }
     }
-
-    async fn init_rocksdb(rocksdb_params: &RocksDBParams) -> RocksDB<O> {
-        let RocksDBParams {
-            instance_path,
-            env,
-            tuning_config,
-            shared_metrics,
-            instance_metrics,
-            cleanup_tries,
-        } = rocksdb_params;
-        tracing::info!("spilling to disk for upsert at {:?}", instance_path);
-
-        RocksDB::new(
-            mz_rocksdb::RocksDBInstance::new(
-                instance_path,
-                mz_rocksdb::InstanceOptions::<_, _, mz_rocksdb::StubMergeOperator<_>>::new(
-                    env.clone(),
-                    *cleanup_tries,
-                    None,
-                    upsert_bincode_opts(),
-                ),
-                tuning_config.clone(),
-                Arc::clone(shared_metrics),
-                Arc::clone(instance_metrics),
-            )
-            .await
-            .unwrap(),
-        )
-    }
 }
 
 #[async_trait::async_trait(?Send)]
-impl<O> UpsertStateBackend<O> for AutoSpillBackend<O>
+impl<O, F, Fut> UpsertStateBackend<O> for AutoSpillBackend<O, F>
 where
     O: Clone + Send + Sync + Serialize + DeserializeOwned + 'static,
+    F: FnOnce() -> Fut + 'static,
+    Fut: std::future::Future<Output = RocksDB<O>>,
 {
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
@@ -115,8 +78,13 @@ where
                     .try_into()
                     .expect("unexpected error while casting");
                 if in_memory_size > self.auto_spill_threshold_bytes {
+                    tracing::info!("spilling to disk for upsert");
+
                     let mut rocksdb_backend =
-                        AutoSpillBackend::init_rocksdb(&self.rockdsdb_params).await;
+                        self.rocksdb_init_fn
+                            .take()
+                            .expect("Can only initialize once")()
+                        .await;
 
                     let (last_known_size, new_puts) = map.drain();
                     let new_puts = new_puts.map(|(k, v)| {

--- a/src/storage/src/upsert/autospill.rs
+++ b/src/storage/src/upsert/autospill.rs
@@ -19,7 +19,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use super::memory::InMemoryHashMap;
 use super::rocksdb::RocksDB;
 use super::types::{
-    GetStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
+    GetStats, MergeStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
 };
 use super::UpsertKey;
 
@@ -120,7 +120,7 @@ where
         }
     }
 
-    async fn multi_merge<M>(&mut self, merges: M) -> Result<PutStats, anyhow::Error>
+    async fn multi_merge<M>(&mut self, merges: M) -> Result<MergeStats, anyhow::Error>
     where
         M: IntoIterator<Item = (UpsertKey, StateValue<O>)>,
     {

--- a/src/storage/src/upsert/memory.rs
+++ b/src/storage/src/upsert/memory.rs
@@ -20,7 +20,8 @@ use std::collections::HashMap;
 use itertools::Itertools;
 
 use super::types::{
-    GetStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize, ValueMetadata,
+    GetStats, MergeStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
+    ValueMetadata,
 };
 use super::UpsertKey;
 
@@ -86,7 +87,7 @@ where
         Ok(stats)
     }
 
-    async fn multi_merge<M>(&mut self, _merges: M) -> Result<PutStats, anyhow::Error>
+    async fn multi_merge<M>(&mut self, _merges: M) -> Result<MergeStats, anyhow::Error>
     where
         M: IntoIterator<Item = (UpsertKey, StateValue<O>)>,
     {

--- a/src/storage/src/upsert/memory.rs
+++ b/src/storage/src/upsert/memory.rs
@@ -59,6 +59,10 @@ impl<O> UpsertStateBackend<O> for InMemoryHashMap<O>
 where
     O: Clone + 'static,
 {
+    fn supports_merge(&self) -> bool {
+        false
+    }
+
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
         P: IntoIterator<Item = (UpsertKey, PutValue<StateValue<O>>)>,
@@ -80,6 +84,13 @@ where
         }
         self.total_size += stats.size_diff;
         Ok(stats)
+    }
+
+    async fn multi_merge<M>(&mut self, _merges: M) -> Result<PutStats, anyhow::Error>
+    where
+        M: IntoIterator<Item = (UpsertKey, StateValue<O>)>,
+    {
+        anyhow::bail!("InMemoryHashMap does not support merging");
     }
 
     async fn multi_get<'r, G, R>(

--- a/src/storage/src/upsert/memory.rs
+++ b/src/storage/src/upsert/memory.rs
@@ -20,8 +20,8 @@ use std::collections::HashMap;
 use itertools::Itertools;
 
 use super::types::{
-    GetStats, MergeStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
-    ValueMetadata,
+    GetStats, MergeStats, MergeValue, PutStats, PutValue, StateValue, UpsertStateBackend,
+    UpsertValueAndSize, ValueMetadata,
 };
 use super::UpsertKey;
 
@@ -89,7 +89,7 @@ where
 
     async fn multi_merge<M>(&mut self, _merges: M) -> Result<MergeStats, anyhow::Error>
     where
-        M: IntoIterator<Item = (UpsertKey, StateValue<O>)>,
+        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<O>>)>,
     {
         anyhow::bail!("InMemoryHashMap does not support merging");
     }

--- a/src/storage/src/upsert/rocksdb.rs
+++ b/src/storage/src/upsert/rocksdb.rs
@@ -13,8 +13,8 @@ use mz_rocksdb::{KeyUpdate, RocksDBInstance};
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::types::{
-    GetStats, MergeStats, PutStats, PutValue, StateValue, UpsertStateBackend, UpsertValueAndSize,
-    ValueMetadata,
+    GetStats, MergeStats, MergeValue, PutStats, PutValue, StateValue, UpsertStateBackend,
+    UpsertValueAndSize, ValueMetadata,
 };
 use super::UpsertKey;
 
@@ -59,7 +59,7 @@ where
                         Some(v) => KeyUpdate::Put(v),
                         None => KeyUpdate::Delete,
                     };
-                    (k, value)
+                    (k, value, None)
                 },
             ))
             .await?;
@@ -72,15 +72,20 @@ where
 
     async fn multi_merge<M>(&mut self, merges: M) -> Result<MergeStats, anyhow::Error>
     where
-        M: IntoIterator<Item = (UpsertKey, StateValue<O>)>,
+        M: IntoIterator<Item = (UpsertKey, MergeValue<StateValue<O>>)>,
     {
         let mut m_stats = MergeStats::default();
-        let stats = self
-            .rocksdb
-            .multi_update(merges.into_iter().map(|(k, v)| (k, KeyUpdate::Merge(v))))
-            .await?;
+        let stats =
+            self.rocksdb
+                .multi_update(merges.into_iter().map(|(k, MergeValue { value, diff })| {
+                    (k, KeyUpdate::Merge(value), Some(diff))
+                }))
+                .await?;
         m_stats.written_merge_operands += stats.processed_updates;
         m_stats.size_written += stats.size_written;
+        if let Some(diff) = stats.size_diff {
+            m_stats.size_diff += diff;
+        }
         Ok(m_stats)
     }
 

--- a/src/storage/src/upsert/rocksdb.rs
+++ b/src/storage/src/upsert/rocksdb.rs
@@ -34,6 +34,10 @@ impl<O> UpsertStateBackend<O> for RocksDB<O>
 where
     O: Send + Sync + Serialize + DeserializeOwned + 'static,
 {
+    fn supports_merge(&self) -> bool {
+        self.rocksdb.supports_merges
+    }
+
     // TODO: Refactor this to allow using using Merge instead of Put for updates.
     async fn multi_put<P>(&mut self, puts: P) -> Result<PutStats, anyhow::Error>
     where
@@ -64,6 +68,14 @@ where
         p_stats.size_diff += size;
 
         Ok(p_stats)
+    }
+
+    async fn multi_merge<M>(&mut self, _merges: M) -> Result<PutStats, anyhow::Error>
+    where
+        M: IntoIterator<Item = (UpsertKey, StateValue<O>)>,
+    {
+        // TODO: Implement
+        Ok(PutStats::default())
     }
 
     async fn multi_get<'r, G, R>(

--- a/src/storage/src/upsert/types.rs
+++ b/src/storage/src/upsert/types.rs
@@ -963,6 +963,9 @@ where
                     // This is a bit misleading as this represents the eventual state after the
                     // `snapshot_merge_function` has been called to merge all the updates,
                     // and not the state after this `multi_merge` call.
+                    //
+                    // This does not accurately report values that have been consolidated to diff == 0, as tracking that
+                    // per-key is extremely difficult.
                     stats.values_diff += diff;
 
                     (k, MergeValue { value: val, diff })

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -188,6 +188,37 @@ def workflow_rehydration(c: Composition) -> None:
             ),
         ),
         (
+            "with DISK and RocksDB Merge Operator",
+            Materialized(
+                options=[
+                    "--orchestrator-process-scratch-directory=/scratch",
+                ],
+                additional_system_parameter_defaults={
+                    "enable_unorchestrated_cluster_replicas": "true",
+                    "disk_cluster_replicas_default": "true",
+                    "enable_disk_cluster_replicas": "true",
+                    # Force backpressure to be enabled.
+                    "storage_dataflow_max_inflight_bytes": "1",
+                    "storage_dataflow_max_inflight_bytes_to_cluster_size_fraction": "0.01",
+                    "storage_dataflow_max_inflight_bytes_disk_only": "false",
+                    "storage_dataflow_delay_sources_past_rehydration": "true",
+                    # Enabling shrinking buffers
+                    "upsert_rocksdb_shrink_allocated_buffers_by_ratio": "4",
+                    "storage_shrink_upsert_unused_buffers_by_ratio": "4",
+                    # Enable the RocksDB merge operator
+                    "storage_rocksdb_use_merge_operator": "true",
+                },
+                environment_extra=materialized_environment_extra,
+            ),
+            Clusterd(
+                name="clusterd1",
+                options=[
+                    "--scratch-directory=/scratch",
+                    "--announce-memory-limit=1048376000",  # 1GiB
+                ],
+            ),
+        ),
+        (
             "without DISK",
             Materialized(
                 options=[


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/26003


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer


The diff isn't huge to review all as one, but you can also review commit-by-commit to understand the semantic changes if that's easier.

I also need to do some performance testing on staging to compare both rehydration methods.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
