### PR TITLE
[explain] Do the heavy lifting for `explain filter pushdown` in a task

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -27,7 +27,7 @@ use mz_sql::ast::ExplainStage;
 use mz_sql::catalog::{CatalogCluster, SessionCatalog};
 // Import `plan` module, but only import select elements to avoid merge conflicts on use statements.
 use mz_catalog::memory::objects::CatalogItem;
-use mz_persist_client::stats::{SnapshotPartStats, SnapshotPartsStats};
+use mz_persist_client::stats::SnapshotPartStats;
 use mz_sql::plan::QueryWhen;
 use mz_sql::plan::{self, HirScalarExpr};
 use mz_sql::session::metadata::SessionMetadata;
@@ -277,8 +277,7 @@ impl Coordinator {
                     return;
                 }
                 ExplainPushdown(stage) => {
-                    let result = self.peek_stage_explain_pushdown(&mut ctx, stage).await;
-                    ctx.retire(result);
+                    self.peek_stage_explain_pushdown(ctx, stage).await;
                     return;
                 }
             }
@@ -992,11 +991,9 @@ impl Coordinator {
     #[instrument]
     async fn peek_stage_explain_pushdown(
         &mut self,
-        ctx: &mut ExecuteContext,
+        ctx: ExecuteContext,
         stage: PeekStageExplainPushdown,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        use futures::stream::TryStreamExt;
-
+    ) {
         let as_of = stage.determination.timestamp_context.antichain();
         let mz_now = stage
             .determination
@@ -1005,77 +1002,85 @@ impl Coordinator {
             .map(|t| ResultSpec::value(Datum::MzTimestamp(*t)))
             .unwrap_or_else(ResultSpec::value_all);
 
-        let futures: FuturesOrdered<_> = stage
-            .imports
-            .into_iter()
-            .map(|(gid, mfp)| {
-                let as_of = &as_of;
-                let mz_now = &mz_now;
-                let this = &self;
-                let ctx = &*ctx;
-                async move {
-                    let catalog_entry = this.catalog.get_entry(&gid);
-                    let full_name = this
-                        .catalog
-                        .for_session(&ctx.session)
-                        .resolve_full_name(&catalog_entry.name);
-                    let name = format!("{}", full_name);
-                    let relation_desc = catalog_entry
-                        .item
-                        .desc_opt()
-                        .expect("source should have a proper desc");
-                    let snapshot_stats: SnapshotPartsStats = this
-                        .controller
-                        .storage
-                        .snapshot_parts_stats(gid, as_of.clone())
-                        .await?;
+        let mut futures = FuturesOrdered::new();
+        for (gid, mfp) in stage.imports {
+            let catalog_entry = self.catalog.get_entry(&gid);
+            let full_name = self
+                .catalog
+                .for_session(&ctx.session)
+                .resolve_full_name(&catalog_entry.name);
+            let name = format!("{}", full_name);
+            let relation_desc = catalog_entry
+                .item
+                .desc_opt()
+                .expect("source should have a proper desc")
+                .into_owned();
+            let stats_future = self
+                .controller
+                .storage
+                .snapshot_parts_stats(gid, as_of.clone())
+                .await;
 
-                    let mut total_bytes = 0;
-                    let mut total_parts = 0;
-                    let mut selected_bytes = 0;
-                    let mut selected_parts = 0;
-                    for SnapshotPartStats {
-                        encoded_size_bytes: bytes,
-                        stats,
-                    } in &snapshot_stats.parts
-                    {
-                        let bytes = u64::cast_from(*bytes);
-                        total_bytes += bytes;
-                        total_parts += 1u64;
-                        let selected = match stats {
-                            None => true,
-                            Some(stats) => {
-                                let stats = stats.decode();
-                                let stats = RelationPartStats::new(
-                                    name.as_str(),
-                                    &snapshot_stats.metrics.pushdown.part_stats,
-                                    &relation_desc,
-                                    &stats,
-                                );
-                                stats.may_match_mfp(mz_now.clone(), &mfp)
-                            }
-                        };
-
-                        if selected {
-                            selected_bytes += bytes;
-                            selected_parts += 1u64;
+            let mz_now = mz_now.clone();
+            // These futures may block if the source is not yet readable at the as-of;
+            // stash them in `futures` and only block on them in a separate task.
+            futures.push_back(async move {
+                let snapshot_stats = match stats_future.await {
+                    Ok(stats) => stats,
+                    Err(e) => return Err(e),
+                };
+                let mut total_bytes = 0;
+                let mut total_parts = 0;
+                let mut selected_bytes = 0;
+                let mut selected_parts = 0;
+                for SnapshotPartStats {
+                    encoded_size_bytes: bytes,
+                    stats,
+                } in &snapshot_stats.parts
+                {
+                    let bytes = u64::cast_from(*bytes);
+                    total_bytes += bytes;
+                    total_parts += 1u64;
+                    let selected = match stats {
+                        None => true,
+                        Some(stats) => {
+                            let stats = stats.decode();
+                            let stats = RelationPartStats::new(
+                                name.as_str(),
+                                &snapshot_stats.metrics.pushdown.part_stats,
+                                &relation_desc,
+                                &stats,
+                            );
+                            stats.may_match_mfp(mz_now.clone(), &mfp)
                         }
+                    };
+
+                    if selected {
+                        selected_bytes += bytes;
+                        selected_parts += 1u64;
                     }
-                    Ok::<_, AdapterError>(Row::pack_slice(&[
-                        name.as_str().into(),
-                        total_bytes.into(),
-                        selected_bytes.into(),
-                        total_parts.into(),
-                        selected_parts.into(),
-                    ]))
                 }
-            })
-            .collect();
+                Ok(Row::pack_slice(&[
+                    name.as_str().into(),
+                    total_bytes.into(),
+                    selected_bytes.into(),
+                    total_parts.into(),
+                    selected_parts.into(),
+                ]))
+            });
+        }
 
-        let rows: Vec<Row> = futures.try_collect().await?;
-        let rows = Box::new(rows.into_row_iter());
-
-        Ok(ExecuteResponse::SendingRowsImmediate { rows })
+        task::spawn(|| "explain filter pushdown", async move {
+            use futures::TryStreamExt;
+            let res = futures
+                .try_collect()
+                .await
+                .map(|rows: Vec<Row>| ExecuteResponse::SendingRowsImmediate {
+                    rows: Box::new(rows.into_row_iter()),
+                })
+                .map_err(|e| e.into());
+            ctx.retire(res);
+        });
     }
 
     /// Determines the query timestamp and acquires read holds on dependent sources

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1731,32 +1731,40 @@ where
         &self,
         id: GlobalId,
         as_of: Antichain<Self::Timestamp>,
-    ) -> Result<SnapshotPartsStats, StorageError<Self::Timestamp>> {
-        let metadata = &self.collection(id)?.collection_metadata;
+    ) -> BoxFuture<'static, Result<SnapshotPartsStats, StorageError<Self::Timestamp>>> {
         // See the comments in Self::snapshot for what's going on here.
-        let result = match metadata.txns_shard.as_ref() {
-            None => {
-                let mut read_handle = self.read_handle_for_snapshot(id).await?;
-                let result = read_handle.snapshot_parts_stats(as_of).await;
-                read_handle.expire().await;
-                result
-            }
-            Some(txns_id) => {
+        let read_handle = self.read_handle_for_snapshot(id).await;
+        let data_snapshot = match self.collection(id) {
+            Err(e) => Err(e),
+            Ok(CollectionState {
+                collection_metadata:
+                    CollectionMetadata {
+                        txns_shard: Some(txns_id),
+                        data_shard,
+                        ..
+                    },
+                ..
+            }) => {
                 let as_of = as_of
-                    .into_option()
+                    .as_option()
                     .expect("cannot read as_of the empty antichain");
                 let txns_read = self.txns.expect_enabled_lazy(txns_id);
                 txns_read.update_gt(as_of.clone()).await;
-                let data_snapshot = txns_read
-                    .data_snapshot(metadata.data_shard, as_of.clone())
-                    .await;
-                let mut handle = self.read_handle_for_snapshot(id).await?;
-                let result = data_snapshot.snapshot_parts_stats(&mut handle).await;
-                handle.expire().await;
-                result
+                let data_snapshot = txns_read.data_snapshot(*data_shard, as_of.clone()).await;
+                Ok(Some(data_snapshot))
             }
+            Ok(_) => Ok(None),
         };
-        result.map_err(|_| StorageError::ReadBeforeSince(id))
+
+        Box::pin(async move {
+            let mut read_handle = read_handle?;
+            let result = match data_snapshot? {
+                Some(data_snapshot) => data_snapshot.snapshot_parts_stats(&mut read_handle).await,
+                None => read_handle.snapshot_parts_stats(as_of).await,
+            };
+            read_handle.expire().await;
+            result.map_err(|_| StorageError::ReadBeforeSince(id))
+        })
     }
 
     #[instrument(level = "debug")]

--- a/test/testdrive/explain-pushdown.td
+++ b/test/testdrive/explain-pushdown.td
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-regex match=(\d+) replacement=<number>
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_explain_pushdown = true
+
+> CREATE CLUSTER sources (SIZE '1', REPLICATION FACTOR 0);
+
+> CREATE SOURCE counter IN CLUSTER sources FROM LOAD GENERATOR COUNTER;
+
+# We expect the explain to time out, so no point waiting for very long...
+$ set-sql-timeout duration=5s force=true
+
+! EXPLAIN FILTER PUSHDOWN FOR SELECT count(*) FROM counter WHERE counter = 1;
+timeout
+
+$ set-sql-timeout duration=default force=true
+
+# Check that we can still handle normal queries
+> SELECT 1 + 1;
+<number>
+
+# If we scale the source cluster up, our query should eventually complete
+> ALTER CLUSTER sources SET (REPLICATION FACTOR 1);
+
+> EXPLAIN FILTER PUSHDOWN FOR SELECT count(*) FROM counter WHERE counter = 1;
+materialize.public.counter <number> <number> <number> <number>


### PR DESCRIPTION
- Split the work for stats snapshotting into two parts: one that needs access to the controller but is fast, and one that doesn't need access to the controller but may be slow.
- Run the possibly-slow half in a task, to avoid blocking a coordinator thread.

### Motivation

See: https://github.com/MaterializeInc/incidents-and-escalations/issues/24

### Tips for reviewer

I'm working on a test for this, but figured I'd better get this up for review in the meantime! Let me know if you have suggestions.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
