### PR TITLE
[persist] Fix up some reversed metrics etc.

### DIFF
--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -569,24 +569,24 @@ where
         Self::delete_all(
             machine.applier.state_versions.blob.borrow(),
             batch_parts.iter().map(|k| k.complete(&shard_id)),
-            &machine.applier.metrics.retries.external.rollup_delete,
-            debug_span!("rollup::delete"),
-            &delete_semaphore,
-        )
-        .await;
-        *batch_parts = PartDeletes::default();
-        timer(&machine.applier.metrics.gc.steps.delete_rollup_seconds);
-
-        Self::delete_all(
-            machine.applier.state_versions.blob.borrow(),
-            rollups.iter().map(|k| k.complete(&shard_id)),
             &machine.applier.metrics.retries.external.batch_delete,
             debug_span!("batch::delete"),
             &delete_semaphore,
         )
         .await;
-        rollups.clear();
+        *batch_parts = PartDeletes::default();
         timer(&machine.applier.metrics.gc.steps.delete_batch_part_seconds);
+
+        Self::delete_all(
+            machine.applier.state_versions.blob.borrow(),
+            rollups.iter().map(|k| k.complete(&shard_id)),
+            &machine.applier.metrics.retries.external.rollup_delete,
+            debug_span!("rollup::delete"),
+            &delete_semaphore,
+        )
+        .await;
+        rollups.clear();
+        timer(&machine.applier.metrics.gc.steps.delete_rollup_seconds);
 
         machine
             .applier


### PR DESCRIPTION
Looks like these have been inverted from the intended meaning.

### Motivation

Previously-unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
