### PR TITLE
catalog: Always store unfinalized shards

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -148,7 +148,7 @@ pub struct CatalogPlans {
 }
 
 impl Catalog {
-    /// Initializess the `storage_controller` to understand all shards that
+    /// Initializes the `storage_controller` to understand all shards that
     /// `self` expects to exist.
     ///
     /// Note that this must be done before creating/rendering collections

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -2367,15 +2367,7 @@ impl CatalogState {
     pub(super) fn update_storage_metadata(&mut self, tx: &Transaction<'_>) {
         use mz_storage_client::controller::StorageTxn;
         self.storage_metadata.collection_metadata = tx.get_collection_metadata();
-        // If we will not perform shard finalization in storage, there's no
-        // benefit in exerting memory pressure on `envd` to cache all of these
-        // unused values.
-        if self
-            .system_configuration
-            .enable_storage_shard_finalization()
-        {
-            self.storage_metadata.unfinalized_shards = tx.get_unfinalized_shards();
-        }
+        self.storage_metadata.unfinalized_shards = tx.get_unfinalized_shards();
     }
 
     /// Returns a read-only view of the current [`StorageMetadata`].


### PR DESCRIPTION
Previously, the enable_storage_shard_finalization flag controlled whether we stored newly deleted but unfinalized shards in the in-memory catalog. When the flag was disabled, we would not store them in memory. This could cause the on-disk catalog state to diverge from the in-memory catalog state which is confusing. Additionally, there are some parts of the code that assume that if a shard is missing from the in-memory catalog, it must have been finalized. There is a careful but fragile dance in the code that prevents leaking shards when enable_storage_shard_finalization is off. Furthermore, on startup all unfinalized shards are loaded into the in-memory catalog regardless of the flag.

This commit simplifies the code by always storing unfinalized shards in the in-memory catalog.

Maybe but probably not fixes #27196

### Motivation
This PR might fix a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
