### PR TITLE
Endow `Equivalence` with a lattice

### DIFF
--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -180,15 +180,10 @@ impl EquivalencePropagation {
                     self.apply(value.0, value.1, equivalences.clone(), get_equivalences);
                 }
             }
-            MirRelationExpr::LetRec { body, .. } => {
-                // Only descend into `body` without more careful analysis.
-                // We could determine non-recursive bindings, for example, and process them.
-                self.apply(
-                    body,
-                    derived.last_child(),
-                    outer_equivalences,
-                    get_equivalences,
-                );
+            MirRelationExpr::LetRec { .. } => {
+                for (child, derived) in expr.children_mut().rev().zip(derived.children_rev()) {
+                    self.apply(child, derived, outer_equivalences.clone(), get_equivalences);
+                }
             }
             MirRelationExpr::Project { input, outputs } => {
                 // Transform `outer_equivalences` to one relevant for `input`.

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -202,21 +202,21 @@ Explained Query:
           ArrangeBy keys=[[#0]]
             Union
               Negate
-                Project (#0, #1)
-                  Join on=(#2 = least(#0, #1) AND #3 = greatest(#0, #1)) type=differential
-                    ArrangeBy keys=[[greatest(#0, #1), least(#0, #1)]]
-                      Get l0
-                    ArrangeBy keys=[[#1, #0]]
-                      Distinct project=[least(#0, #1), greatest(#0, #1)]
-                        Get l1
-              Get l0
+                CrossJoin type=differential
+                  ArrangeBy keys=[[]]
+                    Get l1
+                  ArrangeBy keys=[[]]
+                    Distinct project=[]
+                      Project ()
+                        Get l0
+              Project (#1, #2)
+                ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
               Get l1
     cte l1 =
       Project (#1, #2)
-        Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
-          ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+        Get l0
     cte l0 =
-      Project (#1, #2)
+      Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
         ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
 
 Used Indexes:
@@ -318,21 +318,21 @@ Explained Query:
           ArrangeBy keys=[[#0]]
             Union
               Negate
-                Project (#0, #1)
-                  Join on=(#2 = least(#0, #1) AND #3 = greatest(#0, #1)) type=differential
-                    ArrangeBy keys=[[greatest(#0, #1), least(#0, #1)]]
-                      Get l0
-                    ArrangeBy keys=[[#1, #0]]
-                      Distinct project=[least(#0, #1), greatest(#0, #1)]
-                        Get l1
-              Get l0
+                CrossJoin type=differential
+                  ArrangeBy keys=[[]]
+                    Get l1
+                  ArrangeBy keys=[[]]
+                    Distinct project=[]
+                      Project ()
+                        Get l0
+              Project (#1, #2)
+                ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
               Get l1
     cte l1 =
       Project (#1, #2)
-        Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
-          ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+        Get l0
     cte l0 =
-      Project (#1, #2)
+      Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
         ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
 
 Used Indexes:

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -1336,6 +1336,7 @@ Target cluster: quickstart
 EOF
 
 # Test `LetRec` printing, with and without RECURSION LIMIT
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR
 SELECT * FROM (

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -1350,22 +1350,8 @@ SELECT * FROM (
     SELECT * FROM bar
 );
 ----
-Explained Query:
-  Return
-    Union
-      Get::PassArrangements l0
-        raw=true
-      Get::PassArrangements l1
-        raw=true
-  With Mutually Recursive
-    cte l1 =
-      Get::Collection l1
-        project=(#1)
-        map=((#0 - 2))
-        raw=true
-    cte [recursion_limit=5] l0 =
-      Get::PassArrangements l0
-        raw=true
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: mz_catalog_server
 

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -1335,22 +1335,8 @@ SELECT * FROM (
     SELECT * FROM bar
 );
 ----
-Explained Query:
-  Return
-    Union
-      Get::PassArrangements l0
-        raw=true
-      Get::PassArrangements l1
-        raw=true
-  With Mutually Recursive
-    cte l1 =
-      Get::Collection l1
-        project=(#1)
-        map=((#0 - █))
-        raw=true
-    cte [recursion_limit=5] l0 =
-      Get::PassArrangements l0
-        raw=true
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: mz_catalog_server
 

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -1321,6 +1321,7 @@ Target cluster: quickstart
 EOF
 
 # Test `LetRec` printing, with and without RECURSION LIMIT
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
 SELECT * FROM (

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -2550,46 +2550,46 @@ Explained Query:
                                           ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
                                             Get l2 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                                            Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
-                                              Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                                                Get l1 // { arity: 3 }
+                                            Distinct project=[#0, #1] // { arity: 2 }
+                                              Project (#2, #3) // { arity: 2 }
+                                                Get l1 // { arity: 5 }
                                     Get l2 // { arity: 2 }
-                                Get l1 // { arity: 3 }
+                                Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
+                                  Get l1 // { arity: 5 }
                   Constant // { arity: 2 }
                     - (1450, 0)
       cte l2 =
         Project (#1{person2id}, #2) // { arity: 2 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
       cte l1 =
-        Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
-          Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
-            implementation
-              %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
-            ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-              Project (#1{person2id}, #2) // { arity: 2 }
-                ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-            ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-              Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-                Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-                  Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
-                    implementation
-                      %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
-                      %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                      %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                      %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                      %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                    ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                      ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                    ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                      Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                        Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                    ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                      Project (#9, #10, #12) // { arity: 3 }
-                        Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                    Get l0 // { arity: 1 }
-                    Get l0 // { arity: 1 }
+        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
+          implementation
+            %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
+          ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+            Project (#1{person2id}, #2) // { arity: 2 }
+              ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+          ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                  implementation
+                    %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                      Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                    Project (#9, #10, #12) // { arity: 3 }
+                      Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  Get l0 // { arity: 1 }
+                  Get l0 // { arity: 1 }
       cte l0 =
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Distinct project=[#0{id}] // { arity: 1 }
@@ -2946,44 +2946,44 @@ Explained Query:
                       ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
                         Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                        Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
-                          Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                            Get l1 // { arity: 3 }
+                        Distinct project=[#0, #1] // { arity: 2 }
+                          Project (#2, #3) // { arity: 2 }
+                            Get l1 // { arity: 5 }
                 Get l2 // { arity: 2 }
-            Get l1 // { arity: 3 }
+            Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
+              Get l1 // { arity: 5 }
     cte l2 =
       Project (#1{person2id}, #2) // { arity: 2 }
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
     cte l1 =
-      Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
-        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
-          implementation
-            %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
-          ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-            Project (#1{person2id}, #2) // { arity: 2 }
-              ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-          ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
-                  implementation
-                    %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                    %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                      Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                    Project (#9, #10, #12) // { arity: 3 }
-                      Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  Get l0 // { arity: 1 }
-                  Get l0 // { arity: 1 }
+      Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
+        implementation
+          %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
+        ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+          Project (#1{person2id}, #2) // { arity: 2 }
+            ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+        ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+          Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+            Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+              Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                implementation
+                  %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                  %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                  %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                  %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                  %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                  ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                  Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                    Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                  Project (#9, #10, #12) // { arity: 3 }
+                    Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                Get l0 // { arity: 1 }
+                Get l0 // { arity: 1 }
     cte l0 =
       ArrangeBy keys=[[#0{id}]] // { arity: 1 }
         Distinct project=[#0{id}] // { arity: 1 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -2557,46 +2557,46 @@ Explained Query:
                                           ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
                                             Get l2 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                                            Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
-                                              Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                                                Get l1 // { arity: 3 }
+                                            Distinct project=[#0, #1] // { arity: 2 }
+                                              Project (#2, #3) // { arity: 2 }
+                                                Get l1 // { arity: 5 }
                                     Get l2 // { arity: 2 }
-                                Get l1 // { arity: 3 }
+                                Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
+                                  Get l1 // { arity: 5 }
                   Constant // { arity: 2 }
                     - (1450, 0)
       cte l2 =
         Project (#1{person2id}, #2) // { arity: 2 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
       cte l1 =
-        Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
-          Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
-            implementation
-              %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
-            ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-              Project (#1{person2id}, #2) // { arity: 2 }
-                ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-            ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-              Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-                Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-                  Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
-                    implementation
-                      %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
-                      %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                      %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                      %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                      %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                    ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                      ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                    ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                      Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                        Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                    ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                      Project (#9, #10, #12) // { arity: 3 }
-                        Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                    Get l0 // { arity: 1 }
-                    Get l0 // { arity: 1 }
+        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
+          implementation
+            %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
+          ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+            Project (#1{person2id}, #2) // { arity: 2 }
+              ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+          ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                  implementation
+                    %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                      Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                    Project (#9, #10, #12) // { arity: 3 }
+                      Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  Get l0 // { arity: 1 }
+                  Get l0 // { arity: 1 }
       cte l0 =
         ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Distinct project=[#0{id}] // { arity: 1 }
@@ -2953,44 +2953,44 @@ Explained Query:
                       ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
                         Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                        Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
-                          Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                            Get l1 // { arity: 3 }
+                        Distinct project=[#0, #1] // { arity: 2 }
+                          Project (#2, #3) // { arity: 2 }
+                            Get l1 // { arity: 5 }
                 Get l2 // { arity: 2 }
-            Get l1 // { arity: 3 }
+            Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
+              Get l1 // { arity: 5 }
     cte l2 =
       Project (#1{person2id}, #2) // { arity: 2 }
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
     cte l1 =
-      Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
-        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
-          implementation
-            %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
-          ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-            Project (#1{person2id}, #2) // { arity: 2 }
-              ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-          ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
-                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
-                  implementation
-                    %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                    %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
-                    %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
-                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
-                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                      Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
-                    Project (#9, #10, #12) // { arity: 3 }
-                      Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-                  Get l0 // { arity: 1 }
-                  Get l0 // { arity: 1 }
+      Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
+        implementation
+          %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
+        ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
+          Project (#1{person2id}, #2) // { arity: 2 }
+            ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+        ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+          Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
+            Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+              Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
+                implementation
+                  %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                  %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                  %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                  %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                  %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                  ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                  Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                    Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                  Project (#9, #10, #12) // { arity: 3 }
+                    Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                      ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                Get l0 // { arity: 1 }
+                Get l0 // { arity: 1 }
     cte l0 =
       ArrangeBy keys=[[#0{id}]] // { arity: 1 }
         Distinct project=[#0{id}] // { arity: 1 }

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -397,6 +397,7 @@ EOF
 # Here, SemijoinIdempotence relies on the keys introduced by the `select distinct on` being propagated through the
 # recursive Get. Note that in this test even if SemijoinIdempotence wouldn't work, RedundantJoin would step in. (But
 # see later a similar situation, but with a LEFT JOIN, where RedundantJoin wouldn't be able to eliminate a join.)
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 explain with(keys)
 with mutually recursive
@@ -425,6 +426,7 @@ EOF
 # Similar to the previous test, but the recursive Get is at the other input. This means that the input that should have
 # a known key is the static one, for which key inference works fine.
 # The resulting plan should have 1 join with 2 inputs.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 explain
 with mutually recursive
@@ -450,6 +452,7 @@ EOF
 # Manually written idempotent semijoin.
 # Similar to the previous test, but the CTE from inside c0 is manually lifted to the enclosing LetRec.
 # The resulting plan should have 1 join with 2 inputs.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 explain
 with mutually recursive
@@ -474,6 +477,7 @@ EOF
 # Similar to the previous test, but instead of using bar directly, we add an extra cte (bar2), which will recursively
 # refer to `c0`. `keys` will refer to `bar2` instead of `c0`.
 # The resulting plan should have 1 join with 2 inputs.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 explain
 with mutually recursive
@@ -504,6 +508,7 @@ EOF
 # changes meaning when `bar2` is being assigned after `key`. To correctly handle this situation, we need the expirations
 # in SemijoinIdempotence. To demonstrate this, if we comment out the two `do_expirations` lines, SemijoinIdempotence
 # incorrectly transforms this plan.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 explain with(keys)
 with mutually recursive
@@ -533,6 +538,7 @@ EOF
 # Another negative test. Similar to the first test with `bar2`, but both `keys` and `bar2` are being referenced from the
 # body, which means that SemijoinIdempotence can't kick in, as it would eliminate the intermediate Join's result, which
 # is now being referenced from the body.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 explain
 with mutually recursive

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -556,30 +556,9 @@ union all
 select a, -2, 'keys', a from keys;
 ----
 Explained Query:
-  Return
-    Project (#0, #2, #1, #0)
-      Map (-1)
-        Get l0
-  With Mutually Recursive
-    cte l1 =
-      Distinct project=[#0..=#3]
-        Union
-          Project (#0..=#3)
-            Join on=(#0 = #4) type=differential
-              ArrangeBy keys=[[#0]]
-                Get l1
-              ArrangeBy keys=[[#0]]
-                TopK group_by=[#0] limit=1
-                  Project (#0)
-                    Filter (#0) IS NOT NULL
-                      Get l0
-          Get l1
-    cte l0 =
-      Distinct project=[#0, #1]
-        Union
-          ReadStorage materialize.public.bar
-          Project (#0, #2)
-            Get l1
+  Project (#0, #2, #1, #0)
+    Map (-1)
+      ReadStorage materialize.public.bar
 
 Source materialize.public.bar
 

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -414,24 +414,8 @@ with mutually recursive
   )
 select * from c0;
 ----
-Explained Query:
-  Return // { keys: "([0])" }
-    Get l0 // { keys: "([0])" }
-  With Mutually Recursive
-    cte l0 =
-      TopK group_by=[#0] limit=1 // { keys: "([0])" }
-        Distinct project=[#0..=#3] // { keys: "([0, 1, 2, 3])" }
-          Union // { keys: "()" }
-            Project (#0..=#2, #0) // { keys: "()" }
-              Join on=(#0 = #3) type=differential // { keys: "()" }
-                ArrangeBy keys=[[#0]] // { keys: "()" }
-                  ReadStorage materialize.public.foo // { keys: "()" }
-                ArrangeBy keys=[[#0]] // { keys: "([0])" }
-                  Project (#0) // { keys: "([0])" }
-                    Get l0 // { keys: "([0])" }
-            Get l0 // { keys: "([0])" }
-
-Source materialize.public.foo
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: quickstart
 
@@ -456,25 +440,8 @@ with mutually recursive
   )
 select * from c0;
 ----
-Explained Query:
-  Return
-    Get l0
-  With Mutually Recursive
-    cte l0 =
-      Distinct project=[#0..=#3]
-        Union
-          Project (#0..=#3)
-            Join on=(#0 = #4) type=differential
-              ArrangeBy keys=[[#0]]
-                Get l0
-              ArrangeBy keys=[[#0]]
-                Project (#0)
-                  Filter (#0) IS NOT NULL
-                    ReadStorage materialize.public.bar
-          Get l0
-
-Source materialize.public.bar
-  filter=((#0) IS NOT NULL)
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: quickstart
 
@@ -496,25 +463,8 @@ with mutually recursive
   )
 select * from c0;
 ----
-Explained Query:
-  Return
-    Get l0
-  With Mutually Recursive
-    cte l0 =
-      Distinct project=[#0..=#3]
-        Union
-          Project (#0..=#3)
-            Join on=(#0 = #4) type=differential
-              ArrangeBy keys=[[#0]]
-                Get l0
-              ArrangeBy keys=[[#0]]
-                Project (#0)
-                  Filter (#0) IS NOT NULL
-                    ReadStorage materialize.public.bar
-          Get l0
-
-Source materialize.public.bar
-  filter=((#0) IS NOT NULL)
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: quickstart
 
@@ -542,30 +492,8 @@ with mutually recursive
   )
 select * from c0;
 ----
-Explained Query:
-  Return
-    Get l0
-  With Mutually Recursive
-    cte l0 =
-      Distinct project=[#0..=#3]
-        Union
-          Project (#0..=#3)
-            Join on=(#0 = #4) type=differential
-              ArrangeBy keys=[[#0]]
-                Get l0
-              ArrangeBy keys=[[#0]]
-                TopK group_by=[#0] limit=1
-                  Project (#0)
-                    Distinct project=[#0, #1]
-                      Union
-                        Filter (#0) IS NOT NULL
-                          ReadStorage materialize.public.bar
-                        Project (#0, #2)
-                          Get l0
-          Get l0
-
-Source materialize.public.bar
-  filter=((#0) IS NOT NULL)
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: quickstart
 
@@ -594,40 +522,8 @@ with mutually recursive
   )
 select * from c0;
 ----
-Explained Query:
-  Return // { keys: "([0, 1, 2, 3])" }
-    Get l2 // { keys: "([0, 1, 2, 3])" }
-  With Mutually Recursive
-    cte l2 =
-      Distinct project=[#0..=#3] // { keys: "([0, 1, 2, 3])" }
-        Union // { keys: "()" }
-          Project (#0..=#3) // { keys: "([0, 1, 2, 3])" }
-            Join on=(#0 = #4) type=differential // { keys: "([0, 1, 2, 3])" }
-              ArrangeBy keys=[[#0]] // { keys: "([0, 1, 2, 3])" }
-                Get l2 // { keys: "([0, 1, 2, 3])" }
-              ArrangeBy keys=[[#0]] // { keys: "([0])" }
-                Get l0 // { keys: "([0])" }
-          Get l2 // { keys: "([0, 1, 2, 3])" }
-    cte l1 =
-      Distinct project=[#0, #1] // { keys: "([0, 1])" }
-        Union // { keys: "()" }
-          ReadStorage materialize.public.bar // { keys: "([0])" }
-          Project (#0, #2) // { keys: "()" }
-            Get l2 // { keys: "([0, 1, 2, 3])" }
-    cte l0 =
-      Project (#0) // { keys: "([0])" }
-        Join on=(#0 = #1) type=differential // { keys: "([0])" }
-          ArrangeBy keys=[[#0]] // { keys: "([0])" }
-            Distinct project=[#0] // { keys: "([0])" }
-              Project (#0) // { keys: "()" }
-                Get l2 // { keys: "([0, 1, 2, 3])" }
-          ArrangeBy keys=[[#0]] // { keys: "([0])" }
-            TopK group_by=[#0] limit=1 // { keys: "([0])" }
-              Project (#0) // { keys: "()" }
-                Filter (#0) IS NOT NULL // { keys: "([0, 1])" }
-                  Get l1 // { keys: "([0, 1])" }
-
-Source materialize.public.bar
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: quickstart
 
@@ -661,46 +557,29 @@ select a, -2, 'keys', a from keys;
 ----
 Explained Query:
   Return
-    Union
-      Get l2
-      Project (#0, #2, #1, #0)
-        Map (-1)
-          Get l0
-      Project (#0, #2, #1, #0)
-        Map ("keys", -2)
-          Get l1
+    Project (#0, #2, #1, #0)
+      Map (-1)
+        Get l0
   With Mutually Recursive
-    cte l2 =
+    cte l1 =
       Distinct project=[#0..=#3]
         Union
           Project (#0..=#3)
             Join on=(#0 = #4) type=differential
               ArrangeBy keys=[[#0]]
-                Get l2
+                Get l1
               ArrangeBy keys=[[#0]]
                 TopK group_by=[#0] limit=1
                   Project (#0)
                     Filter (#0) IS NOT NULL
                       Get l0
-          Get l2
-    cte l1 =
-      Project (#0)
-        Join on=(#0 = #1) type=differential
-          ArrangeBy keys=[[#0]]
-            Distinct project=[#0]
-              Project (#0)
-                Get l2
-          ArrangeBy keys=[[#0]]
-            TopK group_by=[#0] limit=1
-              Project (#0)
-                Filter (#0) IS NOT NULL
-                  Get l0
+          Get l1
     cte l0 =
       Distinct project=[#0, #1]
         Union
           ReadStorage materialize.public.bar
           Project (#0, #2)
-            Get l2
+            Get l1
 
 Source materialize.public.bar
 

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -654,6 +654,11 @@ EOF
 
 # Give up when reaching RECURSION LIMIT
 # Same as the previous query, but with RECURSION LIMIT 1.
+# As of #27389 this does not give up after the recursion limit,
+# as doing so is not necessary for equivalence propagation.
+# Issue #28308 tracks tests that may not be serving their intended
+# purpose; perhaps we can remove the test if we remove the
+# column_knowledge transform.
 query T multiline
 EXPLAIN WITH(arity, types)
 WITH MUTUALLY RECURSIVE (RECURSION LIMIT 1)

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -679,8 +679,7 @@ Explained Query:
               Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
                 ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
             Project () // { arity: 0, types: "()" }
-              Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
-                Get l0 // { arity: 2, types: "(integer, integer)" }
+              Get l0 // { arity: 2, types: "(integer, integer)" }
 
 Source materialize.public.t1
   filter=((#0 = 3) AND (#1 = 5))

--- a/test/sqllogictest/transform/non_null_requirements.slt
+++ b/test/sqllogictest/transform/non_null_requirements.slt
@@ -35,14 +35,8 @@ WITH MUTUALLY RECURSIVE
   )
 SELECT * FROM (SELECT * FROM c1 UNION ALL SELECT * FROM c2) WHERE z > 0
 ----
-Explained Query:
-  Return // { arity: 3 }
-    Get l0 // { arity: 3 }
-  With Mutually Recursive
-    cte l0 =
-      Project (#0, #1, #3) // { arity: 3 }
-        Map (42) // { arity: 4 }
-          Get l0 // { arity: 3 }
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/non_null_requirements.slt
+++ b/test/sqllogictest/transform/non_null_requirements.slt
@@ -21,6 +21,10 @@ CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
 
 # Simplify non-nullable trees with multiple non-recursive bindings defined under
 # a single`WITH MUTUALLY RECURSIVE` block
+# As of #27389 this no longer tests what it used to test.
+# Issue #28308 tracks tests that may not be serving their intended
+# purpose; perhaps we can remove the test if we remove the
+# non_null_requirements transform.
 query T multiline
 EXPLAIN WITH(arity, join implementations)
 WITH MUTUALLY RECURSIVE

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -36,6 +36,7 @@ Target cluster: mz_catalog_server
 EOF
 
 ## Test a nested recursive query.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 EXPLAIN WITH MUTUALLY RECURSIVE
     foo (a int8) AS (
@@ -56,6 +57,7 @@ EOF
 
 ## Test inlining at an inner nesting level. (#18889)
 ## `bar` is used only in `baz`, so it should be inlined. The inner WMR should have only one cte.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 EXPLAIN WITH MUTUALLY RECURSIVE
     foo (a int8) AS (
@@ -118,6 +120,7 @@ Target cluster: quickstart
 EOF
 
 ## Test consolidation of not-really nested recursive query.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 EXPLAIN WITH MUTUALLY RECURSIVE
     foo (a int8) AS (
@@ -137,6 +140,7 @@ Target cluster: mz_catalog_server
 EOF
 
 ## Test consolidation of independent recursive query blocks.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 EXPLAIN SELECT * FROM (
     WITH MUTUALLY RECURSIVE
@@ -317,6 +321,7 @@ Target cluster: mz_catalog_server
 EOF
 
 ## RECURSION LIMIT -- consolidation of independent recursive query blocks with different RECURSION LIMIT
+# With #27389 this stopped testing a thing; see issue #28308.
 
 query T multiline
 EXPLAIN SELECT * FROM (
@@ -340,6 +345,7 @@ EOF
 
 ## RECURSION LIMIT -- consolidation of independent recursive query blocks with equal RECURSION LIMIT.
 ## We want to see RECURSION LIMIT printed at the block level rather than on each cte.
+# With #27389 this stopped testing a thing; see issue #28308.
 
 query T multiline
 EXPLAIN SELECT * FROM (
@@ -363,6 +369,7 @@ EOF
 
 ## ITERATION RECURSION -- consolidation of not-really nested recursive query.
 ## Here, the ITERATION RECURSION of the inner WMR is irrelevant, because it's not recursive.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 EXPLAIN WITH MUTUALLY RECURSIVE (RECURSION LIMIT 9)
     foo (a int8) AS (
@@ -382,6 +389,7 @@ Target cluster: mz_catalog_server
 EOF
 
 # ITERATION RECURSION -- a nested recursive query.
+# With #27389 this stopped testing a thing; see issue #28308.
 query T multiline
 EXPLAIN WITH MUTUALLY RECURSIVE (RECURSION LIMIT 17)
     foo (a int8) AS (

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -47,22 +47,8 @@ EXPLAIN WITH MUTUALLY RECURSIVE
     )
 SELECT * FROM foo;
 ----
-Explained Query:
-  Return
-    Get l1
-  With Mutually Recursive
-    cte l1 =
-      Return
-        Threshold
-          Union
-            Get l1
-            Negate
-              Get l0
-      With Mutually Recursive
-        cte l0 =
-          Union
-            Get l1
-            Get l0
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: mz_catalog_server
 
@@ -84,26 +70,8 @@ EXPLAIN WITH MUTUALLY RECURSIVE
     )
 SELECT * FROM foo;
 ----
-Explained Query:
-  Return
-    Get l1
-  With Mutually Recursive
-    cte l1 =
-      Return
-        Threshold
-          Union
-            Get l1
-            Negate
-              Get l0
-      With Mutually Recursive
-        cte l0 =
-          Project (#1)
-            Map ((#0 + 3))
-              Union
-                Filter (#0 > -5)
-                  Get l1
-                Filter (#0 > -5)
-                  Get l0
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: mz_catalog_server
 
@@ -161,14 +129,8 @@ EXPLAIN WITH MUTUALLY RECURSIVE
     )
 SELECT * FROM foo;
 ----
-Explained Query:
-  Return
-    Get l0
-  With Mutually Recursive
-    cte l0 =
-      Union
-        Get l0
-        Get l0
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: mz_catalog_server
 
@@ -188,16 +150,8 @@ SELECT * FROM (
     SELECT * FROM bar
 );
 ----
-Explained Query:
-  Return
-    Union
-      Get l0
-      Get l1
-  With Mutually Recursive
-    cte l1 =
-      Get l1
-    cte l0 =
-      Get l0
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: mz_catalog_server
 
@@ -377,18 +331,8 @@ SELECT * FROM (
     SELECT * FROM bar
 );
 ----
-Explained Query:
-  Return
-    Union
-      Get l0
-      Get l1
-  With Mutually Recursive
-    cte [recursion_limit=7] l1 =
-      Project (#1)
-        Map ((#0 - 2))
-          Get l1
-    cte [recursion_limit=5] l0 =
-      Get l0
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: mz_catalog_server
 
@@ -410,18 +354,8 @@ SELECT * FROM (
     SELECT * FROM bar
 );
 ----
-Explained Query:
-  Return
-    Union
-      Get l0
-      Get l1
-  With Mutually Recursive [recursion_limit=27]
-    cte l1 =
-      Project (#1)
-        Map ((#0 - 2))
-          Get l1
-    cte l0 =
-      Get l0
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: mz_catalog_server
 
@@ -440,14 +374,8 @@ EXPLAIN WITH MUTUALLY RECURSIVE (RECURSION LIMIT 9)
     )
 SELECT * FROM foo;
 ----
-Explained Query:
-  Return
-    Get l0
-  With Mutually Recursive [recursion_limit=9]
-    cte l0 =
-      Union
-        Get l0
-        Get l0
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: mz_catalog_server
 
@@ -465,22 +393,8 @@ EXPLAIN WITH MUTUALLY RECURSIVE (RECURSION LIMIT 17)
     )
 SELECT * FROM foo;
 ----
-Explained Query:
-  Return
-    Get l1
-  With Mutually Recursive [recursion_limit=17]
-    cte l1 =
-      Return
-        Threshold
-          Union
-            Get l1
-            Negate
-              Get l0
-      With Mutually Recursive [recursion_limit=11]
-        cte l0 =
-          Union
-            Get l1
-            Get l0
+Explained Query (fast path):
+  Constant <empty>
 
 Target cluster: mz_catalog_server
 

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -1547,6 +1547,7 @@ EOF
 # (1) a Filter (#1 > 7) over l0 appears twice.
 # (2) l2 is equivalent to l5.
 # (3) l1 is not equivalent (although structurally equal) to l4.
+# With #27389 this stopped testing what it says it tests; see issue #28308.
 query T multiline
 EXPLAIN WITH(arity, join implementations)
 WITH MUTUALLY RECURSIVE

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -1589,38 +1589,26 @@ Explained Query:
       Filter (#0 > 7) // { arity: 2 }
         Get l0 // { arity: 2 }
       Filter (#0 > 7) // { arity: 2 }
-        Get l3 // { arity: 2 }
+        Get l1 // { arity: 2 }
       Filter (#0 > 7) // { arity: 2 }
-        Get l6 // { arity: 2 }
+        Get l2 // { arity: 2 }
   With Mutually Recursive
-    cte l6 =
-      Union // { arity: 2 }
-        Filter (#1 > 7) // { arity: 2 }
-          Get l0 // { arity: 2 }
-        Get l4 // { arity: 2 }
-        Get l4 // { arity: 2 }
-        Get l5 // { arity: 2 }
-        Get l5 // { arity: 2 }
-    cte l5 =
-      Filter (#1 > 7) // { arity: 2 }
-        Get l6 // { arity: 2 }
-    cte l4 =
-      Filter (#1 > 7) // { arity: 2 }
-        Get l3 // { arity: 2 }
-    cte l3 =
-      Union // { arity: 2 }
-        Filter (#1 > 7) // { arity: 2 }
-          Get l0 // { arity: 2 }
-        Get l1 // { arity: 2 }
-        Get l1 // { arity: 2 }
-        Get l2 // { arity: 2 }
-        Get l2 // { arity: 2 }
     cte l2 =
-      Filter (#1 > 7) // { arity: 2 }
-        Get l6 // { arity: 2 }
+      Union // { arity: 2 }
+        Filter (#1 > 7) // { arity: 2 }
+          Get l0 // { arity: 2 }
+        Get l1 // { arity: 2 }
+        Get l1 // { arity: 2 }
+        Get l2 // { arity: 2 }
+        Get l2 // { arity: 2 }
     cte l1 =
-      Filter (#1 > 7) // { arity: 2 }
-        Get l3 // { arity: 2 }
+      Union // { arity: 2 }
+        Filter (#1 > 7) // { arity: 2 }
+          Get l0 // { arity: 2 }
+        Get l1 // { arity: 2 }
+        Get l1 // { arity: 2 }
+        Get l2 // { arity: 2 }
+        Get l2 // { arity: 2 }
     cte l0 =
       Union // { arity: 2 }
         ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -155,15 +155,6 @@ SELECT (SELECT COUNT(*) FROM foo) FROM bar;
 2
 2
 
-## Test that we can determine recursively defined collections are empty
-query I
-WITH MUTUALLY RECURSIVE
-    foo (a int) AS (SELECT * FROM foo UNION SELECT 1),
-    bar (b int) AS (SELECT a + b FROM foo, bar)
-SELECT * FROM bar;
-----
-
-
 ## Test error cases
 
 ## Test a recursive query with mismatched types.

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -155,6 +155,15 @@ SELECT (SELECT COUNT(*) FROM foo) FROM bar;
 2
 2
 
+## Test that we can determine recursively defined collections are empty
+query I
+WITH MUTUALLY RECURSIVE
+    foo (a int) AS (SELECT * FROM foo UNION SELECT 1),
+    bar (b int) AS (SELECT a + b FROM foo, bar)
+SELECT * FROM bar;
+----
+
+
 ## Test error cases
 
 ## Test a recursive query with mismatched types.


### PR DESCRIPTION
This PR provides the `Equivalences` analysis with a lattice describing its state (and providing a "top" element). It also corrects many shortcomings of the analysis that assumed pessimistic execution (and in particular, that the `results` vector would have a shape that it generally does not; oops!).

~TBD: What to do about all the tests that the analysis deletes.~

We concluded that we would annotate these tests with a reference to https://github.com/MaterializeInc/materialize/issues/28308 which is the rendezvous point for tests that were wiped out by this PR, with the goal of triaging them to see which ones should be tested, and how to best do that. 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
