### PR TITLE
expose bytes_sent for sources and bytes_received for sinks

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -6669,7 +6669,8 @@ SELECT
     SUM(messages_staged)::uint8 AS messages_staged,
     SUM(messages_committed)::uint8 AS messages_committed,
     SUM(bytes_staged)::uint8 AS bytes_staged,
-    SUM(bytes_committed)::uint8 AS bytes_committed
+    SUM(bytes_committed)::uint8 AS bytes_committed,
+    SUM(bytes_received)::uint8 AS bytes_received
 FROM mz_internal.mz_sink_statistics_raw
 GROUP BY id",
     access: vec![PUBLIC_SELECT],

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -6606,6 +6606,7 @@ SELECT
     -- Counters
     SUM(messages_received)::uint8 AS messages_received,
     SUM(bytes_received)::uint8 AS bytes_received,
+    SUM(bytes_sent)::uint8 AS bytes_sent,
     SUM(updates_staged)::uint8 AS updates_staged,
     SUM(updates_committed)::uint8 AS updates_committed,
     -- Resetting Gauges

--- a/src/storage-client/src/statistics.proto
+++ b/src/storage-client/src/statistics.proto
@@ -24,6 +24,7 @@ message ProtoSourceStatisticsUpdate {
     uint64 updates_staged = 3;
     uint64 updates_committed = 4;
     uint64 bytes_received = 5;
+    uint64 bytes_sent = 14;
 
     uint64 records_indexed = 7;
     uint64 bytes_indexed = 6;

--- a/src/storage-client/src/statistics.proto
+++ b/src/storage-client/src/statistics.proto
@@ -44,4 +44,5 @@ message ProtoSinkStatisticsUpdate {
     uint64 messages_committed = 3;
     uint64 bytes_staged = 4;
     uint64 bytes_committed = 5;
+    uint64 bytes_received = 6;
 }

--- a/test/testdrive/kafka-sink-statistics.td
+++ b/test/testdrive/kafka-sink-statistics.td
@@ -36,29 +36,32 @@ ALTER SYSTEM SET kafka_transaction_timeout = 5100
 # interval is 60 seconds.
 $ set-sql-timeout duration=2minutes
 
-> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed)
+# TODO(bosconi) SUM(u.bytes_received) > 0 once increment is implemented
+> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed), SUM(u.bytes_received) = 0
   FROM mz_sinks s
   JOIN mz_internal.mz_sink_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('simple_view_sink')
   GROUP BY s.name
   ORDER BY s.name
-simple_view_sink 1 1 true true
+simple_view_sink 1 1 true true true
 
 > INSERT INTO t VALUES ('key1', 'value')
-> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed)
+# TODO(bosconi) SUM(u.bytes_received) > 0 once increment is implemented
+> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed), SUM(u.bytes_received) = 0
   FROM mz_sinks s
   JOIN mz_internal.mz_sink_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('simple_view_sink')
   GROUP BY s.name
   ORDER BY s.name
-simple_view_sink 2 2 true true
+simple_view_sink 2 2 true true true
 
 # check the aggregated view as well
-> SELECT s.name, u.messages_staged, u.messages_committed, u.bytes_staged > 0, bytes_staged = bytes_committed
+# TODO(bosconi) u.bytes_received > 0 once increment is implemented
+> SELECT s.name, u.messages_staged, u.messages_committed, u.bytes_staged > 0, bytes_staged = bytes_committed, u.bytes_received = 0
   FROM mz_sinks s
   JOIN mz_internal.mz_sink_statistics u ON s.id = u.id
   WHERE s.name IN ('simple_view_sink')
-simple_view_sink 2 2 true true
+simple_view_sink 2 2 true true true
 
 > ALTER CONNECTION kafka_conn SET (BROKER 'asdf') WITH (VALIDATE = false);
 
@@ -76,8 +79,9 @@ true
 running
 
 > INSERT INTO t VALUES ('key1', 'value')
-> SELECT s.name, u.messages_staged, u.messages_committed, u.bytes_staged > 0, bytes_staged = bytes_committed
+# TODO(bosconi) u.bytes_received > 0 once increment is implemented
+> SELECT s.name, u.messages_staged, u.messages_committed, u.bytes_staged > 0, bytes_staged = bytes_committed, u.bytes_received = 0
   FROM mz_sinks s
   JOIN mz_internal.mz_sink_statistics u ON s.id = u.id
   WHERE s.name IN ('simple_view_sink')
-simple_view_sink 3 3 true true
+simple_view_sink 3 3 true true true

--- a/test/testdrive/source-statistics-view.td
+++ b/test/testdrive/source-statistics-view.td
@@ -17,11 +17,13 @@ ALTER SYSTEM SET storage_statistics_interval = 2000
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR COUNTER;
 
+# TODO(bosconi) SUM(u.bytes_sent) > 0 once increment is implemented
 > SELECT
     s.name,
     -- Counters
     u.messages_received > 0,
     u.bytes_received > 0,
+    u.bytes_sent = 0,
     u.updates_staged > 0,
     u.updates_committed > 0,
     -- Resetting Gauges
@@ -37,6 +39,6 @@ ALTER SYSTEM SET storage_statistics_interval = 2000
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('counter')
-counter true true true true true true true true true true true true
+counter true true true true true true true true true true true true true
 
 > DROP SOURCE counter CASCADE

--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -92,35 +92,37 @@ $ set-sql-timeout duration=2minutes
 
 # NOTE: These queries are slow to succeed because the default metrics scraping
 # interval is 30 seconds.
+# TODO(bosconi) SUM(u.bytes_sent) > 0 once increment is implemented
 > SELECT s.name,
   bool_and(u.snapshot_committed),
-  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
+  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0, SUM(u.bytes_sent) >= 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('metrics_test_source')
   GROUP BY s.name
   ORDER BY s.name
-metrics_test_source true 2 2 2 true true
+metrics_test_source true 2 2 2 true true true
 
 > DROP SOURCE metrics_test_source CASCADE
 
 # Note that only the base-source has `messages_received`, but the sub-sources have `messages_committed`.
 # Committed will usually, for auction sources, add up to received, but we don't test this (right now) because of
 # jitter on when metrics are produced for each sub-source.
+# TODO(bosconi) SUM(u.bytes_sent) > 0 once increment is implemented
 > SELECT s.name,
   bool_and(u.snapshot_committed),
-  SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
+  SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0, SUM(u.bytes_sent) >= 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('accounts', 'auction_house', 'auctions', 'bids', 'organizations', 'users')
   GROUP BY s.name
   ORDER BY s.name
-accounts       true      false   true  true  false   true
-auction_house  true      true    false false true    true
-auctions       true      false   true  true  false   true
-bids           true      false   true  true  false   true
-organizations  true      false   true  true  false   true
-users          true      false   true  true  false   true
+accounts       true      false   true  true  false   true  true
+auction_house  true      true    false false true    true  true
+auctions       true      false   true  true  false   true  true
+bids           true      false   true  true  false   true  true
+organizations  true      false   true  true  false   true  true
+users          true      false   true  true  false   true  true
 
 > DROP SOURCE auction_house CASCADE
 
@@ -131,6 +133,7 @@ users          true      false   true  true  false   true
 # There could also be up to 11 updates, as updates cause inserts and deletes
 # (5 initial inserts, 2 deletes, and 2 updates). In total 3 records should be present in upsert state.
 # We can't control this, so have to accept the range.
+# TODO(bosconi) SUM(u.bytes_sent) > 0 once increment is implemented
 > SELECT
     s.name,
     bool_and(u.snapshot_committed),
@@ -138,6 +141,7 @@ users          true      false   true  true  false   true
     SUM(u.updates_staged) BETWEEN 3 AND 11,
     SUM(u.updates_committed) BETWEEN 3 AND 11,
     SUM(u.bytes_received) > 0,
+    SUM(u.bytes_sent) >= 0,
     SUM(u.bytes_indexed) > 0,
     SUM(u.records_indexed),
     bool_and(u.rehydration_latency IS NOT NULL)
@@ -146,7 +150,7 @@ users          true      false   true  true  false   true
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
-upsert true 9 true true true true 3 true
+upsert true 9 true true true true true 3 true
 
 # While we can't control how batching works above, we can ensure that this new, later update
 # causes 1 more messages to be received, which is 1 update, a delete.
@@ -169,12 +173,14 @@ SELECT
 $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"key": "mammalmore"}
 
+# TODO(bosconi) SUM(u.bytes_sent) > 0 once increment is implemented
 > SELECT s.name,
     bool_and(u.snapshot_committed),
     SUM(u.messages_received),
     SUM(u.updates_staged),
     SUM(u.updates_committed),
     SUM(u.bytes_received) > 0,
+    SUM(u.bytes_sent) >= 0,
     SUM(u.bytes_indexed) < ${state-bytes},
     SUM(u.records_indexed)
   FROM mz_sources s
@@ -182,21 +188,23 @@ $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} 
   WHERE s.name IN ('upsert')
   GROUP BY s.name
   ORDER BY s.name
-upsert true 10 "${updates-committed}" "${updates-committed}" true true 2
+upsert true 10 "${updates-committed}" "${updates-committed}" true true true 2
 
 # check pre-aggregated view
+# TODO(bosconi) SUM(u.bytes_sent) > 0 once increment is implemented
 > SELECT s.name,
     u.snapshot_committed,
     u.messages_received,
     u.updates_staged,
     u.updates_committed,
     u.bytes_received > 0,
+    u.bytes_sent >= 0,
     u.bytes_indexed < ${state-bytes},
     u.records_indexed,
     u.rehydration_latency IS NOT NULL
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')
-upsert true 10 "${updates-committed}" "${updates-committed}" true true 2 true
+upsert true 10 "${updates-committed}" "${updates-committed}" true true true 2 true
 
 > DROP SOURCE upsert CASCADE

--- a/test/testdrive/statistics-deletion.td
+++ b/test/testdrive/statistics-deletion.td
@@ -69,13 +69,14 @@ one:two
 # NOTE: These queries are slow to succeed because the default metrics scraping
 # interval is 30 seconds. Here we are just ensuring metrics were populated.
 
-> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed)
+# TODO(bosconi) SUM(u.bytes_received) > 0 once increment is implemented
+> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed), SUM(u.bytes_received) = 0
   FROM mz_sinks s
   JOIN mz_internal.mz_sink_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('sink_size', 'sink_cluster')
   GROUP BY s.name
-sink_size 1 1 true true
-sink_cluster 1 1 true true
+sink_size 1 1 true true true
+sink_cluster 1 1 true true true
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0

--- a/test/testdrive/statistics-maintenance.td
+++ b/test/testdrive/statistics-maintenance.td
@@ -45,12 +45,13 @@ one:two
   ENVELOPE UPSERT
 
 # Ensure we produce statistics
-> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed)
+# TODO(bosconi) SUM(u.bytes_received) > 0 once increment is implemented
+> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed), SUM(u.bytes_received) = 0
   FROM mz_sinks s
   JOIN mz_internal.mz_sink_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('sink1')
   GROUP BY s.name
-sink1 1 1 true true
+sink1 1 1 true true true
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
@@ -65,12 +66,13 @@ upsert1 true 1
 > ALTER CLUSTER cluster1 SET (REPLICATION FACTOR = 0)
 
 # Statistics should remain the same
-> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed)
+# TODO(bosconi) SUM(u.bytes_received) > 0 once increment is implemented
+> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed), SUM(u.bytes_received) = 0
   FROM mz_sinks s
   JOIN mz_internal.mz_sink_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('sink1')
   GROUP BY s.name
-sink1 1 1 true true
+sink1 1 1 true true true
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,
@@ -89,12 +91,13 @@ $ kafka-ingest format=bytes topic=upsert key-format=bytes key-terminator=:
 two:three
 
 # Statistics should remain the same
-> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed)
+# TODO(bosconi) SUM(u.bytes_received) > 0 once increment is implemented
+> SELECT s.name, SUM(u.messages_staged), SUM(u.messages_committed), SUM(u.bytes_staged) > 0, SUM(bytes_staged) = SUM(bytes_committed), SUM(u.bytes_received) = 0
   FROM mz_sinks s
   JOIN mz_internal.mz_sink_statistics_raw u ON s.id = u.id
   WHERE s.name IN ('sink1')
   GROUP BY s.name
-sink1 2 2 true true
+sink1 2 2 true true true
 
 > SELECT s.name,
   SUM(u.updates_committed) > 0,

--- a/test/testdrive/webhook-statistics.td
+++ b/test/testdrive/webhook-statistics.td
@@ -19,16 +19,18 @@ ALTER SYSTEM SET storage_statistics_interval = 2000
 $ webhook-append database=materialize schema=public name=webhook_text
 a
 
+# TODO(bosconi) SUM(u.bytes_sent) > 0 once increment is implemented
 > SELECT
     s.name,
     u.messages_received,
     u.bytes_received > 0,
+    u.bytes_sent = 0,
     u.updates_staged,
     u.updates_committed
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('webhook_text')
-webhook_text 1 true 1 1
+webhook_text 1 true true 1 1
 
 $ set-from-sql var=bytes-received
 SELECT
@@ -37,19 +39,28 @@ SELECT
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('webhook_text')
 
+$ set-from-sql var=bytes-sent
+SELECT
+    (u.bytes_sent)::text
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('webhook_text')
+
 $ webhook-append database=materialize schema=public name=webhook_text
 b
 
+# TODO(bosconi) u.bytes_received > ${bytes-received} once increment is implemented
 > SELECT
     s.name,
     u.messages_received,
     u.bytes_received > ${bytes-received},
+    u.bytes_sent = ${bytes-sent},
     u.updates_staged,
     u.updates_committed
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('webhook_text')
-webhook_text 2 true 2 2
+webhook_text 2 true true 2 2
 
 > DROP SOURCE webhook_text CASCADE;
 


### PR DESCRIPTION

* Adds a `bytes_sent` column to `mz_source_statistics`, which reports the number of bytes sent over the network by the source to the upstream.

* Add a `bytes_received` column to `mz_sink_statistics`, which reports the number of bytes received over the network by the sink from the downstream.

* Add internal Prometheus metrics for both of the above.

### Motivation

Implements features requested in https://github.com/MaterializeInc/materialize/issues/26349

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
