### PR TITLE
persist-client: remove sink_correction_peak metrics

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -456,10 +456,6 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             self.metrics
                 .timely_step_duration_seconds
                 .observe(start.elapsed().as_secs_f64());
-            self.persist_clients
-                .metrics()
-                .sink
-                .update_sink_correction_peak_metrics();
 
             // Report frontier information back the coordinator.
             if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2417,18 +2417,6 @@ def workflow_test_replica_metrics(c: Composition) -> None:
     assert (
         mv_correction_max_cap_per_worker > 0
     ), f"unexpected persist sink max correction capacity per worker: {mv_correction_max_cap_per_worker}"
-    mv_correction_peak_len = metrics.get_value(
-        "mz_persist_sink_correction_peak_len_updates"
-    )
-    assert (
-        mv_correction_peak_len > 0
-    ), f"unexpected persist peak correction len: {mv_correction_peak_len}"
-    mv_correction_peak_cap = metrics.get_value(
-        "mz_persist_sink_correction_peak_capacity_updates"
-    )
-    assert (
-        mv_correction_peak_cap > 0
-    ), f"unexpected persist sink peak correction capacity: {mv_correction_peak_cap}"
 
 
 def workflow_test_compute_controller_metrics(c: Composition) -> None:


### PR DESCRIPTION
The `SinkMetrics::update_sink_correction_peak_metrics` method assumed "quiescence", i.e. the temporary ceasing of updates to sink metrics while it was executing. While the method was correct under that assumption, the calling code unfortunately was not able to uphold it. Specifically, `step_or_park` is invoked per worker, so when `update_sink_correction_peak_metrics` is invoked it can only assume that the current worker won't update the sink metrics, but it cannot assume anything about other workers.

As a result of the violated assumption, "Negative aggregate length for persist sink correction" could be logged even when nothing was actually wrong with the persist sink implementation.

This is solved here by removing the problematic peak metrics entirely. Stopping all workers regularly to update them is too costly and updating them without quiescence can lead to incorrect metric values, reducing the metrics' usefullness. The current believe is that the remaining sink correction metrics should be sufficient to monitor persist_sink memory usage in production.

This is an alternative to https://github.com/MaterializeInc/materialize/pull/27306, following discussion on that PR.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/27302

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A