### PR TITLE
Consolidate on references instead of owned data

### DIFF
--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -190,8 +190,15 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidation
     where
         D: Semigroup,
     {
-        let mut data: Vec<_> = data.into_iter().map(clone_tuple).collect();
+        let mut data: Vec<_> = data
+            .into_iter()
+            .map(|(k, v, t, d)| ((k, v), t, d))
+            .collect();
         consolidate_updates(&mut data);
+        let data = data
+            .into_iter()
+            .map(|((k, v), t, d)| clone_tuple((k, v, t, d)))
+            .collect();
         Self::Sorted { data, index: 0 }
     }
 


### PR DESCRIPTION
The current implementation converts a `TupleRef` iterator into a vector and consolidates that. This might cause extra work if the data consolidates well because it needs to convert the whole input into owned data.

With this change, we first collect the references into a vector, consolidate this, and then convert into an owned allocation.

I didn't measure the performance impact, but I saw this as a source of memory allocations in https://pprof.me/c3516597e535d8c64a2184c143c408db

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
