### PR TITLE
scratch: install python3-dev

### DIFF
--- a/misc/scratch/provision.bash
+++ b/misc/scratch/provision.bash
@@ -23,6 +23,7 @@ apt-get install -y \
     libclang-dev \
     lld \
     postgresql-client \
+    python3-dev \
     python3-venv \
     unzip
 


### PR DESCRIPTION
This is needed for aarch64 instances (but I don't know why).

This fixes https://github.com/MaterializeInc/materialize/issues/26052.