### PR TITLE
doc: Update CRDB version in dev guide

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -67,7 +67,7 @@ operations on macOS.)
 On Linux, we recommend using Docker:
 
 ```shell
-docker run --name=cockroach -d -p 26257:26257 -p 26258:8080 cockroachdb/cockroach:v22.2.0 start-single-node --insecure
+docker run --name=cockroach -d -p 26257:26257 -p 26258:8080 cockroachdb/cockroach:v23.1.11 start-single-node --insecure
 ```
 
 If you can successfully connect to CockroachDB with either


### PR DESCRIPTION
This commit updates the CRDB version in the developer guide so that it matches our docker image.

### Motivation
Updates doc

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
