### PR TITLE
persist: Use `DELTA_LENGTH_BYTE_ARRAY` encoding for 'k' and 'v' columns

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -917,6 +917,9 @@ class FlipFlagsAction(Action):
             "enable_variadic_left_join_lowering"
         ] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values[
+            "persist_use_parquet_delta_length_byte_array"
+        ] = BOOLEAN_FLAG_VALUES
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -918,7 +918,7 @@ class FlipFlagsAction(Action):
         ] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values[
-            "persist_use_parquet_delta_length_byte_array"
+            "persist_enable_parquet_delta_length_byte_array"
         ] = BOOLEAN_FLAG_VALUES
 
     def run(self, exe: Executor) -> bool:

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -88,6 +88,12 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                     x.add_dynamic("persist_inline_writes_total_max_bytes", ::mz_dyncfg::ConfigVal::Usize(0));
                     x
                 },
+                {
+                    // Using DELTA_LENGTH_BYTE_ARRAY encoding for 'k' and 'v' columns.
+                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
+                    x.add_dynamic("persist_use_parquet_delta_length_byte_array", ::mz_dyncfg::ConfigVal::Bool(true));
+                    x
+                }
             ];
 
             for (idx, dyncfgs) in dyncfgs.into_iter().enumerate() {

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -91,7 +91,7 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 {
                     // Using DELTA_LENGTH_BYTE_ARRAY encoding for 'k' and 'v' columns.
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
-                    x.add_dynamic("persist_use_parquet_delta_length_byte_array", ::mz_dyncfg::ConfigVal::Bool(true));
+                    x.add_dynamic("persist_enable_parquet_delta_length_byte_array", ::mz_dyncfg::ConfigVal::Bool(true));
                     x
                 }
             ];

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -33,6 +33,7 @@ pub fn all_dyn_configs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_CC_SIZES)
         .add(&crate::indexed::columnar::arrow::ENABLE_ARROW_LGALLOC_NONCC_SIZES)
+        .add(&crate::indexed::columnar::parquet::ENABLE_PARQUET_DELTA_LENGTH_BYTE_ARRAY)
         .add(&crate::s3::ENABLE_S3_LGALLOC_CC_SIZES)
         .add(&crate::s3::ENABLE_S3_LGALLOC_NONCC_SIZES)
 }

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -38,8 +38,8 @@ use crate::metrics::ColumnarMetrics;
 
 const INLINE_METADATA_KEY: &str = "MZ:inline";
 
-pub(crate) const USE_PARQUET_DELTA_LENGTH_BYTE_ARRAY: Config<bool> = Config::new(
-    "persist_use_parquet_delta_length_byte_array",
+pub(crate) const ENABLE_PARQUET_DELTA_LENGTH_BYTE_ARRAY: Config<bool> = Config::new(
+    "persist_enable_parquet_delta_length_byte_array",
     false,
     "'false' by default, when 'true' uses Parquet's `DELTA_LENGTH_BYTE_ARRAY` encoding for the 'k' and 'v' columns."
 );
@@ -118,7 +118,7 @@ pub fn encode_parquet_kvtd<W: Write + Send>(
         .set_max_row_group_size(usize::MAX)
         .set_key_value_metadata(Some(vec![metadata]));
 
-    if USE_PARQUET_DELTA_LENGTH_BYTE_ARRAY.get(&metrics.cfg) {
+    if ENABLE_PARQUET_DELTA_LENGTH_BYTE_ARRAY.get(&metrics.cfg) {
         properties_builder = properties_builder
             .set_column_encoding(
                 ColumnPath::new(vec!["k".to_string()]),


### PR DESCRIPTION
Discovered by @danhhz, Parquet's `PLAIN` encoding is quite inefficient for binary array columns. It encodes data as:
```
[<len 1><blob 1><len 2><blob 2> ... <len N><blob N>]
```
where `DELTA_LENGTH_BYTE_ARRAY` encodes data as:
```
[<len 1>...<len N><blob 1>...<blob N>]
```
The later theoretically allows for zero-copy transformation of the binary data into an Arrow array, because Arrow Binary arrays also concatenate the binary blobs one after another. When describing `DELTA_LENGTH_BYTE_ARRAY` the [Parquet docs](https://parquet.apache.org/docs/file-format/data-pages/encodings/) also state:

> This encoding is always preferred over PLAIN for byte array columns.

The use of the new encoding type is gated by a dyncfg named "persist_enable_parquet_delta_length_byte_array".

### Motivation

Improved performance in Persist encoding and decoding

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
