### PR TITLE
output consistency: add further string types

### DIFF
--- a/misc/python/materialize/output_consistency/enum/enum_constant.py
+++ b/misc/python/materialize/output_consistency/enum/enum_constant.py
@@ -38,11 +38,13 @@ class EnumConstant(Expression):
         value: str,
         add_quotes: bool,
         characteristics: set[ExpressionCharacteristics],
+        tags: set[str] | None = None,
     ):
         super().__init__(characteristics, ValueStorageLayout.ANY, False, False)
         self.value = value
         self.add_quotes = add_quotes
         self.data_type = EnumDataType()
+        self.tags = tags
 
     def resolve_return_type_category(self) -> DataTypeCategory:
         return DataTypeCategory.ENUM
@@ -76,6 +78,12 @@ class EnumConstant(Expression):
 
     def collect_leaves(self) -> list[LeafExpression]:
         return []
+
+    def is_tagged(self, tag: str) -> bool:
+        if self.tags is None:
+            return False
+
+        return tag in self.tags
 
 
 class StringConstant(EnumConstant):

--- a/misc/python/materialize/output_consistency/enum/enum_operation_param.py
+++ b/misc/python/materialize/output_consistency/enum/enum_operation_param.py
@@ -29,6 +29,7 @@ class EnumConstantOperationParam(OperationParam):
         add_null_value: bool = True,
         optional: bool = False,
         invalid_value: str = "invalid_value_123",
+        tags: set[str] | None = None,
     ):
         super().__init__(
             DataTypeCategory.ENUM,
@@ -57,6 +58,7 @@ class EnumConstantOperationParam(OperationParam):
         self.characteristics_per_index: list[set[ExpressionCharacteristics]] = [
             set() for _ in self.values
         ]
+        self.tags = tags
 
     def supports_type(
         self, data_type: DataType, previous_args: list[Expression]
@@ -74,7 +76,7 @@ class EnumConstantOperationParam(OperationParam):
         if self.add_null_value and index == 0:
             quote_value = False
 
-        return EnumConstant(value, quote_value, characteristics)
+        return EnumConstant(value, quote_value, characteristics, self.tags)
 
     def get_valid_values(self) -> list[str]:
         return [

--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from functools import partial
 
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.enum.enum_constant import EnumConstant
 from materialize.output_consistency.expression.expression import (
     Expression,
     LeafExpression,
@@ -20,6 +21,12 @@ from materialize.output_consistency.expression.expression_with_args import (
 )
 from materialize.output_consistency.input_data.operations.date_time_operations_provider import (
     DATE_TIME_OPERATION_TYPES,
+)
+from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
+    TAG_DATA_TYPE_ENUM,
+)
+from materialize.output_consistency.input_data.types.all_types_provider import (
+    internal_type_identifiers_to_data_type_names,
 )
 from materialize.output_consistency.operation.operation import (
     DbFunction,
@@ -128,6 +135,15 @@ def involves_data_type_category(
 def is_known_to_involve_exact_data_types(
     expression: Expression, internal_data_type_identifiers: set[str]
 ):
+    if isinstance(expression, EnumConstant) and expression.is_tagged(
+        TAG_DATA_TYPE_ENUM
+    ):
+        type_names = internal_type_identifiers_to_data_type_names(
+            internal_data_type_identifiers
+        )
+        if expression.value in type_names:
+            return True
+
     exact_data_type = expression.try_resolve_exact_data_type()
 
     if exact_data_type is None:

--- a/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
+++ b/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
@@ -16,6 +16,8 @@ from materialize.output_consistency.input_data.types.all_types_provider import (
     DATA_TYPES,
 )
 
+TAG_DATA_TYPE_ENUM = "data_type"
+
 TIME_ZONE_PARAM = EnumConstantOperationParam(
     ["UTC", "CET", "+8", "America/New_York"], add_quotes=True
 )
@@ -130,5 +132,8 @@ def all_data_types_enum_constant_operation_param(
         if data_type.is_pg_compatible or not must_be_pg_compatible
     ]
     return EnumConstantOperationParam(
-        all_type_names, add_quotes=False, add_invalid_value=False
+        all_type_names,
+        add_quotes=False,
+        add_invalid_value=False,
+        tags={TAG_DATA_TYPE_ENUM},
     )

--- a/misc/python/materialize/output_consistency/input_data/types/all_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/all_types_provider.py
@@ -54,3 +54,22 @@ DATA_TYPES: list[DataType] = list(
         [UUID_DATA_TYPE],
     )
 )
+
+_DATA_TYPE_NAME_BY_INTERNAL_IDENTIFIER: dict[str, str] = {}
+for data_type in DATA_TYPES:
+    _DATA_TYPE_NAME_BY_INTERNAL_IDENTIFIER[
+        data_type.internal_identifier
+    ] = data_type.type_name
+
+
+def get_data_type_name_by_internal_identifier(internal_type_identifier: str) -> str:
+    return _DATA_TYPE_NAME_BY_INTERNAL_IDENTIFIER[internal_type_identifier]
+
+
+def internal_type_identifiers_to_data_type_names(
+    internal_type_identifiers: set[str],
+) -> set[str]:
+    return {
+        get_data_type_name_by_internal_identifier(identifier)
+        for identifier in internal_type_identifiers
+    }

--- a/misc/python/materialize/output_consistency/input_data/types/string_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/string_type_provider.py
@@ -20,7 +20,7 @@ from materialize.output_consistency.operation.return_type_spec import ReturnType
 TEXT_TYPE_IDENTIFIER = "TEXT"
 VARCHAR_8_TYPE_IDENTIFIER = "VARCHAR_8"
 CHAR_8_TYPE_IDENTIFIER = "CHAR_8"
-BPCHAR_TYPE_IDENTIFIER = "BPCHAR"
+BPCHAR_8_TYPE_IDENTIFIER = "BPCHAR_8"
 
 
 class StringDataType(DataType):
@@ -46,8 +46,8 @@ VARCHAR_8_DATA_TYPE = StringDataType(VARCHAR_8_TYPE_IDENTIFIER, "VARCHAR(8)")
 CHAR_8_DATA_TYPE = StringDataType(
     CHAR_8_TYPE_IDENTIFIER, "CHAR(8)", only_few_values=True
 )
-BPCHAR_DATA_TYPE = StringDataType(
-    BPCHAR_TYPE_IDENTIFIER, "BPCHAR", only_few_values=True
+BPCHAR_8_DATA_TYPE = StringDataType(
+    BPCHAR_8_TYPE_IDENTIFIER, "BPCHAR(8)", only_few_values=True
 )
 
 
@@ -55,5 +55,5 @@ STRING_DATA_TYPES: list[StringDataType] = [
     TEXT_DATA_TYPE,
     VARCHAR_8_DATA_TYPE,
     CHAR_8_DATA_TYPE,
-    BPCHAR_DATA_TYPE,
+    BPCHAR_8_DATA_TYPE,
 ]

--- a/misc/python/materialize/output_consistency/input_data/types/string_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/string_type_provider.py
@@ -19,7 +19,7 @@ from materialize.output_consistency.operation.return_type_spec import ReturnType
 
 TEXT_TYPE_IDENTIFIER = "TEXT"
 VARCHAR_8_TYPE_IDENTIFIER = "VARCHAR_8"
-CHAR_8_TYPE_IDENTIFIER = "CHAR_8"
+CHAR_6_TYPE_IDENTIFIER = "CHAR_6"
 BPCHAR_8_TYPE_IDENTIFIER = "BPCHAR_8"
 
 
@@ -43,8 +43,8 @@ class StringDataType(DataType):
 
 TEXT_DATA_TYPE = StringDataType(TEXT_TYPE_IDENTIFIER, "TEXT")
 VARCHAR_8_DATA_TYPE = StringDataType(VARCHAR_8_TYPE_IDENTIFIER, "VARCHAR(8)")
-CHAR_8_DATA_TYPE = StringDataType(
-    CHAR_8_TYPE_IDENTIFIER, "CHAR(8)", only_few_values=True
+CHAR_6_DATA_TYPE = StringDataType(
+    CHAR_6_TYPE_IDENTIFIER, "CHAR(6)", only_few_values=True
 )
 BPCHAR_8_DATA_TYPE = StringDataType(
     BPCHAR_8_TYPE_IDENTIFIER, "BPCHAR(8)", only_few_values=True
@@ -54,6 +54,6 @@ BPCHAR_8_DATA_TYPE = StringDataType(
 STRING_DATA_TYPES: list[StringDataType] = [
     TEXT_DATA_TYPE,
     VARCHAR_8_DATA_TYPE,
-    CHAR_8_DATA_TYPE,
+    CHAR_6_DATA_TYPE,
     BPCHAR_8_DATA_TYPE,
 ]

--- a/misc/python/materialize/output_consistency/input_data/types/string_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/string_type_provider.py
@@ -18,15 +18,21 @@ from materialize.output_consistency.input_data.return_specs.string_return_spec i
 from materialize.output_consistency.operation.return_type_spec import ReturnTypeSpec
 
 TEXT_TYPE_IDENTIFIER = "TEXT"
+VARCHAR_8_TYPE_IDENTIFIER = "VARCHAR_8"
+CHAR_8_TYPE_IDENTIFIER = "CHAR_8"
+BPCHAR_TYPE_IDENTIFIER = "BPCHAR"
 
 
 class StringDataType(DataType):
-    def __init__(self, internal_identifier: str, type_name: str):
+    def __init__(
+        self, internal_identifier: str, type_name: str, only_few_values: bool = False
+    ):
         super().__init__(
             internal_identifier,
             type_name,
             DataTypeCategory.STRING,
         )
+        self.only_few_values = only_few_values
 
     def resolve_return_type_spec(
         self, characteristics: set[ExpressionCharacteristics]
@@ -36,7 +42,18 @@ class StringDataType(DataType):
 
 
 TEXT_DATA_TYPE = StringDataType(TEXT_TYPE_IDENTIFIER, "TEXT")
+VARCHAR_8_DATA_TYPE = StringDataType(VARCHAR_8_TYPE_IDENTIFIER, "VARCHAR(8)")
+CHAR_8_DATA_TYPE = StringDataType(
+    CHAR_8_TYPE_IDENTIFIER, "CHAR(8)", only_few_values=True
+)
+BPCHAR_DATA_TYPE = StringDataType(
+    BPCHAR_TYPE_IDENTIFIER, "BPCHAR", only_few_values=True
+)
 
 
-STRING_DATA_TYPES: list[StringDataType] = []
-STRING_DATA_TYPES.append(TEXT_DATA_TYPE)
+STRING_DATA_TYPES: list[StringDataType] = [
+    TEXT_DATA_TYPE,
+    VARCHAR_8_DATA_TYPE,
+    CHAR_8_DATA_TYPE,
+    BPCHAR_DATA_TYPE,
+]

--- a/misc/python/materialize/output_consistency/input_data/values/string_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/string_values_provider.py
@@ -30,13 +30,16 @@ for string_data_type in STRING_DATA_TYPES:
         {ExpressionCharacteristics.STRING_EMPTY},
     )
     values_of_type.add_raw_value("'a'", "VAL_1", set())
-    values_of_type.add_raw_value("'abc'", "VAL_2", set())
-    values_of_type.add_raw_value("'xAAx'", "VAL_3", set())
-    values_of_type.add_raw_value("'0*a*B_c-dE.$=#(%)?!'", "VAL_4", set())
+
+    if not string_data_type.only_few_values:
+        values_of_type.add_raw_value("'abc'", "VAL_2", set())
+        values_of_type.add_raw_value("'xAAx'", "VAL_3", set())
+        values_of_type.add_raw_value("'0*a*B_c-dE.$=#(%)?!'", "VAL_4", set())
+        values_of_type.add_raw_value("'ff00aa'", "HEX_VAL", set())
+
     values_of_type.add_raw_value(
         "'äÖüß'", "VAL_5", {ExpressionCharacteristics.STRING_WITH_ESZETT}
     )
-    values_of_type.add_raw_value("'ff00aa'", "HEX_VAL", set())
     values_of_type.add_raw_value(
         "' mAA m\n\t '",
         "VAL_W_SPACES",

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -71,7 +71,7 @@ from materialize.output_consistency.input_data.types.number_types_provider impor
 )
 from materialize.output_consistency.input_data.types.string_type_provider import (
     BPCHAR_8_TYPE_IDENTIFIER,
-    CHAR_8_TYPE_IDENTIFIER,
+    CHAR_6_TYPE_IDENTIFIER,
 )
 from materialize.output_consistency.operation.operation import (
     DbFunction,
@@ -161,7 +161,7 @@ class PgPreExecutionInconsistencyIgnoreFilter(
                     is_known_to_involve_exact_data_types,
                     internal_data_type_identifiers={
                         BPCHAR_8_TYPE_IDENTIFIER,
-                        CHAR_8_TYPE_IDENTIFIER,
+                        CHAR_6_TYPE_IDENTIFIER,
                     },
                 ),
                 True,

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -141,7 +141,9 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         if matches_float_comparison(expression):
             return YesIgnore("#22022: real with decimal comparison")
 
-        if operation.is_tagged(TAG_JSONB_TO_TEXT) and expression.matches(
+        if (
+            operation.is_tagged(TAG_JSONB_TO_TEXT) or operation.is_tagged(TAG_CASTING)
+        ) and expression.matches(
             partial(
                 involves_data_type_category, data_type_category=DataTypeCategory.JSONB
             ),


### PR DESCRIPTION
Adding these types when I learned about `BPCHAR` and noticed that it is not behaving like in Postgres: https://github.com/MaterializeInc/materialize/issues/27247

### Commits
This is based on https://github.com/MaterializeInc/materialize/pull/27248.
080e6f63dd output consistency: string type: add VARCHAR, CHAR, BPCHAR
9cd438580d output consistency: explicitly specify the length of BPCHAR
27f1d0cdaf postgres consistency: add ignores
eefa3dde4c postgres consistency: use different length for CHAR type to make it more diverse to BPCHAR(8)
b7e36d8d46 postgres consistency: add further ignores
be166595c8 output consistency: improve is_known_to_involve_exact_data_types expression matcher
1820ef6f6a postgres consistency: extend ignore

### Nightly
https://buildkite.com/materialize/nightly/builds?branch=nrainer-materialize%3Aoutput-consistency%2Fadd-further-string-types ✅ 

### Identified Issues
https://github.com/MaterializeInc/materialize/issues/21981#issuecomment-2126496984