### PR TITLE
.*: Upgrade `compact_bytes` to  `v0.1.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "compact_bytes"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de71a0422a777179ab4baef92325e56396443df4a680bc443b11f63d644ca019"
+checksum = "7142ec2955b9a77690640f940a2baed9d5bfbe2b7a5395fe51da9df04c3af764"
 dependencies = [
  "serde",
  "static_assertions",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -852,6 +852,12 @@ user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-03-26"
 end = "2024-11-16"
 
+[[trusted.compact_bytes]]
+criteria = "safe-to-deploy"
+user-id = 75844 # Parker Timmerman (ParkMyCar)
+start = "2023-10-31"
+end = "2025-05-31"
+
 [[trusted.csv]]
 criteria = "safe-to-deploy"
 user-id = 189 # Andrew Gallant (BurntSushi)

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -274,10 +274,6 @@ criteria = "safe-to-deploy"
 version = "1.3.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.compact_bytes]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.compile-time-run]]
 version = "0.2.12"
 criteria = "safe-to-deploy"

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -239,6 +239,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.compact_bytes]]
+version = "0.1.2"
+when = "2024-05-31"
+user-id = 75844
+user-login = "ParkMyCar"
+user-name = "Parker Timmerman"
+
 [[publisher.core-foundation]]
 version = "0.9.3"
 when = "2022-02-07"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4.35", default-features = false, features = [
   "std",
 ], optional = true }
 clap = { version = "3.2.24", features = ["env"], optional = true }
-compact_bytes = { version = "0.1.1", optional = true }
+compact_bytes = { version = "0.1.2", optional = true }
 ctor = { version = "0.1.26", optional = true }
 derivative = { version = "2.2.0", optional = true }
 either = "1.8.0"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -30,7 +30,7 @@ cfg-if = "1.0.0"
 columnation = { git = "https://github.com/frankmcsherry/columnation" }
 chrono = { version = "0.4.35", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
-compact_bytes = "0.1.1"
+compact_bytes = "0.1.2"
 dec = "0.4.8"
 differential-dataflow = "0.12.0"
 enum_dispatch = "0.3.11"


### PR DESCRIPTION
This PR updates the `compact_bytes` dependency to `v0.1.2` to pickup this PR https://github.com/ParkMyCar/compact_bytes/pull/2.

### Motivation

@antiguru noticed when looking at some profiles that the call to `ComapctBytes::extend_from_slice(...)` was not getting inlined. While inlining is a relatively small performance gain, `extend_from_slice(...)` is an extremely hot code path so even a small improvement here could be nice.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
