### PR TITLE
tests: Fix nightly

### DIFF
--- a/misc/python/materialize/checks/all_checks/ssh.py
+++ b/misc/python/materialize/checks/all_checks/ssh.py
@@ -62,13 +62,12 @@ class SshPg(Check):
             Testdrive(schemas() + dedent(s))
             for s in [
                 """
-                # Also test `required` over `require`.
                 > CREATE CONNECTION pg_ssh2 TO POSTGRES (
                   HOST postgres,
                   DATABASE postgres,
                   USER postgres,
                   PASSWORD SECRET pgpass,
-                  SSL MODE required,
+                  SSL MODE require,
                   SSH TUNNEL ssh_tunnel_0);
 
                 > CREATE SOURCE mz_source_ssh2

--- a/test/mysql-cdc/mysql-cdc-ssl.td
+++ b/test/mysql-cdc/mysql-cdc-ssl.td
@@ -108,11 +108,10 @@ $ mysql-execute name=mysql
 DELETE FROM numbers WHERE number = 2;
 
 # server: hostssl, client: require => OK
-# also test `require` or `required`.
 > CREATE CONNECTION mysql_conn TO MYSQL (
   HOST mysql,
   USER hostssl,
-  SSL MODE require
+  SSL MODE required
   );
 > CREATE SOURCE "mz_source"
   FROM MYSQL CONNECTION mysql_conn


### PR DESCRIPTION
Removes some test changes introduced in https://github.com/MaterializeInc/materialize/pull/27238 to fix nightly

### Motivation

Fix nightly for better signal in the release

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
