### PR TITLE
persist: add `trait ColumnarCodec` and "packed" encodings for `AclType` and `MzAclType`

### DIFF
--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -261,7 +261,7 @@ pub trait Schema<T>: Debug + Send + Sync {
 
 /// A __stable__ encoding for a type that gets durably persisted in an
 /// [`arrow::array::FixedSizeBinaryArray`].
-pub trait ColumnarCodec<T>: Debug + PartialEq + Eq + PartialOrd + Ord {
+pub trait FixedSizeCodec<T>: Debug + PartialEq + Eq + PartialOrd + Ord {
     /// Number of bytes the encoded format requires.
     const SIZE: usize;
 

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -259,6 +259,25 @@ pub trait Schema<T>: Debug + Send + Sync {
     fn encoder(&self, cols: ColumnsMut) -> Result<Self::Encoder, String>;
 }
 
+/// A __stable__ encoding for a type that gets durably persisted in an
+/// [`arrow::array::FixedSizeBinaryArray`].
+pub trait ColumnarCodec<T>: Debug + PartialEq + Eq + PartialOrd + Ord {
+    /// Number of bytes the encoded format requires.
+    const SIZE: usize;
+
+    /// Returns the encoded bytes as a slice.
+    fn as_bytes(&self) -> &[u8];
+    /// Create an instance of `self` from a slice.
+    fn from_bytes(val: &[u8]) -> Result<Self, String>
+    where
+        Self: Sized;
+
+    /// Encode a type of `T` into this format.
+    fn from_value(value: T) -> Self;
+    /// Decode an instance of `T` from this format.
+    fn into_value(self) -> T;
+}
+
 /// A helper for writing tests that validate that a piece of data roundtrips
 /// through the columnar format.
 pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -268,6 +268,9 @@ pub trait ColumnarCodec<T>: Debug + PartialEq + Eq + PartialOrd + Ord {
     /// Returns the encoded bytes as a slice.
     fn as_bytes(&self) -> &[u8];
     /// Create an instance of `self` from a slice.
+    ///
+    /// Note: It is the responsibility of the caller to make sure the provided
+    /// data is valid for `self`.
     fn from_bytes(val: &[u8]) -> Result<Self, String>
     where
         Self: Sized;

--- a/src/repr/benches/packed.rs
+++ b/src/repr/benches/packed.rs
@@ -7,11 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::time::{Duration, Instant};
-
 use chrono::NaiveTime;
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use mz_persist_types::columnar::ColumnarCodec;
+use mz_persist_types::columnar::FixedSizeCodec;
 use mz_proto::chrono::ProtoNaiveTime;
 use mz_proto::{ProtoType, RustType};
 use mz_repr::adt::datetime::PackedNaiveTime;
@@ -37,21 +35,12 @@ fn bench_interval(c: &mut Criterion) {
         })
     });
     group.bench_function("encode/proto", |b| {
-        let mut total_duration = Duration::from_secs(0);
         let mut buf = vec![0u8; 64];
-
-        b.iter_custom(|iters| {
-            for _ in 0..iters {
-                let start = Instant::now();
-                let proto = std::hint::black_box(INTERVAL).into_proto();
-                proto.encode(std::hint::black_box(&mut buf)).unwrap();
-                let elapsed = start.elapsed();
-
-                buf.clear();
-                total_duration += elapsed;
-            }
-            total_duration
-        })
+        b.iter(|| {
+            let proto = std::hint::black_box(INTERVAL).into_proto();
+            proto.encode(std::hint::black_box(&mut buf)).unwrap();
+            buf.clear();
+        });
     });
 
     const PACKED: [u8; 16] = [128, 0, 0, 1, 128, 0, 0, 1, 128, 0, 0, 0, 0, 0, 0, 0];
@@ -88,21 +77,12 @@ fn bench_time(c: &mut Criterion) {
         })
     });
     group.bench_function("encode/proto", |b| {
-        let mut total_duration = Duration::from_secs(0);
         let mut buf = vec![0u8; 64];
-
-        b.iter_custom(|iters| {
-            for _ in 0..iters {
-                let start = Instant::now();
-                let proto = std::hint::black_box(naive_time).into_proto();
-                proto.encode(std::hint::black_box(&mut buf)).unwrap();
-                let elapsed = start.elapsed();
-
-                buf.clear();
-                total_duration += elapsed;
-            }
-            total_duration
-        })
+        b.iter(|| {
+            let proto = std::hint::black_box(naive_time).into_proto();
+            proto.encode(std::hint::black_box(&mut buf)).unwrap();
+            buf.clear();
+        });
     });
 
     const PACKED: [u8; 8] = [0, 0, 14, 77, 0, 0, 0, 0];
@@ -143,20 +123,11 @@ fn bench_acl_item(c: &mut Criterion) {
         })
     });
     group.bench_function("encode/proto", |b| {
-        let mut total_duration = Duration::from_secs(0);
         let mut buf = vec![0u8; 64];
-
-        b.iter_custom(|iters| {
-            for _ in 0..iters {
-                let start = Instant::now();
-                let proto = std::hint::black_box(acl_item).into_proto();
-                proto.encode(std::hint::black_box(&mut buf)).unwrap();
-                let elapsed = start.elapsed();
-
-                buf.clear();
-                total_duration += elapsed;
-            }
-            total_duration
+        b.iter(|| {
+            let proto = std::hint::black_box(acl_item).into_proto();
+            proto.encode(std::hint::black_box(&mut buf)).unwrap();
+            buf.clear();
         })
     });
 
@@ -198,21 +169,12 @@ fn bench_mz_acl_item(c: &mut Criterion) {
         })
     });
     group.bench_function("encode/proto", |b| {
-        let mut total_duration = Duration::from_secs(0);
         let mut buf = vec![0u8; 64];
-
-        b.iter_custom(|iters| {
-            for _ in 0..iters {
-                let start = Instant::now();
-                let proto = std::hint::black_box(acl_item).into_proto();
-                proto.encode(std::hint::black_box(&mut buf)).unwrap();
-                let elapsed = start.elapsed();
-
-                buf.clear();
-                total_duration += elapsed;
-            }
-            total_duration
-        })
+        b.iter(|| {
+            let proto = std::hint::black_box(acl_item).into_proto();
+            proto.encode(std::hint::black_box(&mut buf)).unwrap();
+            buf.clear();
+        });
     });
 
     const PACKED: [u8; 32] = [

--- a/src/repr/benches/packed.rs
+++ b/src/repr/benches/packed.rs
@@ -7,28 +7,66 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::time::{Duration, Instant};
+
 use chrono::NaiveTime;
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use mz_persist_types::columnar::ColumnarCodec;
+use mz_proto::chrono::ProtoNaiveTime;
+use mz_proto::{ProtoType, RustType};
 use mz_repr::adt::datetime::PackedNaiveTime;
-use mz_repr::adt::interval::{Interval, PackedInterval};
+use mz_repr::adt::interval::{Interval, PackedInterval, ProtoInterval};
+use mz_repr::adt::mz_acl_item::{
+    AclItem, AclMode, MzAclItem, PackedAclItem, PackedMzAclItem, ProtoAclItem, ProtoMzAclItem,
+};
+use mz_repr::adt::system::Oid;
+use mz_repr::role_id::RoleId;
+use prost::Message;
 
 fn bench_interval(c: &mut Criterion) {
-    let mut group = c.benchmark_group("PackedInterval");
+    let mut group = c.benchmark_group("Interval");
     group.throughput(Throughput::Elements(1));
 
     const INTERVAL: Interval = Interval::new(1, 1, 0);
     group.bench_function("encode", |b| {
+        let mut buf = vec![0u8; 32];
         b.iter(|| {
-            let packed = PackedInterval::from(std::hint::black_box(INTERVAL));
-            std::hint::black_box(packed);
+            let packed = PackedInterval::from_value(std::hint::black_box(INTERVAL));
+            std::hint::black_box(&mut buf[..PackedInterval::SIZE])
+                .copy_from_slice(packed.as_bytes());
+        })
+    });
+    group.bench_function("encode/proto", |b| {
+        let mut total_duration = Duration::from_secs(0);
+        let mut buf = vec![0u8; 64];
+
+        b.iter_custom(|iters| {
+            for _ in 0..iters {
+                let start = Instant::now();
+                let proto = std::hint::black_box(INTERVAL).into_proto();
+                proto.encode(std::hint::black_box(&mut buf)).unwrap();
+                let elapsed = start.elapsed();
+
+                buf.clear();
+                total_duration += elapsed;
+            }
+            total_duration
         })
     });
 
     const PACKED: [u8; 16] = [128, 0, 0, 1, 128, 0, 0, 1, 128, 0, 0, 0, 0, 0, 0, 0];
     group.bench_function("decode", |b| {
-        let packed = PackedInterval::from_bytes(&PACKED).unwrap();
         b.iter(|| {
-            let normal = Interval::from(std::hint::black_box(packed));
+            let packed = PackedInterval::from_bytes(std::hint::black_box(&PACKED)).unwrap();
+            let normal = std::hint::black_box(packed).into_value();
+            std::hint::black_box(normal);
+        })
+    });
+    const ENCODED: [u8; 4] = [8, 1, 16, 1];
+    group.bench_function("decode/proto", |b| {
+        b.iter(|| {
+            let proto = ProtoInterval::decode(std::hint::black_box(&ENCODED[..])).unwrap();
+            let normal: Interval = std::hint::black_box(proto).into_rust().unwrap();
             std::hint::black_box(normal);
         })
     });
@@ -37,22 +75,49 @@ fn bench_interval(c: &mut Criterion) {
 }
 
 fn bench_time(c: &mut Criterion) {
-    let mut group = c.benchmark_group("PackedNaiveTime");
+    let mut group = c.benchmark_group("NaiveTime");
     group.throughput(Throughput::Elements(1));
 
+    let naive_time = NaiveTime::from_hms_opt(1, 1, 1).unwrap();
     group.bench_function("encode", |b| {
-        let naive_time = NaiveTime::from_hms_opt(1, 1, 1).unwrap();
+        let mut buf = vec![0u8; 32];
         b.iter(|| {
-            let packed = PackedNaiveTime::from(std::hint::black_box(naive_time));
-            std::hint::black_box(packed);
+            let packed = PackedNaiveTime::from_value(std::hint::black_box(naive_time));
+            std::hint::black_box(&mut buf[..PackedNaiveTime::SIZE])
+                .copy_from_slice(packed.as_bytes());
+        })
+    });
+    group.bench_function("encode/proto", |b| {
+        let mut total_duration = Duration::from_secs(0);
+        let mut buf = vec![0u8; 64];
+
+        b.iter_custom(|iters| {
+            for _ in 0..iters {
+                let start = Instant::now();
+                let proto = std::hint::black_box(naive_time).into_proto();
+                proto.encode(std::hint::black_box(&mut buf)).unwrap();
+                let elapsed = start.elapsed();
+
+                buf.clear();
+                total_duration += elapsed;
+            }
+            total_duration
         })
     });
 
     const PACKED: [u8; 8] = [0, 0, 14, 77, 0, 0, 0, 0];
     group.bench_function("decode", |b| {
-        let packed = PackedNaiveTime::from_bytes(&PACKED).unwrap();
         b.iter(|| {
-            let normal = NaiveTime::from(std::hint::black_box(packed));
+            let packed = PackedNaiveTime::from_bytes(std::hint::black_box(&PACKED)).unwrap();
+            let normal = std::hint::black_box(packed).into_value();
+            std::hint::black_box(normal);
+        })
+    });
+    const ENCODED: [u8; 3] = [8, 205, 28];
+    group.bench_function("decode/proto", |b| {
+        b.iter(|| {
+            let proto = ProtoNaiveTime::decode(std::hint::black_box(&ENCODED[..])).unwrap();
+            let normal: NaiveTime = std::hint::black_box(proto).into_rust().unwrap();
             std::hint::black_box(normal);
         })
     });
@@ -60,5 +125,124 @@ fn bench_time(c: &mut Criterion) {
     group.finish()
 }
 
-criterion_group!(benches, bench_interval, bench_time);
+fn bench_acl_item(c: &mut Criterion) {
+    let mut group = c.benchmark_group("AclItem");
+    group.throughput(Throughput::Elements(1));
+
+    let acl_item = AclItem {
+        grantee: Oid(1),
+        grantor: Oid(2),
+        acl_mode: AclMode::all(),
+    };
+    group.bench_function("encode", |b| {
+        let mut buf = vec![0u8; 32];
+        b.iter(|| {
+            let packed = PackedAclItem::from_value(std::hint::black_box(acl_item));
+            std::hint::black_box(&mut buf[..PackedAclItem::SIZE])
+                .copy_from_slice(packed.as_bytes());
+        })
+    });
+    group.bench_function("encode/proto", |b| {
+        let mut total_duration = Duration::from_secs(0);
+        let mut buf = vec![0u8; 64];
+
+        b.iter_custom(|iters| {
+            for _ in 0..iters {
+                let start = Instant::now();
+                let proto = std::hint::black_box(acl_item).into_proto();
+                proto.encode(std::hint::black_box(&mut buf)).unwrap();
+                let elapsed = start.elapsed();
+
+                buf.clear();
+                total_duration += elapsed;
+            }
+            total_duration
+        })
+    });
+
+    const PACKED: [u8; 16] = [0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 224, 0, 3, 15];
+    group.bench_function("decode", |b| {
+        b.iter(|| {
+            let packed = PackedAclItem::from_bytes(std::hint::black_box(&PACKED)).unwrap();
+            let normal = std::hint::black_box(packed).into_value();
+            std::hint::black_box(normal);
+        })
+    });
+    const ENCODED: [u8; 12] = [8, 1, 16, 2, 26, 6, 8, 143, 134, 128, 128, 14];
+    group.bench_function("decode/proto", |b| {
+        b.iter(|| {
+            let proto = ProtoAclItem::decode(std::hint::black_box(&ENCODED[..])).unwrap();
+            let normal: AclItem = std::hint::black_box(proto).into_rust().unwrap();
+            std::hint::black_box(normal);
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_mz_acl_item(c: &mut Criterion) {
+    let mut group = c.benchmark_group("MzAclItem");
+    group.throughput(Throughput::Elements(1));
+
+    let acl_item = MzAclItem {
+        grantee: RoleId::User(1),
+        grantor: RoleId::User(2),
+        acl_mode: AclMode::all(),
+    };
+    group.bench_function("encode", |b| {
+        let mut buf = vec![0u8; 32];
+        b.iter(|| {
+            let packed = PackedMzAclItem::from_value(std::hint::black_box(acl_item));
+            std::hint::black_box(&mut buf[..PackedMzAclItem::SIZE])
+                .copy_from_slice(packed.as_bytes());
+        })
+    });
+    group.bench_function("encode/proto", |b| {
+        let mut total_duration = Duration::from_secs(0);
+        let mut buf = vec![0u8; 64];
+
+        b.iter_custom(|iters| {
+            for _ in 0..iters {
+                let start = Instant::now();
+                let proto = std::hint::black_box(acl_item).into_proto();
+                proto.encode(std::hint::black_box(&mut buf)).unwrap();
+                let elapsed = start.elapsed();
+
+                buf.clear();
+                total_duration += elapsed;
+            }
+            total_duration
+        })
+    });
+
+    const PACKED: [u8; 32] = [
+        0, 0, 1, 44, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 44, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 224,
+        0, 3, 15,
+    ];
+    group.bench_function("decode", |b| {
+        b.iter(|| {
+            let packed = PackedMzAclItem::from_bytes(std::hint::black_box(&PACKED)).unwrap();
+            let normal = std::hint::black_box(packed).into_value();
+            std::hint::black_box(normal);
+        })
+    });
+    const ENCODED: [u8; 16] = [10, 2, 16, 1, 18, 2, 16, 2, 26, 6, 8, 143, 134, 128, 128, 14];
+    group.bench_function("decode/proto", |b| {
+        b.iter(|| {
+            let proto = ProtoMzAclItem::decode(std::hint::black_box(&ENCODED[..])).unwrap();
+            let normal: MzAclItem = std::hint::black_box(proto).into_rust().unwrap();
+            std::hint::black_box(normal);
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_interval,
+    bench_time,
+    bench_acl_item,
+    bench_mz_acl_item
+);
 criterion_main!(benches);

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 
 use chrono::{NaiveDate, NaiveTime, Timelike};
 use mz_lowertest::MzReflect;
-use mz_persist_types::columnar::ColumnarCodec;
+use mz_persist_types::columnar::FixedSizeCodec;
 use mz_pgtz::timezone::Timezone;
 use mz_proto::{RustType, TryFromProtoError};
 use proptest_derive::Arbitrary;
@@ -1911,10 +1911,9 @@ pub(crate) fn split_timestamp_string(value: &str) -> (&str, &str) {
 /// We uphold the invariant that [`PackedNaiveTime`] sorts the same as
 /// [`NaiveTime`].
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
-#[repr(align(8))]
 pub struct PackedNaiveTime([u8; Self::SIZE]);
 
-impl ColumnarCodec<NaiveTime> for PackedNaiveTime {
+impl FixedSizeCodec<NaiveTime> for PackedNaiveTime {
     const SIZE: usize = 8;
 
     fn as_bytes(&self) -> &[u8] {

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 
 use chrono::{NaiveDate, NaiveTime, Timelike};
 use mz_lowertest::MzReflect;
+use mz_persist_types::columnar::ColumnarCodec;
 use mz_pgtz::timezone::Timezone;
 use mz_proto::{RustType, TryFromProtoError};
 use proptest_derive::Arbitrary;
@@ -1910,22 +1911,17 @@ pub(crate) fn split_timestamp_string(value: &str) -> (&str, &str) {
 /// We uphold the invariant that [`PackedNaiveTime`] sorts the same as
 /// [`NaiveTime`].
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[repr(align(8))]
 pub struct PackedNaiveTime([u8; Self::SIZE]);
 
-impl PackedNaiveTime {
-    pub const SIZE: usize = 8;
+impl ColumnarCodec<NaiveTime> for PackedNaiveTime {
+    const SIZE: usize = 8;
 
-    /// Returns a reference to the underlying bytes.
-    pub fn as_bytes(&self) -> &[u8; Self::SIZE] {
+    fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
-    /// Interprets a slice of bytes as a [`PackedNaiveTime`], returns an error
-    /// if the size of the slice is incorrect.
-    ///
-    /// Note: It is the responsibility of the caller to make sure the provided
-    /// data is a valid [`PackedNaiveTime`].
-    pub fn from_bytes(slice: &[u8]) -> Result<Self, String> {
+    fn from_bytes(slice: &[u8]) -> Result<Self, String> {
         let buf: [u8; Self::SIZE] = slice.try_into().map_err(|_| {
             format!(
                 "size for PackedNaiveTime is {} bytes, got {}",
@@ -1935,11 +1931,9 @@ impl PackedNaiveTime {
         })?;
         Ok(PackedNaiveTime(buf))
     }
-}
 
-impl From<NaiveTime> for PackedNaiveTime {
     #[inline]
-    fn from(value: NaiveTime) -> Self {
+    fn from_value(value: NaiveTime) -> Self {
         let secs = value.num_seconds_from_midnight();
         let nano = value.nanosecond();
 
@@ -1950,17 +1944,15 @@ impl From<NaiveTime> for PackedNaiveTime {
 
         PackedNaiveTime(buf)
     }
-}
 
-impl From<PackedNaiveTime> for NaiveTime {
     #[inline]
-    fn from(value: PackedNaiveTime) -> Self {
+    fn into_value(self) -> NaiveTime {
         let mut secs = [0u8; 4];
-        secs.copy_from_slice(&value.0[..4]);
+        secs.copy_from_slice(&self.0[..4]);
         let secs = u32::from_be_bytes(secs);
 
         let mut nano = [0u8; 4];
-        nano.copy_from_slice(&value.0[4..]);
+        nano.copy_from_slice(&self.0[4..]);
         let nano = u32::from_be_bytes(nano);
 
         NaiveTime::from_num_seconds_from_midnight_opt(secs, nano)
@@ -3578,8 +3570,8 @@ mod tests {
     fn proptest_packed_naive_time_roundtrips() {
         let strat = add_arb_duration(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
         proptest!(|(time in strat)| {
-            let packed = PackedNaiveTime::from(time);
-            let rnd = NaiveTime::from(packed);
+            let packed = PackedNaiveTime::from_value(time);
+            let rnd = packed.into_value();
             prop_assert_eq!(time, rnd);
         });
     }
@@ -3589,13 +3581,13 @@ mod tests {
         let time = add_arb_duration(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
         let strat = proptest::collection::vec(time, 0..128);
         proptest!(|(mut times in strat)| {
-            let mut packed: Vec<_> = times.iter().copied().map(PackedNaiveTime::from).collect();
+            let mut packed: Vec<_> = times.iter().copied().map(PackedNaiveTime::from_value).collect();
 
             times.sort();
             packed.sort();
 
             for (time, packed) in times.into_iter().zip(packed.into_iter()) {
-                let rnd = NaiveTime::from(packed);
+                let rnd = packed.into_value();
                 prop_assert_eq!(time, rnd);
             }
         });

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -13,6 +13,7 @@ use std::fmt::{self, Write};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail};
+use mz_persist_types::columnar::ColumnarCodec;
 use mz_proto::{RustType, TryFromProtoError};
 use num_traits::CheckedMul;
 use once_cell::sync::Lazy;
@@ -822,22 +823,21 @@ impl Arbitrary for Interval {
 ///
 /// We uphold the variant that [`PackedInterval`] sorts the same as [`Interval`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(align(8))]
 pub struct PackedInterval([u8; Self::SIZE]);
 
-impl PackedInterval {
+// `as` conversions are okay here because we're doing bit level logic to make
+// sure the sort order of the packed binary is correct. This is implementation
+// is proptest-ed below.
+#[allow(clippy::as_conversions)]
+impl ColumnarCodec<Interval> for PackedInterval {
     const SIZE: usize = 16;
 
-    /// Returns the encoded bytes of the [`PackedInterval`].
-    pub fn as_bytes(&self) -> &[u8] {
+    fn as_bytes(&self) -> &[u8] {
         &self.0[..]
     }
 
-    /// Interprets a slice of bytes as a [`PackedInterval`], returns an error
-    /// if the size of the slice is incorrect.
-    ///
-    /// Note: It is the responsibility of the caller to make sure the provided
-    /// data is a valid [`PackedInterval`].
-    pub fn from_bytes(slice: &[u8]) -> Result<Self, String> {
+    fn from_bytes(slice: &[u8]) -> Result<Self, String> {
         let buf: [u8; Self::SIZE] = slice.try_into().map_err(|_| {
             format!(
                 "size for PackedInterval is {} bytes, got {}",
@@ -847,15 +847,9 @@ impl PackedInterval {
         })?;
         Ok(PackedInterval(buf))
     }
-}
 
-// `as` conversions are okay here because we're doing bit level logic to make
-// sure the sort order of the packed binary is correct. This is implementation
-// is proptest-ed below.
-#[allow(clippy::as_conversions)]
-impl From<Interval> for PackedInterval {
     #[inline]
-    fn from(value: Interval) -> Self {
+    fn from_value(value: Interval) -> Self {
         let mut buf = [0u8; 16];
 
         // Note: We XOR the values to get correct sorting of negative values.
@@ -870,26 +864,21 @@ impl From<Interval> for PackedInterval {
 
         PackedInterval(buf)
     }
-}
 
-// `as` conversions are okay here because we're doing bit level logic to make
-// sure the sort order of the packed binary is correct. This is implementation
-// is proptest-ed below.
-#[allow(clippy::as_conversions)]
-impl From<PackedInterval> for Interval {
-    fn from(value: PackedInterval) -> Self {
+    #[inline]
+    fn into_value(self) -> Interval {
         // Note: We XOR the values to get correct sorting of negative values.
 
         let mut months = [0; 4];
-        months.copy_from_slice(&value.0[..4]);
+        months.copy_from_slice(&self.0[..4]);
         let months = u32::from_be_bytes(months) ^ 0x8000_0000u32;
 
         let mut days = [0; 4];
-        days.copy_from_slice(&value.0[4..8]);
+        days.copy_from_slice(&self.0[4..8]);
         let days = u32::from_be_bytes(days) ^ 0x8000_0000u32;
 
         let mut micros = [0; 8];
-        micros.copy_from_slice(&value.0[8..]);
+        micros.copy_from_slice(&self.0[8..]);
         let micros = u64::from_be_bytes(micros) ^ 0x8000_0000_0000_0000u64;
 
         Interval {
@@ -1402,8 +1391,8 @@ mod test {
     #[mz_ore::test]
     fn proptest_packed_interval_roundtrips() {
         fn roundtrip_interval(og: Interval) {
-            let packed = PackedInterval::from(og);
-            let rnd = Interval::from(packed);
+            let packed = PackedInterval::from_value(og);
+            let rnd = packed.into_value();
 
             assert_eq!(og, rnd);
         }
@@ -1416,12 +1405,12 @@ mod test {
     #[mz_ore::test]
     fn proptest_packed_interval_sorts() {
         fn sort_intervals(mut og: Vec<Interval>) {
-            let mut packed: Vec<_> = og.iter().copied().map(PackedInterval::from).collect();
+            let mut packed: Vec<_> = og.iter().copied().map(PackedInterval::from_value).collect();
 
             og.sort();
             packed.sort();
 
-            let rnd: Vec<_> = packed.into_iter().map(Interval::from).collect();
+            let rnd: Vec<_> = packed.into_iter().map(PackedInterval::into_value).collect();
 
             assert_eq!(og, rnd);
         }

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -13,7 +13,7 @@ use std::fmt::{self, Write};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail};
-use mz_persist_types::columnar::ColumnarCodec;
+use mz_persist_types::columnar::FixedSizeCodec;
 use mz_proto::{RustType, TryFromProtoError};
 use num_traits::CheckedMul;
 use once_cell::sync::Lazy;
@@ -823,14 +823,13 @@ impl Arbitrary for Interval {
 ///
 /// We uphold the variant that [`PackedInterval`] sorts the same as [`Interval`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(align(8))]
 pub struct PackedInterval([u8; Self::SIZE]);
 
 // `as` conversions are okay here because we're doing bit level logic to make
 // sure the sort order of the packed binary is correct. This is implementation
 // is proptest-ed below.
 #[allow(clippy::as_conversions)]
-impl ColumnarCodec<Interval> for PackedInterval {
+impl FixedSizeCodec<Interval> for PackedInterval {
     const SIZE: usize = 16;
 
     fn as_bytes(&self) -> &[u8] {

--- a/src/repr/src/adt/mz_acl_item.rs
+++ b/src/repr/src/adt/mz_acl_item.rs
@@ -397,6 +397,7 @@ impl PackedMzAclItem {
     pub const USER_TAG: u32 = 300;
     pub const PUBLIC_TAG: u32 = 400;
 
+    #[inline]
     fn encode_role(buf: &mut [u8], role: RoleId) {
         soft_assert_no_log!(buf.len() == 12);
 
@@ -419,6 +420,7 @@ impl PackedMzAclItem {
         }
     }
 
+    #[inline]
     fn decode_role(buf: &[u8]) -> RoleId {
         soft_assert_no_log!(buf.len() == 12);
 
@@ -442,7 +444,7 @@ impl PackedMzAclItem {
     }
 }
 
-impl mz_persist_types::columnar::ColumnarCodec<MzAclItem> for PackedMzAclItem {
+impl ColumnarCodec<MzAclItem> for PackedMzAclItem {
     const SIZE: usize = 32;
 
     fn as_bytes(&self) -> &[u8] {
@@ -464,6 +466,7 @@ impl mz_persist_types::columnar::ColumnarCodec<MzAclItem> for PackedMzAclItem {
         Ok(PackedMzAclItem(buf))
     }
 
+    #[inline]
     fn from_value(value: MzAclItem) -> Self {
         let mut buf = [0u8; 32];
 
@@ -474,6 +477,7 @@ impl mz_persist_types::columnar::ColumnarCodec<MzAclItem> for PackedMzAclItem {
         PackedMzAclItem(buf)
     }
 
+    #[inline]
     fn into_value(self) -> MzAclItem {
         let grantee = PackedMzAclItem::decode_role(&self.0[..12]);
         let grantor = PackedMzAclItem::decode_role(&self.0[12..24]);
@@ -639,7 +643,7 @@ impl Columnation for AclItem {
 #[repr(align(8))]
 pub struct PackedAclItem([u8; Self::SIZE]);
 
-impl mz_persist_types::columnar::ColumnarCodec<AclItem> for PackedAclItem {
+impl ColumnarCodec<AclItem> for PackedAclItem {
     const SIZE: usize = 16;
 
     fn as_bytes(&self) -> &[u8] {
@@ -657,6 +661,7 @@ impl mz_persist_types::columnar::ColumnarCodec<AclItem> for PackedAclItem {
         Ok(PackedAclItem(buf))
     }
 
+    #[inline]
     fn from_value(value: AclItem) -> Self {
         let mut buf = [0u8; 16];
 
@@ -667,6 +672,7 @@ impl mz_persist_types::columnar::ColumnarCodec<AclItem> for PackedAclItem {
         PackedAclItem(buf)
     }
 
+    #[inline]
     fn into_value(self) -> AclItem {
         let mut grantee = [0; 4];
         grantee.copy_from_slice(&self.0[..4]);


### PR DESCRIPTION
This PR does a few things:

1. Introduces a `ColumnarCodec` trait that is defines how to encode a type `T` so it can be durably persisted in an `arrow::array::FixedSizeBinaryArray`.
2. Refactors the impls of `PackedInterval` and `PackedNaiveTime` (introduced in https://github.com/MaterializeInc/materialize/pull/27336) to use `ColumnarCodec`.
3. Add `PackedAclItem` and `PackedMzAclItem` which implement `ColumnarCodec`
4. Refactor existing and add more benchmarks to measure the throughput of encoding and decoding for all of the "packed" types vs the existing `ProtoDatum` types.

#### Benchmarks

The existing benchmarks have been reworked a bit to include encoding into an existing buffer and reading from a slice. Also included are benchmarks for the same workflow but using the existing protobuf types, since the motivation for this work is to improve throughput compared to protobuf.

 type              | encode                 | decode
-------------------|------------------------|--------
interval/packed    | ~1,172 mil/second      | ~1,000 mil/second
interval/proto     | ~239.3 mil/second      | ~120.4 mil/second
time/packed        | ~722.1 mil/second      | ~1,038 mil/second
time/proto         | ~336.9 mil/second      | ~187.3 mil/second
acl_item/packed    | ~1,050 mil/second      | ~1,033 mil/second
acl_item/proto     | ~117.7 mil/second      | ~56.5 mil/second
mz_acl_item/packed | ~385.6 mil/second      | ~590.0 mil/second
mz_acl_item/proto  | ~58.9 mil/second       | ~28.5 mil/second

In general, the "packed" representations have a 5x - 20x higher throughput than their protobuf alternatives. FWIW I believe the packed representations are so much faster because protobuf encodes integers with LEB128 and encodes fields one at a time. Whereas the packed representations use a bit more memory but encode integers in their true size and encodes and entire type "all at once".

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/24830

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
