### PR TITLE
storage: wire up a sink version to be recorded in the progress topic

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1010,6 +1010,7 @@ impl CatalogState {
                 from: sink.from,
                 connection: sink.connection,
                 envelope: sink.envelope,
+                version: sink.version,
                 with_snapshot,
                 resolved_ids,
                 cluster_id: in_cluster,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1080,6 +1080,7 @@ impl Coordinator {
             envelope: sink.envelope,
             as_of,
             with_snapshot: sink.with_snapshot,
+            version: sink.version,
             status_id,
             from_storage_metadata: (),
         };

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -922,6 +922,7 @@ impl Coordinator {
             from: sink.from,
             connection: sink.connection,
             envelope: sink.envelope,
+            version: sink.version,
             with_snapshot,
             resolved_ids,
             cluster_id: in_cluster,

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -658,6 +658,7 @@ pub struct Sink {
     // TODO(guswynn): this probably should just be in the `connection`.
     pub envelope: SinkEnvelope,
     pub with_snapshot: bool,
+    pub version: u64,
     pub resolved_ids: ResolvedIds,
     pub cluster_id: ClusterId,
 }

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -457,6 +457,7 @@ Values
 Varchar
 Variadic
 Varying
+Version
 View
 Views
 Warning

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1172,6 +1172,7 @@ impl_display_t!(CreateSubsourceStatement);
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CreateSinkOptionName {
     Snapshot,
+    Version,
 }
 
 impl AstDisplay for CreateSinkOptionName {
@@ -1179,6 +1180,9 @@ impl AstDisplay for CreateSinkOptionName {
         match self {
             CreateSinkOptionName::Snapshot => {
                 f.write_str("SNAPSHOT");
+            }
+            CreateSinkOptionName::Version => {
+                f.write_str("VERSION");
             }
         }
     }
@@ -1193,6 +1197,7 @@ impl WithOptionName for CreateSinkOptionName {
     fn redact_value(&self) -> bool {
         match self {
             CreateSinkOptionName::Snapshot => false,
+            CreateSinkOptionName::Version => false,
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3021,8 +3021,9 @@ impl<'a> Parser<'a> {
 
     /// Parse the name of a CREATE SINK optional parameter
     fn parse_create_sink_option_name(&mut self) -> Result<CreateSinkOptionName, ParserError> {
-        let name = match self.expect_one_of_keywords(&[SNAPSHOT])? {
+        let name = match self.expect_one_of_keywords(&[SNAPSHOT, VERSION])? {
             SNAPSHOT => CreateSinkOptionName::Snapshot,
+            VERSION => CreateSinkOptionName::Version,
             _ => unreachable!(),
         };
         Ok(name)

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -625,11 +625,11 @@ CREATE SINK IF EXISTS foo FROM bar INTO 'baz'
                ^
 
 parse-statement
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SNAPSHOT = true)
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SNAPSHOT = true, VERSION = 42)
 ----
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SNAPSHOT = true)
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SNAPSHOT = true, VERSION = 42)
 =>
-CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("foo")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }], key: None, headers: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(true))) }] })
+CreateSink(CreateSinkStatement { name: Some(UnresolvedItemName([Ident("foo")])), in_cluster: None, if_not_exists: false, from: Name(UnresolvedItemName([Ident("bar")])), connection: Kafka { connection: Name(UnresolvedItemName([Ident("baz")])), options: [KafkaSinkConfigOption { name: Topic, value: Some(Value(String("topic"))) }], key: None, headers: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(true))) }, CreateSinkOption { name: Version, value: Some(Value(Number("42"))) }] })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SNAPSHOT = false)
@@ -1459,21 +1459,21 @@ ALTER MATERIALIZED VIEW name SET (property = true)
 parse-statement
 ALTER SINK name SET (property = true)
 ----
-error: Expected one of SNAPSHOT, found identifier "property"
+error: Expected one of SNAPSHOT or VERSION, found identifier "property"
 ALTER SINK name SET (property = true)
                      ^
 
 parse-statement
 ALTER SINK IF EXISTS name SET (SIZE LARGE)
 ----
-error: Expected one of SNAPSHOT, found SIZE
+error: Expected one of SNAPSHOT or VERSION, found SIZE
 ALTER SINK IF EXISTS name SET (SIZE LARGE)
                                ^
 
 parse-statement
 ALTER SINK name RESET (SIZE)
 ----
-error: Expected one of SNAPSHOT, found SIZE
+error: Expected one of SNAPSHOT or VERSION, found SIZE
 ALTER SINK name RESET (SIZE)
                        ^
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1406,6 +1406,7 @@ pub struct Sink {
     pub connection: StorageSinkConnection<ReferencedConnection>,
     // TODO(guswynn): this probably should just be in the `connection`.
     pub envelope: SinkEnvelope,
+    pub version: u64,
 }
 
 #[derive(Clone, Debug)]

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1173,6 +1173,7 @@ where
                     connection: description.sink.connection,
                     envelope: description.sink.envelope,
                     as_of: description.sink.as_of,
+                    version: description.sink.version,
                     status_id,
                     from_storage_metadata,
                     with_snapshot: description.sink.with_snapshot,
@@ -1255,6 +1256,7 @@ where
                     connection: new_export_description.sink.connection.clone(),
                     envelope: new_export_description.sink.envelope,
                     with_snapshot: new_export_description.sink.with_snapshot,
+                    version: new_export_description.sink.version,
                     // Here we are about to send a RunSinkCommand with the current read capaibility
                     // held by this sink. However, clusters are already running a version of the
                     // sink and nothing guarantees that by the time this command arrives at the

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -34,6 +34,7 @@ message ProtoStorageSinkDesc {
     optional string status_id = 7;
     mz_repr.antichain.ProtoU64Antichain as_of = 11;
     bool with_snapshot = 12;
+    uint64 version = 13;
 }
 
 message ProtoSinkEnvelope {

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -41,6 +41,7 @@ pub struct StorageSinkDesc<S: StorageSinkDescFillState, T = mz_repr::Timestamp> 
     pub from_desc: RelationDesc,
     pub connection: StorageSinkConnection,
     pub with_snapshot: bool,
+    pub version: u64,
     pub envelope: SinkEnvelope,
     pub as_of: Antichain<T>,
     pub status_id: Option<<S as StorageSinkDescFillState>::StatusId>,
@@ -70,6 +71,7 @@ impl<S: Debug + StorageSinkDescFillState + PartialEq, T: Debug + PartialEq + Par
             from_desc,
             connection,
             envelope,
+            version: _,
             // The as of of the descriptions may differ.
             as_of: _,
             status_id,
@@ -142,6 +144,7 @@ impl Arbitrary for StorageSinkDesc<MetadataFilled, mz_repr::Timestamp> {
             any::<Option<ShardId>>(),
             any::<CollectionMetadata>(),
             any::<bool>(),
+            any::<u64>(),
         )
             .prop_map(
                 |(
@@ -153,12 +156,14 @@ impl Arbitrary for StorageSinkDesc<MetadataFilled, mz_repr::Timestamp> {
                     status_id,
                     from_storage_metadata,
                     with_snapshot,
+                    version,
                 )| {
                     StorageSinkDesc {
                         from,
                         from_desc,
                         connection,
                         envelope,
+                        version,
                         as_of: Antichain::from_iter(as_of),
                         status_id,
                         from_storage_metadata,
@@ -181,6 +186,7 @@ impl RustType<ProtoStorageSinkDesc> for StorageSinkDesc<MetadataFilled, mz_repr:
             status_id: self.status_id.into_proto(),
             from_storage_metadata: Some(self.from_storage_metadata.into_proto()),
             with_snapshot: self.with_snapshot,
+            version: self.version,
         }
     }
 
@@ -204,6 +210,7 @@ impl RustType<ProtoStorageSinkDesc> for StorageSinkDesc<MetadataFilled, mz_repr:
                 .from_storage_metadata
                 .into_rust_if_some("ProtoStorageSinkDesc::from_storage_metadata")?,
             with_snapshot: proto.with_snapshot,
+            version: proto.version,
         })
     }
 }

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -1295,22 +1295,42 @@ mod test {
 
         assert_eq!(
             parse_progress_record(b"{\"timestamp\":1}").unwrap(),
-            Antichain::from_elem(2.into()),
+            ProgressRecord {
+                frontier: Antichain::from_elem(2.into()),
+                version: 0,
+            }
         );
 
         assert_eq!(
             parse_progress_record(b"{\"timestamp\":null}").unwrap(),
-            Antichain::new(),
+            ProgressRecord {
+                frontier: Antichain::new(),
+                version: 0,
+            }
         );
 
         assert_eq!(
             parse_progress_record(b"{\"frontier\":[1]}").unwrap(),
-            Antichain::from_elem(1.into()),
+            ProgressRecord {
+                frontier: Antichain::from_elem(1.into()),
+                version: 0,
+            }
         );
 
         assert_eq!(
             parse_progress_record(b"{\"frontier\":[]}").unwrap(),
-            Antichain::new(),
+            ProgressRecord {
+                frontier: Antichain::new(),
+                version: 0,
+            }
+        );
+
+        assert_eq!(
+            parse_progress_record(b"{\"frontier\":[], \"version\": 42}").unwrap(),
+            ProgressRecord {
+                frontier: Antichain::new(),
+                version: 42,
+            }
         );
 
         assert!(parse_progress_record(b"{\"frontier\":null}").is_err());

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -630,7 +630,6 @@ mod tests {
     use mz_ore::now::SYSTEM_TIME;
     use mz_persist_client::cache::PersistClientCache;
     use mz_persist_client::cfg::PersistConfig;
-    use mz_persist_client::critical::CriticalReaderId;
     use mz_persist_client::rpc::PubSubClientConnection;
     use mz_persist_client::{Diagnostics, PersistClient, PersistLocation, ShardId};
     use mz_persist_types::codec_impls::UnitSchema;

--- a/test/testdrive/kafka-sinks.td
+++ b/test/testdrive/kafka-sinks.td
@@ -284,7 +284,7 @@ $ kafka-create-topic topic=snk9 partitions=4
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
   WITH (SIZE = '2')
-contains:Expected one of SNAPSHOT, found SIZE
+contains:Expected one of SNAPSHOT or VERSION, found SIZE
 
 # create sink with SNAPSHOT set
 > CREATE CLUSTER sink_with_options_cluster SIZE '${arg.default-storage-size}';

--- a/test/testdrive/kafka-sinks.td
+++ b/test/testdrive/kafka-sinks.td
@@ -59,6 +59,14 @@ goofus,gallant
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:Expected one of SNAPSHOT
 
+! CREATE SINK invalid_with_option
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM src
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  WITH (VERSION=1)
+contains:CREATE SINK...WITH (VERSION..) is not allowed
+
 > SHOW SINKS
 name               type   size  cluster
 ---------------------------------------


### PR DESCRIPTION
### Motivation

This is the first part of implementing `ALTER SINK`. As @bkirwi pointed out in the design doc the implementation of `ALTER SINK` needs to defend against a zombie cluster attempting to resume sinking a collection on an older sink version. In order to accomplish this this PR adds a `version` field to the sink metadata stored in the catalog which is threaded all the way to the sink timely operator in `clusterd`. The intention is to bump the version counter up every time a sink is altered.

The way this version fencing works is by piggybacking on the pre-existing frontier fencing mechanism. Namely, we extend the metadata that is written to the progress topic to be not just the frontier up to which we've written, but also the version of the sink that did those writes. On startup, each sinks attempts to fence out all previous producers and then confirms that the version that it's about to sink is greater than or equal to the one already in the topic. If that is not the case it bails out.

This PR does not introduce any code paths that actually alter a sink, this will be done in a separate PR.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
