### PR TITLE
Efficient copy of DatumSeq

### DIFF
--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -1812,6 +1812,18 @@ impl RowPacker<'_> {
         self.row.data.extend_from_slice(row.data.as_slice());
     }
 
+    /// Appends the slice of data representing an entire `Row`. The data is not validated.
+    ///
+    /// # Safety
+    ///
+    /// The requirements from [`Row::from_bytes_unchecked`] apply here, too:
+    /// This method relies on `data` being an appropriate row encoding, and can
+    /// result in unsafety if this is not the case.
+    #[inline]
+    pub unsafe fn extend_by_slice_unchecked(&mut self, data: &[u8]) {
+        self.row.data.extend_from_slice(data)
+    }
+
     /// Pushes a [`DatumList`] that is built from a closure.
     ///
     /// The supplied closure will be invoked once with a `Row` that can be used


### PR DESCRIPTION
### Motivation

Previously, copying the contents of a DatumSeq would require iterating the datums in the DatumSeq and copying each item individually. With this change, we exploit the fact that the row encoding in DatumSeq is a correct row encoding, which allows us to copy the contents directly, without going through their datum representation.

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
