### PR TITLE
release: bump to version v0.103.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4010,7 +4010,7 @@ dependencies = [
 
 [[package]]
 name = "mz-balancerd"
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "mz-catalog-debug"
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "mz-clusterd"
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -4528,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 dependencies = [
  "anyhow",
  "askama",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.4",
@@ -6359,7 +6359,7 @@ dependencies = [
 
 [[package]]
 name = "mz-testdrive"
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 dependencies = [
  "anyhow",
  "arrow",

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-balancerd"
 description = "Balancer service."
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-catalog-debug"
 description = "Durable metadata storage debug tool."
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-clusterd"
 description = "Materialize's cluster server."
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-testdrive"
 description = "Integration test driver for Materialize."
-version = "0.102.0-dev"
+version = "0.103.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a