### PR TITLE
feature benchmark: provide scale to ancestor overrides

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -22,7 +22,7 @@ Commits must be ordered descending by their date.
 
 
 def get_ancestor_overrides_for_performance_regressions(
-    scenario_class: type[Any],
+    scenario_class: type[Any], scale: str
 ) -> dict[str, MzVersion]:
     scenario_class_name = scenario_class.__name__
 


### PR DESCRIPTION
I anticipated that we might need this for the feature benchmark running in the release-qualification pipeline.