### PR TITLE
adapter: improve statement roundtripping of various statements

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3319,6 +3319,7 @@ pub enum ExplainSinkSchemaFor {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExplainSinkSchemaStatement<T: AstInfo> {
     pub schema_for: ExplainSinkSchemaFor,
+    pub format: Option<ExplainFormat>,
     pub statement: CreateSinkStatement<T>,
 }
 
@@ -3329,7 +3330,12 @@ impl<T: AstInfo> AstDisplay for ExplainSinkSchemaStatement<T> {
             ExplainSinkSchemaFor::Key => f.write_str("KEY"),
             ExplainSinkSchemaFor::Value => f.write_str("VALUE"),
         }
-        f.write_str(" SCHEMA AS JSON FOR ");
+        f.write_str(" SCHEMA");
+        if let Some(format) = &self.format {
+            f.write_str(" AS ");
+            f.write_node(format);
+        }
+        f.write_str(" FOR ");
         f.write_node(&self.statement);
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3350,14 +3350,23 @@ impl_display_t!(ExplainPushdownStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExplainTimestampStatement<T: AstInfo> {
-    pub format: ExplainFormat,
+    pub format: Option<ExplainFormat>,
     pub select: SelectStatement<T>,
+}
+
+impl<T: AstInfo> ExplainTimestampStatement<T> {
+    pub fn format(&self) -> ExplainFormat {
+        self.format.unwrap_or(ExplainFormat::Text)
+    }
 }
 
 impl<T: AstInfo> AstDisplay for ExplainTimestampStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str("EXPLAIN TIMESTAMP AS ");
-        f.write_node(&self.format);
+        f.write_str("EXPLAIN TIMESTAMP");
+        if let Some(format) = &self.format {
+            f.write_str(" AS ");
+            f.write_node(format);
+        }
         f.write_str(" FOR ");
         f.write_node(&self.select);
     }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2649,17 +2649,25 @@ impl_display!(DropObjectsStatement);
 pub struct DropOwnedStatement<T: AstInfo> {
     /// The roles whose owned objects are being dropped.
     pub role_names: Vec<T::RoleName>,
-    /// Whether `CASCADE` was specified. This will be `false` when
-    /// `RESTRICT` or no drop behavior at all was specified.
-    pub cascade: bool,
+    /// Whether `CASCADE` was specified. `false` for `RESTRICT` and `None` if no drop behavior at
+    /// all was specified.
+    pub cascade: Option<bool>,
+}
+
+impl<T: AstInfo> DropOwnedStatement<T> {
+    pub fn cascade(&self) -> bool {
+        self.cascade == Some(true)
+    }
 }
 
 impl<T: AstInfo> AstDisplay for DropOwnedStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("DROP OWNED BY ");
         f.write_node(&display::comma_separated(&self.role_names));
-        if self.cascade {
+        if let Some(true) = self.cascade {
             f.write_str(" CASCADE");
+        } else if let Some(false) = self.cascade {
+            f.write_str(" RESTRICT");
         }
     }
 }

--- a/src/sql-parser/src/ident.rs
+++ b/src/sql-parser/src/ident.rs
@@ -49,7 +49,7 @@
 /// ident!(FORBIDDEN);
 /// ```
 ///
-/// ```compile_fail
+/// ```ignore
 /// use mz_sql_parser::ident;
 /// const FORBIDDEN: &str = "..";
 /// ident!(FORBIDDEN);

--- a/src/sql-parser/src/lib.rs
+++ b/src/sql-parser/src/lib.rs
@@ -71,9 +71,6 @@ pub fn datadriven_testcase(tc: &datadriven::TestCase) -> String {
         let input = tc.input.strip_suffix('\n').unwrap_or(&tc.input);
         match parser::parse_statements(input) {
             Ok(s) => {
-                if s.len() != 1 {
-                    return "expected exactly one statement\n".to_string();
-                }
                 let stmt = s.into_element().ast;
                 for printed in [stmt.to_ast_string(), stmt.to_ast_string_stable()] {
                     let mut parsed = match parser::parse_statements(&printed) {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -7670,13 +7670,13 @@ impl<'a> Parser<'a> {
     fn parse_explain_timestamp(&mut self) -> Result<Statement<Raw>, ParserError> {
         let format = if self.parse_keyword(AS) {
             match self.parse_one_of_keywords(&[TEXT, JSON, DOT]) {
-                Some(TEXT) => ExplainFormat::Text,
-                Some(JSON) => ExplainFormat::Json,
+                Some(TEXT) => Some(ExplainFormat::Text),
+                Some(JSON) => Some(ExplainFormat::Json),
                 None => return Err(ParserError::new(self.index, "expected a format")),
                 _ => unreachable!(),
             }
         } else {
-            ExplainFormat::Text
+            None
         };
 
         self.expect_keyword(FOR)?;

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -7615,14 +7615,14 @@ impl<'a> Parser<'a> {
 
         let format = if self.parse_keyword(AS) {
             match self.parse_one_of_keywords(&[TEXT, JSON, DOT]) {
-                Some(TEXT) => ExplainFormat::Text,
-                Some(JSON) => ExplainFormat::Json,
-                Some(DOT) => ExplainFormat::Dot,
+                Some(TEXT) => Some(ExplainFormat::Text),
+                Some(JSON) => Some(ExplainFormat::Json),
+                Some(DOT) => Some(ExplainFormat::Dot),
                 None => return Err(ParserError::new(self.index, "expected a format")),
                 _ => unreachable!(),
             }
         } else {
-            ExplainFormat::Text
+            None
         };
 
         if has_stage {
@@ -7639,7 +7639,7 @@ impl<'a> Parser<'a> {
         }
 
         Ok(Statement::ExplainPlan(ExplainPlanStatement {
-            stage: stage.unwrap_or_else(|| ExplainStage::GlobalPlan),
+            stage,
             with_options,
             format,
             explainee,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -7699,16 +7699,20 @@ impl<'a> Parser<'a> {
 
         self.expect_keyword(SCHEMA)?;
 
-        if self.parse_keyword(AS) {
+        let format = if self.parse_keyword(AS) {
             // only json format is supported
             self.expect_keyword(JSON)?;
-        }
+            Some(ExplainFormat::Json)
+        } else {
+            None
+        };
 
         self.expect_keywords(&[FOR, CREATE])?;
 
         if let Statement::CreateSink(statement) = self.parse_create_sink()? {
             Ok(Statement::ExplainSinkSchema(ExplainSinkSchemaStatement {
                 schema_for,
+                format,
                 statement,
             }))
         } else {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4123,10 +4123,13 @@ impl<'a> Parser<'a> {
     fn parse_drop_owned(&mut self) -> Result<Statement<Raw>, ParserError> {
         self.expect_keyword(BY)?;
         let role_names = self.parse_comma_separated(Parser::parse_identifier)?;
-        let cascade = matches!(
-            self.parse_at_most_one_keyword(&[CASCADE, RESTRICT], "DROP")?,
-            Some(CASCADE),
-        );
+        let cascade = if self.parse_keyword(CASCADE) {
+            Some(true)
+        } else if self.parse_keyword(RESTRICT) {
+            Some(false)
+        } else {
+            None
+        };
         Ok(Statement::DropOwned(DropOwnedStatement {
             role_names,
             cascade,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2667,28 +2667,28 @@ DROP OWNED BY joe
 ----
 DROP OWNED BY joe
 =>
-DropOwned(DropOwnedStatement { role_names: [Ident("joe")], cascade: false })
+DropOwned(DropOwnedStatement { role_names: [Ident("joe")], cascade: None })
 
 parse-statement
 DROP OWNED BY joe, mike
 ----
 DROP OWNED BY joe, mike
 =>
-DropOwned(DropOwnedStatement { role_names: [Ident("joe"), Ident("mike")], cascade: false })
+DropOwned(DropOwnedStatement { role_names: [Ident("joe"), Ident("mike")], cascade: None })
 
 parse-statement
 DROP OWNED BY joe, mike RESTRICT
 ----
-DROP OWNED BY joe, mike
+DROP OWNED BY joe, mike RESTRICT
 =>
-DropOwned(DropOwnedStatement { role_names: [Ident("joe"), Ident("mike")], cascade: false })
+DropOwned(DropOwnedStatement { role_names: [Ident("joe"), Ident("mike")], cascade: Some(false) })
 
 parse-statement
 DROP OWNED BY joe, mike CASCADE
 ----
 DROP OWNED BY joe, mike CASCADE
 =>
-DropOwned(DropOwnedStatement { role_names: [Ident("joe"), Ident("mike")], cascade: true })
+DropOwned(DropOwnedStatement { role_names: [Ident("joe"), Ident("mike")], cascade: Some(true) })
 
 parse-statement
 ALTER INDEX IF EXISTS alter_index_table_primary_idx SET (RETAIN HISTORY = FOR '1ms')

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -260,23 +260,23 @@ EXPLAIN VALUE SCHEMA AS TEXT FOR CREATE SINK foo FROM bar INTO KAFKA CONNECTION 
 parse-statement
 EXPLAIN VALUE SCHEMA FOR CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
 ----
-EXPLAIN VALUE SCHEMA AS JSON FOR CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
+EXPLAIN VALUE SCHEMA FOR CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
 =>
-ExplainSinkSchema(ExplainSinkSchemaStatement { schema_for: Value, statement: CreateSinkStatement { name: Some(UnresolvedItemName([Ident("foo")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }], key: None, headers: None }, format: Some(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Upsert), with_options: [] } })
+ExplainSinkSchema(ExplainSinkSchemaStatement { schema_for: Value, format: None, statement: CreateSinkStatement { name: Some(UnresolvedItemName([Ident("foo")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }], key: None, headers: None }, format: Some(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Upsert), with_options: [] } })
 
 parse-statement
-EXPLAIN KEY SCHEMA FOR CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
+EXPLAIN KEY SCHEMA AS JSON FOR CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
 ----
 EXPLAIN KEY SCHEMA AS JSON FOR CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
 =>
-ExplainSinkSchema(ExplainSinkSchemaStatement { schema_for: Key, statement: CreateSinkStatement { name: Some(UnresolvedItemName([Ident("foo")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }], key: None, headers: None }, format: Some(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Upsert), with_options: [] } })
+ExplainSinkSchema(ExplainSinkSchemaStatement { schema_for: Key, format: Some(Json), statement: CreateSinkStatement { name: Some(UnresolvedItemName([Ident("foo")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }], key: None, headers: None }, format: Some(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Upsert), with_options: [] } })
 
 parse-statement
 EXPLAIN KEY SCHEMA FOR CREATE SINK FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
 ----
-EXPLAIN KEY SCHEMA AS JSON FOR CREATE SINK FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
+EXPLAIN KEY SCHEMA FOR CREATE SINK FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
 =>
-ExplainSinkSchema(ExplainSinkSchemaStatement { schema_for: Key, statement: CreateSinkStatement { name: None, in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }], key: None, headers: None }, format: Some(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Upsert), with_options: [] } })
+ExplainSinkSchema(ExplainSinkSchemaStatement { schema_for: Key, format: None, statement: CreateSinkStatement { name: None, in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }], key: None, headers: None }, format: Some(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Upsert), with_options: [] } })
 
 parse-statement
 EXPLAIN SELECT 665 AS OF 3

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -169,9 +169,23 @@ ExplainPlan(ExplainPlanStatement { stage: None, with_options: [], format: None, 
 parse-statement
 EXPLAIN TIMESTAMP FOR SELECT 1
 ----
+EXPLAIN TIMESTAMP FOR SELECT 1
+=>
+ExplainTimestamp(ExplainTimestampStatement { format: None, select: SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None } })
+
+parse-statement
+EXPLAIN TIMESTAMP AS TEXT FOR SELECT 1
+----
 EXPLAIN TIMESTAMP AS TEXT FOR SELECT 1
 =>
-ExplainTimestamp(ExplainTimestampStatement { format: Text, select: SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None } })
+ExplainTimestamp(ExplainTimestampStatement { format: Some(Text), select: SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None } })
+
+parse-statement
+EXPLAIN TIMESTAMP AS JSON FOR SELECT 1
+----
+EXPLAIN TIMESTAMP AS JSON FOR SELECT 1
+=>
+ExplainTimestamp(ExplainTimestampStatement { format: Some(Json), select: SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None } })
 
 parse-statement
 EXPLAIN AS JSON SELECT * FROM foo

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -21,79 +21,79 @@
 parse-statement
 EXPLAIN SELECT 665
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665
+EXPLAIN SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: None, with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN RAW PLAN FOR SELECT 665
 ----
-EXPLAIN RAW PLAN AS TEXT FOR SELECT 665
+EXPLAIN RAW PLAN FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: RawPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: Some(RawPlan), with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN DECORRELATED PLAN FOR SELECT 665
 ----
-EXPLAIN DECORRELATED PLAN AS TEXT FOR SELECT 665
+EXPLAIN DECORRELATED PLAN FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: DecorrelatedPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: Some(DecorrelatedPlan), with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665
+EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN PHYSICAL PLAN FOR SELECT 665
 ----
-EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT 665
+EXPLAIN PHYSICAL PLAN FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: PhysicalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: Some(PhysicalPlan), with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN SELECT 665
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665
+EXPLAIN SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: None, with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR VIEW foo
+EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [], format: None, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR MATERIALIZED VIEW foo
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR MATERIALIZED VIEW foo
+EXPLAIN OPTIMIZED PLAN FOR MATERIALIZED VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: MaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [], format: None, explainee: MaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR INDEX foo
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR INDEX foo
+EXPLAIN OPTIMIZED PLAN FOR INDEX foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Index(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [], format: None, explainee: Index(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR REPLAN VIEW foo
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN VIEW foo
+EXPLAIN OPTIMIZED PLAN FOR REPLAN VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: ReplanView(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [], format: None, explainee: ReplanView(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN LOCALLY OPTIMIZED PLAN FOR REPLAN VIEW foo
 ----
-EXPLAIN LOCALLY OPTIMIZED PLAN AS TEXT FOR REPLAN VIEW foo
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR REPLAN VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: LocalPlan, with_options: [], format: Text, explainee: ReplanView(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: Some(LocalPlan), with_options: [], format: None, explainee: ReplanView(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN PLAN FOR REPLAN VIEW foo
@@ -105,23 +105,23 @@ EXPLAIN PLAN FOR REPLAN VIEW foo
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR REPLAN MATERIALIZED VIEW foo
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN MATERIALIZED VIEW foo
+EXPLAIN OPTIMIZED PLAN FOR REPLAN MATERIALIZED VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: ReplanMaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [], format: None, explainee: ReplanMaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR REPLAN INDEX foo
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR REPLAN INDEX foo
+EXPLAIN OPTIMIZED PLAN FOR REPLAN INDEX foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: ReplanIndex(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [], format: None, explainee: ReplanIndex(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN LOCALLY OPTIMIZED PLAN FOR VIEW foo
 ----
-EXPLAIN LOCALLY OPTIMIZED PLAN AS TEXT FOR VIEW foo
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: LocalPlan, with_options: [], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: Some(LocalPlan), with_options: [], format: None, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN PLAN FOR VIEW foo
@@ -133,38 +133,38 @@ EXPLAIN PLAN FOR VIEW foo
 parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(types) FOR VIEW foo
 ----
-EXPLAIN OPTIMIZED PLAN WITH (TYPES) AS TEXT FOR VIEW foo
+EXPLAIN OPTIMIZED PLAN WITH (TYPES) FOR VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [ExplainPlanOption { name: Types, value: None }], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [ExplainPlanOption { name: Types, value: None }], format: None, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(arity, types) FOR VIEW foo
 ----
-EXPLAIN OPTIMIZED PLAN WITH (ARITY, TYPES) AS TEXT FOR VIEW foo
+EXPLAIN OPTIMIZED PLAN WITH (ARITY, TYPES) FOR VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [ExplainPlanOption { name: Arity, value: None }, ExplainPlanOption { name: Types, value: None }], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [ExplainPlanOption { name: Arity, value: None }, ExplainPlanOption { name: Types, value: None }], format: None, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN ((SELECT 1))
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 1
+EXPLAIN SELECT 1
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: None, with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [], format: Some(Text), explainee: Select(SelectStatement { query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 # regression test for #16029
 parse-statement
 EXPLAIN WITH a AS (SELECT 1) SELECT * FROM a
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
+EXPLAIN WITH a AS (SELECT 1) SELECT * FROM a
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: None, with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN TIMESTAMP FOR SELECT 1
@@ -176,30 +176,30 @@ ExplainTimestamp(ExplainTimestampStatement { format: Text, select: SelectStateme
 parse-statement
 EXPLAIN AS JSON SELECT * FROM foo
 ----
-EXPLAIN OPTIMIZED PLAN AS JSON FOR SELECT * FROM foo
+EXPLAIN AS JSON SELECT * FROM foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Json, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: None, with_options: [], format: Some(Json), explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZER TRACE WITH (types) AS TEXT FOR BROKEN SELECT 1 + 1
 ----
 EXPLAIN OPTIMIZER TRACE WITH (TYPES) AS TEXT FOR BROKEN SELECT 1 + 1
 =>
-ExplainPlan(ExplainPlanStatement { stage: Trace, with_options: [ExplainPlanOption { name: Types, value: None }], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, true) })
+ExplainPlan(ExplainPlanStatement { stage: Some(Trace), with_options: [ExplainPlanOption { name: Types, value: None }], format: Some(Text), explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, true) })
 
 parse-statement
 EXPLAIN LOCALLY OPTIMIZED PLAN FOR CREATE VIEW mv AS SELECT 665
 ----
-EXPLAIN LOCALLY OPTIMIZED PLAN AS TEXT FOR CREATE VIEW mv AS SELECT 665
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR CREATE VIEW mv AS SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: LocalPlan, with_options: [], format: Text, explainee: CreateView(CreateViewStatement { if_exists: Error, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("mv")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } }, false) })
+ExplainPlan(ExplainPlanStatement { stage: Some(LocalPlan), with_options: [], format: None, explainee: CreateView(CreateViewStatement { if_exists: Error, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("mv")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } }, false) })
 
 parse-statement
 EXPLAIN LOCALLY OPTIMIZED PLAN FOR CREATE OR REPLACE VIEW mv AS SELECT 665
 ----
-EXPLAIN LOCALLY OPTIMIZED PLAN AS TEXT FOR CREATE OR REPLACE VIEW mv AS SELECT 665
+EXPLAIN LOCALLY OPTIMIZED PLAN FOR CREATE OR REPLACE VIEW mv AS SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: LocalPlan, with_options: [], format: Text, explainee: CreateView(CreateViewStatement { if_exists: Replace, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("mv")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } }, false) })
+ExplainPlan(ExplainPlanStatement { stage: Some(LocalPlan), with_options: [], format: None, explainee: CreateView(CreateViewStatement { if_exists: Replace, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("mv")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } }, false) })
 
 parse-statement
 EXPLAIN CREATE VIEW mv AS SELECT 665
@@ -211,30 +211,30 @@ EXPLAIN CREATE VIEW mv AS SELECT 665
 parse-statement
 EXPLAIN WITH (humanized expressions) CREATE MATERIALIZED VIEW mv AS SELECT 665
 ----
-EXPLAIN OPTIMIZED PLAN WITH (HUMANIZED EXPRESSIONS) AS TEXT FOR CREATE MATERIALIZED VIEW mv AS SELECT 665
+EXPLAIN WITH (HUMANIZED EXPRESSIONS) CREATE MATERIALIZED VIEW mv AS SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [ExplainPlanOption { name: HumanizedExpressions, value: None }], format: Text, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [] }, false) })
+ExplainPlan(ExplainPlanStatement { stage: None, with_options: [ExplainPlanOption { name: HumanizedExpressions, value: None }], format: None, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [] }, false) })
 
 parse-statement
 EXPLAIN BROKEN CREATE MATERIALIZED VIEW mv AS SELECT 665
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR BROKEN CREATE MATERIALIZED VIEW mv AS SELECT 665
+EXPLAIN BROKEN CREATE MATERIALIZED VIEW mv AS SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [] }, true) })
+ExplainPlan(ExplainPlanStatement { stage: None, with_options: [], format: None, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None, with_options: [] }, true) })
 
 parse-statement
 EXPLAIN BROKEN CREATE DEFAULT INDEX ON q1
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR BROKEN CREATE DEFAULT INDEX ON q1
+EXPLAIN BROKEN CREATE DEFAULT INDEX ON q1
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("q1")])), key_parts: None, with_options: [], if_not_exists: false }, true) })
+ExplainPlan(ExplainPlanStatement { stage: None, with_options: [], format: None, explainee: CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("q1")])), key_parts: None, with_options: [], if_not_exists: false }, true) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR CREATE INDEX ON v(auction_id)
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR CREATE INDEX ON v (auction_id)
+EXPLAIN OPTIMIZED PLAN FOR CREATE INDEX ON v (auction_id)
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("v")])), key_parts: Some([Identifier([Ident("auction_id")])]), with_options: [], if_not_exists: false }, false) })
+ExplainPlan(ExplainPlanStatement { stage: Some(GlobalPlan), with_options: [], format: None, explainee: CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedItemName([Ident("v")])), key_parts: Some([Identifier([Ident("auction_id")])]), with_options: [], if_not_exists: false }, false) })
 
 parse-statement
 EXPLAIN VALUE SCHEMA AS TEXT FOR CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE UPSERT
@@ -267,9 +267,9 @@ ExplainSinkSchema(ExplainSinkSchemaStatement { schema_for: Key, statement: Creat
 parse-statement
 EXPLAIN SELECT 665 AS OF 3
 ----
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665 AS OF 3
+EXPLAIN SELECT 665 AS OF 3
 =>
-ExplainPlan(ExplainPlanStatement { stage: GlobalPlan, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Value(Number("3")))) }, false) })
+ExplainPlan(ExplainPlanStatement { stage: None, with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Value(Number("3")))) }, false) })
 
 parse-statement
 EXPLAIN FILTER PUSHDOWN FOR SELECT * FROM numbers where value > 10
@@ -281,6 +281,6 @@ ExplainPushdown(ExplainPushdownStatement { explainee: Select(SelectStatement { q
 parse-statement
 EXPLAIN PLAN INSIGHTS FOR SELECT 1
 ----
-EXPLAIN PLAN INSIGHTS AS TEXT FOR SELECT 1
+EXPLAIN PLAN INSIGHTS FOR SELECT 1
 =>
-ExplainPlan(ExplainPlanStatement { stage: PlanInsights, with_options: [], format: Text, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })
+ExplainPlan(ExplainPlanStatement { stage: Some(PlanInsights), with_options: [], format: None, explainee: Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }, false) })

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4246,12 +4246,10 @@ pub fn describe_drop_owned(
 
 pub fn plan_drop_owned(
     scx: &StatementContext,
-    DropOwnedStatement {
-        role_names,
-        cascade,
-    }: DropOwnedStatement<Aug>,
+    drop: DropOwnedStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    let role_ids: BTreeSet<_> = role_names.into_iter().map(|role| role.id).collect();
+    let cascade = drop.cascade();
+    let role_ids: BTreeSet<_> = drop.role_names.into_iter().map(|role| role.id).collect();
     let mut drop_ids = Vec::new();
     let mut privilege_revokes = Vec::new();
     let mut default_privilege_revokes = Vec::new();

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -627,10 +627,10 @@ pub fn plan_explain_pushdown(
 
 pub fn plan_explain_timestamp(
     scx: &StatementContext,
-    ExplainTimestampStatement { format, select }: ExplainTimestampStatement<Aug>,
+    explain: ExplainTimestampStatement<Aug>,
     params: &Params,
 ) -> Result<Plan, PlanError> {
-    let format = match format {
+    let format = match explain.format() {
         mz_sql_parser::ast::ExplainFormat::Text => ExplainFormat::Text,
         mz_sql_parser::ast::ExplainFormat::Json => ExplainFormat::Json,
         mz_sql_parser::ast::ExplainFormat::Dot => ExplainFormat::Dot,
@@ -642,12 +642,12 @@ pub fn plan_explain_timestamp(
             desc: _,
             finishing: _,
             scope: _,
-        } = query::plan_root_query(scx, select.query, QueryLifetime::OneShot)?;
+        } = query::plan_root_query(scx, explain.select.query, QueryLifetime::OneShot)?;
         raw_plan.bind_parameters(params)?;
 
         raw_plan
     };
-    let when = query::plan_as_of(scx, select.as_of)?;
+    let when = query::plan_as_of(scx, explain.select.as_of)?;
 
     Ok(Plan::ExplainTimestamp(ExplainTimestampPlan {
         format,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -571,6 +571,8 @@ pub fn plan_explain_schema(
 ) -> Result<Plan, PlanError> {
     let ExplainSinkSchemaStatement {
         schema_for,
+        // Parser limits to JSON.
+        format: _,
         mut statement,
     } = explain_schema;
 


### PR DESCRIPTION
Teach some statements to preserve what the user typed so they can fully roundtrip their to_string impls.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a