### PR TITLE
output consistency: generalize map type structures

### DIFF
--- a/misc/python/materialize/output_consistency/expression/expression_characteristics.py
+++ b/misc/python/materialize/output_consistency/expression/expression_characteristics.py
@@ -42,5 +42,5 @@ class ExpressionCharacteristics(Enum):
     JSON_EMPTY = 150
     JSON_ARRAY = 151
 
-    MAP_EMPTY = 160
+    COLLECTION_EMPTY = 160
     MAP_WITH_DUP_KEYS = 161

--- a/misc/python/materialize/output_consistency/input_data/params/collection_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/collection_operation_param.py
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.output_consistency.operation.operation_param import OperationParam
+
+
+class CollectionOperationParam(OperationParam):
+    """Base for ListOperationParam, MapOperationParam"""
+    pass

--- a/misc/python/materialize/output_consistency/input_data/params/collection_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/collection_operation_param.py
@@ -6,11 +6,71 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-
-
+from materialize.output_consistency.data_type.data_type import DataType
+from materialize.output_consistency.expression.expression import Expression
+from materialize.output_consistency.input_data.params.any_operation_param import (
+    AnyLikeOtherOperationParam,
+)
+from materialize.output_consistency.input_data.return_specs.collection_return_spec import (
+    CollectionReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.types.collection_type_provider import (
+    CollectionDataType,
+)
 from materialize.output_consistency.operation.operation_param import OperationParam
 
 
 class CollectionOperationParam(OperationParam):
     """Base for ListOperationParam, MapOperationParam"""
+
     pass
+
+
+class CollectionLikeOtherCollectionOperationParam(AnyLikeOtherOperationParam):
+    def supports_type(
+        self, data_type: DataType, previous_args: list[Expression]
+    ) -> bool:
+        if not self.matches_collection_type(data_type):
+            return False
+
+        if isinstance(data_type, CollectionDataType):
+            previous_arg = self._get_previous_arg(previous_args)
+
+            previous_arg_ret_type_spec = previous_arg.resolve_return_type_spec()
+            assert isinstance(previous_arg_ret_type_spec, CollectionReturnTypeSpec)
+            return (
+                data_type.value_type_category
+                == previous_arg_ret_type_spec.get_entry_value_type()
+            )
+
+        return False
+
+    def matches_collection_type(self, data_type: DataType) -> bool:
+        return True
+
+
+class CollectionOfOtherElementOperationParam(AnyLikeOtherOperationParam):
+    def supports_type(
+        self, data_type: DataType, previous_args: list[Expression]
+    ) -> bool:
+        if not self.matches_collection_type(data_type):
+            return False
+
+        previous_arg = self._get_previous_arg(previous_args)
+        previous_arg_ret_type_category = previous_arg.resolve_return_type_category()
+
+        assert isinstance(data_type, CollectionDataType)
+        return data_type.value_type_category == previous_arg_ret_type_category
+
+    def matches_collection_type(self, data_type: DataType) -> bool:
+        return True
+
+
+class ElementOfOtherCollectionOperationParam(AnyLikeOtherOperationParam):
+    def supports_type(
+        self, data_type: DataType, previous_args: list[Expression]
+    ) -> bool:
+        previous_arg = self._get_previous_arg(previous_args)
+        previous_arg_ret_type_spec = previous_arg.resolve_return_type_spec()
+        assert isinstance(previous_arg_ret_type_spec, CollectionReturnTypeSpec)
+        return data_type.category == previous_arg_ret_type_spec.get_entry_value_type()

--- a/misc/python/materialize/output_consistency/input_data/params/map_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/map_operation_param.py
@@ -14,13 +14,15 @@ from materialize.output_consistency.expression.expression import Expression
 from materialize.output_consistency.expression.expression_characteristics import (
     ExpressionCharacteristics,
 )
+from materialize.output_consistency.input_data.params.collection_operation_param import (
+    CollectionOperationParam,
+)
 from materialize.output_consistency.input_data.types.map_type_provider import (
     MapDataType,
 )
-from materialize.output_consistency.operation.operation_param import OperationParam
 
 
-class MapOperationParam(OperationParam):
+class MapOperationParam(CollectionOperationParam):
     def __init__(
         self,
         optional: bool = False,

--- a/misc/python/materialize/output_consistency/input_data/params/map_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/map_operation_param.py
@@ -15,6 +15,7 @@ from materialize.output_consistency.expression.expression_characteristics import
     ExpressionCharacteristics,
 )
 from materialize.output_consistency.input_data.params.collection_operation_param import (
+    CollectionLikeOtherCollectionOperationParam,
     CollectionOperationParam,
 )
 from materialize.output_consistency.input_data.types.map_type_provider import (
@@ -39,3 +40,8 @@ class MapOperationParam(CollectionOperationParam):
         self, data_type: DataType, previous_args: list[Expression]
     ) -> bool:
         return isinstance(data_type, MapDataType)
+
+
+class MapLikeOtherMapOperationParam(CollectionLikeOtherCollectionOperationParam):
+    def matches_collection_type(self, data_type: DataType) -> bool:
+        return data_type.category == DataTypeCategory.MAP

--- a/misc/python/materialize/output_consistency/input_data/return_specs/collection_return_spec.py
+++ b/misc/python/materialize/output_consistency/input_data/return_specs/collection_return_spec.py
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.operation.return_type_spec import (
+    InputArgTypeHints,
+    ReturnTypeSpec,
+)
+
+
+class CollectionReturnTypeSpec(ReturnTypeSpec):
+    def __init__(
+        self,
+        data_type_category: DataTypeCategory,
+        param_index_of_map_value_type: int = 0,
+        entry_value_type_category: DataTypeCategory = DataTypeCategory.DYNAMIC,
+    ):
+        super().__init__(data_type_category, [param_index_of_map_value_type])
+        self._entry_value_type_category = entry_value_type_category
+
+    def resolve_type_category(
+        self, input_arg_type_hints: InputArgTypeHints
+    ) -> DataTypeCategory:
+        # update the value type of the collection entries
+        if self._entry_value_type_category == DataTypeCategory.DYNAMIC:
+            self._update_collection_value_type(input_arg_type_hints)
+
+        # provide the actual return value
+        return super().resolve_type_category(input_arg_type_hints)
+
+    def _update_collection_value_type(
+        self, input_arg_type_hints: InputArgTypeHints
+    ) -> None:
+        assert (
+            input_arg_type_hints is not None
+            and self.indices_of_required_input_type_hints is not None
+            and not input_arg_type_hints.is_empty()
+        ), "Invalid state"
+        self._entry_value_type_category = (
+            input_arg_type_hints.type_category_of_requested_args[
+                self.indices_of_required_input_type_hints[0]
+            ]
+        )
+
+    def get_entry_value_type(self) -> DataTypeCategory:
+        assert (
+            self._entry_value_type_category != DataTypeCategory.DYNAMIC
+        ), "entry value type not resolved"
+        return self._entry_value_type_category

--- a/misc/python/materialize/output_consistency/input_data/return_specs/map_return_spec.py
+++ b/misc/python/materialize/output_consistency/input_data/return_specs/map_return_spec.py
@@ -8,45 +8,17 @@
 # by the Apache License, Version 2.0.
 
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
-from materialize.output_consistency.operation.return_type_spec import (
-    InputArgTypeHints,
-    ReturnTypeSpec,
+from materialize.output_consistency.input_data.return_specs.collection_return_spec import (
+    CollectionReturnTypeSpec,
 )
 
 
-class MapReturnTypeSpec(ReturnTypeSpec):
+class MapReturnTypeSpec(CollectionReturnTypeSpec):
     def __init__(
         self,
         param_index_of_map_value_type: int = 0,
         map_value_type_category: DataTypeCategory = DataTypeCategory.DYNAMIC,
     ):
-        super().__init__(DataTypeCategory.MAP, [param_index_of_map_value_type])
-        self._map_value_type_category = map_value_type_category
-
-    def resolve_type_category(
-        self, input_arg_type_hints: InputArgTypeHints
-    ) -> DataTypeCategory:
-        # update the value type of the map
-        if self._map_value_type_category == DataTypeCategory.DYNAMIC:
-            self._update_map_value_type(input_arg_type_hints)
-
-        # provide the actual return value
-        return super().resolve_type_category(input_arg_type_hints)
-
-    def _update_map_value_type(self, input_arg_type_hints: InputArgTypeHints) -> None:
-        assert (
-            input_arg_type_hints is not None
-            and self.indices_of_required_input_type_hints is not None
-            and not input_arg_type_hints.is_empty()
-        ), "Invalid state"
-        self._map_value_type_category = (
-            input_arg_type_hints.type_category_of_requested_args[
-                self.indices_of_required_input_type_hints[0]
-            ]
+        super().__init__(
+            DataTypeCategory.MAP, param_index_of_map_value_type, map_value_type_category
         )
-
-    def get_map_value_type(self) -> DataTypeCategory:
-        assert (
-            self._map_value_type_category != DataTypeCategory.DYNAMIC
-        ), "map value type not resolved"
-        return self._map_value_type_category

--- a/misc/python/materialize/output_consistency/input_data/return_specs/map_value_return_spec.py
+++ b/misc/python/materialize/output_consistency/input_data/return_specs/map_value_return_spec.py
@@ -38,4 +38,4 @@ class DynamicMapValueReturnTypeSpec(DynamicReturnTypeSpec):
         )
 
         assert isinstance(input_arg_return_type_spec, MapReturnTypeSpec)
-        return input_arg_return_type_spec.get_map_value_type()
+        return input_arg_return_type_spec.get_entry_value_type()

--- a/misc/python/materialize/output_consistency/input_data/types/collection_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/collection_type_provider.py
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type import DataType
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.return_specs.collection_return_spec import (
+    CollectionReturnTypeSpec,
+)
+
+
+class CollectionDataType(DataType):
+    def __init__(
+        self,
+        internal_identifier: str,
+        type_name: str,
+        data_type_category: DataTypeCategory,
+        entry_value_1: str,
+        entry_value_2: str,
+        value_type_category: DataTypeCategory,
+        is_pg_compatible: bool,
+    ):
+        super().__init__(
+            internal_identifier,
+            type_name,
+            data_type_category,
+            is_pg_compatible=is_pg_compatible,
+        )
+        self.entry_value_1 = entry_value_1
+        self.entry_value_2 = entry_value_2
+        self.value_type_category = value_type_category
+
+    def resolve_return_type_spec(
+        self, characteristics: set[ExpressionCharacteristics]
+    ) -> CollectionReturnTypeSpec:
+        return self._create_collection_return_type_spec()
+
+    def _create_collection_return_type_spec(self) -> CollectionReturnTypeSpec:
+        raise NotImplementedError

--- a/misc/python/materialize/output_consistency/input_data/types/map_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/map_type_provider.py
@@ -7,43 +7,42 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
-from materialize.output_consistency.expression.expression_characteristics import (
-    ExpressionCharacteristics,
+from materialize.output_consistency.input_data.return_specs.collection_return_spec import (
+    CollectionReturnTypeSpec,
 )
 from materialize.output_consistency.input_data.return_specs.map_return_spec import (
     MapReturnTypeSpec,
 )
-from materialize.output_consistency.operation.return_type_spec import ReturnTypeSpec
+from materialize.output_consistency.input_data.types.collection_type_provider import (
+    CollectionDataType,
+)
 
 MAP_TEXT_TO_DOUBLE_TYPE_IDENTIFIER = "MAP_TEXT_TO_DOUBLE"
 MAP_TEXT_TO_TIMESTAMPTZ_TYPE_IDENTIFIER = "MAP_TEXT_TO_TIMESTAMPTZ"
 MAP_TEXT_TO_TEXT_MAP_TYPE_IDENTIFIER = "MAP_TEXT_TO_TEXT_MAP"
 
 
-class MapDataType(DataType):
+class MapDataType(CollectionDataType):
     def __init__(
         self,
         internal_identifier: str,
         type_name: str,
-        map_value_1: str,
-        map_value_2: str,
+        map_entry_value_1: str,
+        map_entry_value_2: str,
         value_type_category: DataTypeCategory,
     ):
         super().__init__(
             internal_identifier,
             type_name,
             DataTypeCategory.MAP,
+            entry_value_1=map_entry_value_1,
+            entry_value_2=map_entry_value_2,
+            value_type_category=value_type_category,
             is_pg_compatible=False,
         )
-        self.map_value_1 = map_value_1
-        self.map_value_2 = map_value_2
-        self.value_type_category = value_type_category
 
-    def resolve_return_type_spec(
-        self, characteristics: set[ExpressionCharacteristics]
-    ) -> ReturnTypeSpec:
+    def _create_collection_return_type_spec(self) -> CollectionReturnTypeSpec:
         return MapReturnTypeSpec(map_value_type_category=self.value_type_category)
 
 
@@ -72,22 +71,22 @@ def as_sql_map_string(
 MAP_TEXT_TO_DOUBLE_TYPE = MapDataType(
     MAP_TEXT_TO_DOUBLE_TYPE_IDENTIFIER,
     "MAP[TEXT=>DOUBLE]",
-    map_value_1="0.0",
-    map_value_2="4.7",
+    map_entry_value_1="0.0",
+    map_entry_value_2="4.7",
     value_type_category=DataTypeCategory.NUMERIC,
 )
 MAP_TEXT_TO_TIMESTAMPTZ_TYPE = MapDataType(
     MAP_TEXT_TO_TIMESTAMPTZ_TYPE_IDENTIFIER,
     "MAP[TEXT=>TIMESTAMPTZ]",
-    map_value_1="''2024-02-29 11:50:00 EST''",
-    map_value_2="''2024-03-31 01:20:00 Europe/Vienna''",
+    map_entry_value_1="''2024-02-29 11:50:00 EST''",
+    map_entry_value_2="''2024-03-31 01:20:00 Europe/Vienna''",
     value_type_category=DataTypeCategory.DATE_TIME,
 )
 NESTED_MAP_TEXT_TO_TEXT_TEXT_TYPE = MapDataType(
     MAP_TEXT_TO_TEXT_MAP_TYPE_IDENTIFIER,
     "MAP[TEXT=>MAP[TEXT=>TEXT]]",
-    map_value_1=as_sql_map_string({"a": "10", "b": "20"}, omit_quotes=True),
-    map_value_2=as_sql_map_string({"a": "11", "b": "22"}, omit_quotes=True),
+    map_entry_value_1=as_sql_map_string({"a": "10", "b": "20"}, omit_quotes=True),
+    map_entry_value_2=as_sql_map_string({"a": "11", "b": "22"}, omit_quotes=True),
     value_type_category=DataTypeCategory.MAP,
 )
 MAP_DATA_TYPES = [

--- a/misc/python/materialize/output_consistency/input_data/values/map_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/map_values_provider.py
@@ -36,9 +36,9 @@ for map_data_type in MAP_DATA_TYPES:
     # key values should be specified in MAP_FIELD_NAME_PARAM in misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
     MAP_1_CONTENT = dict()
     MAP_1_CONTENT["n"] = "NULL"
-    MAP_1_CONTENT["a"] = map_data_type.map_value_1
-    MAP_1_CONTENT["A"] = map_data_type.map_value_2
-    MAP_1_CONTENT["b"] = map_data_type.map_value_2
+    MAP_1_CONTENT["a"] = map_data_type.entry_value_1
+    MAP_1_CONTENT["A"] = map_data_type.entry_value_2
+    MAP_1_CONTENT["b"] = map_data_type.entry_value_2
 
     values_of_type.add_raw_value(
         as_sql_map_string(
@@ -49,8 +49,8 @@ for map_data_type in MAP_DATA_TYPES:
     )
 
     MAP_W_DUP_KEYS_CONTENT = dict()
-    MAP_W_DUP_KEYS_CONTENT["a"] = map_data_type.map_value_1
-    MAP_W_DUP_KEYS_CONTENT["a"] = map_data_type.map_value_2
+    MAP_W_DUP_KEYS_CONTENT["a"] = map_data_type.entry_value_1
+    MAP_W_DUP_KEYS_CONTENT["a"] = map_data_type.entry_value_2
 
     values_of_type.add_raw_value(
         as_sql_map_string(

--- a/misc/python/materialize/output_consistency/input_data/values/map_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/map_values_provider.py
@@ -30,7 +30,7 @@ for map_data_type in MAP_DATA_TYPES:
             sql_value_by_key=dict(),
         ),
         "EMPTY",
-        {ExpressionCharacteristics.MAP_EMPTY},
+        {ExpressionCharacteristics.COLLECTION_EMPTY},
     )
 
     # key values should be specified in MAP_FIELD_NAME_PARAM in misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py


### PR DESCRIPTION
This is a preparation for https://github.com/MaterializeInc/materialize/pull/27125, which adds the list type and can re-use some of the logic. It will also be helpful when adding the array type.

### Commits
d22107e6b5 output consistency: map type: generalize return spec
9490691987 output consistency: map type: generalize type
8576dd38c5 output consistency: map type: generalize characteristic
85b5b6e30c output consistency: map type: generalize operation param
285eaa6e5f output consistency: map type: add further generalized operation params

### Nightly
https://buildkite.com/materialize/nightly/builds/7792 ✅ (failure unrelated)