### PR TITLE
storage/copy-to-s3: Require format option

### DIFF
--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -30,12 +30,13 @@ ALTER SYSTEM SET enable_copy_to_expr = true;
     REGION = 'us-east-1'
   );
 
-! COPY t TO 's3://path/to/dir';
+! COPY t TO 's3://path/to/dir' WITH (FORMAT = 'csv');
 contains:AWS CONNECTION is required for COPY ... TO <expr>
 
 ! COPY t TO 's3://path/to/dir'
   WITH (
-    AWS CONNECTION = aws_conn
+    AWS CONNECTION = aws_conn,
+    FORMAT = 'text'
   );
 contains:FORMAT TEXT not yet supported
 
@@ -45,6 +46,13 @@ contains:FORMAT TEXT not yet supported
     FORMAT = 'binary'
   );
 contains:FORMAT BINARY not yet supported
+
+! COPY t TO 's3://path/to/dir'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    MAX FILE SIZE = '20MB'
+  );
+contains:COPY TO <expr> requires a FORMAT option
 
 ! COPY t TO '/path/'
   WITH (


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/27101

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

This leaves the default as TEXT for all other COPY statements, but requires the FORMAT option is provided for the copy-to-expr statement.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
