### PR TITLE
*: fix various broken rust docs

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -176,7 +176,7 @@ impl Coordinator {
 
     /// Perform a catalog transaction. [`Coordinator::ship_dataflow`] must be
     /// called after this function successfully returns on any built
-    /// [`DataflowDesc`].
+    /// [`DataflowDesc`](mz_compute_types::dataflows::DataflowDesc).
     #[instrument(name = "coord::catalog_transact_inner")]
     pub(crate) async fn catalog_transact_inner<'a>(
         &mut self,

--- a/src/adapter/src/coord/in_memory_oracle.rs
+++ b/src/adapter/src/coord/in_memory_oracle.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! A timestamp oracle that relies on the [`Catalog`] for persistence/durability
+//! A timestamp oracle that relies on the [`crate::catalog::Catalog`] for persistence/durability
 //! and reserves ranges of timestamps.
 
 use std::fmt::Debug;

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -544,7 +544,7 @@ impl Coordinator {
     /// query remains executable at that time, and returns those.
     ///
     /// The caller is responsible for eventually dropping those read holds using
-    /// [Coordinator::release_read_hold]!
+    /// [Coordinator::release_read_holds]!
     #[mz_ore::instrument(level = "debug")]
     pub(crate) async fn determine_timestamp(
         &mut self,

--- a/src/arrow-util/src/builder.rs
+++ b/src/arrow-util/src/builder.rs
@@ -137,7 +137,7 @@ impl ArrowBuilder {
 
 /// Return the appropriate Arrow DataType for the given ScalarType, plus a string
 /// that should be used as part of the Arrow 'Extension Type' name for fields using
-/// this type: https://arrow.apache.org/docs/format/Columnar.html#extension-types
+/// this type: <https://arrow.apache.org/docs/format/Columnar.html#extension-types>
 fn scalar_to_arrow_datatype(scalar_type: &ScalarType) -> Result<(DataType, String), anyhow::Error> {
     let (data_type, extension_name) = match scalar_type {
         ScalarType::Bool => (DataType::Boolean, "boolean"),

--- a/src/compute/src/containers/stack.rs
+++ b/src/compute/src/containers/stack.rs
@@ -27,7 +27,7 @@ pub enum StackWrapper<T: Columnation> {
     Chunked(ChunkedStack<T>),
 }
 
-/// Runtime switch to select the stack implementation. `true` to use [`ChunkedStac`],
+/// Runtime switch to select the stack implementation. `true` to use [`ChunkedStack`],
 /// `false` to select [`TimelyStack`].
 pub fn use_chunked_stack(enable: bool) {
     ENABLE_CHUNKED_STACK.store(enable, std::sync::atomic::Ordering::Relaxed);

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -356,7 +356,7 @@ where
     /// The output of this function is _not consolidated_.
     ///
     /// The dataflow fragment has the following shape:
-    /// ```ignore
+    /// ```text
     ///     | input
     ///     |
     ///   arrange

--- a/src/fivetran-destination/src/utils.rs
+++ b/src/fivetran-destination/src/utils.rs
@@ -152,7 +152,7 @@ impl<R> AsyncCsvReaderTableAdapter<R>
 where
     R: AsyncRead + Unpin + Send + 'static,
 {
-    /// Creates a new [`AsyncCsvReaderTableAdapter`] from an [`AsyncRead`]-er and a [`Table`].
+    /// Creates a new [`AsyncCsvReaderTableAdapter`] from an [`AsyncRead`]-er and a `Table`.
     pub async fn new(reader: R, table: &Table) -> Result<Self, OpError> {
         let mut csv_reader = csv_async::AsyncReaderBuilder::new().create_reader(reader);
         let csv_headers = csv_reader.headers().await?;

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -653,7 +653,7 @@ pub struct Claims {
 }
 
 /// [`Claims`] that have been validated by
-/// [`Authentication::validate_access_token`].
+/// [`Authenticator::validate_access_token`].
 #[derive(Clone, Debug)]
 pub struct ValidatedClaims {
     /// The time at which the claims expire, represented in seconds since the
@@ -667,7 +667,7 @@ pub struct ValidatedClaims {
     pub tenant_id: Uuid,
     /// Whether the authenticated user is an administrator.
     pub is_admin: bool,
-    // Prevent construction outside of `Authentication::validate_access_token`.
+    // Prevent construction outside of `Authenticator::validate_access_token`.
     _private: (),
 }
 

--- a/src/sql/src/session/vars/polyfill.rs
+++ b/src/sql/src/session/vars/polyfill.rs
@@ -14,10 +14,12 @@ use super::Value;
 
 /// Trait that helps us convert a `fn() -> &'static impl Value` to a `fn() -> &'static dyn Value`.
 ///
-/// For creating a type that implements [`LazyValueFn`] see the [`lazy_fn`] macro.
+/// For creating a type that implements [`LazyValueFn`] see the [`lazy_value`] macro.
 ///
 /// Note: Ideally we could use const generics to pass a function pointer directly to
 /// [`VarDefinition::new`], but Rust doesn't currently support this.
+///
+/// [`VarDefinition::new`]: crate::session::vars::VarDefinition::new
 pub trait LazyValueFn<V: Value>: Copy {
     const LAZY_VALUE_FN: fn() -> &'static dyn Value = || {
         let dyn_val: &'static dyn Value = Self::generate_value();
@@ -53,7 +55,7 @@ pub(crate) use lazy_value;
 /// Note: [`VarDefinition::new`] requires a `&'static V`, where `V: Value`. Ideally we would be
 /// able to pass the value as a const generic parameter, but Rust doesn't yet support this.
 ///
-/// [`VarDefinition::new`]: crate::session::vars2::VarDefinition::new
+/// [`VarDefinition::new`]: crate::session::vars::VarDefinition::new
 macro_rules! value {
     ($t: ty; $l: expr) => {{
         static MY_STATIC: $t = $l;

--- a/src/storage-operators/src/s3_oneshot_sink/parquet.rs
+++ b/src/storage-operators/src/s3_oneshot_sink/parquet.rs
@@ -46,10 +46,10 @@ const DEFAULT_ARRAY_BUILDER_DATA_CAPACITY: usize = 1024;
 /// - The uploader will hold a [`ParquetFile`] object after the first row is added. This
 ///   [`ParquetFile`] holds an [`ArrowBuilder`] and an [`ArrowWriter`].
 ///
-/// - The [`ArrowBuilder`] builds a structure of in-memory [`ColBuilder`]s from incoming
-///   [`mz_repr::Row`]s. Each [`ColBuilder`] holds a specific [`arrow::array::builder`] type
+/// - The [`ArrowBuilder`] builds a structure of in-memory `mz_arrow_util::builder::ColBuilder`s from incoming
+///   [`mz_repr::Row`]s. Each `mz_arrow_util::builder::ColBuilder` holds a specific [`arrow::array::builder`] type
 ///   for constructing a column of the given type. The entire [`ArrowBuilder`] is flushed to
-///   the [`ParquetFile`]'s [`ArrowWriter`] by converting it into a [`RecordBatch`] once we've
+///   the [`ParquetFile`]'s [`ArrowWriter`] by converting it into a [`arrow::record_batch::RecordBatch`] once we've
 ///   given it more than the configured arrow_builder_buffer_bytes.
 ///
 /// - The [`ParquetFile`] holds a [`ArrowWriter`] that buffers until it has enough data to write
@@ -64,6 +64,7 @@ const DEFAULT_ARRAY_BUILDER_DATA_CAPACITY: usize = 1024;
 /// - When the [`ParquetUploader`] is finished, it will flush the active [`ParquetFile`] which will
 ///   flush its [`ArrowBuilder`] and any open row groups to the [`S3MultiPartUploader`] and upload
 ///   the remaining parts to S3.
+/// ```text
 ///       ┌───────────────┐
 ///       │ mz_repr::Rows │
 ///       └───────┬───────┘
@@ -96,6 +97,7 @@ const DEFAULT_ARRAY_BUILDER_DATA_CAPACITY: usize = 1024;
 /// │                               └───────────────────────┘ │
 /// │                                                         │
 /// └─────────────────────────────────────────────────────────┘
+/// ```
 ///
 /// ## File Size & Buffer Sizes
 ///


### PR DESCRIPTION
`cargo doc` seems to produce no warnings now.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a