### PR TITLE
sql: disallow retain history 0 or less than the default

### DIFF
--- a/misc/python/materialize/checks/all_checks/alter_index.py
+++ b/misc/python/materialize/checks/all_checks/alter_index.py
@@ -56,8 +56,8 @@ class AlterIndex(Check):
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "B${kafka-ingest.iteration}"}
 
-                >[version>=8700] ALTER INDEX alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1ms');
-                >[version>=8700] ALTER INDEX alter_index_source_primary_idx SET (RETAIN HISTORY = FOR '1ms');
+                >[version>=8700] ALTER INDEX alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1s');
+                >[version>=8700] ALTER INDEX alter_index_source_primary_idx SET (RETAIN HISTORY = FOR '1s');
 
                 > INSERT INTO alter_index_table SELECT 'C' || generate_series FROM generate_series(1,10000);
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -495,7 +495,7 @@ fn test_subscribe_basic() {
 
     // Create a table with disabled compaction.
     client_writes
-        .batch_execute("CREATE TABLE t (data text) WITH (RETAIN HISTORY FOR 0)")
+        .batch_execute("CREATE TABLE t (data text) WITH (RETAIN HISTORY FOR '1000 hours')")
         .unwrap();
     client_writes.batch_execute("SELECT * FROM t").unwrap();
     client_reads
@@ -597,7 +597,7 @@ fn test_subscribe_basic() {
     // view derived from the index. This previously selected an invalid
     // `AS OF` timestamp (#5391).
     client_writes
-        .batch_execute("ALTER TABLE t SET (RETAIN HISTORY = FOR '1ms')")
+        .batch_execute("ALTER TABLE t SET (RETAIN HISTORY = FOR '1s')")
         .unwrap();
     client_writes
         .batch_execute("CREATE VIEW v AS SELECT * FROM t")

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -745,11 +745,11 @@ CREATE INDEX foo ON myschema.bar (a, b)
 CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
-CREATE INDEX foo ON myschema.bar (a, b) WITH (RETAIN HISTORY = FOR 0)
+CREATE INDEX foo ON myschema.bar (a, b) WITH (RETAIN HISTORY = FOR '1000 hours')
 ----
-CREATE INDEX foo ON myschema.bar (a, b) WITH (RETAIN HISTORY = FOR 0)
+CREATE INDEX foo ON myschema.bar (a, b) WITH (RETAIN HISTORY = FOR '1000 hours')
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [IndexOption { name: RetainHistory, value: Some(RetainHistoryFor(Number("0"))) }], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [IndexOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1000 hours"))) }], if_not_exists: false })
 
 parse-statement
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2083,6 +2083,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: true,
     },
+    {
+        name: enable_unlimited_retain_history,
+        desc: "Disable limits on RETAIN HISTORY (below 1s default, and 0 disables compaction).",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {

--- a/test/retain-history/mzcompose.py
+++ b/test/retain-history/mzcompose.py
@@ -52,7 +52,7 @@ def run_test_consistency(c: Composition) -> None:
 
             > ALTER INDEX testdrive_consistency_table_idx SET (RETAIN HISTORY = FOR '1m')
 
-            > ALTER INDEX testdrive_consistency_table_idx SET (RETAIN HISTORY = FOR 0)
+            > ALTER INDEX testdrive_consistency_table_idx SET (RETAIN HISTORY = FOR '1000 hours')
 
             > ALTER INDEX testdrive_consistency_table_idx RESET (RETAIN HISTORY)
             """,

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -125,12 +125,12 @@ SELECT create_sql FROM (SHOW CREATE MATERIALIZED VIEW mv)
 CREATE MATERIALIZED VIEW "materialize"."public"."mv" IN CLUSTER "quickstart" WITH (REFRESH = ON COMMIT) AS SELECT 1
 
 statement ok
-CREATE TABLE t (a INT) WITH (RETAIN HISTORY FOR 0)
+CREATE TABLE t (a INT) WITH (RETAIN HISTORY FOR '1000 hours')
 
 query T
 SELECT create_sql FROM (SHOW CREATE TABLE t)
 ----
-CREATE TABLE "materialize"."public"."t" ("a" "pg_catalog"."int4") WITH (RETAIN HISTORY = FOR 0)
+CREATE TABLE "materialize"."public"."t" ("a" "pg_catalog"."int4") WITH (RETAIN HISTORY = FOR '1000 hours')
 
 statement ok
 CREATE INDEX i ON t(a)
@@ -176,12 +176,12 @@ SELECT create_sql FROM (SHOW CREATE INDEX i)
 CREATE INDEX "i" IN CLUSTER "quickstart" ON "materialize"."public"."t" ("a") WITH (RETAIN HISTORY = FOR '1m')
 
 statement ok
-ALTER INDEX i SET (RETAIN HISTORY = FOR 0)
+ALTER INDEX i SET (RETAIN HISTORY = FOR '1000 hours')
 
 query T
 SELECT create_sql FROM (SHOW CREATE INDEX i)
 ----
-CREATE INDEX "i" IN CLUSTER "quickstart" ON "materialize"."public"."t" ("a") WITH (RETAIN HISTORY = FOR 0)
+CREATE INDEX "i" IN CLUSTER "quickstart" ON "materialize"."public"."t" ("a") WITH (RETAIN HISTORY = FOR '1000 hours')
 
 statement ok
 ALTER INDEX i RESET (RETAIN HISTORY)

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -274,7 +274,7 @@ SELECT mz_roles.name
 materialize
 
 statement ok
-ALTER INDEX mt_ind SET (RETAIN HISTORY = FOR 0)
+ALTER INDEX mt_ind SET (RETAIN HISTORY = FOR '1000 hours')
 
 statement ok
 ALTER INDEX mt_ind RENAME TO ICs
@@ -305,7 +305,7 @@ statement error must be owner of INDEX materialize.public.jt_ind
 ALTER INDEX jt_ind OWNER TO group_materialize
 
 statement error must be owner of INDEX materialize.public.jt_ind
-ALTER INDEX jt_ind SET (RETAIN HISTORY = FOR 0)
+ALTER INDEX jt_ind SET (RETAIN HISTORY = FOR '1000 hours')
 
 ## Sources
 

--- a/test/sqllogictest/redacted.slt
+++ b/test/sqllogictest/redacted.slt
@@ -36,18 +36,18 @@ ALTER SYSTEM SET enable_redacted_test_option TO true;
 COMPLETE 0
 
 statement ok
-CREATE TABLE redactable_t (a int) WITH (RETAIN HISTORY = FOR '1ms', REDACTED = 'pii');
+CREATE TABLE redactable_t (a int) WITH (RETAIN HISTORY = FOR '2s', REDACTED = 'pii');
 
 query T multiline
 SELECT redacted_create_sql FROM mz_tables WHERE name = 'redactable_t'
 ----
-CREATE TABLE materialize.public.redactable_t (a [s20 AS pg_catalog.int4]) WITH (RETAIN HISTORY = FOR '1ms', REDACTED = '<REDACTED>')
+CREATE TABLE materialize.public.redactable_t (a [s20 AS pg_catalog.int4]) WITH (RETAIN HISTORY = FOR '2s', REDACTED = '<REDACTED>')
 EOF
 
 query T multiline
 SELECT pretty_sql(redacted_create_sql) FROM mz_tables WHERE name = 'redactable_t'
 ----
-CREATE TABLE materialize.public.redactable_t (a [s20 AS pg_catalog.int4]) WITH (RETAIN HISTORY = FOR '1ms', REDACTED = '<REDACTED>');
+CREATE TABLE materialize.public.redactable_t (a [s20 AS pg_catalog.int4]) WITH (RETAIN HISTORY = FOR '2s', REDACTED = '<REDACTED>');
 EOF
 
 statement ok

--- a/test/sqllogictest/retain_history.slt
+++ b/test/sqllogictest/retain_history.slt
@@ -40,7 +40,7 @@ statement ok
 CREATE INDEX idx_a ON view_a (a)
 
 statement ok
-CREATE INDEX idx_b ON view_b (b) WITH (RETAIN HISTORY FOR '1ms')
+CREATE INDEX idx_b ON view_b (b) WITH (RETAIN HISTORY FOR '1001ms')
 
 statement ok
 ALTER INDEX idx_a SET (RETAIN HISTORY FOR '5m')
@@ -193,3 +193,16 @@ idx_c  FOR  1000
 organizations  FOR  1000
 tab_a  FOR  1000
 users  FOR  1000
+
+# Check retain history lower bounds.
+statement error db error: ERROR: RETAIN HISTORY cannot be set lower than 1000ms
+ALTER SOURCE counter SET (RETAIN HISTORY FOR '1ms')
+
+statement error db error: ERROR: RETAIN HISTORY cannot be disabled or set to 0
+ALTER SOURCE counter SET (RETAIN HISTORY FOR '0')
+
+statement error db error: ERROR: RETAIN HISTORY cannot be set lower than 1000ms
+CREATE SOURCE low_rh FROM LOAD GENERATOR COUNTER WITH (RETAIN HISTORY FOR '1ms')
+
+statement error db error: ERROR: RETAIN HISTORY cannot be disabled or set to 0
+CREATE SOURCE low_rh FROM LOAD GENERATOR COUNTER WITH (RETAIN HISTORY FOR '0')

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -792,8 +792,8 @@ CREATE DEFAULT INDEX ON s
 statement ok
 BEGIN
 
-statement error db error: ERROR: ALTER INDEX s_primary_idx SET \(RETAIN HISTORY = FOR 0\) cannot be run inside a transaction block
-ALTER INDEX s_primary_idx SET (RETAIN HISTORY = FOR 0)
+statement error db error: ERROR: ALTER INDEX s_primary_idx SET \(RETAIN HISTORY = FOR '1000 hours'\) cannot be run inside a transaction block
+ALTER INDEX s_primary_idx SET (RETAIN HISTORY = FOR '1000 hours')
 
 query error db error: ERROR: current transaction is aborted, commands ignored until end of transaction block
 SELECT 1

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -13,6 +13,7 @@ $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.mater
 ALTER SYSTEM SET enable_envelope_materialize = true
 ALTER SYSTEM SET enable_index_options = true
 ALTER SYSTEM SET enable_logical_compaction_window = true
+ALTER SYSTEM SET enable_unlimited_retain_history = true
 
 # Test consolidation and compaction behavior.
 #
@@ -111,7 +112,7 @@ $ kafka-create-topic topic=nums
 
 # Disable logical compaction, to ensure we can view historical detail.
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (RETAIN HISTORY = FOR '1000 hours')
+  SET (RETAIN HISTORY = FOR 0)
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
@@ -194,7 +195,7 @@ mz_timestamp  mz_diff  num
 # Decrease the compaction window and ingest some new data in transaction 4.
 
 > ALTER INDEX materialize.public.nums_primary_idx
-  RESET (RETAIN HISTORY)
+  SET (RETAIN HISTORY = FOR '1ms')
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
 {"array":[{"data":{"num":5},"time":4,"diff":-1}]}
@@ -214,11 +215,11 @@ contains:Timestamp (3) is not valid for all inputs
 # Set the compaction window back to off and advance the number in transactions 5 and 6.
 
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (RETAIN HISTORY = FOR '1000 hours')
+  SET (RETAIN HISTORY = FOR 0)
 
 # But also create an index that compacts frequently.
 > CREATE VIEW nums_compacted AS SELECT * FROM nums
-> CREATE DEFAULT INDEX ON nums_compacted WITH (RETAIN HISTORY = FOR '1s')
+> CREATE DEFAULT INDEX ON nums_compacted WITH (RETAIN HISTORY = FOR '1ms')
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
 {"array":[{"data":{"num":6},"time":5,"diff":-1}]}

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -111,7 +111,7 @@ $ kafka-create-topic topic=nums
 
 # Disable logical compaction, to ensure we can view historical detail.
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (RETAIN HISTORY = FOR 0)
+  SET (RETAIN HISTORY = FOR '1000 hours')
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
@@ -191,11 +191,10 @@ mz_timestamp  mz_diff  num
 > SELECT * FROM nums AS OF 3
 5
 
-# Decrease the compaction window to 1ms and ingest some new data in transaction
-# 4.
+# Decrease the compaction window and ingest some new data in transaction 4.
 
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (RETAIN HISTORY = FOR '1ms')
+  RESET (RETAIN HISTORY)
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
 {"array":[{"data":{"num":5},"time":4,"diff":-1}]}
@@ -215,11 +214,11 @@ contains:Timestamp (3) is not valid for all inputs
 # Set the compaction window back to off and advance the number in transactions 5 and 6.
 
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (RETAIN HISTORY = FOR 0)
+  SET (RETAIN HISTORY = FOR '1000 hours')
 
 # But also create an index that compacts frequently.
 > CREATE VIEW nums_compacted AS SELECT * FROM nums
-> CREATE DEFAULT INDEX ON nums_compacted WITH (RETAIN HISTORY = FOR '1ms')
+> CREATE DEFAULT INDEX ON nums_compacted WITH (RETAIN HISTORY = FOR '1s')
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
 {"array":[{"data":{"num":6},"time":5,"diff":-1}]}


### PR DESCRIPTION
Error if RETAIN HISTORY is less than the default (1s) or disabled. Less than 1s
is bad because 0 is known to be broken and sub 1s compaction is almost always
harmful to users (their queries will likely have always wait 1s) without
benefit. 0 used to mean disabled (i.e., no compaction ever) and is bad because
it'll eventually cause OOMs. Users can specify a very high number if they want
that.

Fixes #27083

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a