### PR TITLE
Frontegg mock additional user endpoints

### DIFF
--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -58,11 +58,15 @@ async fn test_balancer() {
     let users = BTreeMap::from([(
         email.clone(),
         UserConfig {
+            id: None,
             email,
             password,
             tenant_id,
             initial_api_tokens,
             roles,
+            auth_provider: None,
+            verified: None,
+            metadata: None,
         },
     )]);
 
@@ -83,6 +87,7 @@ async fn test_balancer() {
         EXPIRES_IN_SECS,
         // Add a bit of delay so we can test connection de-duplication.
         Some(Duration::from_millis(100)),
+        None,
     )
     .unwrap();
 

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -432,11 +432,15 @@ async fn test_auth_expiry() {
     let users = BTreeMap::from([(
         email.clone(),
         UserConfig {
+            id: None,
             email,
             password,
             tenant_id,
             initial_api_tokens,
             roles,
+            auth_provider: None,
+            verified: None,
+            metadata: None,
         },
     )]);
 
@@ -454,6 +458,7 @@ async fn test_auth_expiry() {
         None,
         SYSTEM_TIME.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();
@@ -553,21 +558,29 @@ async fn test_auth_base_require_tls_frontegg() {
         (
             "uSeR@_.com".to_string(),
             UserConfig {
+                id: None,
                 email: "uSeR@_.com".to_string(),
                 password,
                 tenant_id,
                 initial_api_tokens,
                 roles: Vec::new(),
+                auth_provider: None,
+                verified: None,
+                metadata: None,
             },
         ),
         (
             SYSTEM_USER.name.to_string(),
             UserConfig {
+                id: None,
                 email: SYSTEM_USER.name.to_string(),
                 password: system_password,
                 tenant_id,
                 initial_api_tokens: system_initial_api_tokens,
                 roles: Vec::new(),
+                auth_provider: None,
+                verified: None,
+                metadata: None,
             },
         ),
     ]);
@@ -627,6 +640,7 @@ async fn test_auth_base_require_tls_frontegg() {
         None,
         now.clone(),
         1_000,
+        None,
         None,
     )
     .unwrap();
@@ -1361,16 +1375,21 @@ async fn test_auth_admin_non_superuser() {
         (
             frontegg_user.to_string(),
             UserConfig {
+                id: None,
                 email: frontegg_user.to_string(),
                 password,
                 tenant_id,
                 initial_api_tokens: vec![UserApiToken { client_id, secret }],
                 roles: Vec::new(),
+                auth_provider: None,
+                verified: None,
+                metadata: None,
             },
         ),
         (
             admin_frontegg_user.to_string(),
             UserConfig {
+                id: None,
                 email: admin_frontegg_user.to_string(),
                 password: admin_password,
                 tenant_id,
@@ -1379,6 +1398,9 @@ async fn test_auth_admin_non_superuser() {
                     secret: admin_secret,
                 }],
                 roles: vec![admin_role.to_string()],
+                auth_provider: None,
+                verified: None,
+                metadata: None,
             },
         ),
     ]);
@@ -1397,6 +1419,7 @@ async fn test_auth_admin_non_superuser() {
         None,
         now.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();
@@ -1487,16 +1510,21 @@ async fn test_auth_admin_superuser() {
         (
             frontegg_user.to_string(),
             UserConfig {
+                id: None,
                 email: frontegg_user.to_string(),
                 password,
                 tenant_id,
                 initial_api_tokens: vec![UserApiToken { client_id, secret }],
                 roles: Vec::new(),
+                auth_provider: None,
+                verified: None,
+                metadata: None,
             },
         ),
         (
             admin_frontegg_user.to_string(),
             UserConfig {
+                id: None,
                 email: admin_frontegg_user.to_string(),
                 password: admin_password,
                 tenant_id,
@@ -1505,6 +1533,9 @@ async fn test_auth_admin_superuser() {
                     secret: admin_secret,
                 }],
                 roles: vec![admin_role.to_string()],
+                auth_provider: None,
+                verified: None,
+                metadata: None,
             },
         ),
     ]);
@@ -1523,6 +1554,7 @@ async fn test_auth_admin_superuser() {
         None,
         now.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();
@@ -1613,16 +1645,21 @@ async fn test_auth_admin_superuser_revoked() {
         (
             frontegg_user.to_string(),
             UserConfig {
+                id: None,
                 email: frontegg_user.to_string(),
                 password,
                 tenant_id,
                 initial_api_tokens: vec![UserApiToken { client_id, secret }],
                 roles: Vec::new(),
+                auth_provider: None,
+                verified: None,
+                metadata: None,
             },
         ),
         (
             admin_frontegg_user.to_string(),
             UserConfig {
+                id: None,
                 email: admin_frontegg_user.to_string(),
                 password: admin_password,
                 tenant_id,
@@ -1631,6 +1668,9 @@ async fn test_auth_admin_superuser_revoked() {
                     secret: admin_secret,
                 }],
                 roles: vec![admin_role.to_string()],
+                auth_provider: None,
+                verified: None,
+                metadata: None,
             },
         ),
     ]);
@@ -1649,6 +1689,7 @@ async fn test_auth_admin_superuser_revoked() {
         None,
         now.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();
@@ -1747,11 +1788,15 @@ async fn test_auth_deduplication() {
     let users = BTreeMap::from([(
         frontegg_user.to_string(),
         UserConfig {
+            id: None,
             email: frontegg_user.to_string(),
             password,
             tenant_id,
             initial_api_tokens: vec![UserApiToken { client_id, secret }],
             roles: Vec::new(),
+            auth_provider: None,
+            verified: None,
+            metadata: None,
         },
     )]);
     let issuer = "frontegg-mock".to_owned();
@@ -1769,6 +1814,7 @@ async fn test_auth_deduplication() {
         None,
         now.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();
@@ -1906,11 +1952,15 @@ async fn test_refresh_task_metrics() {
     let users = BTreeMap::from([(
         frontegg_user.to_string(),
         UserConfig {
+            id: None,
             email: frontegg_user.to_string(),
             password,
             tenant_id,
             initial_api_tokens: vec![UserApiToken { client_id, secret }],
             roles: Vec::new(),
+            auth_provider: None,
+            verified: None,
+            metadata: None,
         },
     )]);
     let issuer = "frontegg-mock".to_owned();
@@ -1928,6 +1978,7 @@ async fn test_refresh_task_metrics() {
         None,
         now.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();
@@ -2036,16 +2087,21 @@ async fn test_superuser_can_alter_cluster() {
         (
             frontegg_user.to_string(),
             UserConfig {
+                id: None,
                 email: frontegg_user.to_string(),
                 password,
                 tenant_id,
                 initial_api_tokens: vec![UserApiToken { client_id, secret }],
                 roles: Vec::new(),
+                auth_provider: None,
+                verified: None,
+                metadata: None,
             },
         ),
         (
             admin_frontegg_user.to_string(),
             UserConfig {
+                id: None,
                 email: admin_frontegg_user.to_string(),
                 password: admin_password.clone(),
                 tenant_id,
@@ -2054,6 +2110,9 @@ async fn test_superuser_can_alter_cluster() {
                     secret: admin_secret,
                 }],
                 roles: vec![admin_role.to_string()],
+                auth_provider: None,
+                verified: None,
+                metadata: None,
             },
         ),
     ]);
@@ -2072,6 +2131,7 @@ async fn test_superuser_can_alter_cluster() {
         None,
         now.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();
@@ -2161,11 +2221,15 @@ async fn test_refresh_dropped_session() {
     let users = BTreeMap::from([(
         frontegg_user.to_string(),
         UserConfig {
+            id: None,
             email: frontegg_user.to_string(),
             password,
             tenant_id,
             initial_api_tokens: vec![UserApiToken { client_id, secret }],
             roles: Vec::new(),
+            auth_provider: None,
+            verified: None,
+            metadata: None,
         },
     )]);
     let issuer = "frontegg-mock".to_owned();
@@ -2183,6 +2247,7 @@ async fn test_refresh_dropped_session() {
         None,
         now.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();
@@ -2314,11 +2379,15 @@ async fn test_refresh_dropped_session_lru() {
         let secret = Uuid::new_v4();
 
         let user = UserConfig {
+            id: None,
             email: email.to_string(),
             password,
             tenant_id,
             initial_api_tokens: vec![UserApiToken { client_id, secret }],
             roles: Vec::new(),
+            auth_provider: None,
+            verified: None,
+            metadata: None,
         };
         users.insert(email.to_string(), user);
 
@@ -2348,6 +2417,7 @@ async fn test_refresh_dropped_session_lru() {
         None,
         now.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();
@@ -2503,11 +2573,15 @@ async fn test_transient_auth_failures() {
     let users = BTreeMap::from([(
         frontegg_user.to_string(),
         UserConfig {
+            id: None,
             email: frontegg_user.to_string(),
             password,
             tenant_id,
             initial_api_tokens: vec![UserApiToken { client_id, secret }],
             roles: Vec::new(),
+            auth_provider: None,
+            verified: None,
+            metadata: None,
         },
     )]);
     let issuer = "frontegg-mock".to_owned();
@@ -2525,6 +2599,7 @@ async fn test_transient_auth_failures() {
         None,
         now.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();
@@ -2614,11 +2689,15 @@ async fn test_transient_auth_failure_on_refresh() {
     let users = BTreeMap::from([(
         frontegg_user.to_string(),
         UserConfig {
+            id: None,
             email: frontegg_user.to_string(),
             password,
             tenant_id,
             initial_api_tokens: vec![UserApiToken { client_id, secret }],
             roles: Vec::new(),
+            auth_provider: None,
+            verified: None,
+            metadata: None,
         },
     )]);
     let issuer = "frontegg-mock".to_owned();
@@ -2636,6 +2715,7 @@ async fn test_transient_auth_failure_on_refresh() {
         None,
         now.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
+        None,
         None,
     )
     .unwrap();

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2027,6 +2027,7 @@ async fn test_max_connections_limits() {
         SYSTEM_TIME.clone(),
         500,
         None,
+        None,
     )
     .unwrap();
 
@@ -4328,11 +4329,15 @@ async fn test_cert_reloading() {
     let users = BTreeMap::from([(
         email.clone(),
         UserConfig {
+            id: None,
             email,
             password,
             tenant_id,
             initial_api_tokens,
             roles,
+            auth_provider: None,
+            verified: None,
+            metadata: None,
         },
     )]);
 
@@ -4353,6 +4358,7 @@ async fn test_cert_reloading() {
         EXPIRES_IN_SECS,
         // Add a bit of delay so we can test connection de-duplication.
         Some(Duration::from_millis(100)),
+        None,
     )
     .unwrap();
 

--- a/src/frontegg-mock/src/lib.rs
+++ b/src/frontegg-mock/src/lib.rs
@@ -439,7 +439,7 @@ async fn handle_get_user(
             let user_response = UserResponse {
                 id: user.id.unwrap_or_default(),
                 email: user.email.clone(),
-                verified: user.verified.unwrap_or(false),
+                verified: user.verified.unwrap_or(true),
                 metadata: user.metadata.clone().unwrap_or_default(),
                 provider: user.auth_provider.clone().unwrap_or_default(),
                 roles,
@@ -488,7 +488,7 @@ async fn handle_create_user(
         initial_api_tokens: vec![],
         roles: role_names.clone(),
         auth_provider: None,
-        verified: Some(false),
+        verified: Some(true),
         metadata: None,
     };
 
@@ -502,7 +502,7 @@ async fn handle_create_user(
     let user_response = UserResponse {
         id: user_id,
         email: new_user.email.clone(),
-        verified: false,
+        verified: true,
         metadata: String::new(),
         provider: String::new(),
         roles: user_roles,

--- a/src/frontegg-mock/src/main.rs
+++ b/src/frontegg-mock/src/main.rs
@@ -103,12 +103,11 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         Some(s) => serde_json::from_str(s).with_context(|| "decoding --role-permissions")?,
         None => None,
     };
-    let roles: Vec<UserRole> = match &args.roles {
-        Some(s) => serde_json::from_str(s).with_context(|| "decoding --roles")?,
-        None => vec![
-            UserRole { id: "1".to_string(), name: "Organization Admin".to_string() },
-            UserRole { id: "2".to_string(), name: "Organization Member".to_string() },
-        ],
+    let roles = match &args.roles {
+        Some(s) => {
+            Some(serde_json::from_str::<Vec<UserRole>>(s).with_context(|| "decoding --roles")?)
+        }
+        None => None,
     };
     let server = FronteggMockServer::start(
         Some(&addr),

--- a/src/frontegg-mock/src/main.rs
+++ b/src/frontegg-mock/src/main.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use jsonwebtoken::{DecodingKey, EncodingKey};
-use mz_frontegg_mock::{FronteggMockServer, UserConfig};
+use mz_frontegg_mock::{FronteggMockServer, UserConfig, UserRole};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::error::ErrorExt;
 use mz_ore::now::SYSTEM_TIME;
@@ -51,6 +51,10 @@ struct Args {
     /// JSON of the form: `{"rolename": ["permission1", "permission2"]}`
     #[clap(long)]
     role_permissions: Option<String>,
+    /// Roles information.
+    /// JSON of the form: `[{"id":"1", "name": "Organization Admin"}, {"id":"2", "name": "Organization Member"}]`
+    #[clap(long)]
+    roles: Option<String>,
 }
 
 #[tokio::main]
@@ -99,6 +103,13 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         Some(s) => serde_json::from_str(s).with_context(|| "decoding --role-permissions")?,
         None => None,
     };
+    let roles: Vec<UserRole> = match &args.roles {
+        Some(s) => serde_json::from_str(s).with_context(|| "decoding --roles")?,
+        None => vec![
+            UserRole { id: "1".to_string(), name: "Organization Admin".to_string() },
+            UserRole { id: "2".to_string(), name: "Organization Member".to_string() },
+        ],
+    };
     let server = FronteggMockServer::start(
         Some(&addr),
         args.issuer,
@@ -109,6 +120,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         SYSTEM_TIME.clone(),
         500,
         None,
+        roles,
     )?;
 
     println!("frontegg-mock listening...");


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


Currently there are two Frontegg Mock services maintained, one written in Go which lives in the Terraform repo and one written in Rust which lives in the main Materialize repo.

As per the discussion [here](https://github.com/MaterializeInc/terraform-provider-materialize/issues/461), it will be nice to carry over the logic from the Go mock to the Rust mock and deprecate it so that we could only have 1 complete mock service.

This PR is mainly intended as a PoC and only transfers over the following endpoints:

```
/identity/resources/users/v1/{id}
/identity/resources/users/v2"
/identity/resources/roles/v2"
```


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
