### PR TITLE
sql-parser: correct parsing of `SELECT AS OF ...`

### DIFF
--- a/misc/python/materialize/checks/all_checks/materialized_views.py
+++ b/misc/python/materialize/checks/all_checks/materialized_views.py
@@ -23,6 +23,9 @@ class MaterializedViews(Check):
                 > CREATE TABLE materialized_views_table (f1 STRING);
                 > INSERT INTO materialized_views_table SELECT 'T1A' || generate_series FROM generate_series(1,10000);
                 > INSERT INTO materialized_views_table SELECT 'T1B' || generate_series FROM generate_series(1,10000);
+
+                # Regression test for #27167.
+                > CREATE MATERIALIZED VIEW zero_arity AS SELECT;
             """
             )
         )

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5825,7 +5825,9 @@ impl<'a> Parser<'a> {
             // to queries.
             Some(Token::Keyword(OF)) => {
                 self.prev_token();
-                self.prev_token();
+                if after_as {
+                    self.prev_token();
+                }
                 Ok(None)
             }
             // Accept any other identifier after `AS` (though many dialects have restrictions on
@@ -6447,8 +6449,9 @@ impl<'a> Parser<'a> {
 
         let projection = match self.peek_token() {
             // An empty target list is permissible to match PostgreSQL, which
-            // permits these for symmetry with zero column tables.
-            Some(Token::Keyword(kw)) if kw.is_reserved() => vec![],
+            // permits these for symmetry with zero column tables. We need
+            // to sniff out `AS` here specially to support `SELECT AS OF ...`.
+            Some(Token::Keyword(kw)) if kw.is_reserved() || kw == AS => vec![],
             Some(Token::Semicolon) | Some(Token::RParen) | None => vec![],
             _ => {
                 let mut projection = vec![];

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -168,6 +168,13 @@ SELECT LIMIT 1
 ----
 SELECT LIMIT 1
 
+parse-statement
+SELECT AS OF 0
+----
+SELECT AS OF 0
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Value(Number("0")))) })
+
 parse-statement roundtrip
 SELECT (1, 2)
 ----


### PR DESCRIPTION
`SELECT AS OF ...` is a valid SQL query that produces a zero-column, zero-row relation at the specified as-of time. Not very useful, but a semantically valid thing to do nonetheless.

@aalexandrov noticed in #27167 that this query was being misparsed in a way which did not roundtrip, which could result in a broken catalog if such a query were used as the definition of a materialized view.

Fix #27167.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Not worthy of a release note.
