### PR TITLE
storage: allow configuring load generator as of and up to

### DIFF
--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -40,7 +40,7 @@ production, use the `warn-if-unreleased` shortcode to indicate in what version
 the feature will become available:
 
 ```
-{{< warn-if-unreleased v0.86 >}}
+{{< warn-if-unreleased "v0.86" >}}
 ```
 
 This will add a large warning that indicates to users that the change is not
@@ -55,7 +55,7 @@ You can use the `warn-if-unreleased-inline` shortcode for a smaller warning that
 can appear inline in a paragraph, table, or list:
 
 ```
-{{< warn-if-unreleased-inline v0.86 >}}
+{{< warn-if-unreleased-inline "v0.86" >}}
 ```
 
 For new SQL functions, add a `version-added` field to the function's definition:

--- a/doc/user/content/releases/v0.101.md
+++ b/doc/user/content/releases/v0.101.md
@@ -1,0 +1,11 @@
+---
+title: "Materialize v0.101"
+date: 2024-05-29
+released: false
+---
+
+## v0.101
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -37,6 +37,8 @@ _src_name_  | The name for the source.
 **TPCH**     | Use the [tpch](#tpch) load generator.
 **IF NOT EXISTS**  | Do nothing (except issuing a notice) if a source with the same name already exists.
 **TICK INTERVAL**  | The interval at which the next datum should be emitted. Defaults to one second.
+**AS OF**  | The tick at which to start producing data. Defaults to 0. {{< warn-if-unreleased-inline "v0.101" >}}
+**UP TO**  | The tick before which to stop producing data. Defaults to infinite. {{< warn-if-unreleased-inline "v0.101" >}}
 **SCALE FACTOR**   | The scale factor for the `TPCH` generator. Defaults to `0.01` (~ 10MB).
 **MAX CARDINALITY** | Valid for the `COUNTER` generator. Causes the generator to delete old values to keep the collection at most a given size. Defaults to unlimited.
 **KEYS**                    | Valid for [`KEY VALUE` generator](#key-value).

--- a/doc/user/layouts/partials/sql-grammar/load-generator-option.svg
+++ b/doc/user/layouts/partials/sql-grammar/load-generator-option.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="517" height="433">
+<svg xmlns="http://www.w3.org/2000/svg" width="517" height="521">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="51" y="3" width="128" height="32" rx="10"/>
@@ -12,107 +12,126 @@
    <rect x="199" y="3" width="68" height="32"/>
    <rect x="197" y="1" width="68" height="32" class="nonterminal"/>
    <text class="nonterminal" x="207" y="21">interval</text>
-   <rect x="51" y="47" width="130" height="32" rx="10"/>
-   <rect x="49"
+   <rect x="71" y="47" width="62" height="32" rx="10"/>
+   <rect x="69"
          y="45"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="65">AS OF</text>
+   <rect x="71" y="91" width="64" height="32" rx="10"/>
+   <rect x="69"
+         y="89"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="79" y="109">UP TO</text>
+   <rect x="175" y="47" width="44" height="32"/>
+   <rect x="173" y="45" width="44" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="183" y="65">tick</text>
+   <rect x="51" y="135" width="130" height="32" rx="10"/>
+   <rect x="49"
+         y="133"
          width="130"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="65">SCALE FACTOR</text>
-   <rect x="201" y="47" width="100" height="32"/>
-   <rect x="199" y="45" width="100" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="209" y="65">scale_factor</text>
-   <rect x="51" y="91" width="154" height="32" rx="10"/>
+   <text class="terminal" x="59" y="153">SCALE FACTOR</text>
+   <rect x="201" y="135" width="100" height="32"/>
+   <rect x="199" y="133" width="100" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="209" y="153">scale_factor</text>
+   <rect x="51" y="179" width="154" height="32" rx="10"/>
    <rect x="49"
-         y="89"
+         y="177"
          width="154"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="109">MAX CARDINALITY</text>
-   <rect x="225" y="91" width="122" height="32"/>
-   <rect x="223" y="89" width="122" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="233" y="109">max_cardinality</text>
-   <rect x="51" y="135" width="58" height="32" rx="10"/>
+   <text class="terminal" x="59" y="197">MAX CARDINALITY</text>
+   <rect x="225" y="179" width="122" height="32"/>
+   <rect x="223" y="177" width="122" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="233" y="197">max_cardinality</text>
+   <rect x="51" y="223" width="58" height="32" rx="10"/>
    <rect x="49"
-         y="133"
+         y="221"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="153">KEYS</text>
-   <rect x="129" y="135" width="50" height="32"/>
-   <rect x="127" y="133" width="50" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="137" y="153">keys</text>
-   <rect x="51" y="179" width="162" height="32" rx="10"/>
+   <text class="terminal" x="59" y="241">KEYS</text>
+   <rect x="129" y="223" width="50" height="32"/>
+   <rect x="127" y="221" width="50" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="137" y="241">keys</text>
+   <rect x="51" y="267" width="162" height="32" rx="10"/>
    <rect x="49"
-         y="177"
+         y="265"
          width="162"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="197">SNAPSHOT ROUNDS</text>
-   <rect x="233" y="179" width="132" height="32"/>
-   <rect x="231" y="177" width="132" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="241" y="197">snapshot_rounds</text>
-   <rect x="51" y="223" width="226" height="32" rx="10"/>
+   <text class="terminal" x="59" y="285">SNAPSHOT ROUNDS</text>
+   <rect x="233" y="267" width="132" height="32"/>
+   <rect x="231" y="265" width="132" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="241" y="285">snapshot_rounds</text>
+   <rect x="51" y="311" width="226" height="32" rx="10"/>
    <rect x="49"
-         y="221"
+         y="309"
          width="226"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="241">TRANSACTIONAL SNAPSHOT</text>
-   <rect x="297" y="223" width="172" height="32"/>
-   <rect x="295" y="221" width="172" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="305" y="241">transactional_snapshot</text>
-   <rect x="51" y="267" width="102" height="32" rx="10"/>
+   <text class="terminal" x="59" y="329">TRANSACTIONAL SNAPSHOT</text>
+   <rect x="297" y="311" width="172" height="32"/>
+   <rect x="295" y="309" width="172" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="305" y="329">transactional_snapshot</text>
+   <rect x="51" y="355" width="102" height="32" rx="10"/>
    <rect x="49"
-         y="265"
+         y="353"
          width="102"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="285">VALUE SIZE</text>
-   <rect x="173" y="267" width="88" height="32"/>
-   <rect x="171" y="265" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="181" y="285">value_size</text>
-   <rect x="51" y="311" width="56" height="32" rx="10"/>
+   <text class="terminal" x="59" y="373">VALUE SIZE</text>
+   <rect x="173" y="355" width="88" height="32"/>
+   <rect x="171" y="353" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="181" y="373">value_size</text>
+   <rect x="51" y="399" width="56" height="32" rx="10"/>
    <rect x="49"
-         y="309"
+         y="397"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="329">SEED</text>
-   <rect x="127" y="311" width="52" height="32"/>
-   <rect x="125" y="309" width="52" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="135" y="329">seed</text>
-   <rect x="51" y="355" width="106" height="32" rx="10"/>
+   <text class="terminal" x="59" y="417">SEED</text>
+   <rect x="127" y="399" width="52" height="32"/>
+   <rect x="125" y="397" width="52" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="135" y="417">seed</text>
+   <rect x="51" y="443" width="106" height="32" rx="10"/>
    <rect x="49"
-         y="353"
+         y="441"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="373">PARTITIONS</text>
-   <rect x="177" y="355" width="82" height="32"/>
-   <rect x="175" y="353" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="185" y="373">partitions</text>
-   <rect x="51" y="399" width="106" height="32" rx="10"/>
+   <text class="terminal" x="59" y="461">PARTITIONS</text>
+   <rect x="177" y="443" width="82" height="32"/>
+   <rect x="175" y="441" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="185" y="461">partitions</text>
+   <rect x="51" y="487" width="106" height="32" rx="10"/>
    <rect x="49"
-         y="397"
+         y="485"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="417">BATCH SIZE</text>
-   <rect x="177" y="399" width="90" height="32"/>
-   <rect x="175" y="397" width="90" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="185" y="417">batch_size</text>
+   <text class="terminal" x="59" y="505">BATCH SIZE</text>
+   <rect x="177" y="487" width="90" height="32"/>
+   <rect x="175" y="485" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="185" y="505">batch_size</text>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m128 0 h10 m0 0 h10 m68 0 h10 m0 0 h202 m-458 0 h20 m438 0 h20 m-478 0 q10 0 10 10 m458 0 q0 -10 10 -10 m-468 10 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m130 0 h10 m0 0 h10 m100 0 h10 m0 0 h168 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m154 0 h10 m0 0 h10 m122 0 h10 m0 0 h122 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m58 0 h10 m0 0 h10 m50 0 h10 m0 0 h290 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m162 0 h10 m0 0 h10 m132 0 h10 m0 0 h104 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m226 0 h10 m0 0 h10 m172 0 h10 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m102 0 h10 m0 0 h10 m88 0 h10 m0 0 h208 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m56 0 h10 m0 0 h10 m52 0 h10 m0 0 h290 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m106 0 h10 m0 0 h10 m82 0 h10 m0 0 h210 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m106 0 h10 m0 0 h10 m90 0 h10 m0 0 h202 m23 -396 h-3"/>
+         d="m17 17 h2 m20 0 h10 m128 0 h10 m0 0 h10 m68 0 h10 m0 0 h202 m-458 0 h20 m438 0 h20 m-478 0 q10 0 10 10 m458 0 q0 -10 10 -10 m-468 10 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-428 10 h10 m62 0 h10 m0 0 h2 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -44 h10 m44 0 h10 m0 0 h250 m-448 -10 v20 m458 0 v-20 m-458 20 v68 m458 0 v-68 m-458 68 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m130 0 h10 m0 0 h10 m100 0 h10 m0 0 h168 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m154 0 h10 m0 0 h10 m122 0 h10 m0 0 h122 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m58 0 h10 m0 0 h10 m50 0 h10 m0 0 h290 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m162 0 h10 m0 0 h10 m132 0 h10 m0 0 h104 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m226 0 h10 m0 0 h10 m172 0 h10 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m102 0 h10 m0 0 h10 m88 0 h10 m0 0 h208 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m56 0 h10 m0 0 h10 m52 0 h10 m0 0 h290 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m106 0 h10 m0 0 h10 m82 0 h10 m0 0 h210 m-448 -10 v20 m458 0 v-20 m-458 20 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m106 0 h10 m0 0 h10 m90 0 h10 m0 0 h202 m23 -484 h-3"/>
    <polygon points="507 17 515 13 515 21"/>
    <polygon points="507 17 499 13 499 21"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -200,6 +200,8 @@ create_source_load_generator ::=
   with_options?
 load_generator_option ::=
     'TICK INTERVAL' interval
+    | 'AS OF' tick
+    | 'UP TO' tick
     | 'SCALE FACTOR' scale_factor
     | 'MAX CARDINALITY' max_cardinality
     | 'KEYS' keys

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1152,6 +1152,8 @@ impl_display!(LoadGenerator);
 pub enum LoadGeneratorOptionName {
     ScaleFactor,
     TickInterval,
+    AsOf,
+    UpTo,
     MaxCardinality,
     Keys,
     SnapshotRounds,
@@ -1167,6 +1169,8 @@ impl AstDisplay for LoadGeneratorOptionName {
         f.write_str(match self {
             LoadGeneratorOptionName::ScaleFactor => "SCALE FACTOR",
             LoadGeneratorOptionName::TickInterval => "TICK INTERVAL",
+            LoadGeneratorOptionName::AsOf => "AS OF",
+            LoadGeneratorOptionName::UpTo => "UP TO",
             LoadGeneratorOptionName::MaxCardinality => "MAX CARDINALITY",
             LoadGeneratorOptionName::Keys => "KEYS",
             LoadGeneratorOptionName::SnapshotRounds => "SNAPSHOT ROUNDS",
@@ -1190,6 +1194,8 @@ impl WithOptionName for LoadGeneratorOptionName {
         match self {
             LoadGeneratorOptionName::ScaleFactor
             | LoadGeneratorOptionName::TickInterval
+            | LoadGeneratorOptionName::AsOf
+            | LoadGeneratorOptionName::UpTo
             | LoadGeneratorOptionName::MaxCardinality
             | LoadGeneratorOptionName::Keys
             | LoadGeneratorOptionName::SnapshotRounds

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3210,6 +3210,8 @@ impl<'a> Parser<'a> {
 
     fn parse_load_generator_option(&mut self) -> Result<LoadGeneratorOption<Raw>, ParserError> {
         let name = match self.expect_one_of_keywords(&[
+            AS,
+            UP,
             SCALE,
             TICK,
             MAX,
@@ -3221,6 +3223,14 @@ impl<'a> Parser<'a> {
             PARTITIONS,
             BATCH,
         ])? {
+            AS => {
+                self.expect_keyword(OF)?;
+                LoadGeneratorOptionName::AsOf
+            }
+            UP => {
+                self.expect_keyword(TO)?;
+                LoadGeneratorOptionName::UpTo
+            }
             SCALE => {
                 self.expect_keyword(FACTOR)?;
                 LoadGeneratorOptionName::ScaleFactor

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2404,11 +2404,11 @@ CREATE SOURCE lg FROM LOAD GENERATOR KEY VALUE (KEYS = 1, PARTITIONS = 2, TICK I
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: KeyValue, options: [LoadGeneratorOption { name: Keys, value: Some(Value(Number("1"))) }, LoadGeneratorOption { name: Partitions, value: Some(Value(Number("2"))) }, LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1m"))) }, LoadGeneratorOption { name: BatchSize, value: Some(Value(Number("100"))) }, LoadGeneratorOption { name: Seed, value: Some(Value(Number("200"))) }, LoadGeneratorOption { name: ValueSize, value: Some(Value(Number("150"))) }, LoadGeneratorOption { name: SnapshotRounds, value: Some(Value(Number("3"))) }, LoadGeneratorOption { name: TransactionalSnapshot, value: Some(Value(Boolean(false))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
-CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1s', SCALE FACTOR 1, MAX CARDINALITY 100)
+CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1s', SCALE FACTOR 1, MAX CARDINALITY 100, UP TO 5, AS OF 5)
 ----
-CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL = '1s', SCALE FACTOR = 1, MAX CARDINALITY = 100)
+CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL = '1s', SCALE FACTOR = 1, MAX CARDINALITY = 100, UP TO = 5, AS OF = 5)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1s"))) }, LoadGeneratorOption { name: ScaleFactor, value: Some(Value(Number("1"))) }, LoadGeneratorOption { name: MaxCardinality, value: Some(Value(Number("100"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1s"))) }, LoadGeneratorOption { name: ScaleFactor, value: Some(Value(Number("1"))) }, LoadGeneratorOption { name: MaxCardinality, value: Some(Value(Number("100"))) }, LoadGeneratorOption { name: UpTo, value: Some(Value(Number("5"))) }, LoadGeneratorOption { name: AsOf, value: Some(Value(Number("5"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE lg FROM LOAD GENERATOR MARKETING

--- a/src/storage-types/src/sources/load_generator.proto
+++ b/src/storage-types/src/sources/load_generator.proto
@@ -26,6 +26,8 @@ message ProtoLoadGeneratorSourceConnection {
         ProtoKeyValueLoadGenerator key_value = 8;
     }
     optional uint64 tick_micros = 2;
+    uint64 as_of = 9;
+    uint64 up_to = 10;
 }
 
 message ProtoCounterLoadGenerator {

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -31,6 +31,7 @@ include!(concat!(
 pub const LOAD_GENERATOR_KEY_VALUE_OFFSET_DEFAULT: &str = "offset";
 
 /// Data and progress events of the native stream.
+#[derive(Debug)]
 pub enum Event<F: IntoIterator, D> {
     /// Indicates that timestamps have advanced to frontier F
     Progress(F),
@@ -42,6 +43,8 @@ pub enum Event<F: IntoIterator, D> {
 pub struct LoadGeneratorSourceConnection {
     pub load_generator: LoadGenerator,
     pub tick_micros: Option<u64>,
+    pub as_of: u64,
+    pub up_to: u64,
 }
 
 pub static LOAD_GEN_PROGRESS_DESC: Lazy<RelationDesc> =
@@ -474,6 +477,8 @@ impl RustType<ProtoLoadGeneratorSourceConnection> for LoadGeneratorSourceConnect
                 LoadGenerator::KeyValue(kv) => Kind::KeyValue(kv.into_proto()),
             }),
             tick_micros: self.tick_micros,
+            as_of: self.as_of,
+            up_to: self.up_to,
         }
     }
 
@@ -506,6 +511,8 @@ impl RustType<ProtoLoadGeneratorSourceConnection> for LoadGeneratorSourceConnect
                 Kind::KeyValue(kv) => LoadGenerator::KeyValue(kv.into_rust()?),
             },
             tick_micros: proto.tick_micros,
+            as_of: proto.as_of,
+            up_to: proto.up_to,
         })
     }
 }

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -10,14 +10,42 @@
 $ set-arg-default default-replica-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
+> CREATE SOURCE counter_empty
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR COUNTER (AS OF 5, UP TO 5)
+
+> SELECT count(*) FROM counter_empty
+0
+
+> CREATE SOURCE counter_single
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR COUNTER (AS OF 0, UP TO 1)
+
+> SELECT count(*) FROM counter_single
+1
+
+> CREATE SOURCE counter_five
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR COUNTER (AS OF 4, UP TO 5)
+
+> SELECT count(*) FROM counter_five
+5
+
+! CREATE SOURCE counter
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR COUNTER (AS OF 5, UP TO 4)
+contains:UP TO cannot be less than AS OF
+
 ! CREATE SOURCE counter
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR COUNTER (SCALE FACTOR 1)
 exact:COUNTER load generators do not support SCALE FACTOR values
 
+> DROP SOURCE counter_empty, counter_single, counter_five
+
 > CREATE SOURCE auction_house
   IN CLUSTER ${arg.single-replica-cluster}
-  FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
+  FROM LOAD GENERATOR AUCTION (AS OF 300, UP TO 301) FOR ALL TABLES;
 
 > SHOW SOURCES
 accounts                subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
@@ -27,6 +55,9 @@ auctions                subsource      ${arg.default-replica-size}    ${arg.sing
 bids                    subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
 organizations           subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
 users                   subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
+
+> SELECT count(*) FROM bids
+255
 
 # FOR TABLES doesn't always work.
 # A previous test here checked bids, which worked.
@@ -116,13 +147,13 @@ contains: out of range integral type conversion
 
 # Query automatically generated progress topic
 $ set-regex match=\d+ replacement=<NUMBER>
-> SELECT "offset" FROM auction_house_progress
+> SELECT "offset" FROM another.auction_house_progress
 <NUMBER>
 
 # Ensure we report the write frontier of the progress subsource
 $ set-regex match=(\s{12}0|\d{13,20}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\)|true|false) replacement=<>
-> EXPLAIN TIMESTAMP FOR SELECT * FROM auction_house_progress
-"                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: <>\n                       timeline: Some(EpochMilliseconds)\n              session wall time: <> <>\n\nsource materialize.public.auction_house_progress (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"
+> EXPLAIN TIMESTAMP FOR SELECT * FROM another.auction_house_progress
+"                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: <>\n                       timeline: Some(EpochMilliseconds)\n              session wall time: <> <>\n\nsource materialize.another.auction_house_progress (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"
 
 # Check that for all tables clause is rejected with no subsources
 ! CREATE SOURCE counter6


### PR DESCRIPTION
Add new `AS OF` and `UP TO` options to all simple (non-KV) load generators. The former option controls the size of the initial snapshot, while the latter option controls the maximum amount of data generated by the load generator. Both are measured in number of ticks.

For example, with the default tick interval of 1s, setting `AS OF` to 300 and `UP TO` to 420 will create a load generator that starts with 5m worth of data and runs for 2m before ceasing.

This will be useful in the console's quickstart, which falls a little flat at the moment because building an index on a half dozen rows doesn't demonstrate how much faster the index makes queries. With these new load generator options, the console quickstart will be able to use a load generator that starts off with much more data and makes for a much better demo. See https://github.com/MaterializeInc/console/issues/2309.

These options also turn out to be useful in tests, as they allow creating load generators that produce a fixed amount of output against which assertions can be easily written.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature (see above).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow configuring the initial snapshot size and the maximum size for load generator sources.
