### PR TITLE
output consistency: ignore entries refactoring

### DIFF
--- a/misc/python/materialize/output_consistency/query/query_template.py
+++ b/misc/python/materialize/output_consistency/query/query_template.py
@@ -216,3 +216,17 @@ FROM{space_separator}{db_object_name}
             self.where_expression is not None
             and self.where_expression.matches(predicate, check_recursively)
         )
+
+    def matches_specific_select_or_filter_expression(
+        self,
+        select_column_index: int,
+        predicate: Callable[[Expression], bool],
+        check_recursively: bool,
+    ) -> bool:
+        assert 0 <= select_column_index <= self.column_count()
+        return self.select_expressions[select_column_index].matches(
+            predicate, check_recursively
+        ) or (
+            self.where_expression is not None
+            and self.where_expression.matches(predicate, check_recursively)
+        )

--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -9,19 +9,17 @@
 from functools import partial
 
 from materialize.mz_version import MzVersion
-from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.expression.expression import (
     Expression,
-    LeafExpression,
 )
 from materialize.output_consistency.expression.expression_with_args import (
     ExpressionWithArgs,
 )
 from materialize.output_consistency.ignore_filter.expression_matchers import (
+    is_any_date_time_expression,
     is_operation_tagged,
     matches_fun_by_any_name,
     matches_fun_by_name,
-    matches_op_by_any_pattern,
     matches_op_by_pattern,
     matches_x_or_y,
 )
@@ -34,15 +32,8 @@ from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter im
 from materialize.output_consistency.ignore_filter.internal_output_inconsistency_ignore_filter import (
     IgnoreVerdict,
 )
-from materialize.output_consistency.input_data.operations.date_time_operations_provider import (
-    DATE_TIME_OPERATION_TYPES,
-)
 from materialize.output_consistency.input_data.operations.text_operations_provider import (
     TAG_REGEX,
-)
-from materialize.output_consistency.operation.operation import (
-    DbFunction,
-    DbOperation,
 )
 from materialize.output_consistency.selection.selection import DataRowSelection
 
@@ -93,7 +84,7 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
 
         if (
             self.lower_version < MZ_VERSION_0_77_0 <= self.higher_version
-            and self._is_any_date_time_expression(expression)
+            and is_any_date_time_expression(expression)
         ):
             return YesIgnore("Fixed issue regarding time zone handling")
 
@@ -172,55 +163,19 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
                 ),
                 True,
             )
-            and self._is_any_date_time_expression(expression)
+            and is_any_date_time_expression(expression)
         ):
             return YesIgnore("Type of min(time) / max(time) fixed in PR 26335")
 
         if (
             self.lower_version < MZ_VERSION_0_99_0 <= self.higher_version
-            and self._is_any_date_time_expression(expression)
+            and is_any_date_time_expression(expression)
         ):
             return YesIgnore(
                 "Casting intervals to mz_timestamps introduced in PR 26970"
             )
 
         return super().shall_ignore_expression(expression, row_selection)
-
-    def _is_any_date_time_expression(self, expression: Expression) -> bool:
-        all_date_time_function_names = {
-            function.function_name_in_lower_case
-            for function in DATE_TIME_OPERATION_TYPES
-            if isinstance(function, DbFunction)
-        }
-        all_date_time_operation_patterns = {
-            operation.pattern
-            for operation in DATE_TIME_OPERATION_TYPES
-            if isinstance(operation, DbOperation)
-        }
-
-        def is_date_time_leaf_expression(expression: Expression) -> bool:
-            return (
-                isinstance(expression, LeafExpression)
-                and expression.data_type.category == DataTypeCategory.DATE_TIME
-            )
-
-        return (
-            expression.matches(is_date_time_leaf_expression, True)
-            or expression.matches(
-                partial(
-                    matches_fun_by_any_name,
-                    function_names_in_lower_case=all_date_time_function_names,
-                ),
-                True,
-            )
-            or expression.matches(
-                partial(
-                    matches_op_by_any_pattern,
-                    patterns=all_date_time_operation_patterns,
-                ),
-                True,
-            )
-        )
 
     def _contains_only_available_operations(
         self, expression: Expression, mz_version: MzVersion


### PR DESCRIPTION
Just refactorings. Extracted from https://github.com/MaterializeInc/materialize/pull/27194 to make that PR less crowded.

### Commits
846fac5ce9 output consistency: move is_any_date_time_expression
845a86a508 output consistency: add matches_specific_select_or_filter_expression
6ec10945f2 postgres consistency: extract constants
