### PR TITLE
adapter: Refactor `DROP ... CASCADE` into a single `catalog::Op`

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 
 use futures::future::BoxFuture;
+use maplit::btreeset;
 use mz_catalog::durable::{Item, Transaction};
 use mz_catalog::memory::objects::{StateUpdate, StateUpdateKind};
 use mz_ore::collections::CollectionExt;
@@ -222,7 +223,7 @@ fn assign_new_user_global_ids(
 
     // Before updating the item by inserting its new state, ensure we remove its
     // old state.
-    tx.remove_items(news_new_id_set.clone())?;
+    tx.remove_items(&news_new_id_set)?;
 
     // Delete the storage metadata alongside removing the item––this will return
     // the metadata for the deleted entries, which we'll re-associate with the
@@ -327,7 +328,7 @@ fn assign_new_user_global_ids(
                 }
             };
 
-            let comments = tx.drop_comments(curr_id)?;
+            let comments = tx.drop_comments(&btreeset! { curr_id })?;
             for (_id, subcomponent, comment) in comments {
                 tx.update_comment(comment_id, subcomponent, Some(comment))?;
             }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -961,7 +961,7 @@ impl Catalog {
         txn: &mut Transaction<'_>,
         migration_metadata: &mut BuiltinMigrationMetadata,
     ) -> Result<(), Error> {
-        txn.remove_items(migration_metadata.user_drop_ops.drain(..).collect())?;
+        txn.remove_items(&migration_metadata.user_drop_ops.drain(..).collect())?;
         for (id, schema_id, oid, name) in migration_metadata.user_create_ops.drain(..) {
             let entry = state.get_entry(&id);
             let item = entry.item();

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -598,6 +598,14 @@ impl CatalogState {
             .unwrap_or_else(|| panic!("catalog out of sync, missing id {id}"))
     }
 
+    pub fn get_temp_items(&self, conn: &ConnectionId) -> impl Iterator<Item = ObjectId> + '_ {
+        let schema = self
+            .temporary_schemas
+            .get(conn)
+            .unwrap_or_else(|| panic!("catalog out of sync, missing temporary schema for {conn}"));
+        schema.items.values().copied().map(ObjectId::Item)
+    }
+
     /// Gets a type named `name` from exactly one of the system schemas.
     ///
     /// # Panics

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -987,7 +987,7 @@ impl Catalog {
                 }
                 Op::DropObjects(ids) => {
                     // Generate all of the objects that need to get dropped.
-                    let delta = DropObjectsDelta::generate(ids, state, session)?;
+                    let delta = ObjectsToDrop::generate(ids, state, session)?;
 
                     // Drop any associated comments.
                     let deleted = tx.drop_comments(&delta.comments)?;
@@ -2387,7 +2387,7 @@ impl Catalog {
 /// Catalog. This resulted in an unacceptable `O(m * n)` performance for a
 /// `DROP ... CASCADE` statement.
 #[derive(Debug, Default)]
-pub(crate) struct DropObjectsDelta {
+pub(crate) struct ObjectsToDrop {
     pub comments: BTreeSet<CommentObjectId>,
     pub databases: BTreeSet<DatabaseId>,
     pub schemas: BTreeMap<SchemaSpecifier, ResolvedDatabaseSpecifier>,
@@ -2397,13 +2397,13 @@ pub(crate) struct DropObjectsDelta {
     pub items: Vec<GlobalId>,
 }
 
-impl DropObjectsDelta {
+impl ObjectsToDrop {
     pub fn generate(
         objects: impl IntoIterator<Item = ObjectId>,
         state: &CatalogState,
         session: Option<&ConnMeta>,
     ) -> Result<Self, AdapterError> {
-        let mut delta = DropObjectsDelta::default();
+        let mut delta = ObjectsToDrop::default();
 
         for object in objects {
             delta.add_item(object, state, session)?;

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -106,7 +106,7 @@ pub enum Op {
         sub_component: Option<usize>,
         comment: Option<String>,
     },
-    DropObject(ObjectId),
+    DropObjects(Vec<ObjectId>),
     GrantRole {
         role_id: RoleId,
         member_id: RoleId,
@@ -206,10 +206,9 @@ impl Catalog {
             .cloned()
             .map(ObjectId::Item)
             .collect();
-        self.object_dependents(&temp_ids, conn_id)
-            .into_iter()
-            .map(Op::DropObject)
-            .collect()
+        let drop_ids = self.object_dependents(&temp_ids, conn_id);
+
+        vec![Op::DropObjects(drop_ids)]
     }
 
     fn should_audit_log_item(item: &CatalogItem) -> bool {
@@ -268,12 +267,19 @@ impl Catalog {
             )))
         });
 
-        let drop_ids: BTreeSet<_> = ops
+        let drop_ids: BTreeSet<GlobalId> = ops
             .iter()
             .filter_map(|op| match op {
-                Op::DropObject(ObjectId::Item(id)) => Some(*id),
+                Op::DropObjects(ids) => {
+                    let item_ids = ids.iter().filter_map(|id| match id {
+                        ObjectId::Item(id) => Some(*id),
+                        _ => None,
+                    });
+                    Some(item_ids)
+                }
                 _ => None,
             })
+            .flatten()
             .collect();
         let temporary_drops = drop_ids
             .iter()
@@ -979,11 +985,13 @@ impl Catalog {
                         ));
                     }
                 }
-                Op::DropObject(id) => {
+                Op::DropObjects(ids) => {
+                    // Generate all of the objects that need to get dropped.
+                    let delta = DropObjectsDelta::generate(ids, state, session)?;
+
                     // Drop any associated comments.
-                    let comment_id = state.get_comment_id(id.clone());
-                    let deleted = tx.drop_comments(comment_id)?;
-                    let dropped = state.comments.drop_comments(comment_id);
+                    let deleted = tx.drop_comments(&delta.comments)?;
+                    let dropped = state.comments.drop_comments(&delta.comments);
                     mz_ore::soft_assert_eq_or_log!(
                         deleted,
                         dropped,
@@ -995,17 +1003,24 @@ impl Catalog {
                     });
                     builtin_table_updates.extend(updates);
 
-                    // Drop the object.
-                    match id {
-                        ObjectId::Database(id) => {
-                            let database = &state.database_by_id[&id];
-                            if id.is_system() {
-                                return Err(AdapterError::Catalog(Error::new(
-                                    ErrorKind::ReadOnlyDatabase(database.name().to_string()),
-                                )));
-                            }
-                            tx.remove_database(&id)?;
-                            builtin_table_updates.push(state.pack_database_update(&id, -1));
+                    // Drop any items.
+                    let items_to_drop = delta
+                        .items
+                        .iter()
+                        .filter(|id| !state.get_entry(id).item().is_temporary())
+                        .copied()
+                        .collect();
+                    tx.remove_items(&items_to_drop)?;
+
+                    for item_id in delta.items {
+                        let entry = state.get_entry(&item_id);
+
+                        if entry.item().is_storage_collection() {
+                            storage_collections_to_drop.insert(item_id);
+                        }
+
+                        builtin_table_updates.extend(state.pack_item_update(item_id, -1));
+                        if Self::should_audit_log_item(entry.item()) {
                             state.add_to_audit_log(
                                 oracle_write_ts,
                                 session,
@@ -1013,225 +1028,218 @@ impl Catalog {
                                 builtin_table_updates,
                                 audit_events,
                                 EventType::Drop,
-                                ObjectType::Database,
-                                EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
-                                    id: id.to_string(),
-                                    name: database.name.clone(),
+                                catalog_type_to_audit_object_type(entry.item().typ()),
+                                EventDetails::IdFullNameV1(IdFullNameV1 {
+                                    id: item_id.to_string(),
+                                    name: Self::full_name_detail(&state.resolve_full_name(
+                                        entry.name(),
+                                        session.map(|session| session.conn_id()),
+                                    )),
                                 }),
                             )?;
-                            let db = state.database_by_id.get(&id).expect("catalog out of sync");
-                            state.database_by_name.remove(db.name());
-                            state.database_by_id.remove(&id);
                         }
-                        ObjectId::Schema((database_spec, schema_spec)) => {
-                            let schema = state.get_schema(
-                                &database_spec,
-                                &schema_spec,
-                                session
-                                    .map(|session| session.conn_id())
-                                    .unwrap_or(&SYSTEM_CONN_ID),
-                            );
-                            let database_id = match database_spec {
-                                ResolvedDatabaseSpecifier::Ambient => None,
-                                ResolvedDatabaseSpecifier::Id(database_id) => Some(database_id),
-                            };
-                            let schema_id: SchemaId = schema_spec.into();
-                            if schema_id.is_system() {
-                                let name = schema.name();
-                                let full_name = state.resolve_full_schema_name(name);
-                                return Err(AdapterError::Catalog(Error::new(
-                                    ErrorKind::ReadOnlySystemSchema(full_name.to_string()),
-                                )));
-                            }
-                            tx.remove_schema(&database_id, &schema_id)?;
-                            builtin_table_updates.push(state.pack_schema_update(
-                                &database_spec,
-                                &schema_id,
-                                -1,
-                            ));
-                            state.add_to_audit_log(
-                                oracle_write_ts,
-                                session,
-                                tx,
-                                builtin_table_updates,
-                                audit_events,
-                                EventType::Drop,
-                                ObjectType::Schema,
-                                EventDetails::SchemaV2(mz_audit_log::SchemaV2 {
-                                    id: schema_id.to_string(),
-                                    name: schema.name.schema.to_string(),
-                                    database_name: database_id.map(|database_id| {
-                                        state.database_by_id[&database_id].name.clone()
-                                    }),
+                        state.drop_item(item_id);
+                    }
+
+                    // Drop any schemas.
+                    let schemas = delta
+                        .schemas
+                        .iter()
+                        .map(|(schema_spec, database_spec)| {
+                            (SchemaId::from(schema_spec), *database_spec)
+                        })
+                        .collect();
+                    tx.remove_schemas(&schemas)?;
+
+                    for (schema_spec, database_spec) in delta.schemas {
+                        let schema = state.get_schema(
+                            &database_spec,
+                            &schema_spec,
+                            session
+                                .map(|session| session.conn_id())
+                                .unwrap_or(&SYSTEM_CONN_ID),
+                        );
+
+                        let schema_id = SchemaId::from(schema_spec);
+                        let database_id = match database_spec {
+                            ResolvedDatabaseSpecifier::Ambient => None,
+                            ResolvedDatabaseSpecifier::Id(database_id) => Some(database_id),
+                        };
+
+                        builtin_table_updates.push(state.pack_schema_update(
+                            &database_spec,
+                            &schema_id,
+                            -1,
+                        ));
+                        state.add_to_audit_log(
+                            oracle_write_ts,
+                            session,
+                            tx,
+                            builtin_table_updates,
+                            audit_events,
+                            EventType::Drop,
+                            ObjectType::Schema,
+                            EventDetails::SchemaV2(mz_audit_log::SchemaV2 {
+                                id: schema_id.to_string(),
+                                name: schema.name.schema.to_string(),
+                                database_name: database_id.map(|database_id| {
+                                    state.database_by_id[&database_id].name.clone()
                                 }),
-                            )?;
-                            if let ResolvedDatabaseSpecifier::Id(database_id) = database_spec {
-                                let db = state
-                                    .database_by_id
-                                    .get_mut(&database_id)
-                                    .expect("catalog out of sync");
-                                let schema = &db.schemas_by_id[&schema_id];
-                                db.schemas_by_name.remove(&schema.name.schema);
-                                db.schemas_by_id.remove(&schema_id);
-                            }
+                            }),
+                        )?;
+
+                        if let ResolvedDatabaseSpecifier::Id(database_id) = database_spec {
+                            let db = state
+                                .database_by_id
+                                .get_mut(&database_id)
+                                .expect("catalog out of sync");
+                            let schema = &db.schemas_by_id[&schema_id];
+                            db.schemas_by_name.remove(&schema.name.schema);
+                            db.schemas_by_id.remove(&schema_id);
                         }
-                        ObjectId::Role(id) => {
-                            let name = state.get_role(&id).name().to_string();
-                            if id.is_system() || id.is_predefined() {
-                                return Err(AdapterError::Catalog(Error::new(
-                                    ErrorKind::ReservedRoleName(name.clone()),
-                                )));
-                            }
-                            state.ensure_not_reserved_role(&id)?;
-                            tx.remove_role(&name)?;
-                            builtin_table_updates.extend(state.pack_role_update(id, -1));
+                    }
 
-                            let role = state.roles_by_id.remove(&id).expect("catalog out of sync");
-                            state.roles_by_name.remove(role.name());
-                            state.add_to_audit_log(
-                                oracle_write_ts,
-                                session,
-                                tx,
-                                builtin_table_updates,
-                                audit_events,
-                                EventType::Drop,
-                                ObjectType::Role,
-                                EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
-                                    id: role.id.to_string(),
-                                    name: name.clone(),
-                                }),
-                            )?;
-                            info!("drop role {}", role.name());
-                        }
-                        ObjectId::Cluster(id) => {
-                            let cluster = state.get_cluster(id);
-                            let name = &cluster.name;
-                            if id.is_system() {
-                                return Err(AdapterError::Catalog(Error::new(
-                                    ErrorKind::ReadOnlyCluster(name.clone()),
-                                )));
-                            }
-                            tx.remove_cluster(id)?;
-                            builtin_table_updates.extend(state.pack_cluster_update(name, -1));
-                            for id in cluster.log_indexes.values() {
-                                builtin_table_updates.extend(state.pack_item_update(*id, -1));
-                            }
-                            state.add_to_audit_log(
-                                oracle_write_ts,
-                                session,
-                                tx,
-                                builtin_table_updates,
-                                audit_events,
-                                EventType::Drop,
-                                ObjectType::Cluster,
-                                EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
-                                    id: cluster.id.to_string(),
-                                    name: name.clone(),
-                                }),
-                            )?;
-                            let cluster = state
-                                .clusters_by_id
-                                .remove(&id)
-                                .expect("can only drop known clusters");
-                            state.clusters_by_name.remove(&cluster.name);
+                    // Drop any databases.
+                    tx.remove_databases(&delta.databases)?;
 
-                            for id in cluster.log_indexes.values() {
-                                state.drop_item(*id);
-                            }
+                    for database_id in delta.databases {
+                        let database = state.get_database(&database_id).clone();
 
-                            assert!(
-                                cluster.bound_objects.is_empty()
-                                    && cluster.replicas().next().is_none(),
-                                "not all items dropped before cluster"
-                            );
-                        }
-                        ObjectId::ClusterReplica((cluster_id, replica_id)) => {
-                            let cluster = state.get_cluster(cluster_id);
-                            let replica = cluster.replica(replica_id).expect("Must exist");
-                            tx.remove_cluster_replica(replica_id)?;
+                        builtin_table_updates.push(state.pack_database_update(&database_id, -1));
+                        state.add_to_audit_log(
+                            oracle_write_ts,
+                            session,
+                            tx,
+                            builtin_table_updates,
+                            audit_events,
+                            EventType::Drop,
+                            ObjectType::Database,
+                            EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
+                                id: database_id.to_string(),
+                                name: database.name.clone(),
+                            }),
+                        )?;
 
-                            for process_id in replica.process_status.keys() {
-                                let update = state.pack_cluster_replica_status_update(
-                                    cluster_id,
-                                    replica_id,
-                                    *process_id,
-                                    -1,
-                                );
-                                builtin_table_updates.push(update);
-                            }
+                        state.database_by_name.remove(database.name());
+                        state.database_by_id.remove(&database_id);
+                    }
 
-                            builtin_table_updates.extend(state.pack_cluster_replica_update(
+                    // Drop any roles.
+                    tx.remove_roles(&delta.roles)?;
+
+                    for role_id in delta.roles {
+                        builtin_table_updates.extend(state.pack_role_update(role_id, -1));
+
+                        let role = state
+                            .roles_by_id
+                            .remove(&role_id)
+                            .expect("catalog out of sync");
+                        state.roles_by_name.remove(role.name());
+
+                        state.add_to_audit_log(
+                            oracle_write_ts,
+                            session,
+                            tx,
+                            builtin_table_updates,
+                            audit_events,
+                            EventType::Drop,
+                            ObjectType::Role,
+                            EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
+                                id: role.id.to_string(),
+                                name: role.name.clone(),
+                            }),
+                        )?;
+                        info!("drop role {}", role.name());
+                    }
+
+                    // Drop any replicas.
+                    let replicas = delta.replicas.keys().copied().collect();
+                    tx.remove_cluster_replicas(&replicas)?;
+
+                    for (replica_id, cluster_id) in delta.replicas {
+                        let cluster = state.get_cluster(cluster_id);
+                        let replica = cluster.replica(replica_id).expect("Must exist");
+
+                        for process_id in replica.process_status.keys() {
+                            let update = state.pack_cluster_replica_status_update(
                                 cluster_id,
-                                &replica.name,
+                                replica_id,
+                                *process_id,
                                 -1,
-                            ));
-
-                            let details = EventDetails::DropClusterReplicaV1(
-                                mz_audit_log::DropClusterReplicaV1 {
-                                    cluster_id: cluster_id.to_string(),
-                                    cluster_name: cluster.name.clone(),
-                                    replica_id: Some(replica_id.to_string()),
-                                    replica_name: replica.name.clone(),
-                                },
                             );
-                            state.add_to_audit_log(
-                                oracle_write_ts,
-                                session,
-                                tx,
-                                builtin_table_updates,
-                                audit_events,
-                                EventType::Drop,
-                                ObjectType::ClusterReplica,
-                                details,
-                            )?;
-
-                            let cluster = state
-                                .clusters_by_id
-                                .get_mut(&cluster_id)
-                                .expect("can only drop replicas from known instances");
-                            cluster.remove_replica(replica_id);
+                            builtin_table_updates.push(update);
                         }
-                        ObjectId::Item(id) => {
-                            let entry = state.get_entry(&id);
-                            if id.is_system() {
-                                let name = entry.name();
-                                let full_name = state.resolve_full_name(
-                                    name,
-                                    session.map(|session| session.conn_id()),
-                                );
-                                return Err(AdapterError::Catalog(Error::new(
-                                    ErrorKind::ReadOnlyItem(full_name.to_string()),
-                                )));
-                            }
-                            if !entry.item().is_temporary() {
-                                tx.remove_item(id)?;
-                            }
 
-                            if entry.item().is_storage_collection() {
-                                storage_collections_to_drop.insert(id);
-                            }
+                        builtin_table_updates.extend(state.pack_cluster_replica_update(
+                            cluster_id,
+                            &replica.name,
+                            -1,
+                        ));
 
-                            builtin_table_updates.extend(state.pack_item_update(id, -1));
-                            if Self::should_audit_log_item(entry.item()) {
-                                state.add_to_audit_log(
-                                    oracle_write_ts,
-                                    session,
-                                    tx,
-                                    builtin_table_updates,
-                                    audit_events,
-                                    EventType::Drop,
-                                    catalog_type_to_audit_object_type(entry.item().typ()),
-                                    EventDetails::IdFullNameV1(IdFullNameV1 {
-                                        id: id.to_string(),
-                                        name: Self::full_name_detail(&state.resolve_full_name(
-                                            entry.name(),
-                                            session.map(|session| session.conn_id()),
-                                        )),
-                                    }),
-                                )?;
-                            }
-                            state.drop_item(id);
+                        let details = EventDetails::DropClusterReplicaV1(
+                            mz_audit_log::DropClusterReplicaV1 {
+                                cluster_id: cluster_id.to_string(),
+                                cluster_name: cluster.name.clone(),
+                                replica_id: Some(replica_id.to_string()),
+                                replica_name: replica.name.clone(),
+                            },
+                        );
+                        state.add_to_audit_log(
+                            oracle_write_ts,
+                            session,
+                            tx,
+                            builtin_table_updates,
+                            audit_events,
+                            EventType::Drop,
+                            ObjectType::ClusterReplica,
+                            details,
+                        )?;
+
+                        let cluster = state
+                            .clusters_by_id
+                            .get_mut(&cluster_id)
+                            .expect("can only drop replicas from known instances");
+                        cluster.remove_replica(replica_id);
+                    }
+
+                    // Drop any clusters.
+                    tx.remove_clusters(&delta.clusters)?;
+
+                    for cluster_id in delta.clusters {
+                        let cluster = state.get_cluster(cluster_id);
+
+                        builtin_table_updates.extend(state.pack_cluster_update(&cluster.name, -1));
+                        for id in cluster.log_indexes.values() {
+                            builtin_table_updates.extend(state.pack_item_update(*id, -1));
                         }
+
+                        state.add_to_audit_log(
+                            oracle_write_ts,
+                            session,
+                            tx,
+                            builtin_table_updates,
+                            audit_events,
+                            EventType::Drop,
+                            ObjectType::Cluster,
+                            EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
+                                id: cluster.id.to_string(),
+                                name: cluster.name.clone(),
+                            }),
+                        )?;
+                        let cluster = state
+                            .clusters_by_id
+                            .remove(&cluster_id)
+                            .expect("can only drop known clusters");
+                        state.clusters_by_name.remove(&cluster.name);
+
+                        for id in cluster.log_indexes.values() {
+                            state.drop_item(*id);
+                        }
+
+                        assert!(
+                            cluster.bound_objects.is_empty() && cluster.replicas().next().is_none(),
+                            "not all items dropped before cluster"
+                        );
                     }
                 }
                 Op::GrantRole {
@@ -2368,6 +2376,125 @@ impl Catalog {
         }
 
         *privileges = PrivilegeMap::from_mz_acl_items(flat_privileges);
+    }
+}
+
+/// All of the objects that need to be removed in response to an [`Op::DropObjects`].
+///
+/// Note: Previously we used to omit a single `Op::DropObject` for every object
+/// we needed to drop. But removing a batch of objects from a durable Catalog
+/// Transaction is O(n) where `n` is the number of objects that exist in the
+/// Catalog. This resulted in an unacceptable `O(m * n)` performance for a
+/// `DROP ... CASCADE` statement.
+#[derive(Debug, Default)]
+pub(crate) struct DropObjectsDelta {
+    pub comments: BTreeSet<CommentObjectId>,
+    pub databases: BTreeSet<DatabaseId>,
+    pub schemas: BTreeMap<SchemaSpecifier, ResolvedDatabaseSpecifier>,
+    pub clusters: BTreeSet<ClusterId>,
+    pub replicas: BTreeMap<ReplicaId, ClusterId>,
+    pub roles: BTreeSet<RoleId>,
+    pub items: Vec<GlobalId>,
+}
+
+impl DropObjectsDelta {
+    pub fn generate(
+        objects: impl IntoIterator<Item = ObjectId>,
+        state: &CatalogState,
+        session: Option<&ConnMeta>,
+    ) -> Result<Self, AdapterError> {
+        let mut delta = DropObjectsDelta::default();
+
+        for object in objects {
+            delta.add_item(object, state, session)?;
+        }
+
+        Ok(delta)
+    }
+
+    fn add_item(
+        &mut self,
+        object_id: ObjectId,
+        state: &CatalogState,
+        session: Option<&ConnMeta>,
+    ) -> Result<(), AdapterError> {
+        self.comments
+            .insert(state.get_comment_id(object_id.clone()));
+
+        match object_id {
+            ObjectId::Database(database_id) => {
+                let database = &state.database_by_id[&database_id];
+                if database_id.is_system() {
+                    return Err(AdapterError::Catalog(Error::new(
+                        ErrorKind::ReadOnlyDatabase(database.name().to_string()),
+                    )));
+                }
+
+                self.databases.insert(database_id);
+            }
+            ObjectId::Schema((database_spec, schema_spec)) => {
+                let schema = state.get_schema(
+                    &database_spec,
+                    &schema_spec,
+                    session
+                        .map(|session| session.conn_id())
+                        .unwrap_or(&SYSTEM_CONN_ID),
+                );
+                let schema_id: SchemaId = schema_spec.into();
+                if schema_id.is_system() {
+                    let name = schema.name();
+                    let full_name = state.resolve_full_schema_name(name);
+                    return Err(AdapterError::Catalog(Error::new(
+                        ErrorKind::ReadOnlySystemSchema(full_name.to_string()),
+                    )));
+                }
+
+                self.schemas.insert(schema_spec, database_spec);
+            }
+            ObjectId::Role(role_id) => {
+                let name = state.get_role(&role_id).name().to_string();
+                if role_id.is_system() || role_id.is_predefined() {
+                    return Err(AdapterError::Catalog(Error::new(
+                        ErrorKind::ReservedRoleName(name.clone()),
+                    )));
+                }
+                state.ensure_not_reserved_role(&role_id)?;
+
+                self.roles.insert(role_id);
+            }
+            ObjectId::Cluster(cluster_id) => {
+                let cluster = state.get_cluster(cluster_id);
+                let name = &cluster.name;
+                if cluster_id.is_system() {
+                    return Err(AdapterError::Catalog(Error::new(
+                        ErrorKind::ReadOnlyCluster(name.clone()),
+                    )));
+                }
+
+                self.clusters.insert(cluster_id);
+            }
+            ObjectId::ClusterReplica((cluster_id, replica_id)) => {
+                let cluster = state.get_cluster(cluster_id);
+                let replica = cluster.replica(replica_id).expect("Must exist");
+
+                self.replicas.insert(replica.replica_id, cluster.id);
+            }
+            ObjectId::Item(item_id) => {
+                let entry = state.get_entry(&item_id);
+                if item_id.is_system() {
+                    let name = entry.name();
+                    let full_name =
+                        state.resolve_full_name(name, session.map(|session| session.conn_id()));
+                    return Err(AdapterError::Catalog(Error::new(ErrorKind::ReadOnlyItem(
+                        full_name.to_string(),
+                    ))));
+                }
+
+                self.items.push(item_id);
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -199,18 +199,6 @@ pub struct TransactionResult {
 }
 
 impl Catalog {
-    pub fn drop_temp_item_ops(&mut self, conn_id: &ConnectionId) -> Vec<Op> {
-        let temp_ids = self.state.temporary_schemas[conn_id]
-            .items
-            .values()
-            .cloned()
-            .map(ObjectId::Item)
-            .collect();
-        let drop_ids = self.object_dependents(&temp_ids, conn_id);
-
-        vec![Op::DropObjects(drop_ids)]
-    }
-
     fn should_audit_log_item(item: &CatalogItem) -> bool {
         !item.is_temporary()
     }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -212,89 +212,102 @@ impl Coordinator {
 
         for op in &ops {
             match op {
-                catalog::Op::DropObject(ObjectId::Item(id)) => {
-                    match self.catalog().get_entry(id).item() {
-                        CatalogItem::Table(_) => {
-                            tables_to_drop.push(*id);
-                        }
-                        CatalogItem::Source(source) => {
-                            sources_to_drop.push(*id);
-                            if let DataSourceDesc::Ingestion { ingestion_desc, .. } =
-                                &source.data_source
-                            {
-                                match &ingestion_desc.desc.connection {
-                                    GenericSourceConnection::Postgres(conn) => {
-                                        let conn = conn
-                                            .clone()
-                                            .into_inline_connection(self.catalog().state());
-                                        let config = conn
-                                            .connection
-                                            .config(
-                                                self.secrets_reader(),
-                                                self.controller.storage.config(),
-                                                InTask::No,
-                                            )
-                                            .await
-                                            .map_err(|e| {
-                                                AdapterError::Storage(StorageError::Generic(
-                                                    anyhow::anyhow!(
-                                                        "error creating Postgres client for \
-                                                        dropping acquired slots: {}",
-                                                        e.display_with_causes()
-                                                    ),
-                                                ))
-                                            })?;
-
-                                        replication_slots_to_drop
-                                            .push((config, conn.publication_details.slot.clone()));
+                catalog::Op::DropObjects(object_ids) => {
+                    for object_id in object_ids {
+                        match &object_id {
+                            ObjectId::Item(id) => {
+                                match self.catalog().get_entry(id).item() {
+                                    CatalogItem::Table(_) => {
+                                        tables_to_drop.push(*id);
                                     }
-                                    _ => {}
+                                    CatalogItem::Source(source) => {
+                                        sources_to_drop.push(*id);
+                                        if let DataSourceDesc::Ingestion {
+                                            ingestion_desc, ..
+                                        } = &source.data_source
+                                        {
+                                            match &ingestion_desc.desc.connection {
+                                                GenericSourceConnection::Postgres(conn) => {
+                                                    let conn = conn.clone().into_inline_connection(
+                                                        self.catalog().state(),
+                                                    );
+                                                    let config = conn
+                                                    .connection
+                                                    .config(
+                                                        self.secrets_reader(),
+                                                        self.controller.storage.config(),
+                                                        InTask::No,
+                                                    )
+                                                    .await
+                                                    .map_err(|e| {
+                                                        AdapterError::Storage(StorageError::Generic(
+                                                            anyhow::anyhow!(
+                                                                "error creating Postgres client for \
+                                                                dropping acquired slots: {}",
+                                                                e.display_with_causes()
+                                                            ),
+                                                        ))
+                                                    })?;
+
+                                                    replication_slots_to_drop.push((
+                                                        config,
+                                                        conn.publication_details.slot.clone(),
+                                                    ));
+                                                }
+                                                _ => {}
+                                            }
+                                        }
+                                    }
+                                    CatalogItem::Sink(Sink { .. }) => {
+                                        storage_sinks_to_drop.push(*id);
+                                    }
+                                    CatalogItem::Index(Index { cluster_id, .. }) => {
+                                        indexes_to_drop.push((*cluster_id, *id));
+                                    }
+                                    CatalogItem::MaterializedView(MaterializedView {
+                                        cluster_id,
+                                        ..
+                                    }) => {
+                                        materialized_views_to_drop.push((*cluster_id, *id));
+                                    }
+                                    CatalogItem::View(_) => views_to_drop.push(*id),
+                                    CatalogItem::Secret(_) => {
+                                        secrets_to_drop.push(*id);
+                                    }
+                                    CatalogItem::Connection(Connection { connection, .. }) => {
+                                        match connection {
+                                        // SSH connections have an associated secret that should be dropped
+                                        mz_storage_types::connections::Connection::Ssh(_) => {
+                                            secrets_to_drop.push(*id);
+                                        }
+                                        // AWS PrivateLink connections have an associated
+                                        // VpcEndpoint K8S resource that should be dropped
+                                        mz_storage_types::connections::Connection::AwsPrivatelink(_) => {
+                                            vpc_endpoints_to_drop.push(*id);
+                                        }
+                                        _ => (),
+                                    }
+                                    }
+                                    _ => (),
                                 }
                             }
-                        }
-                        CatalogItem::Sink(Sink { .. }) => {
-                            storage_sinks_to_drop.push(*id);
-                        }
-                        CatalogItem::Index(Index { cluster_id, .. }) => {
-                            indexes_to_drop.push((*cluster_id, *id));
-                        }
-                        CatalogItem::MaterializedView(MaterializedView { cluster_id, .. }) => {
-                            materialized_views_to_drop.push((*cluster_id, *id));
-                        }
-                        CatalogItem::View(_) => views_to_drop.push(*id),
-                        CatalogItem::Secret(_) => {
-                            secrets_to_drop.push(*id);
-                        }
-                        CatalogItem::Connection(Connection { connection, .. }) => {
-                            match connection {
-                                // SSH connections have an associated secret that should be dropped
-                                mz_storage_types::connections::Connection::Ssh(_) => {
-                                    secrets_to_drop.push(*id);
-                                }
-                                // AWS PrivateLink connections have an associated
-                                // VpcEndpoint K8S resource that should be dropped
-                                mz_storage_types::connections::Connection::AwsPrivatelink(_) => {
-                                    vpc_endpoints_to_drop.push(*id);
-                                }
-                                _ => (),
+                            ObjectId::Cluster(id) => {
+                                clusters_to_drop.push(*id);
+                                log_indexes_to_drop.extend(
+                                    self.catalog()
+                                        .get_cluster(*id)
+                                        .log_indexes
+                                        .values()
+                                        .cloned(),
+                                );
                             }
+                            ObjectId::ClusterReplica((cluster_id, replica_id)) => {
+                                // Drop the cluster replica itself.
+                                cluster_replicas_to_drop.push((*cluster_id, *replica_id));
+                            }
+                            _ => (),
                         }
-                        _ => (),
                     }
-                }
-                catalog::Op::DropObject(ObjectId::Cluster(id)) => {
-                    clusters_to_drop.push(*id);
-                    log_indexes_to_drop.extend(
-                        self.catalog()
-                            .get_cluster(*id)
-                            .log_indexes
-                            .values()
-                            .cloned(),
-                    );
-                }
-                catalog::Op::DropObject(ObjectId::ClusterReplica((cluster_id, replica_id))) => {
-                    // Drop the cluster replica itself.
-                    cluster_replicas_to_drop.push((*cluster_id, *replica_id));
                 }
                 catalog::Op::ResetSystemConfiguration { name }
                 | catalog::Op::UpdateSystemConfiguration { name, .. } => {
@@ -1184,15 +1197,19 @@ impl Coordinator {
                         | CatalogItem::Func(_) => {}
                     }
                 }
-                Op::DropObject(id) => match id {
-                    ObjectId::Cluster(_) => {
-                        new_clusters -= 1;
-                    }
-                    ObjectId::ClusterReplica((cluster_id, replica_id)) => {
-                        *new_replicas_per_cluster.entry(*cluster_id).or_insert(0) -= 1;
-                        let cluster = self.catalog().get_cluster_replica(*cluster_id, *replica_id);
-                        if let ReplicaLocation::Managed(location) = &cluster.config.location {
-                            let replica_allocation = self
+                Op::DropObjects(object_ids) => {
+                    for id in object_ids {
+                        match id {
+                            ObjectId::Cluster(_) => {
+                                new_clusters -= 1;
+                            }
+                            ObjectId::ClusterReplica((cluster_id, replica_id)) => {
+                                *new_replicas_per_cluster.entry(*cluster_id).or_insert(0) -= 1;
+                                let cluster =
+                                    self.catalog().get_cluster_replica(*cluster_id, *replica_id);
+                                if let ReplicaLocation::Managed(location) = &cluster.config.location
+                                {
+                                    let replica_allocation = self
                                 .catalog()
                                 .cluster_replica_sizes()
                                 .0
@@ -1200,29 +1217,30 @@ impl Coordinator {
                                 .expect(
                                     "location size is validated against the cluster replica sizes",
                                 );
-                            new_credit_consumption_rate -= replica_allocation.credits_per_hour
-                        }
-                    }
-                    ObjectId::Database(_) => {
-                        new_databases -= 1;
-                    }
-                    ObjectId::Schema((database_spec, _)) => {
-                        if let ResolvedDatabaseSpecifier::Id(database_id) = database_spec {
-                            *new_schemas_per_database.entry(database_id).or_insert(0) -= 1;
-                        }
-                    }
-                    ObjectId::Role(_) => {
-                        new_roles -= 1;
-                    }
-                    ObjectId::Item(id) => {
-                        let entry = self.catalog().get_entry(id);
-                        *new_objects_per_schema
-                            .entry((
-                                entry.name().qualifiers.database_spec.clone(),
-                                entry.name().qualifiers.schema_spec.clone(),
-                            ))
-                            .or_insert(0) -= 1;
-                        match entry.item() {
+                                    new_credit_consumption_rate -=
+                                        replica_allocation.credits_per_hour
+                                }
+                            }
+                            ObjectId::Database(_) => {
+                                new_databases -= 1;
+                            }
+                            ObjectId::Schema((database_spec, _)) => {
+                                if let ResolvedDatabaseSpecifier::Id(database_id) = database_spec {
+                                    *new_schemas_per_database.entry(database_id).or_insert(0) -= 1;
+                                }
+                            }
+                            ObjectId::Role(_) => {
+                                new_roles -= 1;
+                            }
+                            ObjectId::Item(id) => {
+                                let entry = self.catalog().get_entry(id);
+                                *new_objects_per_schema
+                                    .entry((
+                                        entry.name().qualifiers.database_spec.clone(),
+                                        entry.name().qualifiers.schema_spec.clone(),
+                                    ))
+                                    .or_insert(0) -= 1;
+                                match entry.item() {
                             CatalogItem::Connection(connection) => match connection.connection {
                                 mz_storage_types::connections::Connection::AwsPrivatelink(_) => {
                                     new_aws_privatelink_connections -= 1;
@@ -1248,8 +1266,10 @@ impl Coordinator {
                             | CatalogItem::Type(_)
                             | CatalogItem::Func(_) => {}
                         }
+                            }
+                        }
                     }
-                },
+                }
                 Op::UpdateItem {
                     name: _,
                     id,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1535,7 +1535,7 @@ impl Coordinator {
                     variant: UpdatePrivilegeVariant::Revoke,
                 },
             ))
-            .chain(ids.into_iter().map(catalog::Op::DropObject))
+            .chain(std::iter::once(catalog::Op::DropObjects(ids)))
             .collect();
 
         Ok(DropOps {

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -599,11 +599,9 @@ impl Coordinator {
             create_sql = stmt.to_ast_string_stable();
         }
 
-        let ops = itertools::chain(
-            drop_ids
-                .into_iter()
-                .map(|id| catalog::Op::DropObject(ObjectId::Item(id))),
-            std::iter::once(catalog::Op::CreateItem {
+        let ops = vec![
+            catalog::Op::DropObjects(drop_ids.into_iter().map(ObjectId::Item).collect()),
+            catalog::Op::CreateItem {
                 id: sink_id,
                 name: name.clone(),
                 item: CatalogItem::MaterializedView(MaterializedView {
@@ -619,9 +617,8 @@ impl Coordinator {
                     initial_as_of: Some(initial_as_of.clone()),
                 }),
                 owner_id: *session.current_role_id(),
-            }),
-        )
-        .collect::<Vec<_>>();
+            },
+        ];
 
         // Pre-allocate a vector of transient GlobalIds for each notice.
         let notice_ids = std::iter::repeat_with(|| self.allocate_transient_id())

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -755,6 +755,12 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    /// Removes the database `id` from the transaction.
+    ///
+    /// Returns an error if `id` is not found.
+    ///
+    /// Runtime is linear with respect to the total number of databases in the catalog.
+    /// DO NOT call this function in a loop, use [`Self::remove_databases`] instead.
     pub fn remove_database(&mut self, id: &DatabaseId) -> Result<(), CatalogError> {
         let prev = self
             .databases
@@ -766,22 +772,37 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub fn remove_databases(&mut self, ids: &BTreeSet<DatabaseId>) -> Result<(), CatalogError> {
-        let to_remove = ids
+    /// Removes all databases in `databases` from the transaction.
+    ///
+    /// Returns an error if any id in `databases` is not found.
+    ///
+    /// NOTE: On error, there still may be some databases removed from the transaction. It
+    /// is up to the caller to either abort the transaction or commit.
+    pub fn remove_databases(
+        &mut self,
+        databases: &BTreeSet<DatabaseId>,
+    ) -> Result<(), CatalogError> {
+        let to_remove = databases
             .iter()
             .map(|id| (DatabaseKey { id: *id }, None))
             .collect();
-        let prev = self.databases.set_many(to_remove, self.op_id)?;
+        let mut prev = self.databases.set_many(to_remove, self.op_id)?;
+        prev.retain(|_k, val| val.is_none());
 
-        for (database_key, prev) in prev {
-            if prev.is_none() {
-                return Err(SqlCatalogError::UnknownDatabase(database_key.id.to_string()).into());
-            }
+        if !prev.is_empty() {
+            let err = prev.keys().map(|k| k.id.to_string()).join(", ");
+            return Err(SqlCatalogError::UnknownDatabase(err).into());
         }
 
         Ok(())
     }
 
+    /// Removes the schema identified by `database_id` and `schema_id` from the transaction.
+    ///
+    /// Returns an error if `(database_id, schema_id)` is not found.
+    ///
+    /// Runtime is linear with respect to the total number of schemas in the catalog.
+    /// DO NOT call this function in a loop, use [`Self::remove_schemas`] instead.
     pub fn remove_schema(
         &mut self,
         database_id: &Option<DatabaseId>,
@@ -801,31 +822,48 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    /// Removes all schemas in `schemas` from the transaction.
+    ///
+    /// Returns an error if any id in `schemas` is not found.
+    ///
+    /// NOTE: On error, there still may be some schemas removed from the transaction. It
+    /// is up to the caller to either abort the transaction or commit.
     pub fn remove_schemas(
         &mut self,
-        ids: &BTreeMap<SchemaId, ResolvedDatabaseSpecifier>,
+        schemas: &BTreeMap<SchemaId, ResolvedDatabaseSpecifier>,
     ) -> Result<(), CatalogError> {
-        let to_remove = ids
+        let to_remove = schemas
             .iter()
             .map(|(schema_id, _)| (SchemaKey { id: *schema_id }, None))
             .collect();
-        let prev = self.schemas.set_many(to_remove, self.op_id)?;
+        let mut prev = self.schemas.set_many(to_remove, self.op_id)?;
+        prev.retain(|_k, v| v.is_none());
 
-        for (schema_key, prev) in prev {
-            if prev.is_none() {
-                let database_spec = ids.get(&schema_key.id).expect("should exist");
-                let database_name = match database_spec {
-                    ResolvedDatabaseSpecifier::Id(id) => format!("{id}."),
-                    ResolvedDatabaseSpecifier::Ambient => "".to_string(),
-                };
-                let err = format!("{}.{}", database_name, schema_key.id);
-                return Err(SqlCatalogError::UnknownSchema(err).into());
-            }
+        if !prev.is_empty() {
+            let err = prev
+                .keys()
+                .map(|k| {
+                    let db_spec = schemas.get(&k.id).expect("should_exist");
+                    let db_name = match db_spec {
+                        ResolvedDatabaseSpecifier::Id(id) => format!("{id}."),
+                        ResolvedDatabaseSpecifier::Ambient => "".to_string(),
+                    };
+                    format!("{}.{}", db_name, k.id)
+                })
+                .join(", ");
+
+            return Err(SqlCatalogError::UnknownSchema(err).into());
         }
 
         Ok(())
     }
 
+    /// Removes the role `name` from the transaction.
+    ///
+    /// Returns an error if `name` is not found.
+    ///
+    /// Runtime is linear with respect to the total number of roles in the catalog.
+    /// DO NOT call this function in a loop, use [`Self::remove_roles`] instead.
     pub fn remove_role(&mut self, name: &str) -> Result<(), CatalogError> {
         let roles = self.roles.delete(|_k, v| v.name == name, self.op_id);
         assert!(
@@ -841,26 +879,38 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    /// Removes all roles in `roles` from the transaction.
+    ///
+    /// Returns an error if any id in `roles` is not found.
+    ///
+    /// NOTE: On error, there still may be some roles removed from the transaction. It
+    /// is up to the caller to either abort the transaction or commit.
     pub fn remove_roles(&mut self, roles: &BTreeSet<RoleId>) -> Result<(), CatalogError> {
         let to_remove = roles
             .iter()
             .map(|role_id| (RoleKey { id: *role_id }, None))
             .collect();
-        let deleted_roles = self.roles.set_many(to_remove, self.op_id)?;
+        let mut prev = self.roles.set_many(to_remove, self.op_id)?;
         assert!(
-            deleted_roles.iter().all(|(k, _)| k.id.is_user()),
+            prev.iter().all(|(k, _)| k.id.is_user()),
             "cannot delete non-user roles"
         );
 
-        for (role_key, prev_val) in deleted_roles {
-            if prev_val.is_none() {
-                return Err(SqlCatalogError::UnknownRole(role_key.id.to_string()).into());
-            }
+        prev.retain(|_k, v| v.is_none());
+        if !prev.is_empty() {
+            let err = prev.keys().map(|k| k.id.to_string()).join(", ");
+            return Err(SqlCatalogError::UnknownRole(err).into());
         }
 
         Ok(())
     }
 
+    /// Removes the cluster `id` from the transaction.
+    ///
+    /// Returns an error if `id` is not found.
+    ///
+    /// Runtime is linear with respect to the total number of clusters in the catalog.
+    /// DO NOT call this function in a loop, use [`Self::remove_clusters`] instead.
     pub fn remove_cluster(&mut self, id: ClusterId) -> Result<(), CatalogError> {
         let deleted = self.clusters.delete(|k, _v| k.id == id, self.op_id);
         if deleted.is_empty() {
@@ -880,17 +930,23 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    /// Removes all cluster in `clusters` from the transaction.
+    ///
+    /// Returns an error if any id in `clusters` is not found.
+    ///
+    /// NOTE: On error, there still may be some clusters removed from the transaction. It is up to
+    /// the caller to either abort the transaction or commit.
     pub fn remove_clusters(&mut self, clusters: &BTreeSet<ClusterId>) -> Result<(), CatalogError> {
         let to_remove = clusters
             .iter()
             .map(|cluster_id| (ClusterKey { id: *cluster_id }, None))
             .collect();
-        let deleted_clusters = self.clusters.set_many(to_remove, self.op_id)?;
+        let mut prev = self.clusters.set_many(to_remove, self.op_id)?;
 
-        for (cluster_key, prev_val) in &deleted_clusters {
-            if prev_val.is_none() {
-                return Err(SqlCatalogError::UnknownCluster(cluster_key.id.to_string()).into());
-            }
+        prev.retain(|_k, v| v.is_none());
+        if !prev.is_empty() {
+            let err = prev.keys().map(|k| k.id.to_string()).join(", ");
+            return Err(SqlCatalogError::UnknownCluster(err).into());
         }
 
         // Cascade delete introspection sources and cluster replicas.
@@ -906,6 +962,12 @@ impl<'a> Transaction<'a> {
         Ok(())
     }
 
+    /// Removes the cluster replica `id` from the transaction.
+    ///
+    /// Returns an error if `id` is not found.
+    ///
+    /// Runtime is linear with respect to the total number of cluster replicas in the catalog.
+    /// DO NOT call this function in a loop, use [`Self::remove_cluster_replicas`] instead.
     pub fn remove_cluster_replica(&mut self, id: ReplicaId) -> Result<(), CatalogError> {
         let deleted = self.cluster_replicas.delete(|k, _v| k.id == id, self.op_id);
         if deleted.len() == 1 {
@@ -916,6 +978,12 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    /// Removes all cluster replicas in `replicas` from the transaction.
+    ///
+    /// Returns an error if any id in `replicas` is not found.
+    ///
+    /// NOTE: On error, there still may be some cluster replicas removed from the transaction. It
+    /// is up to the caller to either abort the transaction or commit.
     pub fn remove_cluster_replicas(
         &mut self,
         replicas: &BTreeSet<ReplicaId>,
@@ -924,14 +992,12 @@ impl<'a> Transaction<'a> {
             .iter()
             .map(|replica_id| (ClusterReplicaKey { id: *replica_id }, None))
             .collect();
-        let prev = self.cluster_replicas.set_many(to_remove, self.op_id)?;
+        let mut prev = self.cluster_replicas.set_many(to_remove, self.op_id)?;
 
-        for (replica_key, prev_val) in prev {
-            if prev_val.is_none() {
-                return Err(
-                    SqlCatalogError::UnknownClusterReplica(replica_key.id.to_string()).into(),
-                );
-            }
+        prev.retain(|_k, v| v.is_none());
+        if !prev.is_empty() {
+            let err = prev.keys().map(|k| k.id.to_string()).join(", ");
+            return Err(SqlCatalogError::UnknownClusterReplica(err).into());
         }
 
         Ok(())

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1636,15 +1636,20 @@ impl CommentsMap {
     /// relation will also drop all of the comments on any columns.
     pub fn drop_comments(
         &mut self,
-        object_id: CommentObjectId,
+        object_ids: &BTreeSet<CommentObjectId>,
     ) -> Vec<(CommentObjectId, Option<usize>, String)> {
-        match self.map.remove(&object_id) {
-            None => Vec::new(),
-            Some(comments) => comments
-                .into_iter()
-                .map(|(sub_comp, comment)| (object_id, sub_comp, comment))
-                .collect(),
+        let mut removed_comments = Vec::new();
+
+        for object_id in object_ids {
+            if let Some(comments) = self.map.remove(object_id) {
+                let removed = comments
+                    .into_iter()
+                    .map(|(sub_comp, comment)| (object_id.clone(), sub_comp, comment));
+                removed_comments.extend(removed);
+            }
         }
+
+        removed_comments
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (CommentObjectId, Option<usize>, &str)> {


### PR DESCRIPTION
This PR refactors `mz_catalog::Op::DropObject` to take a `Vec<ObjectId>` instead of a single `ObjectId`.

Previously a `DROP ... CASCADE` would result in a `Op::DropObject` for every object we needed to drop. This had poor performance because removing a batch of items from a durable catalog transaction is `O(n)`, where `n` is the number of objects in the catalog. But because we would issue an `Op::DropObject` for every item we're dropping, we would have a batch size of 1 and the runtime of `DROP ... CASCADE` became `O(m * n)`, where `m` is the number of objects we're dropping. With this refactoring the runtime of `DROP ... CASCADE` is `O(n)`.

Concretely I tested creating a schema with 1 table and 1,000 views then running `DROP SCHEMA a CASCADE`:

* `main`: ~28 seconds
* This PR: ~700ms

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/26373

### Tips for reviewer

Hiding white space helps, a large code block got surrounded by `for id in object_ids { ... }` and indented

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improves the performance of dropping large amount of items at once.
