### PR TITLE
persist: add basic s3 throughput bench tool to persistcli

### DIFF
--- a/src/persist-cli/src/main.rs
+++ b/src/persist-cli/src/main.rs
@@ -42,6 +42,7 @@ enum Command {
     OpenLoop(crate::open_loop::Args),
     Inspect(mz_persist_client::cli::inspect::InspectArgs),
     Admin(mz_persist_client::cli::admin::AdminArgs),
+    Bench(mz_persist_client::cli::bench::BenchArgs),
     Service(crate::service::Args),
 }
 
@@ -78,6 +79,7 @@ fn main() {
             runtime.block_on(mz_persist_client::cli::inspect::run(command))
         }
         Command::Admin(command) => runtime.block_on(mz_persist_client::cli::admin::run(command)),
+        Command::Bench(command) => runtime.block_on(mz_persist_client::cli::bench::run(command)),
         Command::Service(args) => runtime.block_on(crate::service::run(args)),
     };
 

--- a/src/persist-client/src/cli/args.rs
+++ b/src/persist-client/src/cli/args.rs
@@ -22,7 +22,8 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig};
 use mz_persist::location::{
-    Blob, BlobMetadata, CaSResult, Consensus, ExternalError, ResultStream, SeqNo, VersionedData,
+    Blob, BlobMetadata, CaSResult, Consensus, ExternalError, ResultStream, SeqNo, Tasked,
+    VersionedData,
 };
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -137,6 +138,7 @@ pub(super) async fn make_consensus(
         Arc::new(ReadOnly::new(consensus))
     };
     let consensus = Arc::new(MetricsConsensus::new(consensus, Arc::clone(&metrics)));
+    let consensus = Arc::new(Tasked(consensus));
     Ok(consensus)
 }
 
@@ -160,6 +162,7 @@ pub(super) async fn make_blob(
         Arc::new(ReadOnly::new(blob))
     };
     let blob = Arc::new(MetricsBlob::new(blob, Arc::clone(&metrics)));
+    let blob = Arc::new(Tasked(blob));
     Ok(blob)
 }
 

--- a/src/persist-client/src/cli/bench.rs
+++ b/src/persist-client/src/cli/bench.rs
@@ -1,0 +1,119 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! CLI benchmarking tools for persist
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use mz_persist::indexed::encoding::BlobTraceBatchPart;
+
+use crate::cli::args::StateArgs;
+use crate::internal::state::BatchPart;
+
+/// Commands for read-only inspection of persist state
+#[derive(Debug, clap::Args)]
+pub struct BenchArgs {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+/// Individual subcommands of bench
+#[derive(Debug, clap::Subcommand)]
+pub(crate) enum Command {
+    /// Fetch the blobs in a shard as quickly as possible, repeated some number
+    /// of times.
+    S3Fetch(S3FetchArgs),
+}
+
+/// Fetch the blobs in a shard as quickly as possible, repeated some number of
+/// times.
+#[derive(Debug, Clone, clap::Parser)]
+pub struct S3FetchArgs {
+    #[clap(flatten)]
+    shard: StateArgs,
+
+    #[clap(long, default_value_t = 1)]
+    iters: usize,
+
+    #[clap(long)]
+    decode: bool,
+}
+
+/// Runs the given bench command.
+pub async fn run(command: BenchArgs) -> Result<(), anyhow::Error> {
+    match command.command {
+        Command::S3Fetch(args) => bench_s3(&args).await?,
+    }
+
+    Ok(())
+}
+
+async fn bench_s3(args: &S3FetchArgs) -> Result<(), anyhow::Error> {
+    let decode = args.decode;
+    let shard_id = args.shard.shard_id();
+    let state_versions = args.shard.open().await?;
+    let versions = state_versions
+        .fetch_recent_live_diffs::<u64>(&shard_id)
+        .await;
+    let state = state_versions
+        .fetch_current_state::<u64>(&shard_id, versions.0)
+        .await;
+    let state = state.check_ts_codec(&shard_id)?;
+    let snap = state
+        .snapshot(state.since())
+        .expect("since should be available for reads");
+
+    let start = Instant::now();
+    println!("iter,key,size_bytes,fetch_secs,decode_secs");
+    for iter in 0..args.iters {
+        let mut fetches = Vec::new();
+        for part in snap.iter().flat_map(|x| x.parts.iter()) {
+            let key = match part {
+                BatchPart::Hollow(x) => x.key.complete(&shard_id),
+                BatchPart::Inline { .. } => continue,
+            };
+            let blob = Arc::clone(&state_versions.blob);
+            let metrics = Arc::clone(&state_versions.metrics);
+            let fetch = mz_ore::task::spawn(|| "", async move {
+                let buf = blob.get(&key).await.unwrap().unwrap();
+                let fetch_elapsed = start.elapsed();
+                let buf_len = buf.len();
+                let decode_elapsed = mz_ore::task::spawn_blocking(
+                    || "",
+                    move || {
+                        let start = Instant::now();
+                        if decode {
+                            BlobTraceBatchPart::<u64>::decode(&buf, &metrics.columnar).unwrap();
+                        }
+                        start.elapsed()
+                    },
+                )
+                .await
+                .unwrap();
+                (
+                    key,
+                    buf_len,
+                    fetch_elapsed.as_secs_f64(),
+                    decode_elapsed.as_secs_f64(),
+                )
+            });
+            fetches.push(fetch);
+        }
+        for fetch in fetches {
+            let (key, size_bytes, fetch_secs, decode_secs) = fetch.await.unwrap();
+            println!(
+                "{},{},{},{},{}",
+                iter, key, size_bytes, fetch_secs, decode_secs
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -53,6 +53,7 @@ pub mod cli {
     //! Persist command-line utilities
     pub mod admin;
     pub mod args;
+    pub mod bench;
     pub mod inspect;
 }
 pub mod critical;


### PR DESCRIPTION
This adds a persistcli subcommand which grabs the set of blobs currently in a shard and fetches them all N times. It also optionally decodes them.

- Intended to be run with `bin/mzadmin environment job` against a shard in a real environment.
- This grabs the blobs out of state directly, instead of registering a leased reader, so that it can be read-only. This means there's a possibility that a blob is removed out from under it, resulting in a panic, but it seems to have been pretty rare in my experiments so far.
- Each round is fully finished before starting the next one (no pipelining across rounds).
- The timing and size of each fetch are printed in csv to stdout for followup processing.


### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

I had initially planned to not bother merging this, but this tokio version has been pretty unchanged for the last bit of my testing, so might be worth having around. The shard_source equivalent to this is pretty invasive, so planning to leave that one in a local branch for now.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
