### PR TITLE
platform-checks: Fix MV explain in preflight rollback scenario

### DIFF
--- a/misc/python/materialize/checks/all_checks/materialized_views.py
+++ b/misc/python/materialize/checks/all_checks/materialized_views.py
@@ -166,7 +166,13 @@ class MaterializedViewsAssertNotNull(Check):
 
             > DELETE FROM not_null_table WHERE z IS NULL;
 
-            ? EXPLAIN SELECT * FROM not_null_view1 WHERE x IS NOT NULL
+            ?[version<10300] EXPLAIN SELECT * FROM not_null_view1 WHERE x IS NOT NULL
+            Explained Query:
+              ReadStorage materialize.public.not_null_view1
+
+            Target cluster: quickstart
+
+            ?[version>=10300] EXPLAIN SELECT * FROM not_null_view1 WHERE x IS NOT NULL
             Explained Query:
               ReadStorage materialize.public.not_null_view1
 
@@ -174,7 +180,13 @@ class MaterializedViewsAssertNotNull(Check):
 
             Target cluster: quickstart
 
-            ? EXPLAIN SELECT * FROM not_null_view2 WHERE y IS NOT NULL
+            ?[version<10300] EXPLAIN SELECT * FROM not_null_view2 WHERE y IS NOT NULL
+            Explained Query:
+              ReadStorage materialize.public.not_null_view2
+
+            Target cluster: quickstart
+
+            ?[version>=10300] EXPLAIN SELECT * FROM not_null_view2 WHERE y IS NOT NULL
             Explained Query:
               ReadStorage materialize.public.not_null_view2
 
@@ -182,7 +194,13 @@ class MaterializedViewsAssertNotNull(Check):
 
             Target cluster: quickstart
 
-            ? EXPLAIN SELECT * FROM not_null_view3 WHERE z IS NOT NULL
+            ?[version<10300] EXPLAIN SELECT * FROM not_null_view3 WHERE z IS NOT NULL
+            Explained Query:
+              ReadStorage materialize.public.not_null_view3
+
+            Target cluster: quickstart
+
+            ?[version>=10300] EXPLAIN SELECT * FROM not_null_view3 WHERE z IS NOT NULL
             Explained Query:
               ReadStorage materialize.public.not_null_view3
 


### PR DESCRIPTION
Since this scenario runs the verification code in an older version

Started failing with https://github.com/MaterializeInc/materialize/pull/27332

Seen in https://buildkite.com/materialize/nightly/builds/7940#018fcfbd-0d5c-48d8-abe8-415277ea161a

Test run: https://buildkite.com/materialize/nightly/builds/7948

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
