### PR TITLE
docs: add note that superuser are privileges required for `ALTER SYSTEM SET` and `ALTER SYSTEM RESET`

### DIFF
--- a/doc/user/content/sql/alter-system-reset.md
+++ b/doc/user/content/sql/alter-system-reset.md
@@ -22,6 +22,11 @@ _name_ | The configuration parameter's name.
 
 {{% configuration-parameters %}}
 
+## Privileges
+
+[_Superuser_ privileges](/manage/access-control/#account-management) are required to execute
+this statement.
+
 ## Examples
 
 ### Reset enable RBAC

--- a/doc/user/content/sql/alter-system-set.md
+++ b/doc/user/content/sql/alter-system-set.md
@@ -23,6 +23,11 @@ _value_                 | The value to assign to the configuration parameter.
 
 {{% configuration-parameters %}}
 
+## Privileges
+
+[_Superuser_ privileges](/manage/access-control/#account-management) are required to execute
+this statement.
+
 ## Examples
 
 ### Enable RBAC


### PR DESCRIPTION
Context: slack thread https://materializeinc.slack.com/archives/CU7ELJ6E9/p1715623121851309

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
