### PR TITLE
storage/mysql: ALTER SOURCE for MySQL Sources

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2319,7 +2319,11 @@ impl WithOptionName for AlterSourceAddSubsourceOptionName {
     /// this value could contain sensitive user data. If you're uncertain, err
     /// on the conservative side and return `true`.
     fn redact_value(&self) -> bool {
-        false
+        match self {
+            AlterSourceAddSubsourceOptionName::Details
+            | AlterSourceAddSubsourceOptionName::TextColumns
+            | AlterSourceAddSubsourceOptionName::IgnoreColumns => false,
+        }
     }
 }
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2292,8 +2292,12 @@ impl<T: AstInfo> AstDisplay for AlterSinkStatement<T> {
 pub enum AlterSourceAddSubsourceOptionName {
     /// Columns whose types you want to unconditionally format as text
     TextColumns,
+    /// Columns you want to ignore when ingesting data
+    IgnoreColumns,
     /// Updated `DETAILS` for an ingestion, e.g.
-    /// [`crate::ast::PgConfigOptionName::Details`].
+    /// [`crate::ast::PgConfigOptionName::Details`]
+    /// or
+    /// [`crate::ast::MySqlConfigOptionName::Details`].
     Details,
 }
 
@@ -2301,6 +2305,7 @@ impl AstDisplay for AlterSourceAddSubsourceOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             AlterSourceAddSubsourceOptionName::TextColumns => "TEXT COLUMNS",
+            AlterSourceAddSubsourceOptionName::IgnoreColumns => "IGNORE COLUMNS",
             AlterSourceAddSubsourceOptionName::Details => "DETAILS",
         })
     }
@@ -2314,10 +2319,7 @@ impl WithOptionName for AlterSourceAddSubsourceOptionName {
     /// this value could contain sensitive user data. If you're uncertain, err
     /// on the conservative side and return `true`.
     fn redact_value(&self) -> bool {
-        match self {
-            AlterSourceAddSubsourceOptionName::Details
-            | AlterSourceAddSubsourceOptionName::TextColumns => false,
-        }
+        false
     }
 }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4759,8 +4759,8 @@ impl<'a> Parser<'a> {
     fn parse_alter_source_add_subsource_option(
         &mut self,
     ) -> Result<AlterSourceAddSubsourceOption<Raw>, ParserError> {
-        match self.expect_one_of_keywords(&[TEXT])? {
-            TEXT => {
+        match self.expect_one_of_keywords(&[TEXT, IGNORE])? {
+            ref keyword @ (TEXT | IGNORE) => {
                 self.expect_keyword(COLUMNS)?;
 
                 let _ = self.consume_token(&Token::Eq);
@@ -4777,7 +4777,11 @@ impl<'a> Parser<'a> {
                     });
 
                 Ok(AlterSourceAddSubsourceOption {
-                    name: AlterSourceAddSubsourceOptionName::TextColumns,
+                    name: match *keyword {
+                        TEXT => AlterSourceAddSubsourceOptionName::TextColumns,
+                        IGNORE => AlterSourceAddSubsourceOptionName::IgnoreColumns,
+                        _ => unreachable!(),
+                    },
                     value,
                 })
             }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1424,7 +1424,7 @@ AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")])
 parse-statement
 ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH ()
 ----
-error: Expected one of TEXT, found right parenthesis
+error: Expected one of TEXT or IGNORE, found right parenthesis
 ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH ()
                                                             ^
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -97,8 +97,8 @@ pub use query::{ExprContext, QueryContext, QueryLifetime};
 pub use scope::Scope;
 pub use side_effecting_func::SideEffectingFunc;
 pub use statement::ddl::{
-    AlterSourceAddSubsourceOptionExtracted, PgConfigOptionExtracted, PlannedAlterRoleOption,
-    PlannedRoleVariable,
+    AlterSourceAddSubsourceOptionExtracted, MySqlConfigOptionExtracted, PgConfigOptionExtracted,
+    PlannedAlterRoleOption, PlannedRoleVariable,
 };
 pub use statement::{
     describe, plan, plan_copy_from, resolve_cluster_for_materialized_view, StatementContext,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5593,6 +5593,7 @@ pub fn describe_alter_source(
 generate_extracted_config!(
     AlterSourceAddSubsourceOption,
     (TextColumns, Vec::<UnresolvedItemName>, Default(vec![])),
+    (IgnoreColumns, Vec::<UnresolvedItemName>, Default(vec![])),
     (Details, String)
 );
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -956,6 +956,7 @@ async fn purify_create_source(
                 referenced_subsources,
                 text_columns,
                 ignore_columns,
+                None,
                 source_name,
                 &catalog,
             )
@@ -1387,6 +1388,7 @@ async fn purify_alter_source(
                 &mut referenced_subsources,
                 text_columns,
                 ignore_columns,
+                Some(resolved_source_name.clone()),
                 &unresolved_source_name,
                 &catalog,
             )

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -243,8 +243,8 @@ pub enum MySqlSourcePurificationError {
     UnrecognizedTypes { cols: Vec<(String, String, String)> },
     #[error("duplicated column name references in table {0}: {1:?}")]
     DuplicatedColumnNames(String, Vec<String>),
-    #[error("TEXT COLUMNS refers to columns not currently being added")]
-    DanglingTextColumns { items: Vec<UnresolvedItemName> },
+    #[error("Reference to columns not currently being added")]
+    DanglingColumns { items: Vec<UnresolvedItemName> },
     #[error("Invalid MySQL table reference: {0}")]
     InvalidTableReference(String),
     #[error("No tables found")]
@@ -267,7 +267,7 @@ impl MySqlSourcePurificationError {
                     ", "
                 )
             )),
-            Self::DanglingTextColumns { items } => Some(format!(
+            Self::DanglingColumns { items } => Some(format!(
                 "the following columns are referenced but not added: {}",
                 itertools::join(items, ", ")
             )),

--- a/src/sql/src/pure/mysql.rs
+++ b/src/sql/src/pure/mysql.rs
@@ -14,11 +14,11 @@ use std::ops::DerefMut;
 
 use mz_mysql_util::{validate_source_privileges, MySqlError, MySqlTableDesc, QualifiedTableRef};
 use mz_sql_parser::ast::display::AstDisplay;
-use mz_sql_parser::ast::UnresolvedItemName;
 use mz_sql_parser::ast::{
     ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CreateSubsourceStatement, Ident,
     IdentError, MySqlConfigOptionName, ReferencedSubsources, WithOptionValue,
 };
+use mz_sql_parser::ast::{ReferencedSubsources, UnresolvedItemName};
 
 use crate::catalog::{SessionCatalog, SubsourceCatalog};
 use crate::names::Aug;

--- a/src/sql/src/pure/mysql.rs
+++ b/src/sql/src/pure/mysql.rs
@@ -10,19 +10,20 @@
 //! MySQL utilities for SQL purification.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::ops::DerefMut;
 
 use mz_mysql_util::{validate_source_privileges, MySqlError, MySqlTableDesc, QualifiedTableRef};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::UnresolvedItemName;
 use mz_sql_parser::ast::{
     ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CreateSubsourceStatement, Ident,
-    IdentError, WithOptionValue,
+    IdentError, MySqlConfigOptionName, ReferencedSubsources, WithOptionValue,
 };
 
-use crate::catalog::SubsourceCatalog;
+use crate::catalog::{SessionCatalog, SubsourceCatalog};
 use crate::names::Aug;
 use crate::plan::{PlanError, StatementContext};
-use crate::pure::{MySqlConfigOptionName, MySqlSourcePurificationError};
+use crate::pure::MySqlSourcePurificationError;
 
 use super::RequestedSubsource;
 
@@ -237,4 +238,178 @@ pub(super) async fn validate_requested_subsources_privileges(
         })?;
 
     Ok(())
+}
+
+pub(super) struct PurifiedSubsources {
+    pub(super) new_subsources: Vec<CreateSubsourceStatement<Aug>>,
+    pub(super) tables: Vec<MySqlTableDesc>,
+    pub(super) normalized_text_columns: Vec<WithOptionValue<Aug>>,
+    pub(super) normalized_ignore_columns: Vec<WithOptionValue<Aug>>,
+}
+
+// Purify the referenced subsources, return the list of subsource statements,
+// corresponding tables, and and additional fields necessary to update the source
+// options
+pub(super) async fn purify_subsources(
+    conn: &mut mz_mysql_util::MySqlConn,
+    referenced_subsources: &mut Option<ReferencedSubsources>,
+    text_columns: Vec<UnresolvedItemName>,
+    ignore_columns: Vec<UnresolvedItemName>,
+    source_name: &UnresolvedItemName,
+    catalog: &impl SessionCatalog,
+) -> Result<PurifiedSubsources, PlanError> {
+    // Determine which table schemas to request from mysql. Note that in mysql
+    // a 'schema' is the same as a 'database', and a fully qualified table
+    // name is 'schema_name.table_name' (there is no db_name)
+    let table_schema_request = match referenced_subsources
+        .as_mut()
+        .ok_or(MySqlSourcePurificationError::RequiresReferencedSubsources)?
+    {
+        ReferencedSubsources::All => mz_mysql_util::SchemaRequest::All,
+        ReferencedSubsources::SubsetSchemas(schemas) => mz_mysql_util::SchemaRequest::Schemas(
+            schemas.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+        ),
+        ReferencedSubsources::SubsetTables(tables) => mz_mysql_util::SchemaRequest::Tables(
+            tables
+                .iter()
+                .map(|t| {
+                    let idents = &t.reference.0;
+                    // We only support fully qualified table names for now
+                    if idents.len() != 2 {
+                        Err(MySqlSourcePurificationError::InvalidTableReference(
+                            t.reference.to_ast_string(),
+                        ))?;
+                    }
+                    Ok((idents[0].as_str(), idents[1].as_str()))
+                })
+                .collect::<Result<Vec<_>, MySqlSourcePurificationError>>()?,
+        ),
+    };
+
+    let text_cols_map = map_column_refs(&text_columns, MySqlConfigOptionName::TextColumns)?;
+    let ignore_cols_map = map_column_refs(&ignore_columns, MySqlConfigOptionName::IgnoreColumns)?;
+
+    // Retrieve schemas for all requested tables
+    // NOTE: mysql will only expose the schemas of tables we have at least one privilege on
+    // and we can't tell if a table exists without a privilege, so in some cases we may
+    // return an EmptyDatabase error in the case of privilege issues.
+    let tables = mz_mysql_util::schema_info(
+        conn.deref_mut(),
+        &table_schema_request,
+        &text_cols_map,
+        &ignore_cols_map,
+    )
+    .await
+    .map_err(|err| match err {
+        mz_mysql_util::MySqlError::UnsupportedDataTypes { columns } => {
+            PlanError::from(MySqlSourcePurificationError::UnrecognizedTypes {
+                cols: columns
+                    .into_iter()
+                    .map(|c| (c.qualified_table_name, c.column_name, c.column_type))
+                    .collect(),
+            })
+        }
+        mz_mysql_util::MySqlError::DuplicatedColumnNames {
+            qualified_table_name,
+            columns,
+        } => PlanError::from(MySqlSourcePurificationError::DuplicatedColumnNames(
+            qualified_table_name,
+            columns,
+        )),
+        _ => err.into(),
+    })?;
+
+    if tables.is_empty() {
+        Err(MySqlSourcePurificationError::EmptyDatabase)?;
+    }
+
+    let mysql_catalog = derive_catalog_from_tables(&tables)?;
+
+    let mut validated_requested_subsources = vec![];
+    match referenced_subsources
+        .as_mut()
+        .ok_or(MySqlSourcePurificationError::RequiresReferencedSubsources)?
+    {
+        ReferencedSubsources::All => {
+            for table in &tables {
+                let upstream_name = mysql_upstream_name(table)?;
+                let subsource_name = super::subsource_name_gen(source_name, &table.name)?;
+                validated_requested_subsources.push(RequestedSubsource {
+                    upstream_name,
+                    subsource_name,
+                    table,
+                });
+            }
+        }
+        ReferencedSubsources::SubsetSchemas(schemas) => {
+            let available_schemas: BTreeSet<_> =
+                tables.iter().map(|t| t.schema_name.as_str()).collect();
+            let requested_schemas: BTreeSet<_> = schemas.iter().map(|s| s.as_str()).collect();
+            let missing_schemas: Vec<_> = requested_schemas
+                .difference(&available_schemas)
+                .map(|s| s.to_string())
+                .collect();
+            if !missing_schemas.is_empty() {
+                Err(MySqlSourcePurificationError::NoTablesFoundForSchemas(
+                    missing_schemas,
+                ))?;
+            }
+
+            for table in &tables {
+                if !requested_schemas.contains(table.schema_name.as_str()) {
+                    continue;
+                }
+
+                let upstream_name = mysql_upstream_name(table)?;
+                let subsource_name = super::subsource_name_gen(source_name, &table.name)?;
+                validated_requested_subsources.push(RequestedSubsource {
+                    upstream_name,
+                    subsource_name,
+                    table,
+                });
+            }
+        }
+        ReferencedSubsources::SubsetTables(subsources) => {
+            // The user manually selected a subset of upstream tables so we need to
+            // validate that the names actually exist and are not ambiguous
+            validated_requested_subsources =
+                super::subsource_gen(subsources, &mysql_catalog, source_name)?;
+
+            // subsource_gen automatically inserts the "fully qualified
+            // name," which for MySQL sources includes the fake database
+            // name.
+            for requested_subsource in validated_requested_subsources.iter_mut() {
+                let fake_database_name = requested_subsource.upstream_name.0.remove(0);
+                if fake_database_name.as_str() != MYSQL_DATABASE_FAKE_NAME {
+                    sql_bail!(
+                            "[internal error]: expected first element of upstream reference to be {}, but is {}",
+                            MYSQL_DATABASE_FAKE_NAME,
+                            fake_database_name.as_str()
+                        );
+                }
+            }
+        }
+    }
+
+    if validated_requested_subsources.is_empty() {
+        sql_bail!(
+            "[internal error]: MySQL source must ingest at least one table, but {} matched none",
+            referenced_subsources.as_ref().unwrap().to_ast_string()
+        );
+    }
+
+    super::validate_subsource_names(&validated_requested_subsources)?;
+
+    validate_requested_subsources_privileges(&validated_requested_subsources, conn).await?;
+
+    let scx = StatementContext::new(None, catalog);
+    let new_subsources = generate_targeted_subsources(&scx, validated_requested_subsources)?;
+
+    Ok(PurifiedSubsources {
+        new_subsources,
+        // Normalize column options and remove unused column references.
+        normalized_text_columns: normalize_column_refs(text_columns, &mysql_catalog)?,
+        normalized_ignore_columns: normalize_column_refs(ignore_columns, &mysql_catalog)?,
+        tables,
+    })
 }

--- a/src/sql/src/pure/mysql.rs
+++ b/src/sql/src/pure/mysql.rs
@@ -14,11 +14,11 @@ use std::ops::DerefMut;
 
 use mz_mysql_util::{validate_source_privileges, MySqlError, MySqlTableDesc, QualifiedTableRef};
 use mz_sql_parser::ast::display::AstDisplay;
+use mz_sql_parser::ast::UnresolvedItemName;
 use mz_sql_parser::ast::{
     ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CreateSubsourceStatement, Ident,
     IdentError, MySqlConfigOptionName, ReferencedSubsources, WithOptionValue,
 };
-use mz_sql_parser::ast::{ReferencedSubsources, UnresolvedItemName};
 
 use crate::catalog::{SessionCatalog, SubsourceCatalog};
 use crate::names::Aug;

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -308,6 +308,25 @@ impl RustType<ProtoMySqlSourceDetails> for MySqlSourceDetails {
     }
 }
 
+impl AlterCompatible for MySqlSourceDetails {
+    fn alter_compatible(
+        &self,
+        id: mz_repr::GlobalId,
+        other: &Self,
+    ) -> Result<(), crate::controller::AlterError> {
+        if self.initial_gtid_set == other.initial_gtid_set {
+            Ok(())
+        } else {
+            tracing::warn!(
+                "MySqlSourceDetails incompatible at initial_gtid_set:\nself:\n{:#?}\n\nother\n{:#?}",
+                self,
+                other
+            );
+            Err(crate::controller::AlterError { id })
+        }
+    }
+}
+
 /// Represents a MySQL transaction id
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum GtidState {

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -212,8 +212,8 @@ impl<C: ConnectionAccess> AlterCompatible for MySqlSourceConnection<C> {
             connection_id,
             connection,
             details,
-            text_columns,
-            ignore_columns,
+            text_columns: _,
+            ignore_columns: _,
         } = self;
 
         let compatibility_checks = [
@@ -222,9 +222,10 @@ impl<C: ConnectionAccess> AlterCompatible for MySqlSourceConnection<C> {
                 connection.alter_compatible(id, &other.connection).is_ok(),
                 "connection",
             ),
-            (details == &other.details, "details"),
-            (text_columns == &other.text_columns, "text_columns"),
-            (ignore_columns == &other.ignore_columns, "ignore_columns"),
+            (
+                details.alter_compatible(id, &other.details).is_ok(),
+                "details",
+            ),
         ];
 
         for (compatible, field) in compatibility_checks {

--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-sql-timeout duration=1s
-$ set-max-tries max-tries=20
-
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_mysql_source = true
 
@@ -30,7 +27,6 @@ USE public;
 CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
 INSERT INTO table_a VALUES (1, 'one');
 INSERT INTO table_a VALUES (2, 'two');
-# Check empty publication on ALTER
 
 > CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_conn
@@ -43,11 +39,8 @@ INSERT INTO table_a VALUES (2, 'two');
 $ mysql-execute name=mysql
 DROP TABLE table_a CASCADE;
 
-! ALTER SOURCE mz_source ADD SUBSOURCE table_b;
-contains:mz_source is a mysql source, which does not support ALTER SOURCE.
-
 # Adding a table with the same name as a running table does not allow you to add
-# the new table, even though its OID is the different.
+# the new table.
 
 $ mysql-execute name=mysql
 CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT);
@@ -56,9 +49,13 @@ INSERT INTO table_a VALUES (9, 'nine');
 ! SELECT * FROM table_a;
 contains:table was dropped
 
-# We are not aware that the new table_a is different
+# table names must be fully qualified
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_a;
-contains:mz_source is a mysql source, which does not support ALTER SOURCE.
+contains:Invalid MySQL table reference: table_a
+
+# We are not aware that the new table_a is different
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_a;
+contains:another subsource already refers to public.table_a
 
 > DROP SOURCE mz_source CASCADE;
 
@@ -121,277 +118,321 @@ table_g               subsource
 # Error checking
 #
 
-# TODO #24975 (support ALTER SOURCE)
-#
-# > CREATE TABLE mz_table (a int);
-#
-# > DROP TABLE mz_table;
-#
-# > CREATE SOURCE "mz_source_too"
-#   FROM MYSQL CONNECTION mysql_conn
-#   FOR TABLES (public.table_a AS t_a);
-#
-# > DROP SOURCE mz_source_too CASCADE;
+
+> CREATE TABLE mz_table (a int);
+
+> DROP TABLE mz_table;
+
+> CREATE SOURCE "mz_source_too"
+  FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (public.table_a AS t_a);
+
+> DROP SOURCE mz_source_too CASCADE;
 
 #
 # State checking
 #
 
-# TODO #24975 (support ALTER SOURCE)
-# > DROP SOURCE table_a
-#
-# > SELECT * FROM table_b;
-# 1 one
-# 2 two
-#
-# > SHOW SUBSOURCES ON mz_source
-# mz_source_progress    progress
-# table_b               subsource
-# table_c               subsource
-# table_d               subsource
-# table_e               subsource
-# table_f               subsource
-# table_g               subsource
-#
-# ! SELECT * FROM table_a;
-# contains: unknown catalog item 'table_a'
-#
-# # Makes progress after dropping subsources
-# $ mysql-execute name=mysql
-# INSERT INTO table_b VALUES (3, 'three');
-#
-# > SELECT * FROM table_b;
-# 1 one
-# 2 two
-# 3 three
-#
-# # IF EXISTS works
-# > DROP SOURCE IF EXISTS table_a;
-#
-# # Multiple, repetitive tables work
-# > DROP SOURCE table_b, table_c, table_b, table_c, table_b, table_c;
-#
-# # IF EXISTS works with multiple tables
-# > DROP SOURCE IF EXISTS table_c, table_d;
-#
-# > CREATE MATERIALIZED VIEW mv_e AS SELECT pk + 1 FROM table_e;
-# > CREATE MATERIALIZED VIEW mv_f AS SELECT pk + 1 FROM table_f;
-#
-# # Makes progress after dropping subsources
-# $ mysql-execute name=mysql
-# INSERT INTO table_e VALUES (3, 'three');
-#
-# > SELECT * FROM mv_e;
-# 2
-# 3
-# 4
-#
-# > SHOW MATERIALIZED VIEWS
-# mv_e quickstart
-# mv_f quickstart
-#
-# # RESTRICT works
-# ! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e;
-# contains:cannot drop source "table_e": still depended upon by materialized view "mv_e"
-#
-# ! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e RESTRICT;
-# contains:cannot drop source "table_e": still depended upon by materialized view "mv_e"
-#
-# # CASCADE works
-# > DROP SOURCE table_e CASCADE;
-#
-# # IF NOT EXISTS + CASCADE works
-# > DROP SOURCE IF EXISTS table_e, table_f CASCADE;
-#
+> DROP SOURCE table_a
+
+> SELECT * FROM table_b;
+1 one
+2 two
+
+> SHOW SUBSOURCES ON mz_source
+mz_source_progress    progress
+table_b               subsource
+table_c               subsource
+table_d               subsource
+table_e               subsource
+table_f               subsource
+table_g               subsource
+
+! SELECT * FROM table_a;
+contains: unknown catalog item 'table_a'
+
+# Makes progress after dropping subsources
+$ mysql-execute name=mysql
+INSERT INTO table_b VALUES (3, 'three');
+
+> SELECT * FROM table_b;
+1 one
+2 two
+3 three
+
+# IF EXISTS works
+> DROP SOURCE IF EXISTS table_a;
+
+# Multiple, repetitive tables work
+> DROP SOURCE table_b, table_c, table_b, table_c, table_b, table_c;
+
+# IF EXISTS works with multiple tables
+> DROP SOURCE IF EXISTS table_c, table_d;
+
+> CREATE MATERIALIZED VIEW mv_e AS SELECT pk + 1 FROM table_e;
+> CREATE MATERIALIZED VIEW mv_f AS SELECT pk + 1 FROM table_f;
+
+# Makes progress after dropping subsources
+$ mysql-execute name=mysql
+INSERT INTO table_e VALUES (3, 'three');
+
+> SELECT * FROM mv_e;
+2
+3
+4
+
+> SHOW MATERIALIZED VIEWS
+mv_e quickstart
+mv_f quickstart
+
+# RESTRICT works
+! DROP SOURCE table_e RESTRICT;
+contains:cannot drop source "table_e": still depended upon by materialized view "mv_e"
+
+# CASCADE works
+> DROP SOURCE table_e CASCADE;
+
+# IF NOT EXISTS + CASCADE works
+> DROP SOURCE IF EXISTS table_e, table_f CASCADE;
+
 # TEXT COLUMNS removed from table_f
-# > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
-# <null>
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+<null>
 
-# > SHOW SUBSOURCES ON mz_source
-# mz_source_progress    progress
-# table_g               subsource
-
-# > SHOW MATERIALIZED VIEWS
-
-# MySQL sources must retain at least one subsource, if nothing else than for parsing reasons, i.e.
-# empty input for subsources is invalid.
-# ! ALTER SOURCE mz_source DROP SUBSOURCE table_g;
-# contains:SOURCE "mz_source" must retain at least one non-progress subsource
+> SHOW SUBSOURCES ON mz_source
+mz_source_progress    progress
+table_g               subsource
 
 # Show that all table definitions have been updated
-# > SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE') FROM (SHOW CREATE SOURCE mz_source);
-# "{\"public\".\"table_g\" AS \"materialize\".\"public\".\"table_g\"}"
+> SELECT regexp_match(create_sql, 'FOR TABLES \((.+?)\) EXPOSE') FROM (SHOW CREATE SOURCE mz_source);
+"{\"public\".\"table_g\" AS \"materialize\".\"public\".\"table_g\"}"
+
+> SHOW MATERIALIZED VIEWS
+
+> DROP SOURCE table_g;
+
+> SHOW SUBSOURCES ON mz_source
+mz_source_progress    progress
 
 #
 # Add subsources
+#
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_g;
+contains:another subsource already refers to public.table_g
 
-# TODO #24975 (support ALTER SOURCE)
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_a, public.table_b AS tb;
 
-# ! ALTER SOURCE mz_source ADD SUBSOURCE table_g;
-# contains:another subsource already refers to mysql.public.table_g
-#
-# > ALTER SOURCE mz_source ADD SUBSOURCE table_a, table_b AS tb;
-#
-# > SELECT * FROM table_a;
-# 1 one
-# 2 two
-#
-# ! ALTER SOURCE mz_source ADD SUBSOURCE table_a;
-# contains:another subsource already refers to mysql.public.table_a
-#
-# > SELECT * FROM tb;
-# 1 one
-# 2 two
-# 3 three
-#
-# !SELECT * FROM table_b;
-# contains:unknown catalog item
-#
-# # We can add tables that didn't exist at the time of publication
-# $ mysql-execute name=mysql
-# CREATE TABLE table_h (pk INTEGER PRIMARY KEY, f2 TEXT);
-# INSERT INTO table_h VALUES (1, 'one');
-# INSERT INTO table_h VALUES (2, 'two');
-#
-# > ALTER SOURCE mz_source ADD SUBSOURCE table_h;
-#
-# > SELECT * FROM table_h;
-# 1 one
-# 2 two
-#
-# > SHOW SUBSOURCES ON mz_source
-# mz_source_progress progress
-# table_a            subsource
-# table_g            subsource
-# table_h            subsource
-# tb                 subsource
-#
-# #
-# # Complex subsource operations
-#
-# # If your schema change breaks the subsource, you can fix it.
-# $ mysql-execute name=mysql
-# ALTER TABLE table_a DROP COLUMN f2;
-# INSERT INTO table_a VALUES (3);
-#
-# ! SELECT * FROM table_a;
-# contains:incompatible schema change
-#
-# > SELECT error ~~ '%incompatible schema change%' FROM mz_internal.mz_source_statuses WHERE name = 'table_a';
-# true
-#
-# # Subsource errors not propagated to primary source
-# > SELECT error IS NULL FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
-# true
-#
-# > DROP SOURCE table_a;
-#
-# > ALTER SOURCE mz_source ADD SUBSOURCE table_a;
-#
-# > SELECT * FROM table_a;
-# 1
-# 2
-# 3
-#
-# # If you add columns you can re-ingest them
-# $ mysql-execute name=mysql
-# ALTER TABLE table_a ADD COLUMN f2 text;
-# INSERT INTO table_a VALUES (4, 'four');
-#
-# > SELECT * FROM table_a;
-# 1
-# 2
-# 3
-#
-# > DROP SOURCE table_a;
-# > ALTER SOURCE mz_source ADD SUBSOURCE table_a;
-#
-# > SELECT * FROM table_a;
-# 1 <null>
-# 2 <null>
-# 3 <null>
-# 4 four
-#
-# # If you add a NOT NULL constraint, you can propagate it.
-# $ mysql-execute name=mysql
-# ALTER TABLE table_a ADD COLUMN f3 int DEFAULT 1 NOT NULL;
-# INSERT INTO table_a VALUES (5, 'five', 5);
-#
-# > DROP SOURCE table_a;
-# > ALTER SOURCE mz_source ADD SUBSOURCE table_a;
-#
-# > SELECT * FROM table_a;
-# 1 <null> 1
-# 2 <null> 1
-# 3 <null> 1
-# 4 four 1
-# 5 five 5
-#
-# > EXPLAIN SELECT * FROM table_a WHERE f3 IS NULL;
-# "Explained Query (fast path):\n  Constant <empty>\n"
-#
-# # Can add tables with text columns
-# ! ALTER SOURCE mz_source ADD SUBSOURCE table_f WITH (TEXT COLUMNS [table_f.f2, table_f.f2]);
-# contains: invalid TEXT COLUMNS option value: unexpected multiple references to mysql.public.table_f.f2
-#
-# > ALTER SOURCE mz_source ADD SUBSOURCE table_f WITH (TEXT COLUMNS [table_f.f2]);
-#
-# > SELECT * FROM table_f
-# 1 var0
-# 2 var1
-#
-# > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
-# \"public\".\"table_f\".\"f2\""
-#
-# # Drop a table that's in the publication, which shuffles the tables' output
-# # indexes, then add a table to the publication and ensure it can be added.
-# $ mysql-execute name=mysql
-# DROP TABLE table_c, table_d;
-#
-# CREATE TABLE table_i (pk INTEGER PRIMARY KEY, f2 an_enum);
-# INSERT INTO table_i VALUES (1, 'var0');
-# ALTER TABLE table_i REPLICA IDENTITY FULL;
-# INSERT INTO table_i VALUES (2, 'var1');
-#
-# INSERT INTO table_f VALUES (3, 'var1');
-#
-# > ALTER SOURCE mz_source ADD SUBSOURCE table_i WITH (TEXT COLUMNS [table_i.f2]);
-#
-# > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
-# \"public\".\"table_f\".\"f2\", \"public\".\"table_i\".\"f2\""
-#
-# > SELECT * FROM table_f
-# 1 var0
-# 2 var1
-# 3 var1
-#
-# > DROP SOURCE table_f, table_i;
-#
-# > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
-# <null>
-#
-# ! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS (table_z.a));
-# contains:invalid TEXT COLUMNS option value: table table_z not found in source
-#
-# ! ALTER SOURCE mz_source ADD SUBSOURCE table_e WITH (TEXT COLUMNS [table_f.f2]);
-# contains:TEXT COLUMNS refers to table not currently being added
-# detail:the following tables are referenced but not added: public.table_f
-#
-# # Test adding text cols w/o original text columns
-#
-# > CREATE SOURCE "mz_source_wo_init_text_cols"
-#   FROM MYSQL CONNECTION mysql_conn
-#   FOR TABLES (table_a AS t_a);
-#
-# > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_text_cols);
-# <null>
-#
-# > ALTER SOURCE mz_source_wo_init_text_cols ADD SUBSOURCE table_f AS t_f WITH (TEXT COLUMNS [table_f.f2]);
-#
-# > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_text_cols);
-# \"public\".\"table_f\".\"f2\""
+> SELECT * FROM table_a;
+1 one
+2 two
 
-# add a table after having created the source
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_a;
+contains:another subsource already refers to public.table_a
+
+> SELECT * FROM tb;
+1 one
+2 two
+3 three
+
+! SELECT * FROM table_b;
+contains:unknown catalog item
+
+# We can add tables that didn't exist at the time of publication
+$ mysql-execute name=mysql
+CREATE TABLE table_h (pk INTEGER PRIMARY KEY, f2 TEXT);
+INSERT INTO table_h VALUES (1, 'one');
+INSERT INTO table_h VALUES (2, 'two');
+
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_h;
+
+> SELECT * FROM table_h;
+1 one
+2 two
+
+> SHOW SUBSOURCES ON mz_source
+mz_source_progress progress
+table_a            subsource
+table_g            subsource
+table_h            subsource
+tb                 subsource
+
+#
+# Complex subsource operations
+#
+# If your schema change breaks the subsource, you can fix it.
+$ mysql-execute name=mysql
+ALTER TABLE table_a DROP COLUMN f2;
+INSERT INTO table_a VALUES (3);
+
+! SELECT * FROM table_a;
+contains:incompatible schema change
+
+> SELECT error ~~ '%incompatible schema change%' FROM mz_internal.mz_source_statuses WHERE name = 'table_a';
+true
+
+# Subsource errors not propagated to primary source
+> SELECT error IS NULL FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
+true
+
+> DROP SOURCE table_a;
+
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_a;
+
+> SELECT * FROM table_a;
+1
+2
+3
+
+# If you add columns you can re-ingest them
+$ mysql-execute name=mysql
+ALTER TABLE table_a ADD COLUMN f2 text;
+INSERT INTO table_a VALUES (4, 'four');
+
+> SELECT * FROM table_a;
+1
+2
+3
+
+> DROP SOURCE table_a;
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_a;
+
+> SELECT * FROM table_a;
+1 <null>
+2 <null>
+3 <null>
+4 four
+
+# If you add a NOT NULL constraint, you can propagate it.
+$ mysql-execute name=mysql
+ALTER TABLE table_a ADD COLUMN f3 int DEFAULT 1 NOT NULL;
+INSERT INTO table_a VALUES (5, 'five', 5);
+
+> DROP SOURCE table_a;
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_a;
+
+> SELECT * FROM table_a;
+1 <null> 1
+2 <null> 1
+3 <null> 1
+4 four 1
+5 five 5
+
+> EXPLAIN SELECT * FROM table_a WHERE f3 IS NULL;
+"Explained Query (fast path):\n  Constant <empty>\n\nTarget cluster: quickstart\n"
+
+#
+# Can add tables with text columns
+#
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_f WITH (TEXT COLUMNS [public.table_f.f2, public.table_f.f2]);
+contains: invalid TEXT COLUMNS option value: unexpected multiple references to public.table_f.f2
+
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_f WITH (TEXT COLUMNS [public.table_f.f2]);
+
+> SELECT * FROM table_f
+1 var0
+2 var1
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"public\".\"table_f\".\"f2\""
+
+# Drop a table, which shuffles the tables' output indexes, then add a table and ensure it can be added.
+$ mysql-execute name=mysql
+DROP TABLE table_c, table_d;
+
+CREATE TABLE table_i (pk INTEGER PRIMARY KEY, f2 ENUM ('var0', 'var1'));
+INSERT INTO table_i VALUES (1, 'var0');
+INSERT INTO table_i VALUES (2, 'var1');
+INSERT INTO table_f VALUES (3, 'var1');
+
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_i WITH (TEXT COLUMNS [public.table_i.f2]);
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"public\".\"table_f\".\"f2\", \"public\".\"table_i\".\"f2\""
+
+> SELECT * FROM table_f
+1 var0
+2 var1
+3 var1
+
+> DROP SOURCE table_f, table_i;
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+<null>
+
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_e WITH (TEXT COLUMNS (public.table_z.a));
+contains:Reference to columns not currently being added
+
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_e WITH (TEXT COLUMNS [public.table_f.f2]);
+contains:Reference to columns not currently being added
+detail:the following columns are referenced but not added: public.table_f.f2
+
+# Test adding text cols w/o original text columns
+
+> CREATE SOURCE "mz_source_wo_init_text_cols"
+  FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (public.table_a AS t_a);
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_text_cols);
+<null>
+
+> ALTER SOURCE mz_source_wo_init_text_cols ADD SUBSOURCE public.table_f AS t_f WITH (TEXT COLUMNS [public.table_f.f2]);
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_text_cols);
+"\"public\".\"table_f\".\"f2\""
+
+
+#
+# Can add tables with ignore columns
+#
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_f WITH (IGNORE COLUMNS [public.table_f.f2, public.table_f.f2]);
+contains: invalid IGNORE COLUMNS option value: unexpected multiple references to public.table_f.f2
+
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_f WITH (IGNORE COLUMNS [public.table_f.f2]);
+
+> SELECT * FROM table_f
+1
+2
+3
+
+> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"public\".\"table_f\".\"f2\""
+
+> ALTER SOURCE mz_source ADD SUBSOURCE public.table_i WITH (IGNORE COLUMNS [public.table_i.f2]);
+
+> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+"\"public\".\"table_f\".\"f2\", \"public\".\"table_i\".\"f2\""
+
+> SELECT * FROM table_i
+1
+2
+
+> DROP SOURCE table_f, table_i;
+
+> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
+<null>
+
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_e WITH (IGNORE COLUMNS (public.table_z.a));
+contains:Reference to columns not currently being added
+
+! ALTER SOURCE mz_source ADD SUBSOURCE public.table_e WITH (IGNORE COLUMNS [public.table_f.f2]);
+contains:Reference to columns not currently being added
+detail:the following columns are referenced but not added: public.table_f.f2
+
+# Test adding ignore cols w/o original IGNORE COLUMNS
+
+> CREATE SOURCE "mz_source_wo_init_ignore_cols"
+  FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (public.table_a AS t_a2);
+
+> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_ignore_cols);
+<null>
+
+> ALTER SOURCE mz_source_wo_init_ignore_cols ADD SUBSOURCE public.table_f AS t_f2 WITH (IGNORE COLUMNS [public.table_f.f2]);
+
+> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source_wo_init_ignore_cols);
+"\"public\".\"table_f\".\"f2\""
+
+# Add a table after having created the source
 $ mysql-execute name=mysql
 CREATE TABLE t2 (f1 BOOLEAN);
 

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -695,7 +695,7 @@ DELETE FROM mixED_CAse;
     public."enum_table",
     public.another_enum_table
   );
-contains:TEXT COLUMNS refers to columns not currently being added
+contains:Reference to columns not currently being added
 
 > CREATE SOURCE enum_source
   IN CLUSTER cdc_cluster


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.
Fixes https://github.com/MaterializeInc/materialize/issues/24975

Enables the `ALTER SOURCE .. ADD SUBSOURCE` statement and `DROP SOURCE <subsource>` for MySQL Sources, with equivalent semantics to the Postgres Source (except MySQL also supports the `IGNORE COLUMNS` option in addition to `TEXT COLUMNS`).

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

- Would recommend reviewing with whitespace removed.
- 2 of the commits are just refactors to allow the purification & sequencing of `ALTER SOURCE` statements to allow more than just Postgres sources.
- The `Implement purification for mysql alter source` commit has a large diff since I moved most of the mysql-specific subsource purification logic to a common method that can be shared between create & alter source.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
