### PR TITLE
compute: forward implied capabilities

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -970,6 +970,10 @@ where
         }
         to_drop.into_iter().for_each(|uuid| self.remove_peek(uuid));
 
+        // We might have a chance to forward implied capabilities and reduce the cost of bringing
+        // up the next replica, if the dropped replica was the only one in the cluster.
+        self.forward_implied_capabilities();
+
         Ok(())
     }
 
@@ -2082,6 +2086,41 @@ where
         compute_frontiers.chain(storage_frontiers)
     }
 
+    /// Return the write frontiers of transitive storage dependencies of the given collection.
+    fn transitive_storage_dependency_write_frontiers<'b>(
+        &'b self,
+        collection: &'b CollectionState<T>,
+    ) -> impl Iterator<Item = Antichain<T>> + 'b {
+        let mut storage_ids: BTreeSet<_> =
+            collection.storage_dependencies.iter().copied().collect();
+        let mut todo = collection.compute_dependencies.clone();
+        let mut done = BTreeSet::new();
+
+        while let Some(id) = todo.pop() {
+            if done.contains(&id) {
+                continue;
+            }
+            if let Some(dep) = self.compute.collections.get(&id) {
+                storage_ids.extend(&dep.storage_dependencies);
+                todo.extend(&dep.compute_dependencies)
+            }
+            done.insert(id);
+        }
+
+        let storage_ids = storage_ids
+            .into_iter()
+            .filter(|id| self.storage_controller.check_exists(*id).is_ok())
+            .collect::<Vec<_>>();
+        let storage_frontiers = self
+            .storage_controller
+            .collections_frontiers(storage_ids)
+            .expect("checked above")
+            .into_iter()
+            .map(|(_id, _since, upper)| upper);
+
+        storage_frontiers
+    }
+
     /// Downgrade the warmup capabilities of collections as much as possible.
     ///
     /// The only requirement we have for a collection's warmup capability is that it is for a time
@@ -2137,6 +2176,76 @@ where
         }
     }
 
+    /// Forward the implied capabilities of collections, if possible.
+    ///
+    /// The implied capability of a collection controls (a) which times are still readable (for
+    /// indexes) and (b) with which as-of the collection gets installed on a new replica. We are
+    /// usually not allowed to advance an implied capability beyond the frontier that follows from
+    /// the collection's read policy applied to its write frontier:
+    ///
+    ///  * For sink collections, some external consumer might rely on seeing all distinct times in
+    ///    the input reflected in the output. If we'd forward the implied capability of a sink,
+    ///    we'd risk skipping times in the output across replica restarts.
+    ///  * For index collections, we might make the index unreadable by advancing its read frontier
+    ///    beyond its write frontier.
+    ///
+    /// There is one case where forwarding an implied capability is fine though: an index installed
+    /// on a cluster that has no replicas. Such indexes are not readable anyway until a new replica
+    /// is added, so advancing its read frontier can't make it unreadable. We can thus advance the
+    /// implied capability as long as we make sure that when a new replica is added, the expected
+    /// relationship between write frontier, read policy, and implied capability can be restored
+    /// immediately (modulo computation time).
+    ///
+    /// Forwarding implied capabilities is not necessary for the correct functioning of the
+    /// controller but an optimization that is beneficial in two ways:
+    ///
+    ///  * It relaxes read holds on inputs to forwarded collections, allowing their compaction.
+    ///  * It reduces the amount of historical detail new replicas need to process when computing
+    ///    forwarded collections, as forwarding the implied capability also forwards the corresponding
+    ///    dataflow as-of.
+    fn forward_implied_capabilities(&mut self) {
+        if self.compute.replicas.len() != 0 {
+            return;
+        }
+
+        let mut new_capabilities = BTreeMap::new();
+        for (id, collection) in &self.compute.collections {
+            let Some(read_policy) = &collection.read_policy else {
+                // Collection is write-only, i.e. a sink.
+                continue;
+            };
+
+            // When a new replica is started, it will immediately be able to compute all collection
+            // output up to the write frontier of its transitive storage inputs. So the new implied
+            // read capability should be the read policy applied to that frontier.
+            let mut dep_frontier = Antichain::new();
+            for frontier in self.transitive_storage_dependency_write_frontiers(collection) {
+                dep_frontier.extend(frontier);
+            }
+
+            let new_capability = read_policy.frontier(dep_frontier.borrow());
+            if PartialOrder::less_than(&collection.implied_capability, &new_capability) {
+                new_capabilities.insert(*id, new_capability);
+            }
+        }
+
+        let mut read_capability_changes = BTreeMap::new();
+        for (id, new_capability) in new_capabilities {
+            let collection = self.compute.expect_collection_mut(id);
+            let old_capability = &collection.implied_capability;
+
+            let mut update = ChangeBatch::new();
+            update.extend(old_capability.iter().map(|t| (t.clone(), -1)));
+            update.extend(new_capability.iter().map(|t| (t.clone(), 1)));
+            read_capability_changes.insert(id, update);
+            collection.implied_capability = new_capability;
+        }
+
+        if !read_capability_changes.is_empty() {
+            self.update_read_capabilities(read_capability_changes);
+        }
+    }
+
     /// Process pending maintenance work.
     ///
     /// This method is invoked periodically by the global controller.
@@ -2145,6 +2254,7 @@ where
     pub fn maintain(&mut self) {
         self.rehydrate_failed_replicas();
         self.downgrade_warmup_capabilities();
+        self.forward_implied_capabilities();
         self.schedule_collections();
         self.compute.cleanup_collections();
         self.compute.refresh_state_metrics();


### PR DESCRIPTION
This PR adds an optimization to aggressively forward the implied capabilities of index collections in clusters that don't have replicas installed.

Forwarding is attempted whenever a replica is dropped, and periodically as part of the regular controller maintenance.

### Motivation

  * This PR fixes a previously unreported bug.

When a replica starts in a cluster that previously had no replicas, or was otherwise unhealthy, for a long time, we might force it to retroactively compute the corresponding outputs for all times seen in the inputs since the cluster was last healthy. Depending on the amount of downtime, the number of input times might be large and either severely slow down the replica's  hydration or even prevent it (e.g. by causing an OOM). This is the case even when nobody cares about the historical input times anymore and a lot of work could be avoided by skipping them.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
