### PR TITLE
orchestrator: omit node selector when disk is not required

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -927,7 +927,14 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             "karpenter.sh/do-not-disrupt".to_owned() => "true".to_string(),
         };
 
-        let default_node_selector = [("materialize.cloud/disk".to_string(), disk.to_string())];
+        let default_node_selector = if disk {
+            vec![("materialize.cloud/disk".to_string(), disk.to_string())]
+        } else {
+            // if the cluster doesn't require disk, we can omit the selector
+            // allowing it to be scheduled onto nodes with and without the
+            // selector
+            vec![]
+        };
 
         let node_selector: BTreeMap<String, String> = default_node_selector
             .into_iter()

--- a/test/cloudtest/test_compute.py
+++ b/test/cloudtest/test_compute.py
@@ -145,10 +145,13 @@ def test_disk_label(mz: MaterializeApplication) -> None:
         assert replica_id is not None
 
         node_selectors = get_node_selector(mz, cluster_id, replica_id)
-        assert (
-            node_selectors
-            == f'\'{{"materialize.cloud/disk":"{value}"}} {{"materialize.cloud/disk":"{value}"}}\''
-        ), node_selectors
+        if value == "true":
+            assert (
+                node_selectors
+                == '\'{"materialize.cloud/disk":"true"} {"materialize.cloud/disk":"true"}\''
+            ), node_selectors
+        else:
+            assert node_selectors == "''"
 
         mz.environmentd.sql(f"DROP CLUSTER disk_{value} CASCADE")
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

We want to be able to schedule non-disk clusters on nodes with and without disk. This allows us to binpack all workloads onto the same nodes by omitting the selector from clusters w/o disk.

### Motivation

https://github.com/MaterializeInc/materialize/issues/27200


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
