### PR TITLE
push top_k negations down into reducer

### DIFF
--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -439,8 +439,8 @@ where
         };
         // Turn input into collection.
         let input = input.as_collection(|k, v| (k.into_owned(), v.into_owned()));
-        // Negate oks and concatenate them with the input.
-        (oks.negate().concat(&input), errs)
+        // Concatenate oks with the input.
+        (oks.concat(&input), errs)
     }
 
     fn render_top1_monotonic<S>(
@@ -577,7 +577,7 @@ where
                     if diff.is_positive() {
                         continue;
                     }
-                    target.push((err((*datums).into_owned()), -1));
+                    target.push((err((*datums).into_owned()), 1));
                     return;
                 }
             }
@@ -596,7 +596,7 @@ where
             // dependencies on the user-provided (potentially unbounded) limit.
             target.reserve(source.len());
             for (datums, diff) in source.iter() {
-                target.push((V::ok((*datums).into_owned()), diff.clone()));
+                target.push((V::ok((*datums).into_owned()), -diff));
             }
             // local copies that may count down to zero.
             let mut offset = offset;
@@ -644,7 +644,7 @@ where
                 if diff > 0 {
                     // Emit retractions for the elements actually part of
                     // the set of TopK elements.
-                    target.push((V::ok(datums.into_owned()), -diff));
+                    target.push((V::ok(datums.into_owned()), diff));
                 }
             }
         }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -365,8 +365,6 @@ where
     ///     | \
     ///     |  reduce
     ///     |  |
-    ///     |  negate
-    ///     |  |
     ///     concat
     ///     |
     ///     | output
@@ -437,9 +435,7 @@ where
 
             (input, stage, None)
         };
-        // Turn input into collection.
         let input = input.as_collection(|k, v| (k.into_owned(), v.into_owned()));
-        // Concatenate oks with the input.
         (oks.concat(&input), errs)
     }
 
@@ -543,7 +539,7 @@ where
     let mut datum_vec = mz_repr::DatumVec::new();
 
     // We only want to arrange parts of the input that are not part of the actual output
-    // such that `input.concat(&negated_output.negate())` yields the correct TopK
+    // such that `input.concat(&negated_output)` yields the correct TopK
     // NOTE(vmarcos): The arranged input operator name below is used in the tuning advice
     // built-in view mz_internal.mz_expected_group_size_advice.
     let arranged = input.mz_arrange::<RowRowSpine<_, _>>("Arranged TopK input");


### PR DESCRIPTION

Push negation in `build_topk_negated_stage` down into reducer.

### Motivation

This PR refactors existing code. The negation was being performed at a higher level, so that more work was done than necessary.

### Tips for reviewer


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
- [ ] 
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
