### PR TITLE
expr: always display sources in explain plans

### DIFF
--- a/misc/python/materialize/checks/all_checks/materialized_views.py
+++ b/misc/python/materialize/checks/all_checks/materialized_views.py
@@ -170,17 +170,23 @@ class MaterializedViewsAssertNotNull(Check):
             Explained Query:
               ReadStorage materialize.public.not_null_view1
 
+            Source materialize.public.not_null_view1
+
             Target cluster: quickstart
 
             ? EXPLAIN SELECT * FROM not_null_view2 WHERE y IS NOT NULL
             Explained Query:
               ReadStorage materialize.public.not_null_view2
 
+            Source materialize.public.not_null_view2
+
             Target cluster: quickstart
 
             ? EXPLAIN SELECT * FROM not_null_view3 WHERE z IS NOT NULL
             Explained Query:
               ReadStorage materialize.public.not_null_view3
+
+            Source materialize.public.not_null_view3
 
             Target cluster: quickstart
 

--- a/src/adapter/src/explain/mir.rs
+++ b/src/adapter/src/explain/mir.rs
@@ -133,9 +133,9 @@ impl<'a> Explainable<'a, DataflowDescription<OptimizedMirRelationExpr>> {
             .0
             .source_imports
             .iter_mut()
-            .filter_map(|(id, (source_desc, _))| {
+            .map(|(id, (source_desc, _))| {
                 let op = source_desc.arguments.operators.as_ref();
-                op.map(|op| ExplainSource::new(*id, op, context.config.filter_pushdown))
+                ExplainSource::new(*id, op, context.config.filter_pushdown)
             })
             .collect::<Vec<_>>();
 

--- a/src/compute-types/src/explain.rs
+++ b/src/compute-types/src/explain.rs
@@ -69,9 +69,9 @@ impl<'a> DataflowDescription<Plan> {
         let sources = self
             .source_imports
             .iter_mut()
-            .filter_map(|(id, (source_desc, _))| {
+            .map(|(id, (source_desc, _))| {
                 let op = source_desc.arguments.operators.as_ref();
-                op.map(|op| ExplainSource::new(*id, op, context.config.filter_pushdown))
+                ExplainSource::new(*id, op, context.config.filter_pushdown)
             })
             .collect::<Vec<_>>();
 
@@ -137,9 +137,9 @@ impl<'a> DataflowDescription<OptimizedMirRelationExpr> {
         let sources = self
             .source_imports
             .iter_mut()
-            .filter_map(|(id, (source_desc, _))| {
+            .map(|(id, (source_desc, _))| {
                 let op = source_desc.arguments.operators.as_ref();
-                op.map(|op| ExplainSource::new(*id, op, context.config.filter_pushdown))
+                ExplainSource::new(*id, op, context.config.filter_pushdown)
             })
             .collect::<Vec<_>>();
 

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -140,7 +140,9 @@ where
                     // pass it to the ExplainSource rendering code.
                     if let Some(cols) = cols.as_mut() {
                         let anonymous = std::iter::repeat(String::new());
-                        cols.extend(anonymous.take(src.op.expressions.len()))
+                        cols.extend(
+                            anonymous.take(src.op.map(|op| op.expressions.len()).unwrap_or(0)),
+                        )
                     };
                     // Render source with humanized expressions.
                     mode.expr(src, cols.as_ref()).fmt_text(f, &mut ctx)?;

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -232,6 +232,8 @@ Explained Query:
     Map (integer_to_bigint(#1)) // { arity: 4 }
       ReadStorage materialize.public.agg_pk // { arity: 3 }
 
+Source materialize.public.agg_pk
+
 Target cluster: quickstart
 
 EOF
@@ -250,6 +252,8 @@ Explained Query:
   Project (#0, #3) // { arity: 2 }
     Map (bigint_to_numeric(#2)) // { arity: 4 }
       ReadStorage materialize.public.agg_pk // { arity: 3 }
+
+Source materialize.public.agg_pk
 
 Target cluster: quickstart
 
@@ -735,6 +739,8 @@ Explained Query:
     cte l0 =
       Reduce aggregates=[sum((#0 * #0)), sum(#0), count(#0)]
         ReadStorage materialize.public.t_variance
+
+Source materialize.public.t_variance
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -961,6 +961,8 @@ Explained Query:
     Map (((#0 >> smallint_to_integer(#1)) << smallint_to_integer(#2)), ((#3 << #4) >> #5)) // { arity: 11 }
       ReadStorage materialize.public.nums // { arity: 9 }
 
+Source materialize.public.nums
+
 Target cluster: quickstart
 
 EOF
@@ -993,6 +995,8 @@ Explained Query:
   Project (#9, #10) // { arity: 2 }
     Map (((#0 >> smallint_to_integer(#1)) & #2), ((#3 << #4) & #5)) // { arity: 11 }
       ReadStorage materialize.public.nums // { arity: 9 }
+
+Source materialize.public.nums
 
 Target cluster: quickstart
 
@@ -1029,6 +1033,8 @@ Explained Query:
     Map (((#0 & #1) | #2), ((#3 & #4) | #5), ((#6 & #7) | #8), (integer_to_bigint((smallint_to_integer(#0) & #4)) | #8)) // { arity: 13 }
       ReadStorage materialize.public.nums // { arity: 9 }
 
+Source materialize.public.nums
+
 Target cluster: quickstart
 
 EOF
@@ -1064,6 +1070,8 @@ Explained Query:
     Map (((#0 # #1) & #2), ((#3 # #4) & #5), ((#6 # #7) & #8), (integer_to_bigint((smallint_to_integer(#0) # #4)) & #8)) // { arity: 13 }
       ReadStorage materialize.public.nums // { arity: 9 }
 
+Source materialize.public.nums
+
 Target cluster: quickstart
 
 EOF
@@ -1098,6 +1106,8 @@ Explained Query:
   Project (#9..=#12) // { arity: 4 }
     Map (((#0 # #1) | #2), ((#3 # #4) | #5), ((#6 # #7) | #8), (integer_to_bigint((smallint_to_integer(#0) # #4)) | #8)) // { arity: 13 }
       ReadStorage materialize.public.nums // { arity: 9 }
+
+Source materialize.public.nums
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -100,6 +100,8 @@ Explained Query:
     Reduce group_by=[(#0 % 5)] aggregates=[sum((#0 * #1)), max(#1)] // { arity: 3 }
       ReadStorage materialize.public.v // { arity: 2 }
 
+Source materialize.public.v
+
 Target cluster: quickstart
 
 EOF

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -38,6 +38,8 @@ Explained Query:
     Filter (#0) IS NOT NULL // { types: "(double precision, boolean?)" }
       ReadStorage materialize.public.v // { types: "(double precision?, boolean?)" }
 
+Source materialize.public.v
+
 Target cluster: quickstart
 
 EOF
@@ -52,6 +54,8 @@ Explained Query:
       ReadStorage materialize.public.v // { types: "(double precision?, boolean?)" }
     Filter (#0) IS NOT NULL // { types: "(double precision, boolean?)" }
       ReadStorage materialize.public.v // { types: "(double precision?, boolean?)" }
+
+Source materialize.public.v
 
 Target cluster: quickstart
 
@@ -74,6 +78,8 @@ Explained Query:
             ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
       Constant // { types: "(bigint, text, date?)" }
         - (1, "hello", null)
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -115,6 +121,7 @@ Explained Query:
 
 Source materialize.public.t
   filter=((#0) IS NOT NULL)
+Source materialize.public.u
 
 Target cluster: quickstart
 
@@ -151,6 +158,7 @@ Explained Query:
       Constant // { types: "(boolean?, bigint)" }
         - (null, 10)
 
+Source materialize.public.u
 Source materialize.public.v
   filter=((#0) IS NOT NULL)
 

--- a/test/sqllogictest/attributes/mir_unique_keys.slt
+++ b/test/sqllogictest/attributes/mir_unique_keys.slt
@@ -41,6 +41,8 @@ Explained Query:
         Project (#0) // { keys: "()" }
           ReadStorage materialize.public.t // { keys: "()" }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -269,6 +269,8 @@ Explained Query:
     Map ((#0 != #1), (#0 = #1), (#0 >= #1), (#0 <= #1), (#0 < #1), (#0 > #1), NOT((#2 @> {}))) // { arity: 11 }
       ReadStorage materialize.public.x // { arity: 4 }
 
+Source materialize.public.x
+
 Target cluster: quickstart
 
 EOF
@@ -286,6 +288,8 @@ Explained Query:
   Project (#0) // { arity: 1 }
     ReadStorage materialize.public.y // { arity: 2 }
 
+Source materialize.public.y
+
 Target cluster: quickstart
 
 EOF
@@ -300,6 +304,8 @@ Explained Query:
   Project (#2) // { arity: 1 }
     Map ((null OR NOT(#1) OR (#1) IS NULL)) // { arity: 3 }
       ReadStorage materialize.public.y // { arity: 2 }
+
+Source materialize.public.y
 
 Target cluster: quickstart
 
@@ -317,6 +323,8 @@ Explained Query:
     Map ((#1 AND null AND (#1) IS NOT NULL)) // { arity: 3 }
       ReadStorage materialize.public.y // { arity: 2 }
 
+Source materialize.public.y
+
 Target cluster: quickstart
 
 EOF
@@ -331,6 +339,8 @@ Explained Query:
   Project (#2) // { arity: 1 }
     Map ((null OR (#1 AND (#1) IS NOT NULL))) // { arity: 3 }
       ReadStorage materialize.public.y // { arity: 2 }
+
+Source materialize.public.y
 
 Target cluster: quickstart
 
@@ -347,6 +357,8 @@ Explained Query:
     Map ((null AND (NOT(#1) OR (#1) IS NULL))) // { arity: 3 }
       ReadStorage materialize.public.y // { arity: 2 }
 
+Source materialize.public.y
+
 Target cluster: quickstart
 
 EOF
@@ -360,6 +372,8 @@ Explained Query:
   Project (#2) // { arity: 1 }
     Map ((NOT(#1) OR (#1) IS NULL)) // { arity: 3 }
       ReadStorage materialize.public.y // { arity: 2 }
+
+Source materialize.public.y
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -607,6 +607,15 @@ Explained Query:
       ArrangeBy keys=[[#0]]
         ReadStorage materialize.public.t10
 
+Source materialize.public.t3
+Source materialize.public.t4
+Source materialize.public.t5
+Source materialize.public.t6
+Source materialize.public.t7
+Source materialize.public.t8
+Source materialize.public.t9
+Source materialize.public.t10
+
 Used Indexes:
   - materialize.public.t_x (delta join 1st input (full scan))
   - materialize.public.tt_x (delta join lookup)

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -415,6 +415,8 @@ Explained Query:
             ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
               ReadIndex on=orderline fk_orderline_order=[delta join lookup] // { arity: 10 }
 
+Source materialize.public.neworder
+
 Used Indexes:
   - materialize.public.fk_customer_district (*** full scan ***)
   - materialize.public.fk_order_customer (*** full scan ***)
@@ -1083,6 +1085,8 @@ Explained Query:
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   Project (#0, #4) // { arity: 2 }
                     ReadStorage materialize.public.item // { arity: 5 }
+
+Source materialize.public.item
 
 Used Indexes:
   - materialize.public.fk_orderline_item (differential join)

--- a/test/sqllogictest/distinct_on.slt
+++ b/test/sqllogictest/distinct_on.slt
@@ -36,6 +36,8 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         ReadStorage materialize.public.abc // { arity: 3 }
 
+Source materialize.public.abc
+
 Target cluster: quickstart
 
 EOF
@@ -47,6 +49,8 @@ Explained Query:
   Finish order_by=[#2 asc nulls_last, #1 asc nulls_last] output=[#0]
     TopK group_by=[#2] order_by=[#1 asc nulls_last] limit=1 // { arity: 3 }
       ReadStorage materialize.public.abc // { arity: 3 }
+
+Source materialize.public.abc
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -737,7 +737,14 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
       }
     }
   ],
-  "sources": []
+  "sources": [
+    {
+      "id": {
+        "User": 8
+      },
+      "op": null
+    }
+  ]
 }
 EOF
 
@@ -835,7 +842,14 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
       }
     }
   ],
-  "sources": []
+  "sources": [
+    {
+      "id": {
+        "User": 8
+      },
+      "op": null
+    }
+  ]
 }
 EOF
 
@@ -1908,7 +1922,14 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
       }
     }
   ],
-  "sources": []
+  "sources": [
+    {
+      "id": {
+        "User": 8
+      },
+      "op": null
+    }
+  ]
 }
 EOF
 

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -99,6 +99,8 @@ SELECT * FROM mz_views;
 Explained Query:
   ReadStorage mz_catalog.mz_views
 
+Source mz_catalog.mz_views
+
 Target cluster: quickstart
 
 EOF
@@ -247,6 +249,8 @@ Explained Query:
           Project (#1)
             ReadStorage materialize.public.mv
 
+Source materialize.public.mv
+
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
 
@@ -267,6 +271,8 @@ Explained Query:
       Negate
         Project (#1)
           ReadStorage materialize.public.mv
+
+Source materialize.public.mv
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -397,6 +403,8 @@ Explained Query:
                     ArrangeBy keys=[[]]
                       Project (#0{a})
                         ReadStorage materialize.public.mv
+
+Source materialize.public.mv
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***, differential join)
@@ -557,6 +565,8 @@ INDEX t_a_idx
 materialize.public.t_a_idx:
   ArrangeBy keys=[[#0{a}]]
     ReadStorage materialize.public.t
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -1059,6 +1069,8 @@ Explained Query:
         Reduce aggregates=[lag[ignore_nulls=true, order_by=[#0{x} asc nulls_last]](row(row(row(#0{x}), row(#0{x}, 3, "default")), (#0{x} || #0{x})))]
           ReadStorage materialize.public.t1
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -1074,6 +1086,8 @@ Explained Query:
       FlatMap unnest_list(#0{first_value})
         Reduce aggregates=[first_value[order_by=[#0{x} asc nulls_last] rows between 5 preceding and current row](row(row(row(#0{x}), #0{x}), (#0{x} || #0{x})))]
           ReadStorage materialize.public.t1
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 
@@ -1531,6 +1545,8 @@ SELECT * FROM t4;
 ----
 Explained Query:
   ReadStorage materialize.public.t4
+
+Source materialize.public.t4
 
 Target cluster: no_replicas
 

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -273,6 +273,8 @@ Explained Query:
                       Project (#0{a})
                         ReadStorage materialize.public.mv
 
+Source materialize.public.mv
+
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***, differential join)
 
@@ -576,6 +578,8 @@ Explained Query:
         Reduce aggregates=[lag[ignore_nulls=true, order_by=[#0{x} asc nulls_last]](row(row(row(#0{x}), row(#0{x}, █, █)), (#0{x} || #0{x})))]
           ReadStorage materialize.public.t1
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -591,6 +595,8 @@ Explained Query:
       FlatMap unnest_list(#0{first_value})
         Reduce aggregates=[first_value[order_by=[#0{x} asc nulls_last] rows between 5 preceding and current row](row(row(row(#0{x}), #0{x}), (#0{x} || #0{x})))]
           ReadStorage materialize.public.t1
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -255,7 +255,14 @@ SELECT * FROM u
       }
     }
   ],
-  "sources": []
+  "sources": [
+    {
+      "id": {
+        "User": 2
+      },
+      "op": null
+    }
+  ]
 }
 EOF
 

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -173,6 +173,8 @@ Explained Query:
   Get::PassArrangements materialize.public.u
     raw=true
 
+Source materialize.public.u
+
 Target cluster: quickstart
 
 EOF
@@ -974,6 +976,8 @@ materialize.public.t_a_idx:
     types=[integer?, integer?]
     Get::PassArrangements materialize.public.t
       raw=true
+
+Source materialize.public.t
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -158,6 +158,8 @@ Explained Query:
   Get::PassArrangements materialize.public.u
     raw=true
 
+Source materialize.public.u
+
 Target cluster: quickstart
 
 EOF
@@ -959,6 +961,8 @@ materialize.public.t_a_idx:
     types=[integer?, integer?]
     Get::PassArrangements materialize.public.t
       raw=true
+
+Source materialize.public.t
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/explain/plan_insights.slt
+++ b/test/sqllogictest/explain/plan_insights.slt
@@ -43,7 +43,7 @@ EXPLAIN PLAN INSIGHTS AS JSON FOR SELECT * FROM t
     },
     "optimized": {
       "global": {
-        "text": "Explained Query:\n  ReadStorage materialize.public.t\n\nTarget cluster: quickstart\n",
+        "text": "Explained Query:\n  ReadStorage materialize.public.t\n\nSource materialize.public.t\n\nTarget cluster: quickstart\n",
         "json": {
           "plans": [
             {
@@ -69,7 +69,14 @@ EXPLAIN PLAN INSIGHTS AS JSON FOR SELECT * FROM t
               }
             }
           ],
-          "sources": []
+          "sources": [
+            {
+              "id": {
+                "User": 1
+              },
+              "op": null
+            }
+          ]
         }
       },
       "fast_path": {
@@ -157,7 +164,7 @@ EXPLAIN PLAN INSIGHTS AS JSON FOR SELECT * FROM t t1, t t2
     },
     "optimized": {
       "global": {
-        "text": "Explained Query:\n  Return\n    CrossJoin type=differential\n      Get l0\n      Get l0\n  With\n    cte l0 =\n      ArrangeBy keys=[[]]\n        ReadStorage materialize.public.t\n\nTarget cluster: quickstart\n",
+        "text": "Explained Query:\n  Return\n    CrossJoin type=differential\n      Get l0\n      Get l0\n  With\n    cte l0 =\n      ArrangeBy keys=[[]]\n        ReadStorage materialize.public.t\n\nSource materialize.public.t\n\nTarget cluster: quickstart\n",
         "json": {
           "plans": [
             {
@@ -278,7 +285,14 @@ EXPLAIN PLAN INSIGHTS AS JSON FOR SELECT * FROM t t1, t t2
               }
             }
           ],
-          "sources": []
+          "sources": [
+            {
+              "id": {
+                "User": 1
+              },
+              "op": null
+            }
+          ]
         }
       },
       "fast_path": {

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -247,6 +247,8 @@ Explained Query:
     Map (date_trunc_day_ts(#0)) // { arity: 2 }
       ReadStorage materialize.public.date_trunc_timestamps // { arity: 1 }
 
+Source materialize.public.date_trunc_timestamps
+
 Target cluster: quickstart
 
 EOF
@@ -264,6 +266,9 @@ Explained Query:
           ReadStorage materialize.public.date_trunc_fields // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }
           ReadStorage materialize.public.date_trunc_timestamps // { arity: 1 }
+
+Source materialize.public.date_trunc_fields
+Source materialize.public.date_trunc_timestamps
 
 Target cluster: quickstart
 
@@ -749,6 +754,8 @@ Explained Query:
     Map ((#0) IS NULL) // { arity: 3 }
       ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -761,6 +768,8 @@ Explained Query:
     Map ((#0) IS NULL) // { arity: 3 }
       ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -772,6 +781,8 @@ Explained Query:
   Project (#2) // { arity: 1 }
     Map ((#0) IS NULL) // { arity: 3 }
       ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -788,6 +799,8 @@ Explained Query:
   Project (#2) // { arity: 1 }
     Map (((integer_to_boolean(#0) AND integer_to_boolean(#1))) IS NULL) // { arity: 3 }
       ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/github-14116.slt
+++ b/test/sqllogictest/github-14116.slt
@@ -64,6 +64,7 @@ Explained Query:
           Filter (#0 = #0) AND (#1 = #1) // { arity: 2 }
             ReadStorage materialize.public.test2 // { arity: 2 }
 
+Source materialize.public.test1
 Source materialize.public.test2
   filter=((#0 = #0) AND (#1 = #1))
 

--- a/test/sqllogictest/github-17808.slt
+++ b/test/sqllogictest/github-17808.slt
@@ -47,6 +47,8 @@ Explained Query:
     cte l0 =
       Get l1
 
+Source materialize.public.foo
+
 Target cluster: quickstart
 
 EOF

--- a/test/sqllogictest/github-18708.slt
+++ b/test/sqllogictest/github-18708.slt
@@ -49,8 +49,10 @@ Explained Query:
           ArrangeBy keys=[[]]
             ReadStorage materialize.public.t5
 
+Source materialize.public.t0
 Source materialize.public.t3
   filter=((#1 = text_to_char(text_to_varchar(boolean_to_text(like["0.31161855206970124"](padchar(#1)))))))
+Source materialize.public.t5
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/github-19290.slt
+++ b/test/sqllogictest/github-19290.slt
@@ -26,6 +26,8 @@ Explained Query:
       Get::PassArrangements materialize.public.lineitem
         raw=true
 
+Source materialize.public.lineitem
+
 Target cluster: quickstart
 
 EOF
@@ -44,6 +46,8 @@ Explained Query:
     TopK::MonotonicTop1 group_by=[#3] order_by=[#0 asc nulls_last] must_consolidate
       Get::PassArrangements materialize.public.lineitem
         raw=true
+
+Source materialize.public.lineitem
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/github-21501.slt
+++ b/test/sqllogictest/github-21501.slt
@@ -56,6 +56,8 @@ materialize.public.distinct_on_group_by_limit:
         Project (#0..=#2)
           ReadStorage materialize.public.sections
 
+Source materialize.public.sections
+
 Target cluster: quickstart
 
 EOF

--- a/test/sqllogictest/github-9147.slt
+++ b/test/sqllogictest/github-9147.slt
@@ -29,6 +29,8 @@ Explained Query:
             Filter (#0 > 1) // { arity: 2 }
               ReadStorage materialize.public.t1 // { arity: 2 }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -116,6 +116,7 @@ Explained Query:
               Filter (#0 = #1) // { arity: 2 }
                 ReadStorage materialize.public.table_f5_f6 // { arity: 2 }
 
+Source materialize.public.table_f1
 Source materialize.public.table_f4_f5_f6
   filter=((#1 = #2))
 Source materialize.public.table_f5_f6

--- a/test/sqllogictest/group_size_hints.slt
+++ b/test/sqllogictest/group_size_hints.slt
@@ -38,6 +38,8 @@ materialize.public.distinct_on_group_by_limit:
         Project (#0..=#2)
           ReadStorage materialize.public.sections
 
+Source materialize.public.sections
+
 Target cluster: quickstart
 
 EOF
@@ -75,6 +77,8 @@ materialize.public.distinct_on_group_by_limit:
         Project (#0..=#2)
           ReadStorage materialize.public.sections
 
+Source materialize.public.sections
+
 Target cluster: quickstart
 
 EOF
@@ -111,6 +115,8 @@ materialize.public.distinct_on_group_by_limit:
         Project (#0..=#2)
           ReadStorage materialize.public.sections
 
+Source materialize.public.sections
+
 Target cluster: quickstart
 
 EOF
@@ -140,6 +146,8 @@ materialize.public.distinct_on_group_by_limit:
       Reduce group_by=[#0, #1] aggregates=[max(#2)] exp_group_size=1000
         Project (#0..=#2)
           ReadStorage materialize.public.sections
+
+Source materialize.public.sections
 
 Target cluster: quickstart
 
@@ -171,6 +179,8 @@ materialize.public.distinct_on_group_by_limit:
         Project (#0..=#2)
           ReadStorage materialize.public.sections
 
+Source materialize.public.sections
+
 Target cluster: quickstart
 
 EOF
@@ -200,6 +210,8 @@ materialize.public.distinct_on_group_by_limit:
       Reduce group_by=[#0, #1] aggregates=[max(#2)]
         Project (#0..=#2)
           ReadStorage materialize.public.sections
+
+Source materialize.public.sections
 
 Target cluster: quickstart
 
@@ -256,6 +268,7 @@ materialize.public.sections_of_top_3_courses_per_teacher:
                     Filter (#1) IS NOT NULL
                       ReadStorage materialize.public.sections
 
+Source materialize.public.teachers
 Source materialize.public.sections
   filter=((#1) IS NOT NULL)
 
@@ -305,6 +318,7 @@ materialize.public.max_sections_of_top_3_courses_per_teacher:
                       Filter (#1) IS NOT NULL
                         ReadStorage materialize.public.sections
 
+Source materialize.public.teachers
 Source materialize.public.sections
   filter=((#1) IS NOT NULL)
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -205,6 +205,8 @@ Explained Query:
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.l // { arity: 2 }
 
+Source materialize.public.l
+
 Target cluster: quickstart
 
 EOF
@@ -358,6 +360,7 @@ Explained Query:
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.r // { arity: 2 }
 
+Source materialize.public.l
 Source materialize.public.r
   filter=((#0) IS NOT NULL)
 
@@ -404,6 +407,7 @@ Explained Query:
 
 Source materialize.public.l
   filter=((#0) IS NOT NULL)
+Source materialize.public.r
 
 Target cluster: quickstart
 
@@ -458,6 +462,9 @@ Explained Query:
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.r // { arity: 2 }
+
+Source materialize.public.l
+Source materialize.public.r
 
 Target cluster: quickstart
 
@@ -558,6 +565,8 @@ Explained Query:
       Filter (#1 = 1) // { arity: 2 }
         ReadStorage materialize.public.t4362 // { arity: 2 }
 
+Source materialize.public.t4362
+
 Target cluster: quickstart
 
 EOF
@@ -651,6 +660,9 @@ Explained Query:
       ArrangeBy keys=[[#0]] // { arity: 2 }
         ReadStorage materialize.public.r3 // { arity: 2 }
 
+Source materialize.public.l3
+Source materialize.public.r3
+
 Target cluster: quickstart
 
 EOF
@@ -674,6 +686,9 @@ Explained Query:
         ReadStorage materialize.public.l3 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 2 }
         ReadStorage materialize.public.r3 // { arity: 2 }
+
+Source materialize.public.l3
+Source materialize.public.r3
 
 Target cluster: quickstart
 
@@ -1183,6 +1198,9 @@ Explained Query:
         Project () // { arity: 0 }
           ReadStorage materialize.public.c // { arity: 1 }
 
+Source materialize.public.a
+Source materialize.public.c
+
 Target cluster: quickstart
 
 EOF
@@ -1225,6 +1243,9 @@ Explained Query:
             ReadStorage materialize.public.fuel_test_1
           ArrangeBy keys=[[]]
             ReadStorage materialize.public.fuel_test_2
+
+Source materialize.public.fuel_test_1
+Source materialize.public.fuel_test_2
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/limit.slt
+++ b/test/sqllogictest/limit.slt
@@ -125,6 +125,7 @@ Explained Query:
                   Filter (#0{person_id}) IS NOT NULL // { arity: 3 }
                     ReadStorage materialize.public.preferred_fruits // { arity: 3 }
 
+Source materialize.public.people
 Source materialize.public.preferred_fruits
   filter=((#0{person_id}) IS NOT NULL)
 
@@ -204,6 +205,8 @@ Explained Query:
     TopK group_by=[#0{state}] limit=integer_to_bigint((ascii(substr(#0{state}, 1, 1)) - 64)) // { arity: 2 }
       Project (#1{name}, #0{state}) // { arity: 2 }
         ReadStorage materialize.public.cities // { arity: 3 }
+
+Source materialize.public.cities
 
 Target cluster: quickstart
 
@@ -289,6 +292,7 @@ Explained Query:
           Project (#1) // { arity: 1 }
             ReadStorage materialize.public.cities // { arity: 3 }
 
+Source materialize.public.cities
 Source materialize.public.limits
   filter=((#0{sl}) IS NOT NULL)
 
@@ -327,6 +331,8 @@ Explained Query:
       TopK limit=1 // { arity: 1 }
         Project (#0{name}) // { arity: 1 }
           ReadStorage materialize.public.cities // { arity: 3 }
+
+Source materialize.public.cities
 
 Target cluster: quickstart
 
@@ -389,6 +395,8 @@ Explained Query:
     cte l0 =
       Project (#0{name}, #1{state}) // { arity: 2 }
         ReadStorage materialize.public.cities // { arity: 3 }
+
+Source materialize.public.cities
 
 Target cluster: quickstart
 
@@ -496,6 +504,8 @@ Explained Query:
     ArrangeBy keys=[[]] // { arity: 1 }
       Project (#0{name}) // { arity: 1 }
         ReadStorage materialize.public.cities // { arity: 3 }
+
+Source materialize.public.cities
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -97,6 +97,8 @@ Explained Query:
     Map (integer_to_bigint(#0), integer_to_bigint(#1)) // { types: "(integer?, integer, bigint?, bigint)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -113,6 +115,8 @@ Explained Query:
     Map ((#0) IS NULL, NOT(#2)) // { types: "(integer?, integer, boolean, boolean)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -125,6 +129,8 @@ Explained Query:
     Map ((#0) IS TRUE, NOT(#2)) // { types: "(boolean?, boolean, boolean, boolean)" }
       ReadStorage materialize.public.bool_table // { types: "(boolean?, boolean)" }
 
+Source materialize.public.bool_table
+
 Target cluster: quickstart
 
 EOF
@@ -136,6 +142,8 @@ Explained Query:
   Project (#2, #3) // { types: "(boolean, boolean)" }
     Map ((#0) IS NULL, NOT(#2)) // { types: "(boolean?, boolean, boolean, boolean)" }
       ReadStorage materialize.public.bool_table // { types: "(boolean?, boolean)" }
+
+Source materialize.public.bool_table
 
 Target cluster: quickstart
 
@@ -152,6 +160,8 @@ Explained Query:
   Project (#2..=#5) // { types: "(integer, integer, integer, integer)" }
     Map ((#1 + #1), (#1 + 1), (#1 % #1), (#1 % 2)) // { types: "(integer?, integer, integer, integer, integer, integer)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+
+Source materialize.public.int_table
 
 Target cluster: quickstart
 
@@ -170,6 +180,8 @@ Explained Query:
     Map (greatest(#1), greatest(#1, #1), greatest(#1, #0), greatest(#0, #0)) // { types: "(integer?, integer, integer, integer, integer?, integer?)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -182,6 +194,8 @@ Explained Query:
     Map (least(#1), least(#1, #1), least(#1, #0), least(#0, #0)) // { types: "(integer?, integer, integer, integer, integer?, integer?)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -192,6 +206,8 @@ EXPLAIN WITH(types, no fast path) SELECT COALESCE(col_not_null), COALESCE(col_no
 Explained Query:
   Project (#1, #1, #1, #0) // { types: "(integer, integer, integer, integer?)" }
     ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+
+Source materialize.public.int_table
 
 Target cluster: quickstart
 
@@ -210,6 +226,8 @@ Explained Query:
     Map (case when (#0 = #1) then null else #0 end, error("invalid input syntax for type integer: invalid digit found in string: \"a\"")) // { types: "(integer?, integer, integer?, integer?)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -226,6 +244,8 @@ Explained Query:
     Map ((#1 = 1)) // { types: "(integer?, integer, boolean)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -236,6 +256,8 @@ EXPLAIN WITH(types, no fast path) SELECT col_not_null AND col_not_null , col_not
 Explained Query:
   Project (#1, #1) // { types: "(boolean, boolean)" }
     ReadStorage materialize.public.bool_table // { types: "(boolean?, boolean)" }
+
+Source materialize.public.bool_table
 
 Target cluster: quickstart
 
@@ -249,6 +271,8 @@ Explained Query:
     Map ((#0 AND #1), (#0 OR #1)) // { types: "(boolean?, boolean, boolean?, boolean?)" }
       ReadStorage materialize.public.bool_table // { types: "(boolean?, boolean)" }
 
+Source materialize.public.bool_table
+
 Target cluster: quickstart
 
 EOF
@@ -260,6 +284,8 @@ Explained Query:
   Project (#2, #3) // { types: "(boolean?, boolean)" }
     Map (NOT(#0), NOT(#1)) // { types: "(boolean?, boolean, boolean?, boolean)" }
       ReadStorage materialize.public.bool_table // { types: "(boolean?, boolean)" }
+
+Source materialize.public.bool_table
 
 Target cluster: quickstart
 
@@ -276,6 +302,8 @@ Explained Query:
   Project (#2, #4..=#7) // { types: "(integer, double precision, double precision, double precision, integer)" }
     Map (abs(#1), integer_to_double(#1), log10f64(#3), roundf64(#3), cos(#3), (#1 << #1)) // { types: "(integer?, integer, integer, double precision, double precision, double precision, double precision, integer)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+
+Source materialize.public.int_table
 
 Target cluster: quickstart
 
@@ -307,6 +335,8 @@ Explained Query:
         Project (#1) // { types: "(integer)" }
           ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -335,6 +365,8 @@ Explained Query:
         Project (#1) // { types: "(integer)" }
           ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -351,6 +383,8 @@ Explained Query:
     Map ((#1 like #1), (#0 like #1), (#1 like #0)) // { types: "(text?, text, boolean, boolean?, boolean?)" }
       ReadStorage materialize.public.str_table // { types: "(text?, text)" }
 
+Source materialize.public.str_table
+
 Target cluster: quickstart
 
 EOF
@@ -364,6 +398,8 @@ Explained Query:
   Project (#2..=#5) // { types: "(text, text, text[]?, text)" }
     Map ((#1 || #1), substr(#1, 3, 2), regexp_match(#1, #1), lpad(#1, 3, #1)) // { types: "(text?, text, text, text, text[]?, text)" }
       ReadStorage materialize.public.str_table // { types: "(text?, text)" }
+
+Source materialize.public.str_table
 
 Target cluster: quickstart
 
@@ -396,6 +432,8 @@ Explained Query:
     Map (regexp_match["aaa", case_insensitive=false](#1), regexp_match("aaa", #1)) // { types: "(text?, text, text[]?, text[]?)" }
       ReadStorage materialize.public.str_table // { types: "(text?, text)" }
 
+Source materialize.public.str_table
+
 Target cluster: quickstart
 
 EOF
@@ -411,6 +449,8 @@ Explained Query:
   Project (#2..=#4) // { types: "(text, text, text)" }
     Map (split_string(#1, "a", 100), split_string("a", #1, 100), split_string("a", "a", text_to_integer(#1))) // { types: "(text?, text, text, text, text)" }
       ReadStorage materialize.public.str_table // { types: "(text?, text)" }
+
+Source materialize.public.str_table
 
 Target cluster: quickstart
 
@@ -428,6 +468,8 @@ Explained Query:
     Map ((#1 = 1), true, null, null, null) // { types: "(integer?, integer, boolean, boolean, boolean?, boolean?, boolean?)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -439,6 +481,8 @@ Explained Query:
   Project (#2, #2..=#6) // { types: "(boolean, boolean, boolean, boolean?, boolean?, boolean?)" }
     Map ((#1 != 1), false, null, null, null) // { types: "(integer?, integer, boolean, boolean, boolean?, boolean?, boolean?)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+
+Source materialize.public.int_table
 
 Target cluster: quickstart
 
@@ -474,6 +518,8 @@ Explained Query:
       Distinct project=[#0, #1] // { types: "(integer?, integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -505,6 +551,8 @@ Explained Query:
       Distinct project=[#0, #1] // { types: "(integer?, integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -534,6 +582,8 @@ Explained Query:
     cte l0 =
       Distinct project=[#0, #1] // { types: "(integer?, integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+
+Source materialize.public.int_table
 
 Target cluster: quickstart
 
@@ -623,6 +673,8 @@ Explained Query:
       Project (#1) // { types: "(integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -664,6 +716,8 @@ Explained Query:
       Project () // { types: "()" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -703,6 +757,8 @@ Explained Query:
           Filter (#1 = 1) // { types: "(integer?, integer)" }
             ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -733,6 +789,8 @@ Explained Query:
     cte l0 =
       Project () // { types: "()" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+
+Source materialize.public.int_table
 
 Target cluster: quickstart
 
@@ -808,6 +866,8 @@ Explained Query:
           Filter (#1 = 1) // { types: "(integer?, integer)" }
             ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -823,6 +883,8 @@ Explained Query:
     Map ((#0 - 00:00:01), (#1 - 00:00:01)) // { types: "(timestamp without time zone?, timestamp without time zone, timestamp without time zone?, timestamp without time zone)" }
       ReadStorage materialize.public.ts_table // { types: "(timestamp without time zone?, timestamp without time zone)" }
 
+Source materialize.public.ts_table
+
 Target cluster: quickstart
 
 EOF
@@ -834,6 +896,8 @@ Explained Query:
   Project (#2, #3) // { types: "(interval?, interval?)" }
     Map ((#0 - #1), (#1 - #0)) // { types: "(timestamp without time zone?, timestamp without time zone, interval?, interval?)" }
       ReadStorage materialize.public.ts_table // { types: "(timestamp without time zone?, timestamp without time zone)" }
+
+Source materialize.public.ts_table
 
 Target cluster: quickstart
 
@@ -857,6 +921,8 @@ Explained Query:
       ArrangeBy keys=[[]] // { types: "(integer)" }
         Project (#1) // { types: "(integer)" }
           ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+
+Source materialize.public.int_table
 
 Target cluster: quickstart
 
@@ -895,6 +961,8 @@ Explained Query:
         ArrangeBy keys=[[]] // { types: "(integer)" }
           Project (#1) // { types: "(integer)" }
             ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+
+Source materialize.public.int_table
 
 Target cluster: quickstart
 
@@ -945,6 +1013,8 @@ Explained Query:
       ArrangeBy keys=[[]] // { types: "(integer?, integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -967,6 +1037,8 @@ Explained Query:
       Project (#1) // { types: "(integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
+Source materialize.public.int_table
+
 Target cluster: quickstart
 
 EOF
@@ -980,6 +1052,8 @@ Explained Query:
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
     Project (#0) // { types: "(integer?)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+
+Source materialize.public.int_table
 
 Target cluster: quickstart
 
@@ -996,6 +1070,8 @@ Explained Query:
   Project (#2) // { types: "(integer)" }
     Map (((#1 + 1) + 1)) // { types: "(integer?, integer, integer)" }
       ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+
+Source materialize.public.int_table
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -881,6 +881,8 @@ Explained Query:
     TopK limit=10000
       ReadStorage materialize.public.t
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF

--- a/test/sqllogictest/outer_join.slt
+++ b/test/sqllogictest/outer_join.slt
@@ -239,6 +239,7 @@ Explained Query:
         Get::Collection materialize.public.right1
           raw=true
 
+Source materialize.public.left
 Source materialize.public.right1
   filter=((#0) IS NOT NULL)
 Source materialize.public.right2

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -823,6 +823,7 @@ Explained Query:
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
+Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
   filter=((#2{dim01_d02} < 24))
 
@@ -883,6 +884,7 @@ Explained Query:
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
+Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
   filter=((#2{dim01_d02} < 24))
 
@@ -930,6 +932,7 @@ materialize.public.v:
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
+Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
   filter=((#2{dim01_d02} < 24))
 
@@ -986,6 +989,7 @@ materialize.public.mv:
           Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
+Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
   filter=((#2{dim01_d02} < 24))
 

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -54,6 +54,7 @@ Explained Query:
           Filter (#0) IS NOT NULL
             ReadStorage materialize.public.bar
 
+Source materialize.public.foo
 Source materialize.public.bar
   filter=((#0) IS NOT NULL)
 
@@ -89,6 +90,7 @@ Explained Query:
             Filter (#0) IS NOT NULL
               ReadStorage materialize.public.bar
 
+Source materialize.public.foo_raw
 Source materialize.public.bar
   filter=((#0) IS NOT NULL)
 
@@ -131,6 +133,7 @@ Explained Query:
         Filter (#0) IS NOT NULL
           ReadStorage materialize.public.foo_raw
 
+Source materialize.public.foo_raw
 Source materialize.public.bar
   filter=((#0) IS NOT NULL)
 
@@ -205,8 +208,11 @@ Explained Query:
         Constant
           - (null, null)
 
+Source materialize.public.foo
 Source materialize.public.bar
   filter=((#0) IS NOT NULL)
+Source materialize.public.baz
+Source materialize.public.quux
 
 Target cluster: quickstart
 
@@ -292,8 +298,11 @@ Explained Query:
       Project (#0, #1)
         ReadStorage materialize.public.foo
 
+Source materialize.public.foo
 Source materialize.public.bar
   filter=((#0) IS NOT NULL)
+Source materialize.public.baz
+Source materialize.public.quux
 
 Target cluster: quickstart
 
@@ -344,6 +353,10 @@ Explained Query:
                       Constant
                         - (null)
 
+Source materialize.public.foo
+Source materialize.public.baz
+Source materialize.public.quux
+
 Target cluster: quickstart
 
 EOF
@@ -386,6 +399,7 @@ Explained Query:
                     ReadStorage materialize.public.bar
           Get l0
 
+Source materialize.public.foo
 Source materialize.public.bar
   filter=((#0) IS NOT NULL)
 
@@ -431,6 +445,8 @@ Explained Query:
                   Project (#0) // { keys: "([0])" }
                     Get l0 // { keys: "([0])" }
             Get l0 // { keys: "([0])" }
+
+Source materialize.public.foo
 
 Target cluster: quickstart
 
@@ -626,6 +642,8 @@ Explained Query:
                 Filter (#0) IS NOT NULL // { keys: "([0, 1])" }
                   Get l1 // { keys: "([0, 1])" }
 
+Source materialize.public.bar
+
 Target cluster: quickstart
 
 EOF
@@ -699,6 +717,8 @@ Explained Query:
           Project (#0, #2)
             Get l2
 
+Source materialize.public.bar
+
 Target cluster: quickstart
 
 EOF
@@ -747,6 +767,8 @@ Explained Query:
             Project (#0, #2) // { keys: "([0])" }
               Filter (#0) IS NOT NULL // { keys: "([0])" }
                 Get l1 // { keys: "([0])" }
+
+Source materialize.public.foo_raw
 
 Target cluster: quickstart
 
@@ -797,6 +819,7 @@ Explained Query:
             Filter (#0) IS NOT NULL
               ReadStorage materialize.public.bar
 
+Source materialize.public.foo_raw
 Source materialize.public.bar
   filter=((#0) IS NOT NULL)
 
@@ -845,6 +868,7 @@ Explained Query:
             Filter (#0) IS NOT NULL
               ReadStorage materialize.public.bar
 
+Source materialize.public.foo_raw
 Source materialize.public.bar
   filter=((#0) IS NOT NULL)
 
@@ -935,8 +959,11 @@ Explained Query:
         Constant
           - (null, null)
 
+Source materialize.public.foo
 Source materialize.public.bar
   filter=((#0) IS NOT NULL)
+Source materialize.public.baz
+Source materialize.public.quux
 
 Target cluster: quickstart
 
@@ -1023,8 +1050,11 @@ Explained Query:
         Constant // { arity: 2 }
           - (null, null)
 
+Source materialize.public.foo
 Source materialize.public.bar
   filter=((#0) IS NOT NULL)
+Source materialize.public.baz
+Source materialize.public.quux
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/parse_ident.slt
+++ b/test/sqllogictest/parse_ident.slt
@@ -236,6 +236,8 @@ Explained Query:
     Map (arraytostr(parse_ident(#0, true)))
       ReadStorage materialize.public.t
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -388,6 +390,8 @@ Explained Query:
   Project (#1)
     Map (arraytostr(case when (#0) IS NULL then null else case when ((parse_ident(#0, true) array_length 1) > 3) then error_if_null(null, ("improper relation name (too many dotted names): " || #0)) else (array_fill(null, array[(3 - (parse_ident(#0, true) array_length 1))]) || parse_ident(#0, true)) end end))
       ReadStorage materialize.public.t
+
+Source materialize.public.t
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -137,6 +137,8 @@ Explained Query:
   Finish limit=1000 output=[#0]
     ReadStorage materialize.public.numbers
 
+Source materialize.public.numbers
+
 Target cluster: quickstart
 
 EOF
@@ -147,6 +149,8 @@ EXPLAIN SELECT * from numbers ORDER BY value LIMIT 10;
 Explained Query:
   Finish order_by=[#0 asc nulls_last] limit=10 output=[#0]
     ReadStorage materialize.public.numbers
+
+Source materialize.public.numbers
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -1787,8 +1787,11 @@ EXPLAIN SELECT a::ty FROM t;
 Explained Query:
   ReadStorage materialize.public.t
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
+COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1798,8 +1801,11 @@ EXPLAIN SELECT a::ty FROM t;
 Explained Query:
   ReadStorage materialize.public.t
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
+COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1964,8 +1970,11 @@ EXPLAIN SELECT * FROM v;
 Explained Query:
   ReadStorage materialize.public.t
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
+COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1975,8 +1984,11 @@ EXPLAIN SELECT * FROM v;
 Explained Query:
   ReadStorage materialize.public.t
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
+COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -2071,6 +2083,8 @@ EXPLAIN INDEX i;
 materialize.public.i:
   ArrangeBy keys=[[#0]]
     ReadStorage materialize.public.t
+
+Source materialize.public.t
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -1791,7 +1791,6 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
-COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1805,7 +1804,6 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
-COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1974,7 +1972,6 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
-COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1988,7 +1985,6 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
-COMPLETE 1
 EOF
 COMPLETE 1
 

--- a/test/sqllogictest/record.slt
+++ b/test/sqllogictest/record.slt
@@ -20,6 +20,8 @@ Explained Query:
   Project (#0) // { arity: 1 }
     ReadStorage materialize.public.t1 // { arity: 2 }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -32,6 +34,8 @@ Explained Query:
     Map (row(#0, #0), record_get[1](#2)) // { arity: 4 }
       ReadStorage materialize.public.t1 // { arity: 2 }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -42,6 +46,8 @@ EXPLAIN WITH(arity, join implementations) SELECT (COALESCE(record, ROW(NULL, NUL
 Explained Query:
   Project (#0) // { arity: 1 }
     ReadStorage materialize.public.t1 // { arity: 2 }
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/recursive_type_unioning.slt
+++ b/test/sqllogictest/recursive_type_unioning.slt
@@ -32,6 +32,9 @@ Explained Query:
         Map (row(#0, #1)) // { arity: 3 }
           ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF

--- a/test/sqllogictest/reduce_mfp.slt
+++ b/test/sqllogictest/reduce_mfp.slt
@@ -58,6 +58,8 @@ materialize.public.mv_fusable_mfp_accumulable:
     Get::PassArrangements materialize.public.t
       raw=true
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -97,6 +99,8 @@ materialize.public.mv_complex_mfp_accumulable:
         map=((#2 + 1))
       Get::PassArrangements materialize.public.t
         raw=true
+
+Source materialize.public.t
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -59,6 +59,8 @@ Explained Query:
     Map (is_regexp_match["foo?", case_insensitive=false](#0)) // { arity: 2 }
       ReadStorage materialize.public.data // { arity: 1 }
 
+Source materialize.public.data
+
 Target cluster: quickstart
 
 EOF
@@ -71,6 +73,8 @@ Explained Query:
   Project (#1) // { arity: 1 }
     Map ((#0 ~ #0)) // { arity: 2 }
       ReadStorage materialize.public.data // { arity: 1 }
+
+Source materialize.public.data
 
 Target cluster: quickstart
 
@@ -201,6 +205,8 @@ Explained Query:
 ", "<newline>"), regexp_match["a.*", case_insensitive=false](#0))
       ReadStorage materialize.public.t
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -226,6 +232,8 @@ Explained Query:
     Map (replace(#0, "
 ", "<newline>"), regexp_match["a.*", case_insensitive=true](#0))
       ReadStorage materialize.public.t
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -331,6 +339,8 @@ Explained Query:
 ", "<newline>"), regexp_match(#0, #2))
       ReadStorage materialize.public.t
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -361,6 +371,8 @@ Explained Query:
     Map (replace(#0, "
 ", "<newline>"), regexp_match(#0, #2, "i"))
       ReadStorage materialize.public.t
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -433,6 +445,8 @@ Explained Query:
     ^
 error: incomplete escape sequence, reached end of pattern prematurely"))
     ReadStorage materialize.public.t
+
+Source materialize.public.t
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -79,6 +79,9 @@ Explained Query:
                 Project () // { arity: 0 }
                   ReadStorage materialize.public.t1 // { arity: 1 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -135,6 +138,7 @@ Explained Query:
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -210,6 +214,7 @@ Explained Query:
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -298,6 +303,7 @@ Explained Query:
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -381,6 +387,7 @@ Explained Query:
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -466,6 +473,7 @@ Explained Query:
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -571,6 +579,7 @@ Source materialize.public.t1
   filter=((#0) IS NOT NULL)
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
+Source materialize.public.t3
 
 Target cluster: quickstart
 
@@ -687,6 +696,7 @@ Explained Query:
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -760,6 +770,7 @@ Source materialize.public.t1
   filter=((#0) IS NOT NULL)
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
+Source materialize.public.t3
 
 Target cluster: quickstart
 
@@ -839,6 +850,8 @@ Explained Query:
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
+Source materialize.public.t2
+Source materialize.public.t3
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -262,6 +262,9 @@ Explained Query:
         Project () // { arity: 0 }
           ReadStorage materialize.public.t2 // { arity: 1 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -285,6 +288,10 @@ Explained Query:
           Project () // { arity: 0 }
             ReadStorage materialize.public.t2 // { arity: 1 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+Source materialize.public.t3
+
 Target cluster: quickstart
 
 EOF
@@ -306,6 +313,10 @@ Explained Query:
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Distinct project=[#0] // { arity: 1 }
           ReadStorage materialize.public.t2 // { arity: 1 }
+
+Source materialize.public.t1
+Source materialize.public.t2
+Source materialize.public.t3
 
 Target cluster: quickstart
 
@@ -494,6 +505,9 @@ Explained Query:
       Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.y // { arity: 1 }
 
+Source materialize.public.x
+Source materialize.public.y
+
 Target cluster: quickstart
 
 EOF
@@ -533,6 +547,9 @@ Explained Query:
     cte l0 =
       Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.y // { arity: 1 }
+
+Source materialize.public.x
+Source materialize.public.y
 
 Target cluster: quickstart
 
@@ -575,6 +592,9 @@ Explained Query:
     cte l0 =
       Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.y // { arity: 1 }
+
+Source materialize.public.x
+Source materialize.public.y
 
 Target cluster: quickstart
 
@@ -681,6 +701,9 @@ Explained Query:
     Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.y // { arity: 1 }
+
+Source materialize.public.x
+Source materialize.public.y
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -240,6 +240,8 @@ Explained Query:
         - (9)
         - (10)
 
+Source materialize.public.x
+
 Target cluster: quickstart
 
 EOF
@@ -250,6 +252,8 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM x, generate_series(1, a)
 Explained Query:
   FlatMap generate_series(1, #0, 1) // { arity: 3 }
     ReadStorage materialize.public.x // { arity: 2 }
+
+Source materialize.public.x
 
 Target cluster: quickstart
 
@@ -1420,6 +1424,8 @@ Explained Query:
   Project (#1) // { arity: 1 }
     FlatMap jsonb_object_keys(#0) // { arity: 2 }
       ReadStorage materialize.public.y // { arity: 1 }
+
+Source materialize.public.y
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -90,6 +90,8 @@ Explained Query:
     TopK group_by=[#1] order_by=[#2 desc nulls_first] limit=3 // { arity: 3 }
       ReadStorage materialize.public.cities // { arity: 3 }
 
+Source materialize.public.cities
+
 Target cluster: quickstart
 
 EOF
@@ -118,6 +120,8 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         TopK group_by=[#1] order_by=[#2 desc nulls_first] limit=3 // { arity: 3 }
           ReadStorage materialize.public.cities // { arity: 3 }
+
+Source materialize.public.cities
 
 Target cluster: quickstart
 
@@ -156,6 +160,8 @@ Explained Query:
         Project (#1, #2) // { arity: 2 }
           ReadStorage materialize.public.cities // { arity: 3 }
 
+Source materialize.public.cities
+
 Target cluster: quickstart
 
 EOF
@@ -171,6 +177,8 @@ Explained Query:
   Project (#1, #0) // { arity: 2 }
     TopK group_by=[#1] order_by=[#2 desc nulls_last] limit=3 exp_group_size=1 // { arity: 3 }
       ReadStorage materialize.public.cities // { arity: 3 }
+
+Source materialize.public.cities
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -60,6 +60,7 @@ Explained Query:
               Filter (#0) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
 
@@ -144,6 +145,7 @@ Explained Query:
               Filter (#0) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
 
@@ -189,6 +191,7 @@ Explained Query:
               Filter (#0) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
 
@@ -234,6 +237,7 @@ Explained Query:
               Filter (#0) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
 
@@ -249,6 +253,8 @@ Explained Query:
   Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
     ReadStorage materialize.public.t1 // { arity: 2 }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -260,6 +266,8 @@ Explained Query:
   Filter (#1) IS NOT NULL // { arity: 2 }
     Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
       ReadStorage materialize.public.t1 // { arity: 2 }
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 
@@ -365,6 +373,7 @@ Explained Query:
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
 
@@ -471,6 +480,7 @@ Explained Query:
               Filter (#0) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
 
@@ -518,6 +528,7 @@ Explained Query:
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
 
@@ -565,6 +576,7 @@ Explained Query:
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
 
@@ -691,6 +703,7 @@ Explained Query:
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
 
@@ -734,6 +747,7 @@ Explained Query:
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
 
@@ -891,6 +905,10 @@ Explained Query:
             Filter (#1 = 6) // { arity: 2 }
               ReadStorage materialize.public.t3 // { arity: 2 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+Source materialize.public.t3
+
 Target cluster: quickstart
 
 EOF
@@ -955,6 +973,9 @@ Explained Query:
             ReadStorage materialize.public.t2 // { arity: 1 }
           ArrangeBy keys=[[]] // { arity: 1 }
             ReadStorage materialize.public.t1 // { arity: 1 }
+
+Source materialize.public.t1
+Source materialize.public.t2
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -314,6 +314,7 @@ Explained Query:
                 Project () // { arity: 0 }
                   ReadStorage materialize.public.t1 // { arity: 2 }
 
+Source materialize.public.t1
 Source materialize.public.t2
   filter=((#0 = 123))
 
@@ -421,6 +422,9 @@ Explained Query:
               Project () // { arity: 0 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -448,6 +452,7 @@ Explained Query:
 
 Source materialize.public.t1
   filter=((#0 = 123))
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -584,6 +589,7 @@ Explained Query:
 
 Source materialize.public.double_table
   filter=((#0) IS NOT NULL)
+Source materialize.public.int_table
 
 Target cluster: quickstart
 
@@ -601,6 +607,8 @@ Explained Query:
   Project (#1) // { arity: 1, types: "(text)" }
     Map (coalesce((#0 ->> "field"), "")) // { arity: 2, types: "(jsonb?, text)" }
       ReadStorage materialize.public.json_table // { arity: 1, types: "(jsonb?)" }
+
+Source materialize.public.json_table
 
 Target cluster: quickstart
 
@@ -739,6 +747,8 @@ Explained Query:
           Filter (#1) IS NOT NULL // { arity: 2, types: "(integer, integer)" }
             Get l0 // { arity: 2, types: "(integer, integer?)" }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -784,6 +794,8 @@ Explained Query:
               Get l0 // { arity: 1, types: "(integer)" }
             Constant // { arity: 0, types: "()" }
               - ()
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 
@@ -835,6 +847,8 @@ Explained Query:
               Get l0 // { arity: 1, types: "(integer)" }
             Constant // { arity: 0, types: "()" }
               - ()
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -146,6 +146,8 @@ Explained Query:
             ReadStorage materialize.public.edges // { arity: 2 }
           Get l0 // { arity: 1 }
 
+Source materialize.public.edges
+
 Target cluster: quickstart
 
 EOF

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -43,6 +43,7 @@ Explained Query:
 
 Source materialize.public.t1
   filter=((#0) IS NOT NULL)
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -98,6 +99,9 @@ Explained Query:
     cte l0 =
       Project (#1) // { arity: 1 }
         ReadStorage materialize.public.t1 // { arity: 2 }
+
+Source materialize.public.t1
+Source materialize.public.t2
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -167,6 +167,8 @@ Explained Query:
         ArrangeBy keys=[[#0]] // { arity: 2 }
           ReadStorage materialize.public.baz // { arity: 2 }
 
+Source materialize.public.baz
+
 Used Indexes:
   - materialize.public.foo_idx (delta join 1st input (full scan))
   - materialize.public.bar_idx (*** full scan ***)

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -34,6 +34,8 @@ Explained Query:
       Constant // { arity: 2 }
         - (null, 1)
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -53,6 +55,8 @@ Explained Query:
       ReadStorage materialize.public.t // { arity: 2 }
       Constant // { arity: 2 }
         - (null, 1)
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -74,6 +78,8 @@ Explained Query:
       ReadStorage materialize.public.t // { arity: 2 }
     Constant // { arity: 3 }
       - (null, 1, 2)
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -136,6 +142,8 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 2 }
           ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -156,6 +164,8 @@ Explained Query:
               ReadStorage materialize.public.t // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 2 }
           ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -178,6 +188,8 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 2 }
           ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -191,6 +203,8 @@ Explained Query:
     Map (2) // { arity: 3 }
       ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -203,6 +217,8 @@ Explained Query:
   Project (#2) // { arity: 1 }
     Map (2) // { arity: 3 }
       ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -225,6 +241,8 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#0) // { arity: 1 }
             ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -261,6 +279,8 @@ Explained Query:
           Project () // { types: "()" }
             ReadStorage materialize.public.t // { types: "(integer?, integer?)" }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -288,6 +308,8 @@ Explained Query:
           Project () // { types: "()" }
             ReadStorage materialize.public.t // { types: "(integer?, integer?)" }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -302,6 +324,8 @@ Explained Query:
       FlatMap generate_series(2, 4, 1) // { arity: 1 }
         Project () // { arity: 0 }
           ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -320,6 +344,8 @@ Explained Query:
     Map (123) // { arity: 3 }
       ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -332,6 +358,8 @@ Explained Query:
     Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -346,6 +374,8 @@ Explained Query:
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -358,6 +388,8 @@ Explained Query:
     Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -374,6 +406,8 @@ Explained Query:
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -386,6 +420,8 @@ Explained Query:
     Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -401,6 +437,8 @@ Explained Query:
     Map (123) // { arity: 3 }
       ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -415,6 +453,8 @@ Explained Query:
         Project (#0) // { arity: 1 }
           ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -428,6 +468,8 @@ Explained Query:
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -440,6 +482,8 @@ Explained Query:
     Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -456,18 +500,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
-Target cluster: quickstart
-
-EOF
-
-query T multiline
-explain with(arity, join implementations) select a1.a, a1.literal from (select distinct a, 123 as literal from t) as a1;
-----
-Explained Query:
-  Map (123) // { arity: 2 }
-    Distinct project=[#0] // { arity: 1 }
-      Project (#0) // { arity: 1 }
-        ReadStorage materialize.public.t // { arity: 2 }
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -481,6 +514,23 @@ Explained Query:
     Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
+
+Target cluster: quickstart
+
+EOF
+
+query T multiline
+explain with(arity, join implementations) select a1.a, a1.literal from (select distinct a, 123 as literal from t) as a1;
+----
+Explained Query:
+  Map (123) // { arity: 2 }
+    Distinct project=[#0] // { arity: 1 }
+      Project (#0) // { arity: 1 }
+        ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -494,6 +544,8 @@ Explained Query:
     Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -510,6 +562,8 @@ Explained Query:
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -522,6 +576,8 @@ Explained Query:
     Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -536,6 +592,8 @@ Explained Query:
     Project (#0) // { arity: 1 }
       ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -548,6 +606,8 @@ Explained Query:
     Distinct project=[(#0 + 1)] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -562,6 +622,8 @@ Explained Query:
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -575,6 +637,8 @@ Explained Query:
     Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -595,6 +659,8 @@ Explained Query:
   Map (123) // { arity: 3 }
     ReadStorage materialize.public.t_pk // { arity: 2 }
 
+Source materialize.public.t_pk
+
 Target cluster: quickstart
 
 EOF
@@ -605,6 +671,8 @@ explain with(arity, join implementations) select distinct a1.*, 123 from t_pk as
 Explained Query:
   Map (123) // { arity: 3 }
     ReadStorage materialize.public.t_pk // { arity: 2 }
+
+Source materialize.public.t_pk
 
 Target cluster: quickstart
 
@@ -688,6 +756,8 @@ Explained Query:
         Project () // { arity: 0 }
           ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -711,6 +781,8 @@ Explained Query:
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           ReadStorage materialize.public.t // { arity: 2 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -793,6 +865,8 @@ Explained Query:
                         Filter (#0 = 1308) // { arity: 2 }
                           ReadStorage materialize.public.t // { arity: 2 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -853,6 +927,8 @@ Explained Query:
           Reduce aggregates=[count(*)] // { arity: 1 }
             Project () // { arity: 0 }
               ReadStorage materialize.public.t1 // { arity: 2 }
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/literal_lifting.slt
+++ b/test/sqllogictest/transform/literal_lifting.slt
@@ -49,6 +49,8 @@ Explained Query:
             Project (#1) // { arity: 1 }
               ReadStorage materialize.public.t1 // { arity: 2 }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -90,6 +92,8 @@ Explained Query:
             ReadStorage materialize.public.t1 // { arity: 2 }
           Project (#1) // { arity: 1 }
             ReadStorage materialize.public.t1 // { arity: 2 }
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/monotonic.slt
+++ b/test/sqllogictest/transform/monotonic.slt
@@ -23,6 +23,8 @@ Explained Query:
   TopK limit=1 monotonic
     ReadStorage materialize.public.counter
 
+Source materialize.public.counter
+
 Target cluster: quickstart
 
 EOF
@@ -34,6 +36,8 @@ EXPLAIN SELECT counter % 3, MAX(counter) as sum FROM counter GROUP BY counter % 
 Explained Query:
   Reduce group_by=[(#0 % 3)] aggregates=[max(#0)] monotonic
     ReadStorage materialize.public.counter
+
+Source materialize.public.counter
 
 Target cluster: quickstart
 
@@ -58,6 +62,9 @@ Explained Query:
           ReadStorage materialize.public.v1
         ArrangeBy keys=[[]]
           ReadStorage materialize.public.v2
+
+Source materialize.public.v1
+Source materialize.public.v2
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -273,6 +273,8 @@ Explained Query:
                 Filter (#0) IS NOT NULL
                   Get l0
 
+Source materialize.public.edges
+
 Target cluster: quickstart
 
 EOF
@@ -551,6 +553,8 @@ Explained Query:
               ArrangeBy keys=[[#0]]
                 Filter (#0) IS NOT NULL
                   Get l0
+
+Source materialize.public.edges
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/notice/index_key_empty.slt
+++ b/test/sqllogictest/transform/notice/index_key_empty.slt
@@ -41,6 +41,8 @@ materialize.public.t_idx_empty_key:
   ArrangeBy keys=[[]]
     ReadStorage materialize.public.t
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 Notices:

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -200,6 +200,9 @@ Explained Query:
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
       ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -216,6 +219,9 @@ Explained Query:
       ReadStorage materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
       ReadStorage materialize.public.t2 // { arity: 2 }
+
+Source materialize.public.t1
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -234,6 +240,9 @@ Explained Query:
     ArrangeBy keys=[[#0]] // { arity: 2 }
       ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -250,6 +259,9 @@ Explained Query:
       ReadStorage materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[#0]] // { arity: 2 }
       ReadStorage materialize.public.t2 // { arity: 2 }
+
+Source materialize.public.t1
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -327,6 +339,7 @@ Explained Query:
 
 Source materialize.public.t1
   filter=(((#1 = 27) OR (#1 <= 1995)))
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -652,6 +665,8 @@ Explained Query:
           ReadStorage materialize.public.init
         Get l2
 
+Source materialize.public.init
+
 Target cluster: quickstart
 
 EOF
@@ -696,6 +711,8 @@ Explained Query:
         Project (#0)
           ReadStorage materialize.public.init
         Get l2
+
+Source materialize.public.init
 
 Target cluster: quickstart
 
@@ -749,6 +766,8 @@ Explained Query:
           ReadStorage materialize.public.init
         Get l2
 
+Source materialize.public.init
+
 Target cluster: quickstart
 
 EOF
@@ -796,6 +815,8 @@ Explained Query:
           ReadStorage materialize.public.init
         Filter (#0 > 7)
           Get l2
+
+Source materialize.public.init
 
 Target cluster: quickstart
 
@@ -847,6 +868,8 @@ Explained Query:
           ReadStorage materialize.public.init
         Get l2
 
+Source materialize.public.init
+
 Target cluster: quickstart
 
 EOF
@@ -895,6 +918,8 @@ Explained Query:
           ReadStorage materialize.public.init
         Filter (#0 < 3)
           Get l2
+
+Source materialize.public.init
 
 Target cluster: quickstart
 
@@ -1031,6 +1056,8 @@ Explained Query:
   Filter (((((((((((((#4 * #4) * #4) * #4) * #4) * #4) * #4) * #4) * #4) * #4) * #4) * #4) * #4) > 5)
     Map ((#0 * #1), (#2 + 1), ((((((((((((((((((((((((((#0 + #1) + #2) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3) + #3))
       ReadStorage materialize.public.t
+
+Source materialize.public.t
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/reduce_elision.slt
+++ b/test/sqllogictest/transform/reduce_elision.slt
@@ -50,6 +50,7 @@ Explained Query:
 
 Source materialize.public.x
   filter=((#1) IS NOT NULL)
+Source materialize.public.y
 
 Target cluster: quickstart
 
@@ -92,6 +93,7 @@ Explained Query:
 
 Source materialize.public.x
   filter=((#1) IS NOT NULL)
+Source materialize.public.y
 
 Target cluster: quickstart
 
@@ -135,6 +137,7 @@ Explained Query:
 
 Source materialize.public.x
   filter=((#1) IS NOT NULL)
+Source materialize.public.y
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/reduce_fusion.slt
+++ b/test/sqllogictest/transform/reduce_fusion.slt
@@ -17,6 +17,8 @@ Explained Query:
   Distinct project=[#0..=#2] // { arity: 3 }
     ReadStorage materialize.public.t // { arity: 3 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -28,6 +30,8 @@ Explained Query:
   Distinct project=[(#0 + 1)] // { arity: 1 }
     Project (#1) // { arity: 1 }
       ReadStorage materialize.public.t // { arity: 3 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -41,6 +45,8 @@ Explained Query:
     Project (#1) // { arity: 1 }
       ReadStorage materialize.public.t // { arity: 3 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -52,6 +58,8 @@ Explained Query:
   Distinct project=[] // { arity: 0 }
     Project () // { arity: 0 }
       ReadStorage materialize.public.t // { arity: 3 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -65,6 +73,8 @@ Explained Query:
     Project () // { arity: 0 }
       ReadStorage materialize.public.t // { arity: 3 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -77,6 +87,8 @@ Explained Query:
     Project (#0) // { arity: 1 }
       ReadStorage materialize.public.t // { arity: 3 }
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -88,6 +100,8 @@ Explained Query:
   Distinct project=[((#0 / 10) / 20)] // { arity: 1 }
     Project (#0) // { arity: 1 }
       ReadStorage materialize.public.t // { arity: 3 }
+
+Source materialize.public.t
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/redundant_join.slt
+++ b/test/sqllogictest/transform/redundant_join.slt
@@ -77,6 +77,8 @@ Explained Query:
           Map ((#0 % 2)) // { arity: 3 }
             ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -165,6 +167,8 @@ Explained Query:
       Distinct project=[(#0 % 2)] // { arity: 1 }
         Project (#0) // { arity: 1 }
           ReadStorage materialize.public.t2 // { arity: 2 }
+
+Source materialize.public.t2
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -1287,6 +1287,8 @@ Explained Query:
           Project () // { arity: 0 }
             ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
+Source materialize.public.t2
+
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, lookup)
 
@@ -1318,6 +1320,8 @@ Explained Query:
     cte l0 =
       Project (#0) // { arity: 1 }
         ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+
+Source materialize.public.t2
 
 Used Indexes:
   - materialize.public.i1 (lookup)

--- a/test/sqllogictest/transform/relax_must_consolidate.slt
+++ b/test/sqllogictest/transform/relax_must_consolidate.slt
@@ -75,6 +75,8 @@ Explained Query:
         Get::PassArrangements materialize.public.t
           raw=true
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -197,6 +199,8 @@ Explained Query:
             project=(#1, #2)
           Get::PassArrangements materialize.public.t
             raw=true
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -618,6 +622,8 @@ Explained Query:
           Get::PassArrangements materialize.public.t
             raw=true
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -678,6 +684,8 @@ Explained Query:
             project=(#1, #0)
           Get::PassArrangements materialize.public.t
             raw=true
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -862,6 +870,8 @@ Explained Query:
           Get::PassArrangements materialize.public.t
             raw=true
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -924,6 +934,8 @@ Explained Query:
           Get::PassArrangements materialize.public.t
             raw=true
 
+Source materialize.public.t
+
 Target cluster: quickstart
 
 EOF
@@ -972,6 +984,8 @@ Explained Query:
             project=(#1)
           Get::PassArrangements materialize.public.t
             raw=true
+
+Source materialize.public.t
 
 Target cluster: quickstart
 
@@ -1056,6 +1070,8 @@ Explained Query:
                   project=(#1)
                 Get::PassArrangements materialize.public.t
                   raw=true
+
+Source materialize.public.t
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/scalar_cse.slt
+++ b/test/sqllogictest/transform/scalar_cse.slt
@@ -20,6 +20,8 @@ Explained Query:
     Map ((#1 * #1), (#2 * #1)) // { arity: 4 }
       ReadStorage materialize.public.x // { arity: 2 }
 
+Source materialize.public.x
+
 Target cluster: quickstart
 
 EOF
@@ -31,6 +33,8 @@ Explained Query:
   Project (#3, #4) // { arity: 2 }
     Map ((#1 * #1), (#2 * #1), (#2 + 1)) // { arity: 5 }
       ReadStorage materialize.public.x // { arity: 2 }
+
+Source materialize.public.x
 
 Target cluster: quickstart
 
@@ -47,6 +51,8 @@ Explained Query:
   Project (#3..=#5) // { arity: 3 }
     Map (text_to_jsonb(#0), (#2 -> "Field1"), (#2 -> "Field2"), (#2 -> "Field3")) // { arity: 6 }
       ReadStorage materialize.public.x // { arity: 2 }
+
+Source materialize.public.x
 
 Target cluster: quickstart
 
@@ -65,6 +71,8 @@ Explained Query:
     Map (text_to_jsonb(#0), (#2 -> "Field1"), (#3 -> "Foo"), (#3 -> "Bar"), (#2 -> "Field2"), (#6 -> "Baz"), ((#6 -> "Quux") -> "Zorb")) // { arity: 9 }
       ReadStorage materialize.public.x // { arity: 2 }
 
+Source materialize.public.x
+
 Target cluster: quickstart
 
 EOF
@@ -81,6 +89,8 @@ Explained Query:
   Project (#2, #3) // { arity: 2 }
     Map (case when (#1 = 0) then 0 else (1 / #1) end, case when (#1 != 0) then (1 / #1) else 0 end) // { arity: 4 }
       ReadStorage materialize.public.x // { arity: 2 }
+
+Source materialize.public.x
 
 Target cluster: quickstart
 
@@ -101,6 +111,8 @@ Explained Query:
   Project (#3, #4) // { arity: 2 }
     Map ((#1 / 2), case when (#2 = 0) then 0 else (1 / #2) end, case when (#2 != 0) then (1 / #2) else 0 end) // { arity: 5 }
       ReadStorage materialize.public.x // { arity: 2 }
+
+Source materialize.public.x
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -81,6 +81,8 @@ Explained Query:
         Filter (#0 = 5) // { non_negative: true }
           ReadStorage materialize.public.people // { non_negative: true }
 
+Source materialize.public.people
+
 Target cluster: quickstart
 
 EOF
@@ -105,6 +107,8 @@ Explained Query:
         Filter (#3) IS NOT NULL // { non_negative: true }
           ReadStorage materialize.public.people // { non_negative: true }
 
+Source materialize.public.people
+
 Target cluster: quickstart
 
 EOF
@@ -126,6 +130,8 @@ Explained Query:
         Project (#1) // { non_negative: true }
           Filter (#0 > 1) // { non_negative: true }
             ReadStorage materialize.public.people // { non_negative: true }
+
+Source materialize.public.people
 
 Target cluster: quickstart
 
@@ -152,6 +158,8 @@ Explained Query:
             Project (#0, #1) // { non_negative: true }
               Filter (#0 > 1) // { non_negative: true }
                 ReadStorage materialize.public.people // { non_negative: true }
+
+Source materialize.public.people
 
 Target cluster: quickstart
 
@@ -194,6 +202,8 @@ Explained Query:
       Project (#0, #1) // { non_negative: true }
         ReadStorage materialize.public.people // { non_negative: true }
 
+Source materialize.public.people
+
 Target cluster: quickstart
 
 EOF
@@ -235,6 +245,8 @@ Explained Query:
       Project (#0, #1) // { non_negative: true }
         ReadStorage materialize.public.people // { non_negative: true }
 
+Source materialize.public.people
+
 Target cluster: quickstart
 
 EOF
@@ -262,6 +274,9 @@ Explained Query:
           Project () // { non_negative: true }
             ReadStorage materialize.public.bands // { non_negative: true }
 
+Source materialize.public.bands
+Source materialize.public.people
+
 Target cluster: quickstart
 
 EOF
@@ -284,6 +299,8 @@ Explained Query:
       Distinct project=[#0] // { non_negative: true }
         Project (#1) // { non_negative: true }
           ReadStorage materialize.public.people // { non_negative: true }
+
+Source materialize.public.people
 
 Target cluster: quickstart
 
@@ -311,6 +328,8 @@ Explained Query:
       Reduce group_by=[extract_year_d(#0)] aggregates=[count(*)] // { non_negative: true }
         Project (#2) // { non_negative: true }
           ReadStorage materialize.public.people // { non_negative: true }
+
+Source materialize.public.people
 
 Target cluster: quickstart
 
@@ -352,6 +371,8 @@ Explained Query:
             Filter like["J%"](#1) // { non_negative: true }
               ReadStorage materialize.public.people // { non_negative: true }
 
+Source materialize.public.people
+
 Target cluster: quickstart
 
 EOF
@@ -380,6 +401,8 @@ Explained Query:
         Project (#1) // { non_negative: true }
           Filter (#0 = 2) // { non_negative: true }
             ReadStorage materialize.public.people // { non_negative: true }
+
+Source materialize.public.people
 
 Target cluster: quickstart
 
@@ -426,6 +449,8 @@ Explained Query:
           Project (#0, #2) // { non_negative: false }
             Map ((#1 || "_iter")) // { non_negative: false }
               Get l0 // { non_negative: false }
+
+Source materialize.public.people
 
 Target cluster: quickstart
 
@@ -478,6 +503,8 @@ Explained Query:
                   Filter (#0 > 1) // { non_negative: false }
                     Get l1 // { non_negative: false }
 
+Source materialize.public.people
+
 Target cluster: quickstart
 
 EOF
@@ -513,6 +540,8 @@ Explained Query:
             Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
               Filter (#0 > 1) // { non_negative: false }
                 Get l0 // { non_negative: false }
+
+Source materialize.public.people
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/topk.slt
+++ b/test/sqllogictest/transform/topk.slt
@@ -39,6 +39,8 @@ Explained Query:
             Map ((#0 + #1), (#4 + #2), (#4 + #3)) // { arity: 7 }
               ReadStorage materialize.public.test1 // { arity: 4 }
 
+Source materialize.public.test1
+
 Target cluster: quickstart
 
 EOF
@@ -63,6 +65,8 @@ Explained Query:
       Reduce group_by=[((#0 + #1) + #2), ((#0 + #1) + #3)] aggregates=[sum(#3), count(#3)] // { arity: 4 }
         ReadStorage materialize.public.test1 // { arity: 4 }
 
+Source materialize.public.test1
+
 Target cluster: quickstart
 
 EOF
@@ -76,6 +80,8 @@ Explained Query:
     ReadStorage materialize.public.test1 // { arity: 4 }
     ReadStorage materialize.public.test1 // { arity: 4 }
     ReadStorage materialize.public.test1 // { arity: 4 }
+
+Source materialize.public.test1
 
 Target cluster: quickstart
 
@@ -111,6 +117,8 @@ explain with(arity, join implementations) materialized view mv1;
 materialize.public.mv1:
   TopK order_by=[#0 asc nulls_last] limit=3 offset=3 // { arity: 2 }
     ReadStorage materialize.public.t1 // { arity: 2 }
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -43,6 +43,9 @@ Explained Query:
     ReadStorage materialize.public.t2 // { arity: 2 }
     ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -78,6 +81,9 @@ Explained Query:
       Negate // { arity: 2 }
         ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -105,6 +111,10 @@ Explained Query:
           Negate // { arity: 2 }
             ReadStorage materialize.public.t3 // { arity: 2 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+Source materialize.public.t3
+
 Target cluster: quickstart
 
 EOF
@@ -130,6 +140,10 @@ Explained Query:
             Project (#0, #2) // { arity: 2 }
               Map (null) // { arity: 3 }
                 ReadStorage materialize.public.t3 // { arity: 2 }
+
+Source materialize.public.t1
+Source materialize.public.t2
+Source materialize.public.t3
 
 Target cluster: quickstart
 
@@ -176,6 +190,7 @@ Explained Query:
 
 Source materialize.public.t2
   filter=((#1) IS NOT NULL)
+Source materialize.public.t3
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/union_cancel.slt
+++ b/test/sqllogictest/transform/union_cancel.slt
@@ -38,6 +38,8 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1
 Explained Query:
   ReadStorage materialize.public.t1 // { arity: 2 }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -54,6 +56,8 @@ EXPLAIN WITH(arity, join implementations) SELECT a1.* FROM t1 AS a1 LEFT JOIN t1
 ----
 Explained Query:
   ReadStorage materialize.public.t1 // { arity: 2 }
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 
@@ -108,6 +112,8 @@ Explained Query:
   Threshold // { arity: 2 }
     ReadStorage materialize.public.t1 // { arity: 2 }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -124,6 +130,8 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 EXCEPT ALL SELECT * F
 ----
 Explained Query:
   ReadStorage materialize.public.t1 // { arity: 2 }
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 
@@ -143,6 +151,8 @@ Explained Query:
   Threshold // { arity: 2 }
     ReadStorage materialize.public.t2 // { arity: 2 }
 
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -159,6 +169,8 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t2 UNION ALL SELECT * FR
 Explained Query:
   Threshold // { arity: 2 }
     ReadStorage materialize.public.t2 // { arity: 2 }
+
+Source materialize.public.t2
 
 Target cluster: quickstart
 
@@ -182,6 +194,9 @@ Explained Query:
           ReadStorage materialize.public.t1 // { arity: 2 }
     ReadStorage materialize.public.t1 // { arity: 2 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -203,6 +218,8 @@ Explained Query:
   Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
     ReadStorage materialize.public.t3 // { arity: 2 }
 
+Source materialize.public.t3
+
 Target cluster: quickstart
 
 EOF
@@ -222,6 +239,8 @@ SELECT a1.* FROM t3 AS a1 LEFT JOIN t3_with_key AS a2 ON (a1.f1 = a2.key);
 ----
 Explained Query:
   ReadStorage materialize.public.t3 // { arity: 2 }
+
+Source materialize.public.t3
 
 Target cluster: quickstart
 
@@ -243,6 +262,8 @@ SELECT a1.* FROM t3 AS a1 LEFT JOIN t3_with_key AS a2 ON (a1.f1 = a2.key or (a1.
 ----
 Explained Query:
   ReadStorage materialize.public.t3 // { arity: 2 }
+
+Source materialize.public.t3
 
 Target cluster: quickstart
 
@@ -301,6 +322,8 @@ Explained Query:
         Project (#0)
           ReadStorage materialize.public.init
         Get l2
+
+Source materialize.public.init
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -983,6 +983,8 @@ Explained Query:
     Map (coalesce(#0, 0)) // { types: "(integer?, integer?, integer, integer)" }
       ReadStorage materialize.public.t1 // { types: "(integer?, integer?, integer)" }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -996,6 +998,8 @@ Explained Query:
   Project (#3) // { types: "(integer)" }
     Map (coalesce(#0, #2)) // { types: "(integer?, integer?, integer, integer)" }
       ReadStorage materialize.public.t1 // { types: "(integer?, integer?, integer)" }
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 
@@ -1014,6 +1018,8 @@ Explained Query:
         Project (#0, #1) // { types: "(integer?, integer?)" }
           ReadStorage materialize.public.t1 // { types: "(integer?, integer?, integer)" }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -1029,6 +1035,8 @@ Explained Query:
     Map (coalesce(#0, #1)) // { types: "(integer?, integer?, integer, integer?)" }
       ReadStorage materialize.public.t1 // { types: "(integer?, integer?, integer)" }
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 EOF
@@ -1042,6 +1050,8 @@ Explained Query:
   Project (#3) // { types: "(integer?)" }
     Map (coalesce(#0, (#1 + 5))) // { types: "(integer?, integer?, integer, integer?)" }
       ReadStorage materialize.public.t1 // { types: "(integer?, integer?, integer)" }
+
+Source materialize.public.t1
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -255,6 +255,9 @@ Explained Query:
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t1 // { arity: 2 }
 
+Source materialize.public.t1
+Source materialize.public.t2
+
 Target cluster: quickstart
 
 EOF
@@ -5739,6 +5742,8 @@ Explained Query:
             Reduce group_by=[(2 * #0), (3 * #1)] aggregates=[window_agg[sum order_by=[#0 asc nulls_last, #1 asc nulls_last] rows between unbounded preceding and current row](row(row(row(#0, #1), (#1 - 3)), (#0 + 1), (#1 + 2)))]
               ReadStorage materialize.public.t7
 
+Source materialize.public.t7
+
 Target cluster: quickstart
 
 EOF
@@ -6599,6 +6604,8 @@ Explained Query:
         Project (#0) // { keys: "()" }
           ReadStorage materialize.public.t7 // { keys: "()" }
 
+Source materialize.public.t7
+
 Target cluster: quickstart
 
 EOF
@@ -6652,6 +6659,8 @@ Explained Query:
           Project (#2) // { keys: "()" }
             Map (list[row(integer_to_bigint(#1), row(#0, #1))]) // { keys: "([0])" }
               ReadStorage materialize.public.t9 // { keys: "([0])" }
+
+Source materialize.public.t9
 
 Target cluster: quickstart
 

--- a/test/testdrive/char-varchar-orderby.td
+++ b/test/testdrive/char-varchar-orderby.td
@@ -76,6 +76,8 @@ Explained Query:
   TopK order_by=[#0 asc nulls_first] limit=1
     ReadStorage materialize.public.char_table
 
+Source materialize.public.char_table
+
 Target cluster: quickstart
 
 > SELECT * FROM (SELECT * FROM char_table ORDER BY f1 LIMIT 1 OFFSET 0)

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -344,6 +344,8 @@ Explained Query:
   Project (#0)
     ReadStorage materialize.public.bareformatconfluent
 
+Source materialize.public.bareformatconfluent
+
 Target cluster: quickstart
 
 > CREATE DEFAULT INDEX ON bareformatconfluent;
@@ -376,6 +378,8 @@ Explained Query:
   Distinct project=[#0] monotonic
     Project (#0)
       ReadStorage materialize.public.envelope_none_with_key
+
+Source materialize.public.envelope_none_with_key
 
 Target cluster: quickstart
 

--- a/test/testdrive/monotonic.td
+++ b/test/testdrive/monotonic.td
@@ -233,4 +233,6 @@ Explained Query:
     Get::PassArrangements materialize.public.m1
       raw=true
 
+Source materialize.public.m1
+
 Target cluster: quickstart

--- a/test/testdrive/source-linear-operators.td
+++ b/test/testdrive/source-linear-operators.td
@@ -143,6 +143,8 @@ Explained Query:
           Filter (#3 = 4) AND (#1) IS NOT NULL
             ReadStorage materialize.public.data
 
+Source materialize.public.data
+
 Target cluster: quickstart
 
 > CREATE DEFAULT INDEX ON v;
@@ -272,6 +274,7 @@ Explained Query:
           Filter (#3) IS NULL
             ReadStorage materialize.public.data2
 
+Source materialize.public.data
 Source materialize.public.data2
   filter=((#3) IS NULL)
 

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -54,6 +54,8 @@ Explained Query:
     ArrangeBy keys=[[]]
       ReadStorage materialize.public.t1
 
+Source materialize.public.t1
+
 Target cluster: quickstart
 
 ! SELECT * FROM u1234;


### PR DESCRIPTION
Previously they were only shown if some op was present (like a pushdown filter).

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a