### PR TITLE
compute: fix "frontier updates for unknown collection" error

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -533,11 +533,11 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     ///  2. There must be no outstanding read capabilities on the collection. As long as someone
     ///     still holds read capabilities on a collection, we need to keep it around to be able
     ///     to properly handle downgrading of said capabilities.
-    ///  3. All replica write frontiers for the collection must have advanced to the empty
-    ///     frontier. Advancement to the empty frontier signals that replicas are done computing
-    ///     the collection and that they won't send more `ComputeResponse`s for it. As long as we
-    ///     might receive responses for a collection we want to keep it around to be able to
-    ///     validate and handle these responses.
+    ///  3. All replica frontiers for the collection must have advanced to the empty frontier.
+    ///     Advancement to the empty frontiers signals that replicas are done computing the
+    ///     collection and that they won't send more `ComputeResponse`s for it. As long as we might
+    ///     receive responses for a collection we want to keep it around to be able to validate and
+    ///     handle these responses.
     fn cleanup_collections(&mut self) {
         let to_remove: Vec<_> = self
             .collections_iter()
@@ -546,6 +546,10 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
                     && collection.read_frontier().is_empty()
                     && collection
                         .replica_write_frontiers
+                        .values()
+                        .all(|frontier| frontier.is_empty())
+                    && collection
+                        .replica_input_frontiers
                         .values()
                         .all(|frontier| frontier.is_empty())
             })

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -41,7 +41,8 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// collection.
     ///
     /// Replicas must send `Frontiers` responses for compute collections that are indexes or
-    /// storage sinks. Replicas must not send `Frontiers` responses for subscribes ([#16274]).
+    /// storage sinks. Replicas must not send `Frontiers` responses for subscribes and copy-tos
+    /// ([#16274]).
     ///
     /// Replicas must never report regressing frontiers. Specifically:
     ///


### PR DESCRIPTION
#26665 introduced a new input frontier reported by replicas to the controller, which required some changes to the frontier reporting code on both sides. This introduced two bugs, both of which could result in a "frontier updates for unknown collection" error being logged by the controller when it received a `Frontiers` response for a collection whose state it had already dropped. This PR fixes both of these bugs.

1. Replicas would incorrectly send final `Frontiers` responses for dropped subscribe and copy-to collections.

    For these collection types the compute protocol does not expect `Frontiers` responses. The buggy code therefore checked in `report_dropped_collections` whether a dropped collection was a subscribe (or copy-to) by calling `CollectionState::is_subscribe`. That method was implemented by checking whether the collection had a `sink_token`, but no `sink_write_frontier`, a combination which only occurs for subscribes and copy-to. However, the `sink_token` is had already been dropped by the time a collection is considered in `report_dropped_collections`, making `is_subscribe` always return `false`.

    As a result, the compute controller could receive a final `Frontiers` response for a subscribe or copy-to collection after it had already seen the collection being dropped (e.g. through a `SubscribeResponse::DroppedAt`) and removed its state, causing the "frontier updates for an unknown collection" error.

    The fix is to explicitly store an `is_subscribe_or_copy` flag in the `CollectionState`, rather than trying to piece that information together from related state.

2. The compute controller would not wait for the empty import frontier before removing collection state.

    The compute controller delays dropping collection state until it has observed the empty write frontier from the final `Frontiers` response, to be able to validate all `Frontiers` responses it receives. Due to an oversight, it did not do the same for input frontiers. So if the write frontier was reported to be advanced to the empty frontier before the input frontier, the controller could drop that collection's state before the final `Frontiers` response that reported the input frontier to be advanced to the empty frontier as well. The arrival of that final `Frontiers` response would then cause the "frontier updates for an unknown collection" error.

    The fix is to also wait for the empty input frontier before removing collection state in the compute controller.

    Note that an alternative fix would be to give up on trying to validate all `Frontiers` responses and to assume that all responses for unknown collections are for collections that have already been dropped. We don't consider that here because that change is more invasive and reduces our ability to find bugs in the compute protocol. But it's likely that we will change to this approach once we get rid of the final `Frontiers` response that reports all-empty frontiers (currently blocked by #16271).

### Motivation

  * This PR fixes a recognized bug.

Fixes #27186 

### Tips for reviewer

Regression testing is hard because the error condition only occurs when the controller's collection cleanup task is invoked at exactly the right time. To validate the fixes I ran the Nightlies with a modified version that (a) panics instead of logging an error and (b) always invokes `Instance::maintain` at the end of `handle_frontiers_response`. On main this reliably fails a bunch of tests, but with the changes made here [the only test failures are unrelated](https://buildkite.com/materialize/nightly/builds/7830#018f9bce-0193-4b51-8c20-792a1b8395dd).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A