### PR TITLE
docs: update Redpanda cloud api version ref

### DIFF
--- a/doc/user/content/ingest-data/redpanda-cloud.md
+++ b/doc/user/content/ingest-data/redpanda-cloud.md
@@ -162,7 +162,6 @@ in a region supported by Materialize: `us-east-1`,`us-west-2`, or `eu-west-1`.
     CLOUD_CLIENT_ID="<your-redpanda-client-id>"
     CLOUD_CLIENT_SECRET="<your-redpanda-client-secret>"
     CLUSTER_ID="<your-redpanda-cluster-id>"
-    NAMESPACE_ID="<your-redpanda-namespace-id>"
 
     AUTH_TOKEN=$(
       curl -s -X POST 'https://auth.prd.cloud.redpanda.com/oauth/token' \
@@ -175,11 +174,9 @@ in a region supported by Materialize: `us-east-1`,`us-west-2`, or `eu-west-1`.
 
     CLUSTER_PATCH_BODY="$(cat <<EOF
      {
-       "private_link": {
+       "aws_private_link": {
          "enabled": true,
-         "aws": {
-           "allowed_principals": [ ]
-         }
+         "allowed_principals": [ ]
        }
      }
     EOF
@@ -189,13 +186,13 @@ in a region supported by Materialize: `us-east-1`,`us-west-2`, or `eu-west-1`.
        -H "Content-Type: application/json" \
        -H "Authorization: Bearer $AUTH_TOKEN" \
        -d "$CLUSTER_PATCH_BODY" \
-        $PUBLIC_API_ENDPOINT/v1beta1/clusters/$CLUSTER_ID
+        $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
 
     curl -X GET \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $AUTH_TOKEN" \
-        $PUBLIC_API_ENDPOINT/v1beta1/clusters/$CLUSTER_ID | jq \
-        '.private_link'
+        $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID | jq \
+        '.cluster.aws_private_link'
     ```
 
 1. In the Materialize [SQL shell](https://console.materialize.com/), or your
@@ -236,7 +233,6 @@ principal:
     CLOUD_CLIENT_ID="<your-redpanda-client-id>"
     CLOUD_CLIENT_SECRET="<your-redpanda-client-secret>"
     CLUSTER_ID="<your-redpanda-cluster-id>"
-    NAMESPACE_ID="<your-redpanda-namespace-id>"
 
     MATERIALIZE_CONNECTION_ARN="<arn-created-for-materialize-aws-privatelink-connection>"
 
@@ -251,9 +247,9 @@ principal:
 
     CLUSTER_PATCH_BODY="$(cat <<EOF
      {
-       "private_link": {
+       "aws_private_link": {
          "enabled": true,
-         "aws": { "allowed_principals": ["$MATERIALIZE_CONNECTION_ARN"] }
+         "allowed_principals": ["$MATERIALIZE_CONNECTION_ARN"]
        }
      }
     EOF
@@ -263,7 +259,7 @@ principal:
        -H "Content-Type: application/json" \
        -H "Authorization: Bearer $AUTH_TOKEN" \
        -d "$CLUSTER_PATCH_BODY" \
-       $PUBLIC_API_ENDPOINT/v1beta1/clusters/$CLUSTER_ID
+       $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
     ```
 
 1. In Materialize, validate the AWS PrivateLink connection you created using the


### PR DESCRIPTION
Update references to the Redpanda API to efectively use the latest and greates Redpanda cloud API version

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Simply want to ensure the latest and greatest version of Redpanda Cloud API is being used.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
- Removed references to NAMESPACE since it's not necessary for the calls 
- Update to version v1beta2 in tha reference, the spec was updated accordingly.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
