### PR TITLE
persist-client: fix race in sink peak metrics update

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -456,10 +456,6 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             self.metrics
                 .timely_step_duration_seconds
                 .observe(start.elapsed().as_secs_f64());
-            self.persist_clients
-                .metrics()
-                .sink
-                .update_sink_correction_peak_metrics();
 
             // Report frontier information back the coordinator.
             if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1879,11 +1879,10 @@ impl SinkMetrics {
             }
             UpdateDelta::Negative(delta) => self.correction_capacity_decreases_total.inc_by(delta),
         }
-    }
 
-    /// Updates our estimate of the aggregate peak for the correction buffer
-    /// length and capacity across workers and persist sinks.
-    pub fn update_sink_correction_peak_metrics(&self) {
+        // Update our estimate of the aggregate peak for the correction buffer length and capacity
+        // across workers and persist sinks.
+        //
         // We calculate peak values based on the current values of sink metrics that are shared
         // between all workers. Note that while we fetch these values, other workers may
         // concurrently update them, which means we must expect incorrect results. Produced peak


### PR DESCRIPTION
The `SinkMetrics::update_sink_correction_peak_metrics` method assumed "quiescence", i.e. the temporary ceasing of updates to sink metrics while it was executing. While the method was correct under that assumption, the calling code unfortunately was not able to uphold it. Specifically, `step_or_park` is invoked per worker, so when `update_sink_correction_peak_metrics` is invoked it can only assume that the current worker won't update the sink metrics, but it cannot assume anything about other workers.

As a result of the violated assumption, "Negative aggregate length for persist sink correction" could be logged even when nothing was actually wrong with the persist sink implementation.

Stopping all workers at the same time regularly to update the sink metrics is not an option, so instead of trying to make the calling code uphold the quiescence assumption, this PR instead modifies `update_sink_correction_peak_metrics` to not require quiescence anymore. In essence this just removes the error logging, but the code is also restructured to improve readability.

### Motivation

  * This PR fixes a recognized bug.

Fixes #27302 

### Tips for reviewer

This is the simplest fix, but there might be smarter ones. We could, for example, try to make the calculated peak values more correct, or we could attempt to get rid of `update_sink_correction_peak_metrics` entirely and instead perform the update as part of `report_correction_update_deltas`. Both of these options would require more synchronization between workers and I don't have a good intuition for how that would affect `persist_sink` performance.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
