### PR TITLE
txn-wal: Add more snapshot tests

### DIFF
--- a/src/txn-wal/src/lib.rs
+++ b/src/txn-wal/src/lib.rs
@@ -760,6 +760,7 @@ pub mod tests {
                 .snapshot_and_fetch(&mut data_read)
                 .await
                 .expect("snapshot shouldn't panic");
+            data_read.expire().await;
             let snapshot: Vec<_> = snapshot
                 .into_iter()
                 .map(|((k, v), t, d)| {

--- a/src/txn-wal/src/lib.rs
+++ b/src/txn-wal/src/lib.rs
@@ -551,13 +551,12 @@ pub(crate) async fn cads<T, O, C>(
 
 #[cfg(test)]
 pub mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::sync::Arc;
     use std::sync::Mutex;
 
     use crossbeam_channel::{Receiver, Sender, TryRecvError};
     use differential_dataflow::consolidation::consolidate_updates;
-    use itertools::Itertools;
     use mz_persist_client::read::ReadHandle;
     use mz_persist_client::{Diagnostics, PersistClient, ShardId};
     use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
@@ -772,8 +771,8 @@ pub mod tests {
             // Check that a subscribe would produce the same result.
             let subscribe = self.subscribe(data_id, as_of, as_of + 1).await;
             assert_eq!(
-                snapshot.iter().sorted().collect::<Vec<_>>(),
-                subscribe.output().into_iter().sorted().collect::<Vec<_>>()
+                snapshot.iter().collect::<BTreeSet<_>>(),
+                subscribe.output().into_iter().collect::<BTreeSet<_>>()
             );
 
             // Check that the result is correct.

--- a/src/txn-wal/src/lib.rs
+++ b/src/txn-wal/src/lib.rs
@@ -557,12 +557,14 @@ pub mod tests {
 
     use crossbeam_channel::{Receiver, Sender, TryRecvError};
     use differential_dataflow::consolidation::consolidate_updates;
+    use itertools::Itertools;
     use mz_persist_client::read::ReadHandle;
     use mz_persist_client::{Diagnostics, PersistClient, ShardId};
     use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
     use prost::Message;
 
     use crate::operator::DataSubscribe;
+    use crate::txn_cache::TxnsCache;
     use crate::txn_write::{Txn, TxnApply};
     use crate::txns::{Tidy, TxnsHandle};
 
@@ -740,12 +742,54 @@ pub mod tests {
         #[allow(ungated_async_fn_track_caller)]
         #[track_caller]
         pub async fn assert_snapshot(&self, data_id: ShardId, as_of: u64) {
-            self.assert_subscribe(data_id, as_of, as_of + 1).await;
+            let mut cache: TxnsCache<u64, TxnsCodecDefault> =
+                TxnsCache::open(&self.client, self.txns_id, Some(data_id)).await;
+            let _ = cache.update_gt(&as_of).await;
+            let snapshot = cache.data_snapshot(data_id, as_of);
+            let mut data_read = self
+                .client
+                .open_leased_reader(
+                    data_id,
+                    Arc::new(StringSchema),
+                    Arc::new(UnitSchema),
+                    Diagnostics::from_purpose("assert snapshot"),
+                    true,
+                )
+                .await
+                .expect("reader creation shouldn't panic");
+            let snapshot = snapshot
+                .snapshot_and_fetch(&mut data_read)
+                .await
+                .expect("snapshot shouldn't panic");
+            let snapshot: Vec<_> = snapshot
+                .into_iter()
+                .map(|((k, v), t, d)| {
+                    let (k, ()) = (k.unwrap(), v.unwrap());
+                    (k, t, d)
+                })
+                .collect();
+
+            // Check that a subscribe would produce the same result.
+            let subscribe = self.subscribe(data_id, as_of, as_of + 1).await;
+            assert_eq!(
+                snapshot.iter().sorted().collect::<Vec<_>>(),
+                subscribe.output().into_iter().sorted().collect::<Vec<_>>()
+            );
+
+            // Check that the result is correct.
+            self.assert_eq(data_id, as_of, as_of + 1, snapshot);
         }
 
         #[allow(ungated_async_fn_track_caller)]
         #[track_caller]
         pub async fn assert_subscribe(&self, data_id: ShardId, as_of: u64, until: u64) {
+            let data_subscribe = self.subscribe(data_id, as_of, until).await;
+            self.assert_eq(data_id, as_of, until, data_subscribe.output().clone());
+        }
+
+        #[allow(ungated_async_fn_track_caller)]
+        #[track_caller]
+        pub async fn subscribe(&self, data_id: ShardId, as_of: u64, until: u64) -> DataSubscribe {
             let mut data_subscribe = DataSubscribe::new(
                 "test",
                 self.client.clone(),
@@ -756,7 +800,7 @@ pub mod tests {
                 true,
             );
             data_subscribe.step_past(until - 1).await;
-            self.assert_eq(data_id, as_of, until, data_subscribe.output().clone());
+            data_subscribe
         }
     }
 


### PR DESCRIPTION
This commits adds more tests that test the snapshot functionality directly.

Touches #22173

### Motivation
Adds tests

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
