### PR TITLE
ci: annotate failed miri test cases

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -57,6 +57,8 @@ ERROR_RE = re.compile(
     | environmentd .* unrecognized\ configuration\ parameter
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
     | SUMMARY:\ .*Sanitizer
+    # for miri test summary
+    | FAIL\ \[\s*\d+\.\d+s\]
     )
     .* $
     """,


### PR DESCRIPTION
CI should report the failed test.

### Before

<img width="1154" alt="Bildschirmfoto 2024-05-16 um 15 18 20" src="https://github.com/MaterializeInc/materialize/assets/129728240/3581b778-99b3-4b6a-81c5-7827df762c39">

### After

<img width="1154" alt="Bildschirmfoto 2024-05-16 um 16 42 19" src="https://github.com/MaterializeInc/materialize/assets/129728240/5e207379-1598-46b5-8c8b-303b4eb604bb">

https://buildkite.com/materialize/nightly/builds/7789