### PR TITLE
storage: send pending compaction commands for subsources

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -147,19 +147,6 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     /// The fencing token for this instance of the controller.
     envd_epoch: NonZeroI64,
 
-    /// Keep track of subsources of ingestions that we have dropped. With this,
-    /// we can synthesize `DroppedIds` messages when we see one for the "main"
-    /// ingestion. We do this because the cluster will not send one back by
-    /// itself.
-    ///
-    /// We populate this in `drop_sources_unvalidated` and take it out again in
-    /// `process`, when receiving a `DroppedIds` message for the "main"
-    /// ingestion.
-    ///
-    /// TODO: Make the cluster send back `DroppedIds` messages for subsources
-    /// and remove this.
-    dropped_ingestions: BTreeMap<GlobalId, Vec<GlobalId>>,
-
     /// Collections maintained by the storage controller.
     ///
     /// This collection only grows, although individual collections may be rendered unusable.
@@ -1470,14 +1457,7 @@ where
                         self.pending_compaction_commands
                             .push(pending_compaction_command);
                     }
-                    DataSource::Ingestion(ref ingestion) => {
-                        // Keep track of subsources, so that we can synthesize
-                        // `DroppedIds` messages for the remap shard.
-                        self.dropped_ingestions
-                            .entry(*id)
-                            .or_default()
-                            .push(ingestion.remap_collection_id);
-
+                    DataSource::Ingestion(_) => {
                         ingestions_to_drop.insert(id);
                     }
                     DataSource::IngestionExport { ingestion_id, .. } => {
@@ -1506,13 +1486,6 @@ where
                                     removed.is_some(),
                                     "dropped subsource {id} already removed from source exports"
                                 );
-
-                                // So that we can synthesize `DroppedIds` messages for
-                                // the sources exports (aka. subsources).
-                                self.dropped_ingestions
-                                    .entry(ingestion_id)
-                                    .or_default()
-                                    .push(*id);
                             }
                             _ => unreachable!("SourceExport must only refer to primary sources that already exist"),
                         };
@@ -1820,25 +1793,9 @@ where
                 for id in ids.iter() {
                     tracing::debug!("DroppedIds for collections {id}");
 
-                    if let Some(collection) = self.collections.remove(id) {
-                        match collection.data_source {
-                            DataSource::Ingestion(_ingestion) => {
-                                let dropped_subsources = self
-                                    .dropped_ingestions
-                                    .remove(id)
-                                    .expect("missing dropped subsources");
-
-                                // The cluster is not sending these, so we take
-                                // matters into our own hands!
-                                tracing::debug!(?dropped_subsources, "synthesizing DroppedIds messages for subsources and the remap shard");
-                                self.internal_response_sender
-                                    .send(StorageResponse::DroppedIds(
-                                        dropped_subsources.into_iter().collect(),
-                                    ))
-                                    .expect("we are still alive");
-                            }
-                            _ => (),
-                        }
+                    if let Some(_collection) = self.collections.remove(id) {
+                        // Nothing to do, we already dropped read holds in
+                        // `drop_sources_unvalidated`.
                     } else if let Some(export) = self.exports.get_mut(id) {
                         // TODO: Current main never drops export state, so we
                         // also don't do that, because it would be yet more
@@ -2592,7 +2549,6 @@ where
 
         Self {
             build_info,
-            dropped_ingestions: BTreeMap::new(),
             collections: BTreeMap::default(),
             exports: BTreeMap::default(),
             persist_table_worker,

--- a/src/storage-controller/src/rehydration.rs
+++ b/src/storage-controller/src/rehydration.rs
@@ -494,7 +494,8 @@ where
                         Some(export) => {
                             export.description.as_of.clone_from(frontier);
                         }
-                        None if self.sources.contains_key(id) => continue,
+                        // uppers contains both ingestions and their exports
+                        None if self.uppers.contains_key(id) => continue,
                         None => panic!("AllowCompaction command for non-existent {id}"),
                     }
                 }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1203,7 +1203,9 @@ impl StorageState {
                             // restart a sink in the future.
                             export_description.as_of.clone_from(&frontier);
                         }
-                        None if self.ingestions.contains_key(&id) => (),
+                        // reported_frontiers contains both ingestions and their
+                        // exports
+                        None if self.reported_frontiers.contains_key(&id) => (),
                         None => panic!("AllowCompaction command for non-existent {id}"),
                     }
 

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -976,16 +976,49 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 }
                 StorageCommand::RunIngestions(ingestions) => {
                     ingestions.retain_mut(|ingestion| {
+                        // Subsources can be dropped independently of their
+                        // primary source, so we evaluate them in a separate
+                        // loop.
+                        for export_id in ingestion
+                            .description
+                            .source_exports
+                            .keys()
+                            .filter(|export_id| **export_id != ingestion.id)
+                        {
+                            if drop_commands.remove(export_id) {
+                                self.storage_state.dropped_ids.insert(*export_id);
+                            }
+                        }
+
                         if drop_commands.remove(&ingestion.id)
                             || self.storage_state.dropped_ids.contains(&ingestion.id)
                         {
-                            // Make sure that we report back that the ID was
-                            // dropped.
-                            self.storage_state.dropped_ids.insert(ingestion.id);
+                            // If an ingestion is dropped, so too must all of
+                            // its subsources (i.e. ingestion exports, as well
+                            // as its progress subsource).
+                            for id in ingestion.description.subsource_ids() {
+                                drop_commands.remove(&id);
+                                self.storage_state.dropped_ids.insert(id);
+                            }
 
                             false
                         } else {
-                            expected_objects.extend(ingestion.description.subsource_ids());
+                            let most_recent_defintion =
+                                seen_most_recent_definition.insert(ingestion.id);
+
+                            if most_recent_defintion {
+                                // If this is the most recent definition, this
+                                // is what we will be running when
+                                // reconciliation completes. This definition
+                                // must not include any dropped subsources.
+                                ingestion.description.source_exports.retain(|export_id, _| {
+                                    !self.storage_state.dropped_ids.contains(export_id)
+                                });
+
+                                // After clearing any dropped subsources, we can
+                                // state that we expect all of these to exist.
+                                expected_objects.extend(ingestion.description.subsource_ids());
+                            }
 
                             let running_ingestion =
                                 self.storage_state.ingestions.get(&ingestion.id);
@@ -995,7 +1028,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                             //   is why these commands are run in reverse.
                             // - Ingestions whose descriptions are not exactly
                             //   those that are currently running.
-                            seen_most_recent_definition.insert(ingestion.id)
+                            most_recent_defintion
                                 && running_ingestion != Some(&ingestion.description)
                         }
                     })
@@ -1048,12 +1081,14 @@ impl<'w, A: Allocate> Worker<'w, A> {
         let stale_objects = self
             .storage_state
             .ingestions
-            .keys()
-            .chain(self.storage_state.exports.keys())
+            .values()
+            .map(|i| i.subsource_ids())
+            .flatten()
+            .chain(self.storage_state.exports.keys().copied())
             // Objects are considered stale if we did not see them re-created.
             .filter(|id| !expected_objects.contains(id))
             // Synthesize the drop command
-            .map(|id| (*id, Antichain::new()))
+            .map(|id| (id, Antichain::new()))
             .collect::<Vec<_>>();
 
         trace!(


### PR DESCRIPTION
Now that we can identify subsource clusters, we should be sending them compaction commands.

The approach we take here is unfortunately circuitous.

- Ingestion exports don't have a storage dependency on the primary collection (though they have a catalog dependency), but the primary collection identifies which cluster the ingestion runs on.
- Because there is no storage dependency, the primary collection can be dropped before the ingestion exports. This means we lose the ability to look up the cluster using the storage controller's collection API.
- We cannot simply have the export depend on the primary source––it's possible that the primary source's since is too far advanced because we haven't previously asserted a dependency should exist. This would also be a short-lived dependency as subsources become tables (which will only have a dependency on the remap collection), so I don't know if jumping through all of those hoops is worthwhile, either.

Given all of this, it seems sane to just store the cluster in the `CollectionMetadata` so we can send subsource compaction commands to the cluster on which they run.

Note that after subsources become tables and remap collections become sources, we will no longer need to cache the cluster ID for exports––we'll be able to guarantee that the source doesn't get dropped until all of its exports have been dropped, meaning we'll always be able to consult the storage controller's collections to determine the cluster ID.

### Motivation

This PR adds a known-desirable feature.

Fixes #24773
Progresses #8185 –– [we still need a test that the subsources are actually dropped](https://github.com/MaterializeInc/materialize/issues/8185#issuecomment-2097122895)

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
