### PR TITLE
catalog: Remove public key from catalog state

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -889,7 +889,7 @@ impl CatalogState {
             }
             mz_storage_types::connections::Connection::Csr(_)
             | mz_storage_types::connections::Connection::Postgres(_)
-            // SSH connection table updates are handled elsewhere. The content of the tables is
+            // SSH connection table updates are handled elsewhere. The content of the table is
             // stored in the secret controller, not the durable catalog, which requires special
             // handling.
             | mz_storage_types::connections::Connection::Ssh(_)

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -889,6 +889,9 @@ impl CatalogState {
             }
             mz_storage_types::connections::Connection::Csr(_)
             | mz_storage_types::connections::Connection::Postgres(_)
+            // SSH connection table updates are handled elsewhere. The content of the tables is
+            // stored in the secret controller, not the durable catalog, which requires special
+            // handling.
             | mz_storage_types::connections::Connection::Ssh(_)
             | mz_storage_types::connections::Connection::MySql(_) => (),
         };

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -78,7 +78,7 @@ use crate::catalog::CatalogState;
 use crate::coord::ConnMeta;
 
 /// An update to a built-in table.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BuiltinTableUpdate {
     /// The ID of the table to update.
     pub id: GlobalId,

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -2181,41 +2181,17 @@ impl Catalog {
                 }
                 Op::UpdateRotatedKeys {
                     id,
-                    previous_public_key_pair,
-                    new_public_key_pair,
+                    previous_public_key_pair: _,
+                    new_public_key_pair: _,
                 } => {
+                    // Noting to actually do but log.
                     let entry = state.get_entry(&id);
-                    // Retract old keys
-                    builtin_table_updates.extend(state.pack_ssh_tunnel_connection_update(
-                        id,
-                        &previous_public_key_pair,
-                        -1,
-                    ));
-                    // Insert the new rotated keys
-                    builtin_table_updates.extend(state.pack_ssh_tunnel_connection_update(
-                        id,
-                        &new_public_key_pair,
-                        1,
-                    ));
-
-                    let mut connection = entry.connection()?.clone();
-                    if let mz_storage_types::connections::Connection::Ssh(ref mut ssh) =
-                        connection.connection
-                    {
-                        ssh.public_keys = Some(new_public_key_pair)
-                    }
-                    let new_item = CatalogItem::Connection(connection);
-
-                    let old_entry = state.entry_by_id.remove(&id).expect("catalog out of sync");
                     info!(
                         "update {} {} ({})",
-                        old_entry.item_type(),
-                        state.resolve_full_name(old_entry.name(), old_entry.conn_id()),
+                        entry.item_type(),
+                        state.resolve_full_name(entry.name(), entry.conn_id()),
                         id
                     );
-                    let mut new_entry = old_entry;
-                    new_entry.item = new_item;
-                    state.entry_by_id.insert(id, new_entry);
                 }
             };
             tx.commit_op();

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -587,6 +587,7 @@ pub struct CreateConnectionPlan {
     pub if_not_exists: bool,
     pub connection: Connection,
     pub validate: bool,
+    pub public_key_set: Option<(String, String)>,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3978,6 +3978,7 @@ pub fn plan_create_connection(
             connection,
         },
         validate,
+        public_key_set: None,
     };
     Ok(Plan::CreateConnection(plan))
 }

--- a/src/sql/src/plan/statement/ddl/connection.rs
+++ b/src/sql/src/plan/statement/ddl/connection.rs
@@ -385,7 +385,6 @@ impl ConnectionOptionExtracted {
                         sql_bail!("SSH connections do not support supplying USER value as SECRET")
                     }
                 },
-                public_keys: None,
             }),
             CreateConnectionType::MySql => {
                 scx.require_feature_flag(&crate::session::vars::ENABLE_MYSQL_SOURCE)?;

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -392,6 +392,7 @@ fn generate_rbac_requirements(
             if_not_exists: _,
             connection: _,
             validate: _,
+            public_key_set: _,
         }) => RbacRequirements {
             privileges: vec![(
                 SystemObjectId::Object(name.qualifiers.clone().into()),

--- a/src/storage-types/src/connections.proto
+++ b/src/storage-types/src/connections.proto
@@ -97,15 +97,12 @@ message ProtoSshTunnel {
 }
 
 message ProtoSshConnection {
-    message ProtoPublicKeys {
-        string primary_public_key = 1;
-        string secondary_public_key = 2;
-    }
+    reserved 4;
+    reserved "public_keys";
 
     string host = 1;
     uint32 port = 2;
     string user = 3;
-    ProtoPublicKeys public_keys = 4;
 }
 
 message ProtoAwsPrivatelink {

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -1888,34 +1888,18 @@ impl<C: ConnectionAccess> AlterCompatible for MySqlConnection<C> {
     }
 }
 
-/// A connection to a SSH tunnel.
+/// A connection to an SSH tunnel.
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct SshConnection {
     pub host: String,
     pub port: u16,
     pub user: String,
-    pub public_keys: Option<(String, String)>,
 }
-
-use proto_ssh_connection::ProtoPublicKeys;
 
 use self::inline::{
     ConnectionAccess, ConnectionResolver, InlinedConnection, IntoInlineConnection,
     ReferencedConnection,
 };
-
-impl RustType<ProtoPublicKeys> for (String, String) {
-    fn into_proto(&self) -> ProtoPublicKeys {
-        ProtoPublicKeys {
-            primary_public_key: self.0.into_proto(),
-            secondary_public_key: self.1.into_proto(),
-        }
-    }
-
-    fn from_proto(proto: ProtoPublicKeys) -> Result<Self, TryFromProtoError> {
-        Ok((proto.primary_public_key, proto.secondary_public_key))
-    }
-}
 
 impl RustType<ProtoSshConnection> for SshConnection {
     fn into_proto(&self) -> ProtoSshConnection {
@@ -1923,7 +1907,6 @@ impl RustType<ProtoSshConnection> for SshConnection {
             host: self.host.into_proto(),
             port: self.port.into_proto(),
             user: self.user.into_proto(),
-            public_keys: self.public_keys.into_proto(),
         }
     }
 
@@ -1932,7 +1915,6 @@ impl RustType<ProtoSshConnection> for SshConnection {
             host: proto.host,
             port: proto.port.into_rust()?,
             user: proto.user,
-            public_keys: proto.public_keys.into_rust()?,
         })
     }
 }


### PR DESCRIPTION
Previously, SSH connection public keys were stored in memory in the
`CatalogState` struct. However, this information is not stored durably
in the durable catalog. The actual source of truth is an opaque
`SecretsController`. This presents a challenge for having a
multi-subscriber catalog that listens to durable updates. The catalog
has no way of learning about changes to the public keys. The in-memory
public keys will likely become inconsistent after any changes and
present incorrect information to anyone subscribing to the catalog.

This commit fixes the above issue by removing the public keys from
the `CatalogState` struct.

An alternative, and possibly better, approach would be to store the
public keys in the durable catalog directly. Unfortunately, the
public keys are owned by connections, which are a type of item. Items
must be serialized as a CREATE SQL string, so we'd have to find a way
to encode the public key in a `CREATE CONNECTION` string.

Works towards resolving #24844

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
