### PR TITLE
catalog: Simplify loading user items

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -10,7 +10,7 @@
 //! Logic related to applying updates from a [`mz_catalog::durable::DurableCatalogState`] to a
 //! [`CatalogState`].
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 
 use mz_catalog::builtin::{Builtin, BUILTIN_LOG_LOOKUP, BUILTIN_LOOKUP};
@@ -55,20 +55,14 @@ impl CatalogState {
     // look at the existing bootstrap code for ways of doing this. For now we rely on the caller
     // providing objects in dependency order.
     #[instrument]
-    pub(crate) fn apply_updates_for_bootstrap(
-        &mut self,
-        updates: Vec<StateUpdate>,
-    ) -> Result<(), Error> {
-        let mut updates: VecDeque<_> = updates.into_iter().collect();
-        while let Some(StateUpdate { kind, diff }) = updates.pop_front() {
+    pub(crate) fn apply_updates_for_bootstrap(&mut self, updates: Vec<StateUpdate>) {
+        for StateUpdate { kind, diff } in updates {
             assert_eq!(
                 diff, 1,
                 "initial catalog updates should be consolidated: ({kind:?}, {diff:?})"
             );
             self.apply_update(kind, diff);
         }
-
-        Ok(())
     }
 
     #[instrument(level = "debug")]

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -12,7 +12,6 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
-use std::str::FromStr;
 
 use mz_catalog::builtin::{Builtin, BUILTIN_LOG_LOOKUP, BUILTIN_LOOKUP};
 use mz_catalog::memory::error::{Error, ErrorKind};
@@ -27,29 +26,20 @@ use mz_ore::instrument;
 use mz_ore::now::to_datetime;
 use mz_pgrepr::oid::INVALID_OID;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
-use mz_repr::{Diff, GlobalId};
-use mz_sql::catalog::{CatalogError as SqlCatalogError, CatalogSchema, CatalogType};
+use mz_repr::Diff;
+use mz_sql::catalog::{CatalogSchema, CatalogType};
 use mz_sql::names::{
     ItemQualifiers, QualifiedItemName, QualifiedSchemaName, ResolvedDatabaseSpecifier, ResolvedIds,
     SchemaSpecifier,
 };
+use mz_sql::rbac;
 use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
 use mz_sql::session::vars::{VarError, VarInput};
-use mz_sql::{plan, rbac};
 use mz_sql_parser::ast::Expr;
 use mz_storage_types::sources::Timeline;
-use once_cell::sync::Lazy;
-use regex::Regex;
 use tracing::warn;
 
 use crate::catalog::{BuiltinTableUpdate, CatalogState};
-use crate::AdapterError;
-
-enum ApplyUpdateError {
-    Error(Error),
-    AwaitingIdDependency((GlobalId, mz_catalog::durable::Item, Diff)),
-    AwaitingNameDependency((String, mz_catalog::durable::Item, Diff)),
-}
 
 impl CatalogState {
     /// Update in-memory catalog state from a list of updates made to the durable catalog state.
@@ -69,142 +59,20 @@ impl CatalogState {
         &mut self,
         updates: Vec<StateUpdate>,
     ) -> Result<(), Error> {
-        // TODO(v100): we can refactor this to assume that items are
-        // topologically sorted by their `GlobalId`.
-        let mut awaiting_id_dependencies: BTreeMap<GlobalId, Vec<_>> = BTreeMap::new();
-        let mut awaiting_name_dependencies: BTreeMap<String, Vec<_>> = BTreeMap::new();
         let mut updates: VecDeque<_> = updates.into_iter().collect();
         while let Some(StateUpdate { kind, diff }) = updates.pop_front() {
             assert_eq!(
                 diff, 1,
                 "initial catalog updates should be consolidated: ({kind:?}, {diff:?})"
             );
-            match self.apply_update(kind, diff) {
-                Ok(None) => {}
-                Ok(Some(id)) => {
-                    // Enqueue any items waiting on this dependency.
-                    let mut resolved_dependent_items = Vec::new();
-                    if let Some(dependent_items) = awaiting_id_dependencies.remove(&id) {
-                        resolved_dependent_items.extend(dependent_items);
-                    }
-                    let entry = self.get_entry(&id);
-                    let full_name = self.resolve_full_name(entry.name(), None);
-                    if let Some(dependent_items) =
-                        awaiting_name_dependencies.remove(&full_name.to_string())
-                    {
-                        resolved_dependent_items.extend(dependent_items);
-                    }
-                    let resolved_dependent_items =
-                        resolved_dependent_items
-                            .into_iter()
-                            .map(|(item, diff)| StateUpdate {
-                                kind: StateUpdateKind::Item(item),
-                                diff,
-                            });
-                    updates.extend(resolved_dependent_items);
-                }
-                Err(ApplyUpdateError::Error(err)) => return Err(err),
-                Err(ApplyUpdateError::AwaitingIdDependency((id, item, diff))) => {
-                    awaiting_id_dependencies
-                        .entry(id)
-                        .or_default()
-                        .push((item, diff));
-                }
-                Err(ApplyUpdateError::AwaitingNameDependency((name, item, diff))) => {
-                    awaiting_name_dependencies
-                        .entry(name)
-                        .or_default()
-                        .push((item, diff));
-                }
-            }
-        }
-
-        // Error on any unsatisfied dependencies.
-        if let Some((missing_dep, mut dependents)) = awaiting_id_dependencies.into_iter().next() {
-            let (
-                mz_catalog::durable::Item {
-                    id,
-                    oid: _,
-                    schema_id,
-                    name,
-                    create_sql: _,
-                    owner_id: _,
-                    privileges: _,
-                },
-                diff,
-            ) = dependents.remove(0);
-            let schema = self.find_non_temp_schema(&schema_id);
-            let name = QualifiedItemName {
-                qualifiers: ItemQualifiers {
-                    database_spec: schema.database().clone(),
-                    schema_spec: schema.id().clone(),
-                },
-                item: name,
-            };
-            let name = self.resolve_full_name(&name, None);
-            let action = if diff == 1 { "deserialize" } else { "remove" };
-
-            return Err(Error::new(ErrorKind::Corruption {
-                detail: format!(
-                    "failed to {} item {} ({}): {}",
-                    action,
-                    id,
-                    name,
-                    plan::PlanError::InvalidId(missing_dep)
-                ),
-            }));
-        }
-
-        if let Some((missing_dep, mut dependents)) = awaiting_name_dependencies.into_iter().next() {
-            let (
-                mz_catalog::durable::Item {
-                    id,
-                    oid: _,
-                    schema_id,
-                    name,
-                    create_sql: _,
-                    owner_id: _,
-                    privileges: _,
-                },
-                diff,
-            ) = dependents.remove(0);
-            let schema = self.find_non_temp_schema(&schema_id);
-            let name = QualifiedItemName {
-                qualifiers: ItemQualifiers {
-                    database_spec: schema.database().clone(),
-                    schema_spec: schema.id().clone(),
-                },
-                item: name,
-            };
-            let name = self.resolve_full_name(&name, None);
-            let action = if diff == 1 { "deserialize" } else { "remove" };
-            return Err(Error::new(ErrorKind::Corruption {
-                detail: format!(
-                    "failed to {} item {} ({}): {}",
-                    action,
-                    id,
-                    name,
-                    Error {
-                        kind: ErrorKind::Sql(SqlCatalogError::UnknownItem(missing_dep))
-                    }
-                ),
-            }));
+            self.apply_update(kind, diff);
         }
 
         Ok(())
     }
 
-    /// Applies an update to `self`.
-    ///
-    /// Returns a `GlobalId` on success, if the applied update added a new `GlobalID` to `self`.
-    /// Returns a dependency on failure, if the update could not be applied due to a missing
-    /// dependency.
     #[instrument(level = "debug")]
-    fn apply_update(
-        &mut self,
-        kind: StateUpdateKind,
-        diff: Diff,
-    ) -> Result<Option<GlobalId>, ApplyUpdateError> {
+    fn apply_update(&mut self, kind: StateUpdateKind, diff: Diff) {
         assert!(
             diff == 1 || diff == -1,
             "invalid update in catalog updates: ({kind:?}, {diff:?})"
@@ -212,64 +80,51 @@ impl CatalogState {
         match kind {
             StateUpdateKind::Role(role) => {
                 self.apply_role_update(role, diff);
-                Ok(None)
             }
             StateUpdateKind::Database(database) => {
                 self.apply_database_update(database, diff);
-                Ok(None)
             }
             StateUpdateKind::Schema(schema) => {
                 self.apply_schema_update(schema, diff);
-                Ok(None)
             }
             StateUpdateKind::DefaultPrivilege(default_privilege) => {
                 self.apply_default_privilege_update(default_privilege, diff);
-                Ok(None)
             }
             StateUpdateKind::SystemPrivilege(system_privilege) => {
                 self.apply_system_privilege_update(system_privilege, diff);
-                Ok(None)
             }
             StateUpdateKind::SystemConfiguration(system_configuration) => {
                 self.apply_system_configuration_update(system_configuration, diff);
-                Ok(None)
             }
             StateUpdateKind::Cluster(cluster) => {
                 self.apply_cluster_update(cluster, diff);
-                Ok(None)
             }
             StateUpdateKind::IntrospectionSourceIndex(introspection_source_index) => {
                 self.apply_introspection_source_index_update(introspection_source_index, diff);
-                Ok(None)
             }
             StateUpdateKind::ClusterReplica(cluster_replica) => {
                 self.apply_cluster_replica_update(cluster_replica, diff);
-                Ok(None)
             }
             StateUpdateKind::SystemObjectMapping(system_object_mapping) => {
                 self.apply_system_object_mapping_update(system_object_mapping, diff);
-                Ok(None)
             }
-            StateUpdateKind::Item(item) => self.apply_item_update(item, diff),
+            StateUpdateKind::Item(item) => {
+                self.apply_item_update(item, diff);
+            }
             StateUpdateKind::Comment(comment) => {
                 self.apply_comment_update(comment, diff);
-                Ok(None)
             }
             StateUpdateKind::AuditLog(_audit_log) => {
                 // Audit logs are not stored in-memory.
-                Ok(None)
             }
             StateUpdateKind::StorageUsage(_storage_usage) => {
                 // Storage usage events are not stored in-memory.
-                Ok(None)
             }
             StateUpdateKind::StorageCollectionMetadata(storage_collection_metadata) => {
                 self.apply_storage_collection_metadata_update(storage_collection_metadata, diff);
-                Ok(None)
             }
             StateUpdateKind::UnfinalizedShard(unfinalized_shard) => {
                 self.apply_unfinalized_shard_update(unfinalized_shard, diff);
-                Ok(None)
             }
         }
     }
@@ -728,80 +583,13 @@ impl CatalogState {
         }
     }
 
-    /// Applies an item update to `self`.
-    ///
-    /// Returns a `GlobalId` on success, if the applied update added a new `GlobalID` to `self`.
-    /// Returns a dependency on failure, if the update could not be applied due to a missing
-    /// dependency.
     #[instrument(level = "debug")]
-    fn apply_item_update(
-        &mut self,
-        item: mz_catalog::durable::Item,
-        diff: Diff,
-    ) -> Result<Option<GlobalId>, ApplyUpdateError> {
-        // If we knew beforehand that the items were being applied in dependency
-        // order, then we could fully delegate to `self.insert_item(...)` and`self.drop_item(...)`.
-        // However, we don't know that items are applied in dependency order, so we must handle the
-        // case that the item is valid, but we haven't applied all of its dependencies yet.
+    fn apply_item_update(&mut self, item: mz_catalog::durable::Item, diff: Diff) {
         match diff {
             1 => {
-                // TODO(benesch): a better way of detecting when a view has depended
-                // upon a non-existent logging view. This is fine for now because
-                // the only goal is to produce a nicer error message; we'll bail out
-                // safely even if the error message we're sniffing out changes.
-                static LOGGING_ERROR: Lazy<Regex> =
-                    Lazy::new(|| Regex::new("mz_catalog.[^']*").expect("valid regex"));
-
-                let catalog_item = match self.deserialize_item(&item.create_sql) {
-                    Ok(item) => item,
-                    Err(AdapterError::Catalog(Error {
-                        kind: ErrorKind::Sql(SqlCatalogError::UnknownItem(name)),
-                    })) if LOGGING_ERROR.is_match(&name.to_string()) => {
-                        return Err(ApplyUpdateError::Error(Error::new(
-                            ErrorKind::UnsatisfiableLoggingDependency {
-                                depender_name: name,
-                            },
-                        )));
-                    }
-                    // If we were missing a dependency, wait for it to be added.
-                    Err(AdapterError::PlanError(plan::PlanError::InvalidId(missing_dep))) => {
-                        return Err(ApplyUpdateError::AwaitingIdDependency((
-                            missing_dep,
-                            item,
-                            diff,
-                        )));
-                    }
-                    // If we were missing a dependency, wait for it to be added.
-                    Err(AdapterError::PlanError(plan::PlanError::Catalog(
-                        SqlCatalogError::UnknownItem(missing_dep),
-                    ))) => {
-                        return match GlobalId::from_str(&missing_dep) {
-                            Ok(id) => Err(ApplyUpdateError::AwaitingIdDependency((id, item, diff))),
-                            Err(_) => Err(ApplyUpdateError::AwaitingNameDependency((
-                                missing_dep,
-                                item,
-                                diff,
-                            ))),
-                        }
-                    }
-                    Err(e) => {
-                        let schema = self.find_non_temp_schema(&item.schema_id);
-                        let name = QualifiedItemName {
-                            qualifiers: ItemQualifiers {
-                                database_spec: schema.database().clone(),
-                                schema_spec: schema.id().clone(),
-                            },
-                            item: item.name,
-                        };
-                        let name = self.resolve_full_name(&name, None);
-                        return Err(ApplyUpdateError::Error(Error::new(ErrorKind::Corruption {
-                            detail: format!(
-                                "failed to deserialize item {} ({}): {}\n\n{}",
-                                item.id, name, e, item.create_sql
-                            ),
-                        })));
-                    }
-                };
+                let catalog_item = self
+                    .deserialize_item(&item.create_sql)
+                    .expect("invalid persisted SQL");
                 let schema = self.find_non_temp_schema(&item.schema_id);
                 let name = QualifiedItemName {
                     qualifiers: ItemQualifiers {
@@ -818,18 +606,9 @@ impl CatalogState {
                     item.owner_id,
                     PrivilegeMap::from_mz_acl_items(item.privileges),
                 );
-                Ok(Some(item.id))
             }
             -1 => {
-                let entry = self.get_entry(&item.id);
-                if let Some(id) = entry.referenced_by().first() {
-                    return Err(ApplyUpdateError::AwaitingIdDependency((*id, item, diff)));
-                }
-                if let Some(id) = entry.used_by().first() {
-                    return Err(ApplyUpdateError::AwaitingIdDependency((*id, item, diff)));
-                }
                 self.drop_item(item.id);
-                Ok(None)
             }
             _ => unreachable!("invalid diff: {diff}"),
         }

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -125,7 +125,7 @@ pub(crate) async fn migrate(
             diff: 1,
         })
         .collect();
-    state.apply_updates_for_bootstrap(item_updates)?;
+    state.apply_updates_for_bootstrap(item_updates);
 
     info!("migrating from catalog version {:?}", catalog_version);
 

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -310,7 +310,7 @@ impl Catalog {
                     | StateUpdateKind::IntrospectionSourceIndex(_)
                     | StateUpdateKind::ClusterReplica(_) => cluster_updates.push(update),
                     StateUpdateKind::SystemObjectMapping(system_object_mapping) => builtin_item_updates.push((system_object_mapping, update.diff)),
-                    StateUpdateKind::Item(_) => item_updates.push(update),
+                    StateUpdateKind::Item(item) => item_updates.push((item, update.diff)),
                     StateUpdateKind::Comment(_)
                     | StateUpdateKind::AuditLog(_)
                     | StateUpdateKind::StorageUsage(_)
@@ -356,6 +356,9 @@ impl Catalog {
                     }),
                 }
             }
+
+            // Sort item updates by GlobalId.
+            let item_updates: Vec<_> = item_updates.into_iter().sorted_by_key(|(item, _diff)| item.id).map(|(item, diff)| StateUpdate {kind: StateUpdateKind::Item(item), diff}).collect();
 
             let pre_view_updates = iter::empty()
                 .chain(pre_cluster_updates.into_iter())

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -377,9 +377,9 @@ impl Catalog {
                 .chain(builtin_index_updates.into_iter())
                 .collect();
 
-            state.apply_updates_for_bootstrap(pre_view_updates)?;
+            state.apply_updates_for_bootstrap(pre_view_updates);
             Self::parse_views(&mut state, builtin_views).await;
-            state.apply_updates_for_bootstrap(post_view_updates)?;
+            state.apply_updates_for_bootstrap(post_view_updates);
 
             let last_seen_version = txn
                 .get_catalog_content_version()
@@ -400,12 +400,12 @@ impl Catalog {
                 // Throw the existing item updates away because they may have been re-written in
                 // the migration.
                 let item_updates = txn.get_items().map(|item| StateUpdate{kind: StateUpdateKind::Item(item), diff: 1}).collect();
-                state.apply_updates_for_bootstrap(item_updates)?;
+                state.apply_updates_for_bootstrap(item_updates);
             } else {
-                state.apply_updates_for_bootstrap(item_updates)?;
+                state.apply_updates_for_bootstrap(item_updates);
             }
 
-            state.apply_updates_for_bootstrap(post_item_updates)?;
+            state.apply_updates_for_bootstrap(post_item_updates);
 
             // Migrate builtin items.
             let id_fingerprint_map: BTreeMap<_, _> = BUILTINS::iter()


### PR DESCRIPTION
Previously, the catalog would discover dependencies between user items as the items were loaded. However, a recent change guaranteed that the order of item GlobalIds matches the dependency order. This commit takes advantage of that fact by loading items in GlobalId order and assuming they are being loaded in dependency order.

Works towards resolving #24844

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
