### PR TITLE
storage: avoid resetting sink statistics when using ALTER CONNECTION

### DIFF
--- a/test/testdrive/kafka-sink-statistics.td
+++ b/test/testdrive/kafka-sink-statistics.td
@@ -52,3 +52,13 @@ simple_view_sink 2 2 true true
   JOIN mz_internal.mz_sink_statistics u ON s.id = u.id
   WHERE s.name IN ('simple_view_sink')
 simple_view_sink 2 2 true true
+
+> ALTER CONNECTION kafka_conn SET (BROKER 'asdf') WITH (VALIDATE = false);
+> ALTER CONNECTION kafka_conn SET (BROKER '${testdrive.kafka-addr}') WITH (VALIDATE = true);
+
+> INSERT INTO t VALUES ('key1', 'value')
+> SELECT s.name, u.messages_staged, u.messages_committed, u.bytes_staged > 0, bytes_staged = bytes_committed
+  FROM mz_sinks s
+  JOIN mz_internal.mz_sink_statistics u ON s.id = u.id
+  WHERE s.name IN ('simple_view_sink')
+simple_view_sink 3 3 true true


### PR DESCRIPTION
We never want to reset statistics, it just makes client's lives harder! Sources don't seem to have the same issue, but I hardened some code anyways!

### Motivation


  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
