### PR TITLE
pgcompat: add some missing columns for Metaplane

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -5164,6 +5164,7 @@ SELECT
     o.name AS table_name,
     c.name AS column_name,
     c.position::int8 AS ordinal_position,
+    c.default AS column_default,
     CASE WHEN c.nullable THEN 'YES' ELSE 'NO' END AS is_nullable,
     c.type AS data_type,
     NULL::pg_catalog.int4 AS character_maximum_length,

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -3682,6 +3682,9 @@ pub static PG_CLASS: Lazy<BuiltinView> = Lazy::new(|| {
     0::pg_catalog.oid AS relam,
     -- MZ doesn't have tablespaces so reltablespace is filled in with 0 implying the default tablespace
     0::pg_catalog.oid AS reltablespace,
+    -- MZ doesn't support (estimated) row counts currently.
+    -- Postgres defines a value of -1 as unknown.
+    -1::float4 as reltuples,
     -- MZ doesn't use TOAST tables so reltoastrelid is filled with 0
     0::pg_catalog.oid AS reltoastrelid,
     EXISTS (SELECT id, oid, name, on_id, cluster_id FROM mz_catalog.mz_indexes where mz_indexes.on_id = class_objects.id) AS relhasindex,

--- a/test/sqllogictest/information_schema_columns.slt
+++ b/test/sqllogictest/information_schema_columns.slt
@@ -18,9 +18,14 @@ CREATE VIEW other.public.v AS SELECT 1 AS num, 'a' AS char
 statement ok
 CREATE VIEW v AS SELECT 1 AS num, 'a' AS char
 
-query TTTTTTTTTT colnames,rowsort
-SELECT * FROM information_schema.columns WHERE table_name = 'v'
+statement ok
+CREATE TABLE t (c1 int DEFAULT 1234, c2 int DEFAULT 1 + 2)
+
+query TTTTTTTTTTT colnames,rowsort
+SELECT * FROM information_schema.columns WHERE table_name = 'v' OR table_name = 't'
 ----
-table_catalog  table_schema  table_name  column_name  ordinal_position  is_nullable data_type  character_maximum_length  numeric_precision  numeric_scale
-materialize    public        v           num          1                 NO          integer    NULL                      NULL               NULL
-materialize    public        v           char         2                 NO          text       NULL                      NULL               NULL
+table_catalog table_schema table_name column_name ordinal_position column_default is_nullable data_type character_maximum_length numeric_precision numeric_scale
+materialize  public  t  c1  1  1234  YES  integer  NULL  NULL  NULL
+materialize  public  t  c2  2  1␠+␠2  YES  integer  NULL  NULL  NULL
+materialize  public  v  char  2  NULL  NO  text  NULL  NULL  NULL
+materialize  public  v  num  1  NULL  NO  integer  NULL  NULL  NULL

--- a/test/sqllogictest/pg_catalog_class.slt
+++ b/test/sqllogictest/pg_catalog_class.slt
@@ -22,13 +22,13 @@ statement ok
 CREATE TABLE other.public.bar (a int)
 
 # Normal table
-query TIIIIBTTIBBBBTBB
+query TIIIIBTTIBBBBTBBI
 SELECT relname, reloftype, relam, reltablespace, reltoastrelid, relhasindex, relpersistence, relkind, relchecks,
-    relhasrules, relhastriggers, relrowsecurity, relforcerowsecurity, relreplident, relispartition, relhasoids
+    relhasrules, relhastriggers, relrowsecurity, relforcerowsecurity, relreplident, relispartition, relhasoids, reltuples
 FROM pg_catalog.pg_class
 WHERE relname = 'a';
 ----
-a 0 0 0 0 false p r 0 false false false false d false false
+a 0 0 0 0 false p r 0 false false false false d false false -1
 
 statement ok
 CREATE DEFAULT INDEX ON a

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -25,6 +25,7 @@ reloftype           false       oid
 relowner            false       oid
 relam               false       oid
 reltablespace       false       oid
+reltuples           false       real
 reltoastrelid       false       oid
 relhasindex         false       boolean
 relpersistence      false       char


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Improvements to our Postgres compatibility story. More context: https://materializeinc.slack.com/archives/C073KLQ0QHM/p1715968613948499

* ~Adds in `pg_catalog.pg_user`~ Moved to another PR.
* Adds `reltuples` column to `pg_catalog.pg_class`
* Adds `column_default` column to `information_schema.columns`

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
