### PR TITLE
storage: Arc-ify StorageCollections

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -219,7 +219,7 @@ impl StorageMetadata {
 ///
 /// Data written to the implementor of this trait should make a consistent view
 /// of the data available through [`StorageMetadata`].
-#[async_trait(?Send)]
+#[async_trait]
 pub trait StorageTxn<T> {
     /// Retrieve all of the visible storage metadata.
     ///
@@ -701,7 +701,7 @@ pub trait StorageController: Debug {
     /// On boot, seed the controller's metadata/state.
     async fn initialize_state(
         &mut self,
-        txn: &mut dyn StorageTxn<Self::Timestamp>,
+        txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
         init_ids: BTreeSet<GlobalId>,
         drop_ids: BTreeSet<GlobalId>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
@@ -713,7 +713,7 @@ pub trait StorageController: Debug {
     /// subsequent calls that require [`StorageMetadata`] as a parameter.
     async fn prepare_state(
         &mut self,
-        txn: &mut dyn StorageTxn<Self::Timestamp>,
+        txn: &mut (dyn StorageTxn<Self::Timestamp> + Send),
         ids_to_add: BTreeSet<GlobalId>,
         ids_to_drop: BTreeSet<GlobalId>,
     ) -> Result<(), StorageError<Self::Timestamp>>;

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::num::NonZeroI64;
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -91,7 +92,7 @@ pub trait StorageCollections: Debug {
     /// We also get `drop_ids`, which tells us about all collections that we
     /// might have known about before and have now been dropped.
     async fn initialize_state(
-        &mut self,
+        &self,
         txn: &mut dyn StorageTxn<Self::Timestamp>,
         init_ids: BTreeSet<GlobalId>,
         drop_ids: BTreeSet<GlobalId>,
@@ -109,12 +110,12 @@ pub trait StorageCollections: Debug {
     /// good and there is no possibility of the old code running concurrently
     /// with the new code.
     async fn init_txns(
-        &mut self,
+        &self,
         init_ts: Self::Timestamp,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
     /// Update storage configuration with new parameters.
-    fn update_parameters(&mut self, config_params: StorageParameters);
+    fn update_parameters(&self, config_params: StorageParameters);
 
     /// Returns the [CollectionMetadata] of the collection identified by `id`.
     fn collection_metadata(
@@ -186,7 +187,7 @@ pub trait StorageCollections: Debug {
     /// The data modified in the `StorageTxn` must be made available in all
     /// subsequent calls that require [`StorageMetadata`] as a parameter.
     async fn prepare_state(
-        &mut self,
+        &self,
         txn: &mut dyn StorageTxn<Self::Timestamp>,
         ids_to_add: BTreeSet<GlobalId>,
         ids_to_drop: BTreeSet<GlobalId>,
@@ -215,7 +216,7 @@ pub trait StorageCollections: Debug {
     /// the collections is a table. A None may be given if none of the
     /// collections are a table (i.e. all materialized views, sources, etc).
     async fn create_collections(
-        &mut self,
+        &self,
         storage_metadata: &StorageMetadata,
         register_ts: Option<Self::Timestamp>,
         mut collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
@@ -229,7 +230,7 @@ pub trait StorageCollections: Debug {
     /// is really only relevant because newly created subsources depend on the
     /// remap shard, and we can't just have them start at since 0.
     async fn alter_ingestion_source_desc(
-        &mut self,
+        &self,
         ingestion_id: GlobalId,
         source_desc: SourceDesc,
     ) -> Result<(), StorageError<Self::Timestamp>>;
@@ -239,7 +240,7 @@ pub trait StorageCollections: Debug {
     ///
     /// See NOTE on [StorageCollections::alter_ingestion_source_desc].
     async fn alter_ingestion_connections(
-        &mut self,
+        &self,
         source_connections: BTreeMap<GlobalId, GenericSourceConnection<InlinedConnection>>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
@@ -249,7 +250,7 @@ pub trait StorageCollections: Debug {
     /// Collection state is only fully dropped, however, once there are not more
     /// outstanding [ReadHolds](ReadHold) for a collection.
     fn drop_collections(
-        &mut self,
+        &self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
@@ -266,7 +267,7 @@ pub trait StorageCollections: Debug {
     /// the controller due to a restart. Once command history becomes durable we
     /// can remove this method and use the normal `drop_sources`.
     fn drop_collections_unvalidated(
-        &mut self,
+        &self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
     );
@@ -284,12 +285,12 @@ pub trait StorageCollections: Debug {
     ///
     /// Identifiers not present in `policies` retain their existing read
     /// policies.
-    fn set_read_policies(&mut self, policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>);
+    fn set_read_policies(&self, policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>);
 
     /// Acquires and returns the earliest possible read holds for the specified
     /// collections.
     fn acquire_read_holds(
-        &mut self,
+        &self,
         desired_holds: Vec<GlobalId>,
     ) -> Result<Vec<ReadHold<Self::Timestamp>>, ReadHoldError>;
 
@@ -298,7 +299,7 @@ pub trait StorageCollections: Debug {
     /// This is a legacy interface that should _not_ be used! It is only used by
     /// the compute controller.
     fn update_read_capabilities(
-        &mut self,
+        &self,
         updates: &mut BTreeMap<GlobalId, ChangeBatch<Self::Timestamp>>,
     );
 }
@@ -371,7 +372,7 @@ pub struct StorageCollectionsImpl<
     txns: TxnsWal<T>,
     /// Whether we have run `txns_init` yet (required before create_collections
     /// and the various flavors of append).
-    txns_init_run: bool,
+    txns_init_run: Arc<AtomicBool>,
 
     /// Storage configuration parameters.
     config: Arc<Mutex<StorageConfiguration>>,
@@ -513,7 +514,7 @@ where
             finalized_shards,
             collections,
             txns,
-            txns_init_run: false,
+            txns_init_run: Arc::new(AtomicBool::new(false)),
             envd_epoch,
             config,
             persist_location,
@@ -993,7 +994,7 @@ where
     }
 
     /// Remove any shards that we know are finalized
-    fn synchronize_finalized_shards(&mut self, storage_metadata: &StorageMetadata) {
+    fn synchronize_finalized_shards(&self, storage_metadata: &StorageMetadata) {
         self.finalized_shards
             .lock()
             .expect("lock poisoned")
@@ -1019,7 +1020,7 @@ where
     type Timestamp = T;
 
     async fn initialize_state(
-        &mut self,
+        &self,
         txn: &mut dyn StorageTxn<T>,
         init_ids: BTreeSet<GlobalId>,
         drop_ids: BTreeSet<GlobalId>,
@@ -1074,18 +1075,22 @@ where
     /// See [crate::controller::StorageController::init_txns] and its
     /// implementation.
     async fn init_txns(
-        &mut self,
+        &self,
         _init_ts: Self::Timestamp,
     ) -> Result<(), StorageError<Self::Timestamp>> {
-        assert_eq!(self.txns_init_run, false);
+        assert_eq!(
+            self.txns_init_run.load(std::sync::atomic::Ordering::SeqCst),
+            false
+        );
 
         // We don't initialize the txns system, the `StorageController` does
         // that. All we care about is that initialization has been run.
-        self.txns_init_run = true;
+        self.txns_init_run
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
 
-    fn update_parameters(&mut self, config_params: StorageParameters) {
+    fn update_parameters(&self, config_params: StorageParameters) {
         // We serialize the dyncfg updates in StorageParameters, but configure
         // persist separately.
         config_params.dyncfg_updates.apply(self.persist.cfg());
@@ -1247,7 +1252,7 @@ where
     }
 
     async fn prepare_state(
-        &mut self,
+        &self,
         txn: &mut dyn StorageTxn<T>,
         ids_to_add: BTreeSet<GlobalId>,
         ids_to_drop: BTreeSet<GlobalId>,
@@ -1287,12 +1292,13 @@ where
     // a method/move individual parts to their own methods.
     #[instrument(level = "debug")]
     async fn create_collections(
-        &mut self,
+        &self,
         storage_metadata: &StorageMetadata,
         register_ts: Option<Self::Timestamp>,
         mut collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
     ) -> Result<(), StorageError<Self::Timestamp>> {
-        assert!(self.txns_init_run);
+        assert!(self.txns_init_run.load(std::sync::atomic::Ordering::SeqCst));
+
         // Validate first, to avoid corrupting state.
         // 1. create a dropped identifier, or
         // 2. create an existing identifier with a new description.
@@ -1640,7 +1646,7 @@ where
     }
 
     async fn alter_ingestion_source_desc(
-        &mut self,
+        &self,
         ingestion_id: GlobalId,
         source_desc: SourceDesc,
     ) -> Result<(), StorageError<Self::Timestamp>> {
@@ -1664,7 +1670,7 @@ where
     }
 
     async fn alter_ingestion_connections(
-        &mut self,
+        &self,
         source_connections: BTreeMap<GlobalId, GenericSourceConnection<InlinedConnection>>,
     ) -> Result<(), StorageError<Self::Timestamp>> {
         let mut self_collections = self.collections.lock().expect("lock poisoned");
@@ -1699,7 +1705,7 @@ where
     }
 
     fn drop_collections(
-        &mut self,
+        &self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
     ) -> Result<(), StorageError<Self::Timestamp>> {
@@ -1712,7 +1718,7 @@ where
     }
 
     fn drop_collections_unvalidated(
-        &mut self,
+        &self,
         storage_metadata: &StorageMetadata,
         identifiers: Vec<GlobalId>,
     ) {
@@ -1788,7 +1794,7 @@ where
         self.synchronize_finalized_shards(storage_metadata);
     }
 
-    fn set_read_policies(&mut self, policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>) {
+    fn set_read_policies(&self, policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>) {
         let mut collections = self.collections.lock().expect("lock poisoned");
 
         let user_capabilities = collections
@@ -1817,7 +1823,7 @@ where
     }
 
     fn acquire_read_holds(
-        &mut self,
+        &self,
         desired_holds: Vec<GlobalId>,
     ) -> Result<Vec<ReadHold<Self::Timestamp>>, ReadHoldError> {
         let mut collections = self.collections.lock().expect("lock poisoned");
@@ -1867,7 +1873,7 @@ where
     }
 
     fn update_read_capabilities(
-        &mut self,
+        &self,
         updates: &mut BTreeMap<GlobalId, ChangeBatch<Self::Timestamp>>,
     ) {
         let mut collections = self.collections.lock().expect("lock poisoned");

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -259,7 +259,7 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     recorded_replica_frontiers: BTreeMap<(GlobalId, ReplicaId), Antichain<T>>,
 
     /// Handle to a [StorageCollections].
-    storage_collections: Box<dyn StorageCollections<Timestamp = T>>,
+    storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
 }
 
 #[async_trait(?Send)]
@@ -2450,7 +2450,7 @@ where
         txn_wal_tables: TxnWalTablesImpl,
         connection_context: ConnectionContext,
         txn: &dyn StorageTxn<T>,
-        storage_collections: Box<dyn StorageCollections<Timestamp = T> + Send>,
+        storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2277,7 +2277,7 @@ where
 
     async fn initialize_state(
         &mut self,
-        txn: &mut dyn StorageTxn<T>,
+        txn: &mut (dyn StorageTxn<T> + Send),
         init_ids: BTreeSet<GlobalId>,
         drop_ids: BTreeSet<GlobalId>,
     ) -> Result<(), StorageError<T>> {
@@ -2288,7 +2288,7 @@ where
 
     async fn prepare_state(
         &mut self,
-        txn: &mut dyn StorageTxn<T>,
+        txn: &mut (dyn StorageTxn<T> + Send),
         ids_to_add: BTreeSet<GlobalId>,
         ids_to_drop: BTreeSet<GlobalId>,
     ) -> Result<(), StorageError<T>> {


### PR DESCRIPTION
### Motivation

This will make it easier to share a StorageCollections within a process.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
