### PR TITLE
.*: Add `Apache 2.0 WITH LLVM-exception` and `Unicode-DFS-2016` licenses as accepted

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -2,6 +2,7 @@
 # See: https://github.com/EmbarkStudios/cargo-about/issues/201
 accepted = [
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "CC0-1.0",
     "0BSD",
     "BSD-2-Clause",
@@ -12,6 +13,7 @@ accepted = [
     "MPL-2.0",
     "OpenSSL",
     "Zlib",
+    "Unicode-DFS-2016",
 ]
 private = { ignore = true }
 workarounds = ["ring"]

--- a/deny.toml
+++ b/deny.toml
@@ -205,6 +205,7 @@ ignore = [
 [licenses]
 allow = [
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "CC0-1.0",
     "0BSD",
     "BSD-2-Clause",
@@ -214,6 +215,7 @@ allow = [
     "MIT",
     "MPL-2.0",
     "Zlib",
+    "Unicode-DFS-2016",
 ]
 copyleft = "deny"
 private = { ignore = true }


### PR DESCRIPTION
This PR adds the `Apache 2.0 WITH LLVM-exception` and `Unicode-DFS-2016` licenses as accepted. @benesch took an initial look and it should be fine to add these, waiting on a final stamp from legal before merging.

### Motivation

https://github.com/MaterializeInc/materialize/pull/27346 adds transitive dependencies with these licenses.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
