### PR TITLE
storage: attempt to reduce flakiness of kafka-sink-statistics.td

### DIFF
--- a/test/testdrive/kafka-sink-statistics.td
+++ b/test/testdrive/kafka-sink-statistics.td
@@ -9,6 +9,13 @@
 
 $ set-arg-default single-replica-cluster=quickstart
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET kafka_default_metadata_fetch_interval = 1000
+ALTER SYSTEM SET storage_statistics_collection_interval = 1000
+ALTER SYSTEM SET storage_statistics_interval = 2000
+ALTER SYSTEM SET kafka_socket_timeout = 5000
+ALTER SYSTEM SET kafka_transaction_timeout = 5100
+
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
@@ -54,7 +61,19 @@ simple_view_sink 2 2 true true
 simple_view_sink 2 2 true true
 
 > ALTER CONNECTION kafka_conn SET (BROKER 'asdf') WITH (VALIDATE = false);
+
+# Ensure we shut down first, so the insert later comes after we have restarted.
+> SELECT count(*) > 0 FROM mz_internal.mz_sink_status_history
+  JOIN mz_sinks ON mz_sink_status_history.sink_id = mz_sinks.id
+  WHERE status = 'stalled'
+  AND name = 'simple_view_sink'
+true
+
 > ALTER CONNECTION kafka_conn SET (BROKER '${testdrive.kafka-addr}') WITH (VALIDATE = true);
+
+> SELECT status FROM mz_internal.mz_sink_statuses
+  WHERE name = 'simple_view_sink'
+running
 
 > INSERT INTO t VALUES ('key1', 'value')
 > SELECT s.name, u.messages_staged, u.messages_committed, u.bytes_staged > 0, bytes_staged = bytes_committed


### PR DESCRIPTION
@nrainer-materialize lets let this bake for a bit!

may help: https://github.com/MaterializeInc/materialize/issues/27255

### Motivation


  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
