### PR TITLE
Remove AWS connections LD flag

### DIFF
--- a/misc/python/materialize/checks/all_checks/aws.py
+++ b/misc/python/materialize/checks/all_checks/aws.py
@@ -26,7 +26,6 @@ class AwsConnection(Check):
             dedent(
                 """
                 $[version>=8000] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-                ALTER SYSTEM SET enable_aws_connection = true
                 ALTER SYSTEM SET enable_connection_validation_syntax = true
 
                 > CREATE CONNECTION aws_assume_role

--- a/misc/python/materialize/checks/all_checks/aws.py
+++ b/misc/python/materialize/checks/all_checks/aws.py
@@ -25,6 +25,9 @@ class AwsConnection(Check):
         return Testdrive(
             dedent(
                 """
+                $[version<10300] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                ALTER SYSTEM SET enable_aws_connection = true
+
                 $[version>=8000] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
                 ALTER SYSTEM SET enable_connection_validation_syntax = true
 

--- a/misc/python/materialize/checks/all_checks/copy_to_s3.py
+++ b/misc/python/materialize/checks/all_checks/copy_to_s3.py
@@ -25,6 +25,9 @@ class CopyToS3(Check):
         return Testdrive(
             dedent(
                 """
+                $[version<10300] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                ALTER SYSTEM SET enable_aws_connection = true
+
                 > CREATE SECRET minio AS '${arg.aws-secret-access-key}'
                 > CREATE CONNECTION aws_conn1 TO AWS (ENDPOINT '${arg.aws-endpoint}', REGION 'us-east-1', ACCESS KEY ID '${arg.aws-access-key-id}', SECRET ACCESS KEY SECRET minio)
                 > COPY (SELECT 1, 2, 3) TO 's3://copytos3/key1' WITH (AWS CONNECTION = aws_conn1, FORMAT = 'csv');

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -60,7 +60,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "disk_cluster_replicas_default": "true",
     "enable_alter_swap": "true",
     "enable_assert_not_null": "true",
-    "enable_aws_connection": "true",
     "enable_columnation_lgalloc": "true",
     "enable_comment": "true",
     "enable_compute_chunked_stack": "true",

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -553,8 +553,6 @@ fn test_pgtest_mz() {
             "enable_raise_statement",
             "enable_unorchestrated_cluster_replicas",
             "enable_unsafe_functions",
-            // The following flags are required to test out the COPY TO s3 feature
-            "enable_aws_connection",
             "enable_copy_to_expr",
         ],
     );

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3941,9 +3941,7 @@ pub fn plan_create_connection(
     } = stmt;
     let connection_options_extracted = connection::ConnectionOptionExtracted::try_from(values)?;
     let connection = connection_options_extracted.try_into_connection(scx, connection_type)?;
-    if let Connection::Aws(_) = &connection {
-        scx.require_feature_flag(&vars::ENABLE_AWS_CONNECTION)?;
-    } else if let Connection::MySql(_) = &connection {
+    if let Connection::MySql(_) = &connection {
         scx.require_feature_flag(&vars::ENABLE_MYSQL_SOURCE)?;
     }
     let name = scx.allocate_qualified_name(normalize::unresolved_item_name(name)?)?;

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1969,13 +1969,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_aws_connection,
-        desc: "CREATE CONNECTION ... TO AWS",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
         name: enable_mysql_source,
         desc: "Create a MySQL connection or source",
         default: false,

--- a/test/aws-localstack/aws-connection/aws-connection.td
+++ b/test/aws-localstack/aws-connection/aws-connection.td
@@ -10,7 +10,6 @@
 # Tests for AWS connections.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_aws_connection = true;
 ALTER SYSTEM SET enable_connection_validation_syntax = true;
 
 # Test assume role connections.

--- a/test/aws-localstack/copy-to-s3/copy-to-s3.td
+++ b/test/aws-localstack/copy-to-s3/copy-to-s3.td
@@ -10,7 +10,6 @@
 # Tests for COPY TO expr.
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_aws_connection = true;
 ALTER SYSTEM SET enable_copy_to_expr = true;
 
 # Prepare table data

--- a/test/aws/mzcompose.py
+++ b/test/aws/mzcompose.py
@@ -111,7 +111,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             port=6877,
             user="mz_system",
             sql="""
-            ALTER SYSTEM SET enable_aws_connection = true;
             ALTER SYSTEM SET enable_connection_validation_syntax = true;
             """,
         )

--- a/test/copy-to-s3/http/setup.td
+++ b/test/copy-to-s3/http/setup.td
@@ -10,7 +10,6 @@
 $ set-max-tries max-tries=1
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_aws_connection = true;
 ALTER SYSTEM SET enable_copy_to_expr = true;
 ALTER SYSTEM SET max_sources = 50;
 ALTER SYSTEM SET max_result_size = '100 GB';

--- a/test/copy-to-s3/nightly/setup.td
+++ b/test/copy-to-s3/nightly/setup.td
@@ -10,7 +10,6 @@
 $ set-max-tries max-tries=1
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_aws_connection = true;
 ALTER SYSTEM SET enable_copy_to_expr = true;
 ALTER SYSTEM SET max_sources = 50;
 ALTER SYSTEM SET max_result_size = '100 GB';

--- a/test/copy-to-s3/s3-auth-checks.td
+++ b/test/copy-to-s3/s3-auth-checks.td
@@ -13,7 +13,6 @@
 $ set-max-tries max-tries=1
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_aws_connection = true;
 ALTER SYSTEM SET enable_copy_to_expr = true;
 
 # There are 3 users with different permissions policies to validate:

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -3372,22 +3372,6 @@ DROP CONNECTION c
 statement ok
 CREATE SECRET s3_api_secret_key as 'secret_key';
 
-# Disable aws connections
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_aws_connection TO false;
-----
-COMPLETE 0
-
-# aws connections is now disabled by default
-statement error db error: ERROR: CREATE CONNECTION ... TO AWS is not supported
-CREATE CONNECTION materialize.public.a TO AWS (ACCESS KEY ID = 'access_key', SECRET ACCESS KEY = SECRET s3_api_secret_key) WITH (VALIDATE = false);
-
-# Enable aws connections
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_aws_connection TO true;
-----
-COMPLETE 0
-
 statement ok
 CREATE CONNECTION materialize.public.a TO AWS (ACCESS KEY ID = 'access_key', SECRET ACCESS KEY = SECRET s3_api_secret_key) WITH (VALIDATE = false);
 
@@ -3402,12 +3386,6 @@ a  materialize=U/materialize
 
 statement ok
 DROP CONNECTION a
-
-# Disable aws connections
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_aws_connection TO false;
-----
-COMPLETE 0
 
 statement ok
 DROP SECRET s3_api_secret_key;

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -13,7 +13,6 @@
 $ set-max-tries max-tries=1
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_aws_connection = true;
 ALTER SYSTEM SET enable_copy_to_expr = true;
 
 # Prepare table data


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.
 Fixes https://github.com/MaterializeInc/materialize/issues/27404
AWS Connections are now in PuPr

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
