### PR TITLE
Revert "adapter: log manual uses of mz_introspection"

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -77,19 +77,6 @@ impl Coordinator {
             let responses = ExecuteResponse::generated_from(&PlanKind::from(&plan));
             ctx.tx_mut().set_allowed(responses);
 
-            // Warn about users explicitly selecting the mz_introspection cluster. We are thinking
-            // about renaming this cluster, and this helps us gauge how much of a breaking change
-            // doing so would be.
-            // TODO(#26731): remove this warning again
-            let session = ctx.session();
-            if !session.user().is_internal() && session.vars().cluster() == "mz_introspection" {
-                tracing::warn!(
-                    github_26731 = true,
-                    user = session.user().name,
-                    "user manually selected `mz_introspection` cluster"
-                );
-            }
-
             // Scope the borrow of the Catalog because we need to mutate the Coordinator state below.
             let target_cluster = match ctx.session().transaction().cluster() {
                 // Use the current transaction's cluster.


### PR DESCRIPTION
This reverts #26732.

The warning has fulfilled its purpose: It has been active in production for a time and informed us that there are plenty of users that manually target the `mz_introspection` cluster. Which means that when we implement #26731 we need to include some kind of automatic name translation to ensure that the old name will continue to work until all users have migrated.

### Motivation

   * This PR removes an exploratory warning.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A