### PR TITLE
adapter: implement alter sink

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -595,7 +595,8 @@ impl ExecuteResponse {
             | AlterSchemaSwap
             | AlterSecret
             | AlterConnection
-            | AlterSource => &[AlteredObject],
+            | AlterSource
+            | AlterSink => &[AlteredObject],
             AlterDefaultPrivileges => &[AlteredDefaultPrivileges],
             AlterSetCluster => &[AlteredObject],
             AlterRole => &[AlteredRole],

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -115,7 +115,7 @@ use mz_secrets::{SecretsController, SecretsReader};
 use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
 use mz_sql::names::ResolvedIds;
-use mz_sql::plan::{self, CreateConnectionPlan, Params, QueryWhen};
+use mz_sql::plan::{self, AlterSinkPlan, CreateConnectionPlan, Params, QueryWhen};
 use mz_sql::rbac::UnauthorizedError;
 use mz_sql::session::user::{RoleMetadata, User};
 use mz_sql::session::vars::{ConnectionCounter, SystemVars};
@@ -1425,8 +1425,7 @@ pub struct Coordinator {
     cluster_scheduling_decisions: BTreeMap<ClusterId, BTreeMap<&'static str, SchedulingDecision>>,
 
     /// Tracks the state associated with the currently installed watchsets.
-    installed_watch_sets:
-        BTreeMap<WatchSetId, (ConnectionId, (StatementLoggingId, StatementLifecycleEvent))>,
+    installed_watch_sets: BTreeMap<WatchSetId, (ConnectionId, WatchSetResponse)>,
 
     /// Tracks the currently installed watchsets for each connection.
     connection_watch_sets: BTreeMap<ConnectionId, BTreeSet<WatchSetId>>,
@@ -2729,7 +2728,7 @@ impl Coordinator {
         conn_id: ConnectionId,
         objects: BTreeSet<GlobalId>,
         t: Timestamp,
-        state: (StatementLoggingId, StatementLifecycleEvent),
+        state: WatchSetResponse,
     ) {
         let ws_id = self.controller.install_compute_watch_set(objects, t);
         self.connection_watch_sets
@@ -2747,7 +2746,7 @@ impl Coordinator {
         conn_id: ConnectionId,
         objects: BTreeSet<GlobalId>,
         t: Timestamp,
-        state: (StatementLoggingId, StatementLifecycleEvent),
+        state: WatchSetResponse,
     ) {
         let ws_id = self.controller.install_storage_watch_set(objects, t);
         self.connection_watch_sets
@@ -3372,4 +3371,20 @@ impl StorageConstraints {
             compute_ids: Default::default(),
         }
     }
+}
+
+#[derive(Debug)]
+pub(crate) enum WatchSetResponse {
+    StatementDependenciesReady(StatementLoggingId, StatementLifecycleEvent),
+    AlterSinkReady(AlterSinkReadyContext),
+}
+
+#[derive(Debug)]
+pub(crate) struct AlterSinkReadyContext {
+    ctx: ExecuteContext,
+    otel_ctx: OpenTelemetryContext,
+    plan: AlterSinkPlan,
+    plan_validity: PlanValidity,
+    resolved_ids: ResolvedIds,
+    read_hold: ReadHolds<Timestamp>,
 }

--- a/src/adapter/src/coord/catalog_serving.rs
+++ b/src/adapter/src/coord/catalog_serving.rs
@@ -118,6 +118,7 @@ pub fn auto_run_on_catalog_server<'a, 's, 'p>(
         | Plan::AlterSchemaRename(_)
         | Plan::AlterSchemaSwap(_)
         | Plan::AlterSecret(_)
+        | Plan::AlterSink(_)
         | Plan::AlterSystemSet(_)
         | Plan::AlterSystemReset(_)
         | Plan::AlterSystemResetAll(_)

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -450,21 +450,8 @@ impl Coordinator {
                         WatchSetResponse::StatementDependenciesReady(id, ev) => {
                             self.record_statement_lifecycle_event(&id, &ev, now);
                         }
-                        WatchSetResponse::AlterSinkReady(mut c) => {
-                            c.otel_ctx.attach_as_parent();
-                            let result = match c.plan_validity.check(self.catalog()) {
-                                Ok(()) => {
-                                    self.sequence_alter_sink_finish(
-                                        c.ctx.session_mut(),
-                                        c.plan,
-                                        c.resolved_ids,
-                                        c.read_hold,
-                                    )
-                                    .await
-                                }
-                                Err(e) => Err(e),
-                            };
-                            c.ctx.retire(result);
+                        WatchSetResponse::AlterSinkReady(ctx) => {
+                            self.sequence_alter_sink_finish(ctx).await;
                         }
                     }
                 }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -417,6 +417,9 @@ impl Coordinator {
                     let result = self.sequence_alter_secret(ctx.session(), plan).await;
                     ctx.retire(result);
                 }
+                Plan::AlterSink(plan) => {
+                    self.sequence_alter_sink_prepare(ctx, plan).await;
+                }
                 Plan::AlterSource(plan) => {
                     let result = self.sequence_alter_source(ctx.session_mut(), plan).await;
                     ctx.retire(result);

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -50,7 +50,7 @@ use crate::coord::{
     PeekStage, PeekStageCopyTo, PeekStageExplainPlan, PeekStageExplainPushdown, PeekStageFinish,
     PeekStageLinearizeTimestamp, PeekStageOptimize, PeekStageRealTimeRecency,
     PeekStageTimestampReadHold, PeekStageValidate, PlanValidity, RealTimeRecencyContext,
-    TargetCluster,
+    TargetCluster, WatchSetResponse,
 };
 use crate::error::AdapterError;
 use crate::explain::optimizer_trace::OptimizerTrace;
@@ -873,14 +873,20 @@ impl Coordinator {
                 conn_id.clone(),
                 transitive_storage_deps,
                 ts,
-                (uuid, StatementLifecycleEvent::StorageDependenciesFinished),
+                WatchSetResponse::StatementDependenciesReady(
+                    uuid,
+                    StatementLifecycleEvent::StorageDependenciesFinished,
+                ),
             );
             self.install_compute_watch_set(
                 conn_id,
                 transitive_compute_deps,
                 ts,
-                (uuid, StatementLifecycleEvent::ComputeDependenciesFinished),
-            );
+                WatchSetResponse::StatementDependenciesReady(
+                    uuid,
+                    StatementLifecycleEvent::ComputeDependenciesFinished,
+                ),
+            )
         }
 
         let max_query_size = ctx.session().vars().max_query_result_size();

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -222,6 +222,8 @@ pub enum AdapterError {
     RtrTimeout(String),
     /// A humanized version of [`StorageError::RtrDropFailure`].
     RtrDropFailure(String),
+    /// The collection requested to be sinked cannot be read at any timestamp
+    UnreadableSinkCollection,
 }
 
 impl AdapterError {
@@ -525,6 +527,7 @@ impl AdapterError {
             AdapterError::SubsourceAlreadyReferredTo { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::RtrTimeout(_) => SqlState::QUERY_CANCELED,
             AdapterError::RtrDropFailure(_) => SqlState::UNDEFINED_OBJECT,
+            AdapterError::UnreadableSinkCollection => SqlState::from_code("MZ009"),
         }
     }
 
@@ -750,6 +753,9 @@ impl fmt::Display for AdapterError {
                 f,
                 "real-time source dropped before ingesting the upstream system's visible frontier"
             ),
+            AdapterError::UnreadableSinkCollection => {
+                write!(f, "collection is not readable at any time")
+            }
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2281,7 +2281,7 @@ impl<T: AstInfo> AstDisplay for AlterSinkStatement<T> {
 
         match &self.action {
             AlterSinkAction::ChangeRelation(from) => {
-                f.write_str("FROM ");
+                f.write_str("SET FROM ");
                 f.write_node(from);
             }
             AlterSinkAction::SetOptions(options) => {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2260,6 +2260,7 @@ impl_display_t!(AlterIndexStatement);
 pub enum AlterSinkAction<T: AstInfo> {
     SetOptions(Vec<CreateSinkOption<T>>),
     ResetOptions(Vec<CreateSinkOptionName>),
+    ChangeRelation(T::ItemName),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2279,6 +2280,10 @@ impl<T: AstInfo> AstDisplay for AlterSinkStatement<T> {
         f.write_str(" ");
 
         match &self.action {
+            AlterSinkAction::ChangeRelation(from) => {
+                f.write_str("FROM ");
+                f.write_node(from);
+            }
             AlterSinkAction::SetOptions(options) => {
                 f.write_str("SET (");
                 f.write_node(&display::comma_separated(options));

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4920,9 +4920,20 @@ impl<'a> Parser<'a> {
 
         Ok(
             match self
-                .expect_one_of_keywords(&[RESET, SET, RENAME, OWNER])
+                .expect_one_of_keywords(&[FROM, RESET, SET, RENAME, OWNER])
                 .map_no_statement_parser_err()?
             {
+                FROM => {
+                    let from = self
+                        .parse_raw_name()
+                        .map_parser_err(StatementKind::AlterSink)?;
+
+                    Statement::AlterSink(AlterSinkStatement {
+                        sink_name: name,
+                        if_exists,
+                        action: AlterSinkAction::ChangeRelation(from),
+                    })
+                }
                 RESET => {
                     self.expect_token(&Token::LParen)
                         .map_parser_err(StatementKind::AlterSink)?;

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1478,9 +1478,9 @@ ALTER SINK name RESET (SIZE)
                        ^
 
 parse-statement
-ALTER SINK name FROM foobar
+ALTER SINK name SET FROM foobar
 ----
-ALTER SINK name FROM foobar
+ALTER SINK name SET FROM foobar
 =>
 AlterSink(AlterSinkStatement { sink_name: UnresolvedItemName([Ident("name")]), if_exists: false, action: ChangeRelation(Name(UnresolvedItemName([Ident("foobar")]))) })
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1478,6 +1478,13 @@ ALTER SINK name RESET (SIZE)
                        ^
 
 parse-statement
+ALTER SINK name FROM foobar
+----
+ALTER SINK name FROM foobar
+=>
+AlterSink(AlterSinkStatement { sink_name: UnresolvedItemName([Ident("name")]), if_exists: false, action: ChangeRelation(Name(UnresolvedItemName([Ident("foobar")]))) })
+
+parse-statement
 ALTER INDEX name RENAME TO name2
 ----
 ALTER INDEX name RENAME TO name2

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1026,7 +1026,7 @@ pub struct AlterSourcePlan {
     pub action: AlterSourceAction,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AlterSinkPlan {
     pub id: GlobalId,
     pub sink: Sink,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -163,6 +163,7 @@ pub enum Plan {
     AlterSchemaRename(AlterSchemaRenamePlan),
     AlterSchemaSwap(AlterSchemaSwapPlan),
     AlterSecret(AlterSecretPlan),
+    AlterSink(AlterSinkPlan),
     AlterSystemSet(AlterSystemSetPlan),
     AlterSystemReset(AlterSystemResetPlan),
     AlterSystemResetAll(AlterSystemResetAllPlan),
@@ -212,8 +213,7 @@ impl Plan {
             StatementKind::AlterRole => &[PlanKind::AlterRole],
             StatementKind::AlterSecret => &[PlanKind::AlterNoop, PlanKind::AlterSecret],
             StatementKind::AlterSetCluster => &[PlanKind::AlterNoop, PlanKind::AlterSetCluster],
-            // TODO: If we ever support ALTER SINK again, this will need to be changed
-            StatementKind::AlterSink => &[PlanKind::AlterNoop],
+            StatementKind::AlterSink => &[PlanKind::AlterNoop, PlanKind::AlterSink],
             StatementKind::AlterSource => &[
                 PlanKind::AlterNoop,
                 PlanKind::AlterSource,
@@ -380,6 +380,7 @@ impl Plan {
             Plan::AlterSchemaRename(_) => "alter rename schema",
             Plan::AlterSchemaSwap(_) => "alter swap schema",
             Plan::AlterSecret(_) => "alter secret",
+            Plan::AlterSink(_) => "alter sink",
             Plan::AlterSystemSet(_) => "alter system",
             Plan::AlterSystemReset(_) => "alter system",
             Plan::AlterSystemResetAll(_) => "alter system",
@@ -1023,6 +1024,14 @@ pub enum AlterSourceAction {
 pub struct AlterSourcePlan {
     pub id: GlobalId,
     pub action: AlterSourceAction,
+}
+
+#[derive(Debug)]
+pub struct AlterSinkPlan {
+    pub id: GlobalId,
+    pub sink: Sink,
+    pub with_snapshot: bool,
+    pub in_cluster: ClusterId,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -980,7 +980,25 @@ fn generate_rbac_requirements(
             item_usage: &CREATE_ITEM_USAGE,
             ..Default::default()
         },
-
+        Plan::AlterSink(plan::AlterSinkPlan {
+            id,
+            sink,
+            with_snapshot: _,
+            in_cluster,
+        }) => {
+            let mut privileges = generate_read_privileges(catalog, iter::once(sink.from), role_id);
+            privileges.push((
+                SystemObjectId::Object(in_cluster.into()),
+                AclMode::CREATE,
+                role_id,
+            ));
+            RbacRequirements {
+                ownership: vec![ObjectId::Item(*id)],
+                privileges,
+                item_usage: &CREATE_ITEM_USAGE,
+                ..Default::default()
+            }
+        }
         Plan::AlterClusterRename(plan::AlterClusterRenamePlan {
             id,
             name: _,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -428,6 +428,13 @@ pub trait StorageController: Debug {
         exports: Vec<(GlobalId, ExportDescription<Self::Timestamp>)>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
+    /// Create the sinks described by the `ExportDescription`.
+    async fn alter_export(
+        &mut self,
+        id: GlobalId,
+        export: ExportDescription<Self::Timestamp>,
+    ) -> Result<(), StorageError<Self::Timestamp>>;
+
     /// For each identified export, alter its [`StorageSinkConnection`].
     async fn alter_export_connections(
         &mut self,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -428,7 +428,7 @@ pub trait StorageController: Debug {
         exports: Vec<(GlobalId, ExportDescription<Self::Timestamp>)>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
-    /// Create the sinks described by the `ExportDescription`.
+    /// Alter the sink identified by the given id to match the provided `ExportDescription`.
     async fn alter_export(
         &mut self,
         id: GlobalId,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -313,28 +313,51 @@ where
         (Antichain<Self::Timestamp>, Antichain<Self::Timestamp>),
         StorageError<Self::Timestamp>,
     > {
-        let frontiers = self.storage_collections.collection_frontiers(id)?;
-
-        Ok((frontiers.implied_capability, frontiers.write_frontier))
+        Ok(match self.export(id) {
+            Ok(export) => (
+                export.read_hold.since().clone(),
+                export.write_frontier.clone(),
+            ),
+            Err(_) => {
+                let frontiers = self.storage_collections.collection_frontiers(id)?;
+                (frontiers.implied_capability, frontiers.write_frontier)
+            }
+        })
     }
 
     fn collections_frontiers(
         &self,
-        ids: Vec<GlobalId>,
+        mut ids: Vec<GlobalId>,
     ) -> Result<Vec<(GlobalId, Antichain<T>, Antichain<T>)>, StorageError<Self::Timestamp>> {
-        let res = self
-            .storage_collections
-            .collections_frontiers(ids)?
-            .into_iter()
-            .map(|frontiers| {
-                (
-                    frontiers.id,
-                    frontiers.implied_capability,
-                    frontiers.write_frontier,
-                )
-            });
+        // The ids might be either normal collections or exports. Both have frontiers that might be
+        // interesting to external observers.
+        let mut result = vec![];
+        ids.retain(|&id| match self.export(id) {
+            Ok(export) => {
+                result.push((
+                    id,
+                    export.read_hold.since().clone(),
+                    export.write_frontier.clone(),
+                ));
+                false
+            }
+            Err(_) => true,
+        });
 
-        Ok(res.collect_vec())
+        result.extend(
+            self.storage_collections
+                .collections_frontiers(ids)?
+                .into_iter()
+                .map(|frontiers| {
+                    (
+                        frontiers.id,
+                        frontiers.implied_capability,
+                        frontiers.write_frontier,
+                    )
+                }),
+        );
+
+        Ok(result)
     }
 
     fn active_collection_metadatas(&self) -> Vec<(GlobalId, CollectionMetadata)> {
@@ -1186,6 +1209,68 @@ where
 
             client.send(StorageCommand::RunSinks(vec![cmd]));
         }
+        Ok(())
+    }
+
+    async fn alter_export(
+        &mut self,
+        id: GlobalId,
+        description: ExportDescription<Self::Timestamp>,
+    ) -> Result<(), StorageError<Self::Timestamp>> {
+        let from_id = description.sink.from;
+
+        // Acquire read holds at StorageCollections to ensure that the
+        // sinked collection is not dropped while we're sinking it.
+        let desired_read_holds = vec![from_id.clone()];
+        let read_hold = self
+            .storage_collections
+            .acquire_read_holds(desired_read_holds)
+            .expect("missing dependency")
+            .into_element();
+        let from_storage_metadata = self.storage_collections.collection_metadata(from_id)?;
+
+        // Check whether the sink's write frontier is beyond the read hold we got
+        let cur_export = self.exports.get_mut(&id).expect("export does not exist");
+        let input_readable = cur_export
+            .write_frontier
+            .iter()
+            .all(|t| read_hold.since().less_than(t));
+        if !input_readable {
+            return Err(StorageError::ReadBeforeSince(from_id));
+        }
+
+        cur_export.description = description.clone();
+
+        let status_id = match description.sink.status_id.clone() {
+            Some(id) => Some(self.storage_collections.collection_metadata(id)?.data_shard),
+            None => None,
+        };
+
+        let cmd = RunSinkCommand {
+            id,
+            description: StorageSinkDesc {
+                from: from_id,
+                from_desc: description.sink.from_desc,
+                connection: description.sink.connection,
+                envelope: description.sink.envelope,
+                as_of: description.sink.as_of,
+                version: description.sink.version,
+                status_id,
+                from_storage_metadata,
+                with_snapshot: description.sink.with_snapshot,
+            },
+        };
+
+        // Fetch the client for this exports's cluster.
+        let client = self
+            .clients
+            .get_mut(&description.instance_id)
+            .ok_or_else(|| StorageError::ExportInstanceMissing {
+                storage_instance_id: description.instance_id,
+                export_id: id,
+            })?;
+
+        client.send(StorageCommand::RunSinks(vec![cmd]));
         Ok(())
     }
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1230,7 +1230,10 @@ where
         let from_storage_metadata = self.storage_collections.collection_metadata(from_id)?;
 
         // Check whether the sink's write frontier is beyond the read hold we got
-        let cur_export = self.exports.get_mut(&id).expect("export does not exist");
+        let cur_export = self
+            .exports
+            .get_mut(&id)
+            .ok_or_else(|| StorageError::IdentifierMissing(id))?;
         let input_readable = cur_export
             .write_frontier
             .iter()

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -67,6 +67,7 @@ pub async fn run_sql(mut cmd: SqlCommand, state: &State) -> Result<ControlFlow, 
         | CreateRole(_)
         | AlterObjectRename(_)
         | AlterIndex(_)
+        | AlterSink(_)
         | Discard(_)
         | DropObjects(_)
         | SetVariable(_) => false,
@@ -311,7 +312,7 @@ pub async fn run_fail_sql(
     cmd: FailSqlCommand,
     state: &State,
 ) -> Result<ControlFlow, anyhow::Error> {
-    use Statement::{Commit, Fetch, Rollback};
+    use Statement::{AlterSink, Commit, Fetch, Rollback};
 
     let stmts = mz_sql_parser::parser::parse_statements(&cmd.query)
         .map_err(|e| format!("unable to parse SQL: {}: {}", cmd.query, e));
@@ -349,6 +350,7 @@ pub async fn run_fail_sql(
         Some(Commit(_)) | Some(Rollback(_)) => false,
         // FETCH should not be retried because it consumes data on each response.
         Some(Fetch(_)) => false,
+        Some(AlterSink(_)) => false,
         Some(_) => true,
     };
 

--- a/test/testdrive/alter-sink.td
+++ b/test/testdrive/alter-sink.td
@@ -9,8 +9,6 @@
 
 $ set-arg-default single-replica-cluster=quickstart
 
-# Verify that envelope types are correctly reported in mz_sinks
-
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
@@ -34,15 +32,67 @@ $ set-arg-default single-replica-cluster=quickstart
   FORMAT JSON
   ENVELOPE DEBEZIUM;
 
-> ALTER SINK sink FROM post_alter;
+$ kafka-verify-data format=json sink=materialize.public.sink key=false
+{"before": null, "after": {"pre_name": "fish"}}
+
+> ALTER SINK sink SET FROM post_alter;
 
 # The sink will start sinking updates from `post_alter` at the timestamp that
 # the previous dataflow happens to stop. This happens pretty quickly but we
-# wait a few milliseconds more for good measure to avoid flaking.
-$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=200ms
+# wait a few seconds more for good measure to avoid flaking.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=4s
 
 > INSERT INTO post_alter VALUES ('chips', 42);
 
 $ kafka-verify-data format=json sink=materialize.public.sink key=false
-{"before": null, "after": {"pre_name": "fish"}}
 {"before": null, "after": {"post_name": "chips", "post_value": 42}}
+
+
+# Test that backward incompatible schema changes lead to an error
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE TABLE post_alter_incompatible (post_value int);
+
+> CREATE SINK incompatible_sink
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM pre_alter
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-alter-sink-incompatible-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+$ kafka-verify-data format=avro sink=materialize.public.incompatible_sink sort-messages=true
+{"before": null, "after": {"row": {"pre_name": {"string": "fish"}}}}
+
+> ALTER SINK incompatible_sink SET FROM post_alter_incompatible;
+
+> SELECT st.error LIKE '%schema being registered is incompatible with an earlier schema%'
+  FROM mz_sinks s JOIN mz_internal.mz_sink_statuses st ON s.id = st.id
+  WHERE s.name = 'incompatible_sink';
+true
+
+# Create a cluster with no replicas so sources can't make progress. This will ensure `ALTER SINK` hangs forever until we cancel it.
+> CREATE CLUSTER no_replicas REPLICAS ()
+
+> CREATE SOURCE counter
+  IN CLUSTER no_replicas
+  FROM LOAD GENERATOR COUNTER;
+
+> CREATE SINK wedged_sink
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM counter
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-alter-sink-${testdrive.seed}')
+  FORMAT JSON
+  ENVELOPE DEBEZIUM;
+
+$ set-from-sql var=backend-pid
+SELECT CAST(pg_backend_pid() AS text);
+
+$ postgres-execute background=true connection=postgres://materialize:materialize@${testdrive.materialize-sql-addr}
+SELECT mz_unsafe.mz_sleep(3);
+SELECT pg_cancel_backend(CAST(${backend-pid} AS int4));
+
+! ALTER SINK wedged_sink SET FROM post_alter;
+contains:canceling statement due to user request

--- a/test/testdrive/alter-sink.td
+++ b/test/testdrive/alter-sink.td
@@ -1,0 +1,48 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-arg-default single-replica-cluster=quickstart
+
+# Verify that envelope types are correctly reported in mz_sinks
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE CONNECTION csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE TABLE pre_alter (pre_name string);
+> INSERT INTO pre_alter VALUES ('fish');
+
+> CREATE TABLE post_alter (post_name string, post_value int);
+# This value should be ignored by the sink because the alter will happen after
+# this record has been inserted and we don't re-emit a snapshot of the new
+# collection when it changes.
+> INSERT INTO post_alter VALUES ('ignored', 0);
+
+> CREATE SINK sink
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM pre_alter
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-alter-sink-${testdrive.seed}')
+  FORMAT JSON
+  ENVELOPE DEBEZIUM;
+
+> ALTER SINK sink FROM post_alter;
+
+# The sink will start sinking updates from `post_alter` at the timestamp that
+# the previous dataflow happens to stop. This happens pretty quickly but we
+# wait a few milliseconds more for good measure to avoid flaking.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=200ms
+
+> INSERT INTO post_alter VALUES ('chips', 42);
+
+$ kafka-verify-data format=json sink=materialize.public.sink key=false
+{"before": null, "after": {"pre_name": "fish"}}
+{"before": null, "after": {"post_name": "chips", "post_value": 42}}


### PR DESCRIPTION
### Motivation

The implementation of `ALTER SINK` as described in the [design document here](https://www.notion.so/materialize/ALTER-SINK-MVP-ffa7e969830a49eb979043510425e3b0).

`ALTER SINK` currently only supports swapping out the relation the sink is reading from. Every other detail of the sink (envelope, format, etc) stays the same and must be compatible with the new relation. Here compatible means that a `CREATE SINK` statement would have succeeded had it be submitted with the new `FROM` collection. This is precisely how the planner chooses to plan an `ALTER SINK` as well. It generates the equivalent `CREATE SINK` statement where all but the from collection is the same and if that plans successfully we move ahead.

After we obtain an `ALTER SINK` plan successfully the coordinator takes a read hold on the new collection and installs a watch set for the current sink's upper so that it gets notified when the previous sink's upper has overlap with the new collection's since. This process is described in detail in the design doc.

Once the watchset finishes we go ahead and swap out the alter sink definition. That part is exactly the same as when we swap out the sink definition during an `ALTER CONNECTION`. 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
