### PR TITLE
storage: dyncfg-ify various mz_storage::source durations

### DIFF
--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -12,6 +12,8 @@
 
 use mz_dyncfg::{Config, ConfigSet};
 
+// Flow control
+
 /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
 /// Configuration for basic hydration backpressure.
 pub const DELAY_SOURCES_PAST_REHYDRATION: Config<bool> = Config::new(
@@ -22,6 +24,8 @@ pub const DELAY_SOURCES_PAST_REHYDRATION: Config<bool> = Config::new(
         (namely, upsert) till after rehydration is finished",
 );
 
+// Controller
+
 /// When enabled, force-downgrade the controller's since handle on the shard
 /// during shard finalization.
 pub const STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION: Config<bool> = Config::new(
@@ -31,6 +35,8 @@ pub const STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION: Config<bool> = Config::ne
     "When enabled, force-downgrade the controller's since handle on the shard\
     during shard finalization",
 );
+
+// Kafka
 
 /// Rules for enriching the `client.id` property of Kafka clients with
 /// additional data.
@@ -48,6 +54,8 @@ pub const KAFKA_CLIENT_ID_ENRICHMENT_RULES: Config<fn() -> serde_json::Value> = 
     "Rules for enriching the `client.id` property of Kafka clients with additional data.",
 );
 
+// Networking
+
 /// Whether or not to enforce that external connection addresses are global
 /// (not private or local) when resolving them.
 pub const ENFORCE_EXTERNAL_ADDRESSES: Config<bool> = Config::new(
@@ -56,6 +64,8 @@ pub const ENFORCE_EXTERNAL_ADDRESSES: Config<bool> = Config::new(
     "Whether or not to enforce that external connection addresses are global \
           (not private or local) when resolving them",
 );
+
+// Upsert
 
 /// Whether or not to prevent buffering the entire _upstream_ snapshot in
 /// memory when processing it in memory. This is generally understood to reduce
@@ -86,6 +96,8 @@ pub const STORAGE_UPSERT_MAX_SNAPSHOT_BATCH_BUFFERING: Config<Option<usize>> = C
     None,
     "Limit snapshot buffering in upsert.",
 );
+
+// RocksDB
 
 /// How many times to try to cleanup old RocksDB DB's on disk before giving up.
 pub const STORAGE_ROCKSDB_CLEANUP_TRIES: Config<usize> = Config::new(

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -10,6 +10,8 @@
 //! Dyncfgs used by the storage layer. Despite their name, these can be used
 //! "statically" during rendering, or dynamically within timely operators.
 
+use std::time::Duration;
+
 use mz_dyncfg::{Config, ConfigSet};
 
 // Flow control
@@ -52,6 +54,22 @@ pub const KAFKA_CLIENT_ID_ENRICHMENT_RULES: Config<fn() -> serde_json::Value> = 
     "kafka_client_id_enrichment_rules",
     || serde_json::json!([]),
     "Rules for enriching the `client.id` property of Kafka clients with additional data.",
+);
+
+// MySQL
+
+/// Replication heartbeat interval requested from the MySQL server.
+pub const MYSQL_REPLICATION_HEARTBEAT_INTERVAL: Config<Duration> = Config::new(
+    "mysql_replication_heartbeat_interval",
+    Duration::from_secs(30),
+    "Replication heartbeat interval requested from the MySQL server.",
+);
+
+/// Interval to fetch `offset_known`, from `@gtid_executed`
+pub const MYSQL_OFFSET_KNOWN_INTERVAL: Config<Duration> = Config::new(
+    "mysql_offset_known_interval",
+    Duration::from_secs(10),
+    "Interval to fetch `offset_known`, from `@gtid_executed`",
 );
 
 // Networking
@@ -112,6 +130,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&DELAY_SOURCES_PAST_REHYDRATION)
         .add(&STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION)
         .add(&KAFKA_CLIENT_ID_ENRICHMENT_RULES)
+        .add(&MYSQL_REPLICATION_HEARTBEAT_INTERVAL)
+        .add(&MYSQL_OFFSET_KNOWN_INTERVAL)
         .add(&ENFORCE_EXTERNAL_ADDRESSES)
         .add(&STORAGE_UPSERT_PREVENT_SNAPSHOT_BUFFERING)
         .add(&STORAGE_UPSERT_MAX_SNAPSHOT_BATCH_BUFFERING)

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -72,6 +72,22 @@ pub const MYSQL_OFFSET_KNOWN_INTERVAL: Config<Duration> = Config::new(
     "Interval to fetch `offset_known`, from `@gtid_executed`",
 );
 
+// Postgres
+
+/// Interval to poll `confirmed_flush_lsn` to get a resumption lsn.
+pub const PG_FETCH_SLOT_RESUME_LSN_INTERVAL: Config<Duration> = Config::new(
+    "postgres_fetch_slot_resume_lsn_interval",
+    Duration::from_millis(500),
+    "Interval to poll `confirmed_flush_lsn` to get a resumption lsn.",
+);
+
+/// Interval to fetch `offset_known`, from `pg_current_wal_lsn`
+pub const PG_OFFSET_KNOWN_INTERVAL: Config<Duration> = Config::new(
+    "pg_offset_known_interval",
+    Duration::from_secs(10),
+    "Interval to fetch `offset_known`, from `pg_current_wal_lsn`",
+);
+
 // Networking
 
 /// Whether or not to enforce that external connection addresses are global
@@ -132,6 +148,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&KAFKA_CLIENT_ID_ENRICHMENT_RULES)
         .add(&MYSQL_REPLICATION_HEARTBEAT_INTERVAL)
         .add(&MYSQL_OFFSET_KNOWN_INTERVAL)
+        .add(&PG_FETCH_SLOT_RESUME_LSN_INTERVAL)
+        .add(&PG_OFFSET_KNOWN_INTERVAL)
         .add(&ENFORCE_EXTERNAL_ADDRESSES)
         .add(&STORAGE_UPSERT_PREVENT_SNAPSHOT_BUFFERING)
         .add(&STORAGE_UPSERT_MAX_SNAPSHOT_BATCH_BUFFERING)

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -56,6 +56,24 @@ pub const KAFKA_CLIENT_ID_ENRICHMENT_RULES: Config<fn() -> serde_json::Value> = 
     "Rules for enriching the `client.id` property of Kafka clients with additional data.",
 );
 
+/// The maximum time we will wait before re-polling rdkafka to see if new partitions/data are
+/// available.
+pub const KAFKA_POLL_MAX_WAIT: Config<Duration> = Config::new(
+    "kafka_poll_max_wait",
+    Duration::from_secs(1),
+    "The maximum time we will wait before re-polling rdkafka to see if new partitions/data are \
+    available.",
+);
+
+/// The timeout when seeking through a consumer when fast-forwarding it. We expect this
+/// to happen quickly.
+pub const KAFKA_FAST_FORWARD_SEEK_TIMEOUT: Config<Duration> = Config::new(
+    "kafka_fast_forward_seek_timeout",
+    Duration::from_secs(1),
+    "The timeout when seeking through a consumer when fast-forwarding it. We expect this \
+    to happen quickly.",
+);
+
 // MySQL
 
 /// Replication heartbeat interval requested from the MySQL server.
@@ -146,6 +164,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&DELAY_SOURCES_PAST_REHYDRATION)
         .add(&STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION)
         .add(&KAFKA_CLIENT_ID_ENRICHMENT_RULES)
+        .add(&KAFKA_POLL_MAX_WAIT)
+        .add(&KAFKA_FAST_FORWARD_SEEK_TIMEOUT)
         .add(&MYSQL_REPLICATION_HEARTBEAT_INTERVAL)
         .add(&MYSQL_OFFSET_KNOWN_INTERVAL)
         .add(&PG_FETCH_SLOT_RESUME_LSN_INTERVAL)

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -43,7 +43,6 @@ use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::num::NonZeroU64;
 use std::pin::pin;
-use std::time::Duration;
 
 use differential_dataflow::{AsCollection, Collection};
 use futures::StreamExt;
@@ -512,10 +511,11 @@ async fn raw_stream<'a>(
     // Request that the stream provide us with a heartbeat message when no other messages have
     // been sent. This isn't strictly necessary, but is a lightweight additional general
     // health-check for the replication stream
-    let heartbeat = Duration::from_secs(30);
     conn.query_drop(format!(
         "SET @master_heartbeat_period = {};",
-        heartbeat.as_nanos()
+        mz_storage_types::dyncfgs::MYSQL_REPLICATION_HEARTBEAT_INTERVAL
+            .get(config.config.config_set())
+            .as_nanos()
     ))
     .await?;
 

--- a/src/storage/src/source/mysql/statistics.rs
+++ b/src/storage/src/source/mysql/statistics.rs
@@ -87,8 +87,10 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
             let mut offset_committed = None;
 
             let upstream_stream = async_stream::stream!({
-                // TODO(guswynn): make configurable (at the same time as the pg one).
-                let mut interval = tokio::time::interval(std::time::Duration::from_secs(10));
+                let mut interval = tokio::time::interval(
+                    mz_storage_types::dyncfgs::MYSQL_OFFSET_KNOWN_INTERVAL
+                        .get(config.config.config_set()),
+                );
                 loop {
                     interval.tick().await;
 


### PR DESCRIPTION
I had to do it for the `offset_known` ones, so I did it for all non-trivial (I think) `Duration`'s in `mz_storage::source`. 

### Motivation

   * This PR refactors existing code.
 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
