### PR TITLE
sql: optimize regexp_replace for static regexes

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -450,6 +450,17 @@ message ProtoBinaryFunc {
         mz_repr.relation_and_scalar.ProtoScalarType elem_type = 1;
         bool rev = 2;
     }
+    message ProtoRegexpReplace {
+        mz_repr.adt.regex.ProtoRegex regex = 1;
+        uint64 limit = 2;
+    }
+    message ProtoRegexpReplaceResult {
+        oneof result {
+            ProtoRegexpReplace ok = 1;
+            ProtoEvalError err = 2;
+        }
+    }
+
 
     reserved 93; // timezone_time
     reserved 108; // map_get_values
@@ -641,6 +652,7 @@ message ProtoBinaryFunc {
         google.protobuf.Empty constant_time_eq_bytes = 189;
         google.protobuf.Empty timezone_offset = 190;
         google.protobuf.Empty pretty_sql = 191;
+        ProtoRegexpReplaceResult regexp_replace = 192;
     }
 }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2231,8 +2231,12 @@ pub enum BinaryFunc {
     Gt,
     Gte,
     LikeEscape,
-    IsLikeMatch { case_insensitive: bool },
-    IsRegexpMatch { case_insensitive: bool },
+    IsLikeMatch {
+        case_insensitive: bool,
+    },
+    IsRegexpMatch {
+        case_insensitive: bool,
+    },
     ToCharTimestamp,
     ToCharTimestampTz,
     DateBinTimestamp,
@@ -2256,9 +2260,15 @@ pub enum BinaryFunc {
     TimezoneIntervalTime,
     TimezoneOffset,
     TextConcat,
-    JsonbGetInt64 { stringify: bool },
-    JsonbGetString { stringify: bool },
-    JsonbGetPath { stringify: bool },
+    JsonbGetInt64 {
+        stringify: bool,
+    },
+    JsonbGetString {
+        stringify: bool,
+    },
+    JsonbGetPath {
+        stringify: bool,
+    },
     JsonbContainsString,
     JsonbConcat,
     JsonbContainsJsonb,
@@ -2278,7 +2288,9 @@ pub enum BinaryFunc {
     TrimLeading,
     TrimTrailing,
     EncodedBytesCharLength,
-    ListLengthMax { max_layer: usize },
+    ListLengthMax {
+        max_layer: usize,
+    },
     ArrayContains,
     ArrayLength,
     ArrayLower,
@@ -2300,8 +2312,13 @@ pub enum BinaryFunc {
     GetByte,
     ConstantTimeEqBytes,
     ConstantTimeEqString,
-    RangeContainsElem { elem_type: ScalarType, rev: bool },
-    RangeContainsRange { rev: bool },
+    RangeContainsElem {
+        elem_type: ScalarType,
+        rev: bool,
+    },
+    RangeContainsRange {
+        rev: bool,
+    },
     RangeOverlaps,
     RangeAfter,
     RangeBefore,

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -34,6 +34,7 @@ use mz_ore::lex::LexBuf;
 use mz_ore::option::OptionExt;
 use mz_ore::result::ResultExt;
 use mz_ore::soft_assert_eq_or_log;
+use mz_ore::str::StrExt;
 use mz_pgrepr::Type;
 use mz_pgtz::timezone::{Timezone, TimezoneSpec};
 use mz_proto::chrono::any_naive_datetime;
@@ -2112,33 +2113,6 @@ fn regexp_split_to_array_re<'a>(
     Ok(temp_storage.push_unary_row(row))
 }
 
-fn regexp_replace<'a>(
-    source: Datum<'a>,
-    pattern: Datum<'a>,
-    replacement: Datum<'a>,
-    flags: Datum<'a>,
-    temp_storage: &'a RowArena,
-) -> Result<Datum<'a>, EvalError> {
-    let source = source.unwrap_str();
-    let pattern = pattern.unwrap_str();
-    let replacement = replacement.unwrap_str();
-    let flags = flags.unwrap_str();
-    // 'g' means to replace all instead of the first. Use a Cow to avoid allocating in the fast
-    // path. We could switch build_regex to take an iter which would also achieve that.
-    let (n, flags) = if flags.contains('g') {
-        let flags = flags.replace('g', "");
-        (0, Cow::Owned(flags))
-    } else {
-        (1, Cow::Borrowed(flags))
-    };
-    let regexp = build_regex(pattern, &flags)?;
-    let replaced = match regexp.replacen(source, n, replacement) {
-        Cow::Borrowed(s) => s,
-        Cow::Owned(s) => temp_storage.push_string(s),
-    };
-    Ok(Datum::String(replaced))
-}
-
 fn pretty_sql<'a>(
     sql: Datum<'a>,
     width: Datum<'a>,
@@ -2341,6 +2315,9 @@ pub enum BinaryFunc {
     MzAclItemContainsPrivilege,
     ParseIdent,
     PrettySql,
+    RegexpReplace {
+        regex: Result<(Regex, usize), EvalError>,
+    },
 }
 
 impl BinaryFunc {
@@ -2603,6 +2580,10 @@ impl BinaryFunc {
             BinaryFunc::MzAclItemContainsPrivilege => mz_acl_item_contains_privilege(a, b),
             BinaryFunc::ParseIdent => parse_ident(a, b, temp_storage),
             BinaryFunc::PrettySql => pretty_sql(a, b, temp_storage),
+            BinaryFunc::RegexpReplace { regex } => match regex {
+                Ok((regex, limit)) => regexp_replace_static(a, b, regex, *limit, temp_storage),
+                Err(err) => Err(err.clone()),
+            },
         }
     }
 
@@ -2791,6 +2772,7 @@ impl BinaryFunc {
 
             ParseIdent => ScalarType::Array(Box::new(ScalarType::String)).nullable(in_nullable),
             PrettySql => ScalarType::String.nullable(in_nullable),
+            RegexpReplace { .. } => ScalarType::String.nullable(in_nullable),
         }
     }
 
@@ -2991,7 +2973,8 @@ impl BinaryFunc {
             | UuidGenerateV5
             | MzAclItemContainsPrivilege
             | ParseIdent
-            | PrettySql => false,
+            | PrettySql
+            | RegexpReplace { .. } => false,
 
             JsonbGetInt64 { .. }
             | JsonbGetString { .. }
@@ -3195,7 +3178,8 @@ impl BinaryFunc {
             | ConstantTimeEqBytes
             | ConstantTimeEqString
             | ParseIdent
-            | PrettySql => false,
+            | PrettySql
+            | RegexpReplace { .. } => false,
         }
     }
 
@@ -3462,6 +3446,7 @@ impl BinaryFunc {
             BinaryFunc::ParseIdent => (false, false),
             BinaryFunc::ConstantTimeEqBytes | BinaryFunc::ConstantTimeEqString => (false, false),
             BinaryFunc::PrettySql => (false, false),
+            BinaryFunc::RegexpReplace { .. } => (false, false),
         }
     }
 }
@@ -3669,6 +3654,16 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::MzAclItemContainsPrivilege => f.write_str("mz_aclitem_contains_privilege"),
             BinaryFunc::ParseIdent => f.write_str("parse_ident"),
             BinaryFunc::PrettySql => f.write_str("pretty_sql"),
+            BinaryFunc::RegexpReplace { regex } => match regex {
+                Ok((regex, limit)) => write!(
+                    f,
+                    "regexp_replace[{}, case_insensitive={}, limit={}]",
+                    regex.pattern.quoted(),
+                    regex.case_insensitive,
+                    limit
+                ),
+                Err(err) => write!(f, "regexp_replace[EvalError]: {err}"),
+            },
         }
     }
 }
@@ -4081,6 +4076,20 @@ impl RustType<ProtoBinaryFunc> for BinaryFunc {
             BinaryFunc::ConstantTimeEqBytes => ConstantTimeEqBytes(()),
             BinaryFunc::ConstantTimeEqString => ConstantTimeEqString(()),
             BinaryFunc::PrettySql => PrettySql(()),
+            BinaryFunc::RegexpReplace { regex } => {
+                use crate::scalar::proto_binary_func::*;
+                RegexpReplace(ProtoRegexpReplaceResult {
+                    result: Some(match regex {
+                        Ok((regex, limit)) => {
+                            proto_regexp_replace_result::Result::Ok(ProtoRegexpReplace {
+                                regex: Some(regex.into_proto()),
+                                limit: limit.into_proto(),
+                            })
+                        }
+                        Err(err) => proto_regexp_replace_result::Result::Err(err.into_proto()),
+                    }),
+                })
+            }
         };
         ProtoBinaryFunc { kind: Some(kind) }
     }
@@ -4284,6 +4293,27 @@ impl RustType<ProtoBinaryFunc> for BinaryFunc {
                 ConstantTimeEqBytes(()) => Ok(BinaryFunc::ConstantTimeEqBytes),
                 ConstantTimeEqString(()) => Ok(BinaryFunc::ConstantTimeEqString),
                 PrettySql(()) => Ok(BinaryFunc::PrettySql),
+                RegexpReplace(inner) => {
+                    use crate::scalar::proto_binary_func::*;
+                    Ok(BinaryFunc::RegexpReplace {
+                        regex: match inner.result {
+                            Some(proto_regexp_replace_result::Result::Ok(regexp_replace)) => Ok((
+                                regexp_replace
+                                    .regex
+                                    .into_rust_if_some("ProtoRegexReplace::regex")?,
+                                regexp_replace.limit.into_rust()?,
+                            )),
+                            Some(proto_regexp_replace_result::Result::Err(err)) => {
+                                Err(err.into_rust()?)
+                            }
+                            None => {
+                                return Err(TryFromProtoError::missing_field(
+                                    "ProtoRegexpReplaceResult::result",
+                                ))
+                            }
+                        },
+                    })
+                }
             }
         } else {
             Err(TryFromProtoError::missing_field("ProtoBinaryFunc::kind"))
@@ -6370,6 +6400,50 @@ fn regexp_match_static<'a>(
     Ok(temp_storage.push_unary_row(row))
 }
 
+fn regexp_replace_dynamic<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let source = datums[0];
+    let pattern = datums[1];
+    let replacement = datums[2];
+    let flags = match datums.get(3) {
+        Some(d) => d.unwrap_str(),
+        None => "",
+    };
+    let (limit, flags) = regexp_replace_parse_flags(flags);
+    let regexp = build_regex(pattern.unwrap_str(), &flags)?;
+    regexp_replace_static(source, replacement, &regexp, limit, temp_storage)
+}
+
+/// Sets `limit` based on the presence of 'g' in `flags` for use in `Regex::replacen`,
+/// and removes 'g' from `flags` if present.
+pub(crate) fn regexp_replace_parse_flags(flags: &str) -> (usize, Cow<str>) {
+    // 'g' means to replace all instead of the first. Use a Cow to avoid allocating in the fast
+    // path. We could switch build_regex to take an iter which would also achieve that.
+    let (limit, flags) = if flags.contains('g') {
+        let flags = flags.replace('g', "");
+        (0, Cow::Owned(flags))
+    } else {
+        (1, Cow::Borrowed(flags))
+    };
+    (limit, flags)
+}
+
+fn regexp_replace_static<'a>(
+    source: Datum<'a>,
+    replacement: Datum<'a>,
+    regexp: &regex::Regex,
+    limit: usize,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let replaced = match regexp.replacen(source.unwrap_str(), limit, replacement.unwrap_str()) {
+        Cow::Borrowed(s) => s,
+        Cow::Owned(s) => temp_storage.push_string(s),
+    };
+    Ok(Datum::String(replaced))
+}
+
 pub fn build_regex(needle: &str, flags: &str) -> Result<Regex, EvalError> {
     let mut case_insensitive = false;
     // Note: Postgres accepts it when both flags are present, taking the last one. We do the same.
@@ -7681,14 +7755,7 @@ impl VariadicFunc {
                 };
                 regexp_split_to_array(ds[0], ds[1], flags, temp_storage)
             }
-            VariadicFunc::RegexpReplace => {
-                let flags = if ds.len() == 3 {
-                    Datum::String("")
-                } else {
-                    ds[3]
-                };
-                regexp_replace(ds[0], ds[1], ds[2], flags, temp_storage)
-            }
+            VariadicFunc::RegexpReplace => regexp_replace_dynamic(&ds, temp_storage),
         }
     }
 

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -295,7 +295,6 @@ def compileFastSltConfig() -> SltRunConfig:
         "test/sqllogictest/recursion_limit.slt",
         "test/sqllogictest/recursive_type_unioning.slt",
         "test/sqllogictest/regclass.slt",
-        "test/sqllogictest/regex.slt",
         "test/sqllogictest/regproc.slt",
         "test/sqllogictest/regressions.slt",
         "test/sqllogictest/regtype.slt",

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -528,15 +528,46 @@ SELECT regexp_split_to_table('no match', 'nope')
 ----
 no match
 
-query T
-SELECT regexp_replace('foobarbaz', 'b..', 'X')
+# Test regexp_replace success paths
+
+query T multiline
+EXPLAIN
+SELECT regexp_replace('FOOBARBAZ', 'b..', 'X');
 ----
-fooXbaz
+Explained Query (fast path):
+  Constant
+    - ("FOOBARBAZ")
+
+Target cluster: quickstart
+
+EOF
 
 query T
-SELECT regexp_replace('foobarbaz', 'b..', 'X', 'g')
+SELECT regexp_replace('FOOBARBAZ', 'b..', 'X');
 ----
-fooXX
+FOOBARBAZ
+
+query T multiline
+EXPLAIN
+SELECT regexp_replace('FOOBARBAZ', 'b..', 'X', 'i');
+----
+Explained Query (fast path):
+  Constant
+    - ("FOOXBAZ")
+
+Target cluster: quickstart
+
+EOF
+
+query T
+SELECT regexp_replace('FOOBARBAZ', 'b..', 'X', 'i');
+----
+FOOXBAZ
+
+query T
+SELECT regexp_replace('FOOBARBAZ', 'b..', 'X', 'ig');
+----
+FOOXX
 
 query T
 SELECT regexp_replace('foobarbaz', 'b(..)', 'X${1}Y', 'g')
@@ -547,3 +578,162 @@ query T
 SELECT regexp_replace('foobarbaz', 'no match', 'X')
 ----
 foobarbaz
+
+statement ok
+CREATE TABLE r(s string, regex string, replacement string);
+
+statement ok
+INSERT INTO r VALUES ('foobarbaz', 'b..', 'X'), ('foobarbaz', 'b(..)', '>${1}<'), ('FOOBARBAZ', 'b..', 'X'), ('FOOZARZAZ', 'b..', 'X');
+
+query T multiline
+EXPLAIN
+SELECT regexp_replace(s, 'b..', 'X') FROM r;
+----
+Explained Query:
+  Project (#3)
+    Map (regexp_replace["b..", case_insensitive=false, limit=1](#0, "X"))
+      ReadStorage materialize.public.r
+
+Target cluster: quickstart
+
+EOF
+
+query TT
+SELECT s, regexp_replace(s, 'b..', 'X') FROM r;
+----
+foobarbaz
+fooXbaz
+foobarbaz
+fooXbaz
+FOOBARBAZ
+FOOBARBAZ
+FOOZARZAZ
+FOOZARZAZ
+
+query T multiline
+EXPLAIN
+SELECT regexp_replace(s, 'b..', 'X', 'i') FROM r;
+----
+Explained Query:
+  Project (#3)
+    Map (regexp_replace["b..", case_insensitive=true, limit=1](#0, "X"))
+      ReadStorage materialize.public.r
+
+Target cluster: quickstart
+
+EOF
+
+query TT
+SELECT s, regexp_replace(s, 'b..', 'X', 'i') FROM r;
+----
+FOOBARBAZ
+FOOXBAZ
+foobarbaz
+fooXbaz
+foobarbaz
+fooXbaz
+FOOZARZAZ
+FOOZARZAZ
+
+query T multiline
+EXPLAIN
+SELECT regexp_replace(s, 'b..', 'X', 'ig') FROM r;
+----
+Explained Query:
+  Project (#3)
+    Map (regexp_replace["b..", case_insensitive=true, limit=0](#0, "X"))
+      ReadStorage materialize.public.r
+
+Target cluster: quickstart
+
+EOF
+
+query TT
+SELECT s, regexp_replace(s, 'b..', 'X', 'ig') FROM r;
+----
+FOOBARBAZ
+FOOXX
+foobarbaz
+fooXX
+foobarbaz
+fooXX
+FOOZARZAZ
+FOOZARZAZ
+
+query T multiline
+EXPLAIN
+SELECT regexp_replace(s, regex, replacement, 'ig') FROM r;
+----
+Explained Query:
+  Project (#3)
+    Map (regexp_replace(#0, #1, #2, "ig"))
+      ReadStorage materialize.public.r
+
+Target cluster: quickstart
+
+EOF
+
+query TT
+SELECT s, regexp_replace(s, regex, replacement, 'ig') FROM r;
+----
+FOOBARBAZ
+FOOXX
+foobarbaz
+fooXX
+FOOZARZAZ
+FOOZARZAZ
+foobarbaz
+foo>ar<>az<
+
+# Test regexp_replace error paths
+
+query T multiline
+EXPLAIN
+SELECT regexp_replace('foobarbaz', 'b(..', 'X', 'ig');
+----
+Explained Query (fast path):
+  Error "invalid regular expression: regex parse error:
+    b(..
+     ^
+error: unclosed group"
+
+Target cluster: quickstart
+
+EOF
+
+query error invalid regular expression: regex parse error:
+SELECT regexp_replace('foobarbaz', 'b(..', 'X', 'ig');
+
+query error invalid regular expression flag: x
+SELECT regexp_replace('foobarbaz', 'b(..', 'X', 'igx');
+
+statement ok
+CREATE TABLE e(s string, regex string, replacement string);
+
+statement ok
+INSERT INTO e VALUES ('foobarbaz', 'b(..', 'X');
+
+query T multiline
+EXPLAIN
+SELECT s, regexp_replace(s, 'b(..', replacement, 'ig') FROM e;
+----
+Explained Query:
+  Project (#0, #3)
+    Map (regexp_replace[EvalError]: invalid regular expression: regex parse error:
+    b(..
+     ^
+error: unclosed group(#0, #2))
+      ReadStorage materialize.public.e
+
+Target cluster: quickstart
+
+EOF
+
+query error invalid regular expression: regex parse error:
+SELECT s, regexp_replace(s, 'b(..', replacement, 'ig') FROM e;
+
+query error invalid regular expression: regex parse error:
+SELECT s, regexp_replace(s, regex, replacement, 'ig') FROM e;
+
+query error invalid regular expression flag: x
+SELECT regexp_replace(s, regex, replacement, 'igx') FROM e;


### PR DESCRIPTION
Mirroring the `regexp_match` sql function, this PR pre-processes static regexes for `regexp_replace`.

Fixes #22172 

### Motivation

The `Regex` object is now constructed from their string representation only once when possible, instead of constructing the same object repeatedly across multiple rows.

### Tips for reviewer

- The implementation follows the style of `regexp_match`, except we need a binary function here.
- Because of the `g` flag, we need to carry around an extra integer. I created a new proto object `ProtoRegexReplace` to be able to represent this.
- I've extended the tests to ensure the fast and slow paths are taken appropriately. 
- [x] I've tried to guess the correct output for the functions in `impl BinaryFunc`. These should be verified properly though, as I don't yet understand the exact implications of these functions.
- [x] The code for computing `n` is repeated in two places and should be hoisted out to a helper function. What's the best file for that?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
