### PR TITLE
ci: fix junit.xml reporting

### DIFF
--- a/misc/python/materialize/mzcompose/test_result.py
+++ b/misc/python/materialize/mzcompose/test_result.py
@@ -121,7 +121,7 @@ def determine_error_from_docker_compose_failure(
     e: CommandFailureCausedUIError, output: str | None, test_context: str | None
 ) -> TestFailureDetails:
     command = to_sanitized_command_str(e.cmd)
-    context_prefix = f"{test_context}: " if test_context else None
+    context_prefix = f"{test_context}: " if test_context is not None else ""
     return TestFailureDetails(
         f"{context_prefix}Docker compose failed: {command}",
         details=output,


### PR DESCRIPTION
Get rid of the `None` prefix.

<img width="1158" alt="Bildschirmfoto 2024-05-15 um 10 53 00" src="https://github.com/MaterializeInc/materialize/assets/129728240/cde4afa2-9ef1-4727-8a21-b2b2f0388ee9">
