### PR TITLE
bazel: Disable nightly test target

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1608,7 +1608,7 @@ steps:
         agents:
           queue: linux-aarch64-small
 
-  # TODO(parkmycar): Re-enable when we auto-generate BUILD.bazel files for Cargo.toml.
+  # TODO(#27381): Re-enable when we auto-generate BUILD.bazel files for Cargo.toml.
   # - group: ":bazel: Bazel"
   #   key: bazel
   #   steps:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1608,21 +1608,22 @@ steps:
         agents:
           queue: linux-aarch64-small
 
-  - group: ":bazel: Bazel"
-    key: bazel
-    steps:
-      - id: bazel-test-x86_64
-        label: ":bazel: Test (x86_64)"
-        command: bin/ci-builder run stable bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
-        depends_on: []
-        timeout_in_minutes: 60
-        agents:
-          queue: builder-linux-x86_64
+  # TODO(parkmycar): Re-enable when we auto-generate BUILD.bazel files for Cargo.toml.
+  # - group: ":bazel: Bazel"
+  #   key: bazel
+  #   steps:
+  #     - id: bazel-test-x86_64
+  #       label: ":bazel: Test (x86_64)"
+  #       command: bin/ci-builder run stable bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
+  #       depends_on: []
+  #       timeout_in_minutes: 60
+  #       agents:
+  #         queue: builder-linux-x86_64
 
-      - id: bazel-test-aarch64
-        label: ":bazel: Test (aarch64)"
-        command: bin/ci-builder run stable bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
-        depends_on: []
-        timeout_in_minutes: 60
-        agents:
-          queue: builder-linux-aarch64
+  #     - id: bazel-test-aarch64
+  #       label: ":bazel: Test (aarch64)"
+  #       command: bin/ci-builder run stable bazel test //... --remote_cache=https://bazel-remote.dev.materialize.com
+  #       depends_on: []
+  #       timeout_in_minutes: 60
+  #       agents:
+  #         queue: builder-linux-aarch64


### PR DESCRIPTION
Now that we've added the Rust setup for Bazel, the nightly test job will break whenever someone updates the dependencies of a crate in our workspace because we're not re-pinning Bazel's Rust dependencies. We've gotten enough signal from CI that the Bazel caching works, so for now I'm opting to disable the Bazel test target until the auto-gen of BUILD.bazel files merges to prevent Nightly from being unnecessarily red.

### Motivation

Make nightly green

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
