### PR TITLE
persist-txn: Add graphviz maelstrom dependency

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -97,6 +97,7 @@ RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-ge
     gdb \
     git \
     gnupg2 \
+    graphviz \
     jq \
     lcov \
     libc-dbg \

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -97,7 +97,6 @@ RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-ge
     gdb \
     git \
     gnupg2 \
-    graphviz \
     jq \
     lcov \
     libc-dbg \

--- a/src/persist-cli/ci-base/Dockerfile
+++ b/src/persist-cli/ci-base/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
     curl \
     git \
     gnuplot \
+    graphviz \
     openjdk-11-jre
 
 RUN mkdir -p /usr/local/share/java \


### PR DESCRIPTION
This commit adds the graphviz package to our CI docker images, which is needed by the maelstrom tests.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
