### PR TITLE
doc/user: make placeholders more obvious in COPY TO S3 docs

### DIFF
--- a/doc/user/content/serve-results/s3.md
+++ b/doc/user/content/serve-results/s3.md
@@ -119,7 +119,7 @@ Next, you must attach the policy you just created to a Materialize-specific
                "Action": "sts:AssumeRole",
                "Condition": {
                    "StringEquals": {
-                       "sts:ExternalId": "mz_00000000-0000-0000-0000-000000000000_u0"
+                       "sts:ExternalId": "PENDING"
                    }
                }
            }
@@ -148,12 +148,13 @@ Next, you must attach the policy you just created to a Materialize-specific
 
 1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
    client connected to Materialize, create an [AWS connection](/sql/create-connection/#aws),
-   replacing `<role>` with the name of the role you created in the previous
-   step:
+   replacing `<account-id>` with the 12-digit number that identifies your
+   AWS account, and  `<role>` with the name of the role you created in the
+   previous step:
 
    ```sql
    CREATE CONNECTION aws_connection
-      TO AWS (ASSUME ROLE ARN = 'arn:aws:iam::001234567890:role/<role>');
+      TO AWS (ASSUME ROLE ARN = 'arn:aws:iam::<account-id>:role/<role>');
    ```
 
 1. Retrieve the external ID for the connection:
@@ -165,14 +166,22 @@ Next, you must attach the policy you just created to a Materialize-specific
     WHERE c.name = 'aws_connection';
    ```
 
+   The external ID will have the following format:
+
+   ```text
+   mz_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX_uXXX
+   ```
+
 1. In your AWS account, find the IAM role you created in [Create an IAM role](#create-an-iam-role)
    and, under **Trust relationships**, click **Edit trust policy**. Use the
    `external_id` from the previous step to update the trust policy's
-   `ExternalId`, then click **Update policy**.
+   `sts:ExternalId`, then click **Update policy**.
 
-   {{< warning >}}Failing to constrain the external ID in your role trust policy
+   {{< warning >}}
+   Failing to constrain the external ID in your role trust policy
    will allow other Materialize customers to assume your role and use AWS
-   privileges you have granted the role!{{< /warning >}}
+   privileges you have granted the role!
+   {{< /warning >}}
 
 1. Back in Materialize, validate the AWS connection you created using the
    [`VALIDATE CONNECTION`](/sql/validate-connection) command.
@@ -184,7 +193,7 @@ Next, you must attach the policy you just created to a Materialize-specific
    If no validation error is returned, you're ready to use this connection to
    run a bulk export from Materialize to your target S3 bucket! 🔥
 
-## Step 4. Run a bulk export
+## Step 3. Run a bulk export
 
 To export data to your target S3 bucket, use the [`COPY TO`](/sql/copy-to/#copy-to-s3)
 command, and the AWS connection you created in the previous step.
@@ -224,7 +233,7 @@ bucket. When the copy operation is complete, this file is deleted. This allows
 using the [`s3:ObjectRemoved` event](https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html#supported-notification-event-types)
 to trigger downstream processing.
 
-## Step 5. (Optional) Add scheduling
+## Step 4. (Optional) Add scheduling
 
 Bulk exports to Amazon S3 using the `COPY TO` command are _one-shot_: every time
 you want to export results, you must run the command. To automate running bulk


### PR DESCRIPTION
We got some great feedback from one of our early testers that the placeholders in our documentation were not sufficiently obvious.

Also correct the step numbering.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
