### PR TITLE
storage: fix proptest for ExportReference

### DIFF
--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -83,7 +83,9 @@ impl proptest::prelude::Arbitrary for ExportReference {
         // Generate a set of valid `Ident` strings.
         let string_strategy = string_regex("[a-zA-Z_][a-zA-Z0-9_$]{3,10}").unwrap();
 
-        vec(string_strategy, 0..100)
+        // We only ever expect between 1 and 3 elements of the reference. We
+        // could theoretically expect more, but we can never expect 0.
+        vec(string_strategy, 1..=3)
             .prop_map(|inner| {
                 ExportReference(inner.into_iter().map(|i| Ident::new(i).unwrap()).collect())
             })


### PR DESCRIPTION
`ExportReference`s should never be empty, but I forgot to state that in `Arbitrary` impl.

### Motivation

This PR fixes a recognized bug. Fixes #27277

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
