### PR TITLE
[persist] Refactorings to support bounded state size

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -761,10 +761,7 @@ where
         // `CompactConfig::new` by overriding the inline writes threshold
         // config. This is a bit action-at-a-distance, so defensively detect if
         // this breaks here and log and correct it if so.
-        let has_inline_parts = batch.batch.parts.iter().any(|x| match x {
-            BatchPart::Hollow(_) => false,
-            BatchPart::Inline { .. } => true,
-        });
+        let has_inline_parts = batch.batch.parts.iter().any(|x| x.is_inline());
         if has_inline_parts {
             error!(%shard_id, ?cfg, "compaction result unexpectedly had inline writes");
             let () = batch

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -711,7 +711,11 @@ where
                 desc.lower().elements(),
                 desc.upper().elements()
             ),
+            *shard_id,
+            blob,
             Arc::clone(&metrics),
+            shard_metrics,
+            metrics.read.compaction.clone(),
             FetchBatchFilter::Compaction {
                 since: desc.since().clone(),
             },
@@ -720,15 +724,7 @@ where
         );
 
         for (desc, parts) in runs {
-            consolidator.enqueue_run(
-                *shard_id,
-                &blob,
-                &metrics,
-                |m| &m.compaction,
-                &shard_metrics,
-                desc,
-                parts.iter().cloned(),
-            );
+            consolidator.enqueue_run(desc, parts.iter().cloned());
         }
 
         let remaining_budget = consolidator.start_prefetches();

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -727,7 +727,7 @@ where
                 |m| &m.compaction,
                 &shard_metrics,
                 desc,
-                parts,
+                parts.iter().cloned(),
             );
         }
 

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -333,7 +333,7 @@ where
         while let Some(_) = states.next(|diff| match diff {
             InspectDiff::FromInitial(_) => {}
             InspectDiff::Diff(diff) => {
-                diff.map_blob_deletes(|blob| match blob {
+                diff.blob_deletes().for_each(|blob| match blob {
                     HollowBlobRef::Batch(batch) => {
                         seqno_held_parts += batch.part_count();
                     }
@@ -524,7 +524,7 @@ where
         while let Some(state) = states.next(|diff| match diff {
             InspectDiff::FromInitial(_) => {}
             InspectDiff::Diff(diff) => {
-                diff.map_blob_deletes(|blob| match blob {
+                diff.blob_deletes().for_each(|blob| match blob {
                     HollowBlobRef::Batch(batch) => {
                         for part in &batch.parts {
                             // we use BTreeSets for fast lookups elsewhere, but we should never

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -992,7 +992,11 @@ where
 
         let mut consolidator = Consolidator::new(
             format!("{}[as_of={:?}]", self.shard_id(), as_of.elements()),
+            self.shard_id(),
+            Arc::clone(&self.blob),
             Arc::clone(&self.metrics),
+            Arc::clone(&self.machine.applier.shard_metrics),
+            self.metrics.read.snapshot.clone(),
             FetchBatchFilter::Snapshot {
                 as_of: as_of.clone(),
             },
@@ -1004,11 +1008,6 @@ where
         for batch in batches {
             for run in batch.runs() {
                 consolidator.enqueue_run(
-                    self.shard_id(),
-                    &self.blob,
-                    &self.metrics,
-                    |m| &m.snapshot,
-                    &self.machine.applier.shard_metrics,
                     &batch.desc,
                     run.into_iter()
                         .filter(|p| should_fetch_part(p.stats()))

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -906,6 +906,7 @@ pub(crate) struct UnexpiredReadHandleState {
 #[derive(Debug)]
 pub struct Cursor<K: Codec, V: Codec, T: Timestamp + Codec64, D> {
     consolidator: Consolidator<T, D>,
+    _lease: Lease,
     _schemas: Schemas<K, V>,
 }
 
@@ -999,27 +1000,26 @@ where
             SPLIT_OLD_RUNS.get(&self.cfg.configs),
         );
 
-        let filter = FetchBatchFilter::Snapshot { as_of };
+        let lease = self.lease_seqno();
         for batch in batches {
             for run in batch.runs() {
-                let leased_parts: Vec<_> = run
-                    .into_iter()
-                    .map(|part| {
-                        self.lease_batch_part(batch.desc.clone(), part.clone(), filter.clone())
-                    })
-                    .filter(|p| should_fetch_part(p.part.stats()))
-                    .collect();
-                consolidator.enqueue_leased_run(
+                consolidator.enqueue_run(
+                    self.shard_id(),
                     &self.blob,
+                    &self.metrics,
                     |m| &m.snapshot,
                     &self.machine.applier.shard_metrics,
-                    leased_parts.into_iter(),
+                    &batch.desc,
+                    run.into_iter()
+                        .filter(|p| should_fetch_part(p.stats()))
+                        .cloned(),
                 );
             }
         }
 
         Ok(Cursor {
             consolidator,
+            _lease: lease,
             _schemas: self.schemas.clone(),
         })
     }

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -212,7 +212,7 @@ impl StorageUsageClient {
         let mut batches_bytes = 0;
         let mut rollup_bytes = 0;
         while let Some(_) = states_iter.next(|diff| {
-            diff.referenced_blob_fn(|blob| match blob {
+            diff.referenced_blobs().for_each(|blob| match blob {
                 HollowBlobRef::Batch(batch) => {
                     batches_bytes += batch.encoded_size_bytes();
                 }
@@ -447,7 +447,7 @@ impl StorageUsageClient {
         let mut referenced_batches_bytes = BTreeMap::new();
         let mut referenced_other_bytes = 0;
         while let Some(_) = states_iter.next(|x| {
-            x.referenced_blob_fn(|x| match x {
+            x.referenced_blobs().for_each(|x| match x {
                 HollowBlobRef::Batch(x) => {
                     for part in x.parts.iter() {
                         let part = match part {


### PR DESCRIPTION
### Motivation

Refactorings in support of a prototype for: https://github.com/MaterializeInc/materialize/issues/26939

We're setting that aside temporarily (hit the timebox) but I think these changes are either mildly positive or neutral, so I'm hoping to land them soon and avoid some bitrot.

### Tips for reviewer

I've outlined the reasoning in the commit messages, but let me know if you have questions!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
