### PR TITLE
Guard access to analysis results

### DIFF
--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -614,3 +614,30 @@ Used Indexes:
 Target cluster: quickstart
 
 EOF
+
+# Regression test for gh issue 27348 (cardinality + WMR panic)
+query T multiline
+explain with(cardinality)
+with mutually recursive
+  t(x int) as (select 1 union all select * from u),
+  u(x int) as (select t.x+1 from t where x < 7)
+(select * from t);
+----
+Explained Query:
+  Return // { cardinality: "unknown^1" }
+    Get l0 // { cardinality: "unknown^1 + 1" }
+  With Mutually Recursive
+    cte l1 =
+      Project (#1) // { cardinality: "unknown^1 * 0.33 + 0.33" }
+        Filter (#0 < 7) // { cardinality: "unknown^1 * 0.33 + 0.33" }
+          Map ((#0 + 1)) // { cardinality: "unknown^1 + 1" }
+            Get l0 // { cardinality: "unknown^1 + 1" }
+    cte l0 =
+      Union // { cardinality: "unknown^1 + 1" }
+        Get l1 // { cardinality: "unknown^1" }
+        Constant // { cardinality: "1" }
+          - (1)
+
+Target cluster: mz_introspection
+
+EOF


### PR DESCRIPTION
The `Analysis` framework reveals the results of expression children as part of the ongoing derivation, but this means that information about non-children may not be available, and in particular information about future bindings in a `LetRec` are not available. This means that implementors must themselves guard against out-of-bounds access based on these identifiers, using e.g. `results.get(id)` rather than `results[id]`.

There seemed to be only one instance of this, in our cardinality computation. It seems localized to `Get` expression handling.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
