### PR TITLE
pg_compat: add pg_size_pretty

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -929,6 +929,10 @@
     description: Alias for `has_role` for PostgreSQL compatibility.
   - signature: 'pg_is_in_recovery() -> bool'
     description: Returns if the a recovery is still in progress.
+  - signature: 'pg_size_pretty(size: bigint) -> text'
+    description: Converts a size in bytes expressed as a 64-bit integer into a human-readable format with size units.
+  - signature: 'pg_size_pretty(size: numeric) -> text'
+    description: Converts a size in bytes expressed as a numeric value into a human-readable format with size units.
   - signature: 'pg_table_is_visible(relation: oid) -> boolean'
     description: Reports whether the relation with the specified OID is visible in the search path.
   - signature: 'pg_tablespace_location(tablespace: oid) -> text'

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1652,6 +1652,34 @@ SELECT pg_stat_get_numscans('pg_views'::regclass::oid)
 ----
 -1
 
+query T rowsort
+SELECT pg_size_pretty(size) FROM (VALUES (10239::bigint), (10240::bigint), (10485247::bigint), (10485248::bigint), (10736893951::bigint), (10736893952::bigint), (10994579406847::bigint), (10994579406848::bigint), (11258449312612351::bigint), (11258449312612352::bigint)) x(size)
+----
+10239 bytes
+10 kB
+10239 kB
+10 MB
+10239 MB
+10 GB
+10239 GB
+10 TB
+10239 TB
+10 PB
+
+query T rowsort
+SELECT pg_size_pretty(-1 * size) FROM (VALUES (10239::bigint), (10240::bigint), (10485247::bigint), (10485248::bigint), (10736893951::bigint), (10736893952::bigint), (10994579406847::bigint), (10994579406848::bigint), (11258449312612351::bigint), (11258449312612352::bigint)) x(size)
+----
+-10239 bytes
+-10 kB
+-10239 kB
+-10 MB
+-10239 MB
+-10 GB
+-10239 GB
+-10 TB
+-10239 TB
+-10 PB
+
 # mz_unsafe functions can't be executed with the enable_unsafe_functions flag turned off
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
### Motivation

* This PR adds a known-desirable feature.

Found myself wanting this the other day and realized it could be implemented in SQL. 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
