### PR TITLE
Include name of export in index already exists notice

### DIFF
--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -210,6 +210,7 @@ impl Optimize<Index> for Optimizer {
                 index_id,
                 index_key: idx.keys.clone(),
                 index_on_id: idx.on,
+                exported_index_id: self.exported_index_id,
             });
         }
 

--- a/src/transform/src/notice/index_already_exists.rs
+++ b/src/transform/src/notice/index_already_exists.rs
@@ -29,6 +29,8 @@ pub struct IndexAlreadyExists {
     pub index_key: Vec<MirScalarExpr>,
     /// The id of the object that the index is on.
     pub index_on_id: GlobalId,
+    /// The id the index that duplicates existing indexes.
+    pub exported_index_id: GlobalId,
 }
 
 impl OptimizerNoticeApi for IndexAlreadyExists {
@@ -42,6 +44,9 @@ impl OptimizerNoticeApi for IndexAlreadyExists {
         humanizer: &dyn ExprHumanizer,
         redacted: bool,
     ) -> fmt::Result {
+        let exported_index_name = humanizer
+            .humanize_id(self.exported_index_id)
+            .unwrap_or_else(|| self.exported_index_id.to_string());
         let index_name = humanizer
             .humanize_id(self.index_id)
             .unwrap_or_else(|| self.index_id.to_string());
@@ -56,7 +61,7 @@ impl OptimizerNoticeApi for IndexAlreadyExists {
 
         write!(
             f,
-            "The current index is identical to {index_name}, which \
+            "Index {exported_index_name} is identical to {index_name}, which \
              is also defined on {index_on_id_name}({index_key})."
         )
     }

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -568,7 +568,7 @@ Used Indexes:
 Target cluster: quickstart
 
 Notices:
-  - Notice: The current index is identical to materialize.public.iv_b_idx, which is also defined on iv(b).
+  - Notice: Index materialize.public.iv_b_idx_2 is identical to materialize.public.iv_b_idx, which is also defined on iv(b).
     Hint: Please drop all indexes except the first index created on iv(b) and recreate all dependent objects.
 
 EOF

--- a/test/sqllogictest/explain/replan_catalog_items.slt
+++ b/test/sqllogictest/explain/replan_catalog_items.slt
@@ -184,7 +184,7 @@ Used Indexes:
 Target cluster: quickstart
 
 Notices:
-  - Notice: The current index is identical to materialize.public.v_idx, which is also defined on v(x).
+  - Notice: Index materialize.public.v_x_idx is identical to materialize.public.v_idx, which is also defined on v(x).
     Hint: Please drop all indexes except the first index created on v(x) and recreate all dependent objects.
 
 EOF

--- a/test/sqllogictest/transform/notice/index_already_exists.slt
+++ b/test/sqllogictest/transform/notice/index_already_exists.slt
@@ -47,7 +47,7 @@ Used Indexes:
 Target cluster: quickstart
 
 Notices:
-  - Notice: The current index is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+  - Notice: Index materialize.public.t_idx2 is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
     Hint: Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
 
 EOF
@@ -70,7 +70,7 @@ Used Indexes:
 Target cluster: quickstart
 
 Notices:
-  - Notice: The current index is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+  - Notice: Index materialize.public.t_idx2 is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
     Hint: Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
 
 EOF
@@ -86,8 +86,8 @@ WHERE
   idx.name LIKE 't_idx%'
 ----
 An identical index already exists
-The current index is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
-The current index is identical to materialize.public.t_idx1, which is also defined on t((a + █)).
+Index materialize.public.t_idx2 is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+Index materialize.public.t_idx2 is identical to materialize.public.t_idx1, which is also defined on t((a + █)).
 Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
 Please drop all indexes except the first index created on t((a + █)) and recreate all dependent objects.
 NULL
@@ -127,7 +127,7 @@ Used Indexes:
 Target cluster: quickstart
 
 Notices:
-  - Notice: The current index is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+  - Notice: Index materialize.public.t_idx3 is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
     Hint: Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
 
 EOF
@@ -143,8 +143,8 @@ WHERE
   idx.name = 't_idx3'
 ----
 An identical index already exists
-The current index is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
-The current index is identical to materialize.public.t_idx1, which is also defined on t((a + █)).
+Index materialize.public.t_idx3 is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+Index materialize.public.t_idx3 is identical to materialize.public.t_idx1, which is also defined on t((a + █)).
 Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
 Please drop all indexes except the first index created on t((a + █)) and recreate all dependent objects.
 NULL


### PR DESCRIPTION
Include the name of the exported index in the index already exists notice.

### Motivation

  * This PR fixes a previously unreported bug: https://materializeinc.slack.com/archives/CU7ELJ6E9/p1716231408100059

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
