### PR TITLE
persist: add support for columnar decode to s3 bench tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7604,6 +7604,7 @@ dependencies = [
  "mz-persist-client",
  "mz-persist-types",
  "mz-repr",
+ "mz-storage-types",
  "mz-timestamp-oracle",
  "mz-txn-wal",
  "num_cpus",

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -33,6 +33,7 @@ mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-repr = { path = "../repr" }
+mz-storage-types = { path = "../storage-types" }
 mz-timestamp-oracle = { path = "../timestamp-oracle" }
 mz-txn-wal = { path = "../txn-wal" }
 num_cpus = "1.14.0"

--- a/src/persist-client/src/cli/bench.rs
+++ b/src/persist-client/src/cli/bench.rs
@@ -9,12 +9,18 @@
 
 //! CLI benchmarking tools for persist
 
+use std::fmt::Debug;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-use mz_persist::indexed::encoding::BlobTraceBatchPart;
+use mz_dyncfg::ConfigUpdates;
+use mz_persist::indexed::encoding::{BlobTraceBatchPart, BlobTraceUpdates};
+use mz_persist_types::columnar::{PartDecoder, Schema};
+use mz_persist_types::dyn_struct::DynStructCol;
+use mz_persist_types::Codec;
 
 use crate::cli::args::StateArgs;
+use crate::fetch::PART_DECODE_FORMAT;
 use crate::internal::state::BatchPart;
 
 /// Commands for read-only inspection of persist state
@@ -43,22 +49,37 @@ pub struct S3FetchArgs {
     iters: usize,
 
     #[clap(long)]
+    parse: bool,
+
+    /// HACK: Decodes the K, V data assuming the schema of lineitem table from
+    /// the TPCH load generator source.
+    #[clap(long, requires = "parse")]
     decode: bool,
 }
 
 /// Runs the given bench command.
-pub async fn run(command: BenchArgs) -> Result<(), anyhow::Error> {
+pub async fn run<K: Codec + Default + Debug>(
+    command: BenchArgs,
+    key_schema: Arc<K::Schema>,
+) -> Result<(), anyhow::Error> {
     match command.command {
-        Command::S3Fetch(args) => bench_s3(&args).await?,
+        Command::S3Fetch(args) => bench_s3::<K>(&args, key_schema).await?,
     }
 
     Ok(())
 }
 
-async fn bench_s3(args: &S3FetchArgs) -> Result<(), anyhow::Error> {
+async fn bench_s3<K: Codec + Default + Debug>(
+    args: &S3FetchArgs,
+    key_schema: Arc<K::Schema>,
+) -> Result<(), anyhow::Error> {
+    let parse = args.parse;
     let decode = args.decode;
     let shard_id = args.shard.shard_id();
     let state_versions = args.shard.open().await?;
+    let mut dyncfg_updates = ConfigUpdates::default();
+    dyncfg_updates.add(&PART_DECODE_FORMAT, "row_with_validate");
+    dyncfg_updates.apply(&state_versions.cfg);
     let versions = state_versions
         .fetch_recent_live_diffs::<u64>(&shard_id)
         .await;
@@ -70,9 +91,9 @@ async fn bench_s3(args: &S3FetchArgs) -> Result<(), anyhow::Error> {
         .snapshot(state.since())
         .expect("since should be available for reads");
 
-    let start = Instant::now();
-    println!("iter,key,size_bytes,fetch_secs,decode_secs");
+    println!("iter,key,size_bytes,fetch_secs,parse_secs,decode_secs");
     for iter in 0..args.iters {
+        let start = Instant::now();
         let mut fetches = Vec::new();
         for part in snap.iter().flat_map(|x| x.parts.iter()) {
             let key = match part {
@@ -81,18 +102,46 @@ async fn bench_s3(args: &S3FetchArgs) -> Result<(), anyhow::Error> {
             };
             let blob = Arc::clone(&state_versions.blob);
             let metrics = Arc::clone(&state_versions.metrics);
+            let key_schema = Arc::clone(&key_schema);
             let fetch = mz_ore::task::spawn(|| "", async move {
                 let buf = blob.get(&key).await.unwrap().unwrap();
                 let fetch_elapsed = start.elapsed();
                 let buf_len = buf.len();
-                let decode_elapsed = mz_ore::task::spawn_blocking(
+                let (parse_elapsed, decode_elapsed) = mz_ore::task::spawn_blocking(
                     || "",
                     move || {
-                        let start = Instant::now();
-                        if decode {
-                            BlobTraceBatchPart::<u64>::decode(&buf, &metrics.columnar).unwrap();
+                        if parse {
+                            let parse_start = Instant::now();
+                            let updates =
+                                BlobTraceBatchPart::<u64>::decode(&buf, &metrics.columnar).unwrap();
+                            let parse_elapsed = parse_start.elapsed();
+                            let decode_elapsed = if decode {
+                                let decode_start = Instant::now();
+                                match &updates.updates {
+                                    BlobTraceUpdates::Row(_) => {}
+                                    BlobTraceUpdates::Both(codec, structured) => {
+                                        let len = codec.len();
+                                        if let Some(key) = &structured.key {
+                                            let col =
+                                                DynStructCol::from_arrow(key_schema.columns(), key)
+                                                    .unwrap();
+                                            let decoder = key_schema.decoder(col.as_ref()).unwrap();
+                                            let mut k = K::default();
+                                            for idx in 0..len {
+                                                decoder.decode(idx, &mut k);
+                                                std::hint::black_box(&k);
+                                            }
+                                        }
+                                    }
+                                }
+                                decode_start.elapsed()
+                            } else {
+                                Duration::ZERO
+                            };
+                            (parse_elapsed, decode_elapsed)
+                        } else {
+                            (Duration::ZERO, Duration::ZERO)
                         }
-                        start.elapsed()
                     },
                 )
                 .await
@@ -101,16 +150,17 @@ async fn bench_s3(args: &S3FetchArgs) -> Result<(), anyhow::Error> {
                     key,
                     buf_len,
                     fetch_elapsed.as_secs_f64(),
+                    parse_elapsed.as_secs_f64(),
                     decode_elapsed.as_secs_f64(),
                 )
             });
             fetches.push(fetch);
         }
         for fetch in fetches {
-            let (key, size_bytes, fetch_secs, decode_secs) = fetch.await.unwrap();
+            let (key, size_bytes, fetch_secs, parse_secs, decode_secs) = fetch.await.unwrap();
             println!(
-                "{},{},{},{},{}",
-                iter, key, size_bytes, fetch_secs, decode_secs
+                "{},{},{},{},{},{}",
+                iter, key, size_bytes, fetch_secs, parse_secs, decode_secs
             );
         }
     }


### PR DESCRIPTION
This needs a schema and relies on a pretty major hack of hardcoding
lineitem, which is what I've been testing with.

I'm also trying to start standardizing on fetch/parse/decode as the
jargon for s3-to-bytes/bytes-to-arrow/arrow-to-KV respectively.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
