### PR TITLE
buildkite search: single line result

### DIFF
--- a/misc/python/materialize/buildkite_insights/annotation_search/README.md
+++ b/misc/python/materialize/buildkite_insights/annotation_search/README.md
@@ -15,6 +15,7 @@ usage: buildkite-annotation-search [-h]
                                    [--only-failed-builds]
                                    [--only-failed-build-step-key ONLY_FAILED_BUILD_STEP_KEY]
                                    [--short]
+                                   [--oneline]
                                    [--use-regex]
                                    {cleanup,coverage,deploy,deploy-mz-lsp-server,deploy-mz,deploy-website,license,nightly,release-qualification,security,slt,test,www}
                                    pattern

--- a/misc/python/materialize/buildkite_insights/annotation_search/annotation_search.py
+++ b/misc/python/materialize/buildkite_insights/annotation_search/annotation_search.py
@@ -49,6 +49,7 @@ def search_build(
     fetch_mode: FetchMode,
     max_entries_to_print: int,
     short_result_presentation: bool,
+    one_line_match_presentation: bool,
 ) -> int:
     assert max_entries_to_print >= 0
 
@@ -86,6 +87,7 @@ def search_build(
             search_value=search_value,
             use_regex=use_regex,
             short_result_presentation=short_result_presentation,
+            one_line_match_presentation=one_line_match_presentation,
         )
 
     return len(matched_annotations)
@@ -181,6 +183,7 @@ def main(
     pattern: str,
     use_regex: bool,
     short_result_presentation: bool,
+    one_line_match_presentation: bool,
 ) -> None:
     assert len(pattern) > 0, "pattern must not be empty"
 
@@ -231,6 +234,7 @@ def main(
                 fetch_mode=fetch_annotations_mode,
                 max_entries_to_print=max_entries_to_print,
                 short_result_presentation=short_result_presentation,
+                one_line_match_presentation=one_line_match_presentation,
             )
         except RateLimitExceeded:
             print("Aborting due to exceeded rate limit!")
@@ -297,6 +301,11 @@ if __name__ == "__main__":
         action="store_true",
     )
     parser.add_argument(
+        "--oneline",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
         "--only-failed-build-step-key", action="append", default=[], type=str
     )
     parser.add_argument(
@@ -304,6 +313,9 @@ if __name__ == "__main__":
         action="store_true",
     )
     args = parser.parse_args()
+
+    if args.short and args.oneline:
+        print("Note: --oneline will be ignored if --short is set")
 
     main(
         args.pipeline,
@@ -319,4 +331,5 @@ if __name__ == "__main__":
         args.pattern,
         args.use_regex,
         args.short,
+        args.oneline,
     )

--- a/misc/python/materialize/buildkite_insights/annotation_search/annotation_search_presentation.py
+++ b/misc/python/materialize/buildkite_insights/annotation_search/annotation_search_presentation.py
@@ -40,6 +40,7 @@ def print_annotation_match(
     search_value: str,
     use_regex: bool,
     short_result_presentation: bool,
+    one_line_match_presentation: bool,
 ) -> None:
     print(
         with_formatting(
@@ -57,6 +58,7 @@ def print_annotation_match(
             input=annotation.title_and_text,
             search_value=search_value,
             use_regex=use_regex,
+            one_line_match_presentation=one_line_match_presentation,
         )
         matched_snippet = highlight_match(
             input=matched_snippet,

--- a/misc/python/materialize/buildkite_insights/annotation_search/annotation_search_presentation.py
+++ b/misc/python/materialize/buildkite_insights/annotation_search/annotation_search_presentation.py
@@ -41,15 +41,6 @@ def print_annotation_match(
     use_regex: bool,
     short_result_presentation: bool,
 ) -> None:
-    matched_snippet = trim_match(
-        input=annotation.title_and_text, search_value=search_value, use_regex=use_regex
-    )
-    matched_snippet = highlight_match(
-        input=matched_snippet,
-        search_value=search_value,
-        use_regex=use_regex,
-    )
-
     print(
         with_formatting(
             f"Match in build #{build_number} (pipeline {build_pipeline} on {branch}):",
@@ -62,6 +53,17 @@ def print_annotation_match(
         print(f"Annotation: {with_formatting(annotation.title, COLOR_CYAN)}")
 
     if not short_result_presentation:
+        matched_snippet = trim_match(
+            input=annotation.title_and_text,
+            search_value=search_value,
+            use_regex=use_regex,
+        )
+        matched_snippet = highlight_match(
+            input=matched_snippet,
+            search_value=search_value,
+            use_regex=use_regex,
+        )
+
         print(SHORT_SEPARATOR)
         print(matched_snippet)
 

--- a/misc/python/materialize/buildkite_insights/annotation_search/annotation_search_presentation.py
+++ b/misc/python/materialize/buildkite_insights/annotation_search/annotation_search_presentation.py
@@ -55,7 +55,7 @@ def print_annotation_match(
 
     if not short_result_presentation:
         matched_snippet = trim_match(
-            input=annotation.title_and_text,
+            match_text=annotation.title_and_text,
             search_value=search_value,
             use_regex=use_regex,
             one_line_match_presentation=one_line_match_presentation,

--- a/misc/python/materialize/buildkite_insights/artifact_search/artifact_search_presentation.py
+++ b/misc/python/materialize/buildkite_insights/artifact_search/artifact_search_presentation.py
@@ -40,6 +40,7 @@ def print_artifact_match(
         search_value=search_value,
         use_regex=use_regex,
         search_offset=search_offset,
+        one_line_match_presentation=False,
     )
     matched_snippet = highlight_match(
         input=matched_snippet,

--- a/misc/python/materialize/buildkite_insights/artifact_search/artifact_search_presentation.py
+++ b/misc/python/materialize/buildkite_insights/artifact_search/artifact_search_presentation.py
@@ -36,7 +36,7 @@ def print_artifact_match(
     search_offset: int,
 ) -> None:
     matched_snippet = trim_match(
-        input=content,
+        match_text=content,
         search_value=search_value,
         use_regex=use_regex,
         search_offset=search_offset,

--- a/misc/python/materialize/buildkite_insights/util/search_utility.py
+++ b/misc/python/materialize/buildkite_insights/util/search_utility.py
@@ -36,7 +36,7 @@ def highlight_match(
 
 
 def trim_match(
-    input: str,
+    match_text: str,
     search_value: str,
     use_regex: bool,
     one_line_match_presentation: bool,
@@ -44,28 +44,51 @@ def trim_match(
     max_chars_after_match: int = 300,
     search_offset: int = 0,
 ) -> str:
-    input = input.strip()
+    match_text = match_text.strip()
     case_insensitive_pattern = _search_value_to_pattern(search_value, use_regex)
 
-    match = case_insensitive_pattern.search(input, pos=search_offset)
+    match = case_insensitive_pattern.search(match_text, pos=search_offset)
     assert match is not None
 
     match_begin_index = match.start()
     match_end_index = match.end()
 
     if one_line_match_presentation:
-        cut_off_index_begin = input.rfind("\n", 0, match_begin_index)
+        match_text = _trim_match_to_one_line(
+            match_text, match_begin_index, match_end_index
+        )
 
-        if cut_off_index_begin == -1:
-            cut_off_index_begin = 0
+    match_text = _trim_match_to_max_length(
+        match_text,
+        match_begin_index,
+        match_end_index,
+        max_chars_after_match,
+        max_chars_before_match,
+    )
 
-        cut_off_index_end = input.find("\n", match_end_index)
+    return match_text
 
-        if cut_off_index_end == -1:
-            cut_off_index_end = len(input)
 
-        input = input[cut_off_index_begin:cut_off_index_end]
+def _trim_match_to_one_line(
+    input: str, match_begin_index: int, match_end_index: int
+) -> str:
+    cut_off_index_begin = input.rfind("\n", 0, match_begin_index)
+    if cut_off_index_begin == -1:
+        cut_off_index_begin = 0
+    cut_off_index_end = input.find("\n", match_end_index)
+    if cut_off_index_end == -1:
+        cut_off_index_end = len(input)
+    input = input[cut_off_index_begin:cut_off_index_end]
+    return input
 
+
+def _trim_match_to_max_length(
+    input: str,
+    match_begin_index: int,
+    match_end_index: int,
+    max_chars_after_match: int,
+    max_chars_before_match: int,
+) -> str:
     # identify cut-off point before first match
     if match_begin_index > max_chars_before_match:
         cut_off_index_begin = input.find(
@@ -93,7 +116,6 @@ def trim_match(
 
     if cut_off_index_begin > 0:
         result = f"[...] {result}"
-
     if cut_off_index_end != len(input):
         result = f"{result} [...]"
 

--- a/misc/python/materialize/buildkite_insights/util/search_utility.py
+++ b/misc/python/materialize/buildkite_insights/util/search_utility.py
@@ -39,6 +39,7 @@ def trim_match(
     input: str,
     search_value: str,
     use_regex: bool,
+    one_line_match_presentation: bool,
     max_chars_before_match: int = 300,
     max_chars_after_match: int = 300,
     search_offset: int = 0,
@@ -51,6 +52,19 @@ def trim_match(
 
     match_begin_index = match.start()
     match_end_index = match.end()
+
+    if one_line_match_presentation:
+        cut_off_index_begin = input.rfind("\n", 0, match_begin_index)
+
+        if cut_off_index_begin == -1:
+            cut_off_index_begin = 0
+
+        cut_off_index_end = input.find("\n", match_end_index)
+
+        if cut_off_index_end == -1:
+            cut_off_index_end = len(input)
+
+        input = input[cut_off_index_begin:cut_off_index_end]
 
     # identify cut-off point before first match
     if match_begin_index > max_chars_before_match:


### PR DESCRIPTION
Helpful to concisely filter matches.

### Output

```
Match in build #7887 (pipeline nightly on main):
URL: https://buildkite.com/materialize/nightly/builds/7887
Annotation: Feature benchmark against merge base or 'latest' 3 (#2)
----------
Failure in Scenario 'FullOuterJoin': New regression against v0.101.0
-------------------------------------------------------------------------------------
Match in build #7862 (pipeline nightly on v0.101.0):
URL: https://buildkite.com/materialize/nightly/builds/7862
Annotation: Feature benchmark against merge base or 'latest' 1
----------
Failure in Scenario 'FastPathLimit': New regression against v0.100.1
-------------------------------------------------------------------------------------
Match in build #7862 (pipeline nightly on v0.101.0):
URL: https://buildkite.com/materialize/nightly/builds/7862
Annotation: Feature benchmark against merge base or 'latest' 1 (#2)
----------
Failure in Scenario 'FastPathLimit': New regression against v0.100.1
-------------------------------------------------------------------------------------
```