### PR TITLE
persist: "packed" encodings for `Interval` and `Time`

### DIFF
--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -17,6 +17,10 @@ harness = false
 name = "strconv"
 harness = false
 
+[[bench]]
+name = "packed"
+harness = false
+
 [dependencies]
 anyhow = "1.0.66"
 arrow = { version = "51.0.0", default-features = false }

--- a/src/repr/benches/packed.rs
+++ b/src/repr/benches/packed.rs
@@ -19,7 +19,7 @@ fn bench_interval(c: &mut Criterion) {
     const INTERVAL: Interval = Interval::new(1, 1, 0);
     group.bench_function("encode", |b| {
         b.iter(|| {
-            let packed = PackedInterval::from(INTERVAL);
+            let packed = PackedInterval::from(std::hint::black_box(INTERVAL));
             std::hint::black_box(packed);
         })
     });
@@ -28,7 +28,7 @@ fn bench_interval(c: &mut Criterion) {
     group.bench_function("decode", |b| {
         let packed = PackedInterval::from_bytes(&PACKED).unwrap();
         b.iter(|| {
-            let normal = Interval::from(packed);
+            let normal = Interval::from(std::hint::black_box(packed));
             std::hint::black_box(normal);
         })
     });
@@ -43,7 +43,7 @@ fn bench_time(c: &mut Criterion) {
     group.bench_function("encode", |b| {
         let naive_time = NaiveTime::from_hms_opt(1, 1, 1).unwrap();
         b.iter(|| {
-            let packed = PackedNaiveTime::from(naive_time);
+            let packed = PackedNaiveTime::from(std::hint::black_box(naive_time));
             std::hint::black_box(packed);
         })
     });
@@ -52,7 +52,7 @@ fn bench_time(c: &mut Criterion) {
     group.bench_function("decode", |b| {
         let packed = PackedNaiveTime::from_bytes(&PACKED).unwrap();
         b.iter(|| {
-            let normal = NaiveTime::from(packed);
+            let normal = NaiveTime::from(std::hint::black_box(packed));
             std::hint::black_box(normal);
         })
     });

--- a/src/repr/benches/packed.rs
+++ b/src/repr/benches/packed.rs
@@ -1,0 +1,64 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use chrono::NaiveTime;
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use mz_repr::adt::datetime::PackedNaiveTime;
+use mz_repr::adt::interval::{Interval, PackedInterval};
+
+fn bench_interval(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PackedInterval");
+    group.throughput(Throughput::Elements(1));
+
+    const INTERVAL: Interval = Interval::new(1, 1, 0);
+    group.bench_function("encode", |b| {
+        b.iter(|| {
+            let packed = PackedInterval::from(INTERVAL);
+            std::hint::black_box(packed);
+        })
+    });
+
+    const PACKED: [u8; 16] = [128, 0, 0, 1, 128, 0, 0, 1, 128, 0, 0, 0, 0, 0, 0, 0];
+    group.bench_function("decode", |b| {
+        let packed = PackedInterval::from_bytes(&PACKED).unwrap();
+        b.iter(|| {
+            let normal = Interval::from(packed);
+            std::hint::black_box(normal);
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_time(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PackedNaiveTime");
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("encode", |b| {
+        let naive_time = NaiveTime::from_hms_opt(1, 1, 1).unwrap();
+        b.iter(|| {
+            let packed = PackedNaiveTime::from(naive_time);
+            std::hint::black_box(packed);
+        })
+    });
+
+    const PACKED: [u8; 8] = [0, 0, 14, 77, 0, 0, 0, 0];
+    group.bench_function("decode", |b| {
+        let packed = PackedNaiveTime::from_bytes(&PACKED).unwrap();
+        b.iter(|| {
+            let normal = NaiveTime::from(packed);
+            std::hint::black_box(normal);
+        })
+    });
+
+    group.finish()
+}
+
+criterion_group!(benches, bench_interval, bench_time);
+criterion_main!(benches);

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1944,8 +1944,8 @@ impl From<NaiveTime> for PackedNaiveTime {
 
         let mut buf = [0u8; Self::SIZE];
 
-        (&mut buf[..4]).copy_from_slice(&secs.to_be_bytes());
-        (&mut buf[4..]).copy_from_slice(&nano.to_be_bytes());
+        (buf[..4]).copy_from_slice(&secs.to_be_bytes());
+        (buf[4..]).copy_from_slice(&nano.to_be_bytes());
 
         PackedNaiveTime(buf)
     }

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1920,18 +1920,19 @@ impl PackedNaiveTime {
         &self.0
     }
 
-    /// Interprets a slice of bytes as a [`PackedNaiveTime`].
+    /// Interprets a slice of bytes as a [`PackedNaiveTime`], returns an error
+    /// if the size of the slice is incorrect.
     ///
-    /// Returns an error if the size of the slice is incorrect.
+    /// Note: It is the responsibility of the caller to make sure the provided
+    /// data is a valid [`PackedNaiveTime`].
     pub fn from_bytes(slice: &[u8]) -> Result<Self, String> {
-        if slice.len() != Self::SIZE {
-            let err = format!("expected {} bytes, got {}", Self::SIZE, slice.len());
-            return Err(err);
-        }
-
-        let mut buf = [0u8; Self::SIZE];
-        buf.copy_from_slice(slice);
-
+        let buf: [u8; Self::SIZE] = slice.try_into().map_err(|_| {
+            format!(
+                "size for PackedNaiveTime is {} bytes, got {}",
+                Self::SIZE,
+                slice.len()
+            )
+        })?;
         Ok(PackedNaiveTime(buf))
     }
 }

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -832,19 +832,19 @@ impl PackedInterval {
         &self.0[..]
     }
 
-    /// Creates a [`PackedInterval`] from a slice of bytes, returns an error if the size is
-    /// incorrect.
+    /// Interprets a slice of bytes as a [`PackedInterval`], returns an error
+    /// if the size of the slice is incorrect.
+    ///
+    /// Note: It is the responsibility of the caller to make sure the provided
+    /// data is a valid [`PackedInterval`].
     pub fn from_bytes(slice: &[u8]) -> Result<Self, String> {
-        if slice.len() != Self::SIZE {
-            return Err(format!(
-                "size for PackedInterval is incorrect, {}",
+        let buf: [u8; Self::SIZE] = slice.try_into().map_err(|_| {
+            format!(
+                "size for PackedInterval is {} bytes, got {}",
+                Self::SIZE,
                 slice.len()
-            ));
-        }
-
-        let mut buf = [0u8; 16];
-        buf.copy_from_slice(&slice[..16]);
-
+            )
+        })?;
         Ok(PackedInterval(buf))
     }
 }

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -872,6 +872,10 @@ impl From<Interval> for PackedInterval {
     }
 }
 
+// `as` conversions are okay here because we're doing bit level logic to make
+// sure the sort order of the packed binary is correct. This is implementation
+// is proptest-ed below.
+#[allow(clippy::as_conversions)]
 impl From<PackedInterval> for Interval {
     fn from(value: PackedInterval) -> Self {
         // Note: We XOR the values to get correct sorting of negative values.

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -4181,7 +4181,7 @@ fn arb_interval() -> BoxedStrategy<Interval> {
         .boxed()
 }
 
-fn add_arb_duration<T: 'static + Copy + Add<chrono::Duration> + std::fmt::Debug>(
+pub(crate) fn add_arb_duration<T: 'static + Copy + Add<chrono::Duration> + std::fmt::Debug>(
     to: T,
 ) -> BoxedStrategy<T::Output>
 where


### PR DESCRIPTION
This PR implements "packed" encodings for `Interval` and `Time` that will be used for writing structured data in Persist.

The packed encodings are designed to be as fast as possible and have the same sort order as the original types. They're based on discussion from https://github.com/MaterializeInc/materialize/pull/26175. I added benchmarks that measure throughput and locally I get the following results:

 type    | encode              | decode
---------|---------------------|--------
interval | ~1.5 billion/second | ~1.6 billion/second
time     | ~2.5 billion/second | ~1.3 billion/second

I believe the implementations can be optimized further with SIMD, but right now that requires `inline_asm!` or the `Nightly` compiler.

Note: The code placement feels a bit weird since these impls should only be used by Persist, so I was thinking of putting the impl behind a trait like `mz_persist_types::ColumnarCodec`, but was curious what other folks thought.

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/24830

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
