### PR TITLE
doc/user: add anchor links to functions in docs

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -53,9 +53,8 @@ table.inline-headings {
             margin-bottom: 0.3em;
             padding-left: 2em;
         }
-        p.heading {
-            margin-bottom: -0.1em;
-            text-indent: -1.75em;
+        .heading .highlight {
+            display: inline-block;
         }
     }
 }

--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -79,7 +79,7 @@ Apache License, Version 2.0. */}}
     <script>
       /* Add anchor links to headings */
       anchors.add(
-        ".content h2, .content h3, .content h4, .content h5, .content h6"
+        ".content h2, .content h3, .content h4, .content h5, .content h6, .heading"
       );
 
       /* Copy anchor links to clipboard on click */

--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -34,9 +34,9 @@
       {{/*  We use clojure highlighting simply because it looks best with the
       components we want to highlight. In the future, this should be customized
       in some way.  */}}
-      <p class="heading {{if (not (isset $.Params 0))}}docsearch_l3{{end}}" id="{{ index (split .signature "(") 0 | urlize }}">
-        {{ highlight .signature "clojure" "hl_inline=true" }}
-      </p>
+      <div class="heading {{if (not (isset $.Params 0))}}docsearch_l3{{end}}" id="{{ index (split .signature "(") 0 | urlize }}">
+        {{ highlight .signature "clojure" "hl_inline=false" }}
+      </div>
 
       <p>
         {{ .description | $.Page.RenderString }}


### PR DESCRIPTION
Also swapping the &lt;p> for a &lt;div>, which should fix Algolia's scraping of function names.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
