### PR TITLE
output consistency: add list type

### DIFF
--- a/misc/python/materialize/output_consistency/data_type/data_type_category.py
+++ b/misc/python/materialize/output_consistency/data_type/data_type_category.py
@@ -29,6 +29,7 @@ class DataTypeCategory(Enum):
     ENUM = 200
 
     ARRAY = 300
-    MAP = 301
+    LIST = 301
+    MAP = 302
 
     OTHER_UNSUPPORTED = 400

--- a/misc/python/materialize/output_consistency/expression/expression_characteristics.py
+++ b/misc/python/materialize/output_consistency/expression/expression_characteristics.py
@@ -44,3 +44,4 @@ class ExpressionCharacteristics(Enum):
 
     COLLECTION_EMPTY = 160
     MAP_WITH_DUP_KEYS = 161
+    LIST_WITH_DUP_ENTRIES = 162

--- a/misc/python/materialize/output_consistency/input_data/operations/all_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/all_operations_provider.py
@@ -33,6 +33,9 @@ from materialize.output_consistency.input_data.operations.generic_operations_pro
 from materialize.output_consistency.input_data.operations.jsonb_operations_provider import (
     JSONB_OPERATION_TYPES,
 )
+from materialize.output_consistency.input_data.operations.list_operations_provider import (
+    LIST_OPERATION_TYPES,
+)
 from materialize.output_consistency.input_data.operations.map_operations_provider import (
     MAP_OPERATION_TYPES,
 )
@@ -68,6 +71,7 @@ ALL_OPERATION_TYPES: list[DbOperationOrFunction] = list(
         CRYPTO_OPERATION_TYPES,
         JSONB_OPERATION_TYPES,
         MAP_OPERATION_TYPES,
+        LIST_OPERATION_TYPES,
         UUID_OPERATION_TYPES,
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
@@ -1,0 +1,117 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.input_data.params.any_operation_param import (
+    AnyLikeOtherOperationParam,
+    AnyOperationParam,
+)
+from materialize.output_consistency.input_data.params.collection_operation_param import (
+    ElementOfOtherCollectionOperationParam,
+)
+from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
+    COLLECTION_INDEX_PARAM,
+    COLLECTION_INDEX_PARAM_OPT,
+)
+from materialize.output_consistency.input_data.params.list_operation_param import (
+    ListLikeOtherListOperationParam,
+    ListOfOtherElementOperationParam,
+    ListOperationParam,
+)
+from materialize.output_consistency.input_data.return_specs.list_return_spec import (
+    ListReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.number_return_spec import (
+    NumericReturnTypeSpec,
+)
+from materialize.output_consistency.operation.operation import (
+    DbFunction,
+    DbOperation,
+    DbOperationOrFunction,
+)
+
+# all operations will be disabled for Postgres at the bottom
+LIST_OPERATION_TYPES: list[DbOperationOrFunction] = []
+
+LIST_OPERATION_TYPES.append(
+    DbOperation(
+        "$ || $",
+        [
+            ListOperationParam(),
+            ListLikeOtherListOperationParam(index_of_previous_param=0),
+        ],
+        ListReturnTypeSpec(),
+        comment="concatenate lists (equal to list_cat)",
+    )
+)
+
+LIST_OPERATION_TYPES.append(
+    DbOperation(
+        "$ || $",
+        [
+            ListOperationParam(),
+            ElementOfOtherCollectionOperationParam(index_of_previous_param=0),
+        ],
+        ListReturnTypeSpec(),
+        comment="append element to list (equal to list_append)",
+    )
+)
+
+LIST_OPERATION_TYPES.append(
+    DbOperation(
+        "$ || $",
+        [
+            AnyOperationParam(),
+            ListOfOtherElementOperationParam(index_of_previous_param=0),
+        ],
+        ListReturnTypeSpec(),
+        comment="prepend element to list (equal to list_prepend)",
+    )
+)
+
+LIST_OPERATION_TYPES.append(
+    DbFunction(
+        "list_agg",
+        [
+            AnyOperationParam(),
+            AnyLikeOtherOperationParam(index_of_previous_param=0, optional=True),
+            AnyLikeOtherOperationParam(index_of_previous_param=0, optional=True),
+            AnyLikeOtherOperationParam(index_of_previous_param=0, optional=True),
+        ],
+        ListReturnTypeSpec(),
+    )
+)
+
+LIST_OPERATION_TYPES.append(
+    DbFunction(
+        "list_length",
+        [ListOperationParam()],
+        NumericReturnTypeSpec(only_integer=True),
+    )
+)
+
+LIST_OPERATION_TYPES.append(
+    DbOperation(
+        "$[$]",
+        [ListOperationParam(), COLLECTION_INDEX_PARAM],
+        ListReturnTypeSpec(),
+        comment="access list element",
+    )
+)
+
+LIST_OPERATION_TYPES.append(
+    DbOperation(
+        "$[$:$]",
+        [ListOperationParam(), COLLECTION_INDEX_PARAM_OPT, COLLECTION_INDEX_PARAM_OPT],
+        ListReturnTypeSpec(),
+        comment="slice list",
+    )
+)
+for operation in LIST_OPERATION_TYPES:
+    # Postgres does not support the list type
+    operation.is_pg_compatible = False

--- a/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
+++ b/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
@@ -112,6 +112,14 @@ UUID_VALUE_PARAM = EnumConstantOperationParam(
     add_invalid_value=True,
 )
 
+COLLECTION_INDEX_PARAM = EnumConstantOperationParam(
+    ["0", "1", "2", "8"], add_quotes=False, add_invalid_value=False
+)
+
+COLLECTION_INDEX_PARAM_OPT = EnumConstantOperationParam(
+    ["0", "1", "2", "8"], add_quotes=False, add_invalid_value=False, optional=True
+)
+
 
 def all_data_types_enum_constant_operation_param(
     must_be_pg_compatible: bool,

--- a/misc/python/materialize/output_consistency/input_data/params/list_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/list_operation_param.py
@@ -1,0 +1,53 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.output_consistency.data_type.data_type import DataType
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.expression.expression import Expression
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.params.collection_operation_param import (
+    CollectionLikeOtherCollectionOperationParam,
+    CollectionOfOtherElementOperationParam,
+    CollectionOperationParam,
+)
+from materialize.output_consistency.input_data.types.list_type_provider import (
+    ListDataType,
+)
+
+
+class ListOperationParam(CollectionOperationParam):
+    def __init__(
+        self,
+        optional: bool = False,
+        incompatibilities: set[ExpressionCharacteristics] | None = None,
+    ):
+        super().__init__(
+            DataTypeCategory.LIST,
+            optional,
+            incompatibilities,
+            incompatibility_combinations=None,
+        )
+
+    def supports_type(
+        self, data_type: DataType, previous_args: list[Expression]
+    ) -> bool:
+        return isinstance(data_type, ListDataType)
+
+
+class ListLikeOtherListOperationParam(CollectionLikeOtherCollectionOperationParam):
+    def matches_collection_type(self, data_type: DataType) -> bool:
+        return data_type.category == DataTypeCategory.LIST
+
+
+class ListOfOtherElementOperationParam(CollectionOfOtherElementOperationParam):
+    def matches_collection_type(self, data_type: DataType) -> bool:
+        return data_type.category == DataTypeCategory.LIST

--- a/misc/python/materialize/output_consistency/input_data/return_specs/list_return_spec.py
+++ b/misc/python/materialize/output_consistency/input_data/return_specs/list_return_spec.py
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.input_data.return_specs.collection_return_spec import (
+    CollectionReturnTypeSpec,
+)
+
+
+class ListReturnTypeSpec(CollectionReturnTypeSpec):
+    def __init__(
+        self,
+        param_index_of_map_value_type: int = 0,
+        list_value_type_category: DataTypeCategory = DataTypeCategory.DYNAMIC,
+    ):
+        super().__init__(
+            DataTypeCategory.LIST,
+            param_index_of_map_value_type,
+            list_value_type_category,
+        )

--- a/misc/python/materialize/output_consistency/input_data/types/all_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/all_types_provider.py
@@ -21,6 +21,9 @@ from materialize.output_consistency.input_data.types.date_time_types_provider im
 from materialize.output_consistency.input_data.types.jsonb_type_provider import (
     JSONB_DATA_TYPE,
 )
+from materialize.output_consistency.input_data.types.list_type_provider import (
+    LIST_DATA_TYPES,
+)
 from materialize.output_consistency.input_data.types.map_type_provider import (
     MAP_DATA_TYPES,
 )
@@ -43,6 +46,7 @@ DATA_TYPES: list[DataType] = list(
         [BYTEA_DATA_TYPE],
         [JSONB_DATA_TYPE],
         MAP_DATA_TYPES,
+        LIST_DATA_TYPES,
         [UUID_DATA_TYPE],
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/types/list_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/list_type_provider.py
@@ -1,0 +1,84 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.input_data.return_specs.collection_return_spec import (
+    CollectionReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.list_return_spec import (
+    ListReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.types.collection_type_provider import (
+    CollectionDataType,
+)
+
+DOUBLE_LIST_TYPE_IDENTIFIER = "DOUBLE_LIST"
+TIMESTAMPTZ_LIST_TYPE_IDENTIFIER = "TIMESTAMPTZ_LIST"
+NESTED_TEXT_LIST_IDENTIFIER = "NESTED_TEXT_LIST"
+
+
+class ListDataType(CollectionDataType):
+    def __init__(
+        self,
+        internal_identifier: str,
+        type_name: str,
+        list_entry_value_1: str,
+        list_entry_value_2: str,
+        value_type_category: DataTypeCategory,
+    ):
+        super().__init__(
+            internal_identifier,
+            type_name,
+            DataTypeCategory.LIST,
+            entry_value_1=list_entry_value_1,
+            entry_value_2=list_entry_value_2,
+            value_type_category=value_type_category,
+            is_pg_compatible=False,
+        )
+
+    def _create_collection_return_type_spec(self) -> CollectionReturnTypeSpec:
+        return ListReturnTypeSpec(list_value_type_category=self.value_type_category)
+
+
+def as_list_sql(values: list[str], as_castable_string: bool = True) -> str:
+    entries_str = ", ".join(values)
+    sql = f"{{{entries_str}}}"
+
+    if as_castable_string:
+        sql = f"'{sql}'"
+
+    return sql
+
+
+DOUBLE_LIST_TYPE = ListDataType(
+    DOUBLE_LIST_TYPE_IDENTIFIER,
+    type_name="DOUBLE LIST",
+    list_entry_value_1="0.0",
+    list_entry_value_2="4.7",
+    value_type_category=DataTypeCategory.NUMERIC,
+)
+TIMESTAMPTZ_LIST_TYPE = ListDataType(
+    TIMESTAMPTZ_LIST_TYPE_IDENTIFIER,
+    type_name="TIMESTAMPTZ LIST",
+    list_entry_value_1="2024-02-29 11:50:00 EST",
+    list_entry_value_2="2024-03-31 01:20:00 Europe/Vienna",
+    value_type_category=DataTypeCategory.DATE_TIME,
+)
+NESTED_TEXT_LIST_TYPE = ListDataType(
+    NESTED_TEXT_LIST_IDENTIFIER,
+    type_name="TEXT LIST LIST",
+    list_entry_value_1=as_list_sql(["a", "b"], as_castable_string=False),
+    list_entry_value_2=as_list_sql(["a", "A"], as_castable_string=False),
+    value_type_category=DataTypeCategory.LIST,
+)
+LIST_DATA_TYPES = [
+    DOUBLE_LIST_TYPE,
+    TIMESTAMPTZ_LIST_TYPE,
+    NESTED_TEXT_LIST_TYPE,
+]

--- a/misc/python/materialize/output_consistency/input_data/values/all_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/all_values_provider.py
@@ -23,6 +23,9 @@ from materialize.output_consistency.input_data.values.date_time_values_provider 
 from materialize.output_consistency.input_data.values.jsonb_values_provider import (
     JSONB_DATA_TYPE_WITH_VALUES,
 )
+from materialize.output_consistency.input_data.values.list_values_provider import (
+    VALUES_PER_LIST_DATA_TYPE,
+)
 from materialize.output_consistency.input_data.values.map_values_provider import (
     VALUES_PER_MAP_DATA_TYPE,
 )
@@ -45,6 +48,7 @@ ALL_DATA_TYPES_WITH_VALUES: list[DataTypeWithValues] = list(
         [TEXT_DATA_TYPE_WITH_VALUES],
         [JSONB_DATA_TYPE_WITH_VALUES],
         list(VALUES_PER_MAP_DATA_TYPE.values()),
+        list(VALUES_PER_LIST_DATA_TYPE.values()),
         [UUID_DATA_TYPE_WITH_VALUES],
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/values/list_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/list_values_provider.py
@@ -1,0 +1,56 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type_with_values import (
+    DataTypeWithValues,
+)
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.types.list_type_provider import (
+    LIST_DATA_TYPES,
+    ListDataType,
+    as_list_sql,
+)
+
+VALUES_PER_LIST_DATA_TYPE: dict[ListDataType, DataTypeWithValues] = dict()
+
+for list_data_type in LIST_DATA_TYPES:
+    values_of_type = DataTypeWithValues(list_data_type)
+    VALUES_PER_LIST_DATA_TYPE[list_data_type] = values_of_type
+
+    values_of_type.add_raw_value(
+        as_list_sql([]),
+        "EMPTY",
+        {ExpressionCharacteristics.COLLECTION_EMPTY},
+    )
+
+    values_of_type.add_raw_value(
+        as_list_sql([list_data_type.entry_value_1]),
+        "ONE_ELEM",
+        set(),
+    )
+
+    values_of_type.add_raw_value(
+        as_list_sql([list_data_type.entry_value_1, list_data_type.entry_value_2]),
+        "TWO_ELEM",
+        set(),
+    )
+
+    values_of_type.add_raw_value(
+        as_list_sql(
+            [
+                list_data_type.entry_value_1,
+                list_data_type.entry_value_1,
+                list_data_type.entry_value_2,
+            ]
+        ),
+        "DUP_ELEM",
+        {ExpressionCharacteristics.LIST_WITH_DUP_ENTRIES},
+    )


### PR DESCRIPTION
### Prerequisites
This is based on:
* https://github.com/MaterializeInc/materialize/pull/27129
* https://github.com/MaterializeInc/materialize/pull/27128

### Commits
1b33e4d6f1 output consistency: list type: add type and return spec
47d675708d output consistency: list type: add operation params
16a90193e2 output consistency: list type: add list values
d3659a7edf output consistency: list type: add operations

### Nightly
* https://buildkite.com/materialize/nightly/builds/7791 ✅ (failure is unrelated and fixed on main)
* https://buildkite.com/materialize/nightly/builds/7825 ✅ 