### PR TITLE
ore: Make `SegmentedBytes` overall faster

### DIFF
--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -157,6 +157,11 @@ required-features = ["async"]
 name = "id_gen"
 harness = false
 
+[[bench]]
+name = "bytes"
+harness = false
+required-features = ["bytes_", "region", "tracing_", "lgalloc", "derivative"]
+
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
 development = ["tokio-test"]

--- a/src/ore/benches/bytes.rs
+++ b/src/ore/benches/bytes.rs
@@ -1,0 +1,104 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::io::{Read, Seek, SeekFrom};
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use mz_ore::bytes::SegmentedBytes;
+use mz_ore::cast::CastFrom;
+
+fn bench_reader(c: &mut Criterion) {
+    let mut reader_group = c.benchmark_group("reader");
+
+    for num_segments in [1, 2, 4, 8, 16, 32, 64, 128] {
+        reader_group.bench_with_input(
+            BenchmarkId::new("seek", num_segments),
+            &num_segments,
+            |b, n| {
+                let segments = vec![vec![42u8; 1000]; *n];
+                let bytes: SegmentedBytes = segments.into_iter().map(Bytes::from).collect();
+                let mut reader = bytes.reader();
+
+                let half_way = u64::cast_from((1000 * n) / 2);
+
+                b.iter(|| {
+                    reader.seek(SeekFrom::Start(half_way)).unwrap();
+                    std::hint::black_box(&mut reader);
+                    reader.seek(SeekFrom::Start(0)).unwrap();
+                });
+            },
+        );
+    }
+
+    for num_segments in [1, 2, 4, 8, 16, 32, 64, 128] {
+        reader_group.bench_with_input(
+            BenchmarkId::new("read", num_segments),
+            &num_segments,
+            |b, n| {
+                let segments = vec![vec![42u8; 1000]; *n];
+                let bytes: SegmentedBytes = segments.into_iter().map(Bytes::from).collect();
+                let mut reader = bytes.reader();
+
+                let mut buf = Vec::with_capacity(1000 * n);
+
+                b.iter(|| {
+                    reader.read_to_end(&mut buf).unwrap();
+                    reader.seek(SeekFrom::Start(0)).unwrap();
+                    std::hint::black_box((&mut reader, &mut buf));
+                    buf.clear();
+                });
+            },
+        );
+    }
+
+    for num_segments in [1, 2, 4, 8, 16, 32, 64, 128] {
+        reader_group.bench_with_input(
+            BenchmarkId::new("seek + read", num_segments),
+            &num_segments,
+            |b, n| {
+                let segments = vec![vec![42u8; 1000]; *n];
+                let bytes: SegmentedBytes = segments.into_iter().map(Bytes::from).collect();
+                let mut reader = bytes.reader();
+
+                let half_way = u64::cast_from((1000 * n) / 2);
+                let mut buf = Vec::with_capacity(1000 * n);
+
+                b.iter(|| {
+                    reader.seek(SeekFrom::Start(half_way)).unwrap();
+                    reader.read_to_end(&mut buf).unwrap();
+
+                    std::hint::black_box((&mut reader, &mut buf));
+
+                    reader.seek(SeekFrom::Start(0)).unwrap();
+                    buf.clear();
+                });
+            },
+        );
+    }
+
+    for num_segments in [1, 2, 4, 8, 16, 32, 64, 128] {
+        reader_group.bench_with_input(
+            BenchmarkId::new("create", num_segments),
+            &num_segments,
+            |b, n| {
+                let segments = vec![vec![42u8; 1000]; *n];
+                let bytes: SegmentedBytes = segments.into_iter().map(Bytes::from).collect();
+
+                b.iter(|| {
+                    let reader = bytes.clone().reader();
+                    std::hint::black_box(reader);
+                });
+            },
+        );
+    }
+}
+
+criterion_group!(benches, bench_reader);
+criterion_main!(benches);

--- a/src/ore/src/bytes.rs
+++ b/src/ore/src/bytes.rs
@@ -57,6 +57,9 @@ pub struct SegmentedBytes<const N: usize = 1> {
 /// collection when creating a [`SegmentedReader`].
 type Padding = usize;
 
+/// Default value used for [`Padding`].
+const PADDING_DEFAULT: usize = 0;
+
 /// A [Bytes] or an [LgBytes].
 ///
 /// TODO: Once we've validated the persist s3 usage of LgBytes, change the CYA
@@ -174,7 +177,7 @@ impl<const N: usize> SegmentedBytes<N> {
     pub fn push(&mut self, b: Bytes) {
         self.len += b.len();
         self.segments
-            .push((MaybeLgBytes::Bytes(b), Default::default()));
+            .push((MaybeLgBytes::Bytes(b), PADDING_DEFAULT));
     }
 
     /// Consumes `self` returning a type that implements [`io::Read`] and [`io::Seek`].
@@ -259,7 +262,7 @@ impl From<Bytes> for SegmentedBytes {
     fn from(value: Bytes) -> Self {
         let len = value.len();
         let mut segments = SmallVec::new();
-        segments.push((MaybeLgBytes::Bytes(value), Default::default()));
+        segments.push((MaybeLgBytes::Bytes(value), PADDING_DEFAULT));
 
         SegmentedBytes { segments, len }
     }
@@ -269,7 +272,7 @@ impl From<MaybeLgBytes> for SegmentedBytes {
     fn from(value: MaybeLgBytes) -> Self {
         let len = value.len();
         let mut segments = SmallVec::new();
-        segments.push((value, Default::default()));
+        segments.push((value, PADDING_DEFAULT));
 
         SegmentedBytes { segments, len }
     }
@@ -282,7 +285,7 @@ impl From<Vec<MaybeLgBytes>> for SegmentedBytes {
 
         for segment in value {
             len += segment.len();
-            segments.push((segment, Default::default()));
+            segments.push((segment, PADDING_DEFAULT));
         }
 
         SegmentedBytes { segments, len }
@@ -302,7 +305,7 @@ impl<const N: usize> FromIterator<Bytes> for SegmentedBytes<N> {
 
         for segment in iter {
             len += segment.len();
-            segments.push((MaybeLgBytes::Bytes(segment), Default::default()));
+            segments.push((MaybeLgBytes::Bytes(segment), PADDING_DEFAULT));
         }
 
         SegmentedBytes { segments, len }


### PR DESCRIPTION
This PR refactors `SegmentedBytes`, specifically the `SegmentedReader`, to generally improve performance.

Previously the `SegmentedReader` would create a `BTreeMap` and precompute the segment offsets, and when reading, lookup the correct segment from this map. This allowed for very fast seek time, but made reading slower than necessary, and creating a `SegmentedReader` _extremely_ slow.

We refactor `SegmentedBytes` and `SegmentedReader` in a few ways:

1. `SegmentedReader` now maintains a pointer, tracking the current segment that we'd read from, eliminating the logarithmic lookup in the `std::io::Read` path.
2. `SegmentedReader` does a logarithmic lookup of the correct segment when seeking. This slows down the `std::io::Seek` code path, but from our profiling we don't appear to seek often, or at all.
    * Note, even though seeking got slower, the improvements to read make up for it. Benchmarks show a seek + read is still faster than before.
3. `SegmentedBytes` maintains some padding in `segments` that we use to segment offsets when creating a `SegmentedReader`. This makes the creation path dramatically faster as we no longer need to create a `BTreeMap` which could result in multiple allocations.

To validate performance I added some micro benchmarks, and for correctness I added new proptests.

### Motivation

@danhhz did some benchmarking which showed a lot of time for arrow-rs being spent in creating a `SegmentedReader`, [Slack](https://materializeinc.slack.com/archives/C03P1EGB7A7/p1716222345290609). Fixing this should bring the performance of `arrow-rs` inline with `arrow2`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Internal performance improvements
