### PR TITLE
cargo test: Bump timeouts in test_webhook_source_batch_interval

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -3923,7 +3923,7 @@ async fn test_webhook_source_batch_interval() {
     let first_duration = start.elapsed();
     assert!(resp.status().is_success());
     // All is normal, the request should be fast.
-    assert!(first_duration < Duration::from_secs(2));
+    assert!(first_duration < Duration::from_secs(4));
 
     // Change our batch interval to be very high.
     let sys_client = server
@@ -3965,7 +3965,7 @@ async fn test_webhook_source_batch_interval() {
     assert!(resp.status().is_success());
 
     // The second event should finish quickly like the first!
-    assert!(second_duration < Duration::from_secs(2));
+    assert!(second_duration < Duration::from_secs(4));
     // But the third will now be stuck behind the batch interval so it will take longer!
     assert!(third_duration > Duration::from_secs(7));
 }


### PR DESCRIPTION
As reported in https://materializeinc.slack.com/archives/C01LKF361MZ/p1717407989364929 Seen in https://buildkite.com/materialize/test/builds/83039

I'd be happier with a not-time-dependent way of testing this @parkmycar any ideas?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
