### PR TITLE
persist: Delete `arrow2` and 'persist_use_arrow_rs_library' dyncfg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,12 +100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9180feb72ccbc07cfe5ef7fa8bbf86ca71490d5dc9ef8ea02c7298ba94e7f7d"
 
 [[package]]
-name = "array-init-cursor"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,16 +204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-format"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb83ada98f9d252a3c3642d96c53a357684a87d2e9a753ddf2a30bae20b91790"
-dependencies = [
- "planus",
- "serde",
-]
-
-[[package]]
 name = "arrow-ipc"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,31 +282,6 @@ dependencies = [
  "num",
  "regex",
  "regex-syntax 0.8.3",
-]
-
-[[package]]
-name = "arrow2"
-version = "0.16.0"
-source = "git+https://github.com/MaterializeInc/arrow2.git?branch=parquet_binary_next_iter#61e271a3f70bc993f8b7854b73e8fee099803d1c"
-dependencies = [
- "ahash",
- "arrow-format",
- "base64 0.13.1",
- "bytemuck",
- "chrono",
- "dyn-clone",
- "either",
- "ethnum",
- "fallible-streaming-iterator",
- "foreign_vec",
- "futures",
- "getrandom",
- "hash_hasher",
- "num-traits",
- "parquet2",
- "rustc_version",
- "simdutf8",
- "streaming-iterator",
 ]
 
 [[package]]
@@ -1138,26 +1097,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590b1af059a21c47d4da7cd11f05e08b1992b58b5b4acf2a5e10d7e53aed3d74"
 dependencies = [
  "regex",
-]
-
-[[package]]
-name = "bytemuck"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562e382481975bc61d11275ac5e62a19abd00b0547d99516a415336f183dcd0e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
 ]
 
 [[package]]
@@ -2274,12 +2213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethnum"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eac3c0b9fa6eb75255ebb42c0ba3e2210d102a66d2795afef6fed668f373311"
-
-[[package]]
 name = "eventsource-client"
 version = "0.11.0"
 source = "git+https://github.com/MaterializeInc/rust-eventsource-client#fb749fde693a9757289238ee71d4e9b3590fb24b"
@@ -2319,12 +2252,6 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
@@ -2439,12 +2366,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "foreign_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1b05cbd864bcaecbd3455d6d967862d446e4ebfc3c2e5e5b9841e53cba6673"
 
 [[package]]
 name = "form_urlencoded"
@@ -2686,12 +2607,6 @@ dependencies = [
  "crunchy",
  "num-traits",
 ]
-
-[[package]]
-name = "hash_hasher"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
@@ -5302,7 +5217,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arrow",
- "arrow2",
  "async-stream",
  "async-trait",
  "aws-config",
@@ -7173,29 +7087,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parquet-format-safe"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1131c54b167dd4e4799ce762e1ab01549ebb94d5bdd13e6ec1b467491c378e1f"
-dependencies = [
- "async-trait",
- "futures",
-]
-
-[[package]]
-name = "parquet2"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aefc53bedbf9bbe0ff8912befafaafe30ced83851fb0aebe86696a9289ebb29e"
-dependencies = [
- "async-stream",
- "futures",
- "parquet-format-safe",
- "seq-macro",
- "streaming-decompression",
-]
-
-[[package]]
 name = "parse-zoneinfo"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7367,15 +7258,6 @@ name = "pkg-config"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
-
-[[package]]
-name = "planus"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1691dd09e82f428ce8d6310bd6d5da2557c82ff17694d2a32cad7242aea89f"
-dependencies = [
- "array-init-cursor",
-]
 
 [[package]]
 name = "plotters"
@@ -8749,12 +8631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 
 [[package]]
-name = "simdutf8"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970da16e7c682fa90a261cf0724dee241c9f7831635ecc4e988ae8f3b505559"
-
-[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8918,21 +8794,6 @@ name = "str_indices"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f026164926842ec52deb1938fae44f83dfdb82d0a5b0270c5bd5935ab74d6dd"
-
-[[package]]
-name = "streaming-decompression"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc687acd5dc742c4a7094f2927a8614a68e4743ef682e7a2f9f0f711656cc92"
-dependencies = [
- "fallible-streaming-iterator",
-]
-
-[[package]]
-name = "streaming-iterator"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303235c177994a476226b80d076bd333b7b560fb05bd242a10609d11b07f81f5"
 
 [[package]]
 name = "stringprep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,9 +237,6 @@ openssh = { git = "https://github.com/MaterializeInc/openssh.git" }
 reqwest-middleware = { git = "https://github.com/MaterializeInc/reqwest-middleware.git" }
 reqwest-retry = { git = "https://github.com/MaterializeInc/reqwest-middleware.git" }
 
-# To pick up https://github.com/MaterializeInc/arrow2/commit/61e271a3f70bc993f8b7854b73e8fee099803d1c
-arrow2 = { git = "https://github.com/MaterializeInc/arrow2.git", branch = "parquet_binary_next_iter" }
-
 [patch."https://github.com/frankmcsherry/columnation"]
 # Projects that do not reliably release to crates.io.
 columnation = { git = "https://github.com/MaterializeInc/columnation.git" }

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -811,17 +811,6 @@ steps:
               composition: platform-checks
               args: [--scenario=TogglePersistRoundtripSpine, "--seed=$BUILDKITE_JOB_ID"]
 
-      - id: checks-toggle-persist-use-arrow-rs-library
-        label: "Checks toggling persist use arrow_rs library"
-        depends_on: build-aarch64
-        timeout_in_minutes: 45
-        agents:
-          queue: linux-aarch64-large
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: platform-checks
-              args: [--scenario=TogglePersistUseArrowRsLibrary, "--seed=$BUILDKITE_JOB_ID"]
-
       - id: checks-migrate-aarch64-x86-64
         label: "Checks migrate from aarch64 to x86-64"
         depends_on: [build-x86_64, build-aarch64]

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -337,19 +337,3 @@ class TogglePersistRoundtripSpine(SystemVarChange):
                 )
             ],
         )
-
-
-class TogglePersistUseArrowRsLibrary(SystemVarChange):
-    def __init__(self, checks: list[type[Check]], executor: Executor, seed: str | None):
-        super().__init__(
-            checks,
-            executor,
-            seed,
-            [
-                SystemVarChangeEntry(
-                    name="persist_use_arrow_rs_library",
-                    value_for_manipulate_phase_1="read",
-                    value_for_manipulate_phase_2="read_and_write",
-                )
-            ],
-        )

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -917,11 +917,6 @@ class FlipFlagsAction(Action):
             "enable_variadic_left_join_lowering"
         ] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
-        self.flags_with_values["persist_use_arrow_rs_library"] = [
-            "off",
-            "read",
-            "read_and_write",
-        ]
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -113,7 +113,7 @@ async = [
   "tokio",
   "tracing",
 ]
-bytes_ = ["bytes", "compact_bytes", "smallvec", "smallvec/const_generics"]
+bytes_ = ["bytes", "compact_bytes", "smallvec", "smallvec/const_generics", "region", "tracing_"]
 network = ["async", "bytes", "hyper", "smallvec", "tonic", "tracing"]
 region = ["lgalloc"]
 tracing_ = [

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -88,18 +88,6 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                     x.add_dynamic("persist_inline_writes_total_max_bytes", ::mz_dyncfg::ConfigVal::Usize(0));
                     x
                 },
-                {
-                    // Exercises reading with arrow-rs
-                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
-                    x.add_dynamic("persist_use_arrow_rs_library", ::mz_dyncfg::ConfigVal::String("read".to_string()));
-                    x
-                },
-                {
-                    // Exercises reading and writing with arrow-rs
-                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
-                    x.add_dynamic("persist_use_arrow_rs_library", ::mz_dyncfg::ConfigVal::String("read_and_write".to_string()));
-                    x
-                },
             ];
 
             for (idx, dyncfgs) in dyncfgs.into_iter().enumerate() {

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -11,18 +11,17 @@
 //!
 //! For efficiency/performance, we directly expose the columnar structure of
 //! persist's internal encoding to users during encoding and decoding. For
-//! ergonomics, we wrap the arrow2 crate we use to read and write parquet data.
+//! ergonomics, we wrap the [`arrow`] crate we use to read and write parquet data.
 //!
 //! Some of the requirements that led to this design:
 //! - Support a separation of data and schema because Row is not
 //!   self-describing: e.g. a Datum::Null can be one of many possible column
 //!   types. A RelationDesc is necessary to describe a Row schema.
-//! - Narrow down arrow2::data_types::DataType (the arrow "logical" types) to a
+//! - Narrow down [`arrow::datatypes::DataType`] (the arrow "logical" types) to a
 //!   set we want to support in persist.
-//! - Associate an arrow2::io::parquet::write::Encoding with each of those
-//!   types.
+//! - Associate a [`parquet::basic::Encoding`] with each of those types.
 //! - Do `dyn Any` downcasting of columns once per part, not once per update.
-//! - Unlike arrow2, be precise about whether each column is optional or not.
+//! - Unlike [`arrow`], be precise about whether each column is optional or not.
 //!
 //! The primary presentation of this abstraction is a sealed trait [Data], which
 //! is implemented for the owned version of each type of data that can be stored
@@ -36,7 +35,7 @@
 //! when downcasting the types back.
 //!
 //! Note: The "Data" strategy is roughly how columnation works and the
-//! "DataType" strategy is roughly how arrow2 works. Doing both of them gets us
+//! "DataType" strategy is roughly how [`arrow`] works. Doing both of them gets us
 //! the benefits of both, while the downside is code duplication and cognitive
 //! overhead.
 //!
@@ -180,7 +179,7 @@ pub struct DataType {
 /// type. Because of this, the variants are named after the rust type.
 ///
 /// NB: This intentionally exists as a subset of [arrow::datatypes::DataType].
-/// It also represents slightly different semantics. The arrow2 DataType always
+/// It also represents slightly different semantics. The [`arrow`] DataType always
 /// indicates an optional field, where as these all indicate non-optional fields
 /// (which may be made optional via [DataType]).
 #[derive(Debug, Clone)]

--- a/src/persist-types/src/dyn_struct.rs
+++ b/src/persist-types/src/dyn_struct.rs
@@ -460,9 +460,9 @@ impl From<DynStructMut> for DynStructCol {
     }
 }
 
-/// A new-type wrapper for an `arrow2` validity column.
+/// A new-type wrapper for an [`arrow`] validity column.
 ///
-/// The `arrow2` crate has an optimization where the validity column can be
+/// The [`arrow`] crate has an optimization where the validity column can be
 /// elided if every value is true. This is the common case for the `Ok` struct
 /// of our `SourceData`, so seems worth opting in to ourselves.
 ///

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -60,7 +60,7 @@ impl Part {
         let (mut fields, mut arrays) = (Vec::new(), Vec::<Arc<dyn Array>>::new());
 
         {
-            // arrow2 doesn't allow empty struct arrays. To make a future schema
+            // arrow doesn't allow empty struct arrays. To make a future schema
             // migration for <no columns> <-> <one optional column> easier, we
             // model this as a missing column (rather than something like
             // NullArray). This also matches how we'd do the same for nested
@@ -72,7 +72,7 @@ impl Part {
         }
 
         {
-            // arrow2 doesn't allow empty struct arrays. To make a future schema
+            // arrow doesn't allow empty struct arrays. To make a future schema
             // migration for <no columns> <-> <one optional column> easier, we
             // model this as a missing column (rather than something like
             // NullArray). This also matches how we'd do the same for nested

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -24,7 +24,6 @@ bench = false
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 arrow = { version = "51.0.0", default-features = false }
-arrow2 = { version = "0.16.0", features = ["io_ipc", "io_parquet"] }
 async-trait = "0.1.68"
 async-stream = "0.3.3"
 aws-config = { version = "1.2.0", default-features = false }

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -33,7 +33,6 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_CC_SIZES)
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_NONCC_SIZES)
-        .add(&crate::indexed::columnar::parquet::USE_ARROW_RS_LIBRARY)
         .add(&crate::s3::ENABLE_S3_LGALLOC_CC_SIZES)
         .add(&crate::s3::ENABLE_S3_LGALLOC_NONCC_SIZES)
 }

--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -92,12 +92,6 @@ impl<'a> From<&'a str> for Error {
     }
 }
 
-impl From<arrow2::error::Error> for Error {
-    fn from(e: arrow2::error::Error) -> Self {
-        Error::String(e.to_string())
-    }
-}
-
 impl From<parquet::errors::ParquetError> for Error {
     fn from(e: parquet::errors::ParquetError) -> Self {
         Error::String(e.to_string())

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -9,24 +9,24 @@
 
 //! Apache Parquet encodings and utils for persist data
 
-use std::io::{Read, Seek, Write};
+use std::io::Write;
 use std::sync::Arc;
 
-use arrow2::io::parquet::read::{infer_schema, read_metadata, FileReader};
-use arrow2::io::parquet::write::{
-    CompressionOptions, Encoding, FileWriter, KeyValue, RowGroupIterator, Version, WriteOptions,
-};
+use arrow::record_batch::RecordBatch;
 use differential_dataflow::trace::Description;
-use mz_dyncfg::Config;
 use mz_ore::bytes::SegmentedBytes;
 use mz_persist_types::Codec64;
+use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ParquetRecordBatchReaderBuilder};
+use parquet::arrow::ArrowWriter;
+use parquet::basic::{Compression, Encoding};
+use parquet::file::metadata::KeyValue;
+use parquet::file::properties::{EnabledStatistics, WriterProperties, WriterVersion};
 use timely::progress::{Antichain, Timestamp};
 
 use crate::error::Error;
 use crate::gen::persist::ProtoBatchFormat;
 use crate::indexed::columnar::arrow::{
-    decode_arrow_batch_kvtd, decode_arrow_batch_kvtd_arrow_rs, encode_arrow_batch_kvtd,
-    encode_arrow_batch_kvtd_arrow_rs, SCHEMA_ARROW2_KVTD, SCHEMA_ARROW_RS_KVTD,
+    decode_arrow_batch_kvtd, encode_arrow_batch_kvtd, SCHEMA_ARROW_RS_KVTD,
 };
 use crate::indexed::columnar::ColumnarRecords;
 use crate::indexed::encoding::{
@@ -34,77 +34,19 @@ use crate::indexed::encoding::{
 };
 use crate::metrics::ColumnarMetrics;
 
-#[derive(Debug, Copy, Clone)]
-enum UseArrowRsLibrary {
-    Off,
-    Read,
-    ReadAndWrite,
-}
-
-impl UseArrowRsLibrary {
-    /// Returns whether or not we should use [`arrow`] for reads.
-    fn for_reads(&self) -> bool {
-        matches!(
-            self,
-            UseArrowRsLibrary::Read | UseArrowRsLibrary::ReadAndWrite
-        )
-    }
-
-    /// Returns whether or not we should use [`arrow`] for writes.
-    fn for_writes(&self) -> bool {
-        matches!(self, UseArrowRsLibrary::ReadAndWrite)
-    }
-
-    /// Parses the provided string, returns [`UseArrowRsLibrary::Off`] on any failure.
-    fn from_str(s: &str) -> UseArrowRsLibrary {
-        match s.to_lowercase().as_str() {
-            "read" => UseArrowRsLibrary::Read,
-            "read_and_write" => UseArrowRsLibrary::ReadAndWrite,
-            "off" => UseArrowRsLibrary::Off,
-            val => {
-                // Complain loudly if the value is not what we expect.
-                tracing::error!(?val, "unrecognized value for persist_use_arrow_rs_library");
-                UseArrowRsLibrary::Off
-            }
-        }
-    }
-
-    /// Returns a string representation for [`UseArrowRsLibrary`].
-    const fn to_str(self) -> &'static str {
-        match self {
-            UseArrowRsLibrary::Off => "off",
-            UseArrowRsLibrary::Read => "read",
-            UseArrowRsLibrary::ReadAndWrite => "read_and_write",
-        }
-    }
-}
-
-pub(crate) const USE_ARROW_RS_LIBRARY: Config<&str> = Config::new(
-    "persist_use_arrow_rs_library",
-    UseArrowRsLibrary::Off.to_str(),
-    "'off' by default, providing 'read' will use the newer arrow-rs library for reads, 'read_and_write' will use it for both reads and writes.",
-);
-
 const INLINE_METADATA_KEY: &str = "MZ:inline";
 
 /// Encodes an BlobTraceBatchPart into the Parquet format.
 pub fn encode_trace_parquet<W: Write + Send, T: Timestamp + Codec64>(
     w: &mut W,
     batch: &BlobTraceBatchPart<T>,
-    metrics: &ColumnarMetrics,
+    _metrics: &ColumnarMetrics,
 ) -> Result<(), Error> {
     // Better to error now than write out an invalid batch.
     batch.validate()?;
-    let inline_meta = encode_trace_inline_meta(batch, ProtoBatchFormat::ParquetKvtd);
 
-    let use_arrow_rs = UseArrowRsLibrary::from_str(&USE_ARROW_RS_LIBRARY.get(&metrics.cfg));
-    if use_arrow_rs.for_writes() {
-        metrics.arrow_metrics.encode_arrow_rs.inc();
-        encode_parquet_kvtd_arrow_rs(w, inline_meta, &batch.updates)
-    } else {
-        metrics.arrow_metrics.encode_arrow2.inc();
-        encode_parquet_kvtd(w, inline_meta, &batch.updates)
-    }
+    let inline_meta = encode_trace_inline_meta(batch, ProtoBatchFormat::ParquetKvtd);
+    encode_parquet_kvtd(w, inline_meta, &batch.updates)
 }
 
 /// Decodes a BlobTraceBatchPart from the Parquet format.
@@ -112,47 +54,21 @@ pub fn decode_trace_parquet<T: Timestamp + Codec64>(
     buf: SegmentedBytes,
     metrics: &ColumnarMetrics,
 ) -> Result<BlobTraceBatchPart<T>, Error> {
-    let use_arrow_rs = UseArrowRsLibrary::from_str(&USE_ARROW_RS_LIBRARY.get(&metrics.cfg));
-    let (metadata, updates) = if use_arrow_rs.for_reads() {
-        let metadata =
-            parquet::arrow::arrow_reader::ArrowReaderMetadata::load(&buf, Default::default())?;
-        let metadata = metadata
-            .metadata()
-            .file_metadata()
-            .key_value_metadata()
-            .as_ref()
-            .and_then(|x| x.iter().find(|x| x.key == INLINE_METADATA_KEY));
+    let metadata = ArrowReaderMetadata::load(&buf, Default::default())?;
+    let metadata = metadata
+        .metadata()
+        .file_metadata()
+        .key_value_metadata()
+        .as_ref()
+        .and_then(|x| x.iter().find(|x| x.key == INLINE_METADATA_KEY));
 
-        let (format, meta) = decode_trace_inline_meta(metadata.and_then(|x| x.value.as_ref()))?;
-        let updates = match format {
-            ProtoBatchFormat::Unknown => return Err("unknown format".into()),
-            ProtoBatchFormat::ArrowKvtd => {
-                return Err("ArrowKVTD format not supported in parquet".into())
-            }
-            ProtoBatchFormat::ParquetKvtd => decode_parquet_file_kvtd_parquet_rs(buf, metrics)?,
-        };
-        metrics.arrow_metrics.decode_arrow_rs.inc();
-
-        (meta, updates)
-    } else {
-        let mut reader = buf.reader();
-        let metadata = read_metadata(&mut reader).map_err(|err| err.to_string())?;
-        let metadata = metadata
-            .key_value_metadata()
-            .as_ref()
-            .and_then(|x| x.iter().find(|x| x.key == INLINE_METADATA_KEY));
-
-        let (format, meta) = decode_trace_inline_meta(metadata.and_then(|x| x.value.as_ref()))?;
-        let updates = match format {
-            ProtoBatchFormat::Unknown => return Err("unknown format".into()),
-            ProtoBatchFormat::ArrowKvtd => {
-                return Err("ArrowKVTD format not supported in parquet".into())
-            }
-            ProtoBatchFormat::ParquetKvtd => decode_parquet_file_kvtd(&mut reader, metrics)?,
-        };
-        metrics.arrow_metrics.decode_arrow2.inc();
-
-        (meta, updates)
+    let (format, metadata) = decode_trace_inline_meta(metadata.and_then(|x| x.value.as_ref()))?;
+    let updates = match format {
+        ProtoBatchFormat::Unknown => return Err("unknown format".into()),
+        ProtoBatchFormat::ArrowKvtd => {
+            return Err("ArrowKVTD format not supported in parquet".into())
+        }
+        ProtoBatchFormat::ParquetKvtd => decode_parquet_file_kvtd(buf, metrics)?,
     };
 
     let ret = BlobTraceBatchPart {
@@ -173,59 +89,16 @@ pub fn decode_trace_parquet<T: Timestamp + Codec64>(
     Ok(ret)
 }
 
-fn encode_parquet_kvtd<W: Write>(
-    w: &mut W,
-    inline_base64: String,
-    iter: &[ColumnarRecords],
-) -> Result<(), Error> {
-    let iter = iter.into_iter().map(|x| Ok(encode_arrow_batch_kvtd(x)));
-
-    let options = WriteOptions {
-        write_statistics: false,
-        compression: CompressionOptions::Uncompressed,
-        version: Version::V2,
-        data_pagesize_limit: None, // use default limit
-    };
-    let row_groups = RowGroupIterator::try_new(
-        iter,
-        &SCHEMA_ARROW2_KVTD,
-        options,
-        vec![
-            vec![Encoding::Plain],
-            vec![Encoding::Plain],
-            vec![Encoding::Plain],
-            vec![Encoding::Plain],
-        ],
-    )?;
-
-    let metadata = vec![KeyValue {
-        key: INLINE_METADATA_KEY.into(),
-        value: Some(inline_base64),
-    }];
-    let mut writer = FileWriter::try_new(w, (**SCHEMA_ARROW2_KVTD).clone(), options)?;
-    for group in row_groups {
-        writer.write(group?).map_err(|err| err.to_string())?;
-    }
-    writer.end(Some(metadata)).map_err(|err| err.to_string())?;
-
-    Ok(())
-}
-
 /// Encodes [`ColumnarRecords`] to Parquet using the [`parquet`] crate.
-pub fn encode_parquet_kvtd_arrow_rs<W: Write + Send>(
+pub fn encode_parquet_kvtd<W: Write + Send>(
     w: &mut W,
     inline_base64: String,
     iter: &[ColumnarRecords],
 ) -> Result<(), Error> {
-    use arrow::record_batch::RecordBatch;
-    use parquet::arrow::ArrowWriter;
-    use parquet::basic::{Compression, Encoding};
-    use parquet::file::properties::{EnabledStatistics, WriterProperties, WriterVersion};
+    let metadata = KeyValue::new(INLINE_METADATA_KEY.to_string(), inline_base64);
 
-    let metadata =
-        parquet::file::metadata::KeyValue::new(INLINE_METADATA_KEY.to_string(), inline_base64);
-
-    // Configure our writer to match arrow2 so the blobs can roundtrip.
+    // We configure our writer to match the defaults from `arrow2` so our blobs
+    // can roundtrip. Eventually we should tune these settings.
     let properties = WriterProperties::builder()
         .set_dictionary_enabled(false)
         .set_encoding(Encoding::PLAIN)
@@ -240,7 +113,7 @@ pub fn encode_parquet_kvtd_arrow_rs<W: Write + Send>(
     let mut writer = ArrowWriter::try_new(w, Arc::clone(&*SCHEMA_ARROW_RS_KVTD), Some(properties))?;
 
     let batches = iter.into_iter().map(|c| {
-        let cols = encode_arrow_batch_kvtd_arrow_rs(c);
+        let cols = encode_arrow_batch_kvtd(c);
         RecordBatch::try_new(Arc::clone(&*SCHEMA_ARROW_RS_KVTD), cols)
     });
 
@@ -254,39 +127,11 @@ pub fn encode_parquet_kvtd_arrow_rs<W: Write + Send>(
     Ok(())
 }
 
-/// Decodes [`ColumnarRecords`] from a reader, using [`arrow2`].
-pub fn decode_parquet_file_kvtd<R: Read + Seek>(
-    r: &mut R,
-    metrics: &ColumnarMetrics,
-) -> Result<Vec<ColumnarRecords>, Error> {
-    let metadata = read_metadata(r)?;
-    let schema = infer_schema(&metadata)?;
-    let reader = FileReader::new(r, metadata.row_groups, schema, None, None, None);
-
-    let file_schema = reader.schema().fields.as_slice();
-    // We're not trying to accept any sort of user created data, so be strict.
-    if file_schema != SCHEMA_ARROW2_KVTD.fields {
-        return Err(format!(
-            "expected arrow schema {:?} got: {:?}",
-            SCHEMA_ARROW2_KVTD.fields, file_schema
-        )
-        .into());
-    }
-
-    let mut ret = Vec::new();
-    for batch in reader {
-        ret.push(decode_arrow_batch_kvtd(&batch?, metrics)?);
-    }
-    Ok(ret)
-}
-
 /// Decodes [`ColumnarRecords`] from a reader, using [`arrow`].
-pub fn decode_parquet_file_kvtd_parquet_rs(
+pub fn decode_parquet_file_kvtd(
     r: impl parquet::file::reader::ChunkReader + 'static,
     metrics: &ColumnarMetrics,
 ) -> Result<Vec<ColumnarRecords>, Error> {
-    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-
     let builder = ParquetRecordBatchReaderBuilder::try_new(r)?;
 
     // To match arrow2, we default the batch size to the number of rows in the RowGroup.
@@ -308,7 +153,7 @@ pub fn decode_parquet_file_kvtd_parquet_rs(
     let mut ret = Vec::new();
     for batch in reader {
         let batch = batch.map_err(|e| Error::String(e.to_string()))?;
-        ret.push(decode_arrow_batch_kvtd_arrow_rs(&batch, metrics)?);
+        ret.push(decode_arrow_batch_kvtd(&batch, metrics)?);
     }
     Ok(ret)
 }

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -646,7 +646,7 @@ mod tests {
                 sizes(DataGenerator::new(1_000, record_size_bytes, 1_000)),
                 sizes(DataGenerator::new(1_000, record_size_bytes, 1_000 / 100)),
             ),
-            "1/1=1027 25/1=2778 1000/1=73022 1000/100=113067"
+            "1/1=951 25/1=2702 1000/1=72943 1000/100=72943"
         );
     }
 }

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -78,27 +78,13 @@ impl S3BlobMetrics {
 /// Metrics specific to our usage of Arrow and Parquet.
 #[derive(Debug, Clone)]
 pub struct ArrowMetrics {
-    pub(crate) encode_arrow2: IntCounter,
-    pub(crate) decode_arrow2: IntCounter,
-    pub(crate) encode_arrow_rs: IntCounter,
-    pub(crate) decode_arrow_rs: IntCounter,
+    // TODO(parkmycar): Add some metrics here.
 }
 
 impl ArrowMetrics {
     /// Returns a new [ArrowMetrics] instance connected to the given registry.
-    pub fn new(registry: &MetricsRegistry) -> Self {
-        let operations: IntCounterVec = registry.register(metric!(
-            name: "mz_persist_arrow_operations",
-            help: "number of raw Arrow operations",
-            var_labels: ["op", "library"],
-        ));
-
-        ArrowMetrics {
-            encode_arrow2: operations.with_label_values(&["encode", "arrow2"]),
-            decode_arrow2: operations.with_label_values(&["decode", "arrow2"]),
-            encode_arrow_rs: operations.with_label_values(&["encode", "arrow_rs"]),
-            decode_arrow_rs: operations.with_label_values(&["decode", "arrow_rs"]),
-        }
+    pub fn new(_registry: &MetricsRegistry) -> Self {
+        ArrowMetrics {}
     }
 }
 
@@ -106,6 +92,7 @@ impl ArrowMetrics {
 #[derive(Debug)]
 pub struct ColumnarMetrics {
     pub(crate) lgbytes_arrow: LgBytesOpMetrics,
+    #[allow(dead_code)] // TODO(parkmycar): In a follow up PR I'll be adding metrics.
     pub(crate) arrow_metrics: ArrowMetrics,
     // TODO: Having these two here isn't quite the right thing to do, but it
     // saves a LOT of plumbing.

--- a/test/sqllogictest/explain/pushdown.slt
+++ b/test/sqllogictest/explain/pushdown.slt
@@ -63,12 +63,12 @@ INSERT INTO numbers VALUES (1), (2), (3);
 query TIIII
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value > 10;
 ----
-materialize.public.numbers  1039  0  1  0
+materialize.public.numbers  963  0  1  0
 
 query TIIII
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value < 10;
 ----
-materialize.public.numbers  1039  1039  1  1
+materialize.public.numbers  963  963  1  1
 
 # Verify that pushdown of jsonb_get_string is infallible. Before this was
 # fixed, a filter expression on a jsonb field that is not present in all parts
@@ -93,7 +93,7 @@ INSERT INTO jsonb_fields VALUES (2, '{ "other-field": "value" }');
 query TIIII
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM jsonb_fields where timestamp > 1000 AND payload->>'field' = 'not-value';
 ----
-materialize.public.jsonb_fields  2011  0  2  0
+materialize.public.jsonb_fields  1859  0  2  0
 
 # EXPLAIN FILTER PUSHDOWN should work even if there are no replicas.
 statement ok
@@ -105,7 +105,7 @@ SET CLUSTER = no_replicas;
 query TIIII
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM jsonb_fields where timestamp > 1000 AND payload->>'field' = 'not-value';
 ----
-materialize.public.jsonb_fields  2011  0  2  0
+materialize.public.jsonb_fields  1859  0  2  0
 
 # ----------------------------------------
 # Cleanup


### PR DESCRIPTION
This PR removes `arrow2` from our dependency tree entirely, and the feature gate that enabled switching between `arrow2` and `arrow-rs`.

Note: I'm not expecting any issues, but to be on the safe side I would like to keep our `arrow2` fork around for a few weeks, just in case we need to revert this PR.

### Motivation

We already migrated all of our stats collection to `arrow-rs` and today I moved the feature flag `persist_use_arrow_rs_library` to 100% of users. Removing `arrow2` simplifies our code and makes it easier to rebase https://github.com/MaterializeInc/materialize/pull/26561, introducing structured data into Persist.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
