### PR TITLE
ci: increase timeout of slow cloudtests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1488,7 +1488,7 @@ steps:
   - id: cloudtest-slow
     label: "Slow Cloudtest"
     depends_on: build-aarch64
-    timeout_in_minutes: 35
+    timeout_in_minutes: 45
     env:
       CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
     agents:


### PR DESCRIPTION
Increase timeout again.

Recent timeout: https://buildkite.com/materialize/nightly/builds/7756#018f734a-8a57-4636-93f9-9b0d586918ce