### PR TITLE
compute: add read-only mode for controller/clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,6 +4433,7 @@ name = "mz-compute"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bytesize",
  "clap",

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1525,7 +1525,16 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: txn-wal-fencing
+    agents:
+      queue: linux-aarch64
 
+  - id: read-only-cluster
+    label: Read-only cluster
+    depends_on: build-aarch64
+    timeout_in_minutes: 30
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: read-only-cluster
     agents:
       queue: linux-aarch64
 

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -54,6 +54,7 @@ class Materialized(Service):
         sanity_restart: bool = True,
         platform: str | None = None,
         healthcheck: list[str] | None = None,
+        read_only_controllers: bool = False,
     ) -> None:
         if name is None:
             name = "materialized"
@@ -109,6 +110,9 @@ class Materialized(Service):
 
         if unsafe_mode:
             command += ["--unsafe-mode"]
+
+        if read_only_controllers:
+            command += ["--read-only-controllers"]
 
         if not environment_id:
             environment_id = DEFAULT_MZ_ENVIRONMENT_ID

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -692,6 +692,16 @@ impl SessionClient {
         self.send_without_session(|tx| Command::Dump { tx }).await
     }
 
+    /// Allow the controller (and clusters they control) to now affect changes
+    /// to external systems.
+    ///
+    /// No authorization is performed, so access to this function must be
+    /// limited to internal servers or superusers.
+    pub async fn controller_allow_writes(&mut self) -> Result<bool, anyhow::Error> {
+        self.send_without_session(|tx| Command::ControllerAllowWrites { tx })
+            .await
+    }
+
     /// Tells the coordinator a statement has finished execution, in the cases
     /// where we have no other reason to communicate with the coordinator.
     pub fn retire_execute(
@@ -861,6 +871,7 @@ impl SessionClient {
                 | Command::RetireExecute { .. }
                 | Command::CheckConsistency { .. }
                 | Command::Dump { .. } => {}
+                Command::ControllerAllowWrites { .. } => {}
             };
             cmd
         });

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -127,6 +127,10 @@ pub enum Command {
     Dump {
         tx: oneshot::Sender<Result<serde_json::Value, anyhow::Error>>,
     },
+
+    ControllerAllowWrites {
+        tx: oneshot::Sender<Result<bool, anyhow::Error>>,
+    },
 }
 
 impl Command {
@@ -143,7 +147,8 @@ impl Command {
             | Command::SetSystemVars { .. }
             | Command::RetireExecute { .. }
             | Command::CheckConsistency { .. }
-            | Command::Dump { .. } => None,
+            | Command::Dump { .. }
+            | Command::ControllerAllowWrites { .. } => None,
         }
     }
 
@@ -160,7 +165,8 @@ impl Command {
             | Command::SetSystemVars { .. }
             | Command::RetireExecute { .. }
             | Command::CheckConsistency { .. }
-            | Command::Dump { .. } => None,
+            | Command::Dump { .. }
+            | Command::ControllerAllowWrites { .. } => None,
         }
     }
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1985,6 +1985,9 @@ impl Coordinator {
         // Announce the completion of initialization.
         self.controller.initialization_complete();
 
+        // Allow controller to go out of read-only mode right away.
+        self.controller.allow_writes();
+
         // Expose mapping from T-shirt sizes to actual sizes
         builtin_table_updates.extend(self.catalog().state().pack_all_replica_size_updates());
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -306,6 +306,7 @@ impl Message {
                 Command::RetireExecute { .. } => "command-retire_execute",
                 Command::CheckConsistency { .. } => "command-check_consistency",
                 Command::Dump { .. } => "command-dump",
+                Command::ControllerAllowWrites { .. } => "command-controller-allow-writes",
             },
             Message::ControllerReady => "controller_ready",
             Message::PurifiedStatementReady(_) => "purified_statement_ready",

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -228,6 +228,11 @@ impl Coordinator {
                 Command::Dump { tx } => {
                     let _ = tx.send(self.dump());
                 }
+
+                Command::ControllerAllowWrites { tx } => {
+                    self.controller.allow_writes();
+                    let _ = tx.send(Ok(true));
+                }
             }
         }
         .instrument(debug_span!("handle_command"))

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -441,6 +441,8 @@ pub struct CommandMetrics<M> {
     pub initialization_complete: M,
     /// Metrics for `UpdateConfiguration`.
     pub update_configuration: M,
+    /// Metrics for `AllowWrites`.
+    pub allow_writes: M,
 }
 
 impl<M> CommandMetrics<M> {
@@ -459,6 +461,7 @@ impl<M> CommandMetrics<M> {
             cancel_peek: build_metric("cancel_peek"),
             initialization_complete: build_metric("initialization_complete"),
             update_configuration: build_metric("update_configuration"),
+            allow_writes: build_metric("allow_writes"),
         }
     }
 
@@ -491,6 +494,7 @@ impl<M> CommandMetrics<M> {
             AllowCompaction { .. } => &self.allow_compaction,
             Peek(_) => &self.peek,
             CancelPeek { .. } => &self.cancel_peek,
+            AllowWrites { .. } => &self.allow_writes,
         }
     }
 
@@ -507,6 +511,7 @@ impl<M> CommandMetrics<M> {
             CancelPeek(_) => &self.cancel_peek,
             InitializationComplete(_) => &self.initialization_complete,
             UpdateConfiguration(_) => &self.update_configuration,
+            AllowWrites(_) => &self.allow_writes,
         }
     }
 }

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -45,6 +45,7 @@ message ProtoComputeCommand {
         google.protobuf.Empty initialization_complete = 7;
         ProtoComputeParameters update_configuration = 8;
         mz_repr.global_id.ProtoGlobalId schedule = 9;
+        google.protobuf.Empty allow_writes = 10;
     }
 }
 

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -87,6 +87,28 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// [Initialization Stage]: super#initialization-stage
     InitializationComplete,
 
+    /// `AllowWrites` informs the replica that it can transition out of the
+    /// read-only computation stage and into the read-write computation stage.
+    /// It is now allowed to affect changes to external systems (writes).
+    ///
+    /// After initialization is complete, an instance starts out in the
+    /// read-only computation stage. Only when receiving this command will it go
+    /// out of that and allow running operations to do writes.
+    ///
+    /// An instance that has once been told that it can go into read-write mode
+    /// can never go out of that mode again. It is okay for a read-only
+    /// controller to re-connect to an instance that is already in read-write
+    /// mode: _someone_ has already told the instance that it is okay to write
+    /// and there is no way in the protocol to transition an instance back to
+    /// read-only mode.
+    ///
+    /// NOTE: We don't have a protocol in place that allows writes only after a
+    /// certain, controller-determined, timestamp. Such a protocol would allow
+    /// tighter control and could allow the instance to avoid work. However, it
+    /// is more work to put in place the logic for that so we leave it as future
+    /// work for now.
+    AllowWrites,
+
     /// `UpdateConfiguration` instructs the replica to update its configuration, according to the
     /// given [`ComputeParameters`].
     ///
@@ -245,20 +267,6 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
         /// This Value must match a [`Peek::uuid`] value transmitted in a previous `Peek` command.
         uuid: Uuid,
     },
-
-    /// Allow this instance to affect writes to external systems from now on.
-    ///
-    /// An instance starts out in read-only mode. Only when receiving this
-    /// command will it go out of that and allow running operations to do
-    /// writes.
-    ///
-    /// NOTE: We don't allow flipping back to read-only mode. We also don't have
-    /// a protocol in place that allows writes only after a certain timestamps.
-    /// Those are all things we might want to do in the future but this initial
-    /// version is keeping things minimal!
-    ///
-    /// WIP: Naming is hard, I'm very open to suggestions!
-    AllowWrites,
 }
 
 impl RustType<ProtoComputeCommand> for ComputeCommand<mz_repr::Timestamp> {

--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -98,6 +98,7 @@ where
         let mut final_configuration = ComputeParameters::default();
 
         let mut initialization_complete = false;
+        let mut read_only = true;
 
         for command in self.commands.drain(..) {
             match command {
@@ -130,6 +131,9 @@ where
                 }
                 ComputeCommand::CancelPeek { uuid } => {
                     live_peeks.remove(&uuid);
+                }
+                ComputeCommand::AllowWrites => {
+                    read_only = false;
                 }
             }
         }
@@ -243,6 +247,10 @@ where
         command_counts.initialization_complete.borrow().set(count);
         if initialization_complete {
             self.commands.push(ComputeCommand::InitializationComplete);
+        }
+
+        if !read_only {
+            self.commands.push(ComputeCommand::AllowWrites);
         }
 
         self.reduced_count = self.commands.len();

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -115,6 +115,16 @@ pub const COPY_TO_S3_MULTIPART_PART_SIZE_BYTES: Config<usize> = Config::new(
     "The size of each part in a multipart upload to S3.",
 );
 
+/// Whether the compute `persist_sink` obeys read-only mode. When false, it
+/// writes regardless of that mode.
+///
+/// As an escape hatch for de-risking rollout of read-only computation mode.
+pub const PERSIST_SINK_OBEY_READ_ONLY: Config<bool> = Config::new(
+    "compute_persist_sink_obey_read_only",
+    true,
+    "Whether the compute persist_sink obeys read-only mode.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -131,4 +141,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COPY_TO_S3_PARQUET_ROW_GROUP_FILE_RATIO)
         .add(&COPY_TO_S3_ARROW_BUILDER_BUFFER_RATIO)
         .add(&COPY_TO_S3_MULTIPART_PART_SIZE_BYTES)
+        .add(&PERSIST_SINK_OBEY_READ_ONLY)
 }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
+async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytesize = "1.1.0"
 clap = { version = "3.2.24", features = ["derive", "env"] }

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -17,7 +17,6 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{Collection, Hashable};
 use mz_compute_types::sinks::{ComputeSinkDesc, PersistSinkConnection};
 use mz_ore::cast::CastFrom;
-use mz_ore::collections::HashMap;
 use mz_persist_client::batch::{Batch, BatchBuilder, ProtoBatch};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::operators::shard_source::SnapshotMode;
@@ -32,7 +31,7 @@ use serde::{Deserialize, Serialize};
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::{
-    Broadcast, Capability, CapabilitySet, ConnectLoop, Feedback, Inspect,
+    Broadcast, Capability, CapabilitySet, ConnectLoop, Feedback, Inspect, Probe,
 };
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
@@ -231,6 +230,7 @@ where
         target,
         &batch_descriptions,
         &written_batches,
+        &persist_oks,
         persist_clients,
         compute_state.read_only_rx.clone(),
     );
@@ -853,17 +853,20 @@ where
             correction_oks.advance_by(&persist_frontier);
             correction_errs.advance_by(&persist_frontier);
 
+            // Discard batch descriptions whose upper is already not beyond the
+            // persist frontier. Those have no chance of being applied to the
+            // shard succesfully.
+            in_flight_batches
+                .retain(|(lower, _upper), _cap| PartialOrder::less_equal(&persist_frontier, lower));
+
             if read_only.borrow().clone() {
                 // We are not allowed to do writes, so go back to the beginning
                 // of the loop.
                 //
-                // We are only bailing here to make sure that we keep our
-                // corrections buffers up to date, which will potentially
-                // consolidate things out.
-                //
-                // WIP: We need to do something about in_flight_batches: we keep
-                // accumulating those. Maybe we can remove those that are not
-                // beyond both the persist and desired frontier?
+                // We are bailing here and not earlier to make sure that we keep
+                // our corrections buffers up to date, which will potentially
+                // consolidate things out, and to make sure that we weed out
+                // batches that we can never apply.
                 continue;
             }
 
@@ -963,6 +966,7 @@ fn append_batches<G>(
     target: &CollectionMetadata,
     batch_descriptions: &Stream<G, (Antichain<Timestamp>, Antichain<Timestamp>)>,
     batches: &Stream<G, BatchOrData>,
+    persist_oks: &Stream<G, (Row, Timestamp, Diff)>,
     persist_clients: Arc<PersistClientCache>,
     mut read_only: watch::Receiver<bool>,
 ) -> (Stream<G, ()>, Rc<dyn Any>)
@@ -996,6 +1000,10 @@ where
     let mut batches_input =
         append_op.new_disconnected_input(batches, Exchange::new(move |_| hashed_id));
 
+    // We use this to discard batches and batch descriptions that can never be
+    // applied because the persist frontier is already past their upper.
+    let persist_probe = persist_oks.probe();
+
     // This operator accepts the batch descriptions and tokens that represent
     // written batches. Written batches get appended to persist when we learn
     // from our input frontiers that we have seen all batches for a given batch
@@ -1025,7 +1033,12 @@ where
             incomplete: Option<BatchBuilder<SourceData, (), Timestamp, Diff>>,
         }
 
-        let mut in_flight_batches = HashMap::<
+        // We use iteration only for weeding out batches that no longer have a
+        // chance of being applied. Otherwise we only use insertion and
+        // deletion. We don't use iteration order for determining what batches
+        // get written in which order.
+        #[allow(clippy::disallowed_types)]
+        let mut in_flight_batches = std::collections::HashMap::<
             (Antichain<Timestamp>, Antichain<Timestamp>),
             BatchSet,
         >::new();
@@ -1138,16 +1151,52 @@ where
                 }
             };
 
+            // Only retain descriptions and batches that still have a chance of
+            // being applied.
+            in_flight_descriptions.retain(|(_lower, upper)| {
+                upper.is_empty() || upper.iter().any(|ts| persist_probe.less_equal(ts))
+            });
+
+            for ((_lower, upper), batch_set) in in_flight_batches.iter_mut() {
+                if upper.is_empty() || upper.iter().any(|ts| persist_probe.less_equal(ts)) {
+                    continue;
+                }
+
+                // We're not keeping this batch. Be nice and delete any data
+                // that has been written.
+                for batch in batch_set.finished.drain(..) {
+                    batch.delete().await;
+                }
+                if let Some(batch) = batch_set.incomplete.take() {
+                    batch
+                        .finish(upper.clone()).await
+                        .expect("invalid usage")
+                        .delete().await;
+                }
+            }
+            // It's annoying that we're first iterating and doing the retain,
+            // but we can't do the batch deletion inside retain because we need
+            // async.
+            in_flight_batches.retain(|(lower, _upper), batch_set| {
+                if PartialOrder::less_equal(&persist_upper, lower) {
+                    return true;
+                }
+
+                // We're not keeping this batch, make sure that the above loop
+                // cleared and deleted all the batches.
+                assert!(batch_set.finished.is_empty());
+                assert!(batch_set.incomplete.is_none());
+
+                false
+            });
+
             if read_only.borrow().clone() {
                 // We are not allowed to do writes, so go back to the beginning
                 // of the loop.
                 //
-                // We are only bailing here to make sure that we keep reading
+                // We are bailing here and not earlier to make sure that we weed
+                // out batches that we can never apply and that we keep reading
                 // our inputs.
-                //
-                // WIP: We need to do something about in_flight_descriptions: we
-                // keep accumulating those. Maybe we can remove those that are
-                // not beyond both the persist and desired frontier?
                 continue;
             }
 

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -298,6 +298,14 @@ where
         self.compute.initialization_complete();
     }
 
+    /// Allow this controller and instances controller by it to write to
+    /// external systems.
+    pub fn allow_writes(&mut self) {
+        self.compute.allow_writes();
+        // TODO: Storage does not yet understand the concept of read-only
+        // instances.
+    }
+
     /// Returns `Some` if there is an immediately available
     /// internally-generated response that we need to return to the
     /// client (as opposed to waiting for a response from compute or storage).

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -556,6 +556,13 @@ pub struct Args {
     // === Tracing options. ===
     #[clap(flatten)]
     tracing: TracingCliArgs,
+
+    // === Testing options. ===
+    /// Whether or not to start controllers in read-only mode. This is only
+    /// meant for use during development of read-only clusters and 0dt upgrades
+    /// and should go away once we have proper orchestration during upgrades.
+    #[clap(long)]
+    read_only_controllers: bool,
 }
 
 #[derive(ArgEnum, Debug, Clone)]
@@ -963,6 +970,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 internal_console_redirect_url: args.internal_console_redirect_url,
                 txn_wal_tables_cli: args.persist_txn_tables,
                 reload_certs: mz_server_core::default_cert_reload_ticker(),
+                read_only_controllers: args.read_only_controllers,
             })
             .await
     })?;

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -67,6 +67,7 @@ use crate::BUILD_INFO;
 
 mod catalog;
 mod console;
+mod control;
 mod memory;
 mod metrics;
 mod probe;
@@ -441,6 +442,13 @@ impl InternalHttpServer {
             .route(
                 "/api/coordinator/dump",
                 routing::get(catalog::handle_coordinator_dump),
+            )
+            // This is called /api/control, because it's mean as a control endpoint.
+            // Not controller, as in the thing that a Coordinator holds and which is
+            // currently the only thing that this _can_ control.
+            .route(
+                "/api/control/allow-writes",
+                routing::post(control::handle_controller_allow_writes),
             )
             .route(
                 "/internal-console",

--- a/src/environmentd/src/http/control.rs
+++ b/src/environmentd/src/http/control.rs
@@ -1,0 +1,29 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apach
+
+//! HTTP endpoints for controlling the coordinator and the controllers.
+
+use axum::response::IntoResponse;
+use axum::TypedHeader;
+use headers::ContentType;
+use http::StatusCode;
+
+use crate::http::AuthedClient;
+
+pub async fn handle_controller_allow_writes(mut client: AuthedClient) -> impl IntoResponse {
+    match client
+        .client
+        .controller_allow_writes()
+        .await
+        .map(|c| c.to_string())
+    {
+        Ok(res) => Ok((TypedHeader(ContentType::text()), res)),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
+}

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -167,6 +167,10 @@ pub struct Config {
     // === Testing options. ===
     /// A now generation function for mocking time.
     pub now: NowFn,
+    /// Whether or not to start controllers in read-only mode. This is only
+    /// meant for use during development of read-only clusters and 0dt upgrades
+    /// and should go away once we have proper orchestration during upgrades.
+    pub read_only_controllers: bool,
 }
 
 /// Configuration for network listeners.
@@ -543,6 +547,7 @@ impl Listeners {
             webhook_concurrency_limit: webhook_concurrency_limit.clone(),
             http_host_name: config.http_host_name,
             tracing_handle: config.tracing_handle,
+            read_only_controllers: config.read_only_controllers,
         })
         .instrument(info_span!("adapter::serve"))
         .await?;

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -532,6 +532,7 @@ impl Listeners {
                 internal_console_redirect_url: config.internal_console_redirect_url,
                 txn_wal_tables_cli: Some(TxnWalTablesImpl::Lazy),
                 reload_certs,
+                read_only_controllers: false,
             })
             .await?;
 

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1083,6 +1083,7 @@ impl<'a> RunnerInner<'a> {
             internal_console_redirect_url: None,
             txn_wal_tables_cli: Some(TxnWalTablesImpl::Lazy),
             reload_certs: mz_server_core::cert_reload_never_reload(),
+            read_only_controllers: false,
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/test/read-only-cluster/mzcompose.py
+++ b/test/read-only-cluster/mzcompose.py
@@ -1,0 +1,164 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+
+import requests
+
+from materialize import buildkite
+from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services.clusterd import Clusterd
+from materialize.mzcompose.services.kafka import Kafka
+from materialize.mzcompose.services.localstack import Localstack
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.redpanda import Redpanda
+from materialize.mzcompose.services.schema_registry import SchemaRegistry
+from materialize.mzcompose.services.testdrive import Testdrive
+from materialize.mzcompose.services.toxiproxy import Toxiproxy
+from materialize.mzcompose.services.zookeeper import Zookeeper
+
+SERVICES = [
+    Zookeeper(),
+    Kafka(),
+    SchemaRegistry(),
+    Localstack(),
+    Clusterd(),
+    Materialized(),
+    Redpanda(),
+    Toxiproxy(),
+    Testdrive(materialize_params={"cluster": "cluster"}, no_reset=True),
+]
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    for name in buildkite.shard_list(
+        list(c.workflows.keys()), lambda workflow: workflow
+    ):
+        if name == "default":
+            continue
+        with c.test_case(name):
+            c.workflow(name)
+
+
+def workflow_compute(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """Verify that compute parts are read-only when Mz is restarted in read-only-mode"""
+    c.down(destroy_volumes=True)
+    c.up(
+        "zookeeper",
+        "kafka",
+        "schema-registry",
+        "localstack",
+        "materialized",
+        "clusterd",
+    )
+    c.up("testdrive", persistent=True)
+
+    # Make sure cluster is owned by the system so it doesn't get dropped
+    # between testdrive runs.
+    c.sql(
+        """
+        ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
+        DROP CLUSTER IF EXISTS cluster CASCADE;
+        CREATE CLUSTER cluster REPLICAS (
+            replica1 (
+                STORAGECTL ADDRESSES ['clusterd:2100'],
+                STORAGE ADDRESSES ['clusterd:2103'],
+                COMPUTECTL ADDRESSES ['clusterd:2101'],
+                COMPUTE ADDRESSES ['clusterd:2102'],
+                WORKERS 2
+            )
+        );
+        GRANT ALL ON CLUSTER cluster TO materialize;
+        ALTER SYSTEM SET cluster = cluster;
+    """,
+        port=6877,
+        user="mz_system",
+    )
+
+    c.testdrive(
+        dedent(
+            """
+        > SET CLUSTER = cluster;
+        > CREATE table t (a int, b int);
+        > INSERT INTO t VALUES (1, 2);
+        > CREATE INDEX t_idx ON t (a, b);
+        > CREATE MATERIALIZED VIEW mv AS SELECT sum(a) FROM t;
+        > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+        > SELECT * FROM mv;
+        1
+        > SELECT max(b) FROM t;
+        2
+        """
+        )
+    )
+
+    c.kill("materialized")
+    c.kill("clusterd")
+    with c.override(Materialized(read_only_controllers=True)):
+        c.up("materialized")
+        c.up("clusterd")
+        c.testdrive(
+            dedent(
+                """
+            > SET CLUSTER = cluster;
+            > SELECT 1
+            1
+            > INSERT INTO t VALUES (3, 4);
+            > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+            > SELECT * FROM mv;
+            1
+            > SELECT max(b) FROM t;
+            4
+            > SELECT mz_unsafe.mz_sleep(5)
+            <null>
+            > INSERT INTO t VALUES (5, 6);
+            > SELECT * FROM mv;
+            1
+            > SELECT max(b) FROM t;
+            6
+            > DROP INDEX t_idx
+            > CREATE INDEX t_idx ON t (a, b)
+            > SELECT max(b) FROM t;
+            6
+            > CREATE MATERIALIZED VIEW mv2 AS SELECT sum(a) FROM t;
+
+            $ set-regex match=(s\\d+|\\d{13}|[ ]{12}0|u\\d{1,3}|\\(\\d+-\\d\\d-\\d\\d\\s\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d\\)) replacement=<>
+
+            > EXPLAIN TIMESTAMP FOR SELECT * FROM mv2;
+            "                query timestamp: <> <>\\nlargest not in advance of upper: <> <>\\n                          upper:[<> <>]\\n                          since:[<> <>]\\n        can respond immediately: false\\n                       timeline: Some(EpochMilliseconds)\\n              session wall time: <> <>\\n\\nsource materialize.public.mv2 (<>, storage):\\n                  read frontier:[<> <>]\\n                 write frontier:[<> <>]\\n"
+            """
+            )
+        )
+
+        port = c.port("materialized", 6878)
+        resp = requests.post(f"http://localhost:{port}/api/control/allow-writes")
+        assert resp.status_code == 200, resp
+        print(resp.text)
+
+        c.testdrive(
+            dedent(
+                """
+            > SET CLUSTER = cluster;
+            > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+            > SELECT * FROM mv;
+            9
+            > SELECT * FROM mv2;
+            9
+            > SELECT max(b) FROM t;
+            6
+            > INSERT INTO t VALUES (7, 8);
+            > SELECT * FROM mv;
+            16
+            > SELECT * FROM mv2;
+            16
+            > SELECT max(b) FROM t;
+            8
+            """
+            )
+        )


### PR DESCRIPTION
### Motivation

A part of delivering https://github.com/MaterializeInc/materialize/issues/27406

> [!NOTE]  
> The orchestration via commandline flag and `CONTROLLER ALLOW WRITE` is for demonstration and during local development of zero-downtime related features. Later, with proper 0dt upgrades implemented, the coordinator would start the controller in read-only mode when doing an upgrade and decide when to take a controller out of read-only mode.
> 
> I think we can get a lot of mileage out of this command, though: we can use it to mock upgrade orchestration while we develop many of the other features required for the initial zero-downtime upgrades milestone.

#### Using the new read-only mode

First, start `envd` with controllers in read-only mod:

```
$ bin/environmentd --reset -- --read-only-controllers
```

Then, create a table, index, and a materialized view:

```sql
create table foo (name string, count bigint);
create index foo_idx on foo (name, count);
create materialized view mv as select * from foo;
```

Observe that you can query the table but that the materialized view is
not being updated:

```sql
select * from foo; -- this will use the index, showing that read-only dataflows work as expected
select * from mv; -- this will hang
```

Take controller and clusters out of read-only mode:

```sh
$ curl -X POST localhost:6878/api/control/allow-writes
```

Observe that now the materialized view _does_ make progress:

```sql
select * from mv;
```
### Tips for reviewer

The changes to `persist_sink`, the compute protocol and cluster state need sign-off from someone from the compute team.

The changes that add a new for-testing commandline flag and the new for-testing CONTROLLER ALLOW WRITES need sign off from someone from the adapter team.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
