### PR TITLE
adapter: improve mz_time_to_first_row_seconds metric

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
@@ -21,6 +22,7 @@ use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use mz_adapter_types::connection::{ConnectionId, ConnectionIdType};
 use mz_build_info::BuildInfo;
+use mz_compute_types::ComputeInstanceId;
 use mz_ore::channel::OneshotReceiverExt;
 use mz_ore::collections::CollectionExt;
 use mz_ore::id_gen::{org_id_conn_bits, IdAllocator, IdAllocatorInnerBitSet, MAX_ORG_ID};
@@ -370,7 +372,7 @@ Issue a SQL query to get started. Need help?
             .execute(EMPTY_PORTAL.into(), futures::future::pending(), None)
             .await?
         {
-            (ExecuteResponse::SendingRows { future }, _) => match future.await {
+            (ExecuteResponse::SendingRows { future, .. }, _) => match future.await {
                 PeekResponseUnary::Rows(rows) => Ok(rows),
                 PeekResponseUnary::Canceled => bail!("query canceled"),
                 PeekResponseUnary::Error(e) => bail!(e),
@@ -1046,8 +1048,9 @@ impl RecordFirstRowStream {
         rows: Box<dyn Stream<Item = PeekResponseUnary> + Unpin + Send + Sync>,
         execute_started: Instant,
         client: &SessionClient,
+        instance_id: Option<ComputeInstanceId>,
     ) -> Self {
-        let histogram = Self::histogram(client);
+        let histogram = Self::histogram(client, instance_id);
         Self {
             rows,
             execute_started,
@@ -1056,25 +1059,33 @@ impl RecordFirstRowStream {
         }
     }
 
-    fn histogram(client: &SessionClient) -> Histogram {
+    fn histogram(client: &SessionClient, instance_id: Option<ComputeInstanceId>) -> Histogram {
         let isolation_level = *client
             .session
             .as_ref()
             .expect("session invariant")
             .vars()
             .transaction_isolation();
+        let instance = match instance_id {
+            Some(i) => Cow::Owned(i.to_string()),
+            None => Cow::Borrowed("none"),
+        };
 
         client
             .inner()
             .metrics()
             .time_to_first_row_seconds
-            .with_label_values(&[isolation_level.as_str()])
+            .with_label_values(&[&instance, isolation_level.as_str()])
     }
 
     /// If you want to match [`RecordFirstRowStream`]'s logic but don't need
     /// a UnboundedReceiver, you can tell it when to record an observation.
-    pub fn record(execute_started: Instant, client: &SessionClient) {
-        Self::histogram(client).observe(execute_started.elapsed().as_secs_f64());
+    pub fn record(
+        execute_started: Instant,
+        client: &SessionClient,
+        instance_id: Option<ComputeInstanceId>,
+    ) {
+        Self::histogram(client, instance_id).observe(execute_started.elapsed().as_secs_f64());
     }
 
     pub async fn recv(&mut self) -> Option<PeekResponseUnary> {

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -16,6 +16,7 @@ use derivative::Derivative;
 use enum_kinds::EnumKind;
 use futures::future::BoxFuture;
 use mz_adapter_types::connection::{ConnectionId, ConnectionIdType};
+use mz_compute_types::ComputeInstanceId;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_assert_no_log;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -356,6 +357,7 @@ pub enum ExecuteResponse {
     SendingRows {
         #[derivative(Debug = "ignore")]
         future: RowsFuture,
+        instance_id: ComputeInstanceId,
     },
     /// Like `SendingRows`, but the rows are known to be available
     /// immediately, and thus the execution is considered ended in the coordinator.
@@ -376,6 +378,7 @@ pub enum ExecuteResponse {
     Subscribing {
         rx: RowBatchStream,
         ctx_extra: ExecuteContextExtra,
+        instance_id: ComputeInstanceId,
     },
     /// The active transaction committed.
     TransactionCommitted {

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -38,7 +38,7 @@ use crate::coord::peek::PeekResponseUnary;
 use crate::coord::ExecuteContextExtra;
 use crate::error::AdapterError;
 use crate::session::{EndTransactionAction, RowBatchStream, Session};
-use crate::statement_logging::StatementEndedExecutionReason;
+use crate::statement_logging::{StatementEndedExecutionReason, StatementExecutionStrategy};
 use crate::util::Transmittable;
 use crate::webhook::AppendWebhookResponse;
 use crate::{AdapterNotice, AppendWebhookError};
@@ -358,6 +358,7 @@ pub enum ExecuteResponse {
         #[derivative(Debug = "ignore")]
         future: RowsFuture,
         instance_id: ComputeInstanceId,
+        strategy: StatementExecutionStrategy,
     },
     /// Like `SendingRows`, but the rows are known to be available
     /// immediately, and thus the execution is considered ended in the coordinator.

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -515,7 +515,7 @@ impl crate::coord::Coordinator {
         // differently.
 
         // If we must build the view, ship the dataflow.
-        let (peek_command, drop_dataflow, is_fast_path, peek_target) = match fast_path {
+        let (peek_command, drop_dataflow, is_fast_path, peek_target, strategy) = match fast_path {
             PeekPlan::FastPath(FastPathPlan::PeekExisting(
                 _coll_id,
                 idx_id,
@@ -526,6 +526,7 @@ impl crate::coord::Coordinator {
                 None,
                 true,
                 PeekTarget::Index { id: idx_id },
+                StatementExecutionStrategy::FastPath,
             ),
             PeekPlan::FastPath(FastPathPlan::PeekPersist(coll_id, map_filter_project)) => {
                 let peek_command = (coll_id, None, timestamp, map_filter_project);
@@ -543,6 +544,7 @@ impl crate::coord::Coordinator {
                         id: coll_id,
                         metadata,
                     },
+                    StatementExecutionStrategy::PersistFastPath,
                 )
             }
             PeekPlan::SlowPath(PeekDataflowPlan {
@@ -585,6 +587,7 @@ impl crate::coord::Coordinator {
                     Some(index_id),
                     false,
                     PeekTarget::Index { id: index_id },
+                    StatementExecutionStrategy::Standard,
                 )
             }
             _ => {
@@ -662,6 +665,7 @@ impl crate::coord::Coordinator {
         Ok(crate::ExecuteResponse::SendingRows {
             future: Box::pin(rows_rx),
             instance_id: compute_instance,
+            strategy,
         })
     }
 

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -661,6 +661,7 @@ impl crate::coord::Coordinator {
 
         Ok(crate::ExecuteResponse::SendingRows {
             future: Box::pin(rows_rx),
+            instance_id: compute_instance,
         })
     }
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2619,7 +2619,7 @@ impl Coordinator {
                     Ok(diffs)
                 };
             let diffs = match peek_response {
-                ExecuteResponse::SendingRows { future: batch } => {
+                ExecuteResponse::SendingRows { future: batch, .. } => {
                     // TODO(jkosh44): This timeout should be removed;
                     // we should instead periodically ensure clusters are
                     // healthy and actively cancel any work waiting on unhealthy

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -357,6 +357,7 @@ impl Coordinator {
         let resp = ExecuteResponse::Subscribing {
             rx,
             ctx_extra: std::mem::take(ctx.extra_mut()),
+            instance_id: cluster_id,
         };
         let resp = match copy_to {
             None => resp,

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -108,7 +108,7 @@ impl Metrics {
             time_to_first_row_seconds: registry.register(metric! {
                 name: "mz_time_to_first_row_seconds",
                 help: "Latency of an execute for a successful query from pgwire's perspective",
-                var_labels: ["instance_id", "isolation_level"],
+                var_labels: ["instance_id", "isolation_level", "strategy"],
                 buckets: histogram_seconds_buckets(0.000_128, 32.0)
             }),
             statement_logging_unsampled_bytes: registry.register(metric!(

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -108,8 +108,8 @@ impl Metrics {
             time_to_first_row_seconds: registry.register(metric! {
                 name: "mz_time_to_first_row_seconds",
                 help: "Latency of an execute for a successful query from pgwire's perspective",
-                var_labels: ["isolation_level"],
-                buckets: histogram_seconds_buckets(0.000_128, 8.0)
+                var_labels: ["instance_id", "isolation_level"],
+                buckets: histogram_seconds_buckets(0.000_128, 32.0)
             }),
             statement_logging_unsampled_bytes: registry.register(metric!(
                 name: "mz_statement_logging_unsampled_bytes",

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1271,10 +1271,10 @@ async fn execute_stmt<S: ResultSender>(
             )
             .into()
         }
-        ExecuteResponse::SendingRows { future: mut rows, instance_id } => {
+        ExecuteResponse::SendingRows { future: mut rows, instance_id, strategy } => {
             let rows = match await_rows(sender, client, &mut rows).await? {
                 PeekResponseUnary::Rows(rows) => {
-                    RecordFirstRowStream::record(execute_started, client, Some(instance_id));
+                    RecordFirstRowStream::record(execute_started, client, Some(instance_id), Some(strategy));
                     rows
                 }
                 PeekResponseUnary::Error(e) => {
@@ -1299,6 +1299,7 @@ async fn execute_stmt<S: ResultSender>(
                 execute_started,
                 client,
                 Some(instance_id),
+                None,
             ),
             ctx_extra,
         },


### PR DESCRIPTION
Add cluster id, increase number of buckets, add execution strategy.

Fixes #25482
Fixes #20917

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a