### PR TITLE
adapter: per connection watchset tracking and cancellation

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2757,6 +2757,15 @@ impl Coordinator {
         self.installed_watch_sets.insert(ws_id, (conn_id, state));
     }
 
+    /// Cancels pending watchsets associated with the provided connection id.
+    pub fn cancel_pending_watchsets(&mut self, conn_id: &ConnectionId) {
+        if let Some(ws_ids) = self.connection_watch_sets.remove(conn_id) {
+            for ws_id in ws_ids {
+                self.installed_watch_sets.remove(&ws_id);
+            }
+        }
+    }
+
     /// Returns the state of the [`Coordinator`] formatted as JSON.
     ///
     /// The returned value is not guaranteed to be stable and may change at any point in time.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -96,7 +96,7 @@ use mz_compute_types::plan::Plan;
 use mz_compute_types::ComputeInstanceId;
 use mz_controller::clusters::{ClusterConfig, ClusterEvent, CreateReplicaConfig};
 use mz_controller::ControllerConfig;
-use mz_controller_types::{ClusterId, ReplicaId};
+use mz_controller_types::{ClusterId, ReplicaId, WatchSetId};
 use mz_expr::{MapFilterProject, OptimizedMirRelationExpr};
 use mz_orchestrator::ServiceProcessMetrics;
 use mz_ore::instrument;
@@ -163,7 +163,7 @@ use crate::optimize::dataflows::{
 use crate::optimize::metrics::OptimizerMetrics;
 use crate::optimize::{self, Optimize, OptimizerConfig};
 use crate::session::{EndTransactionAction, Session};
-use crate::statement_logging::StatementEndedExecutionReason;
+use crate::statement_logging::{StatementEndedExecutionReason, StatementLifecycleEvent};
 use crate::util::{ClientTransmitter, CompletedClientTransmitter, ResultExt};
 use crate::webhook::{WebhookAppenderInvalidator, WebhookConcurrencyLimiter};
 use crate::{flags, AdapterNotice, ReadHolds, TimestampProvider};
@@ -1423,6 +1423,13 @@ pub struct Coordinator {
     /// (Clusters that have been dropped or are otherwise out of scope for automatic scheduling are
     /// periodically cleaned up from this Map.)
     cluster_scheduling_decisions: BTreeMap<ClusterId, BTreeMap<&'static str, SchedulingDecision>>,
+
+    /// Tracks the state associated with the currently installed watchsets.
+    installed_watch_sets:
+        BTreeMap<WatchSetId, (ConnectionId, (StatementLoggingId, StatementLifecycleEvent))>,
+
+    /// Tracks the currently installed watchsets for each connection.
+    connection_watch_sets: BTreeMap<ConnectionId, BTreeSet<WatchSetId>>,
 }
 
 impl Coordinator {
@@ -2714,6 +2721,42 @@ impl Coordinator {
             .await;
     }
 
+    /// Install a _watch set_ in the controller that is automatically associated with the given
+    /// connection id. The watchset will be automatically cleared if the connection terminates
+    /// before the watchset completes.
+    pub fn install_compute_watch_set(
+        &mut self,
+        conn_id: ConnectionId,
+        objects: BTreeSet<GlobalId>,
+        t: Timestamp,
+        state: (StatementLoggingId, StatementLifecycleEvent),
+    ) {
+        let ws_id = self.controller.install_compute_watch_set(objects, t);
+        self.connection_watch_sets
+            .entry(conn_id.clone())
+            .or_default()
+            .insert(ws_id);
+        self.installed_watch_sets.insert(ws_id, (conn_id, state));
+    }
+
+    /// Install a _watch set_ in the controller that is automatically associated with the given
+    /// connection id. The watchset will be automatically cleared if the connection terminates
+    /// before the watchset completes.
+    pub fn install_storage_watch_set(
+        &mut self,
+        conn_id: ConnectionId,
+        objects: BTreeSet<GlobalId>,
+        t: Timestamp,
+        state: (StatementLoggingId, StatementLifecycleEvent),
+    ) {
+        let ws_id = self.controller.install_storage_watch_set(objects, t);
+        self.connection_watch_sets
+            .entry(conn_id.clone())
+            .or_default()
+            .insert(ws_id);
+        self.installed_watch_sets.insert(ws_id, (conn_id, state));
+    }
+
     /// Returns the state of the [`Coordinator`] formatted as JSON.
     ///
     /// The returned value is not guaranteed to be stable and may change at any point in time.
@@ -3102,6 +3145,8 @@ pub fn serve(
                     pg_timestamp_oracle_config,
                     check_cluster_scheduling_policies_interval: check_scheduling_policies_interval,
                     cluster_scheduling_decisions: BTreeMap::new(),
+                    installed_watch_sets: BTreeMap::new(),
+                    connection_watch_sets: BTreeMap::new(),
                 };
                 let bootstrap = handle.block_on(async {
                     coord

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1007,6 +1007,7 @@ impl Coordinator {
         }
 
         self.cancel_pending_peeks(&conn_id);
+        self.cancel_pending_watchsets(&conn_id);
         self.cancel_compute_sinks_for_conn(&conn_id).await;
     }
 
@@ -1038,6 +1039,7 @@ impl Coordinator {
             .with_label_values(&[session_type])
             .dec();
         self.cancel_pending_peeks(conn.conn_id());
+        self.cancel_pending_watchsets(&conn_id);
         self.end_session_for_statement_logging(conn.uuid());
 
         // Queue the builtin table update, but do not wait for it to complete. We explicitly do

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -878,7 +878,7 @@ impl Coordinator {
                 transitive_compute_deps,
                 ts,
                 Box::new((uuid, StatementLifecycleEvent::ComputeDependenciesFinished)),
-            )
+            );
         }
 
         let max_query_size = ctx.session().vars().max_query_result_size();

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -837,7 +837,7 @@ impl Coordinator {
         let planned_peek = PlannedPeek {
             plan: peek_plan,
             determination: determination.clone(),
-            conn_id,
+            conn_id: conn_id.clone(),
             source_arity,
             source_ids,
         };
@@ -869,15 +869,17 @@ impl Coordinator {
                     _ => {}
                 }
             }
-            self.controller.install_storage_watch_set(
+            self.install_storage_watch_set(
+                conn_id.clone(),
                 transitive_storage_deps,
                 ts,
-                Box::new((uuid, StatementLifecycleEvent::StorageDependenciesFinished)),
+                (uuid, StatementLifecycleEvent::StorageDependenciesFinished),
             );
-            self.controller.install_compute_watch_set(
+            self.install_compute_watch_set(
+                conn_id,
                 transitive_compute_deps,
                 ts,
-                Box::new((uuid, StatementLifecycleEvent::ComputeDependenciesFinished)),
+                (uuid, StatementLifecycleEvent::ComputeDependenciesFinished),
             );
         }
 

--- a/src/controller-types/src/lib.rs
+++ b/src/controller-types/src/lib.rs
@@ -15,6 +15,16 @@ pub type ClusterId = mz_compute_types::ComputeInstanceId;
 /// Identifies a cluster replica.
 pub type ReplicaId = mz_cluster_client::ReplicaId;
 
+/// Identifies a watch set.
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+pub struct WatchSetId(u64);
+
+impl From<u64> for WatchSetId {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
 pub use mz_compute_types::DEFAULT_COMPUTE_REPLICA_LOGGING_INTERVAL as DEFAULT_REPLICA_LOGGING_INTERVAL;
 
 /// Reports whether a given size name is a "v2" cluster size--i.e., a cluster

--- a/src/ore/src/id_gen.rs
+++ b/src/ore/src/id_gen.rs
@@ -30,13 +30,22 @@ use rand::{Rng, SeedableRng};
 use crate::cast::CastFrom;
 
 /// Manages the allocation of unique IDs.
-#[derive(Debug, Default, Clone)]
-pub struct Gen<Id: From<u64> + Default> {
+#[derive(Debug, Clone)]
+pub struct Gen<Id> {
     id: u64,
     phantom: PhantomData<Id>,
 }
 
-impl<Id: From<u64> + Default> Gen<Id> {
+impl<Id> Default for Gen<Id> {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<Id: From<u64>> Gen<Id> {
     /// Allocates a new identifier of type `Id` and advances the generator.
     pub fn allocate_id(&mut self) -> Id {
         let id = self.id;


### PR DESCRIPTION
### Motivation

The adapter currently installs watchsets in the controller but they are only removed if they finish. If a watchset is installed on a collection whose upper is stuck (e.g a failing source) then we will eventually timeout the connection (or the user will abort it) and leak the installed watchset for the remaining lifetime of the process (or until the source gets unstuck).

This PR adds the ability to cancel a pending watchset and wires up the coordinator to automatically cancel pending watchsets when a connection is terminated or cancelled.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
