### PR TITLE
tests: enable and adjust catalog.td

### DIFF
--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -310,11 +310,6 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
 
-# TODO: Remove skip when #19097 is fixed
-$ skip-end
-$ skip-if
-SELECT true
-
 > CREATE SINK snk
   IN CLUSTER ${arg.single-replica-cluster}
   FROM source_data

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -493,6 +493,7 @@ mz_aws_privatelink_connections
 mz_base_types
 mz_clusters
 mz_cluster_replicas
+mz_cluster_replica_sizes
 mz_columns
 mz_connections
 mz_databases
@@ -588,10 +589,10 @@ name
 mz_aggregates
 mz_aws_connections
 mz_cluster_replica_metrics
-mz_cluster_replica_sizes
 mz_cluster_replica_statuses
 mz_cluster_schedules
 mz_comments
+mz_history_retention_strategies
 mz_internal_cluster_replicas
 mz_kafka_sources
 mz_materialized_view_refresh_strategies
@@ -692,6 +693,7 @@ mz_show_system_privileges
 mz_sink_statistics
 mz_sink_statuses
 mz_source_statistics
+mz_source_statistics_with_history
 mz_source_statuses
 mz_sql_text_redacted
 mz_aws_privatelink_connection_statuses
@@ -710,11 +712,11 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-51
+54
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-182
+183
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2


### PR DESCRIPTION
This addresses 

> Issue is referenced in comment but already closed: [#19097](https://github.com/MaterializeInc/materialize/issues/19097)
test/testdrive/catalog.td:313:
> \# TODO: Remove skip when #19097 is fixed

in https://buildkite.com/materialize/nightly/builds/7919#018fc420-c542-4ca7-b809-be9eeaa98bbd.