### PR TITLE
tests,scalability: wait for indexes to be hydrated

### DIFF
--- a/misc/python/materialize/scalability/schema.py
+++ b/misc/python/materialize/scalability/schema.py
@@ -55,9 +55,16 @@ class Schema:
                     ]
                 )
 
+                # Create indexes and wait until they are queryable. Compute can
+                # delay execution of dataflows when inputs are not yet
+                # available. This would lead to a large outlier on the first
+                # query of the actual workload, when it has to wait for the
+                # index to be ready.
                 if self.create_index:
                     init_sqls.append(f"CREATE INDEX i{t} ON t{t} (f1);")
                     init_sqls.append(f"CREATE INDEX mv_i{t} ON mv{t} (count);")
+                    init_sqls.append(f"SELECT f1 from t{t};")
+                    init_sqls.append(f"SELECT count from mv{t};")
 
         return init_sqls
 


### PR DESCRIPTION
Please see comments in the code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
