### PR TITLE
ci: improve annotating failed miri test cases

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -58,7 +58,7 @@ ERROR_RE = re.compile(
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
     | SUMMARY:\ .*Sanitizer
     # for miri test summary
-    | FAIL\ \[\s*\d+\.\d+s\]
+    | (FAIL|TIMEOUT)\s+\[\s*\d+\.\d+s\]
     )
     .* $
     """,


### PR DESCRIPTION
This is a follow-up to https://github.com/MaterializeInc/materialize/pull/27120 to also capture such entries

```
     Summary [2929.930s] 393 tests run: 392 passed, 1 timed out, 307 skipped
     TIMEOUT [2400.058s] mz-repr adt::mz_acl_item::proptest_packed_mz_acl_item_sorts
error: test run failed
```

as seen in https://buildkite.com/materialize/nightly/builds/7933#018fcd39-ec86-432e-8839-2f0cb382681a.

Nightly: https://buildkite.com/materialize/nightly/builds/7936