### PR TITLE
data-ingest/parallel-workload: Support more Mz types

### DIFF
--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -319,7 +319,7 @@ class MySqlExecutor(Executor):
         )
 
         values = [
-            f"{identifier(field.name)} {str(field.data_type.name(Backend.POSTGRES)).lower()}"
+            f"{identifier(field.name)} {str(field.data_type.name(Backend.MYSQL)).lower()}"
             for field in self.fields
         ]
         keys = [field.name for field in self.fields if field.is_key]
@@ -563,7 +563,7 @@ class KafkaRoundtripExecutor(Executor):
     def create(self, logging_exe: Any | None = None) -> None:
         self.logging_exe = logging_exe
         values = [
-            f"{field.name} {str(field.data_type.name(Backend.POSTGRES)).lower()}"
+            f"{field.name} {str(field.data_type.name(Backend.MATERIALIZE)).lower()}"
             for field in self.fields
         ]
         keys = [field.name for field in self.fields if field.is_key]

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -384,6 +384,7 @@ class CopyToS3Action(Action):
                 "Relation contains unimplemented arrow types",
                 "Cannot encode the following columns/types",
                 "timeout: error trying to connect",
+                "cannot represent decimal value",  # parquet limitation
             ]
         )
         if exe.db.complexity == Complexity.DDL:

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -19,6 +19,7 @@ from materialize.data_ingest.data_type import (
     DATA_TYPES,
     DATA_TYPES_FOR_AVRO,
     DATA_TYPES_FOR_KEY,
+    DATA_TYPES_FOR_MYSQL,
     Bytea,
     DataType,
     Jsonb,
@@ -634,7 +635,7 @@ class MySqlSource(DBObject):
                 Field(f"key{i}", rng.choice(DATA_TYPES_FOR_KEY), True)
             )
         for i in range(rng.randint(0, 20)):
-            fields.append(Field(f"value{i}", rng.choice(DATA_TYPES_FOR_AVRO), False))
+            fields.append(Field(f"value{i}", rng.choice(DATA_TYPES_FOR_MYSQL), False))
         self.columns = [
             MySqlColumn(field.name, field.data_type, False, self) for field in fields
         ]


### PR DESCRIPTION
Verification: https://buildkite.com/materialize/nightly/builds/7983
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
