### PR TITLE
[persist/sinks] Temporarily disable source since holds in CI

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -94,6 +94,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_txn_tables": "lazy",
     "persist_use_critical_since_catalog": "true",
     "persist_use_critical_since_snapshot": "true",
+    # TODO: change to true when #27219 is resolved
     "persist_use_critical_since_source": "false",
     "statement_logging_default_sample_rate": "0.01",
     "statement_logging_max_sample_rate": "0.01",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -94,7 +94,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_txn_tables": "lazy",
     "persist_use_critical_since_catalog": "true",
     "persist_use_critical_since_snapshot": "true",
-    "persist_use_critical_since_source": "true",
+    "persist_use_critical_since_source": "false",
     "statement_logging_default_sample_rate": "0.01",
     "statement_logging_max_sample_rate": "0.01",
     "storage_persist_sink_minimum_batch_updates": "100",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -901,7 +901,7 @@ class FlipFlagsAction(Action):
         BOOLEAN_FLAG_VALUES = ["TRUE", "FALSE"]
 
         self.flags_with_values: dict[str, list[str]] = dict()
-        for flag in ["catalog", "source", "snapshot", "txn"]:
+        for flag in ["catalog", "snapshot", "txn"]:
             self.flags_with_values[
                 f"persist_use_critical_since_{flag}"
             ] = BOOLEAN_FLAG_VALUES


### PR DESCRIPTION
There's a known Kafka sink bug; let's make things a little less noisy as we track that down.

### Motivation

Bug: https://github.com/MaterializeInc/materialize/issues/27219

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
