### PR TITLE
kubectl util: add server-side apply

### DIFF
--- a/misc/python/materialize/cloudtest/util/kubectl.py
+++ b/misc/python/materialize/cloudtest/util/kubectl.py
@@ -202,3 +202,37 @@ class Kubectl:
             contents = contents.replace(old, new)
         yaml_data: dict[str, Any] = yaml.safe_load(contents)
         return yaml_data
+
+    def apply(
+        self,
+        filepath: str,
+        field_manager: str | None = None,
+        server_side: bool = False,
+        namespace: str | None = None,
+    ) -> None:
+        """
+        Apply configuration to a resource from a file.
+
+        :param filepath: The path to the config file being applied.
+        :param field_manager: The field manager that owns the resource being modified.
+        :param server_side: Whether to apply the update server-side, required to avoid field ownership conflicts in some cases.
+        :param namespace: The namespace to apply the update in.
+        """
+        command = [
+            "kubectl",
+            "--context",
+            self.context,
+            "apply",
+            "-f",
+            filepath,
+        ]
+        if field_manager:
+            command.extend(["--field-manager", field_manager])
+        if namespace:
+            command.extend(["-n", namespace])
+        if server_side:
+            command.extend(["--server-side"])
+        subprocess.run(
+            args=command,
+            check=True,
+        )


### PR DESCRIPTION
### Motivation
  * This PR adds a feature that has not yet been specified.
Add kubectl apply func for use in tests that need to make server-side changes.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
