### PR TITLE
explain: minor fixes

### DIFF
--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -478,9 +478,8 @@ impl MirRelationExpr {
             Project { outputs, input } => {
                 FmtNode {
                     fmt_root: |f, ctx| {
-                        // We deliberately don't print humanized indices because
-                        // in practice of our projection list are quite long.
-                        let outputs = Indices(outputs);
+                        let outputs = mode.seq(outputs, self.column_names(ctx));
+                        let outputs = CompactScalars(outputs);
                         write!(f, "{}Project ({})", ctx.indent, outputs)?;
                         self.fmt_attributes(f, ctx)
                     },

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -2292,105 +2292,109 @@ fn unnest_map<'a>(a: Datum<'a>) -> impl Iterator<Item = (Row, Diff)> + 'a {
         .map(move |(k, v)| (Row::pack_slice(&[Datum::from(k), v]), 1))
 }
 
+impl AggregateFunc {
+    /// The base function name without the `~[...]` suffix used when rendering
+    /// variants that represent a parameterized function family.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::MaxNumeric => "max",
+            Self::MaxInt16 => "max",
+            Self::MaxInt32 => "max",
+            Self::MaxInt64 => "max",
+            Self::MaxUInt16 => "max",
+            Self::MaxUInt32 => "max",
+            Self::MaxUInt64 => "max",
+            Self::MaxMzTimestamp => "max",
+            Self::MaxFloat32 => "max",
+            Self::MaxFloat64 => "max",
+            Self::MaxBool => "max",
+            Self::MaxString => "max",
+            Self::MaxDate => "max",
+            Self::MaxTimestamp => "max",
+            Self::MaxTimestampTz => "max",
+            Self::MaxInterval => "max",
+            Self::MaxTime => "max",
+            Self::MinNumeric => "min",
+            Self::MinInt16 => "min",
+            Self::MinInt32 => "min",
+            Self::MinInt64 => "min",
+            Self::MinUInt16 => "min",
+            Self::MinUInt32 => "min",
+            Self::MinUInt64 => "min",
+            Self::MinMzTimestamp => "min",
+            Self::MinFloat32 => "min",
+            Self::MinFloat64 => "min",
+            Self::MinBool => "min",
+            Self::MinString => "min",
+            Self::MinDate => "min",
+            Self::MinTimestamp => "min",
+            Self::MinTimestampTz => "min",
+            Self::MinInterval => "min",
+            Self::MinTime => "min",
+            Self::SumInt16 => "sum",
+            Self::SumInt32 => "sum",
+            Self::SumInt64 => "sum",
+            Self::SumUInt16 => "sum",
+            Self::SumUInt32 => "sum",
+            Self::SumUInt64 => "sum",
+            Self::SumFloat32 => "sum",
+            Self::SumFloat64 => "sum",
+            Self::SumNumeric => "sum",
+            Self::Count => "count",
+            Self::Any => "any",
+            Self::All => "all",
+            Self::JsonbAgg { .. } => "jsonb_agg",
+            Self::JsonbObjectAgg { .. } => "jsonb_object_agg",
+            Self::MapAgg { .. } => "map_agg",
+            Self::ArrayConcat { .. } => "array_agg",
+            Self::ListConcat { .. } => "list_agg",
+            Self::StringAgg { .. } => "string_agg",
+            Self::RowNumber { .. } => "row_number",
+            Self::Rank { .. } => "rank",
+            Self::DenseRank { .. } => "dense_rank",
+            Self::LagLead {
+                lag_lead: LagLeadType::Lag,
+                ..
+            } => "lag",
+            Self::LagLead {
+                lag_lead: LagLeadType::Lead,
+                ..
+            } => "lead",
+            Self::FirstValue { .. } => "first_value",
+            Self::LastValue { .. } => "last_value",
+            Self::WindowAggregate { .. } => "window_agg",
+            Self::Dummy => "dummy",
+        }
+    }
+}
+
 impl<'a, M> fmt::Display for HumanizedExpr<'a, AggregateFunc, M>
 where
     M: HumanizerMode,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use AggregateFunc::*;
+        let name = self.expr.name();
         match self.expr {
-            AggregateFunc::MaxNumeric => f.write_str("max"),
-            AggregateFunc::MaxInt16 => f.write_str("max"),
-            AggregateFunc::MaxInt32 => f.write_str("max"),
-            AggregateFunc::MaxInt64 => f.write_str("max"),
-            AggregateFunc::MaxUInt16 => f.write_str("max"),
-            AggregateFunc::MaxUInt32 => f.write_str("max"),
-            AggregateFunc::MaxUInt64 => f.write_str("max"),
-            AggregateFunc::MaxMzTimestamp => f.write_str("max"),
-            AggregateFunc::MaxFloat32 => f.write_str("max"),
-            AggregateFunc::MaxFloat64 => f.write_str("max"),
-            AggregateFunc::MaxBool => f.write_str("max"),
-            AggregateFunc::MaxString => f.write_str("max"),
-            AggregateFunc::MaxDate => f.write_str("max"),
-            AggregateFunc::MaxTimestamp => f.write_str("max"),
-            AggregateFunc::MaxTimestampTz => f.write_str("max"),
-            AggregateFunc::MaxInterval => f.write_str("max"),
-            AggregateFunc::MaxTime => f.write_str("max"),
-            AggregateFunc::MinNumeric => f.write_str("min"),
-            AggregateFunc::MinInt16 => f.write_str("min"),
-            AggregateFunc::MinInt32 => f.write_str("min"),
-            AggregateFunc::MinInt64 => f.write_str("min"),
-            AggregateFunc::MinUInt16 => f.write_str("min"),
-            AggregateFunc::MinUInt32 => f.write_str("min"),
-            AggregateFunc::MinUInt64 => f.write_str("min"),
-            AggregateFunc::MinMzTimestamp => f.write_str("min"),
-            AggregateFunc::MinFloat32 => f.write_str("min"),
-            AggregateFunc::MinFloat64 => f.write_str("min"),
-            AggregateFunc::MinBool => f.write_str("min"),
-            AggregateFunc::MinString => f.write_str("min"),
-            AggregateFunc::MinDate => f.write_str("min"),
-            AggregateFunc::MinTimestamp => f.write_str("min"),
-            AggregateFunc::MinTimestampTz => f.write_str("min"),
-            AggregateFunc::MinInterval => f.write_str("min"),
-            AggregateFunc::MinTime => f.write_str("min"),
-            AggregateFunc::SumInt16 => f.write_str("sum"),
-            AggregateFunc::SumInt32 => f.write_str("sum"),
-            AggregateFunc::SumInt64 => f.write_str("sum"),
-            AggregateFunc::SumUInt16 => f.write_str("sum"),
-            AggregateFunc::SumUInt32 => f.write_str("sum"),
-            AggregateFunc::SumUInt64 => f.write_str("sum"),
-            AggregateFunc::SumFloat32 => f.write_str("sum"),
-            AggregateFunc::SumFloat64 => f.write_str("sum"),
-            AggregateFunc::SumNumeric => f.write_str("sum"),
-            AggregateFunc::Count => f.write_str("count"),
-            AggregateFunc::Any => f.write_str("any"),
-            AggregateFunc::All => f.write_str("all"),
-            AggregateFunc::JsonbAgg { order_by } => {
+            JsonbAgg { order_by }
+            | JsonbObjectAgg { order_by }
+            | MapAgg { order_by, .. }
+            | ArrayConcat { order_by }
+            | ListConcat { order_by }
+            | StringAgg { order_by }
+            | RowNumber { order_by }
+            | Rank { order_by }
+            | DenseRank { order_by } => {
                 let order_by = order_by.iter().map(|col| self.child(col));
-                write!(f, "jsonb_agg[order_by=[{}]]", separated(", ", order_by))
+                write!(f, "{}[order_by=[{}]]", name, separated(", ", order_by))
             }
-            AggregateFunc::JsonbObjectAgg { order_by } => {
-                let order_by = order_by.iter().map(|col| self.child(col));
-                write!(
-                    f,
-                    "jsonb_object_agg[order_by=[{}]]",
-                    separated(", ", order_by)
-                )
-            }
-            AggregateFunc::MapAgg { order_by, .. } => {
-                let order_by = order_by.iter().map(|col| self.child(col));
-                write!(f, "map_agg[order_by=[{}]]", separated(", ", order_by))
-            }
-            AggregateFunc::ArrayConcat { order_by } => {
-                let order_by = order_by.iter().map(|col| self.child(col));
-                write!(f, "array_agg[order_by=[{}]]", separated(", ", order_by))
-            }
-            AggregateFunc::ListConcat { order_by } => {
-                let order_by = order_by.iter().map(|col| self.child(col));
-                write!(f, "list_agg[order_by=[{}]]", separated(", ", order_by))
-            }
-            AggregateFunc::StringAgg { order_by } => {
-                let order_by = order_by.iter().map(|col| self.child(col));
-                write!(f, "string_agg[order_by=[{}]]", separated(", ", order_by))
-            }
-            AggregateFunc::RowNumber { order_by } => {
-                let order_by = order_by.iter().map(|col| self.child(col));
-                write!(f, "row_number[order_by=[{}]]", separated(", ", order_by))
-            }
-            AggregateFunc::Rank { order_by } => {
-                let order_by = order_by.iter().map(|col| self.child(col));
-                write!(f, "rank[order_by=[{}]]", separated(", ", order_by))
-            }
-            AggregateFunc::DenseRank { order_by } => {
-                let order_by = order_by.iter().map(|col| self.child(col));
-                write!(f, "dense_rank[order_by=[{}]]", separated(", ", order_by))
-            }
-            AggregateFunc::LagLead {
-                lag_lead: LagLeadType::Lag,
+            LagLead {
+                lag_lead: _,
                 ignore_nulls,
                 order_by,
             } => {
                 let order_by = order_by.iter().map(|col| self.child(col));
-                f.write_str("lag")?;
+                f.write_str(name)?;
                 f.write_str("[")?;
                 if *ignore_nulls {
                     f.write_str("ignore_nulls=true, ")?;
@@ -2398,26 +2402,12 @@ where
                 write!(f, "order_by=[{}]", separated(", ", order_by))?;
                 f.write_str("]")
             }
-            AggregateFunc::LagLead {
-                lag_lead: LagLeadType::Lead,
-                ignore_nulls,
-                order_by,
-            } => {
-                let order_by = order_by.iter().map(|col| self.child(col));
-                f.write_str("lag")?;
-                f.write_str("[")?;
-                if *ignore_nulls {
-                    f.write_str("ignore_nulls=true, ")?;
-                }
-                write!(f, "order_by=[{}]", separated(", ", order_by))?;
-                f.write_str("]")
-            }
-            AggregateFunc::FirstValue {
+            FirstValue {
                 order_by,
                 window_frame,
             } => {
                 let order_by = order_by.iter().map(|col| self.child(col));
-                f.write_str("first_value")?;
+                f.write_str(name)?;
                 f.write_str("[")?;
                 write!(f, "order_by=[{}]", separated(", ", order_by))?;
                 if *window_frame != WindowFrame::default() {
@@ -2425,12 +2415,12 @@ where
                 }
                 f.write_str("]")
             }
-            AggregateFunc::LastValue {
+            LastValue {
                 order_by,
                 window_frame,
             } => {
                 let order_by = order_by.iter().map(|col| self.child(col));
-                f.write_str("last_value")?;
+                f.write_str(name)?;
                 f.write_str("[")?;
                 write!(f, "order_by=[{}]", separated(", ", order_by))?;
                 if *window_frame != WindowFrame::default() {
@@ -2438,14 +2428,14 @@ where
                 }
                 f.write_str("]")
             }
-            AggregateFunc::WindowAggregate {
+            WindowAggregate {
                 wrapped_aggregate,
                 order_by,
                 window_frame,
             } => {
                 let order_by = order_by.iter().map(|col| self.child(col));
                 let wrapped_aggregate = self.child(wrapped_aggregate.deref());
-                f.write_str("window_agg")?;
+                f.write_str(name)?;
                 f.write_str("[")?;
                 write!(f, "{} ", wrapped_aggregate)?;
                 write!(f, "order_by=[{}]", separated(", ", order_by))?;
@@ -2454,7 +2444,7 @@ where
                 }
                 f.write_str("]")
             }
-            AggregateFunc::Dummy => f.write_str("dummy"),
+            _ => f.write_str(name),
         }
     }
 }

--- a/src/transform/tests/test_transforms/column_names.spec
+++ b/src/transform/tests/test_transforms/column_names.spec
@@ -107,7 +107,7 @@ explain with=column_names
 Reduce group_by=[#0] aggregates=[min(#1), max(#1)]
   Get t0
 ----
-Reduce group_by=[#0] aggregates=[min(#1), max(#1)] // { column_names: "(c0, #1, #2)" }
+Reduce group_by=[#0] aggregates=[min(#1), max(#1)] // { column_names: "(c0, min_c1, max_c1)" }
   Get t0 // { column_names: "(c0, c1)" }
 
 # TopK

--- a/src/transform/tests/test_transforms/humanized_exprs.spec
+++ b/src/transform/tests/test_transforms/humanized_exprs.spec
@@ -67,7 +67,7 @@ explain with=humanized_exprs
 Project (#1, #0, #1)
   Get t0
 ----
-Project (#1, #0, #1)
+Project (#1{c0}, #0{c1}, #1{c0})
   Get t0
 
 # Map

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -54,6 +54,20 @@ statement ok
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM t WHERE a IS NOT NULL;
 
+statement ok
+CREATE MATERIALIZED VIEW non_empty_mv AS
+SELECT 1 as x, 2 as y;
+
+statement ok
+CREATE INDEX non_empty_mv_idx ON non_empty_mv(y + 7);
+
+statement ok
+CREATE MATERIALIZED VIEW empty_mv AS
+SELECT;
+
+statement ok
+CREATE INDEX empty_mv_idx ON empty_mv();
+
 mode cockroach
 
 # Test target cluster selection for mz_system tables without transactions.
@@ -133,6 +147,37 @@ Target cluster: mz_introspection
 
 EOF
 
+# Test fast path rendering on a non-trivial index.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS TEXT FOR
+SELECT * FROM non_empty_mv where y + 7 = 9
+----
+Explained Query (fast path):
+  Project (#1{x}, #2{y})
+    ReadIndex on=materialize.public.non_empty_mv non_empty_mv_idx=[lookup value=(9)]
+
+Used Indexes:
+  - materialize.public.non_empty_mv_idx (lookup)
+
+Target cluster: quickstart
+
+EOF
+
+# Test fast path rendering on an empty index on an empty relation.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS TEXT FOR
+SELECT * FROM empty_mv
+----
+Explained Query (fast path):
+  ReadIndex on=materialize.public.empty_mv empty_mv_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.empty_mv_idx (*** full scan ***)
+
+Target cluster: quickstart
+
+EOF
+
 # Test basic linear chains (fast path).
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS TEXT FOR
@@ -195,7 +240,7 @@ Explained Query:
   Threshold
     Union
       Distinct project=[#0{a}]
-        Project (#0)
+        Project (#0{a})
           ReadIndex on=t t_a_idx=[*** full scan ***]
       Negate
         Distinct project=[#0{b}]
@@ -217,7 +262,7 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 Explained Query:
   Threshold
     Union
-      Project (#0)
+      Project (#0{a})
         ReadIndex on=t t_a_idx=[*** full scan ***]
       Negate
         Project (#1)
@@ -283,7 +328,7 @@ Explained Query:
   With
     cte l0 =
       Reduce aggregates=[min(#0{a}), max(#0{a})]
-        Project (#0)
+        Project (#0{a})
           ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Used Indexes:
@@ -318,13 +363,13 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
 ----
 Explained Query:
   Return
-    Project (#0, #1)
+    Project (#0{a}, #1{b})
       Join on=(#1{b} = #2{b}) type=differential
         ArrangeBy keys=[[#1{b}]]
           Get l0
         ArrangeBy keys=[[#0{b}]]
           Distinct project=[#0{b}]
-            Project (#0)
+            Project (#0{b})
               Filter (#0{b} > #1{b})
                 CrossJoin type=differential
                   ArrangeBy keys=[[]]
@@ -336,21 +381,21 @@ Explained Query:
                       ReadStorage materialize.public.mv
   With
     cte l0 =
-      Project (#0, #1)
+      Project (#0{a}, #1{b})
         Join on=(#0{a} = #2{a}) type=differential
           ArrangeBy keys=[[#0{a}]]
             ReadIndex on=t t_a_idx=[differential join]
           ArrangeBy keys=[[#0{a}]]
             Distinct project=[#0{a}]
-              Project (#0)
+              Project (#0{a})
                 Filter (#0{a} < #1{a})
                   CrossJoin type=differential
                     ArrangeBy keys=[[]]
                       Distinct project=[#0{a}]
-                        Project (#0)
+                        Project (#0{a})
                           ReadIndex on=t t_a_idx=[*** full scan ***]
                     ArrangeBy keys=[[]]
-                      Project (#0)
+                      Project (#0{a})
                         ReadStorage materialize.public.mv
 
 Used Indexes:
@@ -377,7 +422,7 @@ Explained Query:
             Map (null)
               Union
                 Negate
-                  Project (#0)
+                  Project (#0{b})
                     Get l3
                 Get l1
         ArrangeBy keys=[[#0{b}]]
@@ -386,13 +431,13 @@ Explained Query:
             Map (null)
               Union
                 Negate
-                  Project (#0)
+                  Project (#0{b})
                     Get l4
                 Get l1
   With
     cte l4 =
       TopK group_by=[#0{b}] limit=1
-        Project (#0, #1)
+        Project (#0{b}, #1{a})
           Filter (#0{b}) IS NOT NULL
             Join on=(#0{b} = #2{b}) type=differential
               Get l2
@@ -401,7 +446,7 @@ Explained Query:
                   ReadStorage materialize.public.mv
     cte l3 =
       TopK group_by=[#0{b}] limit=1
-        Project (#0, #1)
+        Project (#0{b}, #1{a})
           Filter (#0{b}) IS NOT NULL
             Join on=(#0{b} = #2{b}) type=differential
               Get l2
@@ -453,11 +498,11 @@ Explained Query:
                       Get l2
           Project ()
             ReadIndex on=t t_a_idx=[*** full scan ***]
-      Project (#0, #2)
+      Project (#0{a}, #2)
         Get l2
   With
     cte l2 =
-      Project (#0..=#2)
+      Project (#0{a}..=#2{a})
         Join on=(#1{b} = #3{b} = #4{b}) type=delta
           Get l1
           Get l1
@@ -598,7 +643,7 @@ FROM
 ----
 Explained Query:
   Return
-    Project (#0..=#2, #4)
+    Project (#0{a}..=#2{max}, #4)
       Filter (#0{a} != #4{max})
         Join on=(#0{a} = #3{a}) type=differential
           ArrangeBy keys=[[#0{a}]]
@@ -608,12 +653,12 @@ Explained Query:
               CrossJoin type=differential
                 ArrangeBy keys=[[]]
                   Distinct project=[#0{a}]
-                    Project (#0)
+                    Project (#0{a})
                       Get l2
                 Get l1
   With
     cte l2 =
-      Project (#0, #1, #3)
+      Project (#0{a}, #1{b}, #3)
         Filter (#0{a} != #3{max})
           Join on=(#0{a} = #2{a}) type=differential
             ArrangeBy keys=[[#0{a}]]
@@ -629,7 +674,7 @@ Explained Query:
       ArrangeBy keys=[[]]
         Get l0
     cte l0 =
-      Project (#0)
+      Project (#0{a})
         ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Used Indexes:
@@ -652,7 +697,7 @@ Explained Query:
   With
     cte l0 =
       ArrangeBy keys=[[]]
-        Project (#0)
+        Project (#0{a})
           ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Used Indexes:
@@ -674,7 +719,7 @@ WHERE t1.b = t2.b AND t2.b = t3.b
 ----
 Explained Query:
   Return
-    Project (#0, #2)
+    Project (#0{a}, #2)
       Join on=(#1{b} = #3{b} = #4{b}) type=delta
         Get l1
         Get l1
@@ -715,7 +760,7 @@ FROM t, u, v
 WHERE a = c and d = e and b = f
 ----
 Explained Query:
-  Project (#0, #1, #0, #3, #3, #1)
+  Project (#0{a}, #1{b}, #0{a}, #3{d}, #3{d}, #1{b})
     Filter (#0{a}) IS NOT NULL AND (#3{d}) IS NOT NULL
       Join on=(#0{a} = #2{c} AND #1{b} = #5{f} AND #3{d} = #4{e}) type=delta
         ArrangeBy keys=[[#0{a}], [#0{a}, #1{b}]]
@@ -745,7 +790,7 @@ FROM t, u, v
 WHERE a = c and d = e and b = f
 ----
 Explained Query:
-  Project (#0, #1, #0, #3, #3, #1)
+  Project (#0{a}, #1{b}, #0{a}, #3{d}, #3{d}, #1{b})
     Filter (#0{a}) IS NOT NULL AND (#3{d}) IS NOT NULL
       Join on=(#0{a} = #2{c} AND #1{b} = #5{f} AND #3{d} = #4{e}) type=delta
         implementation
@@ -784,7 +829,7 @@ FROM t, u, v
 WHERE b = c and d = e
 ----
 Explained Query:
-  Project (#0, #1, #1, #3, #3, #5)
+  Project (#0{a}, #1{b}, #1{b}, #3{d}, #3{d}, #5{f})
     Filter (#1{b}) IS NOT NULL AND (#3{d}) IS NOT NULL
       Join on=(#1{b} = #2{c} AND #3{d} = #4{e}) type=delta
         ArrangeBy keys=[[#1{b}]]
@@ -845,7 +890,7 @@ WHERE a = 0
 GROUP BY a
 ----
 Explained Query:
-  Project (#1, #0)
+  Project (#1{max_b}, #0)
     Map (0)
       Reduce aggregates=[max(#0{b})]
         Project (#1)
@@ -1063,7 +1108,7 @@ FROM t, u
 WHERE t.b = u.c;
 ----
 Explained Query:
-  Project (#0, #1, #1, #3)
+  Project (#0{a}, #1{b}, #1{b}, #3{d})
     Filter (#1{b}) IS NOT NULL
       Join on=(#1{b} = #2{c}) type=differential
         ArrangeBy keys=[[#1{b}]]
@@ -1089,7 +1134,7 @@ FROM t, u
 WHERE t.b = u.d;
 ----
 Explained Query:
-  Project (#0..=#2, #1)
+  Project (#0{a}..=#2{c}, #1{b})
     Filter (#1{b}) IS NOT NULL
       Join on=(#1{b} = #3{d}) type=differential
         ArrangeBy keys=[[#1{b}]]
@@ -1126,7 +1171,7 @@ FROM t, u
 WHERE t.a = u.c
 ----
 Explained Query:
-  Project (#0, #1, #0, #3)
+  Project (#0{a}, #1{b}, #0{a}, #3{d})
     Filter (#0{a}) IS NOT NULL
       Join on=(#0{a} = #2{c}) type=differential
         ArrangeBy keys=[[#0{a}]]
@@ -1152,7 +1197,7 @@ WHERE t1.a = t2.a AND t2.a = t3.a;
 ----
 Explained Query:
   Return
-    Project (#0, #1, #0, #3, #0, #5)
+    Project (#0{a}, #1{b}, #0{a}, #3{b}, #0{a}, #5{b})
       Filter (#0{a}) IS NOT NULL
         Join on=(#0{a} = #2{a} = #4{a}) type=delta
           Get l0
@@ -1328,7 +1373,7 @@ Explained Query:
   Distinct project=[#0{a}, #1{b}]
     Union
       ReadIndex on=t t_a_idx_2=[*** full scan ***]
-      Project (#0, #1)
+      Project (#0{a}, #1{b})
         ReadIndex on=materialize.public.t t_a_idx_2=[lookup value=(5)]
 
 Used Indexes:
@@ -1358,13 +1403,13 @@ SELECT * FROM u WHERE d = 1;
 Explained Query:
   Union
     ReadIndex on=t t_b_idx=[*** full scan ***]
-    Project (#0, #1)
+    Project (#0{a}, #1{b})
       ReadIndex on=materialize.public.t t_b_idx=[lookup value=(7)]
-    Project (#0, #1)
+    Project (#0{a}, #1{b})
       ReadIndex on=materialize.public.t t_a_idx_2=[lookup value=(5)]
     Filter (#0{c} = 3)
       ReadIndex on=u u_d=[*** full scan ***]
-    Project (#0, #1)
+    Project (#0{c}, #1{d})
       ReadIndex on=materialize.public.u u_d=[lookup value=(1)]
 
 Used Indexes:
@@ -1463,7 +1508,7 @@ EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS TEXT FOR
 SELECT * FROM t4;
 ----
 Explained Query (fast path):
-  Project (#1, #0, #2)
+  Project (#1{a}, #0{b}, #2{c})
     ReadIndex on=materialize.public.t4 t4_idx_b=[*** full scan ***]
 
 Used Indexes:

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -270,7 +270,7 @@ SELECT abs(min(a) - max(a)) FROM t
 Explained Query:
   Return
     Project (#2)
-      Map (abs((#0 - #1)))
+      Map (abs((#0{min_a} - #1{max_a})))
         Union
           Get l0
           Map (null, null)
@@ -300,7 +300,7 @@ SELECT abs(min(a) - max(a)) FROM t GROUP BY b
 ----
 Explained Query:
   Project (#3)
-    Map (abs((#1 - #2)))
+    Map (abs((#1{min_a} - #2{max_a})))
       Reduce group_by=[#1{b}] aggregates=[min(#0{a}), max(#0{a})]
         ReadIndex on=t t_a_idx=[*** full scan ***]
 
@@ -599,7 +599,7 @@ FROM
 Explained Query:
   Return
     Project (#0..=#2, #4)
-      Filter (#0{a} != #4)
+      Filter (#0{a} != #4{max})
         Join on=(#0{a} = #3{a}) type=differential
           ArrangeBy keys=[[#0{a}]]
             Get l2
@@ -614,7 +614,7 @@ Explained Query:
   With
     cte l2 =
       Project (#0, #1, #3)
-        Filter (#0{a} != #3)
+        Filter (#0{a} != #3{max})
           Join on=(#0{a} = #2{a}) type=differential
             ArrangeBy keys=[[#0{a}]]
               ReadIndex on=t t_a_idx=[differential join]
@@ -1010,7 +1010,7 @@ FROM t1;
 Explained Query:
   Project (#2)
     Map (record_get[0](#1))
-      FlatMap unnest_list(#0)
+      FlatMap unnest_list(#0{lag})
         Reduce aggregates=[lag[ignore_nulls=true, order_by=[#0{x} asc nulls_last]](row(row(row(#0{x}), row(#0{x}, 3, "default")), (#0{x} || #0{x})))]
           ReadStorage materialize.public.t1
 
@@ -1026,7 +1026,7 @@ FROM t1;
 Explained Query:
   Project (#2)
     Map (record_get[0](#1))
-      FlatMap unnest_list(#0)
+      FlatMap unnest_list(#0{first_value})
         Reduce aggregates=[first_value[order_by=[#0{x} asc nulls_last] rows between 5 preceding and current row](row(row(row(#0{x}), #0{x}), (#0{x} || #0{x})))]
           ReadStorage materialize.public.t1
 

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -203,7 +203,7 @@ Explained Query:
   With
     cte l0 =
       Reduce aggregates=[min(#0{a}), max(#0{a})]
-        Project (#0)
+        Project (#0{a})
           ReadIndex on=t t_a_idx=[*** full scan ***]
 
 Used Indexes:
@@ -238,13 +238,13 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
 ----
 Explained Query:
   Return
-    Project (#0, #1)
+    Project (#0{a}, #1{b})
       Join on=(#1{b} = #2{b}) type=differential
         ArrangeBy keys=[[#1{b}]]
           Get l0
         ArrangeBy keys=[[#0{b}]]
           Distinct project=[#0{b}]
-            Project (#0)
+            Project (#0{b})
               Filter (#0{b} > #1{b})
                 CrossJoin type=differential
                   ArrangeBy keys=[[]]
@@ -256,21 +256,21 @@ Explained Query:
                       ReadStorage materialize.public.mv
   With
     cte l0 =
-      Project (#0, #1)
+      Project (#0{a}, #1{b})
         Join on=(#0{a} = #2{a}) type=differential
           ArrangeBy keys=[[#0{a}]]
             ReadIndex on=t t_a_idx=[differential join]
           ArrangeBy keys=[[#0{a}]]
             Distinct project=[#0{a}]
-              Project (#0)
+              Project (#0{a})
                 Filter (#0{a} < #1{a})
                   CrossJoin type=differential
                     ArrangeBy keys=[[]]
                       Distinct project=[#0{a}]
-                        Project (#0)
+                        Project (#0{a})
                           ReadIndex on=t t_a_idx=[*** full scan ***]
                     ArrangeBy keys=[[]]
-                      Project (#0)
+                      Project (#0{a})
                         ReadStorage materialize.public.mv
 
 Used Indexes:
@@ -297,7 +297,7 @@ Explained Query:
             Map (█)
               Union
                 Negate
-                  Project (#0)
+                  Project (#0{b})
                     Get l3
                 Get l1
         ArrangeBy keys=[[#0{b}]]
@@ -306,13 +306,13 @@ Explained Query:
             Map (█)
               Union
                 Negate
-                  Project (#0)
+                  Project (#0{b})
                     Get l4
                 Get l1
   With
     cte l4 =
       TopK group_by=[#0{b}] limit=█
-        Project (#0, #1)
+        Project (#0{b}, #1{a})
           Filter (#0{b}) IS NOT NULL
             Join on=(#0{b} = #2{b}) type=differential
               Get l2
@@ -321,7 +321,7 @@ Explained Query:
                   ReadStorage materialize.public.mv
     cte l3 =
       TopK group_by=[#0{b}] limit=█
-        Project (#0, #1)
+        Project (#0{b}, #1{a})
           Filter (#0{b}) IS NOT NULL
             Join on=(#0{b} = #2{b}) type=differential
               Get l2
@@ -373,11 +373,11 @@ Explained Query:
                       Get l2
           Project ()
             ReadIndex on=t t_a_idx=[*** full scan ***]
-      Project (#0, #2)
+      Project (#0{a}, #2)
         Get l2
   With
     cte l2 =
-      Project (#0..=#2)
+      Project (#0{a}..=#2{a})
         Join on=(#1{b} = #3{b} = #4{b}) type=delta
           Get l1
           Get l1
@@ -407,7 +407,7 @@ WHERE a = 0
 GROUP BY a
 ----
 Explained Query:
-  Project (#1, #0)
+  Project (#1{max_b}, #0)
     Map (█)
       Reduce aggregates=[max(#0{b})]
         Project (#1)
@@ -625,7 +625,7 @@ FROM t, u
 WHERE t.b = u.c;
 ----
 Explained Query:
-  Project (#0, #1, #1, #3)
+  Project (#0{a}, #1{b}, #1{b}, #3{d})
     Filter (#1{b}) IS NOT NULL
       Join on=(#1{b} = #2{c}) type=differential
         ArrangeBy keys=[[#1{b}]]
@@ -651,7 +651,7 @@ FROM t, u
 WHERE t.b = u.d;
 ----
 Explained Query:
-  Project (#0..=#2, #1)
+  Project (#0{a}..=#2{c}, #1{b})
     Filter (#1{b}) IS NOT NULL
       Join on=(#1{b} = #3{d}) type=differential
         ArrangeBy keys=[[#1{b}]]
@@ -688,7 +688,7 @@ FROM t, u
 WHERE t.a = u.c
 ----
 Explained Query:
-  Project (#0, #1, #0, #3)
+  Project (#0{a}, #1{b}, #0{a}, #3{d})
     Filter (#0{a}) IS NOT NULL
       Join on=(#0{a} = #2{c}) type=differential
         ArrangeBy keys=[[#0{a}]]
@@ -714,7 +714,7 @@ WHERE t1.a = t2.a AND t2.a = t3.a;
 ----
 Explained Query:
   Return
-    Project (#0, #1, #0, #3, #0, #5)
+    Project (#0{a}, #1{b}, #0{a}, #3{b}, #0{a}, #5{b})
       Filter (#0{a}) IS NOT NULL
         Join on=(#0{a} = #2{a} = #4{a}) type=delta
           Get l0
@@ -890,7 +890,7 @@ Explained Query:
   Distinct project=[#0{a}, #1{b}]
     Union
       ReadIndex on=t t_a_idx_2=[*** full scan ***]
-      Project (#0, #1)
+      Project (#0{a}, #1{b})
         ReadIndex on=materialize.public.t t_a_idx_2=[lookup value=(█)]
 
 Used Indexes:
@@ -920,13 +920,13 @@ SELECT * FROM u WHERE d = 1;
 Explained Query:
   Union
     ReadIndex on=t t_b_idx=[*** full scan ***]
-    Project (#0, #1)
+    Project (#0{a}, #1{b})
       ReadIndex on=materialize.public.t t_b_idx=[lookup value=(█)]
-    Project (#0, #1)
+    Project (#0{a}, #1{b})
       ReadIndex on=materialize.public.t t_a_idx_2=[lookup value=(█)]
     Filter (#0{c} = █)
       ReadIndex on=u u_d=[*** full scan ***]
-    Project (#0, #1)
+    Project (#0{c}, #1{d})
       ReadIndex on=materialize.public.u u_d=[lookup value=(█)]
 
 Used Indexes:

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -190,7 +190,7 @@ SELECT abs(min(a) - max(a)) FROM t
 Explained Query:
   Return
     Project (#2)
-      Map (abs((#0 - #1)))
+      Map (abs((#0{min_a} - #1{max_a})))
         Union
           Get l0
           Map (█, █)
@@ -220,7 +220,7 @@ SELECT abs(min(a) - max(a)) FROM t GROUP BY b
 ----
 Explained Query:
   Project (#3)
-    Map (abs((#1 - #2)))
+    Map (abs((#1{min_a} - #2{max_a})))
       Reduce group_by=[#1{b}] aggregates=[min(#0{a}), max(#0{a})]
         ReadIndex on=t t_a_idx=[*** full scan ***]
 
@@ -572,7 +572,7 @@ FROM t1;
 Explained Query:
   Project (#2)
     Map (record_get[0](#1))
-      FlatMap unnest_list(#0)
+      FlatMap unnest_list(#0{lag})
         Reduce aggregates=[lag[ignore_nulls=true, order_by=[#0{x} asc nulls_last]](row(row(row(#0{x}), row(#0{x}, █, █)), (#0{x} || #0{x})))]
           ReadStorage materialize.public.t1
 
@@ -588,7 +588,7 @@ FROM t1;
 Explained Query:
   Project (#2)
     Map (record_get[0](#1))
-      FlatMap unnest_list(#0)
+      FlatMap unnest_list(#0{first_value})
         Reduce aggregates=[first_value[order_by=[#0{x} asc nulls_last] rows between 5 preceding and current row](row(row(row(#0{x}), #0{x}), (#0{x} || #0{x})))]
           ReadStorage materialize.public.t1
 

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -1385,7 +1385,7 @@ Explained Query:
       map=(record_get[0](#1))
     input_key=
     Reduce::Basic
-      aggr=(0, lag[ignore_nulls=true, order_by=[]](row(row(row(#0, #1), row(#1, 3, -5)))))
+      aggr=(0, lead[ignore_nulls=true, order_by=[]](row(row(row(#0, #1), row(#1, 3, -5)))))
       val_plan
         project=(#2)
         map=(row(row(row(#0, #1), row(#1, 3, -5))))

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -1370,7 +1370,7 @@ Explained Query:
       map=(record_get[0](#1))
     input_key=
     Reduce::Basic
-      aggr=(0, lag[ignore_nulls=true, order_by=[]](row(row(row(#0, #1), row(#1, █, █)))))
+      aggr=(0, lead[ignore_nulls=true, order_by=[]](row(row(row(#0, #1), row(#1, █, █)))))
       val_plan
         project=(#2)
         map=(row(row(row(#0, #1), row(#1, █, █))))

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -69,7 +69,7 @@ WHERE mz_now() >= 10000 * (insert_ms / 10000)
   AND mz_now() < 10000 * (1 + insert_ms / 10000)
 ----
 Explained Query:
-  Project (#0, #1)
+  Project (#0{content}, #1{insert_ms})
     Filter (mz_now() >= numeric_to_mz_timestamp((10000 * #3))) AND (mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3))))
       Map ((#1{insert_ms} / 10000))
         ReadStorage materialize.public.events
@@ -94,7 +94,7 @@ WHERE mz_now() >= 10000 * (insert_ms / 10000)
   AND mz_now() < 6 * (10000 + insert_ms / 10000)
 ----
 Explained Query:
-  Project (#0, #1)
+  Project (#0{content}, #1{insert_ms})
     Filter (mz_now() >= numeric_to_mz_timestamp((10000 * #3))) AND (mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3))))
       Map ((#1{insert_ms} / 10000))
         ReadStorage materialize.public.events
@@ -120,7 +120,7 @@ WHERE mz_now() >= insert_ms
   AND mz_now() < insert_ms + 30000
 ----
 Explained Query:
-  Project (#0, #1)
+  Project (#0{content}, #1{insert_ms})
     Filter (mz_now() >= numeric_to_mz_timestamp(#1{insert_ms})) AND (mz_now() < numeric_to_mz_timestamp((#1{insert_ms} + 30000)))
       ReadStorage materialize.public.events
 
@@ -214,7 +214,7 @@ FROM events_timestamped
 WHERE EXTRACT(YEAR FROM inserted_at) = 2021;
 ----
 Explained Query:
-  Project (#0, #1)
+  Project (#0{content}, #1{inserted_at})
     Filter (2021 = extract_year_ts(#1{inserted_at}))
       ReadStorage materialize.public.events_timestamped
 
@@ -236,7 +236,7 @@ FROM events_timestamped
 WHERE mz_now() < try_parse_monotonic_iso8601_timestamp(content);
 ----
 Explained Query:
-  Project (#0, #1)
+  Project (#0{content}, #1{inserted_at})
     Filter (mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(#0{content})))
       ReadStorage materialize.public.events_timestamped
 

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -443,7 +443,7 @@ Explained Query:
   Finish order_by=[#0 desc nulls_first, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#6]
     Return // { arity: 7 }
       Project (#0..=#2, #4, #7, #5, #8) // { arity: 7 }
-        Map ((#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end)), (bigint_to_numeric(#4) / #3)) // { arity: 9 }
+        Map ((#5{sum} / bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end)), (bigint_to_numeric(#4{count}) / #3)) // { arity: 9 }
           Reduce group_by=[#1..=#4] aggregates=[count(*), sum(integer_to_bigint(#0{length})), count(integer_to_bigint(#0{length}))] // { arity: 7 }
             CrossJoin type=differential // { arity: 5 }
               implementation
@@ -455,7 +455,7 @@ Explained Query:
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
               ArrangeBy keys=[[]] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Map ((0 + bigint_to_numeric(#0))) // { arity: 2 }
+                  Map ((0 + bigint_to_numeric(#0{count}))) // { arity: 2 }
                     Union // { arity: 1 }
                       Get l0 // { arity: 1 }
                       Map (0) // { arity: 1 }
@@ -520,7 +520,7 @@ Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #3..=#5) // { arity: 4 }
-        Map (coalesce(#1, 0), coalesce(#2, 0), abs((#3 - #4))) // { arity: 6 }
+        Map (coalesce(#1{count}, 0), coalesce(#2{count}, 0), abs((#3 - #4))) // { arity: 6 }
           Union // { arity: 3 }
             Map (null, null) // { arity: 3 }
               Union // { arity: 1 }
@@ -615,7 +615,7 @@ ORDER BY messageCount DESC, Forum.id
 LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
+  Finish order_by=[#4{count} desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
     Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
       Project (#10, #13, #15, #16) // { arity: 4 }
         Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#25{locationcityid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
@@ -742,7 +742,7 @@ ORDER BY messageCount DESC, au.id
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
+  Finish order_by=[#4{count_messageid} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
       Reduce group_by=[#1{id}..=#3{lastname}, #0{creationdate}] aggregates=[count(#4{messageid})] // { arity: 5 }
         Union // { arity: 5 }
@@ -860,8 +860,8 @@ SELECT CreatorPersonId AS "person.id"
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
-      Map (((bigint_to_numeric((1 * #3)) + (2 * #1)) + (10 * #2))) // { arity: 5 }
-        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1 end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3 end, 0)), count(*)] // { arity: 4 }
+      Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
           Project (#1, #3, #4, #6, #7) // { arity: 5 }
             Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
               implementation
@@ -986,7 +986,7 @@ LIMIT 100
 ;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
         Union // { arity: 2 }
@@ -1093,7 +1093,7 @@ ORDER BY authorityScore DESC, pl.person1id ASC
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
         Union // { arity: 2 }
@@ -1201,7 +1201,7 @@ ORDER BY authorityScore DESC, pl.person1id ASC
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
         Union // { arity: 2 }
@@ -1319,7 +1319,7 @@ SELECT RelatedTag.name AS "relatedTag.name"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1{count} desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{name}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -1442,7 +1442,7 @@ SELECT p.PersonId AS "person.id"
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1, #3]
     Return // { arity: 5 }
-      Map (coalesce(#2, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
+      Map (coalesce(#2{sum}, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
         Reduce group_by=[#0, #1] aggregates=[sum(case when (#3) IS NULL then null else #2 end)] // { arity: 3 }
           Project (#0, #1, #6, #7) // { arity: 4 }
             Join on=(#0 = #2{person1id} AND #5{person2id} = case when (#4) IS NULL then null else #3{person2id} end) type=delta // { arity: 8 }
@@ -1490,7 +1490,7 @@ Explained Query:
     With
       cte l7 =
         Project (#3, #4) // { arity: 2 }
-          Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2, 0))) // { arity: 5 }
+          Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2{count}, 0))) // { arity: 5 }
             Union // { arity: 3 }
               Project (#2, #0, #1) // { arity: 3 }
                 Map (null) // { arity: 3 }
@@ -1602,8 +1602,8 @@ SELECT Person.id AS "person.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
-    Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3)] // { arity: 5 }
+  Finish order_by=[#4{sum_count} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
+    Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3{count})] // { arity: 5 }
       Project (#1..=#3, #25) // { arity: 4 }
         Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
@@ -1712,7 +1712,7 @@ SELECT m.friendId AS "person.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#2 desc nulls_first, #1{name} asc nulls_last, #0{person2id} asc nulls_last] limit=100 output=[#0..=#2]
+  Finish order_by=[#2{count} desc nulls_first, #1{name} asc nulls_last, #0{person2id} asc nulls_last] limit=100 output=[#0..=#2]
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
         Project (#0, #9) // { arity: 2 }
@@ -1950,9 +1950,9 @@ SELECT *
 ORDER BY personCount DESC, messageCount DESC
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 desc nulls_first] output=[#0, #1]
+  Finish order_by=[#1{count} desc nulls_first, #0{count_messageid} desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+      Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
           Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
@@ -2018,9 +2018,9 @@ SELECT *
 ORDER BY personCount DESC, messageCount DESC
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 desc nulls_first] output=[#0, #1]
+  Finish order_by=[#1{count} desc nulls_first, #0{count_messageid} desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+      Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
           Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
@@ -2121,7 +2121,7 @@ Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #3..=#5) // { arity: 4 }
-        Map (coalesce(#2, 0), coalesce(#1, 0), case when (#1 > 0) then (bigint_to_double(#2) / bigint_to_double(#1)) else 0 end) // { arity: 6 }
+        Map (coalesce(#2{sum}, 0), coalesce(#1{count}, 0), case when (#1{count} > 0) then (bigint_to_double(#2{sum}) / bigint_to_double(#1{count})) else 0 end) // { arity: 6 }
           Union // { arity: 3 }
             Map (null, null) // { arity: 3 }
               Union // { arity: 1 }
@@ -2192,7 +2192,7 @@ Explained Query:
           Get l2 // { arity: 1 }
       cte l2 =
         Project (#0) // { arity: 1 }
-          Filter (bigint_to_numeric(#2) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
+          Filter (bigint_to_numeric(#2{count_messageid}) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
             Reduce group_by=[#1{id}, #0{creationdate}] aggregates=[count(#2{messageid})] // { arity: 3 }
               Union // { arity: 3 }
                 Project (#6, #7, #16) // { arity: 3 }
@@ -2322,10 +2322,10 @@ SELECT score_ranks.Person1Id AS "person1.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=100 output=[#0..=#3]
+  Finish order_by=[#3{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #1, #3, #4) // { arity: 4 }
-        TopK group_by=[#2{id}] order_by=[#4 desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
+        TopK group_by=[#2{id}] order_by=[#4{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Map (null) // { arity: 5 }
               Union // { arity: 4 }
@@ -2541,10 +2541,10 @@ EXPLAIN WITH(humanized expressions, arity, join implementations) WITH
 SELECT coalesce(w, -1) FROM results ORDER BY w ASC LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#1 asc nulls_last] limit=20 output=[#2]
+  Finish order_by=[#1{min} asc nulls_last] limit=20 output=[#2]
     Return // { arity: 3 }
       Project (#1, #2, #2) // { arity: 3 }
-        Filter (#1{person2id} = 15393162796819) AND (#2 = #2) // { arity: 3 }
+        Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
           Get l4 // { arity: 3 }
     With Mutually Recursive
       cte l4 =
@@ -2563,7 +2563,7 @@ Explained Query:
                             Get l4 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0, #1, #3) // { arity: 3 }
-                            Map ((10 / bigint_to_double((coalesce(#2, 0) + 10)))) // { arity: 4 }
+                            Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
                               Union // { arity: 3 }
                                 Map (null) // { arity: 3 }
                                   Union // { arity: 2 }
@@ -2769,7 +2769,7 @@ Explained Query:
   Return // { arity: 1 }
     Return // { arity: 1 }
       Project (#1) // { arity: 1 }
-        Map (coalesce(#0, -1)) // { arity: 2 }
+        Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
           Union // { arity: 1 }
             Get l18 // { arity: 1 }
             Map (null) // { arity: 1 }
@@ -2781,7 +2781,7 @@ Explained Query:
                   - ()
     With
       cte l18 =
-        Reduce aggregates=[min(#0)] // { arity: 1 }
+        Reduce aggregates=[min(#0{min})] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
@@ -2798,15 +2798,15 @@ Explained Query:
                         Get l17 // { arity: 4 }
       cte l17 =
         Project (#0..=#3) // { arity: 4 }
-          Join on=(#4 = #5) type=differential // { arity: 6 }
+          Join on=(#4 = #5{max}) type=differential // { arity: 6 }
             implementation
               %1[#0]UK » %0:l16[#4]K
             ArrangeBy keys=[[#4]] // { arity: 5 }
               Project (#0..=#3, #5) // { arity: 5 }
                 Filter (#5) IS NOT NULL // { arity: 6 }
                   Get l16 // { arity: 6 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
+            ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+              Filter (#0{max}) IS NOT NULL // { arity: 1 }
                 Reduce aggregates=[max(#0)] // { arity: 1 }
                   Project (#5) // { arity: 1 }
                     Get l16 // { arity: 6 }
@@ -2851,7 +2851,7 @@ Explained Query:
             Get l8 // { arity: 2 }
     cte l14 =
       Project (#1) // { arity: 1 }
-        Map ((#0 / 2)) // { arity: 2 }
+        Map ((#0{min} / 2)) // { arity: 2 }
           Union // { arity: 1 }
             Get l13 // { arity: 1 }
             Map (null) // { arity: 1 }
@@ -2986,7 +2986,7 @@ Explained Query:
               Get l4 // { arity: 3 }
     cte l4 =
       Project (#0, #1, #3) // { arity: 3 }
-        Map ((10 / bigint_to_double((coalesce(#2, 0) + 10)))) // { arity: 4 }
+        Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
           Union // { arity: 3 }
             Map (null) // { arity: 3 }
               Union // { arity: 2 }
@@ -3158,8 +3158,8 @@ Explained Query:
   Finish order_by=[#6 desc nulls_first, #0{id} asc nulls_last] limit=20 output=[#0, #1, #4]
     Return // { arity: 7 }
       Project (#0..=#2, #0, #4..=#6) // { arity: 7 }
-        Filter (#2 <= 5) AND (#5 <= 5) // { arity: 7 }
-          Map ((#1 + #4)) // { arity: 7 }
+        Filter (#2{count_person2id} <= 5) AND (#5{count_person2id} <= 5) // { arity: 7 }
+          Map ((#1{count_messageid} + #4{count_messageid})) // { arity: 7 }
             Join on=(#0{id} = #3{id}) type=differential // { arity: 6 }
               implementation
                 %0[#0]UKAif » %1[#0]UKAiif
@@ -3332,7 +3332,7 @@ ORDER BY messageCount DESC, Message1.CreatorPersonId ASC
 LIMIT 10
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
+  Finish order_by=[#1{count_messageid} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
@@ -3452,7 +3452,7 @@ ORDER BY mutualFriendCount DESC, k1.InterestedId ASC, k2.InterestedId ASC
 LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#2 desc nulls_first, #0{personid} asc nulls_last, #1{personid} asc nulls_last] limit=20 output=[#0..=#2]
+  Finish order_by=[#2{count} desc nulls_first, #0{personid} asc nulls_last, #1{personid} asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
       Reduce group_by=[#0{personid}, #1{personid}] aggregates=[count(*)] // { arity: 3 }
         Project (#0, #1) // { arity: 2 }
@@ -3558,7 +3558,7 @@ materialize.public.pathq19:
   With
     cte l0 =
       Project (#0, #1, #3) // { arity: 3 }
-        Map (greatest(f64toi64(roundf64((40 - sqrtf64(bigint_to_double(#2))))), 1)) // { arity: 4 }
+        Map (greatest(f64toi64(roundf64((40 - sqrtf64(bigint_to_double(#2{count}))))), 1)) // { arity: 4 }
           Reduce group_by=[#0{person1id}, #1{person2id}] aggregates=[count(*)] // { arity: 3 }
             Project (#16, #17) // { arity: 2 }
               Filter (#0{creatorpersonid} != #11{creatorpersonid}) AND (#16{person1id} < #17{person2id}) // { arity: 18 }
@@ -3652,15 +3652,15 @@ Explained Query:
   Return // { arity: 3 }
     Return // { arity: 3 }
       Project (#0..=#2) // { arity: 3 }
-        Join on=(#2 = #3) type=differential // { arity: 4 }
+        Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
           implementation
             %1[#0]UK » %0:l1[#2]K
-          ArrangeBy keys=[[#2]] // { arity: 3 }
-            Filter (#2) IS NOT NULL // { arity: 3 }
+          ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+            Filter (#2{min}) IS NOT NULL // { arity: 3 }
               Get l1 // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              Reduce aggregates=[min(#0)] // { arity: 1 }
+          ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+            Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
                 Project (#2) // { arity: 1 }
                   Get l1 // { arity: 3 }
     With
@@ -3768,15 +3768,15 @@ WHERE w = (SELECT MIN(w) FROM paths)
 Explained Query:
   Return // { arity: 3 }
     Project (#0..=#2) // { arity: 3 }
-      Join on=(#2 = #3) type=differential // { arity: 4 }
+      Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
         implementation
           %1[#0]UK » %0:l2[#2]K
-        ArrangeBy keys=[[#2]] // { arity: 3 }
-          Filter (#2) IS NOT NULL // { arity: 3 }
+        ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+          Filter (#2{min}) IS NOT NULL // { arity: 3 }
             Get l2 // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Filter (#0) IS NOT NULL // { arity: 1 }
-            Reduce aggregates=[min(#0)] // { arity: 1 }
+        ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+          Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+            Reduce aggregates=[min(#0{min})] // { arity: 1 }
               Project (#2) // { arity: 1 }
                 Get l2 // { arity: 3 }
   With Mutually Recursive
@@ -3791,7 +3791,7 @@ Explained Query:
             Constant // { arity: 0 }
               - ()
     cte l3 =
-      Reduce aggregates=[min(#0)] // { arity: 1 }
+      Reduce aggregates=[min(#0{min})] // { arity: 1 }
         Project (#2) // { arity: 1 }
           Get l2 // { arity: 3 }
     cte l2 =
@@ -3935,15 +3935,15 @@ Explained Query:
     Return // { arity: 3 }
       Return // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Join on=(#2 = #3) type=differential // { arity: 4 }
+          Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
             implementation
               %1[#0]UK » %0:l9[#2]K
-            ArrangeBy keys=[[#2]] // { arity: 3 }
-              Filter (#2) IS NOT NULL // { arity: 3 }
+            ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+              Filter (#2{min}) IS NOT NULL // { arity: 3 }
                 Get l9 // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[min(#0)] // { arity: 1 }
+            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+              Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+                Reduce aggregates=[min(#0{min})] // { arity: 1 }
                   Project (#2) // { arity: 1 }
                     Get l9 // { arity: 3 }
       With
@@ -3963,15 +3963,15 @@ Explained Query:
                       Get l8 // { arity: 4 }
         cte l8 =
           Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5) type=differential // { arity: 6 }
+            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
               implementation
                 %1[#0]UK » %0:l7[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
                   Filter (#2{id}) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
                     Get l7 // { arity: 6 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Filter (#0) IS NOT NULL // { arity: 1 }
+              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                Filter (#0{max}) IS NOT NULL // { arity: 1 }
                   Reduce aggregates=[max(#0)] // { arity: 1 }
                     Project (#5) // { arity: 1 }
                       Get l7 // { arity: 6 }
@@ -4016,7 +4016,7 @@ Explained Query:
           ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
       cte l5 =
         Project (#1) // { arity: 1 }
-          Map ((#0 / 2)) // { arity: 2 }
+          Map ((#0{min} / 2)) // { arity: 2 }
             Union // { arity: 1 }
               Get l4 // { arity: 1 }
               Map (null) // { arity: 1 }
@@ -4168,19 +4168,19 @@ Explained Query:
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
-          Filter (#1 = #3) // { arity: 4 }
-            Join on=(#1 = #2) type=differential // { arity: 4 }
+          Filter (#1{min} = #3{min_min}) // { arity: 4 }
+            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
               implementation
                 %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1]] // { arity: 2 }
+              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
                 Get l1 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
                   CrossJoin type=differential // { arity: 2 }
                     implementation
                       %0[×] » %1:l2[×]
                     ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
                         Get l2 // { arity: 1 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Get l2 // { arity: 1 }
@@ -4276,19 +4276,19 @@ Explained Query:
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
-          Filter (#1 = #3) // { arity: 4 }
-            Join on=(#1 = #2) type=differential // { arity: 4 }
+          Filter (#1{min} = #3{min_min}) // { arity: 4 }
+            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
               implementation
                 %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1]] // { arity: 2 }
+              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
                 Get l1 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
                   CrossJoin type=differential // { arity: 2 }
                     implementation
                       %0[×] » %1:l2[×]
                     ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
                         Get l2 // { arity: 1 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Get l2 // { arity: 1 }
@@ -4385,19 +4385,19 @@ Explained Query:
     Return // { arity: 3 }
       Return // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Filter (#1 = #4) // { arity: 5 }
-            Join on=(#1 = #3) type=differential // { arity: 5 }
+          Filter (#1{min} = #4{min_min}) // { arity: 5 }
+            Join on=(#1{min} = #3{min}) type=differential // { arity: 5 }
               implementation
                 %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1]] // { arity: 3 }
+              ArrangeBy keys=[[#1{min}]] // { arity: 3 }
                 Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
                   CrossJoin type=differential // { arity: 2 }
                     implementation
                       %0[×] » %1:l2[×]
                     ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
                         Get l2 // { arity: 1 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Get l2 // { arity: 1 }
@@ -4428,7 +4428,7 @@ Explained Query:
       cte l0 =
         Project (#3, #0..=#2) // { arity: 4 }
           Map (10995116285979) // { arity: 4 }
-            Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
+            Reduce group_by=[#0{dst}, #2{min}] aggregates=[min(#1)] // { arity: 3 }
               Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
                 Distinct project=[#0{dst}..=#2] // { arity: 3 }
                   Union // { arity: 3 }
@@ -4536,15 +4536,15 @@ Explained Query:
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
-          Join on=(#1 = #2) type=differential // { arity: 3 }
+          Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
             implementation
               %1[#0]UK » %0:l11[#1]K
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              Filter (#1) IS NOT NULL // { arity: 2 }
+            ArrangeBy keys=[[#1{min}]] // { arity: 2 }
+              Filter (#1{min}) IS NOT NULL // { arity: 2 }
                 Get l11 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[min(#0)] // { arity: 1 }
+            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+              Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+                Reduce aggregates=[min(#0{min})] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Get l11 // { arity: 2 }
       With
@@ -4565,15 +4565,15 @@ Explained Query:
                         Get l10 // { arity: 4 }
         cte l10 =
           Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5) type=differential // { arity: 6 }
+            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
               implementation
                 %1[#0]UK » %0:l9[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
                   Filter (#5) IS NOT NULL // { arity: 6 }
                     Get l9 // { arity: 6 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Filter (#0) IS NOT NULL // { arity: 1 }
+              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                Filter (#0{max}) IS NOT NULL // { arity: 1 }
                   Reduce aggregates=[max(#0)] // { arity: 1 }
                     Project (#5) // { arity: 1 }
                       Get l9 // { arity: 6 }
@@ -4632,7 +4632,7 @@ Explained Query:
                 Get l0 // { arity: 1 }
       cte l7 =
         Project (#1) // { arity: 1 }
-          Map ((#0 / 2)) // { arity: 2 }
+          Map ((#0{min} / 2)) // { arity: 2 }
             Union // { arity: 1 }
               Get l6 // { arity: 1 }
               Map (null) // { arity: 1 }

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -442,7 +442,7 @@ SELECT messageYear, isComment, lengthCategory
 Explained Query:
   Finish order_by=[#0 desc nulls_first, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#6]
     Return // { arity: 7 }
-      Project (#0..=#2, #4, #7, #5, #8) // { arity: 7 }
+      Project (#0..=#2, #4, #7, #5{sum}, #8) // { arity: 7 }
         Map ((#5{sum} / bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end)), (bigint_to_numeric(#4{count}) / #3)) // { arity: 9 }
           Reduce group_by=[#1..=#4] aggregates=[count(*), sum(integer_to_bigint(#0{length})), count(integer_to_bigint(#0{length}))] // { arity: 7 }
             CrossJoin type=differential // { arity: 5 }
@@ -519,20 +519,20 @@ SELECT t.name AS "tag.name"
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
-      Project (#0, #3..=#5) // { arity: 4 }
+      Project (#0{name}, #3..=#5) // { arity: 4 }
         Map (coalesce(#1{count}, 0), coalesce(#2{count}, 0), abs((#3 - #4))) // { arity: 6 }
           Union // { arity: 3 }
             Map (null, null) // { arity: 3 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{name}) // { arity: 1 }
                     Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
             Get l2 // { arity: 3 }
     With
       cte l2 =
-        Project (#1, #3, #4) // { arity: 3 }
+        Project (#1{count}, #3, #4) // { arity: 3 }
           Join on=(#0{id} = #2{id}) type=differential // { arity: 5 }
             implementation
               %1[#0]UKA » %0:l1[#0]K
@@ -540,7 +540,7 @@ Explained Query:
               Get l1 // { arity: 2 }
             ArrangeBy keys=[[#0{id}]] // { arity: 3 }
               Reduce group_by=[#0{id}] aggregates=[count(case when (#2{creationdate} < 2010-09-16 00:00:00 UTC) then #1{messageid} else null end), count(case when (#2{creationdate} >= 2010-09-16 00:00:00 UTC) then #1{messageid} else null end)] // { arity: 3 }
-                Project (#0, #2, #4) // { arity: 3 }
+                Project (#0{id}, #2{creationdate}, #4) // { arity: 3 }
                   Filter (#4{creationdate} < 2010-12-25 00:00:00 UTC) AND (#4{creationdate} >= 2010-06-08 00:00:00 UTC) // { arity: 17 }
                     Join on=(#0{id} = #3{tagid} AND #2{messageid} = #5{messageid}) type=delta // { arity: 17 }
                       implementation
@@ -548,7 +548,7 @@ Explained Query:
                         %1:message_hastag_tag » %2:message[#1]KAiif » %0:l1[#0]K
                         %2:message » %1:message_hastag_tag[#1]KA » %0:l1[#0]K
                       ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                        Project (#0) // { arity: 1 }
+                        Project (#0{id}) // { arity: 1 }
                           Get l1 // { arity: 2 }
                       ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
                         ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
@@ -749,7 +749,7 @@ Explained Query:
           Map (null) // { arity: 5 }
             Union // { arity: 4 }
               Negate // { arity: 4 }
-                Project (#0..=#3) // { arity: 4 }
+                Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
                   Join on=(#1{id} = #4{id}) type=differential // { arity: 5 }
                     implementation
                       %1[#0]UKA » %0:l2[#1]K
@@ -762,7 +762,7 @@ Explained Query:
           Get l3 // { arity: 5 }
     With
       cte l3 =
-        Project (#0..=#3, #5) // { arity: 5 }
+        Project (#0{creationdate}..=#3{lastname}, #5) // { arity: 5 }
           Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{containerforumid} = #18{id}) type=delta // { arity: 19 }
             implementation
               %0:l2 » %1:message[#9]KA » %2[#0]UKA » %3[#0]UKA
@@ -784,7 +784,7 @@ Explained Query:
         ArrangeBy keys=[[#1{id}]] // { arity: 4 }
           Get l1 // { arity: 4 }
       cte l1 =
-        Project (#0..=#3) // { arity: 4 }
+        Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
           Join on=(#1{id} = #11{id} = #12{personid}) type=delta // { arity: 13 }
             implementation
               %0:person » %1[#0]UKA » %2[#0]UKA
@@ -808,9 +808,9 @@ Explained Query:
                     ArrangeBy keys=[[#1{forumid}]] // { arity: 3 }
                       ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
       cte l0 =
-        Project (#0) // { arity: 1 }
+        Project (#0{id}) // { arity: 1 }
           TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
-            Project (#0, #2) // { arity: 2 }
+            Project (#0{id}, #2) // { arity: 2 }
               Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
                 ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
 
@@ -862,14 +862,14 @@ Explained Query:
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
         Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
-          Project (#1, #3, #4, #6, #7) // { arity: 5 }
+          Project (#1{count}, #3{count}, #4, #6, #7) // { arity: 5 }
             Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
               implementation
                 %0:l0 » %1[#0]K » %2[#0]K
                 %1 » %0:l0[#0]Kef » %2[#0]K
                 %2 » %0:l0[#0]Kef » %1[#0]K
               ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                Project (#1, #2) // { arity: 2 }
+                Project (#1{creatorpersonid}, #2) // { arity: 2 }
                   Filter (#0{name} = "Sikh_Empire") // { arity: 3 }
                     Get l0 // { arity: 3 }
               ArrangeBy keys=[[#0{parentmessageid}]] // { arity: 3 }
@@ -880,7 +880,7 @@ Explained Query:
                     Threshold // { arity: 1 }
                       Union // { arity: 1 }
                         Negate // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{parentmessageid}) // { arity: 1 }
                             Get l1 // { arity: 2 }
                         Get l3 // { arity: 1 }
               ArrangeBy keys=[[#0{messageid}]] // { arity: 3 }
@@ -891,7 +891,7 @@ Explained Query:
                     Threshold // { arity: 1 }
                       Union // { arity: 1 }
                         Negate // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 2 }
                         Get l3 // { arity: 1 }
     With
@@ -909,7 +909,7 @@ Explained Query:
             Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
       cte l0 =
-        Project (#1, #5, #16) // { arity: 3 }
+        Project (#1{messageid}, #5, #16) // { arity: 3 }
           Filter (#0{id}) IS NOT NULL // { arity: 20 }
             Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
               implementation
@@ -993,14 +993,14 @@ Explained Query:
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
                   Get l4 // { arity: 2 }
-              Project (#0) // { arity: 1 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
           Get l4 // { arity: 2 }
     With
       cte l4 =
-        Project (#0, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1022,14 +1022,14 @@ Explained Query:
                       Get l1 // { arity: 2 }
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Distinct project=[#0{messageid}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
-            Project (#1, #2) // { arity: 2 }
+            Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l2 =
-        Project (#0, #1, #3) // { arity: 3 }
+        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
           Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
@@ -1100,14 +1100,14 @@ Explained Query:
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
                   Get l4 // { arity: 2 }
-              Project (#0) // { arity: 1 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
           Get l4 // { arity: 2 }
     With
       cte l4 =
-        Project (#0, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1129,14 +1129,14 @@ Explained Query:
                       Get l1 // { arity: 2 }
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Distinct project=[#0{messageid}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
-            Project (#1, #2) // { arity: 2 }
+            Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l2 =
-        Project (#0, #1, #3) // { arity: 3 }
+        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
           Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
@@ -1208,14 +1208,14 @@ Explained Query:
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
                   Get l4 // { arity: 2 }
-              Project (#0) // { arity: 1 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
           Get l4 // { arity: 2 }
     With
       cte l4 =
-        Project (#0, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1235,7 +1235,7 @@ Explained Query:
                       implementation
                         %1[#0]UKA » %0:l2[#0]Kef
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                        Project (#1, #2) // { arity: 2 }
+                        Project (#1{creatorpersonid}, #2) // { arity: 2 }
                           Get l2 // { arity: 3 }
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Distinct project=[#0{messageid}] // { arity: 1 }
@@ -1250,7 +1250,7 @@ Explained Query:
         Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
           Get l0 // { arity: 3 }
       cte l1 =
-        Project (#0..=#2, #4) // { arity: 4 }
+        Project (#0{name}..=#2{creatorpersonid}, #4) // { arity: 4 }
           Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
             implementation
               %1:person_likes_message[#2]KA » %0:l0[#1]K
@@ -1259,7 +1259,7 @@ Explained Query:
             ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l0 =
-        Project (#1, #5, #16) // { arity: 3 }
+        Project (#1{messageid}, #5, #16) // { arity: 3 }
           Filter (#0{id}) IS NOT NULL // { arity: 20 }
             Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
               implementation
@@ -1331,7 +1331,7 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{messageid}) // { arity: 1 }
                     Join on=(#0{messageid} = #1{messageid}) type=differential // { arity: 2 }
                       implementation
                         %0:l2[#0]UKA » %1[#0]UKA
@@ -1344,7 +1344,7 @@ Explained Query:
     With
       cte l2 =
         Distinct project=[#0{messageid}] // { arity: 1 }
-          Project (#0) // { arity: 1 }
+          Project (#0{messageid}) // { arity: 1 }
             Get l1 // { arity: 2 }
       cte l1 =
         Project (#2, #18) // { arity: 2 }
@@ -1454,7 +1454,7 @@ Explained Query:
                 Get l7 // { arity: 2 }
               ArrangeBy keys=[[#0{person1id}], [case when (#2) IS NULL then null else #1{person2id} end]] // { arity: 3 }
                 Union // { arity: 3 }
-                  Project (#1..=#3) // { arity: 3 }
+                  Project (#1{person2id}..=#3) // { arity: 3 }
                     Map (true) // { arity: 4 }
                       ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                   Map (null, null) // { arity: 3 }
@@ -1492,11 +1492,11 @@ Explained Query:
         Project (#3, #4) // { arity: 2 }
           Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2{count}, 0))) // { arity: 5 }
             Union // { arity: 3 }
-              Project (#2, #0, #1) // { arity: 3 }
+              Project (#2{count}, #0, #1{creatorpersonid}) // { arity: 3 }
                 Map (null) // { arity: 3 }
                   Union // { arity: 2 }
                     Negate // { arity: 2 }
-                      Project (#0, #1) // { arity: 2 }
+                      Project (#0{creatorpersonid}, #1{count}) // { arity: 2 }
                         Join on=(#0{creatorpersonid} = #2{id}) type=differential // { arity: 3 }
                           implementation
                             %0:l4[#0]UKA » %1[#0]UKA
@@ -1510,13 +1510,13 @@ Explained Query:
                   Negate // { arity: 1 }
                     Get l6 // { arity: 1 }
                   Get l2 // { arity: 1 }
-              Project (#0, #0, #1) // { arity: 3 }
+              Project (#0{id}, #0{id}, #1{id}) // { arity: 3 }
                 Get l5 // { arity: 2 }
       cte l6 =
-        Project (#0) // { arity: 1 }
+        Project (#0{id}) // { arity: 1 }
           Get l5 // { arity: 2 }
       cte l5 =
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{id}, #2) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 3 }
             implementation
               %1:l4[#0]UKA » %0:l2[#0]K
@@ -1552,7 +1552,7 @@ Explained Query:
                 %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
               Get l0 // { arity: 11 }
               ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                Project (#1, #2) // { arity: 2 }
+                Project (#1{tagid}, #2) // { arity: 2 }
                   ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
               Get l1 // { arity: 5 }
       cte l1 =
@@ -1604,7 +1604,7 @@ SELECT Person.id AS "person.id"
 Explained Query:
   Finish order_by=[#4{sum_count} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3{count})] // { arity: 5 }
-      Project (#1..=#3, #25) // { arity: 4 }
+      Project (#1{firstname}..=#3{count}, #25) // { arity: 4 }
         Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
             implementation
@@ -1715,7 +1715,7 @@ Explained Query:
   Finish order_by=[#2{count} desc nulls_first, #1{name} asc nulls_last, #0{person2id} asc nulls_last] limit=100 output=[#0..=#2]
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
-        Project (#0, #9) // { arity: 2 }
+        Project (#0{person2id}, #9) // { arity: 2 }
           Filter (#7{tagid}) IS NOT NULL // { arity: 12 }
             Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
               implementation
@@ -1760,7 +1760,7 @@ Explained Query:
                           ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
               ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
                 Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                  Project (#1, #9) // { arity: 2 }
+                  Project (#1{creatorpersonid}, #9) // { arity: 2 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
               ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                 Distinct project=[#0{messageid}] // { arity: 1 }
@@ -1884,7 +1884,7 @@ Explained Query:
       Filter (#0{id} < #1{person2id}) // { arity: 2 }
         Get l0 // { arity: 2 }
     cte l0 =
-      Project (#1, #21) // { arity: 2 }
+      Project (#1{person2id}, #21) // { arity: 2 }
         Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#1{id}) IS NOT NULL AND (#8{locationcityid}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
           Join on=(#1{id} = #20{person1id} AND #8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 22 }
             implementation
@@ -1966,14 +1966,14 @@ Explained Query:
                         Get l0 // { arity: 11 }
                         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
                           Distinct project=[#0{id}] // { arity: 1 }
-                            Project (#0) // { arity: 1 }
+                            Project (#0{id}) // { arity: 1 }
                               Get l1 // { arity: 2 }
                   Project (#1) // { arity: 1 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
               Get l1 // { arity: 2 }
     With
       cte l1 =
-        Project (#1, #12) // { arity: 2 }
+        Project (#1{messageid}, #12) // { arity: 2 }
           Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#1{id}) IS NOT NULL AND (#15{content}) IS NOT NULL // { arity: 25 }
             Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
               implementation
@@ -2024,7 +2024,7 @@ Explained Query:
         Project (#1) // { arity: 1 }
           Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
-              Project (#1, #11) // { arity: 2 }
+              Project (#1{messageid}, #11) // { arity: 2 }
                 Get l1 // { arity: 12 }
               Project (#1, #22) // { arity: 2 }
                 Map (null) // { arity: 23 }
@@ -2035,7 +2035,7 @@ Explained Query:
                       Union // { arity: 11 }
                         Negate // { arity: 11 }
                           Distinct project=[#0{creationdate}..=#10{email}] // { arity: 11 }
-                            Project (#0..=#10) // { arity: 11 }
+                            Project (#0{creationdate}..=#10{email}) // { arity: 11 }
                               Get l1 // { arity: 12 }
                         Distinct project=[#0{creationdate}..=#10{email}] // { arity: 11 }
                           ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
@@ -2043,17 +2043,17 @@ Explained Query:
                       ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
     With
       cte l1 =
-        Project (#0..=#11) // { arity: 12 }
+        Project (#0{creationdate}..=#11{messageid}) // { arity: 12 }
           Join on=(#12{rootpostlanguage} = #13{rootpostlanguage}) type=differential // { arity: 14 }
             implementation
               %1[#0]UKA » %0:l0[#12]Kiif
             ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
-              Project (#0..=#10, #12, #13) // { arity: 13 }
+              Project (#0{creationdate}..=#10{email}, #12{rootpostlanguage}, #13) // { arity: 13 }
                 Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
                   Get l0 // { arity: 17 }
             ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
               Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{rootpostlanguage}) // { arity: 1 }
                   Filter (#0{rootpostlanguage} = varchar_to_text(#1)) // { arity: 2 }
                     FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
                       Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
@@ -2066,7 +2066,7 @@ Explained Query:
           ArrangeBy keys=[[]] // { arity: 11 }
             ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
           ArrangeBy keys=[[]] // { arity: 6 }
-            Project (#0, #1, #3, #4, #8, #9) // { arity: 6 }
+            Project (#0{creationdate}, #1{messageid}, #3{content}, #4{length}, #8, #9) // { arity: 6 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -2120,19 +2120,19 @@ SELECT Z.zombieid AS "zombie.id"
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
-      Project (#0, #3..=#5) // { arity: 4 }
+      Project (#0{id}, #3..=#5) // { arity: 4 }
         Map (coalesce(#2{sum}, 0), coalesce(#1{count}, 0), case when (#1{count} > 0) then (bigint_to_double(#2{sum}) / bigint_to_double(#1{count})) else 0 end) // { arity: 6 }
           Union // { arity: 3 }
             Map (null, null) // { arity: 3 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{id}) // { arity: 1 }
                     Get l8 // { arity: 3 }
                 Get l2 // { arity: 1 }
             Get l8 // { arity: 3 }
     With
       cte l8 =
-        Project (#0, #2, #3) // { arity: 3 }
+        Project (#0{id}, #2{sum}, #3) // { arity: 3 }
           Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %1[#0]UKA » %0:l4[#0]K
@@ -2155,7 +2155,7 @@ Explained Query:
                               Get l7 // { arity: 1 }
                             Get l6 // { arity: 1 }
       cte l7 =
-        Project (#0) // { arity: 1 }
+        Project (#0{id}) // { arity: 1 }
           Join on=(#0{id} = #1{id}) type=differential // { arity: 2 }
             implementation
               %0:l6[#0]UKA » %1[#0]UKA
@@ -2166,10 +2166,10 @@ Explained Query:
                 Get l3 // { arity: 1 }
       cte l6 =
         Distinct project=[#0{id}] // { arity: 1 }
-          Project (#0) // { arity: 1 }
+          Project (#0{id}) // { arity: 1 }
             Get l5 // { arity: 2 }
       cte l5 =
-        Project (#1, #23) // { arity: 2 }
+        Project (#1{creatorpersonid}, #23) // { arity: 2 }
           Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 28 }
             Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
@@ -2191,7 +2191,7 @@ Explained Query:
         Filter (#0{id}) IS NOT NULL // { arity: 1 }
           Get l2 // { arity: 1 }
       cte l2 =
-        Project (#0) // { arity: 1 }
+        Project (#0{id}) // { arity: 1 }
           Filter (bigint_to_numeric(#2{count_messageid}) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
             Reduce group_by=[#1{id}, #0{creationdate}] aggregates=[count(#2{messageid})] // { arity: 3 }
               Union // { arity: 3 }
@@ -2206,7 +2206,7 @@ Explained Query:
                         Union // { arity: 16 }
                           Negate // { arity: 16 }
                             Distinct project=[#0{id}..=#15{email}] // { arity: 16 }
-                              Project (#0..=#15) // { arity: 16 }
+                              Project (#0{id}..=#15{email}) // { arity: 16 }
                                 Filter (#0{id} = #0{id}) AND (#3{id} = #3{id}) // { arity: 17 }
                                   Get l1 // { arity: 17 }
                           Distinct project=[#0{id}..=#15{email}] // { arity: 16 }
@@ -2215,7 +2215,7 @@ Explained Query:
                       ArrangeBy keys=[[#0{id}..=#15{email}]] // { arity: 16 }
                         Get l0 // { arity: 16 }
       cte l1 =
-        Project (#0..=#15, #17) // { arity: 17 }
+        Project (#0{id}..=#15{email}, #17) // { arity: 17 }
           Filter (#16{creationdate} <= 2012-11-09 00:00:00 UTC) AND (#16{creationdate} >= #6{creationdate}) // { arity: 29 }
             Join on=(#7{id} = #25{creatorpersonid}) type=differential // { arity: 29 }
               implementation
@@ -2226,7 +2226,7 @@ Explained Query:
               ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 13 }
                 ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
       cte l0 =
-        Project (#0, #2..=#6, #8..=#15, #17, #18) // { arity: 16 }
+        Project (#0{id}, #2{partofcontinentid}..=#6{creationdate}, #8{firstname}..=#15{email}, #17, #18) // { arity: 16 }
           Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL AND (#4{id}) IS NOT NULL // { arity: 19 }
             Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
               implementation
@@ -2324,21 +2324,21 @@ SELECT score_ranks.Person1Id AS "person1.id"
 Explained Query:
   Finish order_by=[#3{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
-      Project (#0, #1, #3, #4) // { arity: 4 }
+      Project (#0{id}, #1{person2id}, #3{sum}, #4) // { arity: 4 }
         TopK group_by=[#2{id}] order_by=[#4{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Map (null) // { arity: 5 }
               Union // { arity: 4 }
                 Negate // { arity: 4 }
-                  Project (#2, #3, #0, #1) // { arity: 4 }
+                  Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
                     Get l11 // { arity: 5 }
-                Project (#2, #3, #0, #1) // { arity: 4 }
+                Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
                   Get l3 // { arity: 4 }
-            Project (#2, #3, #0, #1, #4) // { arity: 5 }
+            Project (#2{id}, #3{name}, #0{id}, #1{person2id}, #4{sum}) // { arity: 5 }
               Get l11 // { arity: 5 }
     With
       cte l11 =
-        Project (#0..=#3, #6) // { arity: 5 }
+        Project (#0{id}..=#3{person2id}, #6) // { arity: 5 }
           Join on=(#2{id} = #4 AND #3{person2id} = #5) type=differential // { arity: 7 }
             implementation
               %1[#0, #1]UKKA » %0:l3[#2, #3]KK
@@ -2362,7 +2362,7 @@ Explained Query:
                               Get l10 // { arity: 2 }
                             Get l9 // { arity: 2 }
       cte l10 =
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{id}, #1{person2id}) // { arity: 2 }
           Join on=(#0{id} = #2{personid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %0:l9[#0, #1]UKKA » %1[#0, #1]UKKA
@@ -2379,10 +2379,10 @@ Explained Query:
                       ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l9 =
         Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
-          Project (#0, #1) // { arity: 2 }
+          Project (#0{id}, #1{person2id}) // { arity: 2 }
             Get l8 // { arity: 6 }
       cte l8 =
-        Project (#0..=#4, #7) // { arity: 6 }
+        Project (#0{id}..=#4, #7) // { arity: 6 }
           Join on=(#0{id} = #5{id} AND #1{person2id} = #6{person2id}) type=differential // { arity: 8 }
             implementation
               %0:l4[#0, #1]KK » %1[#0, #1]KK
@@ -2398,7 +2398,7 @@ Explained Query:
                       Get l7 // { arity: 2 }
                     Get l5 // { arity: 2 }
       cte l7 =
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{id}, #1{person2id}) // { arity: 2 }
           Join on=(#0{id} = #2{creatorpersonid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %0:l5[#0, #1]UKKA » %1[#0, #1]UKKA
@@ -2419,7 +2419,7 @@ Explained Query:
           ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
       cte l5 =
         Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
-          Project (#0, #1) // { arity: 2 }
+          Project (#0{id}, #1{person2id}) // { arity: 2 }
             Get l4 // { arity: 5 }
       cte l4 =
         Map (case when #2 then #1{person2id} else #0{id} end, case when #2 then #0{id} else #1{person2id} end) // { arity: 5 }
@@ -2543,12 +2543,12 @@ SELECT coalesce(w, -1) FROM results ORDER BY w ASC LIMIT 20
 Explained Query:
   Finish order_by=[#1{min} asc nulls_last] limit=20 output=[#2]
     Return // { arity: 3 }
-      Project (#1, #2, #2) // { arity: 3 }
+      Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
         Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
           Get l4 // { arity: 3 }
     With Mutually Recursive
       cte l4 =
-        Project (#2, #0, #1) // { arity: 3 }
+        Project (#2{min}, #0, #1{person2id}) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
               Distinct project=[#0{person2id}, #1] // { arity: 2 }
@@ -2562,13 +2562,13 @@ Explained Query:
                           Project (#1, #2) // { arity: 2 }
                             Get l4 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                          Project (#0, #1, #3) // { arity: 3 }
+                          Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
                             Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
                               Union // { arity: 3 }
                                 Map (null) // { arity: 3 }
                                   Union // { arity: 2 }
                                     Negate // { arity: 2 }
-                                      Project (#0, #1) // { arity: 2 }
+                                      Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
                                             %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
@@ -2576,26 +2576,26 @@ Explained Query:
                                             Get l3 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                                             Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
-                                              Project (#0, #1) // { arity: 2 }
+                                              Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                                 Get l2 // { arity: 3 }
                                     Get l3 // { arity: 2 }
                                 Get l2 // { arity: 3 }
                   Constant // { arity: 2 }
                     - (1450, 0)
       cte l3 =
-        Project (#1, #2) // { arity: 2 }
+        Project (#1{person2id}, #2) // { arity: 2 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
       cte l2 =
-        Project (#0, #1, #4) // { arity: 3 }
+        Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
           Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
             implementation
               %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
             ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-              Project (#1, #2) // { arity: 2 }
+              Project (#1{person2id}, #2) // { arity: 2 }
                 ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
             ArrangeBy keys=[[#1, #0]] // { arity: 3 }
               Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
+                Project (#0{person1id}..=#2{parentmessageid}) // { arity: 3 }
                   Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
                     implementation
                       %0:l1 » %1[#0]UKA » %2[#0]UKA
@@ -2614,7 +2614,7 @@ Explained Query:
                           Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                             ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
       cte l1 =
-        Project (#0, #1, #3, #4) // { arity: 4 }
+        Project (#0{person1id}, #1{person2id}, #3{containerforumid}, #4) // { arity: 4 }
           Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
             implementation
               %0:l0 » %1[#0]UKA » %2[#0]UKA
@@ -2633,7 +2633,7 @@ Explained Query:
                   Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                     ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
       cte l0 =
-        Project (#1, #2, #5, #6, #8) // { arity: 5 }
+        Project (#1{person2id}, #2{containerforumid}, #5, #6, #8) // { arity: 5 }
           Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
             implementation
               %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
@@ -2642,7 +2642,7 @@ Explained Query:
             ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
             ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-              Project (#1, #9, #10, #12) // { arity: 4 }
+              Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
                 ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
               Project (#9, #10, #12) // { arity: 3 }
@@ -2789,11 +2789,11 @@ Explained Query:
                   implementation
                     %0:l17[#1]Kef » %1:l17[#1]Kef
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
+                    Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
                         Get l17 // { arity: 4 }
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
+                    Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
                         Get l17 // { arity: 4 }
       cte l17 =
@@ -2937,7 +2937,7 @@ Explained Query:
         Union // { arity: 2 }
           Distinct project=[#0{person2id}, #1] // { arity: 2 }
             Union // { arity: 2 }
-              Project (#1, #0) // { arity: 2 }
+              Project (#1, #0{person2id}) // { arity: 2 }
                 CrossJoin type=differential // { arity: 2 }
                   implementation
                     %0:l5[×] » %1[×]
@@ -2962,36 +2962,36 @@ Explained Query:
             implementation
               %0:l6[#0]Kf » %1:l6[#0]Kf
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{person2id}) // { arity: 1 }
                 Filter #1 // { arity: 2 }
                   Get l6 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{person2id}) // { arity: 1 }
                 Filter NOT(#1) // { arity: 2 }
                   Get l6 // { arity: 2 }
     cte l6 =
       Union // { arity: 2 }
-        Project (#1, #0) // { arity: 2 }
+        Project (#1, #0{person2id}) // { arity: 2 }
           Get l5 // { arity: 2 }
         Get l8 // { arity: 2 }
     cte l5 =
-      Project (#1, #3) // { arity: 2 }
+      Project (#1{person2id}, #3) // { arity: 2 }
         Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
             %0:l8[#0]K » %1:l4[#0]K
           ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
             Get l8 // { arity: 2 }
           ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
+            Project (#0{person1id}, #1{person2id}) // { arity: 2 }
               Get l4 // { arity: 3 }
     cte l4 =
-      Project (#0, #1, #3) // { arity: 3 }
+      Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
         Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
           Union // { arity: 3 }
             Map (null) // { arity: 3 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
+                  Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                     Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
                         %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
@@ -2999,24 +2999,24 @@ Explained Query:
                         Get l3 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                         Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
-                          Project (#0, #1) // { arity: 2 }
+                          Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                             Get l2 // { arity: 3 }
                 Get l3 // { arity: 2 }
             Get l2 // { arity: 3 }
     cte l3 =
-      Project (#1, #2) // { arity: 2 }
+      Project (#1{person2id}, #2) // { arity: 2 }
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
     cte l2 =
-      Project (#0, #1, #4) // { arity: 3 }
+      Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
           implementation
             %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
           ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-            Project (#1, #2) // { arity: 2 }
+            Project (#1{person2id}, #2) // { arity: 2 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
             Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
+              Project (#0{person1id}..=#2{parentmessageid}) // { arity: 3 }
                 Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
                   implementation
                     %0:l1 » %1[#0]UKA » %2[#0]UKA
@@ -3035,7 +3035,7 @@ Explained Query:
                         Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                           ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
     cte l1 =
-      Project (#0, #1, #3, #4) // { arity: 4 }
+      Project (#0{person1id}, #1{person2id}, #3{containerforumid}, #4) // { arity: 4 }
         Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
           implementation
             %0:l0 » %1[#0]UKA » %2[#0]UKA
@@ -3054,7 +3054,7 @@ Explained Query:
                 Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                   ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
     cte l0 =
-      Project (#1, #2, #5, #6, #8) // { arity: 5 }
+      Project (#1{person2id}, #2{containerforumid}, #5, #6, #8) // { arity: 5 }
         Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
           implementation
             %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
@@ -3063,7 +3063,7 @@ Explained Query:
           ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
             ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
           ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-            Project (#1, #9, #10, #12) // { arity: 4 }
+            Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
           ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
             Project (#9, #10, #12) // { arity: 3 }
@@ -3157,7 +3157,7 @@ LIMIT 20
 Explained Query:
   Finish order_by=[#6 desc nulls_first, #0{id} asc nulls_last] limit=20 output=[#0, #1, #4]
     Return // { arity: 7 }
-      Project (#0..=#2, #0, #4..=#6) // { arity: 7 }
+      Project (#0{id}..=#2{count_person2id}, #0{id}, #4{count_messageid}..=#6) // { arity: 7 }
         Filter (#2{count_person2id} <= 5) AND (#5{count_person2id} <= 5) // { arity: 7 }
           Map ((#1{count_messageid} + #4{count_messageid})) // { arity: 7 }
             Join on=(#0{id} = #3{id}) type=differential // { arity: 6 }
@@ -3171,7 +3171,7 @@ Explained Query:
                       Union // { arity: 2 }
                         Negate // { arity: 2 }
                           Distinct project=[#0{id}, #1{messageid}] // { arity: 2 }
-                            Project (#0, #1) // { arity: 2 }
+                            Project (#0{id}, #1{messageid}) // { arity: 2 }
                               Get l5 // { arity: 3 }
                         Get l3 // { arity: 2 }
               ArrangeBy keys=[[#0{id}]] // { arity: 3 }
@@ -3182,12 +3182,12 @@ Explained Query:
                       Union // { arity: 2 }
                         Negate // { arity: 2 }
                           Distinct project=[#0{id}, #1{messageid}] // { arity: 2 }
-                            Project (#0, #1) // { arity: 2 }
+                            Project (#0{id}, #1{messageid}) // { arity: 2 }
                               Get l7 // { arity: 3 }
                         Get l6 // { arity: 2 }
     With
       cte l7 =
-        Project (#0, #1, #4) // { arity: 3 }
+        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
             implementation
               %0:l6 » %1:l4[#1]KA » %2[#0]UKA
@@ -3198,10 +3198,10 @@ Explained Query:
             Get l4 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{id}) // { arity: 1 }
                   Get l6 // { arity: 2 }
       cte l6 =
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{id}, #2) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
             implementation
               %0:l0 » %1[#0]K » %2[#0]UKA
@@ -3210,7 +3210,7 @@ Explained Query:
             Get l0 // { arity: 1 }
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1, #9) // { arity: 2 }
+                Project (#1{creatorpersonid}, #9) // { arity: 2 }
                   Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
@@ -3224,7 +3224,7 @@ Explained Query:
                       ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                         ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
       cte l5 =
-        Project (#0, #1, #4) // { arity: 3 }
+        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
             implementation
               %0:l3 » %1:l4[#1]KA » %2[#0]UKA
@@ -3235,13 +3235,13 @@ Explained Query:
             Get l4 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{id}) // { arity: 1 }
                   Get l3 // { arity: 2 }
       cte l4 =
         ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
       cte l3 =
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{id}, #2) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
             implementation
               %0:l0 » %1[#0]K » %2[#0]UKA
@@ -3250,7 +3250,7 @@ Explained Query:
             Get l0 // { arity: 1 }
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1, #9) // { arity: 2 }
+                Project (#1{creatorpersonid}, #9) // { arity: 2 }
                   Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
@@ -3335,7 +3335,7 @@ Explained Query:
   Finish order_by=[#1{count_messageid} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{creatorpersonid}, #1{messageid}) // { arity: 2 }
           Join on=(#0{creatorpersonid} = #3{creatorpersonid} AND #2{containerforumid} = #4{containerforumid}) type=differential // { arity: 5 }
             implementation
               %0:l2[#0, #2]KK » %1[#0, #1]KK
@@ -3344,7 +3344,7 @@ Explained Query:
             ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
+                  Project (#0{creatorpersonid}, #1{containerforumid}) // { arity: 2 }
                     Join on=(#0{creatorpersonid} = #2{personid} AND #1{containerforumid} = #3{forumid}) type=differential // { arity: 4 }
                       implementation
                         %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
@@ -3352,16 +3352,16 @@ Explained Query:
                         Get l3 // { arity: 2 }
                       ArrangeBy keys=[[#0{personid}, #1{forumid}]] // { arity: 2 }
                         Distinct project=[#1{personid}, #0{forumid}] // { arity: 2 }
-                          Project (#1, #2) // { arity: 2 }
+                          Project (#1{personid}, #2) // { arity: 2 }
                             ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
                 Get l3 // { arity: 2 }
     With
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{containerforumid}] // { arity: 2 }
-          Project (#0, #2) // { arity: 2 }
+          Project (#0{creatorpersonid}, #2) // { arity: 2 }
             Get l2 // { arity: 3 }
       cte l2 =
-        Project (#1, #4, #6) // { arity: 3 }
+        Project (#1{messageid}, #4, #6) // { arity: 3 }
           Filter (#2{containerforumid} != #6{containerforumid}) AND (#5{creatorpersonid} != #7{creatorpersonid}) AND ((#0{creationdate} + 12:00:00) < #3{creationdate}) // { arity: 15 }
             Join on=(#2{containerforumid} = #10{forumid} = #13{forumid} AND #4{messageid} = #8{parentmessageid} AND #5{creatorpersonid} = #14{personid} AND #7{creatorpersonid} = #11{personid}) type=delta // { arity: 15 }
               implementation
@@ -3371,11 +3371,11 @@ Explained Query:
                 %3:l1 » %4:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
                 %4:l1 » %3:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
               ArrangeBy keys=[[#2{containerforumid}]] // { arity: 3 }
-                Project (#0, #2, #3) // { arity: 3 }
+                Project (#0{creationdate}, #2{containerforumid}, #3) // { arity: 3 }
                   Filter (#3{containerforumid}) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
               ArrangeBy keys=[[#1{messageid}, #2{creatorpersonid}], [#2{creatorpersonid}]] // { arity: 4 }
-                Project (#0..=#3) // { arity: 4 }
+                Project (#0{creationdate}..=#3{containerforumid}) // { arity: 4 }
                   Get l0 // { arity: 5 }
               ArrangeBy keys=[[#0{creatorpersonid}, #1{parentmessageid}]] // { arity: 2 }
                 Project (#2, #4) // { arity: 2 }
@@ -3387,7 +3387,7 @@ Explained Query:
         ArrangeBy keys=[[#1{forumid}], [#2{personid}]] // { arity: 3 }
           ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[delta join lookup] forum_hasmember_person_personid=[delta join lookup] // { arity: 3 }
       cte l0 =
-        Project (#0, #1, #9, #10, #12) // { arity: 5 }
+        Project (#0{creationdate}, #1{messageid}, #9, #10, #12) // { arity: 5 }
           Join on=(#1{messageid} = #13{messageid}) type=differential // { arity: 14 }
             implementation
               %1[#0]UKA » %0:message[#1]KA
@@ -3403,7 +3403,7 @@ Explained Query:
                       ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
                     ArrangeBy keys=[[#0{id}]] // { arity: 1 }
                       Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#0) // { arity: 1 }
+                        Project (#0{id}) // { arity: 1 }
                           Filter (#0{id}) IS NOT NULL // { arity: 5 }
                             ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
 
@@ -3455,7 +3455,7 @@ Explained Query:
   Finish order_by=[#2{count} desc nulls_first, #0{personid} asc nulls_last, #1{personid} asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
       Reduce group_by=[#0{personid}, #1{personid}] aggregates=[count(*)] // { arity: 3 }
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{personid}, #1{personid}) // { arity: 2 }
           Join on=(#0{personid} = #2{personid} AND #1{personid} = #3{personid}) type=differential // { arity: 4 }
             implementation
               %0:l1[#0, #1]KK » %1[#0, #1]KK
@@ -3464,7 +3464,7 @@ Explained Query:
             ArrangeBy keys=[[#0{personid}, #1{personid}]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
+                  Project (#0{personid}, #1{personid}) // { arity: 2 }
                     Join on=(#0{personid} = #2{person2id} AND #1{personid} = #3{person1id}) type=differential // { arity: 4 }
                       implementation
                         %0:l2[#0, #1]UKKA » %1[#0, #1]UKKA
@@ -3472,7 +3472,7 @@ Explained Query:
                         Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#0{person2id}, #1{person1id}]] // { arity: 2 }
                         Distinct project=[#1{person2id}, #0{person1id}] // { arity: 2 }
-                          Project (#1, #2) // { arity: 2 }
+                          Project (#1{person2id}, #2) // { arity: 2 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                 Get l2 // { arity: 2 }
     With
@@ -3480,7 +3480,7 @@ Explained Query:
         Distinct project=[#0{personid}, #1{personid}] // { arity: 2 }
           Get l1 // { arity: 2 }
       cte l1 =
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{personid}, #2) // { arity: 2 }
           Filter (#0{personid} != #2{personid}) // { arity: 4 }
             Join on=(#1{person2id} = #3{person2id}) type=differential // { arity: 4 }
               implementation
@@ -3489,7 +3489,7 @@ Explained Query:
               Get l0 // { arity: 2 }
       cte l0 =
         ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
-          Project (#0, #9) // { arity: 2 }
+          Project (#0{personid}, #9) // { arity: 2 }
             Filter (#1{tagid}) IS NOT NULL // { arity: 10 }
               Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
                 implementation
@@ -3497,7 +3497,7 @@ Explained Query:
                   %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
                   %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
                 ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                  Project (#1, #2) // { arity: 2 }
+                  Project (#1{tagid}, #2) // { arity: 2 }
                     ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
                 ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                   ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
@@ -3553,11 +3553,11 @@ materialize.public.pathq19:
   Return // { arity: 3 }
     Union // { arity: 3 }
       Get l0 // { arity: 3 }
-      Project (#1, #0, #2) // { arity: 3 }
+      Project (#1{person1id}, #0{person2id}, #2) // { arity: 3 }
         Get l0 // { arity: 3 }
   With
     cte l0 =
-      Project (#0, #1, #3) // { arity: 3 }
+      Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
         Map (greatest(f64toi64(roundf64((40 - sqrtf64(bigint_to_double(#2{count}))))), 1)) // { arity: 4 }
           Reduce group_by=[#0{person1id}, #1{person2id}] aggregates=[count(*)] // { arity: 3 }
             Project (#16, #17) // { arity: 2 }
@@ -3651,7 +3651,7 @@ SELECT src, dst, w
 Explained Query:
   Return // { arity: 3 }
     Return // { arity: 3 }
-      Project (#0..=#2) // { arity: 3 }
+      Project (#0{id}..=#2{min}) // { arity: 3 }
         Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
           implementation
             %1[#0]UK » %0:l1[#2]K
@@ -3665,7 +3665,7 @@ Explained Query:
                   Get l1 // { arity: 3 }
     With
       cte l1 =
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0{id}..=#2{min}) // { arity: 3 }
           Join on=(#1{id} = #3{id} = #4{id}) type=delta // { arity: 5 }
             implementation
               %0:l0 » %1[#0]UKA » %2[#0]UKA
@@ -3688,7 +3688,7 @@ Explained Query:
       Reduce group_by=[#0{id}, #1{id}] aggregates=[min(#2)] // { arity: 3 }
         Distinct project=[#0{id}..=#2] // { arity: 3 }
           Union // { arity: 3 }
-            Project (#1, #1, #12) // { arity: 3 }
+            Project (#1{id}, #1{id}, #12) // { arity: 3 }
               Map (0) // { arity: 13 }
                 ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
             Project (#0, #4, #6) // { arity: 3 }
@@ -3767,7 +3767,7 @@ WHERE w = (SELECT MIN(w) FROM paths)
 ----
 Explained Query:
   Return // { arity: 3 }
-    Project (#0..=#2) // { arity: 3 }
+    Project (#0{id}..=#2{min}) // { arity: 3 }
       Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
         implementation
           %1[#0]UK » %0:l2[#2]K
@@ -3796,7 +3796,7 @@ Explained Query:
           Get l2 // { arity: 3 }
     cte l2 =
       Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-        Project (#0, #2, #3, #5) // { arity: 4 }
+        Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
           Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
             implementation
               %0:l0[#1]K » %1:l1[#1]K
@@ -3809,7 +3809,7 @@ Explained Query:
     cte l1 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
-          Project (#1, #1, #12) // { arity: 3 }
+          Project (#1{id}, #1{id}, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
           Project (#0, #5, #7) // { arity: 3 }
@@ -3840,7 +3840,7 @@ Explained Query:
     cte l0 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
-          Project (#1, #1, #12) // { arity: 3 }
+          Project (#1{id}, #1{id}, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
           Project (#0, #5, #7) // { arity: 3 }
@@ -3934,7 +3934,7 @@ Explained Query:
   Finish order_by=[#0{id} asc nulls_last, #1{id} asc nulls_last] output=[#0..=#2]
     Return // { arity: 3 }
       Return // { arity: 3 }
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0{id}..=#2{min}) // { arity: 3 }
           Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
             implementation
               %1[#0]UK » %0:l9[#2]K
@@ -3949,16 +3949,16 @@ Explained Query:
       With
         cte l9 =
           Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-            Project (#0, #2, #3, #5) // { arity: 4 }
+            Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
               Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
                 implementation
                   %0:l8[#1]Kef » %1:l8[#1]Kef
                 ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1..=#3) // { arity: 3 }
+                  Project (#1{id}..=#3) // { arity: 3 }
                     Filter (#0 = false) // { arity: 4 }
                       Get l8 // { arity: 4 }
                 ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1..=#3) // { arity: 3 }
+                  Project (#1{id}..=#3) // { arity: 3 }
                     Filter (#0 = true) // { arity: 4 }
                       Get l8 // { arity: 4 }
         cte l8 =
@@ -3979,7 +3979,7 @@ Explained Query:
       cte l7 =
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
-            Project (#1, #0, #0, #2..=#4) // { arity: 6 }
+            Project (#1{id}, #0, #0, #2{id}..=#4) // { arity: 6 }
               Map (0, false, 0) // { arity: 5 }
                 Union // { arity: 2 }
                   Project (#1, #12) // { arity: 2 }
@@ -4167,7 +4167,7 @@ Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{dst}, #1{min}) // { arity: 2 }
           Filter (#1{min} = #3{min_min}) // { arity: 4 }
             Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
               implementation
@@ -4189,12 +4189,12 @@ Explained Query:
           Project (#1) // { arity: 1 }
             Get l1 // { arity: 2 }
         cte l1 =
-          Project (#0, #1) // { arity: 2 }
+          Project (#0{dst}, #1{min}) // { arity: 2 }
             Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#1, #2) // { arity: 2 }
+                Project (#1{min}, #2) // { arity: 2 }
                   Get l0 // { arity: 3 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
@@ -4209,7 +4209,7 @@ Explained Query:
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
-        Project (#2, #0, #1) // { arity: 3 }
+        Project (#2{min}, #0, #1{dst}) // { arity: 3 }
           Map (10995116285979) // { arity: 3 }
             Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
               Distinct project=[#0{dst}, #1] // { arity: 2 }
@@ -4220,7 +4220,7 @@ Explained Query:
                         implementation
                           %0:l0[#0]UK » %1:pathq20[#0]KA
                         ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                          Project (#1, #2) // { arity: 2 }
+                          Project (#1{min}, #2) // { arity: 2 }
                             Get l0 // { arity: 3 }
                         ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                           ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
@@ -4275,7 +4275,7 @@ Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{dst}, #1{min}) // { arity: 2 }
           Filter (#1{min} = #3{min_min}) // { arity: 4 }
             Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
               implementation
@@ -4297,7 +4297,7 @@ Explained Query:
           Project (#1) // { arity: 1 }
             Get l1 // { arity: 2 }
         cte l1 =
-          Project (#0, #1) // { arity: 2 }
+          Project (#0{dst}, #1{min}) // { arity: 2 }
             Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
@@ -4384,7 +4384,7 @@ Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
       Return // { arity: 3 }
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0{dst}..=#2{min}) // { arity: 3 }
           Filter (#1{min} = #4{min_min}) // { arity: 5 }
             Join on=(#1{min} = #3{min}) type=differential // { arity: 5 }
               implementation
@@ -4406,12 +4406,12 @@ Explained Query:
           Project (#1) // { arity: 1 }
             Get l1 // { arity: 3 }
         cte l1 =
-          Project (#0..=#2) // { arity: 3 }
+          Project (#0{dst}..=#2{min}) // { arity: 3 }
             Join on=(#0{dst} = #3{personid}) type=differential // { arity: 4 }
               implementation
                 %1[#0]UKA » %0:l0[#0]K
               ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
-                Project (#1..=#3) // { arity: 3 }
+                Project (#1{min}..=#3) // { arity: 3 }
                   Get l0 // { arity: 4 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
@@ -4426,7 +4426,7 @@ Explained Query:
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
-        Project (#3, #0..=#2) // { arity: 4 }
+        Project (#3{min}, #0..=#2{min}) // { arity: 4 }
           Map (10995116285979) // { arity: 4 }
             Reduce group_by=[#0{dst}, #2{min}] aggregates=[min(#1)] // { arity: 3 }
               Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
@@ -4438,7 +4438,7 @@ Explained Query:
                           implementation
                             %1:pathq20[#0]KA » %0:l0[#0]K
                           ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
-                            Project (#1..=#3) // { arity: 3 }
+                            Project (#1{min}..=#3) // { arity: 3 }
                               Get l0 // { arity: 4 }
                           ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                             ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
@@ -4535,7 +4535,7 @@ Explained Query:
   Finish order_by=[#0{personid} asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{personid}, #1{min}) // { arity: 2 }
           Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
             implementation
               %1[#0]UK » %0:l11[#1]K
@@ -4549,18 +4549,18 @@ Explained Query:
                     Get l11 // { arity: 2 }
       With
         cte l11 =
-          Project (#1, #2) // { arity: 2 }
+          Project (#1{min}, #2) // { arity: 2 }
             Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0, #2, #3, #5) // { arity: 4 }
+              Project (#0{personid}, #2{personid}, #3, #5) // { arity: 4 }
                 Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                   implementation
                     %0:l10[#1]Kef » %1:l10[#1]Kef
                   ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
+                    Project (#1{personid}..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
                         Get l10 // { arity: 4 }
                   ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
+                    Project (#1{personid}..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
                         Get l10 // { arity: 4 }
         cte l10 =
@@ -4581,14 +4581,14 @@ Explained Query:
       cte l9 =
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
-            Project (#0..=#2, #4, #3, #5) // { arity: 6 }
+            Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
               Map (false, 0, 0) // { arity: 6 }
                 Distinct project=[#0..=#2{personid}] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#1, #0, #0) // { arity: 3 }
                       Map (10995116285979, false) // { arity: 2 }
                         Get l8 // { arity: 0 }
-                    Project (#1, #0, #0) // { arity: 3 }
+                    Project (#1{personid}, #0, #0) // { arity: 3 }
                       Map (true) // { arity: 2 }
                         CrossJoin type=differential // { arity: 1 }
                           implementation

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -450,7 +450,7 @@ Explained Query:
   Finish order_by=[#0 desc nulls_first, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#6]
     Return // { arity: 7 }
       Project (#0..=#2, #4, #7, #5, #8) // { arity: 7 }
-        Map ((#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end)), (bigint_to_numeric(#4) / #3)) // { arity: 9 }
+        Map ((#5{sum} / bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end)), (bigint_to_numeric(#4{count}) / #3)) // { arity: 9 }
           Reduce group_by=[#1..=#4] aggregates=[count(*), sum(integer_to_bigint(#0{length})), count(integer_to_bigint(#0{length}))] // { arity: 7 }
             CrossJoin type=differential // { arity: 5 }
               implementation
@@ -462,7 +462,7 @@ Explained Query:
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
               ArrangeBy keys=[[]] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Map ((0 + bigint_to_numeric(#0))) // { arity: 2 }
+                  Map ((0 + bigint_to_numeric(#0{count}))) // { arity: 2 }
                     Union // { arity: 1 }
                       Get l0 // { arity: 1 }
                       Map (0) // { arity: 1 }
@@ -527,7 +527,7 @@ Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #3..=#5) // { arity: 4 }
-        Map (coalesce(#1, 0), coalesce(#2, 0), abs((#3 - #4))) // { arity: 6 }
+        Map (coalesce(#1{count}, 0), coalesce(#2{count}, 0), abs((#3 - #4))) // { arity: 6 }
           Union // { arity: 3 }
             Map (null, null) // { arity: 3 }
               Union // { arity: 1 }
@@ -622,7 +622,7 @@ ORDER BY messageCount DESC, Forum.id
 LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
+  Finish order_by=[#4{count} desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
     Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
       Project (#10, #13, #15, #16) // { arity: 4 }
         Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#25{locationcityid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
@@ -749,7 +749,7 @@ ORDER BY messageCount DESC, au.id
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
+  Finish order_by=[#4{count_messageid} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
       Reduce group_by=[#1{id}..=#3{lastname}, #0{creationdate}] aggregates=[count(#4{messageid})] // { arity: 5 }
         Union // { arity: 5 }
@@ -867,8 +867,8 @@ SELECT CreatorPersonId AS "person.id"
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
-      Map (((bigint_to_numeric((1 * #3)) + (2 * #1)) + (10 * #2))) // { arity: 5 }
-        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1 end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3 end, 0)), count(*)] // { arity: 4 }
+      Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
           Project (#1, #3, #4, #6, #7) // { arity: 5 }
             Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
               implementation
@@ -993,7 +993,7 @@ LIMIT 100
 ;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
         Union // { arity: 2 }
@@ -1100,7 +1100,7 @@ ORDER BY authorityScore DESC, pl.person1id ASC
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
         Union // { arity: 2 }
@@ -1208,7 +1208,7 @@ ORDER BY authorityScore DESC, pl.person1id ASC
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1{sum} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
         Union // { arity: 2 }
@@ -1326,7 +1326,7 @@ SELECT RelatedTag.name AS "relatedTag.name"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1{count} desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{name}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -1449,7 +1449,7 @@ SELECT p.PersonId AS "person.id"
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1, #3]
     Return // { arity: 5 }
-      Map (coalesce(#2, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
+      Map (coalesce(#2{sum}, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
         Reduce group_by=[#0, #1] aggregates=[sum(case when (#3) IS NULL then null else #2 end)] // { arity: 3 }
           Project (#0, #1, #6, #7) // { arity: 4 }
             Join on=(#0 = #2{person1id} AND #5{person2id} = case when (#4) IS NULL then null else #3{person2id} end) type=delta // { arity: 8 }
@@ -1497,7 +1497,7 @@ Explained Query:
     With
       cte l7 =
         Project (#3, #4) // { arity: 2 }
-          Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2, 0))) // { arity: 5 }
+          Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2{count}, 0))) // { arity: 5 }
             Union // { arity: 3 }
               Project (#2, #0, #1) // { arity: 3 }
                 Map (null) // { arity: 3 }
@@ -1609,8 +1609,8 @@ SELECT Person.id AS "person.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
-    Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3)] // { arity: 5 }
+  Finish order_by=[#4{sum_count} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
+    Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3{count})] // { arity: 5 }
       Project (#1..=#3, #25) // { arity: 4 }
         Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
@@ -1719,7 +1719,7 @@ SELECT m.friendId AS "person.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#2 desc nulls_first, #1{name} asc nulls_last, #0{person2id} asc nulls_last] limit=100 output=[#0..=#2]
+  Finish order_by=[#2{count} desc nulls_first, #1{name} asc nulls_last, #0{person2id} asc nulls_last] limit=100 output=[#0..=#2]
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
         Project (#0, #9) // { arity: 2 }
@@ -1957,9 +1957,9 @@ SELECT *
 ORDER BY personCount DESC, messageCount DESC
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 desc nulls_first] output=[#0, #1]
+  Finish order_by=[#1{count} desc nulls_first, #0{count_messageid} desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+      Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
           Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
@@ -2025,9 +2025,9 @@ SELECT *
 ORDER BY personCount DESC, messageCount DESC
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 desc nulls_first] output=[#0, #1]
+  Finish order_by=[#1{count} desc nulls_first, #0{count_messageid} desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+      Reduce group_by=[#0{count_messageid}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
           Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
@@ -2128,7 +2128,7 @@ Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #3..=#5) // { arity: 4 }
-        Map (coalesce(#2, 0), coalesce(#1, 0), case when (#1 > 0) then (bigint_to_double(#2) / bigint_to_double(#1)) else 0 end) // { arity: 6 }
+        Map (coalesce(#2{sum}, 0), coalesce(#1{count}, 0), case when (#1{count} > 0) then (bigint_to_double(#2{sum}) / bigint_to_double(#1{count})) else 0 end) // { arity: 6 }
           Union // { arity: 3 }
             Map (null, null) // { arity: 3 }
               Union // { arity: 1 }
@@ -2199,7 +2199,7 @@ Explained Query:
           Get l2 // { arity: 1 }
       cte l2 =
         Project (#0) // { arity: 1 }
-          Filter (bigint_to_numeric(#2) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
+          Filter (bigint_to_numeric(#2{count_messageid}) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
             Reduce group_by=[#1{id}, #0{creationdate}] aggregates=[count(#2{messageid})] // { arity: 3 }
               Union // { arity: 3 }
                 Project (#6, #7, #16) // { arity: 3 }
@@ -2329,10 +2329,10 @@ SELECT score_ranks.Person1Id AS "person1.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=100 output=[#0..=#3]
+  Finish order_by=[#3{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #1, #3, #4) // { arity: 4 }
-        TopK group_by=[#2{id}] order_by=[#4 desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
+        TopK group_by=[#2{id}] order_by=[#4{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Map (null) // { arity: 5 }
               Union // { arity: 4 }
@@ -2548,10 +2548,10 @@ EXPLAIN WITH(humanized expressions, arity, join implementations) WITH
 SELECT coalesce(w, -1) FROM results ORDER BY w ASC LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#1 asc nulls_last] limit=20 output=[#2]
+  Finish order_by=[#1{min} asc nulls_last] limit=20 output=[#2]
     Return // { arity: 3 }
       Project (#1, #2, #2) // { arity: 3 }
-        Filter (#1{person2id} = 15393162796819) AND (#2 = #2) // { arity: 3 }
+        Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
           Get l4 // { arity: 3 }
     With Mutually Recursive
       cte l4 =
@@ -2570,7 +2570,7 @@ Explained Query:
                             Get l4 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0, #1, #3) // { arity: 3 }
-                            Map ((10 / bigint_to_double((coalesce(#2, 0) + 10)))) // { arity: 4 }
+                            Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
                               Union // { arity: 3 }
                                 Map (null) // { arity: 3 }
                                   Union // { arity: 2 }
@@ -2776,7 +2776,7 @@ Explained Query:
   Return // { arity: 1 }
     Return // { arity: 1 }
       Project (#1) // { arity: 1 }
-        Map (coalesce(#0, -1)) // { arity: 2 }
+        Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
           Union // { arity: 1 }
             Get l18 // { arity: 1 }
             Map (null) // { arity: 1 }
@@ -2788,7 +2788,7 @@ Explained Query:
                   - ()
     With
       cte l18 =
-        Reduce aggregates=[min(#0)] // { arity: 1 }
+        Reduce aggregates=[min(#0{min})] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
@@ -2805,15 +2805,15 @@ Explained Query:
                         Get l17 // { arity: 4 }
       cte l17 =
         Project (#0..=#3) // { arity: 4 }
-          Join on=(#4 = #5) type=differential // { arity: 6 }
+          Join on=(#4 = #5{max}) type=differential // { arity: 6 }
             implementation
               %1[#0]UK » %0:l16[#4]K
             ArrangeBy keys=[[#4]] // { arity: 5 }
               Project (#0..=#3, #5) // { arity: 5 }
                 Filter (#5) IS NOT NULL // { arity: 6 }
                   Get l16 // { arity: 6 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
+            ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+              Filter (#0{max}) IS NOT NULL // { arity: 1 }
                 Reduce aggregates=[max(#0)] // { arity: 1 }
                   Project (#5) // { arity: 1 }
                     Get l16 // { arity: 6 }
@@ -2858,7 +2858,7 @@ Explained Query:
             Get l8 // { arity: 2 }
     cte l14 =
       Project (#1) // { arity: 1 }
-        Map ((#0 / 2)) // { arity: 2 }
+        Map ((#0{min} / 2)) // { arity: 2 }
           Union // { arity: 1 }
             Get l13 // { arity: 1 }
             Map (null) // { arity: 1 }
@@ -2993,7 +2993,7 @@ Explained Query:
               Get l4 // { arity: 3 }
     cte l4 =
       Project (#0, #1, #3) // { arity: 3 }
-        Map ((10 / bigint_to_double((coalesce(#2, 0) + 10)))) // { arity: 4 }
+        Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
           Union // { arity: 3 }
             Map (null) // { arity: 3 }
               Union // { arity: 2 }
@@ -3165,8 +3165,8 @@ Explained Query:
   Finish order_by=[#6 desc nulls_first, #0{id} asc nulls_last] limit=20 output=[#0, #1, #4]
     Return // { arity: 7 }
       Project (#0..=#2, #0, #4..=#6) // { arity: 7 }
-        Filter (#2 <= 5) AND (#5 <= 5) // { arity: 7 }
-          Map ((#1 + #4)) // { arity: 7 }
+        Filter (#2{count_person2id} <= 5) AND (#5{count_person2id} <= 5) // { arity: 7 }
+          Map ((#1{count_messageid} + #4{count_messageid})) // { arity: 7 }
             Join on=(#0{id} = #3{id}) type=differential // { arity: 6 }
               implementation
                 %0[#0]UKAif » %1[#0]UKAiif
@@ -3339,7 +3339,7 @@ ORDER BY messageCount DESC, Message1.CreatorPersonId ASC
 LIMIT 10
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
+  Finish order_by=[#1{count_messageid} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
@@ -3459,7 +3459,7 @@ ORDER BY mutualFriendCount DESC, k1.InterestedId ASC, k2.InterestedId ASC
 LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#2 desc nulls_first, #0{personid} asc nulls_last, #1{personid} asc nulls_last] limit=20 output=[#0..=#2]
+  Finish order_by=[#2{count} desc nulls_first, #0{personid} asc nulls_last, #1{personid} asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
       Reduce group_by=[#0{personid}, #1{personid}] aggregates=[count(*)] // { arity: 3 }
         Project (#0, #1) // { arity: 2 }
@@ -3565,7 +3565,7 @@ materialize.public.pathq19:
   With
     cte l0 =
       Project (#0, #1, #3) // { arity: 3 }
-        Map (greatest(f64toi64(roundf64((40 - sqrtf64(bigint_to_double(#2))))), 1)) // { arity: 4 }
+        Map (greatest(f64toi64(roundf64((40 - sqrtf64(bigint_to_double(#2{count}))))), 1)) // { arity: 4 }
           Reduce group_by=[#0{person1id}, #1{person2id}] aggregates=[count(*)] // { arity: 3 }
             Project (#16, #17) // { arity: 2 }
               Filter (#0{creatorpersonid} != #11{creatorpersonid}) AND (#16{person1id} < #17{person2id}) // { arity: 18 }
@@ -3659,15 +3659,15 @@ Explained Query:
   Return // { arity: 3 }
     Return // { arity: 3 }
       Project (#0..=#2) // { arity: 3 }
-        Join on=(#2 = #3) type=differential // { arity: 4 }
+        Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
           implementation
             %1[#0]UK » %0:l1[#2]K
-          ArrangeBy keys=[[#2]] // { arity: 3 }
-            Filter (#2) IS NOT NULL // { arity: 3 }
+          ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+            Filter (#2{min}) IS NOT NULL // { arity: 3 }
               Get l1 // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              Reduce aggregates=[min(#0)] // { arity: 1 }
+          ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+            Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+              Reduce aggregates=[min(#0{min})] // { arity: 1 }
                 Project (#2) // { arity: 1 }
                   Get l1 // { arity: 3 }
     With
@@ -3775,15 +3775,15 @@ WHERE w = (SELECT MIN(w) FROM paths)
 Explained Query:
   Return // { arity: 3 }
     Project (#0..=#2) // { arity: 3 }
-      Join on=(#2 = #3) type=differential // { arity: 4 }
+      Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
         implementation
           %1[#0]UK » %0:l2[#2]K
-        ArrangeBy keys=[[#2]] // { arity: 3 }
-          Filter (#2) IS NOT NULL // { arity: 3 }
+        ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+          Filter (#2{min}) IS NOT NULL // { arity: 3 }
             Get l2 // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Filter (#0) IS NOT NULL // { arity: 1 }
-            Reduce aggregates=[min(#0)] // { arity: 1 }
+        ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+          Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+            Reduce aggregates=[min(#0{min})] // { arity: 1 }
               Project (#2) // { arity: 1 }
                 Get l2 // { arity: 3 }
   With Mutually Recursive
@@ -3798,7 +3798,7 @@ Explained Query:
             Constant // { arity: 0 }
               - ()
     cte l3 =
-      Reduce aggregates=[min(#0)] // { arity: 1 }
+      Reduce aggregates=[min(#0{min})] // { arity: 1 }
         Project (#2) // { arity: 1 }
           Get l2 // { arity: 3 }
     cte l2 =
@@ -3942,15 +3942,15 @@ Explained Query:
     Return // { arity: 3 }
       Return // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Join on=(#2 = #3) type=differential // { arity: 4 }
+          Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
             implementation
               %1[#0]UK » %0:l9[#2]K
-            ArrangeBy keys=[[#2]] // { arity: 3 }
-              Filter (#2) IS NOT NULL // { arity: 3 }
+            ArrangeBy keys=[[#2{min}]] // { arity: 3 }
+              Filter (#2{min}) IS NOT NULL // { arity: 3 }
                 Get l9 // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[min(#0)] // { arity: 1 }
+            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+              Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+                Reduce aggregates=[min(#0{min})] // { arity: 1 }
                   Project (#2) // { arity: 1 }
                     Get l9 // { arity: 3 }
       With
@@ -3970,15 +3970,15 @@ Explained Query:
                       Get l8 // { arity: 4 }
         cte l8 =
           Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5) type=differential // { arity: 6 }
+            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
               implementation
                 %1[#0]UK » %0:l7[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
                   Filter (#2{id}) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
                     Get l7 // { arity: 6 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Filter (#0) IS NOT NULL // { arity: 1 }
+              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                Filter (#0{max}) IS NOT NULL // { arity: 1 }
                   Reduce aggregates=[max(#0)] // { arity: 1 }
                     Project (#5) // { arity: 1 }
                       Get l7 // { arity: 6 }
@@ -4023,7 +4023,7 @@ Explained Query:
           ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
       cte l5 =
         Project (#1) // { arity: 1 }
-          Map ((#0 / 2)) // { arity: 2 }
+          Map ((#0{min} / 2)) // { arity: 2 }
             Union // { arity: 1 }
               Get l4 // { arity: 1 }
               Map (null) // { arity: 1 }
@@ -4175,19 +4175,19 @@ Explained Query:
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
-          Filter (#1 = #3) // { arity: 4 }
-            Join on=(#1 = #2) type=differential // { arity: 4 }
+          Filter (#1{min} = #3{min_min}) // { arity: 4 }
+            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
               implementation
                 %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1]] // { arity: 2 }
+              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
                 Get l1 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
                   CrossJoin type=differential // { arity: 2 }
                     implementation
                       %0[×] » %1:l2[×]
                     ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
                         Get l2 // { arity: 1 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Get l2 // { arity: 1 }
@@ -4283,19 +4283,19 @@ Explained Query:
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
-          Filter (#1 = #3) // { arity: 4 }
-            Join on=(#1 = #2) type=differential // { arity: 4 }
+          Filter (#1{min} = #3{min_min}) // { arity: 4 }
+            Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
               implementation
                 %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1]] // { arity: 2 }
+              ArrangeBy keys=[[#1{min}]] // { arity: 2 }
                 Get l1 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
                   CrossJoin type=differential // { arity: 2 }
                     implementation
                       %0[×] » %1:l2[×]
                     ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
                         Get l2 // { arity: 1 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Get l2 // { arity: 1 }
@@ -4392,19 +4392,19 @@ Explained Query:
     Return // { arity: 3 }
       Return // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Filter (#1 = #4) // { arity: 5 }
-            Join on=(#1 = #3) type=differential // { arity: 5 }
+          Filter (#1{min} = #4{min_min}) // { arity: 5 }
+            Join on=(#1{min} = #3{min}) type=differential // { arity: 5 }
               implementation
                 %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1]] // { arity: 3 }
+              ArrangeBy keys=[[#1{min}]] // { arity: 3 }
                 Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+              ArrangeBy keys=[[#0{min}]] // { arity: 2 }
+                Reduce group_by=[#0{min}] aggregates=[min(#1{min})] // { arity: 2 }
                   CrossJoin type=differential // { arity: 2 }
                     implementation
                       %0[×] » %1:l2[×]
                     ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
+                      Distinct project=[#0{min}] // { arity: 1 }
                         Get l2 // { arity: 1 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Get l2 // { arity: 1 }
@@ -4435,7 +4435,7 @@ Explained Query:
       cte l0 =
         Project (#3, #0..=#2) // { arity: 4 }
           Map (10995116285979) // { arity: 4 }
-            Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
+            Reduce group_by=[#0{dst}, #2{min}] aggregates=[min(#1)] // { arity: 3 }
               Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
                 Distinct project=[#0{dst}..=#2] // { arity: 3 }
                   Union // { arity: 3 }
@@ -4543,15 +4543,15 @@ Explained Query:
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
-          Join on=(#1 = #2) type=differential // { arity: 3 }
+          Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
             implementation
               %1[#0]UK » %0:l11[#1]K
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              Filter (#1) IS NOT NULL // { arity: 2 }
+            ArrangeBy keys=[[#1{min}]] // { arity: 2 }
+              Filter (#1{min}) IS NOT NULL // { arity: 2 }
                 Get l11 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[min(#0)] // { arity: 1 }
+            ArrangeBy keys=[[#0{min_min}]] // { arity: 1 }
+              Filter (#0{min_min}) IS NOT NULL // { arity: 1 }
+                Reduce aggregates=[min(#0{min})] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Get l11 // { arity: 2 }
       With
@@ -4572,15 +4572,15 @@ Explained Query:
                         Get l10 // { arity: 4 }
         cte l10 =
           Project (#0..=#3) // { arity: 4 }
-            Join on=(#4 = #5) type=differential // { arity: 6 }
+            Join on=(#4 = #5{max}) type=differential // { arity: 6 }
               implementation
                 %1[#0]UK » %0:l9[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
                   Filter (#5) IS NOT NULL // { arity: 6 }
                     Get l9 // { arity: 6 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Filter (#0) IS NOT NULL // { arity: 1 }
+              ArrangeBy keys=[[#0{max}]] // { arity: 1 }
+                Filter (#0{max}) IS NOT NULL // { arity: 1 }
                   Reduce aggregates=[max(#0)] // { arity: 1 }
                     Project (#5) // { arity: 1 }
                       Get l9 // { arity: 6 }
@@ -4639,7 +4639,7 @@ Explained Query:
                 Get l0 // { arity: 1 }
       cte l7 =
         Project (#1) // { arity: 1 }
-          Map ((#0 / 2)) // { arity: 2 }
+          Map ((#0{min} / 2)) // { arity: 2 }
             Union // { arity: 1 }
               Get l6 // { arity: 1 }
               Map (null) // { arity: 1 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -449,7 +449,7 @@ SELECT messageYear, isComment, lengthCategory
 Explained Query:
   Finish order_by=[#0 desc nulls_first, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#6]
     Return // { arity: 7 }
-      Project (#0..=#2, #4, #7, #5, #8) // { arity: 7 }
+      Project (#0..=#2, #4, #7, #5{sum}, #8) // { arity: 7 }
         Map ((#5{sum} / bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end)), (bigint_to_numeric(#4{count}) / #3)) // { arity: 9 }
           Reduce group_by=[#1..=#4] aggregates=[count(*), sum(integer_to_bigint(#0{length})), count(integer_to_bigint(#0{length}))] // { arity: 7 }
             CrossJoin type=differential // { arity: 5 }
@@ -526,20 +526,20 @@ SELECT t.name AS "tag.name"
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
-      Project (#0, #3..=#5) // { arity: 4 }
+      Project (#0{name}, #3..=#5) // { arity: 4 }
         Map (coalesce(#1{count}, 0), coalesce(#2{count}, 0), abs((#3 - #4))) // { arity: 6 }
           Union // { arity: 3 }
             Map (null, null) // { arity: 3 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{name}) // { arity: 1 }
                     Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
             Get l2 // { arity: 3 }
     With
       cte l2 =
-        Project (#1, #3, #4) // { arity: 3 }
+        Project (#1{count}, #3, #4) // { arity: 3 }
           Join on=(#0{id} = #2{id}) type=differential // { arity: 5 }
             implementation
               %1[#0]UKA » %0:l1[#0]K
@@ -547,7 +547,7 @@ Explained Query:
               Get l1 // { arity: 2 }
             ArrangeBy keys=[[#0{id}]] // { arity: 3 }
               Reduce group_by=[#0{id}] aggregates=[count(case when (#2{creationdate} < 2010-09-16 00:00:00 UTC) then #1{messageid} else null end), count(case when (#2{creationdate} >= 2010-09-16 00:00:00 UTC) then #1{messageid} else null end)] // { arity: 3 }
-                Project (#0, #2, #4) // { arity: 3 }
+                Project (#0{id}, #2{creationdate}, #4) // { arity: 3 }
                   Filter (#4{creationdate} < 2010-12-25 00:00:00 UTC) AND (#4{creationdate} >= 2010-06-08 00:00:00 UTC) // { arity: 17 }
                     Join on=(#0{id} = #3{tagid} AND #2{messageid} = #5{messageid}) type=delta // { arity: 17 }
                       implementation
@@ -555,7 +555,7 @@ Explained Query:
                         %1:message_hastag_tag » %2:message[#1]KAiif » %0:l1[#0]K
                         %2:message » %1:message_hastag_tag[#1]KA » %0:l1[#0]K
                       ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                        Project (#0) // { arity: 1 }
+                        Project (#0{id}) // { arity: 1 }
                           Get l1 // { arity: 2 }
                       ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
                         ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
@@ -756,7 +756,7 @@ Explained Query:
           Map (null) // { arity: 5 }
             Union // { arity: 4 }
               Negate // { arity: 4 }
-                Project (#0..=#3) // { arity: 4 }
+                Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
                   Join on=(#1{id} = #4{id}) type=differential // { arity: 5 }
                     implementation
                       %1[#0]UKA » %0:l2[#1]K
@@ -769,7 +769,7 @@ Explained Query:
           Get l3 // { arity: 5 }
     With
       cte l3 =
-        Project (#0..=#3, #5) // { arity: 5 }
+        Project (#0{creationdate}..=#3{lastname}, #5) // { arity: 5 }
           Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{containerforumid} = #18{id}) type=delta // { arity: 19 }
             implementation
               %0:l2 » %1:message[#9]KA » %2[#0]UKA » %3[#0]UKA
@@ -791,7 +791,7 @@ Explained Query:
         ArrangeBy keys=[[#1{id}]] // { arity: 4 }
           Get l1 // { arity: 4 }
       cte l1 =
-        Project (#0..=#3) // { arity: 4 }
+        Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
           Join on=(#1{id} = #11{id} = #12{personid}) type=delta // { arity: 13 }
             implementation
               %0:person » %1[#0]UKA » %2[#0]UKA
@@ -815,9 +815,9 @@ Explained Query:
                     ArrangeBy keys=[[#1{forumid}]] // { arity: 3 }
                       ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
       cte l0 =
-        Project (#0) // { arity: 1 }
+        Project (#0{id}) // { arity: 1 }
           TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
-            Project (#0, #2) // { arity: 2 }
+            Project (#0{id}, #2) // { arity: 2 }
               Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
                 ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
 
@@ -869,14 +869,14 @@ Explained Query:
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3{count})) + (2 * #1{sum})) + (10 * #2{sum}))) // { arity: 5 }
         Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(case when (#2) IS NULL then null else #1{count} end, 0)), sum(coalesce(case when (#4) IS NULL then null else #3{count} end, 0)), count(*)] // { arity: 4 }
-          Project (#1, #3, #4, #6, #7) // { arity: 5 }
+          Project (#1{count}, #3{count}, #4, #6, #7) // { arity: 5 }
             Join on=(#0{messageid} = #2{parentmessageid} = #5{messageid}) type=delta // { arity: 8 }
               implementation
                 %0:l0 » %1[#0]K » %2[#0]K
                 %1 » %0:l0[#0]Kef » %2[#0]K
                 %2 » %0:l0[#0]Kef » %1[#0]K
               ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                Project (#1, #2) // { arity: 2 }
+                Project (#1{creatorpersonid}, #2) // { arity: 2 }
                   Filter (#0{name} = "Sikh_Empire") // { arity: 3 }
                     Get l0 // { arity: 3 }
               ArrangeBy keys=[[#0{parentmessageid}]] // { arity: 3 }
@@ -887,7 +887,7 @@ Explained Query:
                     Threshold // { arity: 1 }
                       Union // { arity: 1 }
                         Negate // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{parentmessageid}) // { arity: 1 }
                             Get l1 // { arity: 2 }
                         Get l3 // { arity: 1 }
               ArrangeBy keys=[[#0{messageid}]] // { arity: 3 }
@@ -898,7 +898,7 @@ Explained Query:
                     Threshold // { arity: 1 }
                       Union // { arity: 1 }
                         Negate // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 2 }
                         Get l3 // { arity: 1 }
     With
@@ -916,7 +916,7 @@ Explained Query:
             Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
       cte l0 =
-        Project (#1, #5, #16) // { arity: 3 }
+        Project (#1{messageid}, #5, #16) // { arity: 3 }
           Filter (#0{id}) IS NOT NULL // { arity: 20 }
             Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
               implementation
@@ -1000,14 +1000,14 @@ Explained Query:
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
                   Get l4 // { arity: 2 }
-              Project (#0) // { arity: 1 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
           Get l4 // { arity: 2 }
     With
       cte l4 =
-        Project (#0, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1029,14 +1029,14 @@ Explained Query:
                       Get l1 // { arity: 2 }
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Distinct project=[#0{messageid}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
-            Project (#1, #2) // { arity: 2 }
+            Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l2 =
-        Project (#0, #1, #3) // { arity: 3 }
+        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
           Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
@@ -1107,14 +1107,14 @@ Explained Query:
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
                   Get l4 // { arity: 2 }
-              Project (#0) // { arity: 1 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
           Get l4 // { arity: 2 }
     With
       cte l4 =
-        Project (#0, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1136,14 +1136,14 @@ Explained Query:
                       Get l1 // { arity: 2 }
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Distinct project=[#0{messageid}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{messageid}) // { arity: 1 }
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
-            Project (#1, #2) // { arity: 2 }
+            Project (#1{personid}, #2) // { arity: 2 }
               Get l2 // { arity: 3 }
       cte l2 =
-        Project (#0, #1, #3) // { arity: 3 }
+        Project (#0{messageid}, #1{creatorpersonid}, #3) // { arity: 3 }
           Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
@@ -1215,14 +1215,14 @@ Explained Query:
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{creatorpersonid}) // { arity: 1 }
                   Get l4 // { arity: 2 }
-              Project (#0) // { arity: 1 }
+              Project (#0{creatorpersonid}) // { arity: 1 }
                 Get l3 // { arity: 2 }
           Get l4 // { arity: 2 }
     With
       cte l4 =
-        Project (#0, #3) // { arity: 2 }
+        Project (#0{creatorpersonid}, #3) // { arity: 2 }
           Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
@@ -1242,7 +1242,7 @@ Explained Query:
                       implementation
                         %1[#0]UKA » %0:l2[#0]Kef
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
-                        Project (#1, #2) // { arity: 2 }
+                        Project (#1{creatorpersonid}, #2) // { arity: 2 }
                           Get l2 // { arity: 3 }
                       ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Distinct project=[#0{messageid}] // { arity: 1 }
@@ -1257,7 +1257,7 @@ Explained Query:
         Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
           Get l0 // { arity: 3 }
       cte l1 =
-        Project (#0..=#2, #4) // { arity: 4 }
+        Project (#0{name}..=#2{creatorpersonid}, #4) // { arity: 4 }
           Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
             implementation
               %1:person_likes_message[#2]KA » %0:l0[#1]K
@@ -1266,7 +1266,7 @@ Explained Query:
             ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l0 =
-        Project (#1, #5, #16) // { arity: 3 }
+        Project (#1{messageid}, #5, #16) // { arity: 3 }
           Filter (#0{id}) IS NOT NULL // { arity: 20 }
             Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
               implementation
@@ -1338,7 +1338,7 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{messageid}) // { arity: 1 }
                     Join on=(#0{messageid} = #1{messageid}) type=differential // { arity: 2 }
                       implementation
                         %0:l2[#0]UKA » %1[#0]UKA
@@ -1351,7 +1351,7 @@ Explained Query:
     With
       cte l2 =
         Distinct project=[#0{messageid}] // { arity: 1 }
-          Project (#0) // { arity: 1 }
+          Project (#0{messageid}) // { arity: 1 }
             Get l1 // { arity: 2 }
       cte l1 =
         Project (#2, #18) // { arity: 2 }
@@ -1461,7 +1461,7 @@ Explained Query:
                 Get l7 // { arity: 2 }
               ArrangeBy keys=[[#0{person1id}], [case when (#2) IS NULL then null else #1{person2id} end]] // { arity: 3 }
                 Union // { arity: 3 }
-                  Project (#1..=#3) // { arity: 3 }
+                  Project (#1{person2id}..=#3) // { arity: 3 }
                     Map (true) // { arity: 4 }
                       ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                   Map (null, null) // { arity: 3 }
@@ -1499,11 +1499,11 @@ Explained Query:
         Project (#3, #4) // { arity: 2 }
           Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2{count}, 0))) // { arity: 5 }
             Union // { arity: 3 }
-              Project (#2, #0, #1) // { arity: 3 }
+              Project (#2{count}, #0, #1{creatorpersonid}) // { arity: 3 }
                 Map (null) // { arity: 3 }
                   Union // { arity: 2 }
                     Negate // { arity: 2 }
-                      Project (#0, #1) // { arity: 2 }
+                      Project (#0{creatorpersonid}, #1{count}) // { arity: 2 }
                         Join on=(#0{creatorpersonid} = #2{id}) type=differential // { arity: 3 }
                           implementation
                             %0:l4[#0]UKA » %1[#0]UKA
@@ -1517,13 +1517,13 @@ Explained Query:
                   Negate // { arity: 1 }
                     Get l6 // { arity: 1 }
                   Get l2 // { arity: 1 }
-              Project (#0, #0, #1) // { arity: 3 }
+              Project (#0{id}, #0{id}, #1{id}) // { arity: 3 }
                 Get l5 // { arity: 2 }
       cte l6 =
-        Project (#0) // { arity: 1 }
+        Project (#0{id}) // { arity: 1 }
           Get l5 // { arity: 2 }
       cte l5 =
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{id}, #2) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 3 }
             implementation
               %1:l4[#0]UKA » %0:l2[#0]K
@@ -1559,7 +1559,7 @@ Explained Query:
                 %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
               Get l0 // { arity: 11 }
               ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                Project (#1, #2) // { arity: 2 }
+                Project (#1{tagid}, #2) // { arity: 2 }
                   ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
               Get l1 // { arity: 5 }
       cte l1 =
@@ -1611,7 +1611,7 @@ SELECT Person.id AS "person.id"
 Explained Query:
   Finish order_by=[#4{sum_count} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3{count})] // { arity: 5 }
-      Project (#1..=#3, #25) // { arity: 4 }
+      Project (#1{firstname}..=#3{count}, #25) // { arity: 4 }
         Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
             implementation
@@ -1722,7 +1722,7 @@ Explained Query:
   Finish order_by=[#2{count} desc nulls_first, #1{name} asc nulls_last, #0{person2id} asc nulls_last] limit=100 output=[#0..=#2]
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
-        Project (#0, #9) // { arity: 2 }
+        Project (#0{person2id}, #9) // { arity: 2 }
           Filter (#7{tagid}) IS NOT NULL // { arity: 12 }
             Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
               implementation
@@ -1767,7 +1767,7 @@ Explained Query:
                           ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
               ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
                 Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                  Project (#1, #9) // { arity: 2 }
+                  Project (#1{creatorpersonid}, #9) // { arity: 2 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
               ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                 Distinct project=[#0{messageid}] // { arity: 1 }
@@ -1891,7 +1891,7 @@ Explained Query:
       Filter (#0{id} < #1{person2id}) // { arity: 2 }
         Get l0 // { arity: 2 }
     cte l0 =
-      Project (#1, #21) // { arity: 2 }
+      Project (#1{person2id}, #21) // { arity: 2 }
         Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#1{id}) IS NOT NULL AND (#8{locationcityid}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
           Join on=(#1{id} = #20{person1id} AND #8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 22 }
             implementation
@@ -1973,14 +1973,14 @@ Explained Query:
                         Get l0 // { arity: 11 }
                         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
                           Distinct project=[#0{id}] // { arity: 1 }
-                            Project (#0) // { arity: 1 }
+                            Project (#0{id}) // { arity: 1 }
                               Get l1 // { arity: 2 }
                   Project (#1) // { arity: 1 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
               Get l1 // { arity: 2 }
     With
       cte l1 =
-        Project (#1, #12) // { arity: 2 }
+        Project (#1{messageid}, #12) // { arity: 2 }
           Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#1{id}) IS NOT NULL AND (#15{content}) IS NOT NULL // { arity: 25 }
             Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
               implementation
@@ -2031,7 +2031,7 @@ Explained Query:
         Project (#1) // { arity: 1 }
           Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
-              Project (#1, #11) // { arity: 2 }
+              Project (#1{messageid}, #11) // { arity: 2 }
                 Get l1 // { arity: 12 }
               Project (#1, #22) // { arity: 2 }
                 Map (null) // { arity: 23 }
@@ -2042,7 +2042,7 @@ Explained Query:
                       Union // { arity: 11 }
                         Negate // { arity: 11 }
                           Distinct project=[#0{creationdate}..=#10{email}] // { arity: 11 }
-                            Project (#0..=#10) // { arity: 11 }
+                            Project (#0{creationdate}..=#10{email}) // { arity: 11 }
                               Get l1 // { arity: 12 }
                         Distinct project=[#0{creationdate}..=#10{email}] // { arity: 11 }
                           ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
@@ -2050,17 +2050,17 @@ Explained Query:
                       ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
     With
       cte l1 =
-        Project (#0..=#11) // { arity: 12 }
+        Project (#0{creationdate}..=#11{messageid}) // { arity: 12 }
           Join on=(#12{rootpostlanguage} = #13{rootpostlanguage}) type=differential // { arity: 14 }
             implementation
               %1[#0]UKA » %0:l0[#12]Kiif
             ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
-              Project (#0..=#10, #12, #13) // { arity: 13 }
+              Project (#0{creationdate}..=#10{email}, #12{rootpostlanguage}, #13) // { arity: 13 }
                 Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
                   Get l0 // { arity: 17 }
             ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
               Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{rootpostlanguage}) // { arity: 1 }
                   Filter (#0{rootpostlanguage} = varchar_to_text(#1)) // { arity: 2 }
                     FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
                       Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
@@ -2073,7 +2073,7 @@ Explained Query:
           ArrangeBy keys=[[]] // { arity: 11 }
             ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
           ArrangeBy keys=[[]] // { arity: 6 }
-            Project (#0, #1, #3, #4, #8, #9) // { arity: 6 }
+            Project (#0{creationdate}, #1{messageid}, #3{content}, #4{length}, #8, #9) // { arity: 6 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -2127,19 +2127,19 @@ SELECT Z.zombieid AS "zombie.id"
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
-      Project (#0, #3..=#5) // { arity: 4 }
+      Project (#0{id}, #3..=#5) // { arity: 4 }
         Map (coalesce(#2{sum}, 0), coalesce(#1{count}, 0), case when (#1{count} > 0) then (bigint_to_double(#2{sum}) / bigint_to_double(#1{count})) else 0 end) // { arity: 6 }
           Union // { arity: 3 }
             Map (null, null) // { arity: 3 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{id}) // { arity: 1 }
                     Get l8 // { arity: 3 }
                 Get l2 // { arity: 1 }
             Get l8 // { arity: 3 }
     With
       cte l8 =
-        Project (#0, #2, #3) // { arity: 3 }
+        Project (#0{id}, #2{sum}, #3) // { arity: 3 }
           Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %1[#0]UKA » %0:l4[#0]K
@@ -2162,7 +2162,7 @@ Explained Query:
                               Get l7 // { arity: 1 }
                             Get l6 // { arity: 1 }
       cte l7 =
-        Project (#0) // { arity: 1 }
+        Project (#0{id}) // { arity: 1 }
           Join on=(#0{id} = #1{id}) type=differential // { arity: 2 }
             implementation
               %0:l6[#0]UKA » %1[#0]UKA
@@ -2173,10 +2173,10 @@ Explained Query:
                 Get l3 // { arity: 1 }
       cte l6 =
         Distinct project=[#0{id}] // { arity: 1 }
-          Project (#0) // { arity: 1 }
+          Project (#0{id}) // { arity: 1 }
             Get l5 // { arity: 2 }
       cte l5 =
-        Project (#1, #23) // { arity: 2 }
+        Project (#1{creatorpersonid}, #23) // { arity: 2 }
           Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 28 }
             Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
@@ -2198,7 +2198,7 @@ Explained Query:
         Filter (#0{id}) IS NOT NULL // { arity: 1 }
           Get l2 // { arity: 1 }
       cte l2 =
-        Project (#0) // { arity: 1 }
+        Project (#0{id}) // { arity: 1 }
           Filter (bigint_to_numeric(#2{count_messageid}) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
             Reduce group_by=[#1{id}, #0{creationdate}] aggregates=[count(#2{messageid})] // { arity: 3 }
               Union // { arity: 3 }
@@ -2213,7 +2213,7 @@ Explained Query:
                         Union // { arity: 16 }
                           Negate // { arity: 16 }
                             Distinct project=[#0{id}..=#15{email}] // { arity: 16 }
-                              Project (#0..=#15) // { arity: 16 }
+                              Project (#0{id}..=#15{email}) // { arity: 16 }
                                 Filter (#0{id} = #0{id}) AND (#3{id} = #3{id}) // { arity: 17 }
                                   Get l1 // { arity: 17 }
                           Distinct project=[#0{id}..=#15{email}] // { arity: 16 }
@@ -2222,7 +2222,7 @@ Explained Query:
                       ArrangeBy keys=[[#0{id}..=#15{email}]] // { arity: 16 }
                         Get l0 // { arity: 16 }
       cte l1 =
-        Project (#0..=#15, #17) // { arity: 17 }
+        Project (#0{id}..=#15{email}, #17) // { arity: 17 }
           Filter (#16{creationdate} <= 2012-11-09 00:00:00 UTC) AND (#16{creationdate} >= #6{creationdate}) // { arity: 29 }
             Join on=(#7{id} = #25{creatorpersonid}) type=differential // { arity: 29 }
               implementation
@@ -2233,7 +2233,7 @@ Explained Query:
               ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 13 }
                 ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
       cte l0 =
-        Project (#0, #2..=#6, #8..=#15, #17, #18) // { arity: 16 }
+        Project (#0{id}, #2{partofcontinentid}..=#6{creationdate}, #8{firstname}..=#15{email}, #17, #18) // { arity: 16 }
           Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL AND (#4{id}) IS NOT NULL // { arity: 19 }
             Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
               implementation
@@ -2331,21 +2331,21 @@ SELECT score_ranks.Person1Id AS "person1.id"
 Explained Query:
   Finish order_by=[#3{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
-      Project (#0, #1, #3, #4) // { arity: 4 }
+      Project (#0{id}, #1{person2id}, #3{sum}, #4) // { arity: 4 }
         TopK group_by=[#2{id}] order_by=[#4{sum} desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Map (null) // { arity: 5 }
               Union // { arity: 4 }
                 Negate // { arity: 4 }
-                  Project (#2, #3, #0, #1) // { arity: 4 }
+                  Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
                     Get l11 // { arity: 5 }
-                Project (#2, #3, #0, #1) // { arity: 4 }
+                Project (#2{id}, #3{name}, #0{id}, #1{person2id}) // { arity: 4 }
                   Get l3 // { arity: 4 }
-            Project (#2, #3, #0, #1, #4) // { arity: 5 }
+            Project (#2{id}, #3{name}, #0{id}, #1{person2id}, #4{sum}) // { arity: 5 }
               Get l11 // { arity: 5 }
     With
       cte l11 =
-        Project (#0..=#3, #6) // { arity: 5 }
+        Project (#0{id}..=#3{person2id}, #6) // { arity: 5 }
           Join on=(#2{id} = #4 AND #3{person2id} = #5) type=differential // { arity: 7 }
             implementation
               %1[#0, #1]UKKA » %0:l3[#2, #3]KK
@@ -2369,7 +2369,7 @@ Explained Query:
                               Get l10 // { arity: 2 }
                             Get l9 // { arity: 2 }
       cte l10 =
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{id}, #1{person2id}) // { arity: 2 }
           Join on=(#0{id} = #2{personid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %0:l9[#0, #1]UKKA » %1[#0, #1]UKKA
@@ -2386,10 +2386,10 @@ Explained Query:
                       ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l9 =
         Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
-          Project (#0, #1) // { arity: 2 }
+          Project (#0{id}, #1{person2id}) // { arity: 2 }
             Get l8 // { arity: 6 }
       cte l8 =
-        Project (#0..=#4, #7) // { arity: 6 }
+        Project (#0{id}..=#4, #7) // { arity: 6 }
           Join on=(#0{id} = #5{id} AND #1{person2id} = #6{person2id}) type=differential // { arity: 8 }
             implementation
               %0:l4[#0, #1]KK » %1[#0, #1]KK
@@ -2405,7 +2405,7 @@ Explained Query:
                       Get l7 // { arity: 2 }
                     Get l5 // { arity: 2 }
       cte l7 =
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{id}, #1{person2id}) // { arity: 2 }
           Join on=(#0{id} = #2{creatorpersonid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %0:l5[#0, #1]UKKA » %1[#0, #1]UKKA
@@ -2426,7 +2426,7 @@ Explained Query:
           ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
       cte l5 =
         Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
-          Project (#0, #1) // { arity: 2 }
+          Project (#0{id}, #1{person2id}) // { arity: 2 }
             Get l4 // { arity: 5 }
       cte l4 =
         Map (case when #2 then #1{person2id} else #0{id} end, case when #2 then #0{id} else #1{person2id} end) // { arity: 5 }
@@ -2550,12 +2550,12 @@ SELECT coalesce(w, -1) FROM results ORDER BY w ASC LIMIT 20
 Explained Query:
   Finish order_by=[#1{min} asc nulls_last] limit=20 output=[#2]
     Return // { arity: 3 }
-      Project (#1, #2, #2) // { arity: 3 }
+      Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
         Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
           Get l4 // { arity: 3 }
     With Mutually Recursive
       cte l4 =
-        Project (#2, #0, #1) // { arity: 3 }
+        Project (#2{min}, #0, #1{person2id}) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
               Distinct project=[#0{person2id}, #1] // { arity: 2 }
@@ -2569,13 +2569,13 @@ Explained Query:
                           Project (#1, #2) // { arity: 2 }
                             Get l4 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                          Project (#0, #1, #3) // { arity: 3 }
+                          Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
                             Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
                               Union // { arity: 3 }
                                 Map (null) // { arity: 3 }
                                   Union // { arity: 2 }
                                     Negate // { arity: 2 }
-                                      Project (#0, #1) // { arity: 2 }
+                                      Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
                                             %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
@@ -2583,26 +2583,26 @@ Explained Query:
                                             Get l3 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                                             Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
-                                              Project (#0, #1) // { arity: 2 }
+                                              Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                                 Get l2 // { arity: 3 }
                                     Get l3 // { arity: 2 }
                                 Get l2 // { arity: 3 }
                   Constant // { arity: 2 }
                     - (1450, 0)
       cte l3 =
-        Project (#1, #2) // { arity: 2 }
+        Project (#1{person2id}, #2) // { arity: 2 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
       cte l2 =
-        Project (#0, #1, #4) // { arity: 3 }
+        Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
           Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
             implementation
               %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
             ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-              Project (#1, #2) // { arity: 2 }
+              Project (#1{person2id}, #2) // { arity: 2 }
                 ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
             ArrangeBy keys=[[#1, #0]] // { arity: 3 }
               Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-                Project (#0..=#2) // { arity: 3 }
+                Project (#0{person1id}..=#2{parentmessageid}) // { arity: 3 }
                   Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
                     implementation
                       %0:l1 » %1[#0]UKA » %2[#0]UKA
@@ -2621,7 +2621,7 @@ Explained Query:
                           Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                             ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
       cte l1 =
-        Project (#0, #1, #3, #4) // { arity: 4 }
+        Project (#0{person1id}, #1{person2id}, #3{containerforumid}, #4) // { arity: 4 }
           Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
             implementation
               %0:l0 » %1[#0]UKA » %2[#0]UKA
@@ -2640,7 +2640,7 @@ Explained Query:
                   Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                     ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
       cte l0 =
-        Project (#1, #2, #5, #6, #8) // { arity: 5 }
+        Project (#1{person2id}, #2{containerforumid}, #5, #6, #8) // { arity: 5 }
           Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
             implementation
               %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
@@ -2649,7 +2649,7 @@ Explained Query:
             ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
             ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-              Project (#1, #9, #10, #12) // { arity: 4 }
+              Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
                 ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
               Project (#9, #10, #12) // { arity: 3 }
@@ -2796,11 +2796,11 @@ Explained Query:
                   implementation
                     %0:l17[#1]Kef » %1:l17[#1]Kef
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
+                    Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
                         Get l17 // { arity: 4 }
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
+                    Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
                         Get l17 // { arity: 4 }
       cte l17 =
@@ -2944,7 +2944,7 @@ Explained Query:
         Union // { arity: 2 }
           Distinct project=[#0{person2id}, #1] // { arity: 2 }
             Union // { arity: 2 }
-              Project (#1, #0) // { arity: 2 }
+              Project (#1, #0{person2id}) // { arity: 2 }
                 CrossJoin type=differential // { arity: 2 }
                   implementation
                     %0:l5[×] » %1[×]
@@ -2969,36 +2969,36 @@ Explained Query:
             implementation
               %0:l6[#0]Kf » %1:l6[#0]Kf
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{person2id}) // { arity: 1 }
                 Filter #1 // { arity: 2 }
                   Get l6 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{person2id}) // { arity: 1 }
                 Filter NOT(#1) // { arity: 2 }
                   Get l6 // { arity: 2 }
     cte l6 =
       Union // { arity: 2 }
-        Project (#1, #0) // { arity: 2 }
+        Project (#1, #0{person2id}) // { arity: 2 }
           Get l5 // { arity: 2 }
         Get l8 // { arity: 2 }
     cte l5 =
-      Project (#1, #3) // { arity: 2 }
+      Project (#1{person2id}, #3) // { arity: 2 }
         Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
             %0:l8[#0]K » %1:l4[#0]K
           ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
             Get l8 // { arity: 2 }
           ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
+            Project (#0{person1id}, #1{person2id}) // { arity: 2 }
               Get l4 // { arity: 3 }
     cte l4 =
-      Project (#0, #1, #3) // { arity: 3 }
+      Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
         Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
           Union // { arity: 3 }
             Map (null) // { arity: 3 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
+                  Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                     Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
                         %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
@@ -3006,24 +3006,24 @@ Explained Query:
                         Get l3 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                         Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
-                          Project (#0, #1) // { arity: 2 }
+                          Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                             Get l2 // { arity: 3 }
                 Get l3 // { arity: 2 }
             Get l2 // { arity: 3 }
     cte l3 =
-      Project (#1, #2) // { arity: 2 }
+      Project (#1{person2id}, #2) // { arity: 2 }
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
     cte l2 =
-      Project (#0, #1, #4) // { arity: 3 }
+      Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
           implementation
             %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
           ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-            Project (#1, #2) // { arity: 2 }
+            Project (#1{person2id}, #2) // { arity: 2 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
             Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
+              Project (#0{person1id}..=#2{parentmessageid}) // { arity: 3 }
                 Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
                   implementation
                     %0:l1 » %1[#0]UKA » %2[#0]UKA
@@ -3042,7 +3042,7 @@ Explained Query:
                         Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                           ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
     cte l1 =
-      Project (#0, #1, #3, #4) // { arity: 4 }
+      Project (#0{person1id}, #1{person2id}, #3{containerforumid}, #4) // { arity: 4 }
         Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
           implementation
             %0:l0 » %1[#0]UKA » %2[#0]UKA
@@ -3061,7 +3061,7 @@ Explained Query:
                 Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                   ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
     cte l0 =
-      Project (#1, #2, #5, #6, #8) // { arity: 5 }
+      Project (#1{person2id}, #2{containerforumid}, #5, #6, #8) // { arity: 5 }
         Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
           implementation
             %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
@@ -3070,7 +3070,7 @@ Explained Query:
           ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
             ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
           ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-            Project (#1, #9, #10, #12) // { arity: 4 }
+            Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
           ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
             Project (#9, #10, #12) // { arity: 3 }
@@ -3164,7 +3164,7 @@ LIMIT 20
 Explained Query:
   Finish order_by=[#6 desc nulls_first, #0{id} asc nulls_last] limit=20 output=[#0, #1, #4]
     Return // { arity: 7 }
-      Project (#0..=#2, #0, #4..=#6) // { arity: 7 }
+      Project (#0{id}..=#2{count_person2id}, #0{id}, #4{count_messageid}..=#6) // { arity: 7 }
         Filter (#2{count_person2id} <= 5) AND (#5{count_person2id} <= 5) // { arity: 7 }
           Map ((#1{count_messageid} + #4{count_messageid})) // { arity: 7 }
             Join on=(#0{id} = #3{id}) type=differential // { arity: 6 }
@@ -3178,7 +3178,7 @@ Explained Query:
                       Union // { arity: 2 }
                         Negate // { arity: 2 }
                           Distinct project=[#0{id}, #1{messageid}] // { arity: 2 }
-                            Project (#0, #1) // { arity: 2 }
+                            Project (#0{id}, #1{messageid}) // { arity: 2 }
                               Get l5 // { arity: 3 }
                         Get l3 // { arity: 2 }
               ArrangeBy keys=[[#0{id}]] // { arity: 3 }
@@ -3189,12 +3189,12 @@ Explained Query:
                       Union // { arity: 2 }
                         Negate // { arity: 2 }
                           Distinct project=[#0{id}, #1{messageid}] // { arity: 2 }
-                            Project (#0, #1) // { arity: 2 }
+                            Project (#0{id}, #1{messageid}) // { arity: 2 }
                               Get l7 // { arity: 3 }
                         Get l6 // { arity: 2 }
     With
       cte l7 =
-        Project (#0, #1, #4) // { arity: 3 }
+        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
             implementation
               %0:l6 » %1:l4[#1]KA » %2[#0]UKA
@@ -3205,10 +3205,10 @@ Explained Query:
             Get l4 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{id}) // { arity: 1 }
                   Get l6 // { arity: 2 }
       cte l6 =
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{id}, #2) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
             implementation
               %0:l0 » %1[#0]K » %2[#0]UKA
@@ -3217,7 +3217,7 @@ Explained Query:
             Get l0 // { arity: 1 }
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1, #9) // { arity: 2 }
+                Project (#1{creatorpersonid}, #9) // { arity: 2 }
                   Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
@@ -3231,7 +3231,7 @@ Explained Query:
                       ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                         ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
       cte l5 =
-        Project (#0, #1, #4) // { arity: 3 }
+        Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
             implementation
               %0:l3 » %1:l4[#1]KA » %2[#0]UKA
@@ -3242,13 +3242,13 @@ Explained Query:
             Get l4 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{id}) // { arity: 1 }
                   Get l3 // { arity: 2 }
       cte l4 =
         ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
       cte l3 =
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{id}, #2) // { arity: 2 }
           Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=delta // { arity: 4 }
             implementation
               %0:l0 » %1[#0]K » %2[#0]UKA
@@ -3257,7 +3257,7 @@ Explained Query:
             Get l0 // { arity: 1 }
             ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                Project (#1, #9) // { arity: 2 }
+                Project (#1{creatorpersonid}, #9) // { arity: 2 }
                   Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
@@ -3342,7 +3342,7 @@ Explained Query:
   Finish order_by=[#1{count_messageid} desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{creatorpersonid}, #1{messageid}) // { arity: 2 }
           Join on=(#0{creatorpersonid} = #3{creatorpersonid} AND #2{containerforumid} = #4{containerforumid}) type=differential // { arity: 5 }
             implementation
               %0:l2[#0, #2]KK » %1[#0, #1]KK
@@ -3351,7 +3351,7 @@ Explained Query:
             ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
+                  Project (#0{creatorpersonid}, #1{containerforumid}) // { arity: 2 }
                     Join on=(#0{creatorpersonid} = #2{personid} AND #1{containerforumid} = #3{forumid}) type=differential // { arity: 4 }
                       implementation
                         %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
@@ -3359,16 +3359,16 @@ Explained Query:
                         Get l3 // { arity: 2 }
                       ArrangeBy keys=[[#0{personid}, #1{forumid}]] // { arity: 2 }
                         Distinct project=[#1{personid}, #0{forumid}] // { arity: 2 }
-                          Project (#1, #2) // { arity: 2 }
+                          Project (#1{personid}, #2) // { arity: 2 }
                             ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
                 Get l3 // { arity: 2 }
     With
       cte l3 =
         Distinct project=[#0{creatorpersonid}, #1{containerforumid}] // { arity: 2 }
-          Project (#0, #2) // { arity: 2 }
+          Project (#0{creatorpersonid}, #2) // { arity: 2 }
             Get l2 // { arity: 3 }
       cte l2 =
-        Project (#1, #4, #6) // { arity: 3 }
+        Project (#1{messageid}, #4, #6) // { arity: 3 }
           Filter (#2{containerforumid} != #6{containerforumid}) AND (#5{creatorpersonid} != #7{creatorpersonid}) AND ((#0{creationdate} + 12:00:00) < #3{creationdate}) // { arity: 15 }
             Join on=(#2{containerforumid} = #10{forumid} = #13{forumid} AND #4{messageid} = #8{parentmessageid} AND #5{creatorpersonid} = #14{personid} AND #7{creatorpersonid} = #11{personid}) type=delta // { arity: 15 }
               implementation
@@ -3378,11 +3378,11 @@ Explained Query:
                 %3:l1 » %4:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
                 %4:l1 » %3:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
               ArrangeBy keys=[[#2{containerforumid}]] // { arity: 3 }
-                Project (#0, #2, #3) // { arity: 3 }
+                Project (#0{creationdate}, #2{containerforumid}, #3) // { arity: 3 }
                   Filter (#3{containerforumid}) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
               ArrangeBy keys=[[#1{messageid}, #2{creatorpersonid}], [#2{creatorpersonid}]] // { arity: 4 }
-                Project (#0..=#3) // { arity: 4 }
+                Project (#0{creationdate}..=#3{containerforumid}) // { arity: 4 }
                   Get l0 // { arity: 5 }
               ArrangeBy keys=[[#0{creatorpersonid}, #1{parentmessageid}]] // { arity: 2 }
                 Project (#2, #4) // { arity: 2 }
@@ -3394,7 +3394,7 @@ Explained Query:
         ArrangeBy keys=[[#1{forumid}], [#2{personid}]] // { arity: 3 }
           ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[delta join lookup] forum_hasmember_person_personid=[delta join lookup] // { arity: 3 }
       cte l0 =
-        Project (#0, #1, #9, #10, #12) // { arity: 5 }
+        Project (#0{creationdate}, #1{messageid}, #9, #10, #12) // { arity: 5 }
           Join on=(#1{messageid} = #13{messageid}) type=differential // { arity: 14 }
             implementation
               %1[#0]UKA » %0:message[#1]KA
@@ -3410,7 +3410,7 @@ Explained Query:
                       ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
                     ArrangeBy keys=[[#0{id}]] // { arity: 1 }
                       Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#0) // { arity: 1 }
+                        Project (#0{id}) // { arity: 1 }
                           Filter (#0{id}) IS NOT NULL // { arity: 5 }
                             ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
 
@@ -3462,7 +3462,7 @@ Explained Query:
   Finish order_by=[#2{count} desc nulls_first, #0{personid} asc nulls_last, #1{personid} asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
       Reduce group_by=[#0{personid}, #1{personid}] aggregates=[count(*)] // { arity: 3 }
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{personid}, #1{personid}) // { arity: 2 }
           Join on=(#0{personid} = #2{personid} AND #1{personid} = #3{personid}) type=differential // { arity: 4 }
             implementation
               %0:l1[#0, #1]KK » %1[#0, #1]KK
@@ -3471,7 +3471,7 @@ Explained Query:
             ArrangeBy keys=[[#0{personid}, #1{personid}]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
+                  Project (#0{personid}, #1{personid}) // { arity: 2 }
                     Join on=(#0{personid} = #2{person2id} AND #1{personid} = #3{person1id}) type=differential // { arity: 4 }
                       implementation
                         %0:l2[#0, #1]UKKA » %1[#0, #1]UKKA
@@ -3479,7 +3479,7 @@ Explained Query:
                         Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#0{person2id}, #1{person1id}]] // { arity: 2 }
                         Distinct project=[#1{person2id}, #0{person1id}] // { arity: 2 }
-                          Project (#1, #2) // { arity: 2 }
+                          Project (#1{person2id}, #2) // { arity: 2 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                 Get l2 // { arity: 2 }
     With
@@ -3487,7 +3487,7 @@ Explained Query:
         Distinct project=[#0{personid}, #1{personid}] // { arity: 2 }
           Get l1 // { arity: 2 }
       cte l1 =
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{personid}, #2) // { arity: 2 }
           Filter (#0{personid} != #2{personid}) // { arity: 4 }
             Join on=(#1{person2id} = #3{person2id}) type=differential // { arity: 4 }
               implementation
@@ -3496,7 +3496,7 @@ Explained Query:
               Get l0 // { arity: 2 }
       cte l0 =
         ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
-          Project (#0, #9) // { arity: 2 }
+          Project (#0{personid}, #9) // { arity: 2 }
             Filter (#1{tagid}) IS NOT NULL // { arity: 10 }
               Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
                 implementation
@@ -3504,7 +3504,7 @@ Explained Query:
                   %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
                   %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
                 ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                  Project (#1, #2) // { arity: 2 }
+                  Project (#1{tagid}, #2) // { arity: 2 }
                     ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
                 ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                   ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
@@ -3560,11 +3560,11 @@ materialize.public.pathq19:
   Return // { arity: 3 }
     Union // { arity: 3 }
       Get l0 // { arity: 3 }
-      Project (#1, #0, #2) // { arity: 3 }
+      Project (#1{person1id}, #0{person2id}, #2) // { arity: 3 }
         Get l0 // { arity: 3 }
   With
     cte l0 =
-      Project (#0, #1, #3) // { arity: 3 }
+      Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
         Map (greatest(f64toi64(roundf64((40 - sqrtf64(bigint_to_double(#2{count}))))), 1)) // { arity: 4 }
           Reduce group_by=[#0{person1id}, #1{person2id}] aggregates=[count(*)] // { arity: 3 }
             Project (#16, #17) // { arity: 2 }
@@ -3658,7 +3658,7 @@ SELECT src, dst, w
 Explained Query:
   Return // { arity: 3 }
     Return // { arity: 3 }
-      Project (#0..=#2) // { arity: 3 }
+      Project (#0{id}..=#2{min}) // { arity: 3 }
         Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
           implementation
             %1[#0]UK » %0:l1[#2]K
@@ -3672,7 +3672,7 @@ Explained Query:
                   Get l1 // { arity: 3 }
     With
       cte l1 =
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0{id}..=#2{min}) // { arity: 3 }
           Join on=(#1{id} = #3{id} = #4{id}) type=delta // { arity: 5 }
             implementation
               %0:l0 » %1[#0]UKA » %2[#0]UKA
@@ -3695,7 +3695,7 @@ Explained Query:
       Reduce group_by=[#0{id}, #1{id}] aggregates=[min(#2)] // { arity: 3 }
         Distinct project=[#0{id}..=#2] // { arity: 3 }
           Union // { arity: 3 }
-            Project (#1, #1, #12) // { arity: 3 }
+            Project (#1{id}, #1{id}, #12) // { arity: 3 }
               Map (0) // { arity: 13 }
                 ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
             Project (#0, #4, #6) // { arity: 3 }
@@ -3774,7 +3774,7 @@ WHERE w = (SELECT MIN(w) FROM paths)
 ----
 Explained Query:
   Return // { arity: 3 }
-    Project (#0..=#2) // { arity: 3 }
+    Project (#0{id}..=#2{min}) // { arity: 3 }
       Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
         implementation
           %1[#0]UK » %0:l2[#2]K
@@ -3803,7 +3803,7 @@ Explained Query:
           Get l2 // { arity: 3 }
     cte l2 =
       Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-        Project (#0, #2, #3, #5) // { arity: 4 }
+        Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
           Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
             implementation
               %0:l0[#1]K » %1:l1[#1]K
@@ -3816,7 +3816,7 @@ Explained Query:
     cte l1 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
-          Project (#1, #1, #12) // { arity: 3 }
+          Project (#1{id}, #1{id}, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
           Project (#0, #5, #7) // { arity: 3 }
@@ -3847,7 +3847,7 @@ Explained Query:
     cte l0 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
-          Project (#1, #1, #12) // { arity: 3 }
+          Project (#1{id}, #1{id}, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
           Project (#0, #5, #7) // { arity: 3 }
@@ -3941,7 +3941,7 @@ Explained Query:
   Finish order_by=[#0{id} asc nulls_last, #1{id} asc nulls_last] output=[#0..=#2]
     Return // { arity: 3 }
       Return // { arity: 3 }
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0{id}..=#2{min}) // { arity: 3 }
           Join on=(#2{min} = #3{min_min}) type=differential // { arity: 4 }
             implementation
               %1[#0]UK » %0:l9[#2]K
@@ -3956,16 +3956,16 @@ Explained Query:
       With
         cte l9 =
           Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
-            Project (#0, #2, #3, #5) // { arity: 4 }
+            Project (#0{id}, #2{id}, #3, #5) // { arity: 4 }
               Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
                 implementation
                   %0:l8[#1]Kef » %1:l8[#1]Kef
                 ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1..=#3) // { arity: 3 }
+                  Project (#1{id}..=#3) // { arity: 3 }
                     Filter (#0 = false) // { arity: 4 }
                       Get l8 // { arity: 4 }
                 ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                  Project (#1..=#3) // { arity: 3 }
+                  Project (#1{id}..=#3) // { arity: 3 }
                     Filter (#0 = true) // { arity: 4 }
                       Get l8 // { arity: 4 }
         cte l8 =
@@ -3986,7 +3986,7 @@ Explained Query:
       cte l7 =
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
-            Project (#1, #0, #0, #2..=#4) // { arity: 6 }
+            Project (#1{id}, #0, #0, #2{id}..=#4) // { arity: 6 }
               Map (0, false, 0) // { arity: 5 }
                 Union // { arity: 2 }
                   Project (#1, #12) // { arity: 2 }
@@ -4174,7 +4174,7 @@ Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{dst}, #1{min}) // { arity: 2 }
           Filter (#1{min} = #3{min_min}) // { arity: 4 }
             Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
               implementation
@@ -4196,12 +4196,12 @@ Explained Query:
           Project (#1) // { arity: 1 }
             Get l1 // { arity: 2 }
         cte l1 =
-          Project (#0, #1) // { arity: 2 }
+          Project (#0{dst}, #1{min}) // { arity: 2 }
             Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                Project (#1, #2) // { arity: 2 }
+                Project (#1{min}, #2) // { arity: 2 }
                   Get l0 // { arity: 3 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
@@ -4216,7 +4216,7 @@ Explained Query:
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
-        Project (#2, #0, #1) // { arity: 3 }
+        Project (#2{min}, #0, #1{dst}) // { arity: 3 }
           Map (10995116285979) // { arity: 3 }
             Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
               Distinct project=[#0{dst}, #1] // { arity: 2 }
@@ -4227,7 +4227,7 @@ Explained Query:
                         implementation
                           %0:l0[#0]UK » %1:pathq20[#0]KA
                         ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
-                          Project (#1, #2) // { arity: 2 }
+                          Project (#1{min}, #2) // { arity: 2 }
                             Get l0 // { arity: 3 }
                         ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                           ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
@@ -4282,7 +4282,7 @@ Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{dst}, #1{min}) // { arity: 2 }
           Filter (#1{min} = #3{min_min}) // { arity: 4 }
             Join on=(#1{min} = #2{min}) type=differential // { arity: 4 }
               implementation
@@ -4304,7 +4304,7 @@ Explained Query:
           Project (#1) // { arity: 1 }
             Get l1 // { arity: 2 }
         cte l1 =
-          Project (#0, #1) // { arity: 2 }
+          Project (#0{dst}, #1{min}) // { arity: 2 }
             Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
@@ -4391,7 +4391,7 @@ Explained Query:
   Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
       Return // { arity: 3 }
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0{dst}..=#2{min}) // { arity: 3 }
           Filter (#1{min} = #4{min_min}) // { arity: 5 }
             Join on=(#1{min} = #3{min}) type=differential // { arity: 5 }
               implementation
@@ -4413,12 +4413,12 @@ Explained Query:
           Project (#1) // { arity: 1 }
             Get l1 // { arity: 3 }
         cte l1 =
-          Project (#0..=#2) // { arity: 3 }
+          Project (#0{dst}..=#2{min}) // { arity: 3 }
             Join on=(#0{dst} = #3{personid}) type=differential // { arity: 4 }
               implementation
                 %1[#0]UKA » %0:l0[#0]K
               ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
-                Project (#1..=#3) // { arity: 3 }
+                Project (#1{min}..=#3) // { arity: 3 }
                   Get l0 // { arity: 4 }
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
@@ -4433,7 +4433,7 @@ Explained Query:
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
-        Project (#3, #0..=#2) // { arity: 4 }
+        Project (#3{min}, #0..=#2{min}) // { arity: 4 }
           Map (10995116285979) // { arity: 4 }
             Reduce group_by=[#0{dst}, #2{min}] aggregates=[min(#1)] // { arity: 3 }
               Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
@@ -4445,7 +4445,7 @@ Explained Query:
                           implementation
                             %1:pathq20[#0]KA » %0:l0[#0]K
                           ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
-                            Project (#1..=#3) // { arity: 3 }
+                            Project (#1{min}..=#3) // { arity: 3 }
                               Get l0 // { arity: 4 }
                           ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                             ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
@@ -4542,7 +4542,7 @@ Explained Query:
   Finish order_by=[#0{personid} asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+        Project (#0{personid}, #1{min}) // { arity: 2 }
           Join on=(#1{min} = #2{min_min}) type=differential // { arity: 3 }
             implementation
               %1[#0]UK » %0:l11[#1]K
@@ -4556,18 +4556,18 @@ Explained Query:
                     Get l11 // { arity: 2 }
       With
         cte l11 =
-          Project (#1, #2) // { arity: 2 }
+          Project (#1{min}, #2) // { arity: 2 }
             Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
-              Project (#0, #2, #3, #5) // { arity: 4 }
+              Project (#0{personid}, #2{personid}, #3, #5) // { arity: 4 }
                 Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                   implementation
                     %0:l10[#1]Kef » %1:l10[#1]Kef
                   ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
+                    Project (#1{personid}..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
                         Get l10 // { arity: 4 }
                   ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
-                    Project (#1..=#3) // { arity: 3 }
+                    Project (#1{personid}..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
                         Get l10 // { arity: 4 }
         cte l10 =
@@ -4588,14 +4588,14 @@ Explained Query:
       cte l9 =
         Distinct project=[#0..=#5] // { arity: 6 }
           Union // { arity: 6 }
-            Project (#0..=#2, #4, #3, #5) // { arity: 6 }
+            Project (#0..=#2{personid}, #4, #3, #5) // { arity: 6 }
               Map (false, 0, 0) // { arity: 6 }
                 Distinct project=[#0..=#2{personid}] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#1, #0, #0) // { arity: 3 }
                       Map (10995116285979, false) // { arity: 2 }
                         Get l8 // { arity: 0 }
-                    Project (#1, #0, #0) // { arity: 3 }
+                    Project (#1{personid}, #0, #0) // { arity: 3 }
                       Map (true) // { arity: 2 }
                         CrossJoin type=differential // { arity: 1 }
                           implementation

--- a/test/sqllogictest/limit.slt
+++ b/test/sqllogictest/limit.slt
@@ -272,7 +272,7 @@ Explained Query:
           Get l1 // { arity: 2 }
           Map (error("more than one record produced in subquery")) // { arity: 2 }
             Project (#0) // { arity: 1 }
-              Filter (#1 > 1) // { arity: 2 }
+              Filter (#1{count} > 1) // { arity: 2 }
                 Reduce group_by=[#0{state}] aggregates=[count(*)] // { arity: 2 }
                   Project (#0) // { arity: 1 }
                     Get l1 // { arity: 2 }

--- a/test/sqllogictest/limit.slt
+++ b/test/sqllogictest/limit.slt
@@ -108,17 +108,17 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#1{first_name} asc nulls_last, #4{preference} asc nulls_last] output=[#1, #3]
-    Project (#0..=#2, #5, #6) // { arity: 5 }
+    Project (#0{id}..=#2{allowance}, #5, #6) // { arity: 5 }
       Join on=(#0{id} = #3{id} AND #2{allowance} = #4{allowance}) type=differential // { arity: 7 }
         ArrangeBy keys=[[#0{id}, #2{allowance}]] // { arity: 3 }
           ReadStorage materialize.public.people // { arity: 3 }
         ArrangeBy keys=[[#0{id}, #1{allowance}]] // { arity: 4 }
           TopK group_by=[#0{id}, #1{allowance}] order_by=[#3{preference} asc nulls_last] limit=integer_to_bigint(#1{allowance}) offset=1 // { arity: 4 }
-            Project (#0, #1, #3, #4) // { arity: 4 }
+            Project (#0{id}, #1{allowance}, #3{preference}, #4) // { arity: 4 }
               Join on=(#0{id} = #2{person_id}) type=differential // { arity: 5 }
                 ArrangeBy keys=[[#0{id}]] // { arity: 2 }
                   Distinct project=[#0{id}, #1{allowance}] // { arity: 2 }
-                    Project (#0, #2) // { arity: 2 }
+                    Project (#0{id}, #2) // { arity: 2 }
                       Filter (#0{id}) IS NOT NULL // { arity: 3 }
                         ReadStorage materialize.public.people // { arity: 3 }
                 ArrangeBy keys=[[#0{person_id}]] // { arity: 3 }
@@ -162,10 +162,10 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#1 asc nulls_last, #4{preference} asc nulls_last] output=[#1, #3]
-    Project (#2..=#4, #0, #1) // { arity: 5 }
+    Project (#2..=#4{preference}, #0, #1) // { arity: 5 }
       Map (1, "frank", -4) // { arity: 5 }
         TopK order_by=[#1{preference} asc nulls_last] limit=-4 offset=1 // { arity: 2 }
-          Project (#1, #2) // { arity: 2 }
+          Project (#1{preference}, #2) // { arity: 2 }
             Filter (#0{person_id} = 1) // { arity: 3 }
               ReadStorage materialize.public.preferred_fruits // { arity: 3 }
 
@@ -202,7 +202,7 @@ LIMIT 3;
 Explained Query:
   Finish order_by=[#0{state} asc nulls_last, #1{name} asc nulls_last] limit=3 output=[#0, #1]
     TopK group_by=[#0{state}] limit=integer_to_bigint((ascii(substr(#0{state}, 1, 1)) - 64)) // { arity: 2 }
-      Project (#1, #0) // { arity: 2 }
+      Project (#1{name}, #0{state}) // { arity: 2 }
         ReadStorage materialize.public.cities // { arity: 3 }
 
 Target cluster: quickstart
@@ -249,12 +249,12 @@ ORDER BY s.state, c.name;
 Explained Query:
   Finish order_by=[#0{state} asc nulls_last, #1{name} asc nulls_last] output=[#0, #1]
     Return // { arity: 2 }
-      Project (#1, #0) // { arity: 2 }
+      Project (#1{name}, #0{state}) // { arity: 2 }
         TopK group_by=[#1{state}, #2{l}] order_by=[#0{name} asc nulls_last] limit=integer_to_bigint(#2{l}) // { arity: 3 }
-          Project (#0, #1, #3) // { arity: 3 }
+          Project (#0{name}, #1{state}, #3) // { arity: 3 }
             Join on=(#1{state} = #2{state}) type=differential // { arity: 4 }
               ArrangeBy keys=[[#1{state}]] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
+                Project (#0{name}, #1{state}) // { arity: 2 }
                   ReadStorage materialize.public.cities // { arity: 3 }
               ArrangeBy keys=[[#0{state}]] // { arity: 2 }
                 Union // { arity: 2 }
@@ -263,7 +263,7 @@ Explained Query:
                     Union // { arity: 1 }
                       Negate // { arity: 1 }
                         Distinct project=[#0{state}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{state}) // { arity: 1 }
                             Get l2 // { arity: 2 }
                       Get l0 // { arity: 1 }
     With
@@ -271,13 +271,13 @@ Explained Query:
         Union // { arity: 2 }
           Get l1 // { arity: 2 }
           Map (error("more than one record produced in subquery")) // { arity: 2 }
-            Project (#0) // { arity: 1 }
+            Project (#0{state}) // { arity: 1 }
               Filter (#1{count} > 1) // { arity: 2 }
                 Reduce group_by=[#0{state}] aggregates=[count(*)] // { arity: 2 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{state}) // { arity: 1 }
                     Get l1 // { arity: 2 }
       cte l1 =
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{state}, #2) // { arity: 2 }
           Join on=(#1{sl} = substr(#0{state}, 1, 1)) type=differential // { arity: 3 }
             ArrangeBy keys=[[substr(#0{state}, 1, 1)]] // { arity: 1 }
               Get l0 // { arity: 1 }
@@ -325,7 +325,7 @@ Explained Query:
           ReadStorage materialize.public.cities // { arity: 3 }
     ArrangeBy keys=[[]] // { arity: 1 }
       TopK limit=1 // { arity: 1 }
-        Project (#0) // { arity: 1 }
+        Project (#0{name}) // { arity: 1 }
           ReadStorage materialize.public.cities // { arity: 3 }
 
 Target cluster: quickstart
@@ -368,13 +368,13 @@ SELECT s.state, c1.name, c2.name FROM
 ----
 Explained Query:
   Return // { arity: 3 }
-    Project (#1, #0, #3) // { arity: 3 }
+    Project (#1{name}, #0{state}, #3) // { arity: 3 }
       Join on=(#1{state} = #2{state}) type=differential // { arity: 4 }
         ArrangeBy keys=[[#1{state}]] // { arity: 2 }
           Get l1 // { arity: 2 }
         ArrangeBy keys=[[#0{state}]] // { arity: 2 }
           TopK group_by=[#0{state}] limit=integer_to_bigint((char_length(#0{state}) % 4)) // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
+            Project (#0{state}, #1{name}) // { arity: 2 }
               Join on=(#0{state} = #2{state}) type=differential // { arity: 3 }
                 ArrangeBy keys=[[#0{state}]] // { arity: 1 }
                   Distinct project=[#0{state}] // { arity: 1 }
@@ -387,7 +387,7 @@ Explained Query:
       TopK group_by=[#1{state}] limit=integer_to_bigint((char_length(#1{state}) % 3)) // { arity: 2 }
         Get l0 // { arity: 2 }
     cte l0 =
-      Project (#0, #1) // { arity: 2 }
+      Project (#0{name}, #1{state}) // { arity: 2 }
         ReadStorage materialize.public.cities // { arity: 3 }
 
 Target cluster: quickstart
@@ -494,7 +494,7 @@ Explained Query:
         Project (#1) // { arity: 1 }
           ReadStorage materialize.public.cities // { arity: 3 }
     ArrangeBy keys=[[]] // { arity: 1 }
-      Project (#0) // { arity: 1 }
+      Project (#0{name}) // { arity: 1 }
         ReadStorage materialize.public.cities // { arity: 3 }
 
 Target cluster: quickstart

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -106,11 +106,11 @@ FROM
   left_joins_raw.dim01 ON(facts.dim01_k01 > dim01.dim01_k01);
 ----
 Return // { arity: 4 }
-  Project (#0, #4, #1, #10) // { arity: 4 }
+  Project (#0{facts_k01}, #4, #1{facts_d01}, #10) // { arity: 4 }
     Union // { arity: 15 }
       Get l1 // { arity: 15 }
       CrossJoin // { arity: 15 }
-        Project (#0..=#8) // { arity: 9 }
+        Project (#0{facts_k01}..=#8{facts_d05}) // { arity: 9 }
           Join on=(#0{facts_k01} = #9{facts_k01} AND #1{dim01_k01} = #10{dim01_k01} AND #2{dim02_k01} = #11{dim02_k01} AND #3{dim03_k01} = #12{dim03_k01} AND #4{facts_d01} = #13{facts_d01} AND #5{facts_d02} = #14{facts_d02} AND #6{facts_d03} = #15{facts_d03} AND #7{facts_d04} = #16{facts_d04} AND #8{facts_d05} = #17{facts_d05}) // { arity: 18 }
             Union // { arity: 9 }
               Negate // { arity: 9 }
@@ -124,7 +124,7 @@ Return // { arity: 4 }
 With
   cte l1 =
     Filter (#1{dim01_k01} > #9{dim01_k01}) // { arity: 15 }
-      Project (#0..=#14) // { arity: 15 }
+      Project (#0{facts_k01}..=#14{dim01_d05}) // { arity: 15 }
         CrossJoin // { arity: 15 }
           Get l0 // { arity: 9 }
           CrossJoin // { arity: 6 }
@@ -165,12 +165,12 @@ FROM
   left_joins_raw.dim01 ON(facts.dim01_k01 = dim01.dim01_k01);
 ----
 Return // { arity: 4 }
-  Project (#0, #4, #1, #10) // { arity: 4 }
+  Project (#0{facts_k01}, #4, #1{facts_d01}, #10) // { arity: 4 }
     Union // { arity: 15 }
       Map (null, null, null, null, null, null) // { arity: 15 }
         Union // { arity: 9 }
           Negate // { arity: 9 }
-            Project (#0..=#8) // { arity: 9 }
+            Project (#0{facts_k01}..=#8{facts_d05}) // { arity: 9 }
               Join on=(#1{dim01_k01} = #9{dim01_k01}) // { arity: 10 }
                 Get l0 // { arity: 9 }
                 Distinct project=[#0{dim01_k01}] // { arity: 1 }
@@ -181,7 +181,7 @@ Return // { arity: 4 }
 With
   cte l1 =
     Filter (#1{dim01_k01} = #9{dim01_k01}) // { arity: 15 }
-      Project (#0..=#14) // { arity: 15 }
+      Project (#0{facts_k01}..=#14{dim01_d05}) // { arity: 15 }
         CrossJoin // { arity: 15 }
           Get l0 // { arity: 9 }
           CrossJoin // { arity: 6 }
@@ -215,14 +215,14 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 ----
 Return // { arity: 6 }
   Filter true // { arity: 6 }
-    Project (#0, #1, #4..=#7) // { arity: 6 }
+    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
       Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
-        Project (#0..=#2, #6, #3, #12) // { arity: 6 }
+        Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
           Union // { arity: 17 }
             Get l3 // { arity: 17 }
             CrossJoin // { arity: 17 }
-              Project (#0..=#10) // { arity: 11 }
+              Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                 Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
                   Union // { arity: 11 }
                     Negate // { arity: 11 }
@@ -236,7 +236,7 @@ Return // { arity: 6 }
 With
   cte l3 =
     Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
-      Project (#0..=#10, #13..=#18) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
         Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
           Get l2 // { arity: 11 }
           CrossJoin // { arity: 8 }
@@ -276,15 +276,15 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 ----
 Return // { arity: 6 }
   Filter true // { arity: 6 }
-    Project (#0, #1, #4..=#7) // { arity: 6 }
+    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
       Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
-        Project (#0..=#2, #6, #3, #12) // { arity: 6 }
+        Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
           Union // { arity: 17 }
             Map (null, null, null, null, null, null) // { arity: 17 }
               Union // { arity: 11 }
                 Negate // { arity: 11 }
-                  Project (#0..=#10) // { arity: 11 }
+                  Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                     Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
                       Get l2 // { arity: 11 }
                       Distinct project=[#0{x}..=#2] // { arity: 3 }
@@ -296,7 +296,7 @@ Return // { arity: 6 }
 With
   cte l3 =
     Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
-      Project (#0..=#10, #13..=#18) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
         Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
           Get l2 // { arity: 11 }
           CrossJoin // { arity: 8 }
@@ -336,16 +336,16 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 ----
 Return // { arity: 6 }
   Filter true // { arity: 6 }
-    Project (#0, #1, #4..=#7) // { arity: 6 }
+    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
       Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
-        Project (#0, #1, #8, #12, #9, #3) // { arity: 6 }
+        Project (#0{x}, #1{y}, #8, #12, #9, #3{facts_d01}) // { arity: 6 }
           Union // { arity: 17 }
-            Project (#0, #1, #11..=#16, #2..=#10) // { arity: 17 }
+            Project (#0{x}, #1{y}, #11{dim03_k01}..=#16{facts_d05}, #2..=#10{dim02_k01}) // { arity: 17 }
               Map (null, null, null, null, null, null) // { arity: 17 }
                 Union // { arity: 11 }
                   Negate // { arity: 11 }
-                    Project (#0..=#10) // { arity: 11 }
+                    Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                       Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
                         Get l2 // { arity: 11 }
                         Distinct project=[#0{x}..=#2] // { arity: 3 }
@@ -357,7 +357,7 @@ Return // { arity: 6 }
 With
   cte l3 =
     Filter ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
-      Project (#0..=#7, #10..=#18) // { arity: 17 }
+      Project (#0{x}..=#7{dim01_d05}, #10{dim02_k01}..=#18) // { arity: 17 }
         Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 19 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
@@ -401,14 +401,14 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 ----
 Return // { arity: 6 }
   Filter true // { arity: 6 }
-    Project (#0, #1, #4..=#7) // { arity: 6 }
+    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
       Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
-        Project (#0..=#2, #6, #3, #12) // { arity: 6 }
+        Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
           Union // { arity: 17 }
             Get l3 // { arity: 17 }
             CrossJoin // { arity: 17 }
-              Project (#0..=#10) // { arity: 11 }
+              Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                 Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
                   Union // { arity: 11 }
                     Negate // { arity: 11 }
@@ -422,7 +422,7 @@ Return // { arity: 6 }
 With
   cte l3 =
     Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND (#13{dim01_d02} = 24)) // { arity: 17 }
-      Project (#0..=#10, #13..=#18) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
         Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
           Get l2 // { arity: 11 }
           CrossJoin // { arity: 8 }
@@ -466,15 +466,15 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 ----
 Return // { arity: 6 }
   Filter true // { arity: 6 }
-    Project (#0, #1, #4..=#7) // { arity: 6 }
+    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
       Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
-        Project (#0..=#2, #6, #3, #12) // { arity: 6 }
+        Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
           Union // { arity: 17 }
             Map (null, null, null, null, null, null) // { arity: 17 }
               Union // { arity: 11 }
                 Negate // { arity: 11 }
-                  Project (#0..=#10) // { arity: 11 }
+                  Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                     Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
                       Filter (#7{facts_d02} = 42) // { arity: 11 }
                         Get l2 // { arity: 11 }
@@ -487,7 +487,7 @@ Return // { arity: 6 }
 With
   cte l3 =
     Filter (#7{facts_d02} = 42) AND (#13{dim01_d02} = 24) AND ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
-      Project (#0..=#10, #13..=#18) // { arity: 17 }
+      Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
         Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
           Get l2 // { arity: 11 }
           CrossJoin // { arity: 8 }
@@ -531,16 +531,16 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 ----
 Return // { arity: 6 }
   Filter true // { arity: 6 }
-    Project (#0, #1, #4..=#7) // { arity: 6 }
+    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
       Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
-        Project (#0, #1, #8, #12, #9, #3) // { arity: 6 }
+        Project (#0{x}, #1{y}, #8, #12, #9, #3{facts_d01}) // { arity: 6 }
           Union // { arity: 17 }
-            Project (#0, #1, #11..=#16, #2..=#10) // { arity: 17 }
+            Project (#0{x}, #1{y}, #11{dim03_k01}..=#16{facts_d05}, #2..=#10{dim02_k01}) // { arity: 17 }
               Map (null, null, null, null, null, null) // { arity: 17 }
                 Union // { arity: 11 }
                   Negate // { arity: 11 }
-                    Project (#0..=#10) // { arity: 11 }
+                    Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                       Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
                         Filter (#7{facts_d02} = 42) // { arity: 11 }
                           Get l2 // { arity: 11 }
@@ -553,7 +553,7 @@ Return // { arity: 6 }
 With
   cte l3 =
     Filter (#4{dim01_d02} = 24) AND (#13{facts_d02} = 42) AND ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
-      Project (#0..=#7, #10..=#18) // { arity: 17 }
+      Project (#0{x}..=#7{dim01_d05}, #10{dim02_k01}..=#18) // { arity: 17 }
         Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 19 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
@@ -596,16 +596,16 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 ----
 Return // { arity: 6 }
   Filter true // { arity: 6 }
-    Project (#0, #1, #4..=#7) // { arity: 6 }
+    Project (#0{x}, #1{y}, #4{dim02_d02}..=#7) // { arity: 6 }
       Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
-        Project (#0..=#2, #2, #10, #10) // { arity: 6 }
+        Project (#0{x}..=#2{dim01_k01}, #2{dim01_k01}, #10, #10) // { arity: 6 }
           Union // { arity: 14 }
-            Project (#0, #1, #8..=#13, #2..=#7) // { arity: 14 }
+            Project (#0{x}, #1{y}, #8{dim02_k01}..=#13{dim02_d05}, #2..=#7) // { arity: 14 }
               Map (null, null, null, null, null, null) // { arity: 14 }
                 Union // { arity: 8 }
                   Negate // { arity: 8 }
-                    Project (#0..=#7) // { arity: 8 }
+                    Project (#0{x}..=#7{dim02_d05}) // { arity: 8 }
                       Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim02_k01}, #1{y}) = #10) // { arity: 11 }
                         Filter (#5{dim02_d03} < 24) // { arity: 8 }
                           Get l3 // { arity: 8 }
@@ -614,7 +614,7 @@ Return // { arity: 6 }
             Map (null, null, null, null, null, null) // { arity: 14 }
               Union // { arity: 8 }
                 Negate // { arity: 8 }
-                  Project (#0..=#7) // { arity: 8 }
+                  Project (#0{x}..=#7{dim01_d05}) // { arity: 8 }
                     Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim01_k01}, #0{x}) = #10) // { arity: 11 }
                       Filter (#5{dim01_d03} > 42) // { arity: 8 }
                         Get l2 // { arity: 8 }
@@ -629,7 +629,7 @@ With
           Get l4 // { arity: 14 }
   cte l4 =
     Filter (coalesce(#2{dim01_k01}, #0{x}) = coalesce(#8{dim02_k01}, #1{y})) AND (#11{dim02_d03} < 24) AND (#5{dim01_d03} > 42) // { arity: 14 }
-      Project (#0..=#7, #10..=#15) // { arity: 14 }
+      Project (#0{x}..=#7{dim01_d05}, #10{dim02_d02}..=#15) // { arity: 14 }
         Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 16 }
           Get l2 // { arity: 8 }
           Get l3 // { arity: 8 }
@@ -675,14 +675,14 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 ----
 Return // { arity: 6 }
   Filter true // { arity: 6 }
-    Project (#0, #1, #4..=#7) // { arity: 6 }
+    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
       Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
-        Project (#0..=#2, #6, #3, #12) // { arity: 6 }
+        Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
           Union // { arity: 17 }
             Get l8 // { arity: 17 }
             CrossJoin // { arity: 17 }
-              Project (#0..=#10) // { arity: 11 }
+              Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                 Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
                   Union // { arity: 11 }
                     Negate // { arity: 11 }
@@ -695,15 +695,15 @@ Return // { arity: 6 }
                 - (null, null, null, null, null, null)
 With
   cte l8 =
-    Project (#0..=#16) // { arity: 17 }
+    Project (#0{x}..=#16{dim01_d05}) // { arity: 17 }
       Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND #17{any}) // { arity: 18 }
-        Project (#0..=#16, #18) // { arity: 18 }
+        Project (#0{x}..=#16{dim01_d05}, #18) // { arity: 18 }
           Join on=(#12{dim01_d01} = #17{dim01_d01}) // { arity: 19 }
             Get l3 // { arity: 17 }
             Union // { arity: 2 }
               Get l7 // { arity: 2 }
               CrossJoin // { arity: 2 }
-                Project (#0) // { arity: 1 }
+                Project (#0{dim01_d01}) // { arity: 1 }
                   Join on=(#0{dim01_d01} = #1{dim01_d01}) // { arity: 2 }
                     Union // { arity: 1 }
                       Negate // { arity: 1 }
@@ -718,7 +718,7 @@ With
     Union // { arity: 2 }
       Get l6 // { arity: 2 }
       Map (error("more than one record produced in subquery")) // { arity: 2 }
-        Project (#0) // { arity: 1 }
+        Project (#0{dim01_d01}) // { arity: 1 }
           Filter (#1{count} > 1) // { arity: 2 }
             Reduce group_by=[#0{dim01_d01}] aggregates=[count(*)] // { arity: 2 }
               Get l6 // { arity: 2 }
@@ -726,7 +726,7 @@ With
     Union // { arity: 2 }
       Get l5 // { arity: 2 }
       CrossJoin // { arity: 2 }
-        Project (#0) // { arity: 1 }
+        Project (#0{dim01_d01}) // { arity: 1 }
           Join on=(#0{dim01_d01} = #1{dim01_d01}) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
@@ -745,7 +745,7 @@ With
     Distinct project=[#12{dim01_d01}] // { arity: 1 }
       Get l3 // { arity: 17 }
   cte l3 =
-    Project (#0..=#10, #13..=#18) // { arity: 17 }
+    Project (#0{x}..=#10{facts_d05}, #13{dim01_d02}..=#18) // { arity: 17 }
       Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
         Get l2 // { arity: 11 }
         CrossJoin // { arity: 8 }
@@ -798,28 +798,28 @@ Explained Query:
       Map (null, null, null) // { arity: 6 }
         Union // { arity: 3 }
           Negate // { arity: 3 }
-            Project (#0, #2, #3) // { arity: 3 }
+            Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
-          Project (#0, #4, #5) // { arity: 3 }
+          Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-      Project (#0, #2..=#6) // { arity: 6 }
+      Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
         Get l1 // { arity: 7 }
   With
     cte l1 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
         Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
+          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
     cte l0 =
       ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0, #1, #4, #5) // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
@@ -858,28 +858,28 @@ Explained Query:
       Map (null, null, null) // { arity: 6 }
         Union // { arity: 3 }
           Negate // { arity: 3 }
-            Project (#0, #2, #3) // { arity: 3 }
+            Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
-          Project (#0, #4, #5) // { arity: 3 }
+          Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-      Project (#0, #2..=#6) // { arity: 6 }
+      Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
         Get l1 // { arity: 7 }
   With
     cte l1 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
         Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
+          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
     cte l0 =
       ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0, #1, #4, #5) // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
@@ -905,28 +905,28 @@ materialize.public.v:
       Map (null, null, null) // { arity: 6 }
         Union // { arity: 3 }
           Negate // { arity: 3 }
-            Project (#0, #2, #3) // { arity: 3 }
+            Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
-          Project (#0, #4, #5) // { arity: 3 }
+          Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-      Project (#0, #2..=#6) // { arity: 6 }
+      Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
         Get l1 // { arity: 7 }
   With
     cte l1 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
         Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
+          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
     cte l0 =
       ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0, #1, #4, #5) // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
@@ -961,28 +961,28 @@ materialize.public.mv:
       Map (null, null, null) // { arity: 6 }
         Union // { arity: 3 }
           Negate // { arity: 3 }
-            Project (#0, #2, #3) // { arity: 3 }
+            Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
-          Project (#0, #4, #5) // { arity: 3 }
+          Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-      Project (#0, #2..=#6) // { arity: 6 }
+      Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
         Get l1 // { arity: 7 }
   With
     cte l1 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
         Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
+          Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
     cte l0 =
       ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0, #1, #4, #5) // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -696,7 +696,7 @@ Return // { arity: 6 }
 With
   cte l8 =
     Project (#0..=#16) // { arity: 17 }
-      Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND #17) // { arity: 18 }
+      Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND #17{any}) // { arity: 18 }
         Project (#0..=#16, #18) // { arity: 18 }
           Join on=(#12{dim01_d01} = #17{dim01_d01}) // { arity: 19 }
             Get l3 // { arity: 17 }
@@ -719,7 +719,7 @@ With
       Get l6 // { arity: 2 }
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
-          Filter (#1 > 1) // { arity: 2 }
+          Filter (#1{count} > 1) // { arity: 2 }
             Reduce group_by=[#0{dim01_d01}] aggregates=[count(*)] // { arity: 2 }
               Get l6 // { arity: 2 }
   cte l6 =

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -197,10 +197,10 @@ materialize.public.q01_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q01 // { arity: 10 }
 
 materialize.public.q01:
-  Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
+  Project (#0{l_returnflag}..=#5{sum}, #9{count}..=#11, #6) // { arity: 10 }
     Map (bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end), (#2{sum_l_quantity} / #8), (#3{sum_l_extendedprice} / #8), (#7{sum_l_discount} / #8)) // { arity: 12 }
       Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
-        Project (#4..=#9) // { arity: 6 }
+        Project (#4{l_returnflag}..=#9) // { arity: 6 }
           Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -268,7 +268,7 @@ materialize.public.q02_primary_idx:
 
 materialize.public.q02:
   Return // { arity: 8 }
-    Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
+    Project (#5{s_address}, #2{n_name}, #8, #0{s_acctbal}, #1{s_name}, #3{p_partkey}, #4{p_mfgr}, #6{s_phone}) // { arity: 8 }
       Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
         implementation
           %1[#0, #1]UKK » %0:l4[#0, #7]KK
@@ -276,7 +276,7 @@ materialize.public.q02:
           Get l4 // { arity: 9 }
         ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
           Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
-            Project (#0, #4) // { arity: 2 }
+            Project (#0{p_partkey}, #4) // { arity: 2 }
               Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
                 Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                   implementation
@@ -287,7 +287,7 @@ materialize.public.q02:
                     %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                   ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
                     Distinct project=[#0{p_partkey}] // { arity: 1 }
-                      Project (#0) // { arity: 1 }
+                      Project (#0{p_partkey}) // { arity: 1 }
                         Get l4 // { arity: 9 }
                   Get l1 // { arity: 5 }
                   Get l0 // { arity: 7 }
@@ -295,7 +295,7 @@ materialize.public.q02:
                   Get l3 // { arity: 3 }
   With
     cte l4 =
-      Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
+      Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
         Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
           Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
             implementation
@@ -375,7 +375,7 @@ materialize.public.q03_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q03 // { arity: 4 }
 
 materialize.public.q03:
-  Project (#0, #3, #1, #2) // { arity: 4 }
+  Project (#0{o_orderkey}, #3{o_shippriority}, #1{sum}, #2{o_orderdate}) // { arity: 4 }
     Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
       Project (#8, #12, #15, #22, #23) // { arity: 5 }
         Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
@@ -450,12 +450,12 @@ materialize.public.q04:
             ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
           ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
             Distinct project=[#0{o_orderkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{o_orderkey}) // { arity: 1 }
                 Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
             Distinct project=[#0{l_orderkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{l_orderkey}) // { arity: 1 }
                 Filter (#11{l_commitdate} < #12{l_receiptdate}) // { arity: 16 }
                   ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -523,10 +523,10 @@ materialize.public.q05:
           ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}], [#0{l_orderkey}, #1{l_suppkey}]] // { arity: 4 }
-            Project (#0, #2, #5, #6) // { arity: 4 }
+            Project (#0{l_orderkey}, #2{l_extendedprice}, #5, #6) // { arity: 4 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
           ArrangeBy keys=[[#0{s_suppkey}, #1{s_nationkey}]] // { arity: 2 }
-            Project (#0, #3) // { arity: 2 }
+            Project (#0{s_suppkey}, #3) // { arity: 2 }
               Filter (#0{s_suppkey}) IS NOT NULL // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
           ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
@@ -936,9 +936,9 @@ materialize.public.q10_primary_idx:
     ReadGlobalFromSameDataflow materialize.public.q10 // { arity: 8 }
 
 materialize.public.q10:
-  Project (#0, #1, #7, #2, #4, #5, #3, #6) // { arity: 8 }
+  Project (#0{c_custkey}, #1{c_name}, #7{c_comment}, #2{sum}, #4{n_name}, #5{c_address}, #3{c_acctbal}, #6{c_phone}) // { arity: 8 }
     Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
-      Project (#0..=#2, #4, #5, #7, #22, #23, #34) // { arity: 9 }
+      Project (#0{c_custkey}..=#2{c_address}, #4{c_acctbal}, #5{c_comment}, #7{l_discount}, #22, #23, #34) // { arity: 9 }
         Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
             implementation
@@ -1011,7 +1011,7 @@ materialize.public.q11_primary_idx:
 
 materialize.public.q11:
   Return // { arity: 2 }
-    Project (#0, #1) // { arity: 2 }
+    Project (#0{ps_partkey}, #1{sum}) // { arity: 2 }
       Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
         CrossJoin type=differential // { arity: 3 }
           implementation
@@ -1021,11 +1021,11 @@ materialize.public.q11:
               Get l0 // { arity: 3 }
           ArrangeBy keys=[[]] // { arity: 1 }
             Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
-              Project (#1, #2) // { arity: 2 }
+              Project (#1{ps_supplycost}, #2) // { arity: 2 }
                 Get l0 // { arity: 3 }
   With
     cte l0 =
-      Project (#0, #2, #3) // { arity: 3 }
+      Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
         Filter (#13{n_name} = "GERMANY") AND (#1{ps_suppkey}) IS NOT NULL AND (#8{s_nationkey}) IS NOT NULL // { arity: 16 }
           Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
             implementation
@@ -1156,21 +1156,21 @@ materialize.public.q13:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{c_custkey}) // { arity: 1 }
                     Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
                       implementation
                         %1[#0]UKA » %0:l0[#0]KA
                       Get l0 // { arity: 8 }
                       ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
                         Distinct project=[#0{c_custkey}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{c_custkey}) // { arity: 1 }
                             Get l1 // { arity: 2 }
-                Project (#0) // { arity: 1 }
+                Project (#0{c_custkey}) // { arity: 1 }
                   ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
             Get l1 // { arity: 2 }
   With
     cte l1 =
-      Project (#0, #8) // { arity: 2 }
+      Project (#0{c_custkey}, #8) // { arity: 2 }
         Filter (#0{c_custkey}) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
           Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
             implementation
@@ -1301,7 +1301,7 @@ materialize.public.q15_primary_idx:
 
 materialize.public.q15:
   Return // { arity: 5 }
-    Project (#0..=#2, #4, #8) // { arity: 5 }
+    Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
       Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
         Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
           implementation
@@ -1319,7 +1319,7 @@ materialize.public.q15:
   With
     cte l0 =
       Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
-        Project (#2, #5, #6) // { arity: 3 }
+        Project (#2{l_discount}, #5, #6) // { arity: 3 }
           Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -1379,7 +1379,7 @@ materialize.public.q16_primary_idx:
 materialize.public.q16:
   Return // { arity: 4 }
     Reduce group_by=[#1{p_brand}..=#3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
-      Project (#0..=#3) // { arity: 4 }
+      Project (#0{ps_suppkey}..=#3{p_size}) // { arity: 4 }
         Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
           implementation
             %0:l0[#0]K » %1[#0]K
@@ -1389,7 +1389,7 @@ materialize.public.q16:
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{ps_suppkey}) // { arity: 1 }
                     Filter ((#1{s_suppkey}) IS NULL OR (#0{ps_suppkey} = #1{s_suppkey})) // { arity: 2 }
                       CrossJoin type=differential // { arity: 2 }
                         implementation
@@ -1397,17 +1397,17 @@ materialize.public.q16:
                         ArrangeBy keys=[[]] // { arity: 1 }
                           Get l1 // { arity: 1 }
                         ArrangeBy keys=[[]] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{s_suppkey}) // { arity: 1 }
                             Filter like["%Customer%Complaints%"](varchar_to_text(#6{s_comment})) // { arity: 7 }
                               ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
               Get l1 // { arity: 1 }
   With
     cte l1 =
       Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-        Project (#0) // { arity: 1 }
+        Project (#0{ps_suppkey}) // { arity: 1 }
           Get l0 // { arity: 4 }
     cte l0 =
-      Project (#1, #8..=#10) // { arity: 4 }
+      Project (#1{p_brand}, #8..=#10) // { arity: 4 }
         Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
           Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
             implementation
@@ -1483,17 +1483,17 @@ materialize.public.q17:
                 Get l1 // { arity: 3 }
               ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
                 Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
-                  Project (#0, #5) // { arity: 2 }
+                  Project (#0{l_partkey}, #5) // { arity: 2 }
                     Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
                       ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
                         Distinct project=[#0{l_partkey}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{l_partkey}) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
     cte l1 =
-      Project (#1, #4, #5) // { arity: 3 }
+      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
         Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
           Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
@@ -1563,7 +1563,7 @@ materialize.public.q18_primary_idx:
 materialize.public.q18:
   Return // { arity: 6 }
     Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
-      Project (#0..=#5) // { arity: 6 }
+      Project (#0{c_custkey}..=#5{l_quantity}) // { arity: 6 }
         Filter (#7{sum_l_quantity} > 300) // { arity: 8 }
           Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
             implementation
@@ -1572,7 +1572,7 @@ materialize.public.q18:
               Get l1 // { arity: 6 }
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
               Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
-                Project (#0, #5) // { arity: 2 }
+                Project (#0{o_orderkey}, #5) // { arity: 2 }
                   Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                     implementation
                       %0[#0]UKA » %1:l0[#0]KA
@@ -1583,7 +1583,7 @@ materialize.public.q18:
                     Get l0 // { arity: 16 }
   With
     cte l1 =
-      Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
+      Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
         Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
@@ -1746,7 +1746,7 @@ materialize.public.q20_primary_idx:
 
 materialize.public.q20:
   Return // { arity: 2 }
-    Project (#1, #2) // { arity: 2 }
+    Project (#1{s_address}, #2) // { arity: 2 }
       Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
         implementation
           %1[#0]UKA » %0:l0[#0]K
@@ -1754,33 +1754,33 @@ materialize.public.q20:
           Get l0 // { arity: 3 }
         ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 1 }
           Distinct project=[#0{s_suppkey}] // { arity: 1 }
-            Project (#0) // { arity: 1 }
+            Project (#0{s_suppkey}) // { arity: 1 }
               Filter (integer_to_numeric(#2{ps_availqty}) > #5) // { arity: 6 }
                 Join on=(#0{s_suppkey} = #4{ps_suppkey} AND #1{ps_partkey} = #3{ps_partkey}) type=differential // { arity: 6 }
                   implementation
                     %1[#1, #0]UKK » %0:l1[#0, #1]KKf
                   ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
-                    Project (#0, #1, #3) // { arity: 3 }
+                    Project (#0{s_suppkey}, #1{ps_partkey}, #3) // { arity: 3 }
                       Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                         Get l1 // { arity: 4 }
                   ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
-                    Project (#0, #1, #3) // { arity: 3 }
+                    Project (#0{ps_partkey}, #1{ps_suppkey}, #3) // { arity: 3 }
                       Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
                         Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
-                          Project (#0, #1, #6) // { arity: 3 }
+                          Project (#0{ps_partkey}, #1{ps_suppkey}, #6) // { arity: 3 }
                             Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
                               Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
                                 implementation
                                   %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
                                 ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
                                   Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
-                                    Project (#1, #2) // { arity: 2 }
+                                    Project (#1{ps_suppkey}, #2) // { arity: 2 }
                                       Get l1 // { arity: 4 }
                                 ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                   ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
   With
     cte l1 =
-      Project (#0..=#3) // { arity: 4 }
+      Project (#0{s_suppkey}..=#3{ps_availqty}) // { arity: 4 }
         Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
           implementation
             %0 » %1:partsupp[×] » %2[#0]UKA
@@ -1788,18 +1788,18 @@ materialize.public.q20:
             %2 » %1:partsupp[#0]KA » %0[×]
           ArrangeBy keys=[[]] // { arity: 1 }
             Distinct project=[#0{s_suppkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{s_suppkey}) // { arity: 1 }
                 Get l0 // { arity: 3 }
           ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
-            Project (#0..=#2) // { arity: 3 }
+            Project (#0{ps_partkey}..=#2{ps_availqty}) // { arity: 3 }
               ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
           ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
             Distinct project=[#0{p_partkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{p_partkey}) // { arity: 1 }
                 Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
     cte l0 =
-      Project (#0..=#2) // { arity: 3 }
+      Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
         Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
           Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
             implementation
@@ -1887,7 +1887,7 @@ materialize.public.q21:
             Union // { arity: 2 }
               Negate // { arity: 2 }
                 Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
+                  Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
                     Filter (#1{s_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
                       Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                         implementation
@@ -1899,10 +1899,10 @@ materialize.public.q21:
   With
     cte l3 =
       Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{s_suppkey}, #2) // { arity: 2 }
           Get l2 // { arity: 3 }
     cte l2 =
-      Project (#0..=#2) // { arity: 3 }
+      Project (#0{s_suppkey}..=#2{l_orderkey}) // { arity: 3 }
         Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
           implementation
             %1[#1, #0]UKK » %0:l0[#0, #2]KK
@@ -1910,21 +1910,21 @@ materialize.public.q21:
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
             Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-              Project (#0, #1) // { arity: 2 }
+              Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
                 Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
                   Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                     implementation
                       %1:l1[#0]KA » %0[#0]K
                     ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
                       Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                        Project (#0, #2) // { arity: 2 }
+                        Project (#0{s_suppkey}, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
                     Get l1 // { arity: 16 }
     cte l1 =
       ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
     cte l0 =
-      Project (#0, #1, #7) // { arity: 3 }
+      Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
         Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
           Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
             implementation
@@ -2018,7 +2018,7 @@ materialize.public.q22_primary_idx:
 materialize.public.q22:
   Return // { arity: 3 }
     Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
-      Project (#1, #2) // { arity: 2 }
+      Project (#1{c_acctbal}, #2) // { arity: 2 }
         Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
           implementation
             %0:l1[#0]K » %1[#0]K
@@ -2027,7 +2027,7 @@ materialize.public.q22:
           ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{c_custkey}) // { arity: 1 }
                   Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
                     Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
                       implementation
@@ -2042,16 +2042,16 @@ materialize.public.q22:
   With
     cte l2 =
       Distinct project=[#0{c_custkey}] // { arity: 1 }
-        Project (#0) // { arity: 1 }
+        Project (#0{c_custkey}) // { arity: 1 }
           Get l1 // { arity: 3 }
     cte l1 =
-      Project (#0..=#2) // { arity: 3 }
+      Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
         Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
           CrossJoin type=differential // { arity: 5 }
             implementation
               %1[×]UA » %0:l0[×]ef
             ArrangeBy keys=[[]] // { arity: 3 }
-              Project (#0, #4, #5) // { arity: 3 }
+              Project (#0{c_custkey}, #4, #5) // { arity: 3 }
                 Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                   Get l0 // { arity: 9 }
             ArrangeBy keys=[[]] // { arity: 2 }

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -198,7 +198,7 @@ materialize.public.q01_primary_idx:
 
 materialize.public.q01:
   Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
-    Map (bigint_to_numeric(case when (#6 = 0) then null else #6 end), (#2 / #8), (#3 / #8), (#7 / #8)) // { arity: 12 }
+    Map (bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end), (#2{sum_l_quantity} / #8), (#3{sum_l_extendedprice} / #8), (#7{sum_l_discount} / #8)) // { arity: 12 }
       Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
         Project (#4..=#9) // { arity: 6 }
           Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
@@ -269,12 +269,12 @@ materialize.public.q02_primary_idx:
 materialize.public.q02:
   Return // { arity: 8 }
     Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
-      Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10) type=differential // { arity: 11 }
+      Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
         implementation
           %1[#0, #1]UKK » %0:l4[#0, #7]KK
         ArrangeBy keys=[[#0{p_partkey}, #7{ps_supplycost}]] // { arity: 9 }
           Get l4 // { arity: 9 }
-        ArrangeBy keys=[[#0{p_partkey}, #1]] // { arity: 2 }
+        ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
           Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
             Project (#0, #4) // { arity: 2 }
               Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
@@ -750,7 +750,7 @@ materialize.public.q08_primary_idx:
 
 materialize.public.q08:
   Project (#0, #3) // { arity: 2 }
-    Map ((#1 / #2)) // { arity: 4 }
+    Map ((#1{sum} / #2{sum})) // { arity: 4 }
       Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
         Project (#21, #22, #36, #54) // { arity: 4 }
           Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND (#33{o_custkey}) IS NOT NULL AND (#44{c_nationkey}) IS NOT NULL AND (#51{n_regionkey}) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
@@ -1012,7 +1012,7 @@ materialize.public.q11_primary_idx:
 materialize.public.q11:
   Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
-      Filter (#1 > (#2 * 0.0001)) // { arity: 3 }
+      Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
         CrossJoin type=differential // { arity: 3 }
           implementation
             %1[×]UA » %0[×]
@@ -1149,7 +1149,7 @@ materialize.public.q13_primary_idx:
 
 materialize.public.q13:
   Return // { arity: 2 }
-    Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+    Reduce group_by=[#0{count_o_orderkey}] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
         Reduce group_by=[#0{c_custkey}] aggregates=[count(#1{o_orderkey})] // { arity: 2 }
           Union // { arity: 2 }
@@ -1221,7 +1221,7 @@ materialize.public.q14_primary_idx:
 materialize.public.q14:
   Return // { arity: 1 }
     Project (#2) // { arity: 1 }
-      Map (((100 * #0) / #1)) // { arity: 3 }
+      Map (((100 * #0{sum}) / #1{sum})) // { arity: 3 }
         Union // { arity: 2 }
           Get l0 // { arity: 2 }
           Map (null, null) // { arity: 2 }
@@ -1303,17 +1303,17 @@ materialize.public.q15:
   Return // { arity: 5 }
     Project (#0..=#2, #4, #8) // { arity: 5 }
       Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
-        Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8 = #9) type=delta // { arity: 10 }
+        Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
           implementation
             %0:supplier » %1:l0[#0]UKA » %2[#0]UK
             %1:l0 » %2[#0]UK » %0:supplier[#0]KA
             %2 » %1:l0[#1]K » %0:supplier[#0]KA
           ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
             ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] // { arity: 7 }
-          ArrangeBy keys=[[#0{l_suppkey}], [#1]] // { arity: 2 }
+          ArrangeBy keys=[[#0{l_suppkey}], [#1{sum}]] // { arity: 2 }
             Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Reduce aggregates=[max(#0)] // { arity: 1 }
+          ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
+            Reduce aggregates=[max(#0{sum})] // { arity: 1 }
               Project (#1) // { arity: 1 }
                 Get l0 // { arity: 2 }
   With
@@ -1461,7 +1461,7 @@ materialize.public.q17_primary_idx:
 materialize.public.q17:
   Return // { arity: 1 }
     Project (#1) // { arity: 1 }
-      Map ((#0 / 7)) // { arity: 2 }
+      Map ((#0{sum_l_extendedprice} / 7)) // { arity: 2 }
         Union // { arity: 1 }
           Get l2 // { arity: 1 }
           Map (null) // { arity: 1 }
@@ -1475,7 +1475,7 @@ materialize.public.q17:
     cte l2 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Filter (#1{l_quantity} < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
+          Filter (#1{l_quantity} < (0.2 * (#4{sum_l_quantity} / bigint_to_numeric(case when (#5{count} = 0) then null else #5{count} end)))) // { arity: 6 }
             Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
               implementation
                 %1[#0]UKA » %0:l1[#0]K
@@ -1564,7 +1564,7 @@ materialize.public.q18:
   Return // { arity: 6 }
     Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
       Project (#0..=#5) // { arity: 6 }
-        Filter (#7 > 300) // { arity: 8 }
+        Filter (#7{sum_l_quantity} > 300) // { arity: 8 }
           Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
             implementation
               %1[#0]UKAif » %0:l1[#2]Kif
@@ -1765,7 +1765,7 @@ materialize.public.q20:
                         Get l1 // { arity: 4 }
                   ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
                     Project (#0, #1, #3) // { arity: 3 }
-                      Map ((0.5 * #2)) // { arity: 4 }
+                      Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
                         Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
                           Project (#0, #1, #6) // { arity: 3 }
                             Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
@@ -2046,7 +2046,7 @@ materialize.public.q22:
           Get l1 // { arity: 3 }
     cte l1 =
       Project (#0..=#2) // { arity: 3 }
-        Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
+        Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
           CrossJoin type=differential // { arity: 5 }
             implementation
               %1[×]UA » %0:l0[×]ef

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -191,10 +191,10 @@ ORDER BY
 	l_linestatus;
 ----
 materialize.public.q01:
-  Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
+  Project (#0{l_returnflag}..=#5{sum}, #9{count}..=#11, #6) // { arity: 10 }
     Map (bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end), (#2{sum_l_quantity} / #8), (#3{sum_l_extendedprice} / #8), (#7{sum_l_discount} / #8)) // { arity: 12 }
       Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
-        Project (#4..=#9) // { arity: 6 }
+        Project (#4{l_returnflag}..=#9) // { arity: 6 }
           Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -247,7 +247,7 @@ ORDER BY
 ----
 materialize.public.q02:
   Return // { arity: 8 }
-    Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
+    Project (#5{s_address}, #2{n_name}, #8, #0{s_acctbal}, #1{s_name}, #3{p_partkey}, #4{p_mfgr}, #6{s_phone}) // { arity: 8 }
       Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
         implementation
           %1[#0, #1]UKK » %0:l4[#0, #7]KK
@@ -255,7 +255,7 @@ materialize.public.q02:
           Get l4 // { arity: 9 }
         ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
           Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
-            Project (#0, #4) // { arity: 2 }
+            Project (#0{p_partkey}, #4) // { arity: 2 }
               Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
                 Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                   implementation
@@ -266,7 +266,7 @@ materialize.public.q02:
                     %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                   ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
                     Distinct project=[#0{p_partkey}] // { arity: 1 }
-                      Project (#0) // { arity: 1 }
+                      Project (#0{p_partkey}) // { arity: 1 }
                         Get l4 // { arity: 9 }
                   Get l1 // { arity: 5 }
                   Get l0 // { arity: 7 }
@@ -274,7 +274,7 @@ materialize.public.q02:
                   Get l3 // { arity: 3 }
   With
     cte l4 =
-      Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
+      Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
         Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
           Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
             implementation
@@ -345,7 +345,7 @@ ORDER BY
     o_orderdate;
 ----
 materialize.public.q03:
-  Project (#0, #3, #1, #2) // { arity: 4 }
+  Project (#0{o_orderkey}, #3{o_shippriority}, #1{sum}, #2{o_orderdate}) // { arity: 4 }
     Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
       Project (#8, #12, #15, #22, #23) // { arity: 5 }
         Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
@@ -411,12 +411,12 @@ materialize.public.q04:
             ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
           ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
             Distinct project=[#0{o_orderkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{o_orderkey}) // { arity: 1 }
                 Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
             Distinct project=[#0{l_orderkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{l_orderkey}) // { arity: 1 }
                 Filter (#11{l_commitdate} < #12{l_receiptdate}) // { arity: 16 }
                   ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -475,10 +475,10 @@ materialize.public.q05:
           ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}], [#0{l_orderkey}, #1{l_suppkey}]] // { arity: 4 }
-            Project (#0, #2, #5, #6) // { arity: 4 }
+            Project (#0{l_orderkey}, #2{l_extendedprice}, #5, #6) // { arity: 4 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
           ArrangeBy keys=[[#0{s_suppkey}, #1{s_nationkey}]] // { arity: 2 }
-            Project (#0, #3) // { arity: 2 }
+            Project (#0{s_suppkey}, #3) // { arity: 2 }
               Filter (#0{s_suppkey}) IS NOT NULL // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
           ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
@@ -843,9 +843,9 @@ ORDER BY
     revenue DESC;
 ----
 materialize.public.q10:
-  Project (#0, #1, #7, #2, #4, #5, #3, #6) // { arity: 8 }
+  Project (#0{c_custkey}, #1{c_name}, #7{c_comment}, #2{sum}, #4{n_name}, #5{c_address}, #3{c_acctbal}, #6{c_phone}) // { arity: 8 }
     Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
-      Project (#0..=#2, #4, #5, #7, #22, #23, #34) // { arity: 9 }
+      Project (#0{c_custkey}..=#2{c_address}, #4{c_acctbal}, #5{c_comment}, #7{l_discount}, #22, #23, #34) // { arity: 9 }
         Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
             implementation
@@ -909,7 +909,7 @@ ORDER BY
 ----
 materialize.public.q11:
   Return // { arity: 2 }
-    Project (#0, #1) // { arity: 2 }
+    Project (#0{ps_partkey}, #1{sum}) // { arity: 2 }
       Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
         CrossJoin type=differential // { arity: 3 }
           implementation
@@ -919,11 +919,11 @@ materialize.public.q11:
               Get l0 // { arity: 3 }
           ArrangeBy keys=[[]] // { arity: 1 }
             Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
-              Project (#1, #2) // { arity: 2 }
+              Project (#1{ps_supplycost}, #2) // { arity: 2 }
                 Get l0 // { arity: 3 }
   With
     cte l0 =
-      Project (#0, #2, #3) // { arity: 3 }
+      Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
         Filter (#13{n_name} = "GERMANY") AND (#1{ps_suppkey}) IS NOT NULL AND (#8{s_nationkey}) IS NOT NULL // { arity: 16 }
           Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
             implementation
@@ -1036,21 +1036,21 @@ materialize.public.q13:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{c_custkey}) // { arity: 1 }
                     Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
                       implementation
                         %1[#0]UKA » %0:l0[#0]KA
                       Get l0 // { arity: 8 }
                       ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
                         Distinct project=[#0{c_custkey}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{c_custkey}) // { arity: 1 }
                             Get l1 // { arity: 2 }
-                Project (#0) // { arity: 1 }
+                Project (#0{c_custkey}) // { arity: 1 }
                   ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
             Get l1 // { arity: 2 }
   With
     cte l1 =
-      Project (#0, #8) // { arity: 2 }
+      Project (#0{c_custkey}, #8) // { arity: 2 }
         Filter (#0{c_custkey}) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
           Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
             implementation
@@ -1163,7 +1163,7 @@ ORDER BY
 ----
 materialize.public.q15:
   Return // { arity: 5 }
-    Project (#0..=#2, #4, #8) // { arity: 5 }
+    Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
       Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
         Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
           implementation
@@ -1181,7 +1181,7 @@ materialize.public.q15:
   With
     cte l0 =
       Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
-        Project (#2, #5, #6) // { arity: 3 }
+        Project (#2{l_discount}, #5, #6) // { arity: 3 }
           Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -1235,7 +1235,7 @@ ORDER BY
 materialize.public.q16:
   Return // { arity: 4 }
     Reduce group_by=[#1{p_brand}..=#3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
-      Project (#0..=#3) // { arity: 4 }
+      Project (#0{ps_suppkey}..=#3{p_size}) // { arity: 4 }
         Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
           implementation
             %0:l0[#0]K » %1[#0]K
@@ -1245,7 +1245,7 @@ materialize.public.q16:
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{ps_suppkey}) // { arity: 1 }
                     Filter ((#1{s_suppkey}) IS NULL OR (#0{ps_suppkey} = #1{s_suppkey})) // { arity: 2 }
                       CrossJoin type=differential // { arity: 2 }
                         implementation
@@ -1253,17 +1253,17 @@ materialize.public.q16:
                         ArrangeBy keys=[[]] // { arity: 1 }
                           Get l1 // { arity: 1 }
                         ArrangeBy keys=[[]] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{s_suppkey}) // { arity: 1 }
                             Filter like["%Customer%Complaints%"](varchar_to_text(#6{s_comment})) // { arity: 7 }
                               ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
               Get l1 // { arity: 1 }
   With
     cte l1 =
       Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-        Project (#0) // { arity: 1 }
+        Project (#0{ps_suppkey}) // { arity: 1 }
           Get l0 // { arity: 4 }
     cte l0 =
-      Project (#1, #8..=#10) // { arity: 4 }
+      Project (#1{p_brand}, #8..=#10) // { arity: 4 }
         Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
           Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
             implementation
@@ -1330,17 +1330,17 @@ materialize.public.q17:
                 Get l1 // { arity: 3 }
               ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
                 Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
-                  Project (#0, #5) // { arity: 2 }
+                  Project (#0{l_partkey}, #5) // { arity: 2 }
                     Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
                       ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
                         Distinct project=[#0{l_partkey}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{l_partkey}) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
     cte l1 =
-      Project (#1, #4, #5) // { arity: 3 }
+      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
         Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
           Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
@@ -1401,7 +1401,7 @@ ORDER BY
 materialize.public.q18:
   Return // { arity: 6 }
     Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
-      Project (#0..=#5) // { arity: 6 }
+      Project (#0{c_custkey}..=#5{l_quantity}) // { arity: 6 }
         Filter (#7{sum_l_quantity} > 300) // { arity: 8 }
           Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
             implementation
@@ -1410,7 +1410,7 @@ materialize.public.q18:
               Get l1 // { arity: 6 }
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
               Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
-                Project (#0, #5) // { arity: 2 }
+                Project (#0{o_orderkey}, #5) // { arity: 2 }
                   Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                     implementation
                       %0[#0]UKA » %1:l0[#0]KA
@@ -1421,7 +1421,7 @@ materialize.public.q18:
                     Get l0 // { arity: 16 }
   With
     cte l1 =
-      Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
+      Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
         Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
@@ -1566,7 +1566,7 @@ ORDER BY
 ----
 materialize.public.q20:
   Return // { arity: 2 }
-    Project (#1, #2) // { arity: 2 }
+    Project (#1{s_address}, #2) // { arity: 2 }
       Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
         implementation
           %1[#0]UKA » %0:l0[#0]K
@@ -1574,33 +1574,33 @@ materialize.public.q20:
           Get l0 // { arity: 3 }
         ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 1 }
           Distinct project=[#0{s_suppkey}] // { arity: 1 }
-            Project (#0) // { arity: 1 }
+            Project (#0{s_suppkey}) // { arity: 1 }
               Filter (integer_to_numeric(#2{ps_availqty}) > #5) // { arity: 6 }
                 Join on=(#0{s_suppkey} = #4{ps_suppkey} AND #1{ps_partkey} = #3{ps_partkey}) type=differential // { arity: 6 }
                   implementation
                     %1[#1, #0]UKK » %0:l1[#0, #1]KKf
                   ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
-                    Project (#0, #1, #3) // { arity: 3 }
+                    Project (#0{s_suppkey}, #1{ps_partkey}, #3) // { arity: 3 }
                       Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                         Get l1 // { arity: 4 }
                   ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
-                    Project (#0, #1, #3) // { arity: 3 }
+                    Project (#0{ps_partkey}, #1{ps_suppkey}, #3) // { arity: 3 }
                       Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
                         Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
-                          Project (#0, #1, #6) // { arity: 3 }
+                          Project (#0{ps_partkey}, #1{ps_suppkey}, #6) // { arity: 3 }
                             Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
                               Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
                                 implementation
                                   %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
                                 ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
                                   Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
-                                    Project (#1, #2) // { arity: 2 }
+                                    Project (#1{ps_suppkey}, #2) // { arity: 2 }
                                       Get l1 // { arity: 4 }
                                 ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                   ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
   With
     cte l1 =
-      Project (#0..=#3) // { arity: 4 }
+      Project (#0{s_suppkey}..=#3{ps_availqty}) // { arity: 4 }
         Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
           implementation
             %0 » %1:partsupp[×] » %2[#0]UKA
@@ -1608,18 +1608,18 @@ materialize.public.q20:
             %2 » %1:partsupp[#0]KA » %0[×]
           ArrangeBy keys=[[]] // { arity: 1 }
             Distinct project=[#0{s_suppkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{s_suppkey}) // { arity: 1 }
                 Get l0 // { arity: 3 }
           ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
-            Project (#0..=#2) // { arity: 3 }
+            Project (#0{ps_partkey}..=#2{ps_availqty}) // { arity: 3 }
               ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
           ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
             Distinct project=[#0{p_partkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{p_partkey}) // { arity: 1 }
                 Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
     cte l0 =
-      Project (#0..=#2) // { arity: 3 }
+      Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
         Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
           Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
             implementation
@@ -1698,7 +1698,7 @@ materialize.public.q21:
             Union // { arity: 2 }
               Negate // { arity: 2 }
                 Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
+                  Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
                     Filter (#1{s_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
                       Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                         implementation
@@ -1710,10 +1710,10 @@ materialize.public.q21:
   With
     cte l3 =
       Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-        Project (#0, #2) // { arity: 2 }
+        Project (#0{s_suppkey}, #2) // { arity: 2 }
           Get l2 // { arity: 3 }
     cte l2 =
-      Project (#0..=#2) // { arity: 3 }
+      Project (#0{s_suppkey}..=#2{l_orderkey}) // { arity: 3 }
         Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
           implementation
             %1[#1, #0]UKK » %0:l0[#0, #2]KK
@@ -1721,21 +1721,21 @@ materialize.public.q21:
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
             Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-              Project (#0, #1) // { arity: 2 }
+              Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
                 Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
                   Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                     implementation
                       %1:l1[#0]KA » %0[#0]K
                     ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
                       Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                        Project (#0, #2) // { arity: 2 }
+                        Project (#0{s_suppkey}, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
                     Get l1 // { arity: 16 }
     cte l1 =
       ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
     cte l0 =
-      Project (#0, #1, #7) // { arity: 3 }
+      Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
         Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
           Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
             implementation
@@ -1820,7 +1820,7 @@ ORDER BY
 materialize.public.q22:
   Return // { arity: 3 }
     Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
-      Project (#1, #2) // { arity: 2 }
+      Project (#1{c_acctbal}, #2) // { arity: 2 }
         Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
           implementation
             %0:l1[#0]K » %1[#0]K
@@ -1829,7 +1829,7 @@ materialize.public.q22:
           ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{c_custkey}) // { arity: 1 }
                   Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
                     Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
                       implementation
@@ -1844,16 +1844,16 @@ materialize.public.q22:
   With
     cte l2 =
       Distinct project=[#0{c_custkey}] // { arity: 1 }
-        Project (#0) // { arity: 1 }
+        Project (#0{c_custkey}) // { arity: 1 }
           Get l1 // { arity: 3 }
     cte l1 =
-      Project (#0..=#2) // { arity: 3 }
+      Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
         Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
           CrossJoin type=differential // { arity: 5 }
             implementation
               %1[×]UA » %0:l0[×]ef
             ArrangeBy keys=[[]] // { arity: 3 }
-              Project (#0, #4, #5) // { arity: 3 }
+              Project (#0{c_custkey}, #4, #5) // { arity: 3 }
                 Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                   Get l0 // { arity: 9 }
             ArrangeBy keys=[[]] // { arity: 2 }

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -192,7 +192,7 @@ ORDER BY
 ----
 materialize.public.q01:
   Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
-    Map (bigint_to_numeric(case when (#6 = 0) then null else #6 end), (#2 / #8), (#3 / #8), (#7 / #8)) // { arity: 12 }
+    Map (bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end), (#2{sum_l_quantity} / #8), (#3{sum_l_extendedprice} / #8), (#7{sum_l_discount} / #8)) // { arity: 12 }
       Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
         Project (#4..=#9) // { arity: 6 }
           Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
@@ -248,12 +248,12 @@ ORDER BY
 materialize.public.q02:
   Return // { arity: 8 }
     Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
-      Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10) type=differential // { arity: 11 }
+      Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
         implementation
           %1[#0, #1]UKK » %0:l4[#0, #7]KK
         ArrangeBy keys=[[#0{p_partkey}, #7{ps_supplycost}]] // { arity: 9 }
           Get l4 // { arity: 9 }
-        ArrangeBy keys=[[#0{p_partkey}, #1]] // { arity: 2 }
+        ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
           Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
             Project (#0, #4) // { arity: 2 }
               Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
@@ -675,7 +675,7 @@ ORDER BY
 ----
 materialize.public.q08:
   Project (#0, #3) // { arity: 2 }
-    Map ((#1 / #2)) // { arity: 4 }
+    Map ((#1{sum} / #2{sum})) // { arity: 4 }
       Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
         Project (#21, #22, #36, #54) // { arity: 4 }
           Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND (#33{o_custkey}) IS NOT NULL AND (#44{c_nationkey}) IS NOT NULL AND (#51{n_regionkey}) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
@@ -910,7 +910,7 @@ ORDER BY
 materialize.public.q11:
   Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
-      Filter (#1 > (#2 * 0.0001)) // { arity: 3 }
+      Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
         CrossJoin type=differential // { arity: 3 }
           implementation
             %1[×]UA » %0[×]
@@ -1029,7 +1029,7 @@ ORDER BY
 ----
 materialize.public.q13:
   Return // { arity: 2 }
-    Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+    Reduce group_by=[#0{count_o_orderkey}] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
         Reduce group_by=[#0{c_custkey}] aggregates=[count(#1{o_orderkey})] // { arity: 2 }
           Union // { arity: 2 }
@@ -1092,7 +1092,7 @@ WHERE
 materialize.public.q14:
   Return // { arity: 1 }
     Project (#2) // { arity: 1 }
-      Map (((100 * #0) / #1)) // { arity: 3 }
+      Map (((100 * #0{sum}) / #1{sum})) // { arity: 3 }
         Union // { arity: 2 }
           Get l0 // { arity: 2 }
           Map (null, null) // { arity: 2 }
@@ -1165,17 +1165,17 @@ materialize.public.q15:
   Return // { arity: 5 }
     Project (#0..=#2, #4, #8) // { arity: 5 }
       Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
-        Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8 = #9) type=delta // { arity: 10 }
+        Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
           implementation
             %0:supplier » %1:l0[#0]UKA » %2[#0]UK
             %1:l0 » %2[#0]UK » %0:supplier[#0]KA
             %2 » %1:l0[#1]K » %0:supplier[#0]KA
           ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
             ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] // { arity: 7 }
-          ArrangeBy keys=[[#0{l_suppkey}], [#1]] // { arity: 2 }
+          ArrangeBy keys=[[#0{l_suppkey}], [#1{sum}]] // { arity: 2 }
             Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Reduce aggregates=[max(#0)] // { arity: 1 }
+          ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
+            Reduce aggregates=[max(#0{sum})] // { arity: 1 }
               Project (#1) // { arity: 1 }
                 Get l0 // { arity: 2 }
   With
@@ -1308,7 +1308,7 @@ WHERE
 materialize.public.q17:
   Return // { arity: 1 }
     Project (#1) // { arity: 1 }
-      Map ((#0 / 7)) // { arity: 2 }
+      Map ((#0{sum_l_extendedprice} / 7)) // { arity: 2 }
         Union // { arity: 1 }
           Get l2 // { arity: 1 }
           Map (null) // { arity: 1 }
@@ -1322,7 +1322,7 @@ materialize.public.q17:
     cte l2 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Filter (#1{l_quantity} < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
+          Filter (#1{l_quantity} < (0.2 * (#4{sum_l_quantity} / bigint_to_numeric(case when (#5{count} = 0) then null else #5{count} end)))) // { arity: 6 }
             Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
               implementation
                 %1[#0]UKA » %0:l1[#0]K
@@ -1402,7 +1402,7 @@ materialize.public.q18:
   Return // { arity: 6 }
     Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
       Project (#0..=#5) // { arity: 6 }
-        Filter (#7 > 300) // { arity: 8 }
+        Filter (#7{sum_l_quantity} > 300) // { arity: 8 }
           Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
             implementation
               %1[#0]UKAif » %0:l1[#2]Kif
@@ -1585,7 +1585,7 @@ materialize.public.q20:
                         Get l1 // { arity: 4 }
                   ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
                     Project (#0, #1, #3) // { arity: 3 }
-                      Map ((0.5 * #2)) // { arity: 4 }
+                      Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
                         Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
                           Project (#0, #1, #6) // { arity: 3 }
                             Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
@@ -1848,7 +1848,7 @@ materialize.public.q22:
           Get l1 // { arity: 3 }
     cte l1 =
       Project (#0..=#2) // { arity: 3 }
-        Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
+        Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
           CrossJoin type=differential // { arity: 5 }
             implementation
               %1[×]UA » %0:l0[×]ef

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -190,10 +190,10 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#0{l_returnflag} asc nulls_last, #1{l_linestatus} asc nulls_last] output=[#0..=#9]
-    Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
+    Project (#0{l_returnflag}..=#5{sum}, #9{count}..=#11, #6) // { arity: 10 }
       Map (bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end), (#2{sum_l_quantity} / #8), (#3{sum_l_extendedprice} / #8), (#7{sum_l_discount} / #8)) // { arity: 12 }
         Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
-          Project (#4..=#9) // { arity: 6 }
+          Project (#4{l_returnflag}..=#9) // { arity: 6 }
             Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -246,7 +246,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#0{s_acctbal} desc nulls_first, #2{n_name} asc nulls_last, #1{s_name} asc nulls_last, #3{p_partkey} asc nulls_last] output=[#0..=#7]
     Return // { arity: 8 }
-      Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
+      Project (#5{s_address}, #2{n_name}, #8, #0{s_acctbal}, #1{s_name}, #3{p_partkey}, #4{p_mfgr}, #6{s_phone}) // { arity: 8 }
         Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
           implementation
             %1[#0, #1]UKK » %0:l4[#0, #7]KK
@@ -254,7 +254,7 @@ Explained Query:
             Get l4 // { arity: 9 }
           ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
             Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
-              Project (#0, #4) // { arity: 2 }
+              Project (#0{p_partkey}, #4) // { arity: 2 }
                 Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
                   Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                     implementation
@@ -265,7 +265,7 @@ Explained Query:
                       %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                     ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
                       Distinct project=[#0{p_partkey}] // { arity: 1 }
-                        Project (#0) // { arity: 1 }
+                        Project (#0{p_partkey}) // { arity: 1 }
                           Get l4 // { arity: 9 }
                     Get l1 // { arity: 5 }
                     Get l0 // { arity: 7 }
@@ -273,7 +273,7 @@ Explained Query:
                     Get l3 // { arity: 3 }
     With
       cte l4 =
-        Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
+        Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
           Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
             Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
               implementation
@@ -344,7 +344,7 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first, #2{o_orderdate} asc nulls_last] output=[#0..=#3]
-    Project (#0, #3, #1, #2) // { arity: 4 }
+    Project (#0{o_orderkey}, #3{o_shippriority}, #1{sum}, #2{o_orderdate}) // { arity: 4 }
       Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
         Project (#8, #12, #15, #22, #23) // { arity: 5 }
           Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
@@ -410,12 +410,12 @@ Explained Query:
               ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
               Distinct project=[#0{o_orderkey}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{o_orderkey}) // { arity: 1 }
                   Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
                     ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
             ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
               Distinct project=[#0{l_orderkey}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{l_orderkey}) // { arity: 1 }
                   Filter (#11{l_commitdate} < #12{l_receiptdate}) // { arity: 16 }
                     ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -474,10 +474,10 @@ Explained Query:
             ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
             ArrangeBy keys=[[#0{l_orderkey}], [#0{l_orderkey}, #1{l_suppkey}]] // { arity: 4 }
-              Project (#0, #2, #5, #6) // { arity: 4 }
+              Project (#0{l_orderkey}, #2{l_extendedprice}, #5, #6) // { arity: 4 }
                 ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
             ArrangeBy keys=[[#0{s_suppkey}, #1{s_nationkey}]] // { arity: 2 }
-              Project (#0, #3) // { arity: 2 }
+              Project (#0{s_suppkey}, #3) // { arity: 2 }
                 Filter (#0{s_suppkey}) IS NOT NULL // { arity: 7 }
                   ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
             ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
@@ -841,9 +841,9 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#2{sum} desc nulls_first] output=[#0..=#7]
-    Project (#0, #1, #7, #2, #4, #5, #3, #6) // { arity: 8 }
+    Project (#0{c_custkey}, #1{c_name}, #7{c_comment}, #2{sum}, #4{n_name}, #5{c_address}, #3{c_acctbal}, #6{c_phone}) // { arity: 8 }
       Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
-        Project (#0..=#2, #4, #5, #7, #22, #23, #34) // { arity: 9 }
+        Project (#0{c_custkey}..=#2{c_address}, #4{c_acctbal}, #5{c_comment}, #7{l_discount}, #22, #23, #34) // { arity: 9 }
           Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
             Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
               implementation
@@ -907,7 +907,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#1{sum} desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
-      Project (#0, #1) // { arity: 2 }
+      Project (#0{ps_partkey}, #1{sum}) // { arity: 2 }
         Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
@@ -917,11 +917,11 @@ Explained Query:
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[]] // { arity: 1 }
               Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
-                Project (#1, #2) // { arity: 2 }
+                Project (#1{ps_supplycost}, #2) // { arity: 2 }
                   Get l0 // { arity: 3 }
     With
       cte l0 =
-        Project (#0, #2, #3) // { arity: 3 }
+        Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
           Filter (#13{n_name} = "GERMANY") AND (#1{ps_suppkey}) IS NOT NULL AND (#8{s_nationkey}) IS NOT NULL // { arity: 16 }
             Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
               implementation
@@ -1034,21 +1034,21 @@ Explained Query:
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
-                    Project (#0) // { arity: 1 }
+                    Project (#0{c_custkey}) // { arity: 1 }
                       Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
                         implementation
                           %1[#0]UKA » %0:l0[#0]KA
                         Get l0 // { arity: 8 }
                         ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
                           Distinct project=[#0{c_custkey}] // { arity: 1 }
-                            Project (#0) // { arity: 1 }
+                            Project (#0{c_custkey}) // { arity: 1 }
                               Get l1 // { arity: 2 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{c_custkey}) // { arity: 1 }
                     ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
               Get l1 // { arity: 2 }
     With
       cte l1 =
-        Project (#0, #8) // { arity: 2 }
+        Project (#0{c_custkey}, #8) // { arity: 2 }
           Filter (#0{c_custkey}) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
             Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
               implementation
@@ -1160,7 +1160,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#0{s_suppkey} asc nulls_last] output=[#0..=#4]
     Return // { arity: 5 }
-      Project (#0..=#2, #4, #8) // { arity: 5 }
+      Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
         Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
           Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
             implementation
@@ -1178,7 +1178,7 @@ Explained Query:
     With
       cte l0 =
         Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
-          Project (#2, #5, #6) // { arity: 3 }
+          Project (#2{l_discount}, #5, #6) // { arity: 3 }
             Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
@@ -1232,7 +1232,7 @@ Explained Query:
   Finish order_by=[#3{count_ps_suppkey} desc nulls_first, #0{p_brand} asc nulls_last, #1{p_type} asc nulls_last, #2{p_size} asc nulls_last] output=[#0..=#3]
     Return // { arity: 4 }
       Reduce group_by=[#1{p_brand}..=#3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
-        Project (#0..=#3) // { arity: 4 }
+        Project (#0{ps_suppkey}..=#3{p_size}) // { arity: 4 }
           Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
             implementation
               %0:l0[#0]K » %1[#0]K
@@ -1242,7 +1242,7 @@ Explained Query:
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-                    Project (#0) // { arity: 1 }
+                    Project (#0{ps_suppkey}) // { arity: 1 }
                       Filter ((#1{s_suppkey}) IS NULL OR (#0{ps_suppkey} = #1{s_suppkey})) // { arity: 2 }
                         CrossJoin type=differential // { arity: 2 }
                           implementation
@@ -1250,17 +1250,17 @@ Explained Query:
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Get l1 // { arity: 1 }
                           ArrangeBy keys=[[]] // { arity: 1 }
-                            Project (#0) // { arity: 1 }
+                            Project (#0{s_suppkey}) // { arity: 1 }
                               Filter like["%Customer%Complaints%"](varchar_to_text(#6{s_comment})) // { arity: 7 }
                                 ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
                 Get l1 // { arity: 1 }
     With
       cte l1 =
         Distinct project=[#0{ps_suppkey}] // { arity: 1 }
-          Project (#0) // { arity: 1 }
+          Project (#0{ps_suppkey}) // { arity: 1 }
             Get l0 // { arity: 4 }
       cte l0 =
-        Project (#1, #8..=#10) // { arity: 4 }
+        Project (#1{p_brand}, #8..=#10) // { arity: 4 }
           Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
             Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
               implementation
@@ -1326,17 +1326,17 @@ Explained Query:
                 Get l1 // { arity: 3 }
               ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
                 Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
-                  Project (#0, #5) // { arity: 2 }
+                  Project (#0{l_partkey}, #5) // { arity: 2 }
                     Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
                       ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
                         Distinct project=[#0{l_partkey}] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
+                          Project (#0{l_partkey}) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
     cte l1 =
-      Project (#1, #4, #5) // { arity: 3 }
+      Project (#1{l_quantity}, #4, #5) // { arity: 3 }
         Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
           Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
@@ -1397,7 +1397,7 @@ Explained Query:
   Finish order_by=[#4{o_totalprice} desc nulls_first, #3{o_orderdate} asc nulls_last] output=[#0..=#5]
     Return // { arity: 6 }
       Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
-        Project (#0..=#5) // { arity: 6 }
+        Project (#0{c_custkey}..=#5{l_quantity}) // { arity: 6 }
           Filter (#7{sum_l_quantity} > 300) // { arity: 8 }
             Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
               implementation
@@ -1406,7 +1406,7 @@ Explained Query:
                 Get l1 // { arity: 6 }
               ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
                 Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
-                  Project (#0, #5) // { arity: 2 }
+                  Project (#0{o_orderkey}, #5) // { arity: 2 }
                     Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#0]KA
@@ -1417,7 +1417,7 @@ Explained Query:
                       Get l0 // { arity: 16 }
     With
       cte l1 =
-        Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
+        Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
           Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
             Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
               implementation
@@ -1561,7 +1561,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#0{s_name} asc nulls_last] output=[#0, #1]
     Return // { arity: 2 }
-      Project (#1, #2) // { arity: 2 }
+      Project (#1{s_address}, #2) // { arity: 2 }
         Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
           implementation
             %1[#0]UKA » %0:l0[#0]K
@@ -1569,33 +1569,33 @@ Explained Query:
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 1 }
             Distinct project=[#0{s_suppkey}] // { arity: 1 }
-              Project (#0) // { arity: 1 }
+              Project (#0{s_suppkey}) // { arity: 1 }
                 Filter (integer_to_numeric(#2{ps_availqty}) > #5) // { arity: 6 }
                   Join on=(#0{s_suppkey} = #4{ps_suppkey} AND #1{ps_partkey} = #3{ps_partkey}) type=differential // { arity: 6 }
                     implementation
                       %1[#1, #0]UKK » %0:l1[#0, #1]KKf
                     ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
-                      Project (#0, #1, #3) // { arity: 3 }
+                      Project (#0{s_suppkey}, #1{ps_partkey}, #3) // { arity: 3 }
                         Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                           Get l1 // { arity: 4 }
                     ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
-                      Project (#0, #1, #3) // { arity: 3 }
+                      Project (#0{ps_partkey}, #1{ps_suppkey}, #3) // { arity: 3 }
                         Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
                           Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
-                            Project (#0, #1, #6) // { arity: 3 }
+                            Project (#0{ps_partkey}, #1{ps_suppkey}, #6) // { arity: 3 }
                               Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
                                 Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
                                   implementation
                                     %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
                                   ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
                                     Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
-                                      Project (#1, #2) // { arity: 2 }
+                                      Project (#1{ps_suppkey}, #2) // { arity: 2 }
                                         Get l1 // { arity: 4 }
                                   ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                     ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
     With
       cte l1 =
-        Project (#0..=#3) // { arity: 4 }
+        Project (#0{s_suppkey}..=#3{ps_availqty}) // { arity: 4 }
           Join on=(#1{ps_partkey} = #4{p_partkey}) type=delta // { arity: 5 }
             implementation
               %0 » %1:partsupp[×] » %2[#0]UKA
@@ -1603,18 +1603,18 @@ Explained Query:
               %2 » %1:partsupp[#0]KA » %0[×]
             ArrangeBy keys=[[]] // { arity: 1 }
               Distinct project=[#0{s_suppkey}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{s_suppkey}) // { arity: 1 }
                   Get l0 // { arity: 3 }
             ArrangeBy keys=[[], [#0{ps_partkey}]] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
+              Project (#0{ps_partkey}..=#2{ps_availqty}) // { arity: 3 }
                 ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[*** full scan ***] // { arity: 5 }
             ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
               Distinct project=[#0{p_partkey}] // { arity: 1 }
-                Project (#0) // { arity: 1 }
+                Project (#0{p_partkey}) // { arity: 1 }
                   Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
                     ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
       cte l0 =
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
           Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
             Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
               implementation
@@ -1693,7 +1693,7 @@ Explained Query:
               Union // { arity: 2 }
                 Negate // { arity: 2 }
                   Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-                    Project (#0, #1) // { arity: 2 }
+                    Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
                       Filter (#1{s_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
                         Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                           implementation
@@ -1705,10 +1705,10 @@ Explained Query:
     With
       cte l3 =
         Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-          Project (#0, #2) // { arity: 2 }
+          Project (#0{s_suppkey}, #2) // { arity: 2 }
             Get l2 // { arity: 3 }
       cte l2 =
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0{s_suppkey}..=#2{l_orderkey}) // { arity: 3 }
           Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
             implementation
               %1[#1, #0]UKK » %0:l0[#0, #2]KK
@@ -1716,21 +1716,21 @@ Explained Query:
               Get l0 // { arity: 3 }
             ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
               Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
+                Project (#0{l_orderkey}, #1{s_suppkey}) // { arity: 2 }
                   Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
                     Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                       implementation
                         %1:l1[#0]KA » %0[#0]K
                       ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
                         Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
-                          Project (#0, #2) // { arity: 2 }
+                          Project (#0{s_suppkey}, #2) // { arity: 2 }
                             Get l0 // { arity: 3 }
                       Get l1 // { arity: 16 }
       cte l1 =
         ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
           ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
       cte l0 =
-        Project (#0, #1, #7) // { arity: 3 }
+        Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
           Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
             Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
               implementation
@@ -1815,7 +1815,7 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
     Return // { arity: 3 }
       Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
-        Project (#1, #2) // { arity: 2 }
+        Project (#1{c_acctbal}, #2) // { arity: 2 }
           Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
             implementation
               %0:l1[#0]K » %1[#0]K
@@ -1824,7 +1824,7 @@ Explained Query:
             ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
+                  Project (#0{c_custkey}) // { arity: 1 }
                     Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
                       Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
                         implementation
@@ -1839,16 +1839,16 @@ Explained Query:
     With
       cte l2 =
         Distinct project=[#0{c_custkey}] // { arity: 1 }
-          Project (#0) // { arity: 1 }
+          Project (#0{c_custkey}) // { arity: 1 }
             Get l1 // { arity: 3 }
       cte l1 =
-        Project (#0..=#2) // { arity: 3 }
+        Project (#0{c_custkey}..=#2{c_acctbal}) // { arity: 3 }
           Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
             CrossJoin type=differential // { arity: 5 }
               implementation
                 %1[×]UA » %0:l0[×]ef
               ArrangeBy keys=[[]] // { arity: 3 }
-                Project (#0, #4, #5) // { arity: 3 }
+                Project (#0{c_custkey}, #4, #5) // { arity: 3 }
                   Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                     Get l0 // { arity: 9 }
               ArrangeBy keys=[[]] // { arity: 2 }

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -191,7 +191,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#0{l_returnflag} asc nulls_last, #1{l_linestatus} asc nulls_last] output=[#0..=#9]
     Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
-      Map (bigint_to_numeric(case when (#6 = 0) then null else #6 end), (#2 / #8), (#3 / #8), (#7 / #8)) // { arity: 12 }
+      Map (bigint_to_numeric(case when (#6{count} = 0) then null else #6{count} end), (#2{sum_l_quantity} / #8), (#3{sum_l_extendedprice} / #8), (#7{sum_l_discount} / #8)) // { arity: 12 }
         Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
           Project (#4..=#9) // { arity: 6 }
             Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
@@ -247,12 +247,12 @@ Explained Query:
   Finish order_by=[#0{s_acctbal} desc nulls_first, #2{n_name} asc nulls_last, #1{s_name} asc nulls_last, #3{p_partkey} asc nulls_last] output=[#0..=#7]
     Return // { arity: 8 }
       Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
-        Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10) type=differential // { arity: 11 }
+        Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10{min_ps_supplycost}) type=differential // { arity: 11 }
           implementation
             %1[#0, #1]UKK » %0:l4[#0, #7]KK
           ArrangeBy keys=[[#0{p_partkey}, #7{ps_supplycost}]] // { arity: 9 }
             Get l4 // { arity: 9 }
-          ArrangeBy keys=[[#0{p_partkey}, #1]] // { arity: 2 }
+          ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
             Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
               Project (#0, #4) // { arity: 2 }
                 Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
@@ -343,7 +343,7 @@ ORDER BY
     o_orderdate;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #2{o_orderdate} asc nulls_last] output=[#0..=#3]
+  Finish order_by=[#1{sum} desc nulls_first, #2{o_orderdate} asc nulls_last] output=[#0..=#3]
     Project (#0, #3, #1, #2) // { arity: 4 }
       Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
         Project (#8, #12, #15, #22, #23) // { arity: 5 }
@@ -457,7 +457,7 @@ ORDER BY
     revenue DESC;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first] output=[#0, #1]
+  Finish order_by=[#1{sum} desc nulls_first] output=[#0, #1]
     Reduce group_by=[#2{n_name}] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
       Project (#19, #20, #24) // { arity: 3 }
         Filter (#28{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (#25{n_regionkey}) IS NOT NULL // { arity: 30 }
@@ -673,7 +673,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0, #1]
     Project (#0, #3) // { arity: 2 }
-      Map ((#1 / #2)) // { arity: 4 }
+      Map ((#1{sum} / #2{sum})) // { arity: 4 }
         Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
           Project (#21, #22, #36, #54) // { arity: 4 }
             Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND (#33{o_custkey}) IS NOT NULL AND (#44{c_nationkey}) IS NOT NULL AND (#51{n_regionkey}) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
@@ -840,7 +840,7 @@ ORDER BY
     revenue DESC;
 ----
 Explained Query:
-  Finish order_by=[#2 desc nulls_first] output=[#0..=#7]
+  Finish order_by=[#2{sum} desc nulls_first] output=[#0..=#7]
     Project (#0, #1, #7, #2, #4, #5, #3, #6) // { arity: 8 }
       Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
         Project (#0..=#2, #4, #5, #7, #22, #23, #34) // { arity: 9 }
@@ -905,10 +905,10 @@ ORDER BY
     value DESC;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first] output=[#0, #1]
+  Finish order_by=[#1{sum} desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
-        Filter (#1 > (#2 * 0.0001)) // { arity: 3 }
+        Filter (#1{sum} > (#2{sum} * 0.0001)) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
               %1[×]UA » %0[×]
@@ -1025,9 +1025,9 @@ ORDER BY
     c_count DESC;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 desc nulls_first] output=[#0, #1]
+  Finish order_by=[#1{count} desc nulls_first, #0{count_o_orderkey} desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+      Reduce group_by=[#0{count_o_orderkey}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
           Reduce group_by=[#0{c_custkey}] aggregates=[count(#1{o_orderkey})] // { arity: 2 }
             Union // { arity: 2 }
@@ -1089,7 +1089,7 @@ WHERE
 Explained Query:
   Return // { arity: 1 }
     Project (#2) // { arity: 1 }
-      Map (((100 * #0) / #1)) // { arity: 3 }
+      Map (((100 * #0{sum}) / #1{sum})) // { arity: 3 }
         Union // { arity: 2 }
           Get l0 // { arity: 2 }
           Map (null, null) // { arity: 2 }
@@ -1162,17 +1162,17 @@ Explained Query:
     Return // { arity: 5 }
       Project (#0..=#2, #4, #8) // { arity: 5 }
         Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
-          Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8 = #9) type=delta // { arity: 10 }
+          Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
             implementation
               %0:supplier » %1:l0[#0]UKA » %2[#0]UK
               %1:l0 » %2[#0]UK » %0:supplier[#0]KA
               %2 » %1:l0[#1]K » %0:supplier[#0]KA
             ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
               ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] // { arity: 7 }
-            ArrangeBy keys=[[#0{l_suppkey}], [#1]] // { arity: 2 }
+            ArrangeBy keys=[[#0{l_suppkey}], [#1{sum}]] // { arity: 2 }
               Get l0 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Reduce aggregates=[max(#0)] // { arity: 1 }
+            ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
+              Reduce aggregates=[max(#0{sum})] // { arity: 1 }
                 Project (#1) // { arity: 1 }
                   Get l0 // { arity: 2 }
     With
@@ -1229,7 +1229,7 @@ ORDER BY
     p_size;
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, #0{p_brand} asc nulls_last, #1{p_type} asc nulls_last, #2{p_size} asc nulls_last] output=[#0..=#3]
+  Finish order_by=[#3{count_ps_suppkey} desc nulls_first, #0{p_brand} asc nulls_last, #1{p_type} asc nulls_last, #2{p_size} asc nulls_last] output=[#0..=#3]
     Return // { arity: 4 }
       Reduce group_by=[#1{p_brand}..=#3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
         Project (#0..=#3) // { arity: 4 }
@@ -1304,7 +1304,7 @@ WHERE
 Explained Query:
   Return // { arity: 1 }
     Project (#1) // { arity: 1 }
-      Map ((#0 / 7)) // { arity: 2 }
+      Map ((#0{sum_l_extendedprice} / 7)) // { arity: 2 }
         Union // { arity: 1 }
           Get l2 // { arity: 1 }
           Map (null) // { arity: 1 }
@@ -1318,7 +1318,7 @@ Explained Query:
     cte l2 =
       Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Filter (#1{l_quantity} < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
+          Filter (#1{l_quantity} < (0.2 * (#4{sum_l_quantity} / bigint_to_numeric(case when (#5{count} = 0) then null else #5{count} end)))) // { arity: 6 }
             Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
               implementation
                 %1[#0]UKA » %0:l1[#0]K
@@ -1398,7 +1398,7 @@ Explained Query:
     Return // { arity: 6 }
       Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
         Project (#0..=#5) // { arity: 6 }
-          Filter (#7 > 300) // { arity: 8 }
+          Filter (#7{sum_l_quantity} > 300) // { arity: 8 }
             Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
               implementation
                 %1[#0]UKAif » %0:l1[#2]Kif
@@ -1580,7 +1580,7 @@ Explained Query:
                           Get l1 // { arity: 4 }
                     ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
                       Project (#0, #1, #3) // { arity: 3 }
-                        Map ((0.5 * #2)) // { arity: 4 }
+                        Map ((0.5 * #2{sum_l_quantity})) // { arity: 4 }
                           Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
                             Project (#0, #1, #6) // { arity: 3 }
                               Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
@@ -1680,7 +1680,7 @@ ORDER BY
     s_name;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0{s_name} asc nulls_last] output=[#0, #1]
+  Finish order_by=[#1{count} desc nulls_first, #0{s_name} asc nulls_last] output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
@@ -1843,7 +1843,7 @@ Explained Query:
             Get l1 // { arity: 3 }
       cte l1 =
         Project (#0..=#2) // { arity: 3 }
-          Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
+          Filter (#2{c_acctbal} > (#3{sum_c_acctbal} / bigint_to_numeric(case when (#4{count} = 0) then null else #4{count} end))) // { arity: 5 }
             CrossJoin type=differential // { arity: 5 }
               implementation
                 %1[×]UA » %0:l0[×]ef

--- a/test/sqllogictest/transform/notice/index_too_wide_for_literal_constraints.slt
+++ b/test/sqllogictest/transform/notice/index_too_wide_for_literal_constraints.slt
@@ -87,7 +87,7 @@ FROM t6
 WHERE x=5 AND y=6;
 ----
 Explained Query (fast path):
-  Project (#0..=#3)
+  Project (#0{x}..=#3{w})
     ReadIndex on=materialize.public.t6 t6_idx_x_y=[lookup value=(5, 6)]
 
 Used Indexes:
@@ -105,7 +105,7 @@ FROM t6
 WHERE x=5 AND y=6 AND z=7;
 ----
 Explained Query (fast path):
-  Project (#0..=#3)
+  Project (#0{x}..=#3{w})
     ReadIndex on=materialize.public.t6 t6_idx_x_y_z=[lookup value=(█, █, █)]
 
 Used Indexes:
@@ -126,7 +126,7 @@ FROM t6
 WHERE x=5;
 ----
 Explained Query (fast path):
-  Project (#0..=#3)
+  Project (#0{x}..=#3{w})
     ReadIndex on=materialize.public.t6 t6_idx_x=[lookup value=(5)]
 
 Used Indexes:
@@ -168,7 +168,7 @@ FROM t6
 WHERE x=5 AND z=7;
 ----
 Explained Query (fast path):
-  Project (#0..=#3)
+  Project (#0{x}..=#3{w})
     Filter (#2{z} = 7)
       ReadIndex on=materialize.public.t6 t6_idx_x=[lookup value=(5)]
 


### PR DESCRIPTION
This brings the following minor improvements to MIR-based `EXPLAIN` output:

- Infer aggregate function names—we now infer names for columns that bind to aggregate computations in `Reduce` operators based on the aggregate function.
- Humanize `Project` lists—the project columns now appear in humanized `#c{name}` form. We still abbreviate runs of more then three successive columns, though.

### Motivation

These minor suggestions came during a face-to-face discussion.

### Tips for reviewer

Should be straight-forward to review.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
