### PR TITLE
clusterd: add metric for receipt of last envd command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5835,6 +5835,7 @@ dependencies = [
  "mz-secrets",
  "once_cell",
  "os_info",
+ "prometheus",
  "proptest",
  "proptest-derive",
  "prost",

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -28,6 +28,7 @@ mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes" }
 mz-ore = { path = "../ore" }
 once_cell = "1.16.0"
 os_info = "3.5.1"
+prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }


### PR DESCRIPTION
This will make it possible to write an alert to detect clusters that haven't heard from envd in a while, like we saw in MaterializeInc/incidents-and-escalations#28. Envd should be continually chatting with all clusters via the compute protocol, so any stall in communication is usually indicative of a severe problem.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
