### PR TITLE
sql: replace SubsourceCatalog with SubsourceResolver

### DIFF
--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -30,6 +30,7 @@ use mz_repr::{strconv, ColumnName, GlobalId};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{IdentError, UnresolvedItemName};
 use mz_sql_parser::parser::{ParserError, ParserStatementError};
+use mz_storage_types::sources::SubsourceResolutionError;
 
 use crate::catalog::{
     CatalogError, CatalogItemType, ErrorMessageObjectDescription, SystemObjectType,
@@ -257,6 +258,7 @@ pub enum PlanError {
         limit: Duration,
     },
     RetainHistoryRequired,
+    SubsourceResolutionError(SubsourceResolutionError),
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -725,6 +727,7 @@ impl fmt::Display for PlanError {
             Self::RetainHistoryRequired => {
                 write!(f, "RETAIN HISTORY cannot be disabled or set to 0")
             },
+            Self::SubsourceResolutionError(e) => write!(f, "{}", e),
         }
     }
 }
@@ -867,6 +870,12 @@ impl From<MySqlSourcePurificationError> for PlanError {
 impl From<IdentError> for PlanError {
     fn from(e: IdentError) -> Self {
         PlanError::InvalidIdent(e)
+    }
+}
+
+impl From<SubsourceResolutionError> for PlanError {
+    fn from(e: SubsourceResolutionError) -> Self {
+        PlanError::SubsourceResolutionError(e)
     }
 }
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -822,10 +822,15 @@ async fn purify_create_source(
 
             validate_subsource_names(&validated_requested_subsources)?;
 
+            let table_oids: Vec<_> = validated_requested_subsources
+                .iter()
+                .map(|r| r.table.oid)
+                .collect();
+
             postgres::validate_requested_subsources_privileges(
                 &config,
-                &validated_requested_subsources,
                 &storage_configuration.connection_context.ssh_tunnel_manager,
+                &table_oids,
             )
             .await?;
 
@@ -1288,10 +1293,15 @@ async fn purify_alter_source(
 
             validate_subsource_names(&validated_requested_subsources)?;
 
+            let table_oids: Vec<_> = validated_requested_subsources
+                .iter()
+                .map(|r| r.table.oid)
+                .collect();
+
             postgres::validate_requested_subsources_privileges(
                 &config,
-                &validated_requested_subsources,
                 &storage_configuration.connection_context.ssh_tunnel_manager,
+                &table_oids,
             )
             .await?;
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -986,7 +986,7 @@ where
                     };
 
                     if subsource_resolver
-                        .resolve_details_idx(&external_reference.0)
+                        .resolve_idx(&external_reference.0)
                         .is_err()
                     {
                         tracing::warn!(

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -369,7 +369,7 @@ INSERT INTO table_f VALUES (3, 'var1');
 <null>
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS (table_z.a));
-contains:invalid TEXT COLUMNS option value: table table_z not found in source
+contains:invalid TEXT COLUMNS option value: reference to table_z not found in source
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS [table_f.f2]);
 contains:TEXT COLUMNS refers to table not currently being added

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -282,7 +282,7 @@ contains: CREATE SOURCE specifies DETAILS option
     "pk_table"
   );
 contains:referenced items not tables with REPLICA IDENTITY FULL
-detail:referenced items: no_replica_identity
+detail:referenced items: public.no_replica_identity
 
 #
 # Establish direct replication

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -704,7 +704,7 @@ hint: The similarly named column "pk_table.f2" does exist.
   FOR TABLES (
     "enum_table"
   );
-contains: invalid TEXT COLUMNS option value: table table_dne not found in source
+contains: invalid TEXT COLUMNS option value: reference to table_dne not found in source
 
 # Reference exists in two schemas, so is not unambiguous
 ! CREATE SOURCE enum_source
@@ -717,7 +717,7 @@ contains: invalid TEXT COLUMNS option value: table table_dne not found in source
     conflict_schema.another_enum_table AS conflict_enum,
     public.another_enum_table AS public_enum
   );
-contains: invalid TEXT COLUMNS option value: table another_enum_table is ambiguous, consider specifying the schema
+contains: invalid TEXT COLUMNS option value: reference to another_enum_table is ambiguous, consider specifying an additional layer of qualification
 
 ! CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster
@@ -735,7 +735,7 @@ contains: invalid TEXT COLUMNS option value: column name 'foo' must have at leas
     TEXT COLUMNS [foo.bar.qux.qax.foo]
   )
   FOR TABLES (pk_table);
-contains: invalid TEXT COLUMNS option value: qualified name did not have between 1 and 3 components: foo.bar.qux.qax
+contains: invalid TEXT COLUMNS option value: reference to foo.bar.qux.qax not found in source
 
 ! CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster
@@ -754,7 +754,7 @@ contains: invalid TEXT COLUMNS option value: unexpected multiple references to p
     TEXT COLUMNS [enum_table.a, utf8_table.f1]
   )
   FOR TABLES (enum_table);
-contains: invalid TEXT COLUMNS option value: table utf8_table not found in source
+contains: invalid TEXT COLUMNS option value: reference to utf8_table not found in source
 
 # n.b includes a reference to pk_table, which is not a table that's part of the
 # source, but is part of the publication.

--- a/test/pg-cdc/publication-for-table.td
+++ b/test/pg-cdc/publication-for-table.td
@@ -48,4 +48,4 @@ CREATE PUBLICATION mz_source FOR TABLE t1;
 ! CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES (t2);
-contains:table t2 not found
+contains:reference to t2 not found in source

--- a/test/pg-cdc/replica-identity.td
+++ b/test/pg-cdc/replica-identity.td
@@ -34,7 +34,7 @@ INSERT INTO tbl_a VALUES (1);
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES(tbl_a);
 contains:referenced items not tables with REPLICA IDENTITY FULL
-detail:referenced items: tbl_a
+detail:referenced items: public.tbl_a
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE tbl_a REPLICA IDENTITY FULL

--- a/test/pg-cdc/two-source-schemas.td
+++ b/test/pg-cdc/two-source-schemas.td
@@ -52,7 +52,7 @@ contains:multiple subsources would be named t1
 ! CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES (t1);
-contains:table t1 is ambiguous, consider specifying the schema
+contains:reference to t1 is ambiguous, consider specifying an additional layer of qualification
 
 > CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')


### PR DESCRIPTION
`SubsourceResolver` is meant to deprecate `SubsourceCatalog`, and this PR does that. The drive here is to provide an API that lets all sources of all types resolve subsource references to the source's local details about that subsource (e.g. looking up `PgTableDesc` from an `UnresolvedItemName`). This will eventually also be used to look up subsources when determining the subsource schemas and that PR will be up next.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
