### PR TITLE
[persist] Store a vector of cursors instead of a vector of vecs

### DIFF
--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -195,10 +195,7 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidation
 
             // Sort the cursors by the data that they point to.
             let kvt = |(cursor, t, _): &(Cursor, T, D)| {
-                cursor
-                    .clone()
-                    .peek(&part)
-                    .map(move |(k, v, _, _)| (k, v, t.clone()))
+                cursor.get(&part).map(move |(k, v, _, _)| (k, v, t.clone()))
             };
             cursors.sort_by(|a, b| kvt(a).cmp(&kvt(b)));
 
@@ -222,8 +219,8 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidation
                 Some((k, v, t))
             }
             ConsolidationPart::Sorted { part, cursors } => {
-                let (cursor, t, _) = cursors.front_mut()?;
-                let (k, v, _, _) = cursor.peek(part)?;
+                let (cursor, t, _) = cursors.front()?;
+                let (k, v, _, _) = cursor.get(part)?;
                 Some((k, v, t.clone()))
             }
         }
@@ -702,9 +699,9 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64> ConsolidationPartIter<'a,
         match self {
             Self::Encoded { next, .. } => next.clone(),
             Self::Sorted { part, cursors, .. } => {
-                let (mut cursor, t, d) = cursors.front()?.clone();
-                let (k, v, _, _) = cursor.peek(part)?;
-                Some((k, v, t, d))
+                let (cursor, t, d) = cursors.front()?;
+                let (k, v, _, _) = cursor.get(part)?;
+                Some((k, v, t.clone(), d.clone()))
             }
         }
     }
@@ -741,8 +738,8 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64> Iterator
                 out
             }
             ConsolidationPartIter::Sorted { part, cursors, .. } => {
-                let (mut cursor, t, d) = cursors.pop_front()?;
-                let (k, v, _, _) = cursor.peek(part)?;
+                let (cursor, t, d) = cursors.pop_front()?;
+                let (k, v, _, _) = cursor.get(part)?;
                 Some((k, v, t, d))
             }
         }


### PR DESCRIPTION
This in theory should be more memory-efficient, since we only keep a couple indices per entry instead of allocating a fresh Vec.

This is also probably more friendly to our upcoming structured-data future, where we want to keep indices into a columnar representation instead of the data itself.

### Motivation

In #27157, @antiguru helpfully pointed out that we're doing quite a bit of allocation in this codepath under some circumstances. (Roughly, the first time we compact a very large batch.) In particular, we end up taking a columnar representation of the data and turning it into a long list of tiny allocations, which is not great for various reasons... replacing those small allocations with an inline index should reduce both total memory use and the sheer number of allocations.

### Tips for reviewer

Deploying this change in QA and looking and PS data shows quite a bit less memory allocated in this codepath, at least for nontrivially-sized keys and values. Far from a scientific benchmark, though... happy to take suggestions for a more repeatable test!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
