### PR TITLE
Only evaluate the join closure once

### DIFF
--- a/src/compute/src/render/join/mz_join_core.rs
+++ b/src/compute/src/render/join/mz_join_core.rs
@@ -632,7 +632,7 @@ where
                             let mut result = logic(key, val1, val2).into_iter().peekable();
 
                             // We can only produce output if the result return something.
-                            if result.peek().is_some() {
+                            if let Some(first) = result.next() {
                                 // Join times.
                                 cursor1.map_times(storage1, |time1, diff1| {
                                     let time1 = time1.join(meet);
@@ -645,16 +645,16 @@ where
                                 consolidate(&mut buffer);
 
                                 // Special case no results, one result, and potentially many results
-                                match (result.next(), result.peek().is_some(), buffer.len()) {
+                                match (result.peek().is_some(), buffer.len()) {
                                     // Certainly no output
-                                    (None, _, _) | (_, _, 0) => {}
+                                    (_, 0) => {}
                                     // Single element, single time
-                                    (Some(first), false, 1) => {
+                                    (false, 1) => {
                                         let (time, diff) = buffer.pop().unwrap();
                                         temp.push((first, time, diff));
                                     }
                                     // Multiple elements or multiple times
-                                    (Some(first), _, _) => {
+                                    (_, _) => {
                                         for d in std::iter::once(first).chain(result) {
                                             temp.extend(buffer.iter().map(|(time, diff)| {
                                                 (d.clone(), time.clone(), diff.clone())

--- a/src/compute/src/render/join/mz_join_core.rs
+++ b/src/compute/src/render/join/mz_join_core.rs
@@ -635,27 +635,29 @@ where
                                     let diff = diff1.multiply(diff2);
                                     buffer.push((time, diff));
                                 });
-                                consolidate(&mut buffer);
-                                let mut result = result(key, val1, val2).into_iter().peekable();
-                                match (result.next(), result.peek().is_some(), buffer.len()) {
-                                    // Certainly no output
-                                    (None, _, _) | (_, _, 0) => {}
-                                    // Single element, single time
-                                    (Some(first), false, 1) => {
-                                        let (time, diff) = buffer.pop().unwrap();
-                                        temp.push((first, time, diff));
-                                    }
-                                    // Multiple elements or multiple times
-                                    (Some(first), _, _) => {
-                                        for d in std::iter::once(first).chain(result) {
-                                            temp.extend(buffer.iter().map(|(time, diff)| {
-                                                (d.clone(), time.clone(), diff.clone())
-                                            }))
-                                        }
+                            });
+
+                            consolidate(&mut buffer);
+                            let mut result = result(key, val1, val2).into_iter().peekable();
+                            match (result.next(), result.peek().is_some(), buffer.len()) {
+                                // Certainly no output
+                                (None, _, _) | (_, _, 0) => {}
+                                // Single element, single time
+                                (Some(first), false, 1) => {
+                                    let (time, diff) = buffer.pop().unwrap();
+                                    temp.push((first, time, diff));
+                                }
+                                // Multiple elements or multiple times
+                                (Some(first), _, _) => {
+                                    for d in std::iter::once(first).chain(result) {
+                                        temp.extend(buffer.iter().map(|(time, diff)| {
+                                            (d.clone(), time.clone(), diff.clone())
+                                        }))
                                     }
                                 }
-                                buffer.clear();
-                            });
+                            }
+                            buffer.clear();
+
                             cursor2.step_val(storage2);
                         }
                         cursor1.step_val(storage1);


### PR DESCRIPTION
Changes how we evaluate the join closure for linear joins: Instead of evaluating it for every `(time, diff)`, we only evaluate it once and then clone the output for each `(time, diff)`. We special-case the logic for no output, or single datum, single `(time, diff)` to avoid clones.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
