### PR TITLE
compute-client: remove unused code

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -548,8 +548,7 @@ impl CatalogState {
                     log.oid,
                     name.clone(),
                     CatalogItem::Log(Log {
-                        variant: log.variant.clone(),
-                        has_storage_collection: false,
+                        variant: log.variant,
                     }),
                     MZ_SYSTEM_ROLE_ID,
                     PrivilegeMap::from_mz_acl_items(acl_items),

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -9,7 +9,7 @@
 
 use std::collections::BTreeSet;
 
-use mz_catalog::memory::objects::{CatalogItem, Index, Log};
+use mz_catalog::memory::objects::{CatalogItem, Index};
 use mz_compute_types::ComputeInstanceId;
 use mz_expr::{CollectionPlan, MirScalarExpr};
 use mz_repr::GlobalId;
@@ -56,21 +56,13 @@ impl DataflowBuilder<'_> {
                     }
                     CatalogItem::Source(_)
                     | CatalogItem::Table(_)
-                    | CatalogItem::MaterializedView(_)
-                    | CatalogItem::Log(Log {
-                        has_storage_collection: true,
-                        ..
-                    }) => {
+                    | CatalogItem::MaterializedView(_) => {
                         // Record that we are missing at least one index.
                         id_bundle.storage_ids.insert(id);
                     }
-                    CatalogItem::Log(Log {
-                        has_storage_collection: false,
-                        ..
-                    }) => {
-                        // Log sources without storage collections should always
-                        // be protected by an index.
-                        panic!("log source without storage collection {id} is missing index");
+                    CatalogItem::Log(_) => {
+                        // Log sources should always have an index.
+                        panic!("log source {id} is missing index");
                     }
                     _ => {
                         // Non-indexable thing; no work to do.

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -646,8 +646,6 @@ impl Source {
 #[derive(Debug, Clone, Serialize)]
 pub struct Log {
     pub variant: LogVariant,
-    /// Whether the log is backed by a storage collection.
-    pub has_storage_collection: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 
 use mz_proto::{IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, RelationDesc, ScalarType};
-use once_cell::sync::Lazy;
 use proptest::prelude::{any, prop, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -340,31 +339,6 @@ impl RustType<ProtoComputeLog> for ComputeLog {
         }
     }
 }
-
-/// TODO(#25239): Add documentation.
-pub static DEFAULT_LOG_VARIANTS: Lazy<Vec<LogVariant>> = Lazy::new(|| {
-    let default_logs = vec![
-        LogVariant::Timely(TimelyLog::Operates),
-        LogVariant::Timely(TimelyLog::Channels),
-        LogVariant::Timely(TimelyLog::Elapsed),
-        LogVariant::Timely(TimelyLog::Histogram),
-        LogVariant::Timely(TimelyLog::Addresses),
-        LogVariant::Timely(TimelyLog::Parks),
-        LogVariant::Timely(TimelyLog::MessagesSent),
-        LogVariant::Timely(TimelyLog::MessagesReceived),
-        LogVariant::Timely(TimelyLog::Reachability),
-        LogVariant::Differential(DifferentialLog::ArrangementBatches),
-        LogVariant::Differential(DifferentialLog::ArrangementRecords),
-        LogVariant::Differential(DifferentialLog::Sharing),
-        LogVariant::Compute(ComputeLog::DataflowCurrent),
-        LogVariant::Compute(ComputeLog::FrontierCurrent),
-        LogVariant::Compute(ComputeLog::ImportFrontierCurrent),
-        LogVariant::Compute(ComputeLog::PeekCurrent),
-        LogVariant::Compute(ComputeLog::PeekDuration),
-    ];
-
-    default_logs
-});
 
 impl LogVariant {
     /// By which columns should the logs be indexed.


### PR DESCRIPTION
This PR removes `DEFAULT_LOG_VARIANTS` and `Log::has_storage_collection`, two pieces of code related to compute introspection that are not used anymore.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A