### PR TITLE
storage: initialize source/sink statistics with zero/null values.

### DIFF
--- a/src/storage-client/src/statistics.rs
+++ b/src/storage-client/src/statistics.rs
@@ -130,7 +130,7 @@ pub trait StorageMetric {
 }
 
 /// A counter that never resets.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct Counter(u64);
 
 impl StorageMetric for Counter {
@@ -156,7 +156,7 @@ impl From<u64> for Counter {
 }
 
 /// A latency gauge that is reset on every restart.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct ResettingLatency(Option<i64>);
 
 impl From<Option<i64>> for ResettingLatency {
@@ -259,7 +259,7 @@ impl From<u64> for ResettingTotal {
 }
 
 /// A boolean gauge that is never reset.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct Boolean(bool);
 
 impl StorageMetric for Boolean {
@@ -387,7 +387,7 @@ impl StorageMetric for Total {
 }
 
 /// A gauge that has semantics based on the `StorageMetric` implementation of its inner.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct Gauge<T>(T);
 
 impl<T> Gauge<T> {
@@ -465,6 +465,24 @@ pub struct SourceStatisticsUpdate {
 }
 
 impl SourceStatisticsUpdate {
+    pub fn new(id: GlobalId) -> Self {
+        Self {
+            id,
+            messages_received: Default::default(),
+            bytes_received: Default::default(),
+            updates_staged: Default::default(),
+            updates_committed: Default::default(),
+            records_indexed: Default::default(),
+            bytes_indexed: Default::default(),
+            rehydration_latency_ms: Default::default(),
+            snapshot_records_known: Default::default(),
+            snapshot_records_staged: Default::default(),
+            snapshot_committed: Default::default(),
+            offset_known: Default::default(),
+            offset_committed: Default::default(),
+        }
+    }
+
     pub fn summarize<'a, I, F>(values: F) -> Self
     where
         I: IntoIterator<Item = &'a Self>,
@@ -668,6 +686,16 @@ pub struct SinkStatisticsUpdate {
 }
 
 impl SinkStatisticsUpdate {
+    pub fn new(id: GlobalId) -> Self {
+        Self {
+            id,
+            messages_staged: Default::default(),
+            messages_committed: Default::default(),
+            bytes_staged: Default::default(),
+            bytes_committed: Default::default(),
+        }
+    }
+
     pub fn incorporate(&mut self, other: SinkStatisticsUpdate) {
         let SinkStatisticsUpdate {
             messages_staged,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -90,6 +90,7 @@ use tokio_stream::StreamMap;
 use tracing::{debug, info, warn};
 
 use crate::rehydration::RehydratingStorageClient;
+use crate::statistics::StatsState;
 mod collection_mgmt;
 mod collection_status;
 mod persist_handles;
@@ -194,7 +195,7 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     source_statistics: Arc<Mutex<statistics::SourceStatistics>>,
     /// Consolidated metrics updates to periodically write. We do not eagerly initialize this,
     /// and its contents are entirely driven by `StorageResponse::StatisticsUpdates`'s.
-    sink_statistics: Arc<Mutex<BTreeMap<GlobalId, Option<SinkStatisticsUpdate>>>>,
+    sink_statistics: Arc<Mutex<BTreeMap<GlobalId, statistics::StatsState<SinkStatisticsUpdate>>>>,
     /// A way to update the statistics interval in the statistics tasks.
     statistics_interval_sender: Sender<Duration>,
 
@@ -834,7 +835,7 @@ where
                 source_statistics
                     .source_statistics
                     .entry(id)
-                    .or_insert(None);
+                    .or_insert(StatsState::new(SourceStatisticsUpdate::new(id)));
             }
             for id in new_webhook_statistic_entries {
                 source_statistics.webhook_statistics.entry(id).or_default();
@@ -1152,7 +1153,7 @@ where
                 .lock()
                 .expect("poisoned")
                 .entry(id)
-                .or_insert(None);
+                .or_insert(StatsState::new(SinkStatisticsUpdate::new(id)));
 
             client.send(StorageCommand::RunSinks(vec![cmd]));
         }
@@ -1789,12 +1790,7 @@ where
                         shared_stats
                             .source_statistics
                             .entry(stat.id)
-                            .and_modify(|current| match current {
-                                Some(ref mut current) => current.incorporate(stat),
-                                None => {
-                                    *current = Some(stat.with_metrics(&self.metrics));
-                                }
-                            });
+                            .and_modify(|current| current.stat().incorporate(stat));
                     }
                 }
 
@@ -1804,10 +1800,7 @@ where
                         // Don't override it if its been removed.
                         shared_stats
                             .entry(stat.id)
-                            .and_modify(|current| match current {
-                                Some(ref mut current) => current.incorporate(stat),
-                                None => *current = Some(stat),
-                            });
+                            .and_modify(|current| current.stat().incorporate(stat));
                     }
                 }
             }

--- a/src/storage-controller/src/statistics.rs
+++ b/src/storage-controller/src/statistics.rs
@@ -29,18 +29,68 @@ use tokio::sync::oneshot;
 use tokio::sync::watch::Receiver;
 
 use crate::collection_mgmt::CollectionManager;
+use StatsState::*;
+
+#[derive(Debug)]
+pub(super) enum StatsState<Stat> {
+    /// This stat is fully initialized.
+    Initialized(Stat),
+    /// This stat has not been initialized. We must write a `zero_value`
+    /// in one interval, before writing the first real update.
+    NeedsInit {
+        zero_value: Stat,
+        future_update: Stat,
+    },
+}
+
+impl<Stat: Clone> StatsState<Stat> {
+    pub(super) fn new(zero_value: Stat) -> Self {
+        let future_update = zero_value.clone();
+        StatsState::NeedsInit {
+            zero_value,
+            future_update,
+        }
+    }
+
+    /// Get a copy of the stat value that should be emitted to the statistics table.
+    /// After calling this, you must call `mark_initialized`. (These are separate
+    /// to avoid some clones).
+    fn stat_to_emit(&mut self) -> &mut Stat {
+        match self {
+            Initialized(stat) => stat,
+            NeedsInit { zero_value, .. } => zero_value,
+        }
+    }
+
+    /// Make this stat as initialized.
+    fn mark_initialized(&mut self) {
+        match self {
+            Initialized(_) => {}
+            NeedsInit { future_update, .. } => *self = Initialized(future_update.clone()),
+        }
+    }
+
+    /// Get a reference to a stat for additional incorporation.
+    pub(super) fn stat(&mut self) -> &mut Stat {
+        match self {
+            Initialized(stat) => stat,
+            NeedsInit { future_update, .. } => future_update,
+        }
+    }
+}
 
 /// Conversion trait to allow multiple shapes of data in [`spawn_statistics_scraper`].
 pub(super) trait AsStats<Stats> {
-    fn as_stats(&self) -> &BTreeMap<GlobalId, Option<Stats>>;
-    fn as_mut_stats(&mut self) -> &mut BTreeMap<GlobalId, Option<Stats>>;
+    fn as_stats(&self) -> &BTreeMap<GlobalId, StatsState<Stats>>;
+    fn as_mut_stats(&mut self) -> &mut BTreeMap<GlobalId, StatsState<Stats>>;
 }
 
-impl<Stats> AsStats<Stats> for BTreeMap<GlobalId, Option<Stats>> {
-    fn as_stats(&self) -> &BTreeMap<GlobalId, Option<Stats>> {
+impl<Stats> AsStats<Stats> for BTreeMap<GlobalId, StatsState<Stats>> {
+    fn as_stats(&self) -> &BTreeMap<GlobalId, StatsState<Stats>> {
         self
     }
-    fn as_mut_stats(&mut self) -> &mut BTreeMap<GlobalId, Option<Stats>> {
+
+    fn as_mut_stats(&mut self) -> &mut BTreeMap<GlobalId, StatsState<Stats>> {
         self
     }
 }
@@ -58,7 +108,7 @@ pub(super) fn spawn_statistics_scraper<StatsWrapper, Stats, T>(
 ) -> Box<dyn Any + Send + Sync>
 where
     StatsWrapper: AsStats<Stats> + Debug + Send + 'static,
-    Stats: PackableStats + Debug + Send + 'static,
+    Stats: PackableStats + Clone + Debug + Send + 'static,
     T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
 {
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
@@ -80,12 +130,12 @@ where
 
                 shared_stats
                     .as_mut_stats()
-                    .insert(current.0, Some(current.1));
+                    .insert(current.0, StatsState::Initialized(current.1));
             }
 
             let mut row_buf = Row::default();
             for (_, stats) in shared_stats.as_stats().iter() {
-                if let Some(stats) = stats {
+                if let StatsState::Initialized(stats) = stats {
                     stats.pack(row_buf.packer());
                     correction.push((row_buf.clone(), 1));
                 }
@@ -134,12 +184,12 @@ where
                     // up the coordinator. Because we are just moving some data around, we should
                     // be fine!
                     {
-                        let shared_stats = shared_stats.lock().expect("poisoned");
-                        for (_, stats) in shared_stats.as_stats().iter() {
-                            if let Some(stats) = stats {
-                                stats.pack(row_buf.packer());
-                                correction.push((row_buf.clone(), 1));
-                            }
+                        let mut shared_stats = shared_stats.lock().expect("poisoned");
+                        for (_, stats) in shared_stats.as_mut_stats().iter_mut() {
+                            let stat = stats.stat_to_emit();
+                            stat.pack(row_buf.packer());
+                            correction.push((row_buf.clone(), 1));
+                            stats.mark_initialized();
                         }
                     }
 
@@ -173,7 +223,7 @@ pub(super) struct SourceStatistics {
     /// sources must initialize the first values, but we need `None` to mark a source
     /// having been created vs dropped (particularly when a cluster can race and report
     /// statistics for a dropped source, which we must ignore).
-    pub source_statistics: BTreeMap<GlobalId, Option<SourceStatisticsUpdate>>,
+    pub source_statistics: BTreeMap<GlobalId, StatsState<SourceStatisticsUpdate>>,
     /// A shared map with atomics for webhook appenders to update the (currently 4)
     /// statistics that can meaningfully produce. These are periodically
     /// copied into `source_statistics` [`spawn_webhook_statistics_scraper`] to avoid
@@ -182,10 +232,11 @@ pub(super) struct SourceStatistics {
 }
 
 impl AsStats<SourceStatisticsUpdate> for SourceStatistics {
-    fn as_stats(&self) -> &BTreeMap<GlobalId, Option<SourceStatisticsUpdate>> {
+    fn as_stats(&self) -> &BTreeMap<GlobalId, StatsState<SourceStatisticsUpdate>> {
         &self.source_statistics
     }
-    fn as_mut_stats(&mut self) -> &mut BTreeMap<GlobalId, Option<SourceStatisticsUpdate>> {
+
+    fn as_mut_stats(&mut self) -> &mut BTreeMap<GlobalId, StatsState<SourceStatisticsUpdate>> {
         &mut self.source_statistics
     }
 }
@@ -225,10 +276,7 @@ pub(super) fn spawn_webhook_statistics_scraper(
                         shared_stats
                             .source_statistics
                             .entry(*id)
-                            .and_modify(|current| match current {
-                                Some(ref mut current) => current.incorporate(ws.drain_into_update(*id)),
-                                None => *current = Some(ws.drain_into_update(*id)),
-                            });
+                            .and_modify(|current| current.stat().incorporate(ws.drain_into_update(*id)));
                     }
                 }
             }

--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -122,6 +122,24 @@ bids           true      false   true  true  false   true
 organizations  true      false   true  true  false   true
 users          true      false   true  true  false   true
 
+
+# Assert that the codepath that ensures a 0-value as the first value in `mz_source_statistics` occurs, using a `SUBSCRIBE`.
+# Sinks and subsources use the same codepath.
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+> BEGIN
+> DECLARE c CURSOR FOR SUBSCRIBE (
+    SELECT u.messages_received
+      FROM mz_sources s
+      JOIN mz_internal.mz_source_statistics_with_history u ON s.id = u.id
+      WHERE s.name = 'auction_house'
+    )
+  AS OF AT LEAST 0
+
+> FETCH 1 c;
+<TIMESTAMP> 1 0
+
+> COMMIT
+
 > DROP SOURCE auction_house CASCADE
 
 # Test upsert


### PR DESCRIPTION
Closes https://github.com/MaterializeInc/materialize/issues/26829
cc @RobinClowers 



### Motivation
  * This PR adds a known-desirable feature.



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
