### PR TITLE
Fix merge skew in regex.slt

### DIFF
--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -608,6 +608,8 @@ Explained Query:
     Map (regexp_replace["b..", case_insensitive=false, limit=1](#0, "X"))
       ReadStorage materialize.public.r
 
+Source materialize.public.r
+
 Target cluster: quickstart
 
 EOF
@@ -632,6 +634,8 @@ Explained Query:
   Project (#3)
     Map (regexp_replace["b..", case_insensitive=true, limit=1](#0, "X"))
       ReadStorage materialize.public.r
+
+Source materialize.public.r
 
 Target cluster: quickstart
 
@@ -658,6 +662,8 @@ Explained Query:
     Map (regexp_replace["b..", case_insensitive=true, limit=0](#0, "X"))
       ReadStorage materialize.public.r
 
+Source materialize.public.r
+
 Target cluster: quickstart
 
 EOF
@@ -682,6 +688,8 @@ Explained Query:
   Project (#3)
     Map (regexp_replace(#0, #1, #2, "ig"))
       ReadStorage materialize.public.r
+
+Source materialize.public.r
 
 Target cluster: quickstart
 
@@ -738,6 +746,8 @@ Explained Query:
      ^
 error: unclosed group(#0, #2))
       ReadStorage materialize.public.e
+
+Source materialize.public.e
 
 Target cluster: quickstart
 


### PR DESCRIPTION
(It happened due to https://github.com/MaterializeInc/materialize/pull/27300 adding some tests with EXPLAIN plans and at the same time https://github.com/MaterializeInc/materialize/pull/27332 enhancing EXPLAIN plans.)

### Motivation

Fixes minor merge skew in tests.

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
