### PR TITLE
bazel: Update `rust_cxx_bridge` and `protobuf-native` build

### DIFF
--- a/misc/bazel/c_deps/repositories.bzl
+++ b/misc/bazel/c_deps/repositories.bzl
@@ -80,12 +80,12 @@ def c_repositories():
         ],
     )
 
-    PROTOC_VERSION = "3.25.2"
-    PROTOC_SHA256 = "3c83e4301b968d0b4f29a0c29c0b3cde1da81d790ffd344b111c523ba1954392"
+    PROTOC_VERSION = "26.1"
+    PROTOC_INTEGRITY = "sha256-T8X/Gywzn7hs06JfC1MRR4qwgeZa0ljGeJNZzYTUIfg="
     maybe(
         http_archive,
         name = "protobuf",
-        sha256 = PROTOC_SHA256,
+        integrity = PROTOC_INTEGRITY,
         strip_prefix = "protobuf-{}".format(PROTOC_VERSION),
         urls = [
             "https://github.com/protocolbuffers/protobuf/archive/v{}.tar.gz".format(PROTOC_VERSION),

--- a/misc/bazel/c_deps/rust-sys/BUILD.protobuf-native.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.protobuf-native.bazel
@@ -13,20 +13,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Additive BUILD file for the protobuf-native Rust crate."""
-
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@//misc/bazel/rules:rust_cxx_bridge.bzl", "rust_cxx_bridge")
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+
+filegroup(
+    name = "protobuf-native-headers",
+    srcs = glob(["src/**/*.h"]),
+)
+
+copy_to_directory(
+    name = "generated-includes",
+    srcs = [
+        ":protobuf-native-headers",
+        ":internal-bridge/generated",
+        ":io-bridge/generated",
+        ":compiler-bridge/generated",
+    ],
+    out = "protobuf-native",
+    visibility = ["//visibility:public"],
+)
 
 rust_cxx_bridge(
     name = "compiler-bridge",
     src = "src/compiler.rs",
+    hdrs = [":generated-includes"],
     deps = [":protobuf-native-include"],
 )
 
 cc_library(
     name = "compiler-sys",
-    srcs = ["src/compiler.cc"],
+    hdrs = glob(["src/**/*.h"]),
+    srcs = ["src/compiler.cc", ":generated-includes"],
     copts = ["-std=c++17"],
     linkstatic = True,
     deps = [
@@ -38,12 +56,14 @@ cc_library(
 rust_cxx_bridge(
     name = "io-bridge",
     src = "src/io.rs",
+    hdrs = [":generated-includes"],
     deps = [":protobuf-native-include"],
 )
 
 cc_library(
     name = "io-sys",
-    srcs = ["src/io.cc"],
+    hdrs = glob(["src/**/*.h"]),
+    srcs = ["src/io.cc", ":generated-includes"],
     copts = ["-std=c++17"],
     linkstatic = True,
     deps = [
@@ -55,12 +75,14 @@ cc_library(
 rust_cxx_bridge(
     name = "lib-bridge",
     src = "src/lib.rs",
+    hdrs = [":generated-includes"],
     deps = [":protobuf-native-include"],
 )
 
 cc_library(
     name = "lib-sys",
-    srcs = ["src/lib.cc"],
+    hdrs = glob(["src/**/*.h"]),
+    srcs = ["src/lib.cc", ":generated-includes"],
     copts = ["-std=c++17"],
     linkstatic = True,
     deps = [
@@ -81,6 +103,8 @@ cc_library(
     copts = ["-std=c++14"],
     deps = [
         "@cxxbridge//:cxx_cc",
-        "@protobuf//:protobuf_headers",
+        "@protobuf//src/google/protobuf/compiler:code_generator",
+        "@protobuf//src/google/protobuf/compiler:importer",
+        "@com_google_absl//absl/strings:strings",
     ],
 )

--- a/misc/bazel/rules/rust_cxx_bridge.bzl
+++ b/misc/bazel/rules/rust_cxx_bridge.bzl
@@ -24,13 +24,14 @@ Ripped from the `cxx` repository.
 Please see the end of the file for the license.
 """
 
-def rust_cxx_bridge(name, src, deps = []):
+def rust_cxx_bridge(name, src, deps = [], hdrs = []):
     """A macro defining a cxx bridge library
 
     Args:
         name (string): The name of the new target
         src (string): The rust source file to generate a bridge for
         deps (list, optional): A list of dependencies for the underlying cc_library. Defaults to [].
+        hdrs (list, optional): A list of additional headers to the underlying cc_library. Defaults to [].
     """
     native.alias(
         name = "%s/header" % name,
@@ -62,13 +63,15 @@ def rust_cxx_bridge(name, src, deps = []):
     cc_library(
         name = name,
         srcs = [src + ".cc"],
+        hdrs = hdrs,
         linkstatic = True,
         deps = deps + [":%s/include" % name],
     )
 
     cc_library(
         name = "%s/include" % name,
-        hdrs = [src + ".h"],
+        hdrs = hdrs + [src + ".h"],
+        deps = deps,
     )
 
 """


### PR DESCRIPTION
This PR updates the `rust_cxx_bridge` macro and the additive build file for `protobuf-native` so it all works.

### Motivation

When building the higher level `sql` crate which depends on `protobuf-native` we hit linking errors because the generated `cxx` bindings for protobuf-native were not correctly depending on one another. Specifically the `io.cc`, `compiler.cc`, and `lib.cc` files all depend on `internal.cc`, we need to make sure we include the `cxx` generated `internal.h.rs` and `internal.c.rs` files for these targets.

It also updates the version of `protobuf` that we're using so it's the same as the `protobuf-src` Rust crate.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
