### PR TITLE
parallel-workload: Query result can be ok and error at once

### DIFF
--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -194,13 +194,12 @@ class Executor:
                 raise QueryError(
                     f"{result.status_code}: {result.text}", f"HTTP query: {query}"
                 )
-            r = result.json()["results"]
-            assert len(r) == 1, r
-            if "error" in r[0]:
-                raise QueryError(
-                    f"HTTP {r[0]['error']['code']}: {r[0]['error']['message']}\n{r[0]['error'].get('detail', '')}",
-                    query,
-                )
+            for result in result.json()["results"]:
+                if "error" in result:
+                    raise QueryError(
+                        f"HTTP {result['error']['code']}: {result['error']['message']}\n{result['error'].get('detail', '')}",
+                        query,
+                    )
         except requests.exceptions.ReadTimeout as e:
             raise QueryError(f"HTTP read timeout: {e}", query)
         except requests.exceptions.ConnectionError:


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/7954#018fddde-545e-43d0-aaa0-22ac6a8f8378

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
