### PR TITLE
 adapter,tests: make test_session_linearizability resistant to slow propagation of source uppers

### DIFF
--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -1173,7 +1173,7 @@ pub async fn create_postgres_source_with_table<'a>(
     )
 }
 
-pub async fn wait_for_view_population(mz_client: &Client, view_name: &str, source_rows: i64) {
+pub async fn wait_for_pg_table_population(mz_client: &Client, view_name: &str, source_rows: i64) {
     let current_isolation = mz_client
         .query_one("SHOW transaction_isolation", &[])
         .await


### PR DESCRIPTION
I discovered this with my PR that adds more concurrency to the controllers, where upper updates can sometimes be delayed. But it's a potential problem already today, where upper updates from sources can also be delayed.

The first commit is renaming and clearing up some things. The second commit is the actual fix.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
