### PR TITLE
sql: fix SHOW CREATE SOURCE for multi-output load generators

### DIFF
--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -19,6 +19,9 @@ exact:COUNTER load generators do not support SCALE FACTOR values
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
+> SHOW CREATE SOURCE auction_house
+"materialize.public.auction_house" "CREATE SOURCE \"materialize\".\"public\".\"auction_house\" IN CLUSTER \"${arg.single-replica-cluster}\" FROM LOAD GENERATOR AUCTION FOR ALL TABLES EXPOSE PROGRESS AS \"materialize\".\"public\".\"auction_house_progress\""
+
 > SHOW SOURCES
 accounts                subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
 auction_house           load-generator ${arg.default-replica-size}    ${arg.single-replica-cluster}


### PR DESCRIPTION
`SHOW CREATE SOURCE` produced an incompatible command for multi-output load generator sources.

### Motivation

This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix the output of `SHOW CREATE SOURCE` for multi-output load generator sources (e.g. `LOAD GENERATOR AUCTION`) to always include the `FOR ALL TABLES` clause, which is required.