### PR TITLE
storage: accept require/required interchangeably

### DIFF
--- a/misc/python/materialize/checks/all_checks/ssh.py
+++ b/misc/python/materialize/checks/all_checks/ssh.py
@@ -62,12 +62,13 @@ class SshPg(Check):
             Testdrive(schemas() + dedent(s))
             for s in [
                 """
+                # Also test `required` over `require`.
                 > CREATE CONNECTION pg_ssh2 TO POSTGRES (
                   HOST postgres,
                   DATABASE postgres,
                   USER postgres,
                   PASSWORD SECRET pgpass,
-                  SSL MODE require,
+                  SSL MODE required,
                   SSH TUNNEL ssh_tunnel_0);
 
                 > CREATE SOURCE mz_source_ssh2

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -335,7 +335,7 @@ impl ConnectionOptionExtracted {
                     None | Some("disable") => tokio_postgres::config::SslMode::Disable,
                     // "prefer" intentionally omitted because it has dubious security
                     // properties.
-                    Some("require") => tokio_postgres::config::SslMode::Require,
+                    Some("require") | Some("required") => tokio_postgres::config::SslMode::Require,
                     Some("verify_ca") | Some("verify-ca") => {
                         tokio_postgres::config::SslMode::VerifyCa
                     }
@@ -410,7 +410,7 @@ impl ConnectionOptionExtracted {
                     None | Some("DISABLED") => MySqlSslMode::Disabled,
                     // "preferred" intentionally omitted because it has dubious security
                     // properties.
-                    Some("REQUIRED") => MySqlSslMode::Required,
+                    Some("REQUIRED") | Some("REQUIRE") => MySqlSslMode::Required,
                     Some("VERIFY_CA") | Some("VERIFY-CA") => MySqlSslMode::VerifyCa,
                     Some("VERIFY_IDENTITY") | Some("VERIFY-IDENTITY") => {
                         MySqlSslMode::VerifyIdentity

--- a/test/mysql-cdc/mysql-cdc-ssl.td
+++ b/test/mysql-cdc/mysql-cdc-ssl.td
@@ -108,10 +108,11 @@ $ mysql-execute name=mysql
 DELETE FROM numbers WHERE number = 2;
 
 # server: hostssl, client: require => OK
+# also test `require` or `required`.
 > CREATE CONNECTION mysql_conn TO MYSQL (
   HOST mysql,
   USER hostssl,
-  SSL MODE required
+  SSL MODE require
   );
 > CREATE SOURCE "mz_source"
   FROM MYSQL CONNECTION mysql_conn


### PR DESCRIPTION
Based https://materializeinc.slack.com/archives/C04LQV4KUR4/p1716405259031939

Also changed some random tests to test the change

### Motivation

  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
