### PR TITLE
tests: automatically retry data-ingest on network error

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1299,6 +1299,10 @@ steps:
     label: "Data Ingest"
     depends_on: build-aarch64
     timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: 75
+          limit: 1
     agents:
       queue: linux-aarch64
     plugins:


### PR DESCRIPTION
This error occurred a couple of times recently:

```
Match in build MaterializeInc/database-issues#2432 (pipeline nightly on main):
URL: https://buildkite.com/materialize/nightly/builds/7907
Annotation: Data Ingest
-------------------------------------------------------------------------------------
Match in build MaterializeInc/database-issues#2430 (pipeline nightly on main):
URL: https://buildkite.com/materialize/nightly/builds/7900
Annotation: Data Ingest
-------------------------------------------------------------------------------------
Match in build MaterializeInc/database-issues#2418 (pipeline nightly on aljoscha:storage-factor-out-storage-collections):
URL: https://buildkite.com/materialize/nightly/builds/7872
Annotation: Data Ingest
-------------------------------------------------------------------------------------
Match in build MaterializeInc/materialize#7830 (pipeline nightly on teskje:frontiers-update-unknown-panic):
URL: https://buildkite.com/materialize/nightly/builds/7830
Annotation: Data Ingest
```