### PR TITLE
ore: Add must_use to drain_filter_swapping

### DIFF
--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -141,6 +141,7 @@ pub trait VecExt<T> {
     /// assert_eq!(evens, vec![2, 4, 14, 6, 8]);
     /// assert_eq!(odds, vec![1, 15, 3, 13, 5, 11, 9]);
     /// ```
+    #[must_use]
     fn drain_filter_swapping<F>(&mut self, filter: F) -> DrainFilterSwapping<'_, T, F>
     where
         F: FnMut(&mut T) -> bool;


### PR DESCRIPTION
This commit adds the `#[must_use]` annotation to the `drain_filter_swapping` function. `drain_filter_swapping` is evaluated lazily, so if the result is not used then it has no effect, and it is almost certainly a mistake. The annotation helps avoid this mistake by emitting a compiler warning.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
