### PR TITLE
ci: release qualification: add x86 build step (which is referenced as dependency)

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -8,19 +8,22 @@
 # by the Apache License, Version 2.0.
 
 steps:
-  - id: build-aarch64
-    label: Build aarch64
-    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
-    depends_on: []
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-aarch64
-    # Don't build for "trigger_job" source, which indicates that this release
-    # qualification pipeline was triggered automatically by the tests pipeline
-    # because there is a new tag on a v* branch. In this case we want to make
-    # sure we use the exact same version for testing here as was tagged and
-    # will be released, and don't build our own version just for the tests.
-    if: build.source == "ui" || build.source == "schedule" || build.source == "api"
+  - group: Builds
+    key: builds
+    steps:
+      - id: build-aarch64
+        label: Build aarch64
+        command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
+        depends_on: []
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-aarch64
+        # Don't build for "trigger_job" source, which indicates that this release
+        # qualification pipeline was triggered automatically by the tests pipeline
+        # because there is a new tag on a v* branch. In this case we want to make
+        # sure we use the exact same version for testing here as was tagged and
+        # will be released, and don't build our own version just for the tests.
+        if: build.source == "ui" || build.source == "schedule" || build.source == "api"
 
   - group: Zippy
     key: zippy

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -24,6 +24,15 @@ steps:
         # sure we use the exact same version for testing here as was tagged and
         # will be released, and don't build our own version just for the tests.
         if: build.source == "ui" || build.source == "schedule" || build.source == "api"
+      # TODO(def-) Get rid of this for PRs once we don't have any x86-64 tests remaining
+      - id: build-x86_64
+        label: Build x86_64
+        command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
+        depends_on: []
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+
 
   - group: Zippy
     key: zippy


### PR DESCRIPTION
`mysql-cdc-5_7_44` [is stuck in the release qualification](https://buildkite.com/materialize/release-qualification/builds/499#018f8390-b511-4fb3-9fc9-4c5ed0f61506) pipeline:

<img width="605" alt="Bildschirmfoto 2024-05-17 um 09 10 34" src="https://github.com/MaterializeInc/materialize/assets/129728240/176bfc8e-e157-412d-a8cc-67a156081a95">

This is because of the `depends_on` relationship to `build-x86_64`, which does not exist in this pipeline.
I will add the build step but am not sure if the single tests warrants it. We could also move the check into another pipeline.