### PR TITLE
storage: delay panics by a cluster shutdown grace period

### DIFF
--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -16,6 +16,7 @@ use std::convert::Infallible;
 use std::fmt::Debug;
 use std::future::Future;
 use std::hash::Hash;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -146,7 +147,7 @@ pub fn persist_source<G>(
     map_filter_project: Option<&mut MfpPlan>,
     max_inflight_bytes: Option<usize>,
     start_signal: impl Future<Output = ()> + 'static,
-    error_handler: impl FnMut(String) -> () + 'static,
+    error_handler: impl FnOnce(String) -> Pin<Box<dyn Future<Output = ()>>> + 'static,
 ) -> (
     Stream<G, (Row, Timestamp, Diff)>,
     Stream<G, (DataflowError, Timestamp, Diff)>,
@@ -281,7 +282,7 @@ pub fn persist_source_core<'g, G>(
     // If Some, an override for the default listen sleep retry parameters.
     listen_sleep: Option<impl Fn() -> RetryParameters + 'static>,
     start_signal: impl Future<Output = ()> + 'static,
-    error_handler: impl FnMut(String) -> () + 'static,
+    error_handler: impl FnOnce(String) -> Pin<Box<dyn Future<Output = ()>>> + 'static,
 ) -> (
     Stream<
         RefinedScope<'g, G>,

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -14,6 +14,17 @@ use std::time::Duration;
 
 use mz_dyncfg::{Config, ConfigSet};
 
+/// When dataflows observe an invariant violation it is either due to a bug or due to the cluster
+/// being shut down. This configuration defines the amount of time to wait before panicking the
+/// process, which will register the invariant violation.
+pub const CLUSTER_SHUTDOWN_GRACE_PERIOD: Config<Duration> = Config::new(
+    "storage_cluster_shutdown_grace_period",
+    Duration::from_secs(10 * 60),
+    "When dataflows observe an invariant violation it is either due to a bug or due to \
+        the cluster being shut down. This configuration defines the amount of time to \
+        wait before panicking the process, which will register the invariant violation.",
+);
+
 // Flow control
 
 /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
@@ -168,6 +179,7 @@ pub const STORAGE_ROCKSDB_CLEANUP_TRIES: Config<usize> = Config::new(
 /// Adds the full set of all storage `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
+        .add(&CLUSTER_SHUTDOWN_GRACE_PERIOD)
         .add(&DELAY_SOURCES_PAST_REHYDRATION)
         .add(&STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION)
         .add(&KAFKA_CLIENT_ID_ENRICHMENT_RULES)

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -69,13 +69,15 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
         None,
         async {},
         move |error| {
-            let error = format!("storage_sink: {error}");
-            tracing::info!("{error}");
-            let mut command_tx = command_tx.borrow_mut();
-            command_tx.broadcast(InternalStorageCommand::SuspendAndRestart {
-                id: sink_id,
-                reason: error,
-            });
+            Box::pin(async move {
+                let error = format!("storage_sink: {error}");
+                tracing::info!("{error}");
+                let mut command_tx = command_tx.borrow_mut();
+                command_tx.broadcast(InternalStorageCommand::SuspendAndRestart {
+                    id: sink_id,
+                    reason: error,
+                });
+            })
         },
     );
     tokens.extend(persist_tokens);

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -306,6 +306,7 @@ where
                                 } else {
                                     (None, None, None)
                                 };
+
                             let (stream, tok) = persist_source::persist_source_core(
                                 scope,
                                 id,
@@ -318,7 +319,9 @@ where
                                 flow_control,
                                 false.then_some(|| unreachable!()),
                                 async {},
-                                |error| panic!("upsert_rehydration: {error}"),
+                                |error| {
+                                    Box::pin(async move { panic!("upsert_rehydration: {error}") })
+                                },
                             );
                             (
                                 stream.as_collection(),


### PR DESCRIPTION
### Motivation

This PR attempts to strike a balance between getting a useful signal out of invariant violations and reducing false positive rates. When a source attempts to rehydrate on a cluster that has been dropped there is the possibility that it panics before we have a chance to shut the process down. This PR adds a grace period such that the panic is suppressed if the to-be-dropped cluster is actually dropped within a reasonable time frame. If a cluster is still alive after the grace period then the panic happens as usual and will be reported in the usual places.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
