### PR TITLE
sql: support cvs format options in copy-to-s3

### DIFF
--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -138,6 +138,15 @@ contains:S3 bucket path is not empty
     FORMAT = 'csv'
   );
 
+# test CSV format options
+> COPY (SELECT array[1,2]::int[], 83647::integer, '{"s": "ab`c"}'::jsonb, '2010-10-10 10:10:10+00'::timestamp) TO 's3://copytos3/test/4_5'
+  WITH (
+    AWS CONNECTION = aws_conn,
+    FORMAT = 'csv',
+    DELIMITER = ';',
+    QUOTE = '`'
+  )
+
 $ set-from-sql var=key-1
 SELECT TO_CHAR(now(), 'YYYY-MM-DD')
 
@@ -155,6 +164,8 @@ $ s3-verify-data bucket=copytos3 key=test/2_5
 $ s3-verify-data bucket=copytos3 key=test/3
 "{1,2}",f,Infinity,"{""s"":""abc""}",1,32767,2147483647,9223372036854775807,12345678901234567890123.4567890123456789,2010-10-10,10:10:10,2010-10-10 10:10:10,2010-10-10 08:10:10+00,00:00:00,aaaa,\x5c7841414141,това е,\xd182d0b5d0bad181d182
 
+$ s3-verify-data bucket=copytos3 key=test/4_5
+{1,2};83647;`{"s":"ab``c"}`;2010-10-10 10:10:10
 
 # Copy a large amount of data in the background and check to see that the INCOMPLETE
 # sentinel object is written during the copy


### PR DESCRIPTION
These were being silently ignored.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a