### PR TITLE
Remove operator pairs that are inverses

### DIFF
--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -773,6 +773,20 @@ impl MirScalarExpr {
                                     }
                                     _ => {}
                                 }
+                            } else if let Some(inverse_func) = func.inverse() {
+                                if func.preserves_uniqueness()
+                                    && inverse_func.preserves_uniqueness()
+                                {
+                                    if let MirScalarExpr::CallUnary {
+                                        func: inner_func,
+                                        expr,
+                                    } = &mut **expr
+                                    {
+                                        if inner_func == func {
+                                            *e = expr.take();
+                                        }
+                                    }
+                                }
                             }
                         }
                         _ => {}


### PR DESCRIPTION
This PR updates `MirScalarExpr::reduce` to notice and remove two unary operators in sequence that are inverses of each other. One intent is to remove casting between `VARCHAR` and `TEXT`, which when there are no limits for the `VARCHAR` we all agree to be pretty pointless.

One big unknown is when this is known to be safe. The `func.inverse()` function does not provide a function that acts as an inverse on `func`, but rather .. kinda acts like an inverse under some undocumented conditions. Looking at the code, it seems that the idiom is to look at `preserves_uniqueness()` for both functions, and if both are true then we are good to go. This may be incorrect, and we may have to think harder.

cc: @ggevay, @mgree 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
