### PR TITLE
[dnm] persist: Set stats audit to 100% for arrow-rs refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,6 @@ dependencies = [
  "futures",
  "getrandom",
  "hash_hasher",
- "multiversion",
  "num-traits",
  "parquet2",
  "rustc_version",
@@ -3776,26 +3775,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "multiversion"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025c962a3dd3cc5e0e520aa9c612201d127dcdf28616974961a649dca64f5373"
-dependencies = [
- "multiversion-macros",
-]
-
-[[package]]
-name = "multiversion-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a3e2bde382ebf960c1f3e79689fa5941625fe9bf694a1cb64af3e85faff3af"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "mysql_async"
 version = "0.34.1"
 source = "git+https://github.com/MaterializeInc/mysql_async?rev=6afd2136181f2ec93b7ca7de524f6d02b6f10c1d#6afd2136181f2ec93b7ca7de524f6d02b6f10c1d"
@@ -5459,14 +5438,14 @@ name = "mz-persist-types"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "arrow2",
+ "arrow",
  "bytes",
  "chrono",
  "hex",
  "mz-build-tools",
  "mz-ore",
  "mz-proto",
- "parquet2",
+ "parquet",
  "proptest",
  "proptest-derive",
  "prost",
@@ -5764,6 +5743,7 @@ name = "mz-repr"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arrow",
  "bitflags 1.3.2",
  "bytes",
  "cfg-if",

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -28,7 +28,7 @@ use crate::ShardId;
 /// Percent of filtered data to opt in to correctness auditing.
 pub(crate) const STATS_AUDIT_PERCENT: Config<usize> = Config::new(
     "persist_stats_audit_percent",
-    0,
+    100,
     "Percent of filtered data to opt in to correctness auditing (Materialize).",
 );
 

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -13,13 +13,13 @@ workspace = true
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-arrow2 = { version = "0.16.0", features = ["compute_aggregate", "io_ipc", "io_parquet"] }
+arrow = { version = "51.0.0", default-features = false }
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 hex = "0.4.3"
 mz-ore = { path = "../ore", features = ["metrics", "test"], default-features = false }
 mz-proto = { path = "../proto", default-features = false }
-parquet2 = { version = "0.17.1", default-features = false }
+parquet = { version = "51.0.0", default-features = false, features = ["arrow"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -13,22 +13,22 @@ use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use arrow2::array::{
-    Array, BinaryArray, BooleanArray, MutableArray, MutableBinaryArray, MutableBooleanArray,
-    MutablePrimitiveArray, MutableUtf8Array, PrimitiveArray, Utf8Array,
+use arrow::array::{
+    Array, BinaryArray, BinaryBuilder, BooleanArray, BooleanBufferBuilder, BooleanBuilder,
+    PrimitiveArray, PrimitiveBuilder, StringArray, StringBuilder,
 };
-use arrow2::bitmap::{Bitmap, MutableBitmap};
-use arrow2::buffer::Buffer;
-use arrow2::datatypes::DataType as ArrowLogicalType;
-use arrow2::io::parquet::write::Encoding;
-use arrow2::types::NativeType;
+use arrow::buffer::BooleanBuffer;
+use arrow::datatypes::{
+    Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
+    UInt64Type, UInt8Type,
+};
 use bytes::BufMut;
 use timely::order::Product;
 
-use crate::columnar::sealed::ColumnRef;
+use crate::columnar::sealed::{ColumnMut, ColumnRef};
 use crate::columnar::{
-    ColumnCfg, ColumnFormat, ColumnGet, ColumnPush, Data, DataType, OpaqueData, PartDecoder,
-    PartEncoder, Schema,
+    ColumnCfg, ColumnFinish, ColumnFormat, ColumnGet, ColumnPush, Data, DataType, OpaqueData,
+    PartDecoder, PartEncoder, Schema,
 };
 use crate::dyn_col::DynColumnMut;
 use crate::dyn_struct::{
@@ -393,8 +393,8 @@ impl Opaque for i64 {
 impl Data for bool {
     type Cfg = ();
     type Ref<'a> = bool;
-    type Col = Bitmap;
-    type Mut = MutableBitmap;
+    type Col = BooleanBuffer;
+    type Mut = BooleanBufferBuilder;
     type Stats = PrimitiveStats<bool>;
 }
 
@@ -411,7 +411,7 @@ impl Data for Option<bool> {
     type Cfg = ();
     type Ref<'a> = Option<bool>;
     type Col = BooleanArray;
-    type Mut = MutableBooleanArray;
+    type Mut = BooleanBuilder;
     type Stats = OptionStats<PrimitiveStats<bool>>;
 }
 
@@ -425,12 +425,12 @@ impl ColumnCfg<Option<bool>> for () {
 }
 
 macro_rules! data_primitive {
-    ($data:ident, $format:expr) => {
+    ($data:ident, $arrow_type:ident, $format:expr) => {
         impl Data for $data {
             type Cfg = ();
             type Ref<'a> = $data;
-            type Col = Buffer<$data>;
-            type Mut = Vec<$data>;
+            type Col = PrimitiveArray<$arrow_type>;
+            type Mut = PrimitiveBuilder<$arrow_type>;
             type Stats = PrimitiveStats<$data>;
         }
 
@@ -446,8 +446,8 @@ macro_rules! data_primitive {
         impl Data for Option<$data> {
             type Cfg = ();
             type Ref<'a> = Option<$data>;
-            type Col = PrimitiveArray<$data>;
-            type Mut = MutablePrimitiveArray<$data>;
+            type Col = PrimitiveArray<$arrow_type>;
+            type Mut = PrimitiveBuilder<$arrow_type>;
             type Stats = OptionStats<PrimitiveStats<$data>>;
         }
 
@@ -462,23 +462,23 @@ macro_rules! data_primitive {
     };
 }
 
-data_primitive!(u8, ColumnFormat::U8);
-data_primitive!(u16, ColumnFormat::U16);
-data_primitive!(u32, ColumnFormat::U32);
-data_primitive!(u64, ColumnFormat::U64);
-data_primitive!(i8, ColumnFormat::I8);
-data_primitive!(i16, ColumnFormat::I16);
-data_primitive!(i32, ColumnFormat::I32);
-data_primitive!(i64, ColumnFormat::I64);
-data_primitive!(f32, ColumnFormat::F32);
-data_primitive!(f64, ColumnFormat::F64);
+data_primitive!(u8, UInt8Type, ColumnFormat::U8);
+data_primitive!(u16, UInt16Type, ColumnFormat::U16);
+data_primitive!(u32, UInt32Type, ColumnFormat::U32);
+data_primitive!(u64, UInt64Type, ColumnFormat::U64);
+data_primitive!(i8, Int8Type, ColumnFormat::I8);
+data_primitive!(i16, Int16Type, ColumnFormat::I16);
+data_primitive!(i32, Int32Type, ColumnFormat::I32);
+data_primitive!(i64, Int64Type, ColumnFormat::I64);
+data_primitive!(f32, Float32Type, ColumnFormat::F32);
+data_primitive!(f64, Float64Type, ColumnFormat::F64);
 
 impl Data for Vec<u8> {
     type Cfg = ();
     type Ref<'a> = &'a [u8];
     // TODO: Something that more obviously isn't optional.
-    type Col = BinaryArray<i32>;
-    type Mut = MutableBinaryArray<i32>;
+    type Col = BinaryArray;
+    type Mut = BinaryBuilder;
     type Stats = BytesStats;
 }
 
@@ -494,8 +494,8 @@ impl ColumnCfg<Vec<u8>> for () {
 impl Data for Option<Vec<u8>> {
     type Cfg = ();
     type Ref<'a> = Option<&'a [u8]>;
-    type Col = BinaryArray<i32>;
-    type Mut = MutableBinaryArray<i32>;
+    type Col = BinaryArray;
+    type Mut = BinaryBuilder;
     type Stats = OptionStats<BytesStats>;
 }
 
@@ -512,8 +512,8 @@ impl Data for String {
     type Cfg = ();
     type Ref<'a> = &'a str;
     // TODO: Something that more obviously isn't optional.
-    type Col = Utf8Array<i32>;
-    type Mut = MutableUtf8Array<i32>;
+    type Col = StringArray;
+    type Mut = StringBuilder;
     type Stats = PrimitiveStats<String>;
 }
 
@@ -529,8 +529,8 @@ impl ColumnCfg<String> for () {
 impl Data for Option<String> {
     type Cfg = ();
     type Ref<'a> = Option<&'a str>;
-    type Col = Utf8Array<i32>;
-    type Mut = MutableUtf8Array<i32>;
+    type Col = StringArray;
+    type Mut = StringBuilder;
     type Stats = OptionStats<PrimitiveStats<String>>;
 }
 
@@ -580,8 +580,8 @@ impl ColumnCfg<Option<DynStruct>> for DynStructCfg {
 impl Data for OpaqueData {
     type Cfg = ();
     type Ref<'a> = &'a [u8];
-    type Col = BinaryArray<i32>;
-    type Mut = MutableBinaryArray<i32>;
+    type Col = BinaryArray;
+    type Mut = BinaryBuilder;
     type Stats = NoneStats;
 }
 
@@ -597,8 +597,8 @@ impl ColumnCfg<OpaqueData> for () {
 impl Data for Option<OpaqueData> {
     type Cfg = ();
     type Ref<'a> = Option<&'a [u8]>;
-    type Col = BinaryArray<i32>;
-    type Mut = MutableBinaryArray<i32>;
+    type Col = BinaryArray;
+    type Mut = BinaryBuilder;
     type Stats = OptionStats<NoneStats>;
 }
 
@@ -611,38 +611,58 @@ impl ColumnCfg<Option<OpaqueData>> for () {
     }
 }
 
-impl ColumnRef<()> for Bitmap {
+impl ColumnRef<()> for BooleanBuffer {
     fn cfg(&self) -> &() {
         &()
     }
+
     fn len(&self) -> usize {
         self.len()
     }
-    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-        let array = BooleanArray::new(ArrowLogicalType::Boolean, self.clone(), None);
-        (Encoding::Plain, Box::new(array))
+
+    fn to_arrow(&self) -> Arc<dyn Array> {
+        Arc::new(BooleanArray::new(self.clone(), None))
     }
-    fn from_arrow(_cfg: &(), array: &Box<dyn Array>) -> Result<Self, String> {
+
+    fn from_arrow(_cfg: &(), array: &dyn Array) -> Result<Self, String> {
         let array = array
             .as_any()
             .downcast_ref::<BooleanArray>()
             .ok_or_else(|| format!("expected BooleanArray but was {:?}", array.data_type()))?;
-        if array.validity().is_some() {
+        if array.logical_nulls().is_some() {
             return Err("unexpected validity for non-optional bool".to_owned());
         }
+
         Ok(array.values().clone())
     }
 }
 
-impl ColumnGet<bool> for Bitmap {
+impl ColumnGet<bool> for BooleanBuffer {
     fn get<'a>(&'a self, idx: usize) -> bool {
-        self.get_bit(idx)
+        self.value(idx)
     }
 }
 
-impl ColumnPush<bool> for MutableBitmap {
+impl ColumnPush<bool> for BooleanBufferBuilder {
     fn push<'a>(&mut self, val: bool) {
-        <MutableBitmap>::push(self, val)
+        <BooleanBufferBuilder>::append(self, val)
+    }
+}
+
+impl ColumnFinish<bool> for BooleanBufferBuilder {
+    fn finish(mut self) -> <bool as Data>::Col {
+        <BooleanBufferBuilder>::finish(&mut self)
+    }
+}
+
+impl ColumnMut<()> for BooleanBufferBuilder {
+    fn new(_cfg: &()) -> Self {
+        // Note(parkmycar): This capacity was picked arbitrarily.
+        BooleanBufferBuilder::new(128)
+    }
+
+    fn cfg(&self) -> &() {
+        &()
     }
 }
 
@@ -650,13 +670,16 @@ impl ColumnRef<()> for BooleanArray {
     fn cfg(&self) -> &() {
         &()
     }
+
     fn len(&self) -> usize {
         self.len()
     }
-    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-        (Encoding::Plain, Box::new(self.clone()))
+
+    fn to_arrow(&self) -> Arc<dyn Array> {
+        Arc::new(self.clone())
     }
-    fn from_arrow(_cfg: &(), array: &Box<dyn Array>) -> Result<Self, String> {
+
+    fn from_arrow(_cfg: &(), array: &dyn Array) -> Result<Self, String> {
         let array = array
             .as_any()
             .downcast_ref::<BooleanArray>()
@@ -667,7 +690,10 @@ impl ColumnRef<()> for BooleanArray {
 
 impl ColumnGet<Option<bool>> for BooleanArray {
     fn get<'a>(&'a self, idx: usize) -> Option<bool> {
-        if self.validity().map_or(true, |x| x.get_bit(idx)) {
+        if self
+            .logical_nulls()
+            .map_or(true, |nulls| nulls.is_valid(idx))
+        {
             Some(self.value(idx))
         } else {
             None
@@ -675,86 +701,83 @@ impl ColumnGet<Option<bool>> for BooleanArray {
     }
 }
 
-impl ColumnPush<Option<bool>> for MutableBooleanArray {
+impl ColumnMut<()> for BooleanBuilder {
+    fn new(_cfg: &()) -> Self {
+        BooleanBuilder::default()
+    }
+
+    fn cfg(&self) -> &() {
+        &()
+    }
+}
+
+impl ColumnFinish<Option<bool>> for BooleanBuilder {
+    fn finish(mut self) -> <Option<bool> as Data>::Col {
+        <BooleanBuilder>::finish(&mut self)
+    }
+}
+
+impl ColumnPush<Option<bool>> for BooleanBuilder {
     fn push<'a>(&mut self, val: Option<bool>) {
-        <MutableBooleanArray>::push(self, val)
+        <BooleanBuilder>::append_option(self, val)
     }
 }
 
 macro_rules! arrowable_primitive {
-    ($data:ident, $encoding:expr) => {
-        impl ColumnRef<()> for Buffer<$data> {
-            fn cfg(&self) -> &() {
-                &()
-            }
-            fn len(&self) -> usize {
-                self.len()
-            }
-            fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-                let array = PrimitiveArray::new($data::PRIMITIVE.into(), self.clone(), None);
-                ($encoding, Box::new(array.clone()))
-            }
-            fn from_arrow(_cfg: &(), array: &Box<dyn Array>) -> Result<Self, String> {
-                let array = array
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<$data>>()
-                    .ok_or_else(|| {
-                        format!(
-                            "expected {} but was {:?}",
-                            std::any::type_name::<PrimitiveArray<$data>>(),
-                            array.data_type()
-                        )
-                    })?;
-                if array.validity().is_some() {
-                    return Err(format!(
-                        "unexpected validity for non-optional {}",
-                        std::any::type_name::<$data>()
-                    ));
-                }
-                Ok(array.values().clone())
-            }
-        }
-
-        impl ColumnGet<$data> for Buffer<$data> {
+    ($data:ident, $arrow_type:ident) => {
+        impl ColumnGet<$data> for PrimitiveArray<$arrow_type> {
             fn get<'a>(&'a self, idx: usize) -> $data {
-                self[idx]
+                self.value(idx)
             }
         }
 
-        impl ColumnPush<$data> for Vec<$data> {
+        impl ColumnPush<$data> for PrimitiveBuilder<$arrow_type> {
             fn push<'a>(&mut self, val: $data) {
-                <Vec<$data>>::push(self, val)
+                <PrimitiveBuilder<$arrow_type>>::append_value(self, val)
             }
         }
 
-        impl ColumnRef<()> for PrimitiveArray<$data> {
+        impl ColumnFinish<$data> for PrimitiveBuilder<$arrow_type> {
+            fn finish(mut self) -> <$data as Data>::Col {
+                <PrimitiveBuilder<$arrow_type>>::finish(&mut self)
+            }
+        }
+
+        impl ColumnRef<()> for PrimitiveArray<$arrow_type> {
             fn cfg(&self) -> &() {
                 &()
             }
+
             fn len(&self) -> usize {
                 self.len()
             }
-            fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-                ($encoding, Box::new(self.clone()))
+
+            fn to_arrow(&self) -> Arc<dyn Array> {
+                Arc::new(self.clone())
             }
-            fn from_arrow(_cfg: &(), array: &Box<dyn Array>) -> Result<Self, String> {
+
+            fn from_arrow(_cfg: &(), array: &dyn Array) -> Result<Self, String> {
                 let array = array
                     .as_any()
-                    .downcast_ref::<PrimitiveArray<$data>>()
+                    .downcast_ref::<PrimitiveArray<$arrow_type>>()
                     .ok_or_else(|| {
                         format!(
                             "expected {} but was {:?}",
-                            std::any::type_name::<PrimitiveArray<$data>>(),
+                            std::any::type_name::<PrimitiveArray<$arrow_type>>(),
                             array.data_type()
                         )
                     })?;
+
                 Ok(array.clone())
             }
         }
 
-        impl ColumnGet<Option<$data>> for PrimitiveArray<$data> {
+        impl ColumnGet<Option<$data>> for PrimitiveArray<$arrow_type> {
             fn get<'a>(&'a self, idx: usize) -> Option<$data> {
-                if self.validity().map_or(true, |x| x.get_bit(idx)) {
+                if self
+                    .logical_nulls()
+                    .map_or(true, |nulls| nulls.is_valid(idx))
+                {
                     Some(self.value(idx))
                 } else {
                     None
@@ -762,54 +785,76 @@ macro_rules! arrowable_primitive {
             }
         }
 
-        impl ColumnPush<Option<$data>> for MutablePrimitiveArray<$data> {
+        impl ColumnMut<()> for PrimitiveBuilder<$arrow_type> {
+            fn new(_cfg: &()) -> Self {
+                PrimitiveBuilder::<$arrow_type>::default()
+            }
+
+            fn cfg(&self) -> &() {
+                &()
+            }
+        }
+
+        impl ColumnPush<Option<$data>> for PrimitiveBuilder<$arrow_type> {
             fn push<'a>(&mut self, val: Option<$data>) {
-                <MutablePrimitiveArray<$data>>::push(self, val)
+                <PrimitiveBuilder<$arrow_type>>::append_option(self, val)
+            }
+        }
+
+        impl ColumnFinish<Option<$data>> for PrimitiveBuilder<$arrow_type> {
+            fn finish(mut self) -> <Option<$data> as Data>::Col {
+                <PrimitiveBuilder<$arrow_type>>::finish(&mut self)
             }
         }
     };
 }
 
-arrowable_primitive!(u8, Encoding::Plain);
-arrowable_primitive!(u16, Encoding::Plain);
-arrowable_primitive!(u32, Encoding::Plain);
-arrowable_primitive!(u64, Encoding::Plain);
-arrowable_primitive!(i8, Encoding::Plain);
-arrowable_primitive!(i16, Encoding::Plain);
-arrowable_primitive!(i32, Encoding::Plain);
-arrowable_primitive!(i64, Encoding::Plain);
-arrowable_primitive!(f32, Encoding::Plain);
-arrowable_primitive!(f64, Encoding::Plain);
+arrowable_primitive!(u8, UInt8Type);
+arrowable_primitive!(u16, UInt16Type);
+arrowable_primitive!(u32, UInt32Type);
+arrowable_primitive!(u64, UInt64Type);
+arrowable_primitive!(i8, Int8Type);
+arrowable_primitive!(i16, Int16Type);
+arrowable_primitive!(i32, Int32Type);
+arrowable_primitive!(i64, Int64Type);
+arrowable_primitive!(f32, Float32Type);
+arrowable_primitive!(f64, Float64Type);
 
-impl ColumnRef<()> for BinaryArray<i32> {
+impl ColumnRef<()> for BinaryArray {
     fn cfg(&self) -> &() {
         &()
     }
+
     fn len(&self) -> usize {
-        self.len()
+        <BinaryArray as Array>::len(self)
     }
-    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-        (Encoding::Plain, Box::new(self.clone()))
+
+    fn to_arrow(&self) -> Arc<dyn Array> {
+        Arc::new(self.clone())
     }
-    fn from_arrow(_cfg: &(), array: &Box<dyn Array>) -> Result<Self, String> {
+
+    fn from_arrow(_cfg: &(), array: &dyn Array) -> Result<Self, String> {
         let array = array
             .as_any()
-            .downcast_ref::<BinaryArray<i32>>()
-            .ok_or_else(|| format!("expected BinaryArray<i32> but was {:?}", array.data_type()))?;
+            .downcast_ref::<BinaryArray>()
+            .ok_or_else(|| format!("expected BinaryArray but was {:?}", array.data_type()))?;
         Ok(array.clone())
     }
 }
 
-impl ColumnGet<Vec<u8>> for BinaryArray<i32> {
+impl ColumnGet<Vec<u8>> for BinaryArray {
     fn get<'a>(&'a self, idx: usize) -> &'a [u8] {
-        assert!(self.validity().is_none());
+        assert!(self.logical_nulls().is_none());
         self.value(idx)
     }
 }
 
-impl ColumnGet<Option<Vec<u8>>> for BinaryArray<i32> {
+impl ColumnGet<Option<Vec<u8>>> for BinaryArray {
     fn get<'a>(&'a self, idx: usize) -> Option<&'a [u8]> {
-        if self.validity().map_or(true, |x| x.get_bit(idx)) {
+        if self
+            .logical_nulls()
+            .map_or(true, |nulls| nulls.is_valid(idx))
+        {
             Some(self.value(idx))
         } else {
             None
@@ -817,48 +862,76 @@ impl ColumnGet<Option<Vec<u8>>> for BinaryArray<i32> {
     }
 }
 
-impl ColumnPush<Vec<u8>> for MutableBinaryArray<i32> {
-    fn push<'a>(&mut self, val: &'a [u8]) {
-        assert!(self.validity().is_none());
-        <MutableBinaryArray<i32>>::push(self, Some(val))
+impl ColumnMut<()> for BinaryBuilder {
+    fn new(_cfg: &()) -> Self {
+        BinaryBuilder::default()
     }
-}
 
-impl ColumnPush<Option<Vec<u8>>> for MutableBinaryArray<i32> {
-    fn push<'a>(&mut self, val: Option<&'a [u8]>) {
-        <MutableBinaryArray<i32>>::push(self, val)
-    }
-}
-
-impl ColumnRef<()> for Utf8Array<i32> {
     fn cfg(&self) -> &() {
         &()
     }
+}
+
+impl ColumnPush<Vec<u8>> for BinaryBuilder {
+    fn push<'a>(&mut self, val: &'a [u8]) {
+        assert!(self.validity_slice().is_none());
+        <BinaryBuilder>::append_value(self, val)
+    }
+}
+
+impl ColumnFinish<Vec<u8>> for BinaryBuilder {
+    fn finish(mut self) -> <Vec<u8> as Data>::Col {
+        <BinaryBuilder>::finish(&mut self)
+    }
+}
+
+impl ColumnPush<Option<Vec<u8>>> for BinaryBuilder {
+    fn push<'a>(&mut self, val: Option<&'a [u8]>) {
+        <BinaryBuilder>::append_option(self, val)
+    }
+}
+
+impl ColumnFinish<Option<Vec<u8>>> for BinaryBuilder {
+    fn finish(mut self) -> <Vec<u8> as Data>::Col {
+        <BinaryBuilder>::finish(&mut self)
+    }
+}
+
+impl ColumnRef<()> for StringArray {
+    fn cfg(&self) -> &() {
+        &()
+    }
+
     fn len(&self) -> usize {
-        self.len()
+        <StringArray as Array>::len(self)
     }
-    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-        (Encoding::Plain, Box::new(self.clone()))
+
+    fn to_arrow(&self) -> Arc<dyn Array> {
+        Arc::new(self.clone())
     }
-    fn from_arrow(_cfg: &(), array: &Box<dyn Array>) -> Result<Self, String> {
+
+    fn from_arrow(_cfg: &(), array: &dyn Array) -> Result<Self, String> {
         let array = array
             .as_any()
-            .downcast_ref::<Utf8Array<i32>>()
-            .ok_or_else(|| format!("expected Utf8Array<i32> but was {:?}", array.data_type()))?;
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| format!("expected StringArray but was {:?}", array.data_type()))?;
         Ok(array.clone())
     }
 }
 
-impl ColumnGet<String> for Utf8Array<i32> {
+impl ColumnGet<String> for StringArray {
     fn get<'a>(&'a self, idx: usize) -> &'a str {
-        assert!(self.validity().is_none());
+        assert!(self.logical_nulls().is_none());
         self.value(idx)
     }
 }
 
-impl ColumnGet<Option<String>> for Utf8Array<i32> {
+impl ColumnGet<Option<String>> for StringArray {
     fn get<'a>(&'a self, idx: usize) -> Option<&'a str> {
-        if self.validity().map_or(true, |x| x.get_bit(idx)) {
+        if self
+            .logical_nulls()
+            .map_or(true, |nulls| nulls.is_valid(idx))
+        {
             Some(self.value(idx))
         } else {
             None
@@ -866,29 +939,54 @@ impl ColumnGet<Option<String>> for Utf8Array<i32> {
     }
 }
 
-impl ColumnPush<String> for MutableUtf8Array<i32> {
+impl ColumnMut<()> for StringBuilder {
+    fn new(_cfg: &()) -> Self {
+        StringBuilder::default()
+    }
+
+    fn cfg(&self) -> &() {
+        &()
+    }
+}
+
+impl ColumnFinish<String> for StringBuilder {
+    fn finish(mut self) -> <String as Data>::Col {
+        <StringBuilder>::finish(&mut self)
+    }
+}
+
+impl ColumnFinish<Option<String>> for StringBuilder {
+    fn finish(mut self) -> <Option<String> as Data>::Col {
+        <StringBuilder>::finish(&mut self)
+    }
+}
+
+impl ColumnPush<String> for StringBuilder {
     fn push<'a>(&mut self, val: &'a str) {
-        assert!(self.validity().is_none());
-        <MutableUtf8Array<i32>>::push(self, Some(val))
+        assert!(self.validity_slice().is_none());
+        <StringBuilder>::append_value(self, val)
     }
 }
 
-impl ColumnPush<Option<String>> for MutableUtf8Array<i32> {
+impl ColumnPush<Option<String>> for StringBuilder {
     fn push<'a>(&mut self, val: Option<&'a str>) {
-        <MutableUtf8Array<i32>>::push(self, val)
+        <StringBuilder>::append_option(self, val)
     }
 }
 
-impl ColumnGet<OpaqueData> for BinaryArray<i32> {
+impl ColumnGet<OpaqueData> for BinaryArray {
     fn get<'a>(&'a self, idx: usize) -> <OpaqueData as Data>::Ref<'a> {
-        assert!(self.validity().is_none());
+        assert!(self.logical_nulls().is_none());
         self.value(idx)
     }
 }
 
-impl ColumnGet<Option<OpaqueData>> for BinaryArray<i32> {
+impl ColumnGet<Option<OpaqueData>> for BinaryArray {
     fn get<'a>(&'a self, idx: usize) -> <Option<OpaqueData> as Data>::Ref<'a> {
-        if self.validity().map_or(true, |x| x.get_bit(idx)) {
+        if self
+            .logical_nulls()
+            .map_or(true, |nulls| nulls.is_valid(idx))
+        {
             Some(self.value(idx))
         } else {
             None
@@ -896,16 +994,28 @@ impl ColumnGet<Option<OpaqueData>> for BinaryArray<i32> {
     }
 }
 
-impl ColumnPush<OpaqueData> for MutableBinaryArray<i32> {
+impl ColumnPush<OpaqueData> for BinaryBuilder {
     fn push<'a>(&mut self, val: <OpaqueData as Data>::Ref<'a>) {
-        assert!(self.validity().is_none());
-        <MutableBinaryArray<i32>>::push(self, Some(val))
+        assert!(self.validity_slice().is_none());
+        <BinaryBuilder>::append_value(self, val)
     }
 }
 
-impl ColumnPush<Option<OpaqueData>> for MutableBinaryArray<i32> {
+impl ColumnPush<Option<OpaqueData>> for BinaryBuilder {
     fn push<'a>(&mut self, val: <Option<OpaqueData> as Data>::Ref<'a>) {
-        <MutableBinaryArray<i32>>::push(self, val)
+        <BinaryBuilder>::append_option(self, val)
+    }
+}
+
+impl ColumnFinish<OpaqueData> for BinaryBuilder {
+    fn finish(mut self) -> <OpaqueData as Data>::Col {
+        <BinaryBuilder>::finish(&mut self)
+    }
+}
+
+impl ColumnFinish<Option<OpaqueData>> for BinaryBuilder {
+    fn finish(mut self) -> <Option<OpaqueData> as Data>::Col {
+        <BinaryBuilder>::finish(&mut self)
     }
 }
 

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -27,8 +27,8 @@ use timely::order::Product;
 
 use crate::columnar::sealed::{ColumnMut, ColumnRef};
 use crate::columnar::{
-    ColumnCfg, ColumnFinish, ColumnFormat, ColumnGet, ColumnPush, Data, DataType, OpaqueData,
-    PartDecoder, PartEncoder, Schema,
+    ColumnCfg, ColumnFormat, ColumnGet, ColumnPush, Data, DataType, OpaqueData, PartDecoder,
+    PartEncoder, Schema,
 };
 use crate::dyn_col::DynColumnMut;
 use crate::dyn_struct::{
@@ -647,9 +647,7 @@ impl ColumnPush<bool> for BooleanBufferBuilder {
     fn push<'a>(&mut self, val: bool) {
         <BooleanBufferBuilder>::append(self, val)
     }
-}
 
-impl ColumnFinish<bool> for BooleanBufferBuilder {
     fn finish(mut self) -> <bool as Data>::Col {
         <BooleanBufferBuilder>::finish(&mut self)
     }
@@ -711,15 +709,13 @@ impl ColumnMut<()> for BooleanBuilder {
     }
 }
 
-impl ColumnFinish<Option<bool>> for BooleanBuilder {
-    fn finish(mut self) -> <Option<bool> as Data>::Col {
-        <BooleanBuilder>::finish(&mut self)
-    }
-}
-
 impl ColumnPush<Option<bool>> for BooleanBuilder {
     fn push<'a>(&mut self, val: Option<bool>) {
         <BooleanBuilder>::append_option(self, val)
+    }
+
+    fn finish(mut self) -> <Option<bool> as Data>::Col {
+        <BooleanBuilder>::finish(&mut self)
     }
 }
 
@@ -735,9 +731,7 @@ macro_rules! arrowable_primitive {
             fn push<'a>(&mut self, val: $data) {
                 <PrimitiveBuilder<$arrow_type>>::append_value(self, val)
             }
-        }
 
-        impl ColumnFinish<$data> for PrimitiveBuilder<$arrow_type> {
             fn finish(mut self) -> <$data as Data>::Col {
                 <PrimitiveBuilder<$arrow_type>>::finish(&mut self)
             }
@@ -799,9 +793,7 @@ macro_rules! arrowable_primitive {
             fn push<'a>(&mut self, val: Option<$data>) {
                 <PrimitiveBuilder<$arrow_type>>::append_option(self, val)
             }
-        }
 
-        impl ColumnFinish<Option<$data>> for PrimitiveBuilder<$arrow_type> {
             fn finish(mut self) -> <Option<$data> as Data>::Col {
                 <PrimitiveBuilder<$arrow_type>>::finish(&mut self)
             }
@@ -877,9 +869,7 @@ impl ColumnPush<Vec<u8>> for BinaryBuilder {
         assert!(self.validity_slice().is_none());
         <BinaryBuilder>::append_value(self, val)
     }
-}
 
-impl ColumnFinish<Vec<u8>> for BinaryBuilder {
     fn finish(mut self) -> <Vec<u8> as Data>::Col {
         <BinaryBuilder>::finish(&mut self)
     }
@@ -889,9 +879,7 @@ impl ColumnPush<Option<Vec<u8>>> for BinaryBuilder {
     fn push<'a>(&mut self, val: Option<&'a [u8]>) {
         <BinaryBuilder>::append_option(self, val)
     }
-}
 
-impl ColumnFinish<Option<Vec<u8>>> for BinaryBuilder {
     fn finish(mut self) -> <Vec<u8> as Data>::Col {
         <BinaryBuilder>::finish(&mut self)
     }
@@ -949,28 +937,24 @@ impl ColumnMut<()> for StringBuilder {
     }
 }
 
-impl ColumnFinish<String> for StringBuilder {
-    fn finish(mut self) -> <String as Data>::Col {
-        <StringBuilder>::finish(&mut self)
-    }
-}
-
-impl ColumnFinish<Option<String>> for StringBuilder {
-    fn finish(mut self) -> <Option<String> as Data>::Col {
-        <StringBuilder>::finish(&mut self)
-    }
-}
-
 impl ColumnPush<String> for StringBuilder {
     fn push<'a>(&mut self, val: &'a str) {
         assert!(self.validity_slice().is_none());
         <StringBuilder>::append_value(self, val)
+    }
+
+    fn finish(mut self) -> <String as Data>::Col {
+        <StringBuilder>::finish(&mut self)
     }
 }
 
 impl ColumnPush<Option<String>> for StringBuilder {
     fn push<'a>(&mut self, val: Option<&'a str>) {
         <StringBuilder>::append_option(self, val)
+    }
+
+    fn finish(mut self) -> <Option<String> as Data>::Col {
+        <StringBuilder>::finish(&mut self)
     }
 }
 
@@ -999,21 +983,17 @@ impl ColumnPush<OpaqueData> for BinaryBuilder {
         assert!(self.validity_slice().is_none());
         <BinaryBuilder>::append_value(self, val)
     }
+
+    fn finish(mut self) -> <OpaqueData as Data>::Col {
+        <BinaryBuilder>::finish(&mut self)
+    }
 }
 
 impl ColumnPush<Option<OpaqueData>> for BinaryBuilder {
     fn push<'a>(&mut self, val: <Option<OpaqueData> as Data>::Ref<'a>) {
         <BinaryBuilder>::append_option(self, val)
     }
-}
 
-impl ColumnFinish<OpaqueData> for BinaryBuilder {
-    fn finish(mut self) -> <OpaqueData as Data>::Col {
-        <BinaryBuilder>::finish(&mut self)
-    }
-}
-
-impl ColumnFinish<Option<OpaqueData>> for BinaryBuilder {
     fn finish(mut self) -> <Option<OpaqueData> as Data>::Col {
         <BinaryBuilder>::finish(&mut self)
     }

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -96,7 +96,7 @@ pub trait Data: Debug + Send + Sync + Sized + 'static {
     type Col: ColumnGet<Self>;
 
     /// The exclusive builder of columns of this type of data.
-    type Mut: ColumnPush<Self> + ColumnFinish<Self>;
+    type Mut: ColumnPush<Self>;
 
     /// The statistics type of columns of this type of data.
     type Stats: ColumnStats<Self> + StatsFrom<Self::Col>;
@@ -123,11 +123,7 @@ pub trait ColumnGet<T: Data>: ColumnRef<T::Cfg> {
 pub trait ColumnPush<T: Data>: ColumnMut<T::Cfg> {
     /// Pushes a new value into this column.
     fn push<'a>(&mut self, val: T::Ref<'a>);
-}
 
-/// A common trait implemented by `Data::Mut` types. Provides the ability to
-/// "finish" a mutable array, returning the corresponding `Data::Col`.
-pub trait ColumnFinish<T: Data>: ColumnMut<T::Cfg> {
     /// Finishes the mutable column returning the corresponding `Data::Col`.
     fn finish(self) -> T::Col;
 }

--- a/src/persist-types/src/dyn_col.rs
+++ b/src/persist-types/src/dyn_col.rs
@@ -15,9 +15,7 @@ use std::sync::Arc;
 use arrow::array::Array;
 
 use crate::columnar::sealed::{ColumnMut, ColumnRef};
-use crate::columnar::{
-    ColumnCfg, ColumnFinish, ColumnFormat, ColumnGet, ColumnPush, Data, DataType, OpaqueData,
-};
+use crate::columnar::{ColumnCfg, ColumnFormat, ColumnGet, ColumnPush, Data, DataType, OpaqueData};
 use crate::dyn_struct::{DynStruct, ValidityRef};
 use crate::stats::{DynStats, StatsFrom};
 

--- a/src/persist-types/src/dyn_struct.rs
+++ b/src/persist-types/src/dyn_struct.rs
@@ -18,7 +18,7 @@ use arrow::buffer::NullBuffer;
 use arrow::datatypes::{Field, Fields};
 
 use crate::columnar::sealed::{ColumnMut, ColumnRef};
-use crate::columnar::{ColumnFinish, ColumnGet, ColumnPush, Data, DataType};
+use crate::columnar::{ColumnGet, ColumnPush, Data, DataType};
 use crate::dyn_col::{DynColumnMut, DynColumnRef};
 use crate::stats::{OptionStats, StatsFn, StructStats};
 
@@ -314,9 +314,7 @@ impl ColumnPush<DynStruct> for DynStructMut {
         assert!(self.validity.is_none());
         self.push_cols(val);
     }
-}
 
-impl ColumnFinish<DynStruct> for DynStructMut {
     fn finish(self) -> <DynStruct as Data>::Col {
         DynStructCol::from(self)
     }
@@ -343,9 +341,7 @@ impl ColumnPush<Option<DynStruct>> for DynStructMut {
             self.push_cols(DynStructRef::Default);
         }
     }
-}
 
-impl ColumnFinish<Option<DynStruct>> for DynStructMut {
     fn finish(self) -> <Option<DynStruct> as Data>::Col {
         DynStructCol::from(self)
     }

--- a/src/persist-types/src/dyn_struct.rs
+++ b/src/persist-types/src/dyn_struct.rs
@@ -13,13 +13,12 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use arrow2::array::{Array, NullArray, StructArray};
-use arrow2::bitmap::{Bitmap, MutableBitmap};
-use arrow2::datatypes::{DataType as ArrowLogicalType, Field};
-use arrow2::io::parquet::write::Encoding;
+use arrow::array::{Array, BooleanBufferBuilder, NullArray, StructArray};
+use arrow::buffer::NullBuffer;
+use arrow::datatypes::{Field, Fields};
 
 use crate::columnar::sealed::{ColumnMut, ColumnRef};
-use crate::columnar::{ColumnGet, ColumnPush, Data, DataType};
+use crate::columnar::{ColumnFinish, ColumnGet, ColumnPush, Data, DataType};
 use crate::dyn_col::{DynColumnMut, DynColumnRef};
 use crate::stats::{OptionStats, StatsFn, StructStats};
 
@@ -76,7 +75,7 @@ impl Default for DynStructRef<'_> {
 pub struct DynStructCol {
     pub(crate) len: usize,
     pub(crate) cfg: DynStructCfg,
-    pub(crate) validity: Option<<bool as Data>::Col>,
+    pub(crate) validity: Option<NullBuffer>,
     pub(crate) cols: Vec<DynColumnRef>,
 }
 
@@ -84,17 +83,20 @@ impl ColumnRef<DynStructCfg> for DynStructCol {
     fn cfg(&self) -> &DynStructCfg {
         &self.cfg
     }
+
     fn len(&self) -> usize {
         self.len
     }
-    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-        let array: Box<dyn Array> = match self.to_arrow_struct() {
-            Some((array, _col_encodings)) => Box::new(array),
-            None => Box::new(NullArray::new_empty(ArrowLogicalType::Null)),
+
+    fn to_arrow(&self) -> Arc<dyn Array> {
+        let array: Arc<dyn Array> = match self.to_arrow_struct() {
+            Some(array) => Arc::new(array),
+            None => Arc::new(NullArray::new(self.len)),
         };
-        (Encoding::Plain, array)
+        array
     }
-    fn from_arrow(cfg: &DynStructCfg, array: &Box<dyn Array>) -> Result<Self, String> {
+
+    fn from_arrow(cfg: &DynStructCfg, array: &dyn Array) -> Result<Self, String> {
         Self::from_arrow(cfg.clone(), array)
     }
 }
@@ -119,7 +121,7 @@ impl ColumnGet<Option<DynStruct>> for DynStructCol {
         // columnar struct into components via ColumnsRef, so this is unused. We
         // keep it for completeness and also so that any future changes to the
         // code consider it.
-        if self.validity.as_ref().map_or(true, |x| x.get_bit(idx)) {
+        if self.validity.as_ref().map_or(true, |x| x.is_valid(idx)) {
             Some(DynStructRef::Idx {
                 idx,
                 cols: &self.cols,
@@ -202,7 +204,7 @@ impl DynStructCol {
             };
             cols.insert(n.to_owned(), stats);
         }
-        let none = self.validity.as_ref().map_or(0, |x| x.unset_bits());
+        let none = self.validity.as_ref().map_or(0, |x| x.null_count());
         Ok(OptionStats {
             none,
             some: StructStats {
@@ -212,32 +214,31 @@ impl DynStructCol {
         })
     }
 
-    pub(crate) fn to_arrow_struct(&self) -> Option<(StructArray, Vec<Encoding>)> {
-        let (mut fields, mut encodings, mut arrays) = (Vec::new(), Vec::new(), Vec::new());
+    pub(crate) fn to_arrow_struct(&self) -> Option<StructArray> {
+        let (mut fields, mut arrays) = (Vec::new(), Vec::new());
         for (name, _stats_fn, col) in self.cols() {
-            let (encoding, array, is_nullable) = col.to_arrow();
+            let (array, is_nullable) = col.to_arrow();
             fields.push(Field::new(name, array.data_type().clone(), is_nullable));
-            encodings.push(encoding);
             arrays.push(array);
         }
         if fields.is_empty() {
             return None;
         }
-        let array = StructArray::new(ArrowLogicalType::Struct(fields), arrays, None);
-        Some((array, encodings))
+        // TODO(parkmycar): We need to pass the validity bitmap here.
+        Some(StructArray::new(Fields::from(fields), arrays, None))
     }
 
-    #[allow(clippy::borrowed_box)]
-    pub(crate) fn from_arrow(cfg: DynStructCfg, array: &Box<dyn Array>) -> Result<Self, String> {
+    pub(crate) fn from_arrow(cfg: DynStructCfg, array: &dyn Array) -> Result<Self, String> {
         let array = array
             .as_any()
             .downcast_ref::<StructArray>()
             .ok_or_else(|| format!("expected StructArray but was {:?}", array.data_type()))?;
         let len = array.len();
-        let validity = array.validity().cloned();
+        let validity = array.logical_nulls();
         let mut cols = Vec::new();
-        assert_eq!(cfg.cols.len(), array.values().len());
-        for ((_name, typ, _stats_fn), array) in cfg.cols.iter().zip(array.values()) {
+        assert_eq!(cfg.cols.len(), array.num_columns());
+
+        for ((_name, typ, _stats_fn), array) in cfg.cols.iter().zip(array.columns()) {
             let col = DynColumnRef::from_arrow(typ, array)?;
             cols.push(col);
         }
@@ -315,6 +316,12 @@ impl ColumnPush<DynStruct> for DynStructMut {
     }
 }
 
+impl ColumnFinish<DynStruct> for DynStructMut {
+    fn finish(self) -> <DynStruct as Data>::Col {
+        DynStructCol::from(self)
+    }
+}
+
 impl ColumnPush<Option<DynStruct>> for DynStructMut {
     fn push<'a>(&mut self, val: Option<DynStructRef<'a>>) {
         // NB: For efficiency, production codepaths instead deconstruct the
@@ -322,7 +329,10 @@ impl ColumnPush<Option<DynStruct>> for DynStructMut {
         // keep it for completeness and also so that any future changes to the
         // code consider it.
         let len = self.len;
-        let validity = self.validity.get_or_insert_with(MutableBitmap::default);
+        let validity = self
+            .validity
+            // Note(parkmycar): This capacity was picked arbitrarily.
+            .get_or_insert_with(|| BooleanBufferBuilder::new(128));
         debug_assert_eq!(len, validity.len());
 
         if let Some(val) = val {
@@ -335,6 +345,12 @@ impl ColumnPush<Option<DynStruct>> for DynStructMut {
     }
 }
 
+impl ColumnFinish<Option<DynStruct>> for DynStructMut {
+    fn finish(self) -> <Option<DynStruct> as Data>::Col {
+        DynStructCol::from(self)
+    }
+}
+
 impl DynStructMut {
     /// Create a [`DynStructMut`] from individual parts.
     ///
@@ -343,7 +359,7 @@ impl DynStructMut {
     pub fn from_parts(
         cfg: DynStructCfg,
         len: usize,
-        validity: Option<MutableBitmap>,
+        validity: Option<BooleanBufferBuilder>,
         cols: Vec<DynColumnMut>,
     ) -> Self {
         DynStructMut {
@@ -432,12 +448,13 @@ impl DynStructMut {
 impl From<DynStructMut> for DynStructCol {
     fn from(value: DynStructMut) -> Self {
         let cfg = value.cfg;
-        let validity = value.validity.map(<bool as Data>::Col::from);
+        let validity = value.validity.map(|b| NullBuffer::from(b.finish()));
         let cols = value
             .cols
             .into_iter()
             .map(DynColumnRef::from)
             .collect::<Vec<_>>();
+
         DynStructCol {
             len: value.len,
             cfg,
@@ -453,9 +470,9 @@ impl From<DynStructMut> for DynStructCol {
 /// elided if every value is true. This is the common case for the `Ok` struct
 /// of our `SourceData`, so seems worth opting in to ourselves.
 ///
-/// Note: [`Bitmap`] is internally reference counted so cloning is cheap.
+/// Note: [`NullBuffer`] is internally reference counted so cloning is cheap.
 #[derive(Debug, Clone)]
-pub struct ValidityRef(pub(crate) Option<Bitmap>);
+pub struct ValidityRef(pub(crate) Option<NullBuffer>);
 
 impl ValidityRef {
     /// Returns a validity that indicates true for all values.
@@ -467,13 +484,13 @@ impl ValidityRef {
     /// If this is false, the contents of the struct's component fields at `idx`
     /// will be undefined.
     pub fn get(&self, idx: usize) -> bool {
-        self.0.as_ref().map_or(true, |x| x.get_bit(idx))
+        self.0.as_ref().map_or(true, |nulls| nulls.is_valid(idx))
     }
 
     /// Returns whether the set of all indexes that return `true` in `self` is a
     /// superset of the set of all indexes that return `true` in `other`.
     #[allow(clippy::bool_comparison)]
-    pub fn is_superset(&self, other: Option<&<bool as Data>::Col>) -> bool {
+    pub fn is_superset(&self, other: Option<&NullBuffer>) -> bool {
         match (self.0.as_ref(), other) {
             (None, _) => {
                 // None means all-true, which is trivially a superset.
@@ -482,12 +499,12 @@ impl ValidityRef {
             (Some(s), None) => {
                 // None means all-true, so s is only a superset if it's entirely
                 // true.
-                s.unset_bits() == 0
+                s.null_count() == 0
             }
             (Some(s), Some(o)) => {
                 assert_eq!(s.len(), o.len());
                 for idx in 0..s.len() {
-                    if s.get_bit(idx) == false && o.get_bit(idx) == true {
+                    if s.is_valid(idx) == false && o.is_valid(idx) == true {
                         return false;
                     }
                 }
@@ -497,15 +514,15 @@ impl ValidityRef {
     }
 }
 
-/// A new-type wrapper for a mutable `arrow2` validity column.
+/// A new-type wrapper for a mutable [`arrow`] validity column.
 ///
-/// The `arrow2` crate has an optimization where the validity column can be
+/// The [`arrow`] crate has an optimization where the validity column can be
 /// elided if every value is true. This is the common case for the `Ok` struct
 /// of our `SourceData`, so seems worth opting in to ourselves.
 #[derive(Debug)]
 pub struct ValidityMut {
     len: usize,
-    validity: Option<MutableBitmap>,
+    validity: Option<BooleanBufferBuilder>,
 }
 
 impl ValidityMut {
@@ -519,8 +536,8 @@ impl ValidityMut {
             }
         } else {
             let validity = self.validity.get_or_insert_with(|| {
-                let mut ret = MutableBitmap::new();
-                ret.extend_constant(self.len, true);
+                let mut ret = BooleanBufferBuilder::new(self.len);
+                ret.append_n(self.len, true);
                 ret
             });
             validity.push(valid);
@@ -529,7 +546,7 @@ impl ValidityMut {
     }
 
     /// Consumes `self` returning the inner parts.
-    pub fn into_parts(self) -> (usize, Option<MutableBitmap>) {
+    pub fn into_parts(self) -> (usize, Option<BooleanBufferBuilder>) {
         (self.len, self.validity)
     }
 }

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -1665,7 +1665,7 @@ mod tests {
     use proptest::prelude::*;
 
     use crate::columnar::sealed::ColumnMut;
-    use crate::columnar::{ColumnFinish, ColumnPush};
+    use crate::columnar::ColumnPush;
     use crate::dyn_struct::ValidityRef;
 
     use super::*;

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -19,6 +19,7 @@ harness = false
 
 [dependencies]
 anyhow = "1.0.66"
+arrow = { version = "51.0.0", default-features = false }
 bitflags = "1.3.2"
 bytes = "1.3.0"
 cfg-if = "1.0.0"

--- a/src/repr/src/stats.rs
+++ b/src/repr/src/stats.rs
@@ -9,6 +9,7 @@
 
 use std::collections::BTreeMap;
 
+use arrow::array::Array;
 use mz_persist_types::columnar::{ColumnGet, Data};
 use mz_persist_types::dyn_struct::ValidityRef;
 use mz_persist_types::stats::{JsonMapElementStats, JsonStats, PrimitiveStats};


### PR DESCRIPTION
DO NOT MERGE

Based on top of https://github.com/MaterializeInc/materialize/pull/27009, sets the stats audit percent to 100% for testing in CI

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
