### PR TITLE
Support container builders for flat_map variants

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -27,6 +27,7 @@ use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 use timely::container::columnation::Columnation;
+use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::OutputHandle;
 use timely::dataflow::operators::Capability;
@@ -994,10 +995,11 @@ where
         thinning: &Vec<usize>,
     ) -> (MzArrangement<S>, Collection<S, DataflowError, i64>) {
         // Catch-all: Just use RowRow.
-        let (oks, errs) = oks.map_fallible(
-            "FormArrangementKey",
-            specialized_arrangement_key(key.clone(), thinning.clone()),
-        );
+        let (oks, errs) = oks
+            .map_fallible::<CapacityContainerBuilder<_>, CapacityContainerBuilder<_>, _, _, _>(
+                "FormArrangementKey",
+                specialized_arrangement_key(key.clone(), thinning.clone()),
+            );
         let oks = oks.mz_arrange::<RowRowSpine<_, _>>(name);
         (MzArrangement::RowRow(oks), errs)
     }

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -15,6 +15,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use differential_dataflow::consolidation::ConsolidatingContainerBuilder;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
@@ -27,6 +28,7 @@ use mz_repr::{DatumVec, Diff, Row, RowArena, SharedRow};
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::{CollectionExt, StreamExt};
 use timely::container::columnation::Columnation;
+use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::{Map, OkErr};
 use timely::dataflow::Scope;
@@ -266,7 +268,7 @@ where
                     // and projections that could not be applied (e.g. column repetition).
                     if let Some(final_closure) = final_closure {
                         let (updates, errors) =
-                            update_stream.flat_map_fallible("DeltaJoinFinalization", {
+                            update_stream.flat_map_fallible::<ConsolidatingContainerBuilder<_>, ConsolidatingContainerBuilder<_>, _, _, _, _>("DeltaJoinFinalization", {
                                 // Reuseable allocation for unpacking.
                                 let mut datums = DatumVec::new();
                                 move |row| {
@@ -399,7 +401,9 @@ where
     for<'a> Tr::Val<'a>: ToDatumIter,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
-    let (updates, errs) = updates.map_fallible("DeltaJoinKeyPreparation", {
+    let name = "DeltaJoinKeyPreparation";
+    type CB<C> = CapacityContainerBuilder<C>;
+    let (updates, errs) = updates.map_fallible::<CB<_>, CB<_>, _, _, _>(name, {
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();
         let mut key_buf = Tr::KeyOwned::default();
@@ -421,7 +425,6 @@ where
             Ok((key, row_value, time))
         }
     });
-
     let mut datums = DatumVec::new();
 
     if closure.could_error() {

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -267,8 +267,10 @@ where
                     // For example, we may have expressions not pushed down (e.g. literals)
                     // and projections that could not be applied (e.g. column repetition).
                     if let Some(final_closure) = final_closure {
-                        let (updates, errors) =
-                            update_stream.flat_map_fallible::<ConsolidatingContainerBuilder<_>, ConsolidatingContainerBuilder<_>, _, _, _, _>("DeltaJoinFinalization", {
+                        let name = "DeltaJoinFinalization";
+                        type CB<C> = ConsolidatingContainerBuilder<C>;
+                        let (updates, errors) = update_stream
+                            .flat_map_fallible::<CB<_>, CB<_>, _, _, _, _>(name, {
                                 // Reuseable allocation for unpacking.
                                 let mut datums = DatumVec::new();
                                 move |row| {

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -618,7 +618,9 @@ where
 
     reclock_op.build(move |capabilities| async move {
         // The capability of the output after reclocking the source frontier
-        let mut cap_set = CapabilitySet::from_elem(capabilities.into_element());
+        let [ok_cap, err_cap]: [_; 2] = capabilities.try_into().expect("one capability per output");
+        let mut ok_cap_set = CapabilitySet::from_elem(ok_cap);
+        let mut err_cap_set = CapabilitySet::from_elem(err_cap);
 
         // Compute the overall resume upper to report for the ingestion
         let resume_upper = Antichain::from_iter(resume_uppers.values().flat_map(|f| f.iter().cloned()));
@@ -721,7 +723,8 @@ where
                     let mut total_processed = 0;
                     for (((idx, msg), from_ts, diff), into_ts) in timestamper.reclock(msgs) {
                         let into_ts = into_ts.expect("reclock for update not beyond upper failed");
-                        let ts_cap = cap_set.delayed(&into_ts);
+                        let ok_ts_cap = ok_cap_set.delayed(&into_ts);
+                        let err_ts_cap = err_cap_set.delayed(&into_ts);
                         match msg {
                             Ok(message) => {
                                 bytes_read += message.key.byte_len() + message.value.byte_len();
@@ -731,14 +734,14 @@ where
                                     metadata: message.metadata,
                                     from_time: from_ts,
                                 };
-                                reclocked_ok_output.give(&ts_cap, ((idx, ok), into_ts, diff)).await;
+                                reclocked_ok_output.give(&ok_ts_cap, ((idx, ok), into_ts, diff)).await;
                             }
                             Err(SourceReaderError { inner }) => {
                                 let err = SourceError {
                                     source_id: id,
                                     error: inner,
                                 };
-                                reclocked_err_output.give(&ts_cap, ((idx, err), into_ts, diff.into())).await;
+                                reclocked_err_output.give(&err_ts_cap, ((idx, err), into_ts, diff.into())).await;
                             }
                         }
 
@@ -760,8 +763,9 @@ where
                     // most one entry in the `CapabilitySet`. If this ever changes we
                     // need to rethink how we surface this in metrics. We will notice
                     // when that happens because the `expect()` will fail.
+                    // TODO: This only checks `ok_cap_set`, which should be in sync with `err_cap_set`.
                     source_metrics.capability.set(
-                        cap_set
+                        ok_cap_set
                             .iter()
                             .at_most_one()
                             .expect("there can be at most one element for totally ordered times")
@@ -790,7 +794,8 @@ where
                         into_ready_upper.pretty()
                     );
 
-                    cap_set.downgrade(into_ready_upper.elements());
+                    ok_cap_set.downgrade(into_ready_upper.elements());
+                    err_cap_set.downgrade(into_ready_upper.elements());
                     timestamper.compact(into_ready_upper.clone());
                     if into_ready_upper.is_empty() {
                         return;


### PR DESCRIPTION
This change adds support for specifying the container builder to the various variants of `flat_map` and adjusts the call sites. Most use the default capacity-based builder, but some switch to the consolidating variant. I selected places that apply scalar expressions to rows for the consolidating variant, which have the chance to change rows sufficiently that it enables further consolidation.

Best viewed with whitespace changes hidden!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
