### PR TITLE
storage,persist: allow callers of persist_source to handle "cannot serve..." errors

### DIFF
--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -221,6 +221,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                     let (mut ok_stream, err_stream, token) = persist_source::persist_source(
                         inner,
                         *source_id,
+                        "compute_import",
                         Arc::clone(&compute_state.persist_clients),
                         &compute_state.txns_ctx,
                         &compute_state.worker_config,

--- a/src/compute/src/render.rs
+++ b/src/compute/src/render.rs
@@ -221,7 +221,6 @@ pub fn build_compute_dataflow<A: Allocate>(
                     let (mut ok_stream, err_stream, token) = persist_source::persist_source(
                         inner,
                         *source_id,
-                        "compute_import",
                         Arc::clone(&compute_state.persist_clients),
                         &compute_state.txns_ctx,
                         &compute_state.worker_config,
@@ -232,6 +231,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         mfp.as_mut(),
                         compute_state.dataflow_max_inflight_bytes(),
                         start_signal.clone(),
+                        |error| panic!("compute_import: {error}"),
                     );
 
                     // If `mfp` is non-identity, we need to apply what remains.

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -106,6 +106,7 @@ where
     let (persist_oks, persist_errs, token) = mz_storage_operators::persist_source::persist_source(
         &mut desired_oks.scope(),
         sink_id,
+        "compute_persist_sink",
         Arc::clone(&compute_state.persist_clients),
         &compute_state.txns_ctx,
         &compute_state.worker_config,

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -106,7 +106,6 @@ where
     let (persist_oks, persist_errs, token) = mz_storage_operators::persist_source::persist_source(
         &mut desired_oks.scope(),
         sink_id,
-        "compute_persist_sink",
         Arc::clone(&compute_state.persist_clients),
         &compute_state.txns_ctx,
         &compute_state.worker_config,
@@ -117,6 +116,7 @@ where
         None,             // no MFP
         compute_state.dataflow_max_inflight_bytes(),
         start_signal,
+        |error| panic!("compute_persist_sink: {error}"),
     );
 
     Some(Rc::new((

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -134,6 +134,7 @@ impl Subtime {
 pub fn persist_source<G>(
     scope: &mut G,
     source_id: GlobalId,
+    purpose: &str,
     persist_clients: Arc<PersistClientCache>,
     txns_ctx: &TxnsContext,
     // In case we need to use a dyncfg to decide which operators to render in a
@@ -200,6 +201,7 @@ where
         let (stream, source_tokens) = persist_source_core(
             scope,
             source_id,
+            purpose,
             Arc::clone(&persist_clients),
             metadata.clone(),
             as_of.clone(),
@@ -269,6 +271,7 @@ type RefinedScope<'g, G> = Child<'g, G, (<G as ScopeParent>::Timestamp, Subtime)
 pub fn persist_source_core<'g, G>(
     scope: &RefinedScope<'g, G>,
     source_id: GlobalId,
+    purpose: &str,
     persist_clients: Arc<PersistClientCache>,
     metadata: CollectionMetadata,
     as_of: Option<Antichain<Timestamp>>,
@@ -337,6 +340,7 @@ where
     let (fetched, token) = shard_source(
         &mut scope.clone(),
         &name,
+        purpose,
         move || {
             let (c, l) = (
                 Arc::clone(&persist_clients),

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -70,7 +70,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
         async {},
         move |error| {
             let error = format!("storage_sink: {error}");
-            tracing::error!("{error}");
+            tracing::info!("{error}");
             let mut command_tx = command_tx.borrow_mut();
             command_tx.broadcast(InternalStorageCommand::SuspendAndRestart {
                 id: sink_id,

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -54,6 +54,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
     let (ok_collection, err_collection, persist_tokens) = persist_source::persist_source(
         scope,
         sink.from,
+        "sink",
         Arc::clone(&storage_state.persist_clients),
         &storage_state.txns_ctx,
         storage_state.storage_configuration.config_set(),

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -309,7 +309,6 @@ where
                             let (stream, tok) = persist_source::persist_source_core(
                                 scope,
                                 id,
-                                "upsert_rehydration",
                                 persist_clients,
                                 description.ingestion_metadata,
                                 Some(as_of),
@@ -319,6 +318,7 @@ where
                                 flow_control,
                                 false.then_some(|| unreachable!()),
                                 async {},
+                                |error| panic!("upsert_rehydration: {error}"),
                             );
                             (
                                 stream.as_collection(),

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -309,6 +309,7 @@ where
                             let (stream, tok) = persist_source::persist_source_core(
                                 scope,
                                 id,
+                                "upsert_rehydration",
                                 persist_clients,
                                 description.ingestion_metadata,
                                 Some(as_of),

--- a/src/txn-wal/src/operator.rs
+++ b/src/txn-wal/src/operator.rs
@@ -648,7 +648,6 @@ impl DataSubscribe {
                 let (data_stream, token) = shard_source::<String, (), u64, i64, _, _, _, _>(
                     scope,
                     name,
-                    "data_subscribe",
                     move || std::future::ready(client.clone()),
                     data_id,
                     Some(Antichain::from_elem(as_of)),
@@ -660,6 +659,7 @@ impl DataSubscribe {
                     |_, _| true,
                     false.then_some(|| unreachable!()),
                     async {},
+                    |error| panic!("data_subscribe: {error}"),
                     ProjectionPushdown::FetchAll,
                 );
                 (data_stream.leave(), token)

--- a/src/txn-wal/src/operator.rs
+++ b/src/txn-wal/src/operator.rs
@@ -648,6 +648,7 @@ impl DataSubscribe {
                 let (data_stream, token) = shard_source::<String, (), u64, i64, _, _, _, _>(
                     scope,
                     name,
+                    "data_subscribe",
                     move || std::future::ready(client.clone()),
                     data_id,
                     Some(Antichain::from_elem(as_of)),


### PR DESCRIPTION
    storage,persist: allow callers of persist_source to handle "cannot serve..." errors
    
    Partially fixes #19097
    
    Most callers will panic, as before, but they now include their purpose
    in the panic message.
    
    For storage sinks, we now trigger a graceful suspend-and-restart, which
    will get rid of at least one scenario where we previously were seeing
    this panic in CI.
    
    The machanism of the panic for sinks was:
    
    1. We create the source/sink, sending render commands to the cluster.
    2. Cluster does not start rendering yet, for reasons… delays and
       whatnot.
    3. We drop the database which immediately drops the source/sinks,
       releases critical since handles and the like.
    4. **Now the cluster wakes up and tries to render the sink. This fails
       with a panic!**
    
    With this fix, we would trigger a suspend-and-restart but eventually
    notice that the sink has been dropped and not try to re-render its
    dataflow.

Partially fixes #19097

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
