### PR TITLE
Update user docs that reference mz_cluster_replica_sizes to use the new mz_catalog repo for this table

### DIFF
--- a/doc/user/content/free-trial-faqs.md
+++ b/doc/user/content/free-trial-faqs.md
@@ -48,7 +48,7 @@ the following query against Materialize:
 ```sql
 SELECT sum(s.credits_per_hour) AS credit_consumption_rate
   FROM mz_cluster_replicas r
-  JOIN mz_internal.mz_cluster_replica_sizes s ON r.size = s.size;
+  JOIN mz_catalog.mz_cluster_replica_sizes s ON r.size = s.size;
 ```
 
 For example, if you start your free trial by following the [getting started guide](/get-started/quickstart),

--- a/doc/user/content/free-trial-faqs.md
+++ b/doc/user/content/free-trial-faqs.md
@@ -48,7 +48,7 @@ the following query against Materialize:
 ```sql
 SELECT sum(s.credits_per_hour) AS credit_consumption_rate
   FROM mz_cluster_replicas r
-  JOIN mz_catalog.mz_cluster_replica_sizes s ON r.size = s.size;
+  JOIN mz_cluster_replica_sizes s ON r.size = s.size;
 ```
 
 For example, if you start your free trial by following the [getting started guide](/get-started/quickstart),

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -94,7 +94,7 @@ The resource allocations are proportional to the number in the size name. For
 example, a cluster of size `600cc` has 2x as much CPU, memory, and disk as a
 cluster of size `300cc`, and 1.5x as much CPU, memory, and disk as a cluster of
 size `400cc`. To determine the specific resource allocations for a size,
-query the [`mz_catalog.mz_cluster_replica_sizes`] table.
+query the [`mz_cluster_replica_sizes`] table.
 
 
 Clusters of larger sizes can process data faster and handle larger data volumes.
@@ -103,7 +103,7 @@ changes in the resource requirements of your workload.
 
 
 {{< warning >}}
-The values in the `mz_catalog.mz_cluster_replica_sizes` table may change at any
+The values in the `mz_cluster_replica_sizes` table may change at any
 time. You should not rely on them for any kind of capacity planning.
 {{< /warning >}}
 
@@ -294,4 +294,4 @@ The privileges required to execute this statement are:
 [`DROP CLUSTER`]: /sql/drop-cluster/
 [`SELECT`]: /sql/select
 [`SUBSCRIBE`]: /sql/subscribe
-[`mz_catalog.mz_cluster_replica_sizes`]: /sql/system-catalog/mz_catalog#mz_cluster_replica_sizes
+[`mz_cluster_replica_sizes`]: /sql/system-catalog/mz_catalog#mz_cluster_replica_sizes

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -94,7 +94,7 @@ The resource allocations are proportional to the number in the size name. For
 example, a cluster of size `600cc` has 2x as much CPU, memory, and disk as a
 cluster of size `300cc`, and 1.5x as much CPU, memory, and disk as a cluster of
 size `400cc`. To determine the specific resource allocations for a size,
-query the [`mz_internal.mz_cluster_replica_sizes`] table.
+query the [`mz_catalog.mz_cluster_replica_sizes`] table.
 
 
 Clusters of larger sizes can process data faster and handle larger data volumes.
@@ -103,7 +103,7 @@ changes in the resource requirements of your workload.
 
 
 {{< warning >}}
-The values in the `mz_internal.mz_cluster_replica_sizes` table may change at any
+The values in the `mz_catalog.mz_cluster_replica_sizes` table may change at any
 time. You should not rely on them for any kind of capacity planning.
 {{< /warning >}}
 
@@ -294,4 +294,4 @@ The privileges required to execute this statement are:
 [`DROP CLUSTER`]: /sql/drop-cluster/
 [`SELECT`]: /sql/select
 [`SUBSCRIBE`]: /sql/subscribe
-[`mz_internal.mz_cluster_replica_sizes`]: /sql/system-catalog/mz_internal/#mz_cluster_replica_sizes
+[`mz_catalog.mz_cluster_replica_sizes`]: /sql/system-catalog/mz_catalog#mz_cluster_replica_sizes


### PR DESCRIPTION
Docs follow up for https://github.com/MaterializeInc/materialize/issues/26026, now that it's releasing.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
