### PR TITLE
storage: rm misguided soft assert when altering SourceDesc

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1079,12 +1079,6 @@ where
             _ => unreachable!("verified collection refers to ingestion"),
         };
 
-        mz_ore::soft_assert_ne_or_log!(
-            curr_ingestion.desc,
-            source_desc,
-            "alter_ingestion_source_desc should only be called when producing new SourceDesc",
-        );
-
         // Generate new source exports because they might have changed.
         let mut source_exports = BTreeMap::new();
         // Each source includes a `0` output index export "for the


### PR DESCRIPTION
I added an assert that all SourceDesc changes should actually change the SourceDesc. However, I had overlooked the impossible to detect case where:
1. User creates PG source foo with tables a, b.
2. User drops subsource b. This does not update the SourceDesc.
3. User re-adds subsource b without having changed its schema.

In this case, the actual source desc will not have changed whatsoever and spuriously trip the assert. Unclear how to really detect this case, and in light of this use, the assert is of questionable value.


### Motivation

This PR fixes a recognized bug. Fixes #27246

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
