### PR TITLE
ore: Update docs for drain_filter_swapping

### DIFF
--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -96,7 +96,7 @@ pub trait VecExt<T> {
     /// If the closure returns false, the element will remain in the vector and will not be yielded
     /// by the iterator.
     ///
-    /// Using this method is equivalent to the following code:
+    /// Using this method and consuming the iterator is equivalent to the following code:
     ///
     /// ```
     /// # let some_predicate = |x: &mut i32| { *x == 2 || *x == 3 || *x == 6 };
@@ -141,7 +141,7 @@ pub trait VecExt<T> {
     /// assert_eq!(evens, vec![2, 4, 14, 6, 8]);
     /// assert_eq!(odds, vec![1, 15, 3, 13, 5, 11, 9]);
     /// ```
-    #[must_use]
+    #[must_use = "The vector is modified only if the iterator is consumed"]
     fn drain_filter_swapping<F>(&mut self, filter: F) -> DrainFilterSwapping<'_, T, F>
     where
         F: FnMut(&mut T) -> bool;


### PR DESCRIPTION
Followup to dbecc3cf78d5cc6ebfd6ac64e3815e529365d7e9 that adds documentation explaining why the `#[must_use]` exists.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
