### PR TITLE
postgres consistency: fix ignore logic of content mismatches

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
@@ -211,6 +211,8 @@ class PostExecutionInconsistencyIgnoreFilterBase:
         query_template: QueryTemplate,
         contains_aggregation: bool,
     ) -> IgnoreVerdict:
+        # Content mismatch ignore entries should only operate on the expression of the column with the mismatch (and on
+        # expressions in other parts of the query like, for example, the WHERE part)!
         return NoIgnore()
 
     def _shall_ignore_row_count_mismatch(


### PR DESCRIPTION
This is based on https://github.com/MaterializeInc/materialize/pull/27194.

No adjustments to internal output-consistency and version-consistency were necessary because they currently do not implement this ignore function.

Nightly: https://buildkite.com/materialize/nightly/builds/7829 ✅ 