### PR TITLE
tests: run upgrade checks on release docs update, fail on forgotten release bump

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -659,6 +659,7 @@ steps:
     label: "Skip Version Upgrade"
     depends_on: build-aarch64
     timeout_in_minutes: 30
+    inputs: [doc/user/content/releases]
     plugins:
       - ./ci/plugins/mzcompose:
           composition: skip-version-upgrade

--- a/test/skip-version-upgrade/mzcompose.py
+++ b/test/skip-version-upgrade/mzcompose.py
@@ -42,7 +42,14 @@ def workflow_test_version_skips(c: Composition) -> None:
 
     # If the current version is `v0.X.0-dev`, two_minor_releases_before will be `v0.X-2.Y`.
     # where Y is the most recent patch version of the minor version.
-    two_minor_releases_before = get_minor_mz_versions_listed_in_docs()[-2]
+    last_two_minor_releases = get_minor_mz_versions_listed_in_docs()[-2:]
+    two_minor_releases_before = last_two_minor_releases[-2]
+    one_minor_release_before = last_two_minor_releases[-1]
+
+    if current_version.major == one_minor_release_before.major:
+        assert (
+            one_minor_release_before.minor < current_version.minor
+        ), "current minor version matches last released minor version from docs; was the release bump merged?"
 
     print(
         f"Testing that a migration from two minor releases before (={two_minor_releases_before})"


### PR DESCRIPTION
To avoid such issues: https://materializeinc.slack.com/archives/C01LKF361MZ/p1715867464383909