### PR TITLE
compute: avoid needless allocations of strings in text-to-varchar conversion

### DIFF
--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -666,7 +666,7 @@ pub struct CastStringToVarChar {
 
 impl<'a> EagerUnaryFunc<'a> for CastStringToVarChar {
     type Input = &'a str;
-    type Output = Result<VarChar<&str>, EvalError>;
+    type Output = Result<VarChar<&'a str>, EvalError>;
 
     fn call(&self, a: &'a str) -> Result<VarChar<&'a str>, EvalError> {
         let s =

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -666,9 +666,9 @@ pub struct CastStringToVarChar {
 
 impl<'a> EagerUnaryFunc<'a> for CastStringToVarChar {
     type Input = &'a str;
-    type Output = Result<VarChar<String>, EvalError>;
+    type Output = Result<VarChar<&str>, EvalError>;
 
-    fn call(&self, a: &'a str) -> Result<VarChar<String>, EvalError> {
+    fn call(&self, a: &'a str) -> Result<VarChar<&str>, EvalError> {
         let s =
             mz_repr::adt::varchar::format_str(a, self.length, self.fail_on_len).map_err(|_| {
                 assert!(self.fail_on_len);

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -668,7 +668,7 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToVarChar {
     type Input = &'a str;
     type Output = Result<VarChar<&str>, EvalError>;
 
-    fn call(&self, a: &'a str) -> Result<VarChar<&str>, EvalError> {
+    fn call(&self, a: &'a str) -> Result<VarChar<&'a str>, EvalError> {
         let s =
             mz_repr::adt::varchar::format_str(a, self.length, self.fail_on_len).map_err(|_| {
                 assert!(self.fail_on_len);

--- a/src/repr/src/adt/varchar.rs
+++ b/src/repr/src/adt/varchar.rs
@@ -105,7 +105,7 @@ pub fn format_str(
     s: &str,
     length: Option<VarCharMaxLength>,
     fail_on_len: bool,
-) -> Result<String, anyhow::Error> {
+) -> Result<&str, anyhow::Error> {
     Ok(match length {
         // Note that length is 1-indexed, so finding `None` means the string's
         // characters don't exceed the length, while finding `Some` means it
@@ -113,17 +113,17 @@ pub fn format_str(
         Some(l) => {
             let l = usize::cast_from(l.into_u32());
             match s.char_indices().nth(l) {
-                None => s.to_string(),
+                None => s,
                 Some((idx, _)) => {
                     if !fail_on_len || s[idx..].chars().all(|c| c.is_ascii_whitespace()) {
-                        s[..idx].to_string()
+                        &s[..idx]
                     } else {
                         bail!("{} exceeds maximum length of {}", s, l)
                     }
                 }
             }
         }
-        None => s.to_string(),
+        None => s,
     })
 }
 


### PR DESCRIPTION
While working with @frankmcsherry, we noticed that `text_to_varchar` was allocating a fresh string every time, even though `VarChar<S>` accepts `&str`.

### Motivation

  * This PR fixes a previously unreported bug.

  Even when the text fits in the varchar limit, we would allocate a new string. There's no need to do this: just pass a reference.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
