### PR TITLE
statement-logging: "Rows returned" should consider `OFFSET` and `LIMIT`

### DIFF
--- a/test/cluster/statement-logging/statement-logging.td
+++ b/test/cluster/statement-logging/statement-logging.td
@@ -258,3 +258,32 @@ ROLLBACK
 
 > SELECT sql FROM mz_internal.mz_recent_activity_log WHERE statement_type = 'alter_secret';
 "ALTER SECRET my_super_secret AS '<REDACTED>'"
+
+# Test that the number of rows returned in query history respects OFFSET and LIMIT.
+
+> CREATE TABLE t_offset_limit (a int);
+
+> INSERT INTO t_offset_limit SELECT generate_series(1, 5);
+
+> SELECT * FROM t_offset_limit ORDER BY a DESC OFFSET 4;
+1
+
+> SELECT * FROM t_offset_limit ORDER BY a DESC LIMIT 2;
+5
+4
+
+> SELECT * FROM t_offset_limit ORDER BY a DESC OFFSET 100;
+
+> SELECT * FROM t_offset_limit ORDER BY a DESC LIMIT 0;
+
+> SELECT rows_returned FROM mz_internal.mz_recent_activity_log WHERE sql = 'SELECT * FROM t_offset_limit ORDER BY a DESC OFFSET 4';
+1
+
+> SELECT rows_returned FROM mz_internal.mz_recent_activity_log WHERE sql = 'SELECT * FROM t_offset_limit ORDER BY a DESC LIMIT 2';
+2
+
+> SELECT rows_returned FROM mz_internal.mz_recent_activity_log WHERE sql = 'SELECT * FROM t_offset_limit ORDER BY a DESC OFFSET 100';
+0
+
+> SELECT rows_returned FROM mz_internal.mz_recent_activity_log WHERE sql = 'SELECT * FROM t_offset_limit ORDER BY a DESC LIMIT 0';
+0

--- a/test/cluster/statement-logging/statement-logging.td
+++ b/test/cluster/statement-logging/statement-logging.td
@@ -261,6 +261,8 @@ ROLLBACK
 
 # Test that the number of rows returned in query history respects OFFSET and LIMIT.
 
+> RESET cluster
+
 > CREATE TABLE t_offset_limit (a int);
 
 > INSERT INTO t_offset_limit SELECT generate_series(1, 5);


### PR DESCRIPTION
This PR fixes the rows returned metric reported in statement logging to consider any `OFFSET` and `LIMIT` in a query, previously it was not.

### Motivation

Fixes an unreported bug, we discovered this today, [Slack](https://materializeinc.slack.com/archives/C053EPHMU05/p1715868779558259?thread_ts=1715851171.213429&cid=C053EPHMU05)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Changes the "rows returned" metric in statement logging to consider the `OFFSET` and `LIMIT` provided to a query.
