### PR TITLE
draft: determine subsource schema post source planning

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -484,14 +484,14 @@ impl Coordinator {
             PurifiedStatement::PurifiedCreateSource {
                 create_progress_subsource_stmt,
                 create_source_stmt,
-                create_subsource_stmts,
+                subsources,
             } => {
                 self.plan_purified_create_source(
                     &ctx,
                     params,
                     create_progress_subsource_stmt,
                     create_source_stmt,
-                    create_subsource_stmts,
+                    subsources,
                 )
                 .await
             }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -30,6 +30,7 @@ use mz_repr::{strconv, ColumnName, GlobalId};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{IdentError, UnresolvedItemName};
 use mz_sql_parser::parser::{ParserError, ParserStatementError};
+use mz_storage_types::sources::SubsourceResolutionError;
 
 use crate::catalog::{
     CatalogError, CatalogItemType, ErrorMessageObjectDescription, SystemObjectType,
@@ -257,6 +258,7 @@ pub enum PlanError {
         limit: Duration,
     },
     RetainHistoryRequired,
+    SubsourceResolutionError(SubsourceResolutionError),
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -725,6 +727,7 @@ impl fmt::Display for PlanError {
             Self::RetainHistoryRequired => {
                 write!(f, "RETAIN HISTORY cannot be disabled or set to 0")
             },
+            Self::SubsourceResolutionError(e) => write!(f, "{}", e),
         }
     }
 }
@@ -867,6 +870,12 @@ impl From<MySqlSourcePurificationError> for PlanError {
 impl From<IdentError> for PlanError {
     fn from(e: IdentError) -> Self {
         PlanError::InvalidIdent(e)
+    }
+}
+
+impl From<SubsourceResolutionError> for PlanError {
+    fn from(e: SubsourceResolutionError) -> Self {
+        PlanError::SubsourceResolutionError(e)
     }
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -95,7 +95,9 @@ use mz_storage_types::sources::postgres::{
     CastType, PostgresSourceConnection, PostgresSourcePublicationDetails,
     ProtoPostgresSourcePublicationDetails,
 };
-use mz_storage_types::sources::{GenericSourceConnection, SourceConnection, SourceDesc, Timeline};
+use mz_storage_types::sources::{
+    GenericSourceConnection, SourceConnection, SourceDesc, SubsourceResolver, Timeline,
+};
 use prost::Message;
 
 use crate::ast::display::AstDisplay;
@@ -798,38 +800,30 @@ pub fn plan_create_source(
             let details = ProtoPostgresSourcePublicationDetails::decode(&*details)
                 .map_err(|e| sql_err!("{}", e))?;
 
-            // Create a "catalog" of the tables in the PG details.
-            let mut tables_by_name = BTreeMap::new();
-            for table in details.tables.iter() {
-                tables_by_name
-                    .entry(table.name.clone())
-                    .or_insert_with(BTreeMap::new)
-                    .entry(table.namespace.clone())
-                    .or_insert_with(BTreeMap::new)
-                    .entry(connection.database.clone())
-                    .or_insert(table);
-            }
+            let publication_details = PostgresSourcePublicationDetails::from_proto(details)
+                .map_err(|e| sql_err!("{}", e))?;
 
-            let publication_catalog = crate::catalog::SubsourceCatalog(tables_by_name);
+            let subsource_resolver =
+                SubsourceResolver::new(&connection.database, &publication_details.tables)
+                    .expect("references validated during purification");
 
             let mut text_cols: BTreeMap<Oid, BTreeSet<String>> = BTreeMap::new();
 
             // Look up the referenced text_columns in the publication_catalog.
             for name in text_columns {
-                let (qual, col) = match name.0.split_last().expect("must have at least one element")
-                {
-                    (col, qual) => (UnresolvedItemName(qual.to_vec()), col.as_str().to_string()),
-                };
+                let (col, qual) = name.0.split_last().expect("must have at least one element");
 
-                let (_name, table_desc) = publication_catalog
-                    .resolve(qual)
+                let idx = subsource_resolver
+                    .resolve_idx(qual)
                     .expect("known to exist from purification");
+
+                let table_desc = &publication_details.tables[idx];
 
                 assert!(
                     table_desc
                         .columns
                         .iter()
-                        .find(|column| column.name == col)
+                        .find(|column| column.name == col.as_str())
                         .is_some(),
                     "validated column exists in table during purification"
                 );
@@ -837,7 +831,7 @@ pub fn plan_create_source(
                 text_cols
                     .entry(Oid(table_desc.oid))
                     .or_default()
-                    .insert(col);
+                    .insert(col.clone().into_string());
             }
 
             // Here we will generate the cast expressions required to convert the text encoded
@@ -846,7 +840,7 @@ pub fn plan_create_source(
             // on the target table
             let mut table_casts = BTreeMap::new();
 
-            for (i, table) in details.tables.iter().enumerate() {
+            for (i, table) in publication_details.tables.iter().enumerate() {
                 // First, construct an expression context where the expression is evaluated on an
                 // imaginary row which has the same number of columns as the upstream table but all
                 // of the types are text
@@ -996,9 +990,6 @@ pub fn plan_create_source(
                 let r = table_casts.insert(i + 1, column_casts);
                 assert!(r.is_none(), "cannot have table defined multiple times");
             }
-
-            let publication_details = PostgresSourcePublicationDetails::from_proto(details)
-                .map_err(|e| sql_err!("{}", e))?;
 
             let connection =
                 GenericSourceConnection::<ReferencedConnection>::from(PostgresSourceConnection {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -49,7 +49,9 @@ use mz_storage_types::connections::Connection;
 use mz_storage_types::errors::ContextCreationError;
 use mz_storage_types::sources::mysql::MySqlSourceDetails;
 use mz_storage_types::sources::postgres::PostgresSourcePublicationDetails;
-use mz_storage_types::sources::{GenericSourceConnection, SourceConnection};
+use mz_storage_types::sources::{
+    GenericSourceConnection, SourceConnection, SubsourceCatalogReference, SubsourceResolver,
+};
 use prost::Message;
 use protobuf_native::compiler::{SourceTreeDescriptorDatabase, VirtualSourceTree};
 use protobuf_native::MessageLite;
@@ -61,7 +63,7 @@ use crate::ast::{
     CreateSourceSubsource, CreateSubsourceStatement, CsrConnectionAvro, CsrConnectionProtobuf,
     Format, ProtobufSchema, ReferencedSubsources, Value, WithOptionValue,
 };
-use crate::catalog::{CatalogItemType, SessionCatalog, SubsourceCatalog};
+use crate::catalog::{CatalogItemType, SessionCatalog};
 use crate::kafka_util::{KafkaSinkConfigOptionExtracted, KafkaSourceConfigOptionExtracted};
 use crate::names::{
     Aug, FullItemName, PartialItemName, ResolvedColumnReference, ResolvedDataType, ResolvedIds,
@@ -88,9 +90,11 @@ pub(crate) struct RequestedSubsource<'a, T> {
     table: &'a T,
 }
 
-fn subsource_gen<'a, T>(
+fn subsource_gen<'a, T: SubsourceCatalogReference>(
     selected_subsources: &mut Vec<CreateSourceSubsource>,
-    catalog: &SubsourceCatalog<&'a T>,
+    resolver: &SubsourceResolver,
+    references: &'a [T],
+    canonical_width: usize,
     source_name: &UnresolvedItemName,
 ) -> Result<Vec<RequestedSubsource<'a, T>>, PlanError> {
     let mut validated_requested_subsources = vec![];
@@ -118,12 +122,15 @@ fn subsource_gen<'a, T>(
             }
         };
 
-        let (qualified_upstream_name, desc) = catalog.resolve(subsource.reference.clone())?;
+        let (qualified_upstream_name, idx) =
+            resolver.resolve(&subsource.reference.0, canonical_width)?;
+
+        let table = &references[idx];
 
         validated_requested_subsources.push(RequestedSubsource {
             upstream_name: qualified_upstream_name,
             subsource_name,
-            table: *desc,
+            table,
         });
     }
 
@@ -715,10 +722,8 @@ async fn purify_create_source(
                 ))?;
             }
 
-            let publication_catalog = postgres::derive_catalog_from_publication_tables(
-                &connection.database,
-                &publication_tables,
-            )?;
+            let subsource_resolver =
+                SubsourceResolver::new(&connection.database, &publication_tables)?;
 
             let mut validated_requested_subsources = vec![];
             match referenced_subsources
@@ -788,7 +793,9 @@ async fn purify_create_source(
                     // validate that the names actually exist and are not ambiguous
                     validated_requested_subsources.extend(subsource_gen(
                         subsources,
-                        &publication_catalog,
+                        &subsource_resolver,
+                        &publication_tables,
+                        3,
                         source_name,
                     )?);
                 }
@@ -816,7 +823,8 @@ async fn purify_create_source(
             .await?;
 
             let text_cols_dict = postgres::generate_text_columns(
-                &publication_catalog,
+                &subsource_resolver,
+                &publication_tables,
                 &mut text_columns,
                 &PgConfigOptionName::TextColumns.to_ast_string(),
             )?;
@@ -1015,7 +1023,7 @@ async fn purify_create_source(
                 Err(MySqlSourcePurificationError::EmptyDatabase)?;
             }
 
-            let mysql_catalog = mysql::derive_catalog_from_tables(&tables)?;
+            let subsource_resolver = SubsourceResolver::new(MYSQL_DATABASE_FAKE_NAME, &tables)?;
 
             // Normalize column options and remove unused column references.
             if let Some(text_cols_option) = options
@@ -1023,7 +1031,7 @@ async fn purify_create_source(
                 .find(|option| option.name == MySqlConfigOptionName::TextColumns)
             {
                 text_cols_option.value = Some(WithOptionValue::Sequence(
-                    mysql::normalize_column_refs(text_columns, &mysql_catalog)?,
+                    mysql::normalize_column_refs(text_columns, &subsource_resolver, &tables)?,
                 ));
             }
             if let Some(ignore_cols_option) = options
@@ -1031,7 +1039,7 @@ async fn purify_create_source(
                 .find(|option| option.name == MySqlConfigOptionName::IgnoreColumns)
             {
                 ignore_cols_option.value = Some(WithOptionValue::Sequence(
-                    mysql::normalize_column_refs(ignore_columns, &mysql_catalog)?,
+                    mysql::normalize_column_refs(ignore_columns, &subsource_resolver, &tables)?,
                 ));
             }
 
@@ -1084,21 +1092,7 @@ async fn purify_create_source(
                     // The user manually selected a subset of upstream tables so we need to
                     // validate that the names actually exist and are not ambiguous
                     validated_requested_subsources =
-                        subsource_gen(subsources, &mysql_catalog, source_name)?;
-
-                    // subsource_gen automatically inserts the "fully qualified
-                    // name," which for MySQL sources includes the fake database
-                    // name.
-                    for requested_subsource in validated_requested_subsources.iter_mut() {
-                        let fake_database_name = requested_subsource.upstream_name.0.remove(0);
-                        if fake_database_name.as_str() != MYSQL_DATABASE_FAKE_NAME {
-                            sql_bail!(
-                                    "[internal error]: expected first element of upstream reference to be {}, but is {}",
-                                    MYSQL_DATABASE_FAKE_NAME,
-                                    fake_database_name.as_str()
-                                );
-                        }
-                    }
+                        subsource_gen(subsources, &subsource_resolver, &tables, 2, source_name)?;
                 }
             }
 
@@ -1398,14 +1392,14 @@ async fn purify_alter_source(
         ))?;
     }
 
-    let publication_catalog = postgres::derive_catalog_from_publication_tables(
-        &pg_connection.database,
-        &new_publication_tables,
-    )?;
+    let subsource_resolver =
+        SubsourceResolver::new(&pg_connection.database, &new_publication_tables)?;
 
     let validated_requested_subsources = subsource_gen(
         &mut targeted_subsources,
-        &publication_catalog,
+        &subsource_resolver,
+        &new_publication_tables,
+        3,
         &unresolved_source_name,
     )?;
 
@@ -1424,9 +1418,8 @@ async fn purify_alter_source(
     .await?;
 
     let text_cols_dict = postgres::generate_text_columns(
-        &publication_catalog,
-        // In addition to using the `text_columns` values here, we also fully
-        // normalize the objects to which they refer.
+        &subsource_resolver,
+        &new_publication_tables,
         &mut text_columns,
         &AlterSourceAddSubsourceOptionName::TextColumns.to_ast_string(),
     )?;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -803,10 +803,15 @@ async fn purify_create_source(
 
             validate_subsource_names(&validated_requested_subsources)?;
 
+            let table_oids: Vec<_> = validated_requested_subsources
+                .iter()
+                .map(|r| r.table.oid)
+                .collect();
+
             postgres::validate_requested_subsources_privileges(
                 &config,
-                &validated_requested_subsources,
                 &storage_configuration.connection_context.ssh_tunnel_manager,
+                &table_oids,
             )
             .await?;
 
@@ -1406,10 +1411,15 @@ async fn purify_alter_source(
 
     validate_subsource_names(&validated_requested_subsources)?;
 
+    let table_oids: Vec<_> = validated_requested_subsources
+        .iter()
+        .map(|r| r.table.oid)
+        .collect();
+
     postgres::validate_requested_subsources_privileges(
         &config,
-        &validated_requested_subsources,
         &storage_configuration.connection_context.ssh_tunnel_manager,
+        &table_oids,
     )
     .await?;
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1032,7 +1032,7 @@ where
                     };
 
                     if subsource_resolver
-                        .resolve_details_idx(&external_reference.0)
+                        .resolve_idx(&external_reference.0)
                         .is_err()
                     {
                         tracing::warn!(

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -189,7 +189,7 @@ impl<S: Clone> IngestionDescription<S> {
             let ingestion_output = match ingestion_output {
                 Some(ingestion_output) => {
                     subsource_resolver
-                        .resolve_details_idx(&ingestion_output.0)
+                        .resolve_idx(&ingestion_output.0)
                         .expect("must have all subsource references")
                         // output indices are the native details idx + 1 to
                         // account for the `None` value representing 0.
@@ -1448,6 +1448,41 @@ impl<'a> SubsourceResolver {
         Ok(SubsourceResolver { inner })
     }
 
+    /// Returns the canonical reference and index from which it originated in
+    /// the `referenceable_items` provided to [`Self::new`].
+    ///
+    /// # Args
+    /// - `name` is `&[Ident]` to let users provide the inner element of either
+    ///   [`UnresolvedItemName`] or [`ExportReference`].
+    /// - `canonicalize_to_width` limits the number of elements in the returned
+    ///   [`UnresolvedItemName`];this is useful if the source type requires
+    ///   contriving database and schema names that a subsource should not
+    ///   persist as its reference.
+    ///
+    /// # Errors
+    /// - If `name` does not resolve to an item in `self.inner`.
+    ///
+    /// # Panics
+    /// - If `canonicalize_to_width`` is not in `1..=3`.
+    pub fn resolve(
+        &self,
+        name: &[Ident],
+        canonicalize_to_width: usize,
+    ) -> Result<(UnresolvedItemName, usize), SubsourceResolutionError> {
+        let (db, schema, idx) = self.resolve_inner(name)?;
+
+        let item = name.last().expect("must have provided at least 1 element");
+
+        let canonical_name = match canonicalize_to_width {
+            1 => vec![item.clone()],
+            2 => vec![schema.clone(), item.clone()],
+            3 => vec![db.clone(), schema.clone(), item.clone()],
+            o => panic!("canonicalize_to_width values must be 1..=3, but got {}", o),
+        };
+
+        Ok((UnresolvedItemName(canonical_name), idx))
+    }
+
     /// Returns the index from which it originated in the `referenceable_items`
     /// provided to [`Self::new`].
     ///
@@ -1456,15 +1491,38 @@ impl<'a> SubsourceResolver {
     /// [`UnresolvedItemName`] or [`ExportReference`].
     ///
     /// # Errors
-    /// - If the `UnresolvedItemName` does not resolve to an item in
-    ///   `self.inner`.
-    pub fn resolve_details_idx(&self, name: &[Ident]) -> Result<usize, SubsourceResolutionError> {
-        let provided_name = UnresolvedItemName(name.to_vec()).to_string();
+    /// - If `name` does not resolve to an item in `self.inner`.
+    pub fn resolve_idx(&self, name: &[Ident]) -> Result<usize, SubsourceResolutionError> {
+        let (_db, _schema, idx) = self.resolve_inner(name)?;
+        Ok(idx)
+    }
+
+    /// Returns the index from which it originated in the `referenceable_items`
+    /// provided to [`Self::new`].
+    ///
+    /// # Args
+    /// `name` is `&[Ident]` to let users provide the inner element of either
+    /// [`UnresolvedItemName`] or [`ExportReference`].
+    ///
+    /// # Return
+    /// Returns a tuple whose elements are:
+    /// 1. The "database"- or top-level namespace of the reference.
+    /// 2. The "schema"- or second-level namespace of the reference.
+    /// 3. The index to find the item in `referenceable_items` argument provided
+    ///    to `SubsourceResolver::new`.
+    ///
+    /// # Errors
+    /// - If `name` does not resolve to an item in `self.inner`.
+    fn resolve_inner<'name: 'a>(
+        &'a self,
+        name: &'name [Ident],
+    ) -> Result<(&'a Ident, &'a Ident, usize), SubsourceResolutionError> {
+        let get_provided_name = || UnresolvedItemName(name.to_vec()).to_string();
 
         // Names must be composed of 1..=3 elements.
         if !(1..=3).contains(&name.len()) {
             Err(SubsourceResolutionError::DoesNotExist {
-                name: provided_name.clone(),
+                name: get_provided_name(),
             })?;
         }
 
@@ -1486,7 +1544,7 @@ impl<'a> SubsourceResolver {
             self.inner
                 .get(item)
                 .ok_or_else(|| SubsourceResolutionError::DoesNotExist {
-                    name: provided_name.clone(),
+                    name: get_provided_name(),
                 })?;
 
         let schema =
@@ -1494,7 +1552,7 @@ impl<'a> SubsourceResolver {
                 Some(schema) => schema,
                 None => schemas.keys().exactly_one().map_err(|_e| {
                     SubsourceResolutionError::Ambiguous {
-                        name: provided_name.clone(),
+                        name: get_provided_name(),
                     }
                 })?,
             };
@@ -1503,14 +1561,14 @@ impl<'a> SubsourceResolver {
             schemas
                 .get(schema)
                 .ok_or_else(|| SubsourceResolutionError::DoesNotExist {
-                    name: provided_name.clone(),
+                    name: get_provided_name(),
                 })?;
 
         let database = match database {
             Some(database) => database,
             None => databases.keys().exactly_one().map_err(|_e| {
                 SubsourceResolutionError::Ambiguous {
-                    name: provided_name.clone(),
+                    name: get_provided_name(),
                 }
             })?,
         };
@@ -1519,12 +1577,10 @@ impl<'a> SubsourceResolver {
             databases
                 .get(database)
                 .ok_or_else(|| SubsourceResolutionError::DoesNotExist {
-                    name: provided_name.clone(),
+                    name: get_provided_name(),
                 })?;
 
-        // TODO: this same function could also be used to generate canonical
-        // references for subsources.
-        Ok(*reference_idx)
+        Ok((database, schema, *reference_idx))
     }
 }
 

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -369,7 +369,7 @@ INSERT INTO table_f VALUES (3, 'var1');
 <null>
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS (table_z.a));
-contains:invalid TEXT COLUMNS option value: table table_z not found in source
+contains:invalid TEXT COLUMNS option value: reference to table_z not found in source
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS [table_f.f2]);
 contains:TEXT COLUMNS refers to table not currently being added

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -282,7 +282,7 @@ contains: CREATE SOURCE specifies DETAILS option
     "pk_table"
   );
 contains:referenced items not tables with REPLICA IDENTITY FULL
-detail:referenced items: no_replica_identity
+detail:referenced items: public.no_replica_identity
 
 #
 # Establish direct replication

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -704,7 +704,7 @@ hint: The similarly named column "pk_table.f2" does exist.
   FOR TABLES (
     "enum_table"
   );
-contains: invalid TEXT COLUMNS option value: table table_dne not found in source
+contains: invalid TEXT COLUMNS option value: reference to table_dne not found in source
 
 # Reference exists in two schemas, so is not unambiguous
 ! CREATE SOURCE enum_source
@@ -717,7 +717,7 @@ contains: invalid TEXT COLUMNS option value: table table_dne not found in source
     conflict_schema.another_enum_table AS conflict_enum,
     public.another_enum_table AS public_enum
   );
-contains: invalid TEXT COLUMNS option value: table another_enum_table is ambiguous, consider specifying the schema
+contains: invalid TEXT COLUMNS option value: reference to another_enum_table is ambiguous, consider specifying an additional layer of qualification
 
 ! CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster
@@ -735,7 +735,7 @@ contains: invalid TEXT COLUMNS option value: column name 'foo' must have at leas
     TEXT COLUMNS [foo.bar.qux.qax.foo]
   )
   FOR TABLES (pk_table);
-contains: invalid TEXT COLUMNS option value: qualified name did not have between 1 and 3 components: foo.bar.qux.qax
+contains: invalid TEXT COLUMNS option value: reference to foo.bar.qux.qax not found in source
 
 ! CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster
@@ -754,7 +754,7 @@ contains: invalid TEXT COLUMNS option value: unexpected multiple references to p
     TEXT COLUMNS [enum_table.a, utf8_table.f1]
   )
   FOR TABLES (enum_table);
-contains: invalid TEXT COLUMNS option value: table utf8_table not found in source
+contains: invalid TEXT COLUMNS option value: reference to utf8_table not found in source
 
 # n.b includes a reference to pk_table, which is not a table that's part of the
 # source, but is part of the publication.

--- a/test/pg-cdc/publication-for-table.td
+++ b/test/pg-cdc/publication-for-table.td
@@ -48,4 +48,4 @@ CREATE PUBLICATION mz_source FOR TABLE t1;
 ! CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES (t2);
-contains:table t2 not found
+contains:reference to t2 not found in source

--- a/test/pg-cdc/replica-identity.td
+++ b/test/pg-cdc/replica-identity.td
@@ -34,7 +34,7 @@ INSERT INTO tbl_a VALUES (1);
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES(tbl_a);
 contains:referenced items not tables with REPLICA IDENTITY FULL
-detail:referenced items: tbl_a
+detail:referenced items: public.tbl_a
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE tbl_a REPLICA IDENTITY FULL

--- a/test/pg-cdc/two-source-schemas.td
+++ b/test/pg-cdc/two-source-schemas.td
@@ -52,7 +52,7 @@ contains:multiple subsources would be named t1
 ! CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES (t1);
-contains:table t1 is ambiguous, consider specifying the schema
+contains:reference to t1 is ambiguous, consider specifying an additional layer of qualification
 
 > CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')


### PR DESCRIPTION
The commits in the PR refactor source+subsource planning such that we now generate `CreateSubsourceStatement`s after planning the primary source itself. This refactor is necessary to complete #20208, where we will need to know the schema of the Kafka source's output (to determine the schema of its single `IngestionExport`), which is only determined after the primary source itself has been planned.

This PR is only a sketch and likely breaks some of purification's invariants w/r/t normalizing options. There are also many more LOC that coould be refactored to streamline this process––e.g. this code uses `ValidatedRequestedSubsources`, but there is likely a graceful refactor that entirely eliminates the need for that struct.

Includes #27276

### Motivation

This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
