### PR TITLE
storage/copy-to-s3: Fix bugs; refactor ParquetFile / ArrowBuilder structure

### DIFF
--- a/src/arrow-util/src/builder.rs
+++ b/src/arrow-util/src/builder.rs
@@ -316,10 +316,11 @@ fn builder_for_datatype(
                 item_capacity,
             ))
         }
-        DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, _) => {
-            ColBuilder::TimestampMicrosecondBuilder(TimestampMicrosecondBuilder::with_capacity(
-                item_capacity,
-            ))
+        DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, timezone) => {
+            ColBuilder::TimestampMicrosecondBuilder(
+                TimestampMicrosecondBuilder::with_capacity(item_capacity)
+                    .with_timezone_opt(timezone.clone()),
+            )
         }
         DataType::LargeBinary => ColBuilder::LargeBinaryBuilder(LargeBinaryBuilder::with_capacity(
             item_capacity,

--- a/test/copy-to-s3/mzcompose.py
+++ b/test/copy-to-s3/mzcompose.py
@@ -31,7 +31,7 @@ SERVICES = [
     ),
     Materialized(
         additional_system_parameter_defaults={
-            "log_filter": "mz_storage_operators::s3_oneshot_sink=trace,info,warn,mz_environmentd::http=info,debug,warn"
+            "log_filter": "mz_storage_operators::s3_oneshot_sink=trace,debug,info,warn"
         },
     ),
     Testdrive(),
@@ -77,6 +77,9 @@ def workflow_nightly(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     materialized = Materialized(
         default_size=args.default_size,
+        additional_system_parameter_defaults={
+            "log_filter": "mz_storage_operators::s3_oneshot_sink=trace,debug,info,warn"
+        },
     )
 
     with c.override(testdrive, materialized):

--- a/test/copy-to-s3/nightly/tpch1gb.td
+++ b/test/copy-to-s3/nightly/tpch1gb.td
@@ -16,97 +16,97 @@ $ set-max-tries max-tries=1
 > COPY tpch1gb.customer TO 's3://copytos3/test/tpch1gb/csv/customer'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "100MB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'csv'
   );
 > COPY tpch1gb.lineitem TO 's3://copytos3/test/tpch1gb/csv/lineitem'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "100MB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'csv'
   );
 > COPY tpch1gb.nation TO 's3://copytos3/test/tpch1gb/csv/nation'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "100MB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'csv'
   );
 > COPY tpch1gb.orders TO 's3://copytos3/test/tpch1gb/csv/orders'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "100MB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'csv'
   );
 > COPY tpch1gb.part TO 's3://copytos3/test/tpch1gb/csv/part'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "100MB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'csv'
   );
 > COPY tpch1gb.partsupp TO 's3://copytos3/test/tpch1gb/csv/partsupp'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "100MB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'csv'
   );
 > COPY tpch1gb.region TO 's3://copytos3/test/tpch1gb/csv/region'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "100MB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'csv'
   );
 > COPY tpch1gb.supplier TO 's3://copytos3/test/tpch1gb/csv/supplier'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "100MB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'csv'
   );
 
 > COPY (SELECT c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal::text, c_mktsegment, c_comment FROM tpch1gb.customer) TO 's3://copytos3/test/tpch1gb/parquet/customer'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "100MB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'parquet'
   );
 > COPY (SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity::text, l_extendedprice::text, l_discount::text, l_tax::text, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment FROM tpch1gb.lineitem) TO 's3://copytos3/test/tpch1gb/parquet/lineitem'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "1GB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'parquet'
   );
 > COPY tpch1gb.nation TO 's3://copytos3/test/tpch1gb/parquet/nation'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "1GB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'parquet'
   );
 > COPY (SELECT o_orderkey, o_custkey, o_orderstatus, o_totalprice::text, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment FROM tpch1gb.orders) TO 's3://copytos3/test/tpch1gb/parquet/orders'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "1GB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'parquet'
   );
 > COPY (SELECT p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice::text, p_comment FROM tpch1gb.part) TO 's3://copytos3/test/tpch1gb/parquet/part'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "1GB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'parquet'
   );
 > COPY (SELECT ps_partkey, ps_suppkey, ps_availqty, ps_supplycost::text, ps_comment FROM tpch1gb.partsupp) TO 's3://copytos3/test/tpch1gb/parquet/partsupp'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "1GB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'parquet'
   );
 > COPY tpch1gb.region TO 's3://copytos3/test/tpch1gb/parquet/region'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "1GB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'parquet'
   );
 > COPY (SELECT s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal::text, s_comment FROM tpch1gb.supplier) TO 's3://copytos3/test/tpch1gb/parquet/supplier'
   WITH (
     AWS CONNECTION = aws_conn,
-    MAX FILE SIZE = "1GB",
+    MAX FILE SIZE = "50MB",
     FORMAT = 'parquet'
   );

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -117,7 +117,7 @@ contains:MAX FILE SIZE cannot be less than 16MB
     FORMAT = 'csv'
   );
 
-> COPY (SELECT array[1,2]::int[], false::bool, 'Inf'::double, '{"s": "abc"}'::jsonb, 1::mz_timestamp, 32767::smallint, 2147483647::integer, 9223372036854775807::bigint, 12345678901234567890123.4567890123456789::numeric(39,16), '2010-10-10'::date, '10:10:10'::time, '2010-10-10 10:10:10+00'::timestamp, '0 day'::interval, 'aaaa'::text, '\\xAAAA'::bytea, 'това е'::text, 'текст'::bytea) TO 's3://copytos3/test/3'
+> COPY (SELECT array[1,2]::int[], false::bool, 'Inf'::double, '{"s": "abc"}'::jsonb, 1::mz_timestamp, 32767::smallint, 2147483647::integer, 9223372036854775807::bigint, 12345678901234567890123.4567890123456789::numeric(39,16), '2010-10-10'::date, '10:10:10'::time, '2010-10-10 10:10:10+00'::timestamp, '2010-10-10 10:10:10+02'::timestamptz, '0 day'::interval, 'aaaa'::text, '\\xAAAA'::bytea, 'това е'::text, 'текст'::bytea) TO 's3://copytos3/test/3'
   WITH (
     AWS CONNECTION = aws_conn,
     MAX FILE SIZE = "100MB",
@@ -154,7 +154,7 @@ $ s3-verify-data bucket=copytos3 key=test/2_5
 1
 
 $ s3-verify-data bucket=copytos3 key=test/3
-"{1,2}",f,Infinity,"{""s"":""abc""}",1,32767,2147483647,9223372036854775807,12345678901234567890123.4567890123456789,2010-10-10,10:10:10,2010-10-10 10:10:10,00:00:00,aaaa,\x5c7841414141,това е,\xd182d0b5d0bad181d182
+"{1,2}",f,Infinity,"{""s"":""abc""}",1,32767,2147483647,9223372036854775807,12345678901234567890123.4567890123456789,2010-10-10,10:10:10,2010-10-10 10:10:10,2010-10-10 08:10:10+00,00:00:00,aaaa,\x5c7841414141,това е,\xd182d0b5d0bad181d182
 
 
 # Copy a large amount of data in the background and check to see that the INCOMPLETE
@@ -183,7 +183,7 @@ $ s3-verify-data bucket=copytos3 key=test/3
     FORMAT = 'parquet'
   );
 
-> COPY (SELECT array[1,2]::int[], array[array[1, 2], array[NULL, 4]], false::bool, 'Inf'::double, '{"s": "abc"}'::jsonb, '85907cb9-ac9b-4e35-84b8-60dc69368aca'::uuid, 1::mz_timestamp, 32767::smallint, 2147483647::integer, 9223372036854775807::bigint, 1234567890123456789012.4567890123456789::numeric(38,16), '2010-10-10'::date, '10:10:10'::time, '2010-10-10 10:10:10+00'::timestamp, 'aaaa'::text, '\\xAAAA'::bytea, 'това е'::text, 'текст'::bytea) TO 's3://copytos3/parquet_test/3'
+> COPY (SELECT array[1,2]::int[], array[array[1, 2], array[NULL, 4]], false::bool, 'Inf'::double, '{"s": "abc"}'::jsonb, '85907cb9-ac9b-4e35-84b8-60dc69368aca'::uuid, 1::mz_timestamp, 32767::smallint, 2147483647::integer, 9223372036854775807::bigint, 1234567890123456789012.4567890123456789::numeric(38,16), '2010-10-10'::date, '10:10:10'::time, '2010-10-10 10:10:10+00'::timestamp, '2010-10-10 10:10:10+02'::timestamptz, 'aaaa'::text, '\\xAAAA'::bytea, 'това е'::text, 'текст'::bytea) TO 's3://copytos3/parquet_test/3'
   WITH (
     AWS CONNECTION = aws_conn,
     MAX FILE SIZE = "100MB",
@@ -199,7 +199,7 @@ $ s3-verify-data bucket=copytos3 key=parquet_test/2
 2
 
 $ s3-verify-data bucket=copytos3 key=parquet_test/3
-{items: [1, 2], dimensions: 1} {items: [1, 2, , 4], dimensions: 2} false inf {"s":"abc"} 85907cb9ac9b4e3584b860dc69368aca 1 32767 2147483647 9223372036854775807 1234567890123456789012.4567890123456789 2010-10-10 10:10:10 2010-10-10T10:10:10 aaaa 5c7841414141 това е d182d0b5d0bad181d182
+{items: [1, 2], dimensions: 1} {items: [1, 2, , 4], dimensions: 2} false inf {"s":"abc"} 85907cb9ac9b4e3584b860dc69368aca 1 32767 2147483647 9223372036854775807 1234567890123456789012.4567890123456789 2010-10-10 10:10:10 2010-10-10T10:10:10 2010-10-10T08:10:10Z aaaa 5c7841414141 това е d182d0b5d0bad181d182
 
 # Confirm that unimplemented types will early exit before writing to s3
 ! COPY (SELECT '0 day'::interval)  TO 's3://copytos3/parquet_test/5'


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

3 issues motivate this PR:
- On a previous PR, @guswynn suggested that the parquet uploader structure would be simpler if the `ParquetFile` owned the `ArrowBuilder` object, so this implements that change (and it is indeed simpler)
- This PR fixes a recognized bug. Fixes: https://github.com/MaterializeInc/materialize/issues/27126 Previously we had a nested `if let Some(blah) = Option<ParquetFile>.take()` operation that meant the second call would not match since the value was already 'taken', but this has been switched to use a mutable ref instead. This was not being caught by the tests since we had used large `MAX FILE SIZE` values, so I lowered these to ensure we always split to more than 1 file in the tpch1gb tests.
-  Fix an issue handling timestamp-with-timezone columns -- this was missed in the original testing of the arrow util until I discovered it before my demo today

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

2 commits separate the 2 bug fixes. I've added/fixed tests for to verify both cases.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
