### PR TITLE
[DNR, DNM]: IGNORE ERRORS in Get plans

### DIFF
--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -193,6 +193,8 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
     /// Future uses of `import_index` in other dataflow descriptions may use `id`,
     /// as long as this dataflow has not been terminated in the meantime.
     pub fn export_index(&mut self, id: GlobalId, description: IndexDesc, on_type: RelationType) {
+        let ignore_errors = false; // TODO: Should this be a param?
+
         // We first create a "view" named `id` that ensures that the
         // data are correctly arranged and available for export.
         self.insert_plan(
@@ -201,6 +203,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
                 input: Box::new(MirRelationExpr::global_get(
                     description.on_id,
                     on_type.clone(),
+                    ignore_errors,
                 )),
                 keys: vec![description.key.clone()],
             }),

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -86,6 +86,8 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 keys,
                 plan,
                 lir_id: _,
+                // TODO
+                ignore_errors: _,
             } => {
                 ctx.indent.set(); // mark the current indent level
 

--- a/src/compute-types/src/plan/flat_plan.proto
+++ b/src/compute-types/src/plan/flat_plan.proto
@@ -59,6 +59,7 @@ message ProtoFlatPlanNode {
         mz_expr.id.ProtoId id = 1;
         ProtoAvailableCollections keys = 2;
         ProtoGetPlan plan = 3;
+        bool ignore_errors = 4;
     }
 
     message ProtoLetRec {

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -259,6 +259,7 @@ where
                     keys,
                     plan,
                     lir_id: _,
+                    ignore_errors: _,
                 } => {
                     // Interpret the current node.
                     Ok(self.interpret.get(&self.ctx, id, keys, plan))
@@ -543,6 +544,7 @@ where
                     keys,
                     plan,
                     lir_id: _,
+                    ignore_errors: _,
                 } => {
                     // Interpret the current node.
                     let result = self.interpret.get(&self.ctx, id, keys, plan);

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -190,7 +190,12 @@ impl Context {
                 // The plan, not arranged in any way.
                 (plan, AvailableCollections::new_raw())
             }
-            MirRelationExpr::Get { id, typ: _, .. } => {
+            MirRelationExpr::Get {
+                id,
+                typ: _,
+                ignore_errors,
+                ..
+            } => {
                 // This stage can absorb arbitrary MFP operators.
                 let mut mfp = mfp.take();
                 // If `mfp` is the identity, we can surface all imported arrangements.
@@ -261,6 +266,7 @@ impl Context {
                         keys: in_keys,
                         plan,
                         lir_id: self.allocate_lir_id(),
+                        ignore_errors: *ignore_errors,
                     },
                     out_keys,
                 )

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -823,13 +823,18 @@ where
 
                 CollectionBundle::from_collections(ok_collection, err_collection)
             }
-            Get { id, keys, plan } => {
+            Get {
+                id,
+                keys,
+                plan,
+                ignore_errors,
+            } => {
                 // Recover the collection from `self` and then apply `mfp` to it.
                 // If `mfp` happens to be trivial, we can just return the collection.
                 let mut collection = self
                     .lookup_id(id)
                     .unwrap_or_else(|| panic!("Get({:?}) not found at render time", id));
-                match plan {
+                let mut collection = match plan {
                     mz_compute_types::plan::GetPlan::PassArrangements => {
                         // Assert that each of `keys` are present in `collection`.
                         assert!(keys
@@ -856,7 +861,9 @@ where
                             collection.as_collection_core(mfp, None, self.until.clone());
                         CollectionBundle::from_collections(oks, errs)
                     }
-                }
+                };
+                collection.ignore_errors(ignore_errors);
+                collection
             }
             LetRec { .. } => {
                 unreachable!("LetRec should have been extracted and rendered");

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -666,6 +666,15 @@ where
                 .collect(),
         }
     }
+
+    pub fn ignore_errors(&mut self, ignore_errors: bool) {
+        if !ignore_errors {
+            return;
+        }
+        self.collection.as_mut().map(|inner| {
+            inner.1 = Collection::empty(&inner.1.scope());
+        });
+    }
 }
 
 impl<'a, S: Scope, T> CollectionBundle<Child<'a, S, S::Timestamp>, T>

--- a/src/expr-parser/src/parser.rs
+++ b/src/expr-parser/src/parser.rs
@@ -174,11 +174,13 @@ mod relation {
                 id: Id::Global(*id),
                 typ: typ.clone(),
                 access_strategy: AccessStrategy::UnknownOrLocal,
+                ignore_errors: false,
             }),
             None => Ok(MirRelationExpr::Get {
                 id: Id::Local(parse_local_id(ident)?),
                 typ: RelationType::empty(),
                 access_strategy: AccessStrategy::UnknownOrLocal,
+                ignore_errors: false,
             }),
         }
     }
@@ -217,6 +219,7 @@ mod relation {
                         id: Id::Local(id),
                         typ: typ.clone(),
                         access_strategy: AccessStrategy::UnknownOrLocal,
+                        ignore_errors: false,
                     };
                     // Do not use the `union` smart constructor here!
                     MirRelationExpr::Union {

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -462,6 +462,7 @@ impl<'a> MirRelationExprDeserializeContext<'a> {
                         id,
                         typ,
                         access_strategy: AccessStrategy::UnknownOrLocal,
+                        ignore_errors: false,
                     }),
                     None => match self.catalog.get(&name) {
                         None => Err(format!("no catalog object named {}", name)),
@@ -469,6 +470,7 @@ impl<'a> MirRelationExprDeserializeContext<'a> {
                             id: Id::Global(*id),
                             typ: typ.clone(),
                             access_strategy: AccessStrategy::UnknownOrLocal,
+                            ignore_errors: false,
                         }),
                     },
                 }

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -236,6 +236,7 @@ pub fn enforce_linear_chains(expr: &mut MirRelationExpr) -> Result<(), ExplainEr
                         id: Id::Local(id.clone()),
                         typ: input.typ(),
                         access_strategy: AccessStrategy::UnknownOrLocal,
+                        ignore_errors: false,
                     }),
                 };
                 // swap the current body with the replacement

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -115,6 +115,8 @@ pub enum MirRelationExpr {
         /// lowering to LIR, but is used only by EXPLAIN.
         #[mzreflect(ignore)]
         access_strategy: AccessStrategy,
+        /// Whether to ignore errors produced by this collection.
+        ignore_errors: bool,
     },
     /// Introduce a temporary dataflow.
     ///
@@ -1117,15 +1119,17 @@ impl MirRelationExpr {
             id: Id::Local(id),
             typ,
             access_strategy: AccessStrategy::UnknownOrLocal,
+            ignore_errors: false,
         }
     }
 
     /// Constructs the expression for getting a global collection
-    pub fn global_get(id: GlobalId, typ: RelationType) -> Self {
+    pub fn global_get(id: GlobalId, typ: RelationType, ignore_errors: bool) -> Self {
         MirRelationExpr::Get {
             id: Id::Global(id),
             typ,
             access_strategy: AccessStrategy::UnknownOrLocal,
+            ignore_errors,
         }
     }
 
@@ -1525,6 +1529,7 @@ impl MirRelationExpr {
                 id: Id::Local(id),
                 typ: self.typ(),
                 access_strategy: AccessStrategy::UnknownOrLocal,
+                ignore_errors: false,
             };
             let body = (body)(id_gen, get);
             MirRelationExpr::Let {
@@ -1553,6 +1558,7 @@ impl MirRelationExpr {
                 id: Id::Local(id),
                 typ: self.typ(),
                 access_strategy: AccessStrategy::UnknownOrLocal,
+                ignore_errors: false,
             };
             let body = (body)(id_gen, get)?;
             Ok(MirRelationExpr::Let {

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -140,6 +140,7 @@ Endpoint
 Enforced
 Envelope
 Error
+Errors
 Escape
 Estimate
 Every

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -7034,6 +7034,13 @@ impl<'a> Parser<'a> {
         } else if self.parse_keywords(&[ROWS, FROM]) {
             Ok(self.parse_rows_from()?)
         } else {
+            let errors = if self.parse_keywords(&[IGNORE, ERRORS]) {
+                Some(IgnoreErrors::IgnoreErrors)
+            } else if self.parse_keywords(&[ONLY, ERRORS]) {
+                Some(IgnoreErrors::OnlyErrors)
+            } else {
+                None
+            };
             let name = self.parse_raw_name()?;
             if self.consume_token(&Token::LParen) {
                 let args = self.parse_optional_args(false)?;
@@ -7054,6 +7061,7 @@ impl<'a> Parser<'a> {
                 Ok(TableFactor::Table {
                     name,
                     alias: self.parse_optional_table_alias()?,
+                    errors,
                 })
             }
         }

--- a/src/sql-pretty/src/doc.rs
+++ b/src/sql-pretty/src/doc.rs
@@ -415,8 +415,15 @@ fn doc_table_factor<T: AstInfo>(v: &TableFactor<T>) -> RcDoc {
             }
             doc
         }
-        TableFactor::Table { name, alias } => {
+        TableFactor::Table {
+            name,
+            alias,
+            errors,
+        } => {
             let mut doc = doc_display_pass(name);
+            if let Some(errors) = errors {
+                doc = RcDoc::concat([doc_display_pass(errors), RcDoc::text(" "), doc]);
+            }
             if let Some(alias) = alias {
                 doc = nest(doc, RcDoc::text(format!("AS {}", alias)));
             }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1915,9 +1915,14 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
     ) -> mz_sql_parser::ast::TableFactor<Aug> {
         use mz_sql_parser::ast::TableFactor::*;
         match node {
-            Table { name, alias } => Table {
+            Table {
+                name,
+                alias,
+                errors,
+            } => Table {
                 name: self.fold_item_name(name),
                 alias: alias.map(|alias| self.fold_table_alias(alias)),
+                errors,
             },
             Function {
                 function,

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -100,6 +100,7 @@ pub fn normalize_subqueries<'a>(expr: &'a mut HirRelationExpr) -> Result<(), Rec
                         let mut subquery = Get {
                             id: Id::Local(local_id.clone()),
                             typ: RelationType::empty(), // TODO (aalexandrov)
+                            ignore_errors: false,
                         };
                         // swap the current subquery with the replacement
                         std::mem::swap(expr, &mut subquery);

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -99,6 +99,7 @@ pub enum HirRelationExpr {
     Get {
         id: mz_expr::Id,
         typ: RelationType,
+        ignore_errors: bool,
     },
     /// Mutually recursive CTE
     LetRec {
@@ -2059,7 +2060,12 @@ impl VisitChildren<Self> for HirRelationExpr {
 
         use HirRelationExpr::*;
         match self {
-            Constant { rows: _, typ: _ } | Get { id: _, typ: _ } => (),
+            Constant { rows: _, typ: _ }
+            | Get {
+                id: _,
+                typ: _,
+                ignore_errors: _,
+            } => (),
             Let {
                 name: _,
                 id: _,
@@ -2146,7 +2152,12 @@ impl VisitChildren<Self> for HirRelationExpr {
 
         use HirRelationExpr::*;
         match self {
-            Constant { rows: _, typ: _ } | Get { id: _, typ: _ } => (),
+            Constant { rows: _, typ: _ }
+            | Get {
+                id: _,
+                typ: _,
+                ignore_errors: _,
+            } => (),
             Let {
                 name: _,
                 id: _,
@@ -2233,7 +2244,12 @@ impl VisitChildren<Self> for HirRelationExpr {
 
         use HirRelationExpr::*;
         match self {
-            Constant { rows: _, typ: _ } | Get { id: _, typ: _ } => (),
+            Constant { rows: _, typ: _ }
+            | Get {
+                id: _,
+                typ: _,
+                ignore_errors: _,
+            } => (),
             Let {
                 name: _,
                 id: _,
@@ -2321,7 +2337,12 @@ impl VisitChildren<Self> for HirRelationExpr {
 
         use HirRelationExpr::*;
         match self {
-            Constant { rows: _, typ: _ } | Get { id: _, typ: _ } => (),
+            Constant { rows: _, typ: _ }
+            | Get {
+                id: _,
+                typ: _,
+                ignore_errors: _,
+            } => (),
             Let {
                 name: _,
                 id: _,
@@ -2401,7 +2422,11 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
         use HirRelationExpr::*;
         match self {
             Constant { rows: _, typ: _ }
-            | Get { id: _, typ: _ }
+            | Get {
+                id: _,
+                typ: _,
+                ignore_errors: _,
+            }
             | Let {
                 name: _,
                 id: _,
@@ -2477,7 +2502,11 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
         use HirRelationExpr::*;
         match self {
             Constant { rows: _, typ: _ }
-            | Get { id: _, typ: _ }
+            | Get {
+                id: _,
+                typ: _,
+                ignore_errors: _,
+            }
             | Let {
                 name: _,
                 id: _,
@@ -2550,7 +2579,11 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
         use HirRelationExpr::*;
         match self {
             Constant { rows: _, typ: _ }
-            | Get { id: _, typ: _ }
+            | Get {
+                id: _,
+                typ: _,
+                ignore_errors: _,
+            }
             | Let {
                 name: _,
                 id: _,
@@ -2624,7 +2657,11 @@ impl VisitChildren<HirScalarExpr> for HirRelationExpr {
         use HirRelationExpr::*;
         match self {
             Constant { rows: _, typ: _ }
-            | Get { id: _, typ: _ }
+            | Get {
+                id: _,
+                typ: _,
+                ignore_errors: _,
+            }
             | Let {
                 name: _,
                 id: _,

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -229,13 +229,18 @@ impl HirRelationExpr {
                         typ,
                     })
                 }
-                Get { id, typ } => match id {
+                Get {
+                    id,
+                    typ,
+                    ignore_errors,
+                } => match id {
                     mz_expr::Id::Local(local_id) => {
                         let cte_desc = cte_map.get(&local_id).unwrap();
                         let get_cte = SR::Get {
                             id: mz_expr::Id::Local(cte_desc.new_id.clone()),
                             typ: cte_desc.relation_type.clone(),
                             access_strategy: AccessStrategy::UnknownOrLocal,
+                            ignore_errors,
                         };
                         if get_outer == cte_desc.outer_relation {
                             // If the CTE was applied to the same exact relation, we can safely
@@ -289,6 +294,7 @@ impl HirRelationExpr {
                             id,
                             typ,
                             access_strategy: AccessStrategy::UnknownOrLocal,
+                            ignore_errors,
                         })
                     }
                 },

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -2369,6 +2369,7 @@ fn generate_view_sql(
                     relation: TableFactor::Table {
                         name: RawItemName::Name(name.clone()),
                         alias: None,
+                        errors: None,
                     },
                     joins: vec![],
                 }],

--- a/src/transform/src/attribute/column_names.rs
+++ b/src/transform/src/attribute/column_names.rs
@@ -54,6 +54,7 @@ impl<'c> ColumnNames<'c> {
                 id: Id::Global(id),
                 typ,
                 access_strategy: _,
+                ignore_errors: _,
             } => {
                 if let Some(column_names) = self.humanizer.column_names_for_id(*id) {
                     column_names
@@ -66,6 +67,7 @@ impl<'c> ColumnNames<'c> {
                 id: Id::Local(id),
                 typ,
                 access_strategy: _,
+                ignore_errors: _,
             } => {
                 if let Some(column_names) = self.env.get(id) {
                     column_names.clone()

--- a/src/transform/src/cse/anf.rs
+++ b/src/transform/src/cse/anf.rs
@@ -203,6 +203,7 @@ impl Bindings {
                     id: Id::Local(LocalId::new(*id)),
                     typ,
                     access_strategy: AccessStrategy::UnknownOrLocal,
+                    ignore_errors: false,
                 }
             }
 

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -626,6 +626,7 @@ id: {}, key: {:?}",
                         id: Id::Global(global_id),
                         typ: _,
                         access_strategy: persist_or_index,
+                        ignore_errors: _,
                     } => {
                         if let Some(new_idx_id) = full_scan_changes.get(global_id) {
                             match persist_or_index {
@@ -713,6 +714,7 @@ id: {}, key: {:?}",
                     id: Id::Global(global_id),
                     typ: _,
                     access_strategy,
+                    ignore_errors: _,
                 } => match access_strategy {
                     AccessStrategy::Persist => {
                         if objects_to_build_ids.contains(global_id) {
@@ -735,6 +737,7 @@ id: {}, key: {:?}",
                     id: Id::Global(_),
                     typ: _,
                     access_strategy: AccessStrategy::Index(accesses),
+                    ignore_errors: _,
                 } => {
                     for (idx_id, _) in accesses {
                         soft_assert_or_log!(

--- a/src/transform/src/movement/projection_lifting.rs
+++ b/src/transform/src/movement/projection_lifting.rs
@@ -72,12 +72,14 @@ impl ProjectionLifting {
                     id,
                     typ: _,
                     access_strategy: _,
+                    ignore_errors,
                 } => {
                     if let Some((typ, columns)) = gets.get(id) {
                         *relation = MirRelationExpr::Get {
                             id: *id,
                             typ: typ.clone(),
                             access_strategy: AccessStrategy::UnknownOrLocal, // (we are not copying it over)
+                            ignore_errors: *ignore_errors,
                         }
                         .project(columns.clone());
                     }

--- a/src/transform/src/movement/projection_pushdown.rs
+++ b/src/transform/src/movement/projection_pushdown.rs
@@ -451,6 +451,7 @@ impl ProjectionPushdown {
                     id: inner_id,
                     typ,
                     access_strategy: _,
+                    ignore_errors: _,
                 } = &mut **input
                 {
                     if let Some((new_projection, new_type)) = applied_projections.get(inner_id) {

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -368,6 +368,7 @@ mod support {
                     id: Id::Local(id),
                     typ,
                     access_strategy: _,
+                    ignore_errors: _,
                 } => {
                     if let Some(new_type) = types.get(id) {
                         // Assert that the column length has not changed.


### PR DESCRIPTION
(( PR exists only so I can link people to the POC code))

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
