### PR TITLE
dbt-materialize: support overriding generate_cluster_name

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,10 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Add support for overriding the `generate_cluster_name` macro to customize the
+  cluster name generation logic in user projects.
+
 ## 1.8.0 - 2024-05-23
 
 * Update base adapter references as part of

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -297,7 +297,7 @@ class MaterializeAdapter(PostgresAdapter):
         self, cluster_name: str, force_deploy_suffix: bool = False
     ) -> str:
         cluster_name = self.execute_macro(
-            "materialize__generate_cluster_name",
+            "generate_cluster_name",
             kwargs={"custom_cluster_name": cluster_name},
         )
         if (
@@ -305,7 +305,7 @@ class MaterializeAdapter(PostgresAdapter):
             or force_deploy_suffix
         ):
             cluster_name = self.execute_macro(
-                "materialize__generate_deploy_cluster_name",
+                "generate_deploy_cluster_name",
                 kwargs={"custom_cluster_name": cluster_name},
             )
         return cluster_name

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -291,3 +291,21 @@ class MaterializeAdapter(PostgresAdapter):
         self.connections.execute(f"drop view {view_name}")
 
         return columns
+
+    @available
+    def generate_final_cluster_name(
+        self, cluster_name: str, force_deploy_suffix: bool = False
+    ) -> str:
+        cluster_name = self.execute_macro(
+            "materialize__generate_cluster_name",
+            kwargs={"custom_cluster_name": cluster_name},
+        )
+        if (
+            self.connections.profile.cli_vars.get("deploy", False)
+            or force_deploy_suffix
+        ):
+            cluster_name = self.execute_macro(
+                "materialize__generate_deploy_cluster_name",
+                kwargs={"custom_cluster_name": cluster_name},
+            )
+        return cluster_name

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -30,7 +30,7 @@
 {%- endmacro %}
 
 {% macro materialize__create_materialized_view_as(relation, sql) -%}
-  {%- set cluster = generate_cluster_name(config.get('cluster', target.cluster)) -%}
+  {%- set cluster = generate_cluster_name_internal(config.get('cluster', target.cluster)) -%}
 
   create materialized view {{ relation }}
   {% if cluster %}
@@ -92,7 +92,7 @@
     {{exceptions.warn("Model contracts cannot be enforced for custom materializations (see dbt-core #7213)")}}
   {%- endif %}
 
-  {%- set cluster = generate_cluster_name(config.get('cluster', target.cluster)) -%}
+  {%- set cluster = generate_cluster_name_internal(config.get('cluster', target.cluster)) -%}
 
   create source {{ relation }}
   {% if cluster %}
@@ -109,7 +109,7 @@
     {{exceptions.warn("Model contracts cannot be enforced for custom materializations (see dbt-core #7213)")}}
   {%- endif %}
 
-  {%- set cluster = generate_cluster_name(config.get('cluster', target.cluster)) -%}
+  {%- set cluster = generate_cluster_name_internal(config.get('cluster', target.cluster)) -%}
 
   create sink {{ relation }}
   {% if cluster %}
@@ -156,7 +156,7 @@
 {% macro materialize__get_create_index_sql(relation, index_dict) -%}
   {%- set index_config = adapter.parse_index(index_dict) -%}
   {%- set cluster = index_config.cluster or config.get('cluster', target.cluster) -%}
-  {%- set cluster = generate_cluster_name(cluster) -%}
+  {%- set cluster = generate_cluster_name_internal(cluster) -%}
 
     create
     {% if index_config.default -%}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -30,7 +30,7 @@
 {%- endmacro %}
 
 {% macro materialize__create_materialized_view_as(relation, sql) -%}
-  {%- set cluster = generate_cluster_name_internal(config.get('cluster', target.cluster)) -%}
+  {%- set cluster = adapter.generate_final_cluster_name(config.get('cluster', target.cluster)) -%}
 
   create materialized view {{ relation }}
   {% if cluster %}
@@ -92,7 +92,7 @@
     {{exceptions.warn("Model contracts cannot be enforced for custom materializations (see dbt-core #7213)")}}
   {%- endif %}
 
-  {%- set cluster = generate_cluster_name_internal(config.get('cluster', target.cluster)) -%}
+  {%- set cluster = adapter.generate_final_cluster_name(config.get('cluster', target.cluster)) -%}
 
   create source {{ relation }}
   {% if cluster %}
@@ -109,7 +109,7 @@
     {{exceptions.warn("Model contracts cannot be enforced for custom materializations (see dbt-core #7213)")}}
   {%- endif %}
 
-  {%- set cluster = generate_cluster_name_internal(config.get('cluster', target.cluster)) -%}
+  {%- set cluster = adapter.generate_final_cluster_name(config.get('cluster', target.cluster)) -%}
 
   create sink {{ relation }}
   {% if cluster %}
@@ -156,7 +156,7 @@
 {% macro materialize__get_create_index_sql(relation, index_dict) -%}
   {%- set index_config = adapter.parse_index(index_dict) -%}
   {%- set cluster = index_config.cluster or config.get('cluster', target.cluster) -%}
-  {%- set cluster = generate_cluster_name_internal(cluster) -%}
+  {%- set cluster = adapter.generate_final_cluster_name(cluster) -%}
 
     create
     {% if index_config.default -%}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_await.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_await.sql
@@ -38,7 +38,7 @@
 {% set clusters = target_config.get('clusters', []) %}
 
 {% for cluster in clusters %}
-    {% set deploy_cluster = generate_cluster_name_internal(cluster, force_deploy_suffix=True) %}
+    {% set deploy_cluster = adapter.generate_final_cluster_name(cluster, force_deploy_suffix=True) %}
     {{ await_cluster_ready(deploy_cluster, poll_interval) }}
 {% endfor %}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_await.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_await.sql
@@ -38,7 +38,7 @@
 {% set clusters = target_config.get('clusters', []) %}
 
 {% for cluster in clusters %}
-    {% set deploy_cluster = cluster ~ "_dbt_deploy" %}
+    {% set deploy_cluster = generate_cluster_name_internal(cluster, force_deploy_suffix=True) %}
     {{ await_cluster_ready(deploy_cluster, poll_interval) }}
 {% endfor %}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_cleanup.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_cleanup.sql
@@ -39,7 +39,7 @@
 {% endfor %}
 
 {% for cluster in clusters %}
-    {% set deploy_cluster = generate_cluster_name_internal(cluster, force_deploy_suffix=True) %}
+    {% set deploy_cluster = adapter.generate_final_cluster_name(cluster, force_deploy_suffix=True) %}
     {{ log("Dropping cluster " ~ deploy_cluster ~ " for target " ~ current_target_name, info=True) }}
     {% set drop_cluster %}
     DROP CLUSTER IF EXISTS {{ adapter.quote(deploy_cluster) }} CASCADE;

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_cleanup.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_cleanup.sql
@@ -39,7 +39,7 @@
 {% endfor %}
 
 {% for cluster in clusters %}
-    {% set deploy_cluster = cluster ~ "_dbt_deploy" %}
+    {% set deploy_cluster = generate_cluster_name_internal(cluster, force_deploy_suffix=True) %}
     {{ log("Dropping cluster " ~ deploy_cluster ~ " for target " ~ current_target_name, info=True) }}
     {% set drop_cluster %}
     DROP CLUSTER IF EXISTS {{ adapter.quote(deploy_cluster) }} CASCADE;

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
@@ -95,7 +95,7 @@
 {% endfor %}
 
 {% for cluster in clusters %}
-    {% set deploy_cluster = generate_cluster_name_internal(cluster, force_deploy_suffix=True) %}
+    {% set deploy_cluster = adapter.generate_final_cluster_name(cluster, force_deploy_suffix=True) %}
     {% if cluster_exists(deploy_cluster) %}
         {{ log("Deployment cluster " ~ deploy_cluster ~ " already exists", info=True) }}
         {% set cluster_empty %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
@@ -95,7 +95,7 @@
 {% endfor %}
 
 {% for cluster in clusters %}
-    {% set deploy_cluster = cluster ~ "_dbt_deploy" %}
+    {% set deploy_cluster = generate_cluster_name_internal(cluster, force_deploy_suffix=True) %}
     {% if cluster_exists(deploy_cluster) %}
         {{ log("Deployment cluster " ~ deploy_cluster ~ " already exists", info=True) }}
         {% set cluster_empty %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -67,7 +67,7 @@
 {% endfor %}
 
 {% for cluster in clusters %}
-    {% set deploy_cluster = cluster ~ "_dbt_deploy" %}
+    {% set deploy_cluster = generate_cluster_name_internal(cluster, force_deploy_suffix=True) %}
     {% if not cluster_exists(cluster) %}
         {{ exceptions.raise_compiler_error("Production cluster " ~ cluster ~ " does not exist") }}
     {% endif %}
@@ -98,8 +98,8 @@ BEGIN;
 {% endfor %}
 
 {% for cluster in clusters %}
-    {% set deploy_cluster = cluster ~ "_dbt_deploy" %}
-    {{ log("Swapping clusters " ~ cluster ~ " and " ~ deploy_cluster, info=True) }}
+    {% set deploy_cluster = generate_cluster_name_internal(cluster, force_deploy_suffix=True) %}
+    {{ log("Swapping clusters " ~ generate_cluster_name_internal(cluster) ~ " and " ~ deploy_cluster, info=True) }}
     ALTER CLUSTER {{ adapter.quote(cluster) }} SWAP WITH {{ adapter.quote(deploy_cluster) }};
 {% endfor %}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -67,7 +67,7 @@
 {% endfor %}
 
 {% for cluster in clusters %}
-    {% set deploy_cluster = generate_cluster_name_internal(cluster, force_deploy_suffix=True) %}
+    {% set deploy_cluster = adapter.generate_final_cluster_name(cluster, force_deploy_suffix=True) %}
     {% if not cluster_exists(cluster) %}
         {{ exceptions.raise_compiler_error("Production cluster " ~ cluster ~ " does not exist") }}
     {% endif %}
@@ -98,8 +98,8 @@ BEGIN;
 {% endfor %}
 
 {% for cluster in clusters %}
-    {% set deploy_cluster = generate_cluster_name_internal(cluster, force_deploy_suffix=True) %}
-    {{ log("Swapping clusters " ~ generate_cluster_name_internal(cluster) ~ " and " ~ deploy_cluster, info=True) }}
+    {% set deploy_cluster = adapter.generate_final_cluster_name(cluster, force_deploy_suffix=True) %}
+    {{ log("Swapping clusters " ~ adapter.generate_final_cluster_name(cluster) ~ " and " ~ deploy_cluster, info=True) }}
     ALTER CLUSTER {{ adapter.quote(cluster) }} SWAP WITH {{ adapter.quote(deploy_cluster) }};
 {% endfor %}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
@@ -14,17 +14,9 @@
 -- limitations under the License.
 
 {% macro generate_deploy_cluster_name(custom_cluster_name) -%}
-    {{ return(adapter.dispatch('generate_deploy_cluster_name', 'materialize')(custom_cluster_name)) }}
-{%- endmacro %}
-
-{% macro materialize__generate_deploy_cluster_name(custom_cluster_name) -%}
     {{ custom_cluster_name }}_dbt_deploy
 {%- endmacro %}
 
 {% macro generate_cluster_name(custom_cluster_name) -%}
-    {{ return(adapter.dispatch('generate_cluster_name', 'materialize')(custom_cluster_name)) }}
-{%- endmacro %}
-
-{% macro materialize__generate_cluster_name(custom_cluster_name) -%}
     {{ custom_cluster_name }}
 {%- endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
@@ -13,14 +13,18 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+{% macro generate_deploy_cluster_name(custom_cluster_name) -%}
+    {{ return(adapter.dispatch('generate_deploy_cluster_name', 'materialize')(custom_cluster_name)) }}
+{%- endmacro %}
+
 {% macro materialize__generate_deploy_cluster_name(custom_cluster_name) -%}
-
     {{ custom_cluster_name }}_dbt_deploy
+{%- endmacro %}
 
+{% macro generate_cluster_name(custom_cluster_name) -%}
+    {{ return(adapter.dispatch('generate_cluster_name', 'materialize')(custom_cluster_name)) }}
 {%- endmacro %}
 
 {% macro materialize__generate_cluster_name(custom_cluster_name) -%}
-
     {{ custom_cluster_name }}
-
 {%- endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
@@ -13,10 +13,10 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro generate_cluster_name_internal(custom_cluster_name) -%}
+{% macro generate_cluster_name_internal(custom_cluster_name, force_deploy_suffix=False) -%}
 
     {%- set cluster_name = adapter.dispatch('generate_cluster_name', 'materialize')(custom_cluster_name) -%}
-    {%- set deploy_suffix = "_dbt_deploy" if var('deploy', False) else "" -%}
+    {%- set deploy_suffix = "_dbt_deploy" if var('deploy', False) or force_deploy_suffix else "" -%}
     {{ cluster_name }}{{ deploy_suffix }}
 
 {%- endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
@@ -13,11 +13,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro generate_cluster_name_internal(custom_cluster_name, force_deploy_suffix=False) -%}
+{% macro materialize__generate_deploy_cluster_name(custom_cluster_name) -%}
 
-    {%- set cluster_name = adapter.dispatch('generate_cluster_name', 'materialize')(custom_cluster_name) -%}
-    {%- set deploy_suffix = "_dbt_deploy" if var('deploy', False) or force_deploy_suffix else "" -%}
-    {{ cluster_name }}{{ deploy_suffix }}
+    {{ custom_cluster_name }}_dbt_deploy
 
 {%- endmacro %}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
@@ -13,9 +13,16 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro generate_cluster_name(default_cluster) -%}
+{% macro generate_cluster_name_internal(custom_cluster_name) -%}
 
+    {%- set cluster_name = adapter.dispatch('generate_cluster_name', 'materialize')(custom_cluster_name) -%}
     {%- set deploy_suffix = "_dbt_deploy" if var('deploy', False) else "" -%}
-    {{ default_cluster }}{{ deploy_suffix }}
+    {{ cluster_name }}{{ deploy_suffix }}
+
+{%- endmacro %}
+
+{% macro materialize__generate_cluster_name(custom_cluster_name) -%}
+
+    {{ custom_cluster_name }}
 
 {%- endmacro %}


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Fixes #27159

This PR introduces a couple of things:
* A new `generate_deploy_cluster_name` macro responsible for appending the `_dbt_deploy` suffix for the blue/green deployments.
* A new `generate_final_cluster_name` adapter method.
* Users can define their own `generate_cluster_name` macro in their dbt project to override the cluster name generation logic, like one that automatically prefixes each cluster with the target name:

```jinja
{% macro generate_cluster_name(custom_cluster_name, node) -%}

    {%- set default_cluster = target.cluster -%}
    {%- if custom_cluster_name is none -%}

        {{ default_cluster }}

    {%- else -%}

        {{target.name}}_{{ custom_cluster_name }}

    {%- endif -%}

{%- endmacro %}
```