### PR TITLE
get rid of unsafe code for float rounding

### DIFF
--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -37,13 +37,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "roundf32"]
     fn round_float32(a: f32) -> f32 {
-        // f32::round violates IEEE 754 by rounding ties away from zero rather than
-        // to nearest even. There appears to be no way to round ties to nearest even
-        // in Rust natively, so bail out to C.
-        extern "C" {
-            fn rintf(f: f32) -> f32;
-        }
-        unsafe { rintf(a) }
+        a.round_ties_even()
     }
 );
 

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -41,13 +41,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "roundf64"]
     fn round_float64(a: f64) -> f64 {
-        // f64::round violates IEEE 754 by rounding ties away from zero rather than
-        // to nearest even. There appears to be no way to round ties to nearest even
-        // in Rust natively, so bail out to C.
-        extern "C" {
-            fn rint(f: f64) -> f64;
-        }
-        unsafe { rint(a) }
+        a.round_ties_even()
     }
 );
 


### PR DESCRIPTION
this exists now since 1.77 @sploiselle 