### PR TITLE
compute: allow `EagerUnaryFunc`s to identify when they might not error

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4390,6 +4390,11 @@ trait EagerUnaryFunc<'a> {
         Self::Output::nullable()
     }
 
+    /// Whether this function could produce an error
+    fn could_error(&self) -> bool {
+        Self::Output::fallible()
+    }
+
     /// Whether this function preserves uniqueness
     fn preserves_uniqueness(&self) -> bool {
         false
@@ -4436,7 +4441,7 @@ impl<T: for<'a> EagerUnaryFunc<'a>> LazyUnaryFunc for T {
     }
 
     fn could_error(&self) -> bool {
-        T::Output::fallible()
+        self.could_error()
     }
 
     fn preserves_uniqueness(&self) -> bool {

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -147,6 +147,10 @@ impl<'a> EagerUnaryFunc<'a> for CastInt16ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
+    fn could_error(&self) -> bool {
+        self.0.is_some()
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt16)
     }

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -163,6 +163,10 @@ impl<'a> EagerUnaryFunc<'a> for CastInt32ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
+    fn could_error(&self) -> bool {
+        self.0.is_some()
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt32)
     }

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -140,6 +140,10 @@ impl<'a> EagerUnaryFunc<'a> for CastInt64ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
+    fn could_error(&self) -> bool {
+        self.0.is_some()
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt64)
     }

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -568,6 +568,10 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToChar {
         .nullable(input.nullable)
     }
 
+    fn could_error(&self) -> bool {
+        self.fail_on_len && self.length.is_some()
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastCharToString)
     }
@@ -689,11 +693,11 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToVarChar {
     }
 
     fn could_error(&self) -> bool {
-        !self.fail_on_len || self.length.is_none()
+        self.fail_on_len && self.length.is_some()
     }
 
     fn preserves_uniqueness(&self) -> bool {
-        self.fail_on_len || self.length.is_none()
+        !self.fail_on_len || self.length.is_none()
     }
 
     fn inverse(&self) -> Option<crate::UnaryFunc> {

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -688,6 +688,10 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToVarChar {
         .nullable(input.nullable)
     }
 
+    fn could_error(&self) -> bool {
+        !self.fail_on_len || self.length.is_none()
+    }
+
     fn preserves_uniqueness(&self) -> bool {
         self.fail_on_len || self.length.is_none()
     }

--- a/src/expr/src/scalar/func/impls/uint16.rs
+++ b/src/expr/src/scalar/func/impls/uint16.rs
@@ -127,6 +127,10 @@ impl<'a> EagerUnaryFunc<'a> for CastUint16ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
+    fn could_error(&self) -> bool {
+        self.0.is_some()
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint16)
     }

--- a/src/expr/src/scalar/func/impls/uint32.rs
+++ b/src/expr/src/scalar/func/impls/uint32.rs
@@ -133,6 +133,10 @@ impl<'a> EagerUnaryFunc<'a> for CastUint32ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
+    fn could_error(&self) -> bool {
+        self.0.is_some()
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint32)
     }

--- a/src/expr/src/scalar/func/impls/uint64.rs
+++ b/src/expr/src/scalar/func/impls/uint64.rs
@@ -137,6 +137,10 @@ impl<'a> EagerUnaryFunc<'a> for CastUint64ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
+    fn could_error(&self) -> bool {
+        self.0.is_some()
+    }
+
     fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint64)
     }

--- a/src/repr/src/adt/char.rs
+++ b/src/repr/src/adt/char.rs
@@ -126,6 +126,9 @@ impl CharWhiteSpace {
 /// * `fail_on_len` - Return an error if `s`'s character count exceeds the
 ///   specified maximum length.
 /// * `white_space` - Express how to handle trailing whitespace on `s`
+///
+/// This function should only fail when `fail_on_len` is `true` _and_ `length`
+/// is present and exceeded.
 fn format_char_str(
     s: &str,
     length: Option<CharLength>,
@@ -158,6 +161,9 @@ fn format_char_str(
 ///
 /// The value returned is appropriate to store in `Datum::String`, but _is not_
 /// appropriate to return to clients.
+///
+/// This function should only fail when `fail_on_len` is `true` _and_ `length`
+/// is present and exceeded.
 pub fn format_str_trim(
     s: &str,
     length: Option<CharLength>,


### PR DESCRIPTION
As it stands, `LazyUnaryFunc` has a blanket implementation on `::could_error()` that looks at `Self::Output`. But some operations---`text_to_varchar`---may or may not fail depending on parameters.

This PR gives a little more flexibility.

### Motivation

- This PR adds a feature that has not yet been specified.

More fine-grained metadata on unary operations.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
