### PR TITLE
postgres consistency: add ignores

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -88,6 +88,16 @@ def matches_expression_with_only_plain_arguments(expression: Expression) -> bool
     return True
 
 
+def matches_any_expression_arg(
+    expression: Expression, arg_matcher: Callable[[Expression], bool]
+) -> bool:
+    if isinstance(expression, ExpressionWithArgs):
+        for arg_expression in expression.args:
+            if arg_matcher(arg_expression):
+                return True
+    return False
+
+
 def matches_nested_expression(expression: Expression) -> bool:
     return not matches_expression_with_only_plain_arguments(expression)
 

--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -115,6 +115,17 @@ def involves_data_type_category(
     return expression.resolve_return_type_category() == data_type_category
 
 
+def is_known_to_involve_exact_data_types(
+    expression: Expression, internal_data_type_identifiers: set[str]
+):
+    exact_data_type = expression.try_resolve_exact_data_type()
+
+    if exact_data_type is None:
+        return False
+
+    return exact_data_type.internal_identifier in internal_data_type_identifiers
+
+
 def is_operation_tagged(expression: Expression, tag: str) -> bool:
     if isinstance(expression, ExpressionWithArgs):
         return expression.operation.is_tagged(tag)

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -492,6 +492,16 @@ class PgPostExecutionInconsistencyIgnoreFilter(
         if query_template.limit == 0:
             return YesIgnore("#17189: LIMIT 0 does not swallow errors")
 
+        if (
+            query_template.matches_any_expression(
+                partial(matches_fun_by_name, function_name_in_lower_case="pg_typeof"),
+                True,
+            )
+            and "invalid input syntax for type" in mz_error_msg
+        ):
+            # Postgres returns regtype which can be cast to numbers while mz returns a string
+            return YesIgnore("regtype of postgres can be cast")
+
         return NoIgnore()
 
     def _shall_ignore_content_mismatch(

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -619,24 +619,23 @@ class PgPostExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("#26846: eszett in upper")
 
-        if (
-            query_template.matches_any_expression(
-                partial(matches_fun_by_name, function_name_in_lower_case="pg_typeof"),
-                True,
-            )
-            and str(mz_error_details.value) == "time"
-            and str(pg_error_details.value) == "time without time zone"
-        ):
-            return YesIgnore("Different type name for time")
-
         if query_template.matches_any_expression(
             partial(matches_fun_by_name, function_name_in_lower_case="pg_typeof"),
             True,
-        ) and query_template.matches_any_expression(
-            partial(matches_fun_by_name, function_name_in_lower_case="array_agg"),
-            True,
         ):
-            return YesIgnore("#27150: array_agg(pg_typeof(...)) in pg flattens result")
+            if (
+                str(mz_error_details.value) == "time"
+                and str(pg_error_details.value) == "time without time zone"
+            ):
+                return YesIgnore("Different type name for time")
+
+            if query_template.matches_any_expression(
+                partial(matches_fun_by_name, function_name_in_lower_case="array_agg"),
+                True,
+            ):
+                return YesIgnore(
+                    "#27150: array_agg(pg_typeof(...)) in pg flattens result"
+                )
 
         return NoIgnore()
 


### PR DESCRIPTION
Further ignores to address https://buildkite.com/materialize/nightly/builds/7828#018f9aed-fbf9-4836-b24d-cf44ecd54dcb and further issues detected in a long local run.

Let's see, I hope `pg_typeof` does not cause more issues. Otherwise, I will need to consider removing it again.

### Commits
Based on https://github.com/MaterializeInc/materialize/pull/27193.
8f8d1fbb3f postgres consistency: merge outer if-conditions
afd4cde2bc postgres consistency: add ignore (pg_typeof: REAL vs DOUBLE)
4d7781b775 postgres consistency: add ignore (pg_typeof: nested pg_typeof)
0d22d539b2 postgres consistency: add ignore (pg_typeof: casting)
bb32eac70b postgres consistency: broaden typeof ignore (pg_type: TIME)

### Other
I identified a general issue in the ignore mechanism, which I will address in a follow-up.