### PR TITLE
qa canary: ignore read timeout, improve test case infos

### DIFF
--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -67,7 +67,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
             failures = []
 
+            count_chunk = 0
             while time.time() - start_time < args.runtime:
+                count_chunk = count_chunk + 1
                 try:
                     c.testdrive(
                         dedent(
@@ -92,9 +94,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
                     i = 0
                     while time.time() - start_time < args.runtime:
-                        print(f"Running iteration {i}")
+                        print(f"Running iteration {i} of chunk {count_chunk}")
                         c.override_current_testcase_name(
-                            f"iteration {i} of workflow_default"
+                            f"iteration {i} of chunk {count_chunk} in workflow_default"
                         )
                         perform_test(
                             c,
@@ -133,6 +135,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     failures.extend(e.errors)
 
             if len(failures) > 0:
+                # reset test case name to remove current iteration and chunk, which does not apply to collected errors
+                c.override_current_testcase_name("workflow_default")
                 raise FailedTestExecutionError(
                     error_summary="SQL failures occurred",
                     errors=failures,

--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -129,7 +129,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     assert len(e.errors) > 0, "Exception contains not errors"
                     for error in e.errors:
                         print(
-                            f"Test failure occurred ('{error.message}'), collecting it, and continuing."
+                            f"Test failure occurred ({error.message}), collecting it, and continuing."
                         )
                     # collect, continue, and rethrow at the end
                     failures.extend(e.errors)


### PR DESCRIPTION
Based on result in https://buildkite.com/materialize/qa-canary/builds/104.