### PR TITLE
docs: segment uses cookies for storage

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -129,10 +129,12 @@ toCSS | fingerprint }}
     analytics._writeKey=SEGMENT_ID;
     analytics._cdn="https://cdn.segment.materialize.com";
     analytics.load(SEGMENT_ID);
+    {{/* Use cookies for storage by default, since they cross subdomains */}}
+    analytics.load(SEGMENT_ID, storage: { stores: ["cookie", "localStorage", "memory"] });
   {{ else }}
     {{/* Dev */}}
     analytics._writeKey="dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk";
-    analytics.load("dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk");
+    analytics.load("dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk", storage: { stores: ["cookie", "localStorage", "memory"] });
   {{ end }}
   analytics.page();
   }}();


### PR DESCRIPTION
By default, segment looks at localstorage first, which doesn't cross subdomains. This causes the logged in user ID from console to be overwritten in some cases. Instead, we will look at cookies first and fall back to localstorage if the cookie is not set.

### Motivation

  * This PR fixes a previously unreported bug.

https://materializeinc.slack.com/archives/C06GZ7GBKB5/p1717091663493629
