### PR TITLE
adapter: improve mznow hint

### DIFF
--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -295,7 +295,7 @@ impl OptimizerError {
     pub fn hint(&self) -> Option<String> {
         match self {
             Self::UnmaterializableFunction(UnmaterializableFunc::CurrentTimestamp) => {
-                Some("Try using `mz_now()` here instead.".into())
+                Some("In temporal filters `mz_now()` may work instead.".into())
             }
             _ => None,
         }

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -455,7 +455,7 @@ http
 {"query":"CREATE MATERIALIZED VIEW _now AS SELECT now()"}
 ----
 200 OK
-{"results":[{"error":{"message":"cannot materialize call to current_timestamp","code":"0A000","detail":"See: https://materialize.com/docs/sql/functions/now_and_mz_now/","hint":"Try using `mz_now()` here instead."},"notices":[]}]}
+{"results":[{"error":{"message":"cannot materialize call to current_timestamp","code":"0A000","detail":"See: https://materialize.com/docs/sql/functions/now_and_mz_now/","hint":"In temporal filters `mz_now()` may work instead."},"notices":[]}]}
 
 # Test timestamp precision.
 http


### PR DESCRIPTION
It could previously give incorrect advice.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a