### PR TITLE
persist: Don't assert the `logical_nulls` are `None` for non-nullable columns

### DIFF
--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -719,6 +719,7 @@ macro_rules! arrowable_primitive {
     ($data:ident, $arrow_type:ident) => {
         impl ColumnGet<$data> for PrimitiveArray<$arrow_type> {
             fn get<'a>(&'a self, idx: usize) -> $data {
+                assert!(self.is_valid(idx));
                 self.value(idx)
             }
         }
@@ -832,7 +833,7 @@ impl ColumnRef<()> for BinaryArray {
 
 impl ColumnGet<Vec<u8>> for BinaryArray {
     fn get<'a>(&'a self, idx: usize) -> &'a [u8] {
-        assert!(self.logical_nulls().is_none());
+        assert!(self.is_valid(idx));
         self.value(idx)
     }
 }
@@ -905,7 +906,7 @@ impl ColumnRef<()> for StringArray {
 
 impl ColumnGet<String> for StringArray {
     fn get<'a>(&'a self, idx: usize) -> &'a str {
-        assert!(self.logical_nulls().is_none());
+        assert!(self.is_valid(idx));
         self.value(idx)
     }
 }
@@ -956,7 +957,7 @@ impl ColumnPush<Option<String>> for StringBuilder {
 
 impl ColumnGet<OpaqueData> for BinaryArray {
     fn get<'a>(&'a self, idx: usize) -> <OpaqueData as Data>::Ref<'a> {
-        assert!(self.logical_nulls().is_none());
+        assert!(self.is_valid(idx));
         self.value(idx)
     }
 }

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -1268,7 +1268,7 @@ mod tests {
     fn parquet_roundtrip() {
         let (schema, row) = schema_and_row();
         assert_eq!(
-            mz_persist_types::parquet::validate_roundtrip(&schema, &row),
+            mz_persist_types::parquet::validate_roundtrip(&schema, &[row]),
             Ok(())
         );
     }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1570,16 +1570,12 @@ mod tests {
 
         // Non-nullable version of the column.
         let schema = RelationDesc::empty().with_column("col", scalar_type.clone().nullable(false));
-        for row in rows.iter() {
-            assert_eq!(validate_roundtrip(&schema, row), Ok(()));
-        }
+        assert_eq!(validate_roundtrip(&schema, &rows), Ok(()));
 
         // Nullable version of the column.
         let schema = RelationDesc::empty().with_column("col", scalar_type.nullable(true));
         rows.push(SourceData(Ok(Row::pack_slice(&[Datum::Null]))));
-        for row in rows.iter() {
-            assert_eq!(validate_roundtrip(&schema, row), Ok(()));
-        }
+        assert_eq!(validate_roundtrip(&schema, &rows), Ok(()));
     }
 
     #[mz_ore::test]


### PR DESCRIPTION
Currently for a few non-nullable columnar types we assert that there are no nulls when reading from the column. This fails when roundtripping through Parquet with batch of `SourceData` that contains both `Ok` and `Err` values. When deserializing, Parquet appears to set the validity bitmap for child arrays to the validity bitmap of the top-level `StructArray`. For `SourceData` when there is an `Err` value we set the corresponding entry in the `Ok` column to null. This then results in those non-nullable columns, within `Ok`, having nulls.

#### Why didn't we see this before?

Nothing in production, including our stats handling, roundtrips structured data through Parquet. The existing `parquet::validate_roundtrip` helper creates batches of size 1, so we never exercise the scenario of an `Err` and `Ok` in the same batch. I updated this helper though so we do exercise the scenario.

### Motivation

* This PR fixes a previously unreported bug.
    * One of our nightly tests that toggles the existing dyncfg on and off hit this: https://buildkite.com/materialize/nightly/builds/7930 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
