### PR TITLE
ci: improve error annotations

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -231,7 +231,7 @@ def annotate_logged_errors(log_files: list[str]) -> int:
     # Keep track of known errors so we log each only once
     already_reported_issue_numbers: set[int] = set()
 
-    def handle_error(error_message: bytes, location: str, is_junit_error: bool):
+    def handle_log_error(error_message: bytes, location: str):
         # Don't have too huge output, so truncate
         formatted_error_message = f"```\n{sanitize_text(truncate_str(error_message.decode('utf-8'), 10_000))}\n```"
 
@@ -267,10 +267,14 @@ def annotate_logged_errors(log_files: list[str]) -> int:
                         already_reported_issue_numbers.add(issue.info["number"])
                     break
             else:
-                error_type = "Failure" if is_junit_error else "Unknown error"
                 unknown_errors.append(
-                    f"{error_type} in {location}:\n{formatted_error_message}"
+                    f"Unknown error in {location}:\n{formatted_error_message}"
                 )
+
+    def handle_junit_error(error_message: bytes, location: str):
+        # Don't have too huge output, so truncate
+        formatted_error_message = f"```\n{sanitize_text(truncate_str(error_message.decode('utf-8'), 10_000))}\n```"
+        unknown_errors.append(f"Failure in {location}:\n{formatted_error_message}")
 
     for error in errors:
         if isinstance(error, ErrorLog):
@@ -283,14 +287,14 @@ def annotate_logged_errors(log_files: list[str]) -> int:
             else:
                 linked_file: str = error.file
 
-            handle_error(error.match, linked_file, is_junit_error=False)
+            handle_log_error(error.match, linked_file)
         elif isinstance(error, JunitError):
             msg = "\n".join(filter(None, [error.message, error.text]))
             if "in Code Coverage" in error.text or "covered" in error.message:
                 # Don't bother looking up known issues for code coverage report, just print it verbatim as an info message
                 known_errors.append(f"{error.testcase}:\n```\n{msg}\n```")
             else:
-                handle_error(msg.encode("utf-8"), error.testcase, is_junit_error=True)
+                handle_junit_error(msg.encode("utf-8"), error.testcase)
         else:
             raise RuntimeError(f"Unexpected error type: {type(error)}")
 

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -136,6 +136,7 @@ class ErrorLog:
 
 @dataclass
 class JunitError:
+    testclass: str
     testcase: str
     message: str
     text: str
@@ -335,12 +336,17 @@ def _get_errors_from_junit_file(log_file_name: str) -> list[JunitError]:
     error_logs = []
     xml = JUnitXml.fromfile(log_file_name)
     for suite in xml:
-        for case in suite:
-            for result in case.result:
+        for testcase in suite:
+            for result in testcase.result:
                 if not isinstance(result, Error) and not isinstance(result, Failure):
                     continue
                 error_logs.append(
-                    JunitError(case.name, result.message or "", result.text or "")
+                    JunitError(
+                        testcase.classname,
+                        testcase.name,
+                        result.message or "",
+                        result.text or "",
+                    )
                 )
     return error_logs
 

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -271,10 +271,23 @@ def annotate_logged_errors(log_files: list[str]) -> int:
                     f"Unknown error in {location}:\n{formatted_error_message}"
                 )
 
-    def handle_junit_error(error_message: bytes, location: str):
+    def handle_junit_error(
+        error_message: str | None, details: str | None, location: str
+    ):
         # Don't have too huge output, so truncate
-        formatted_error_message = f"```\n{sanitize_text(truncate_str(error_message.decode('utf-8'), 10_000))}\n```"
-        unknown_errors.append(f"Failure in {location}:\n{formatted_error_message}")
+        formatted_error_message = (
+            f" `{sanitize_text(truncate_str(error_message, 1_000))}`"
+            if error_message is not None
+            else ""
+        )
+        formatted_error_details = (
+            f"```\n{sanitize_text(truncate_str(details, 9_000))}\n```"
+            if details is not None
+            else ""
+        )
+        unknown_errors.append(
+            f"Failure in {location}:{formatted_error_message}\n{formatted_error_details}"
+        )
 
     for error in errors:
         if isinstance(error, ErrorLog):
@@ -289,12 +302,12 @@ def annotate_logged_errors(log_files: list[str]) -> int:
 
             handle_log_error(error.match, linked_file)
         elif isinstance(error, JunitError):
-            msg = "\n".join(filter(None, [error.message, error.text]))
             if "in Code Coverage" in error.text or "covered" in error.message:
+                msg = "\n".join(filter(None, [error.message, error.text]))
                 # Don't bother looking up known issues for code coverage report, just print it verbatim as an info message
                 known_errors.append(f"{error.testcase}:\n```\n{msg}\n```")
             else:
-                handle_junit_error(msg.encode("utf-8"), error.testcase)
+                handle_junit_error(error.message, error.text, error.testcase)
         else:
             raise RuntimeError(f"Unexpected error type: {type(error)}")
 


### PR DESCRIPTION
### Changes
* Get rid of "Unknown error in" phrase
* Split error message and error details block

### Before
<img width="1158" alt="Bildschirmfoto 2024-05-15 um 12 11 05" src="https://github.com/MaterializeInc/materialize/assets/129728240/dac003b9-aa8e-4220-bbd7-8f7020a4a662">

### After
(with slightly different data)
![Bildschirmfoto 2024-05-15 um 15 36 53](https://github.com/MaterializeInc/materialize/assets/129728240/3236191d-76fc-4dfd-9ae5-bcb3956f5716)

#### Demo
* https://buildkite.com/materialize/nightly/builds/7782
* https://buildkite.com/materialize/nightly/builds/7777
* https://buildkite.com/materialize/test/builds/82062