### PR TITLE
qa: be case insensitive when finding the mzinc remote

### DIFF
--- a/misc/buildkite/git.bash
+++ b/misc/buildkite/git.bash
@@ -17,8 +17,8 @@ MZ_REPO_REF="${BUILDKITE_REPO_REF:-origin}"
 MZ_REPO_PULL_REQUEST_BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
 
 if [[ "${BUILDKITE:-}" != "true" ]]; then
-  # when running locally, we origin may point to a fork of the repo but we want the mz repo
-  MZ_REPO_REF=$(git remote -v | grep "MaterializeInc/materialize" | grep "fetch" | head -n1 | cut -f1)
+  # when running locally, our origin may point to a fork of the repo but we want the mz repo
+  MZ_REPO_REF=$(git remote -v | grep -i "MaterializeInc/materialize" | grep "fetch" | head -n1 | cut -f1)
 fi
 
 configure_git_user_if_in_buildkite() {


### PR DESCRIPTION
My `bin/lint` was failing the protobuf check. I narrowed it down to a case sensitivity issue in `misc/buildkite/git.bash`.

### Motivation

  * This PR fixes a previously unreported bug.

```ShellSession
$ sh -x ci/test/lint-main/checks/check-protobuf.sh 
+ set -euo pipefail
++ dirname ci/test/lint-main/checks/check-protobuf.sh
+ cd ci/test/lint-main/checks/../../../..
+ . misc/shlib/shlib.bash
++ try_last_failed=false
++ ci_try_passed=0
++ ci_try_total=0
+ . misc/buildkite/git.bash
++ set -euo pipefail
++ . misc/shlib/shlib.bash
+++ try_last_failed=false
+++ ci_try_passed=0
+++ ci_try_total=0
++ MZ_REPO_REF=origin
++ MZ_REPO_PULL_REQUEST_BASE_BRANCH=main
++ [[ '' != \t\r\u\e ]]
+++ git remote -v
+++ grep MaterializeInc/materialize
+++ grep fetch
+++ head -n1
+++ cut -f1
++ MZ_REPO_REF=
$ echo $?
1
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
