### PR TITLE
storage: add SubsourceResolver

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -75,8 +75,8 @@ use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sinks::{StorageSinkConnection, StorageSinkDesc};
 use mz_storage_types::sources::{
-    GenericSourceConnection, IngestionDescription, SourceConnection, SourceData, SourceDesc,
-    SourceExport,
+    ExportReference, GenericSourceConnection, IngestionDescription, SourceConnection, SourceData,
+    SourceDesc, SourceExport,
 };
 use mz_storage_types::AlterCompatible;
 use timely::order::{PartialOrder, TotalOrder};
@@ -628,7 +628,7 @@ where
                 ingestion.source_exports.insert(
                     id,
                     SourceExport {
-                        output_index: 0,
+                        ingestion_output: None,
                         storage_metadata: (),
                     },
                 );
@@ -726,27 +726,15 @@ where
                         CollectionDescription {
                             data_source: DataSource::Ingestion(ingestion_desc),
                             ..
-                        } => {
-                            // DataSource::IngestionExport names the object it
-                            // wants to export, so we look up the output index
-                            // for that name.
-                            let output_index = ingestion_desc
-                                .desc
-                                .connection
-                                .output_idx_for_name(external_reference)
-                                .ok_or(StorageError::MissingSubsourceReference {
-                                    ingestion_id: *ingestion_id,
-                                    reference: external_reference.clone(),
-                                })?;
-
-                            ingestion_desc.source_exports.insert(
-                                id,
-                                SourceExport {
-                                    output_index,
-                                    storage_metadata: (),
-                                },
-                            )
-                        }
+                        } => ingestion_desc.source_exports.insert(
+                            id,
+                            SourceExport {
+                                ingestion_output: Some(ExportReference::from(
+                                    external_reference.clone(),
+                                )),
+                                storage_metadata: (),
+                            },
+                        ),
                         _ => unreachable!(
                             "SourceExport must only refer to primary sources that already exist"
                         ),
@@ -1017,6 +1005,8 @@ where
                     .desc
                     .alter_compatible(ingestion_id, source_desc)?;
 
+                let subsource_resolver = cur_ingestion.desc.connection.get_subsource_resolver();
+
                 // Ensure updated `SourceDesc` contains reference to all
                 // current external references.
                 for export_id in cur_ingestion
@@ -1040,10 +1030,9 @@ where
                         }
                     };
 
-                    if source_desc
-                        .connection
-                        .output_idx_for_name(external_reference)
-                        .is_none()
+                    if subsource_resolver
+                        .resolve_details_idx(&external_reference.0)
+                        .is_err()
                     {
                         tracing::warn!(
                             "subsource {export_id} of {ingestion_id} refers to \
@@ -1073,62 +1062,6 @@ where
     ) -> Result<(), StorageError<Self::Timestamp>> {
         self.check_alter_ingestion_source_desc(ingestion_id, &source_desc)?;
 
-        let collection = self.collection(ingestion_id).expect("validated exists");
-        let curr_ingestion = match &collection.description.data_source {
-            DataSource::Ingestion(active_ingestion) => active_ingestion,
-            _ => unreachable!("verified collection refers to ingestion"),
-        };
-
-        // Generate new source exports because they might have changed.
-        let mut source_exports = BTreeMap::new();
-        // Each source includes a `0` output index export "for the
-        // primary source", whether it's used or not.
-        source_exports.insert(
-            ingestion_id,
-            SourceExport {
-                output_index: 0,
-                storage_metadata: (),
-            },
-        );
-
-        // Get the updated output indices for each source export.
-        //
-        // TODO(#26766): this could be simpler if the output indices
-        // were determined in rendering, e.g. `SourceExport` had an
-        // `Option<UnresolvedItemName>` instead of a `usize` and we
-        // looked up its output index when we were aligning the
-        // rendering outputs.
-        for export_id in curr_ingestion.source_exports.keys() {
-            if *export_id == ingestion_id {
-                // Already inserted above
-                continue;
-            }
-
-            let DataSource::IngestionExport {
-                ingestion_id,
-                external_reference,
-            } = &self.collection(*export_id)?.description.data_source
-            else {
-                panic!("source exports must be DataSource::IngestionExport")
-            };
-
-            let output_index = source_desc
-                .connection
-                .output_idx_for_name(external_reference)
-                .ok_or(StorageError::MissingSubsourceReference {
-                    ingestion_id: *ingestion_id,
-                    reference: external_reference.clone(),
-                })?;
-
-            source_exports.insert(
-                *export_id,
-                SourceExport {
-                    output_index,
-                    storage_metadata: (),
-                },
-            );
-        }
-
         // Update the `SourceDesc` and the source exports
         // simultaneously.
         let collection = self
@@ -1139,8 +1072,8 @@ where
             DataSource::Ingestion(curr_ingestion) => curr_ingestion,
             _ => unreachable!("verified collection refers to ingestion"),
         };
+
         curr_ingestion.desc = source_desc;
-        curr_ingestion.source_exports = source_exports;
         tracing::debug!("altered {ingestion_id}'s SourceDesc");
 
         // n.b. we do not re-run updated ingestions because updating the source
@@ -3724,7 +3657,7 @@ where
         for (
             export_id,
             SourceExport {
-                output_index,
+                ingestion_output,
                 storage_metadata: (),
             },
         ) in ingestion_description.source_exports
@@ -3733,8 +3666,8 @@ where
             source_exports.insert(
                 export_id,
                 SourceExport {
+                    ingestion_output,
                     storage_metadata: export_storage_metadata,
-                    output_index,
                 },
             );
         }

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -76,9 +76,13 @@ message ProtoIngestionDescription {
         mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 2;
     }
     message ProtoSourceExport {
+        reserved 2;
+        reserved "output_index";
+
         mz_repr.global_id.ProtoGlobalId id = 1;
-        uint64 output_index = 2;
+        // uint64 output_index = 2;
         mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 3;
+        repeated string ingestion_output = 4;
     }
 
     reserved 1;

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -34,7 +34,8 @@ use mz_repr::{
     ColumnType, Datum, DatumDecoderT, DatumEncoderT, GlobalId, ProtoRow, RelationDesc, Row,
     RowDecoder, RowEncoder,
 };
-use mz_sql_parser::ast::UnresolvedItemName;
+use mz_sql_parser::ast::{Ident, IdentError, UnresolvedItemName};
+use proptest::collection::vec;
 use proptest::prelude::any;
 use proptest_derive::Arbitrary;
 use prost::Message;
@@ -67,6 +68,32 @@ pub use crate::sources::mysql::MySqlSourceConnection;
 pub use crate::sources::postgres::PostgresSourceConnection;
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage_types.sources.rs"));
+
+/// A fraternal twin of [`UnresolvedItemName`] that can implement [`Arbitrary`].
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct ExportReference(pub Vec<Ident>);
+
+impl proptest::prelude::Arbitrary for ExportReference {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        // Generate a set of valid `Ident` strings.
+        let string_strategy = string_regex("[a-zA-Z_][a-zA-Z0-9_$]{3,10}").unwrap();
+
+        vec(string_strategy, 0..100)
+            .prop_map(|inner| {
+                ExportReference(inner.into_iter().map(|i| Ident::new(i).unwrap()).collect())
+            })
+            .boxed()
+    }
+}
+
+impl From<UnresolvedItemName> for ExportReference {
+    fn from(value: UnresolvedItemName) -> Self {
+        ExportReference(value.0)
+    }
+}
 
 /// A description of a source ingestion
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Arbitrary)]
@@ -1264,6 +1291,189 @@ impl Schema<SourceData> for RelationDesc {
             ok,
             err,
         })
+    }
+}
+
+/// Describes how subsource references should be organized in a multi-level
+/// hierarchy.
+///
+/// For both PostgreSQL and MySQL sources, these levels of reference are
+/// intrinsic to the items which we're referencing. If there are other naming
+/// schemas for other types of sources we discover, we might need to revisit
+/// this.
+pub trait SubsourceCatalogReference {
+    /// The "second" level of namespacing for the reference.
+    fn schema_name(&self) -> &str;
+    /// The lowest level of namespacing for the reference.
+    fn item_name(&self) -> &str;
+}
+
+impl SubsourceCatalogReference for mz_mysql_util::MySqlTableDesc {
+    fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+
+    fn item_name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl SubsourceCatalogReference for mz_postgres_util::desc::PostgresTableDesc {
+    fn schema_name(&self) -> &str {
+        &self.namespace
+    }
+
+    fn item_name(&self) -> &str {
+        &self.name
+    }
+}
+
+// This implementation provides a means of converting arbitrary objects into a
+// `SubsourceCatalogReference`, e.g. load generator view names.
+impl<'a> SubsourceCatalogReference for (&'a str, &'a str) {
+    fn schema_name(&self) -> &str {
+        self.0
+    }
+
+    fn item_name(&self) -> &str {
+        self.1
+    }
+}
+
+/// Stores and resolves references to a `&[T: SubsourceCatalogTable]`.
+///
+/// This is meant to provide an API to quickly look up a source's subsources.
+///
+/// For sources that do not provide any subsources, use the `Default`
+/// implementation, which is empty and will not be able to resolve any
+/// references.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubsourceResolver {
+    inner: BTreeMap<Ident, BTreeMap<Ident, BTreeMap<Ident, usize>>>,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum SubsourceResolutionError {
+    #[error("reference to {name} not found in source")]
+    DoesNotExist { name: String },
+    #[error(
+        "reference to {name} is ambiguous, consider specifying an additional \
+    layer of qualification"
+    )]
+    Ambiguous { name: String },
+    #[error("invalid identifier: {0}")]
+    Ident(#[from] IdentError),
+}
+
+impl<'a> SubsourceResolver {
+    /// Constructs a new `SubsourceResolver` from a slice of `T:
+    /// SubsourceCatalogReference`.
+    ///
+    /// # Errors
+    /// - If any `&str` provided cannot be taken to an [`Ident`].
+    pub fn new<T: SubsourceCatalogReference>(
+        database: &str,
+        referenceable_items: &'a [T],
+    ) -> Result<SubsourceResolver, SubsourceResolutionError> {
+        // An index from table name -> schema name -> database name -> index in
+        // `referenceable_items`.
+        let mut inner = BTreeMap::new();
+
+        let database = Ident::new(database)?;
+
+        for (reference_idx, item) in referenceable_items.iter().enumerate() {
+            let item_name = Ident::new(item.item_name())?;
+            let schema_name = Ident::new(item.schema_name())?;
+
+            inner
+                .entry(item_name)
+                .or_insert_with(BTreeMap::new)
+                .entry(schema_name)
+                .or_insert_with(BTreeMap::new)
+                .entry(database.clone())
+                .or_insert(reference_idx);
+        }
+
+        Ok(SubsourceResolver { inner })
+    }
+
+    /// Returns the index from which it originated in the `referenceable_items`
+    /// provided to [`Self::new`].
+    ///
+    /// # Args
+    /// `name` is `&[Ident]` to let users provide the inner element of either
+    /// [`UnresolvedItemName`] or [`ExportReference`].
+    ///
+    /// # Errors
+    /// - If the `UnresolvedItemName` does not resolve to an item in
+    ///   `self.inner`.
+    pub fn resolve_details_idx(&self, name: &[Ident]) -> Result<usize, SubsourceResolutionError> {
+        let provided_name = UnresolvedItemName(name.to_vec()).to_string();
+
+        // Names must be composed of 1..=3 elements.
+        if !(1..=3).contains(&name.len()) {
+            Err(SubsourceResolutionError::DoesNotExist {
+                name: provided_name.clone(),
+            })?;
+        }
+
+        // Fill on the leading elements with `None` if they aren't present.
+        let mut names = std::iter::repeat(None)
+            .take(3 - name.len())
+            .chain(name.iter().map(Some));
+
+        let database = names.next().flatten();
+        let schema = names.next().flatten();
+        let item = names
+            .next()
+            .flatten()
+            .expect("must have provided the item name");
+
+        assert!(names.next().is_none(), "expected a 3-element iterator");
+
+        let schemas =
+            self.inner
+                .get(item)
+                .ok_or_else(|| SubsourceResolutionError::DoesNotExist {
+                    name: provided_name.clone(),
+                })?;
+
+        let schema =
+            match schema {
+                Some(schema) => schema,
+                None => schemas.keys().exactly_one().map_err(|_e| {
+                    SubsourceResolutionError::Ambiguous {
+                        name: provided_name.clone(),
+                    }
+                })?,
+            };
+
+        let databases =
+            schemas
+                .get(schema)
+                .ok_or_else(|| SubsourceResolutionError::DoesNotExist {
+                    name: provided_name.clone(),
+                })?;
+
+        let database = match database {
+            Some(database) => database,
+            None => databases.keys().exactly_one().map_err(|_e| {
+                SubsourceResolutionError::Ambiguous {
+                    name: provided_name.clone(),
+                }
+            })?,
+        };
+
+        let reference_idx =
+            databases
+                .get(database)
+                .ok_or_else(|| SubsourceResolutionError::DoesNotExist {
+                    name: provided_name.clone(),
+                })?;
+
+        // TODO: this same function could also be used to generate canonical
+        // references for subsources.
+        Ok(*reference_idx)
     }
 }
 

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -190,8 +190,8 @@ impl<C: ConnectionAccess> SourceConnection for KafkaSourceConnection<C> {
             .collect()
     }
 
-    fn output_idx_for_name(&self, _name: &mz_sql_parser::ast::UnresolvedItemName) -> Option<usize> {
-        None
+    fn get_subsource_resolver(&self) -> super::SubsourceResolver {
+        super::SubsourceResolver::default()
     }
 }
 

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -15,7 +15,6 @@ use mz_ore::now::NowFn;
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::numeric::NumericMaxScale;
 use mz_repr::{ColumnType, GlobalId, RelationDesc, Row, ScalarType};
-use mz_sql_parser::ast::UnresolvedItemName;
 use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -121,22 +120,15 @@ impl SourceConnection for LoadGeneratorSourceConnection {
         vec![]
     }
 
-    fn output_idx_for_name(&self, name: &UnresolvedItemName) -> Option<usize> {
-        let name = match &name.0[..] {
-            [database, namespace, name]
-                if database.as_str() == LOAD_GENERATOR_DATABASE_NAME
-                    && namespace.as_str() == self.load_generator.schema_name() =>
-            {
-                name.as_str()
-            }
-            _ => return None,
-        };
-
-        self.load_generator
+    fn get_subsource_resolver(&self) -> super::SubsourceResolver {
+        let views: Vec<_> = self
+            .load_generator
             .views()
-            .iter()
-            .position(|(view_name, _)| *view_name == name)
-            .map(|idx| idx + 1)
+            .into_iter()
+            .map(|(name, _)| (self.load_generator.schema_name(), name))
+            .collect();
+        super::SubsourceResolver::new(LOAD_GENERATOR_DATABASE_NAME, &views)
+            .expect("already validated that SubsourceResolver elements are valid")
     }
 }
 

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -166,8 +166,9 @@ impl<C: ConnectionAccess> SourceConnection for MySqlSourceConnection<C> {
         vec![]
     }
 
-    fn output_idx_for_name(&self, name: &UnresolvedItemName) -> Option<usize> {
-        self.details.output_idx_for_name(name)
+    fn get_subsource_resolver(&self) -> super::SubsourceResolver {
+        super::SubsourceResolver::new("mysql", &self.details.tables)
+            .expect("already validated that SubsourceResolver elements are valid")
     }
 }
 
@@ -251,20 +252,6 @@ pub struct MySqlSourceDetails {
     /// one or more tables before the initial snapshot of all tables is complete.
     #[proptest(strategy = "any_gtidset()")]
     pub initial_gtid_set: String,
-}
-
-impl MySqlSourceDetails {
-    pub fn output_idx_for_name(&self, name: &UnresolvedItemName) -> Option<usize> {
-        let (schema_name, name) = match &name.0[..] {
-            [schema_name, name] => (schema_name.as_str(), name.as_str()),
-            _ => return None,
-        };
-
-        self.tables
-            .iter()
-            .position(|t| t.schema_name == schema_name && t.name == name)
-            .map(|idx| idx + 1)
-    }
 }
 
 fn any_gtidset() -> impl Strategy<Value = String> {

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -96,7 +96,7 @@ where
     let base_source_config = RawSourceCreationConfig {
         name: source_name,
         id,
-        source_exports: description.source_exports.clone(),
+        source_exports: description.source_exports_with_output_indices(),
         timestamp_interval: description.desc.timestamp_interval,
         worker_id: scope.index(),
         worker_count: scope.peers(),

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -126,16 +126,22 @@ impl SourceRender for MySqlSourceConnection {
 
         // Collect the tables that we will be ingesting.
         let mut table_info = BTreeMap::new();
-        for (_id, SourceExport { output_index, .. }) in &config.source_exports {
+        for (
+            _id,
+            SourceExport {
+                ingestion_output, ..
+            },
+        ) in &config.source_exports
+        {
             // Output index 0 is the primary source which is not a table.
-            if *output_index == 0 {
+            if *ingestion_output == 0 {
                 continue;
             }
 
-            let desc = &self.details.tables[output_index - 1];
+            let desc = &self.details.tables[ingestion_output - 1];
             table_info.insert(
                 MySqlTableName::new(&desc.schema_name, &desc.name),
-                (*output_index, desc.clone()),
+                (*ingestion_output, desc.clone()),
             );
         }
 

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -150,7 +150,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
             // Determined which collections need to be snapshot and which already have been.
             if id != config.id && *upper == [GtidPartition::minimum()] {
                 // Convert from `GlobalId` to output index.
-                Some(config.source_exports[&id].output_index)
+                Some(config.source_exports[&id].ingestion_output)
             } else {
                 None
             }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -152,21 +152,24 @@ impl SourceRender for PostgresSourceConnection {
 
         // Collect the tables that we will be ingesting.
         let mut table_info = BTreeMap::new();
-        for SourceExport { output_index, .. } in config.source_exports.values() {
+        for SourceExport {
+            ingestion_output, ..
+        } in config.source_exports.values()
+        {
             // Output index 0 is the primary source which is not a table.
-            if *output_index == 0 {
+            if *ingestion_output == 0 {
                 continue;
             }
 
             // The output index is 1 greater than the publication details' index
             // to account for the primary output being at index 0.
-            let table_idx = *output_index - 1;
+            let table_idx = *ingestion_output - 1;
             let desc = self.publication_details.tables[table_idx].clone();
 
             // Tables are indexed by their native index, but table casts are
             // indexed by the output index.
-            let casts = self.table_casts[output_index].clone();
-            table_info.insert(desc.oid, (*output_index, desc.clone(), casts.clone()));
+            let casts = self.table_casts[ingestion_output].clone();
+            table_info.insert(desc.oid, (*ingestion_output, desc.clone(), casts.clone()));
         }
 
         let metrics = config.metrics.get_postgres_source_metrics(config.id);

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -215,7 +215,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             // Determined which collections need to be snapshot and which already have been.
             if id != config.id && *upper == [MzOffset::minimum()] {
                 // Convert from `GlobalId` to output index.
-                Some(config.source_exports[&id].output_index)
+                Some(config.source_exports[&id].ingestion_output)
             } else {
                 None
             }


### PR DESCRIPTION
There are a number of places where it will be nice to provide a simple and consistent API for resolving subsource references in a source. To demo this approach, I've implemented #26766

- Canonicalize subsource references
- Determine the schema of subources

Another way to look at this is as a generalization of the current [`SubsourceCatalog`](https://github.com/MaterializeInc/materialize/blob/main/src/sql/src/catalog.rs#L1300), which this can replace. I haven't done that work but if this looks good, that will be the next step.

### Motivation

This PR adds a known-desirable feature.

- Closes #26766
- Additional uses of `SubsourceResolver` are obliquely discussed in [Notion](https://www.notion.so/materialize/Generate-subsources-after-planning-sources-683772c62d8e46e1a0c8945fe789f545?pvs=4).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
