### PR TITLE
storage: dont buffer intermediate values in upsert

### DIFF
--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -938,10 +938,10 @@ where
                         )
                         .await;
 
-                        // Emit the _consolidated_ changes to the output.
                         output_handle
                             .give_container(&output_cap, &mut output_updates)
                             .await;
+
                         if let Some(ts) = upper.as_option() {
                             output_cap.downgrade(ts);
                         }
@@ -975,6 +975,10 @@ where
                     &mut state,
                 )
                 .await;
+
+                output_handle
+                    .give_container(&output_cap, &mut output_updates)
+                    .await;
             }
         }
     });


### PR DESCRIPTION
This was an oversight in https://github.com/MaterializeInc/materialize/pull/24663

- Observant readers will realize this is the first flow control related pr!
- ~I am going to see if this lets us shrink the `upsert-snapshot` `bounded-memory` test (I suspect it won't, because the `persist_sink` buffers quite a bit of data.)~
- I'll run nightly (upsert and zippy I think)


### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
