### PR TITLE
dbt-materialize: update changelog for v1.8.0

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt-materialize Changelog
 
-## Unreleased
+## 1.8.0 - 2024-05-23
 
 * Update base adapter references as part of
   [decoupling migration from dbt-core](https://github.com/dbt-labs/dbt-adapters/discussions/87)


### PR DESCRIPTION
Updating the changelog for the release of `dbt-materialize` v1.8.0.

See `CHANGELOG.md` for an overview of the release.

