### PR TITLE
storage/upsert: improve perf of upsert merge operator for rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6235,6 +6235,7 @@ dependencies = [
  "rocksdb",
  "seahash",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "tempfile",
@@ -8597,6 +8598,15 @@ version = "0.7.0"
 source = "git+https://github.com/MaterializeInc/serde-value.git#a84c6b71825efaffb332c0d19f18c2bdf9ee7b40"
 dependencies = [
  "ordered-float 4.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+dependencies = [
  "serde",
 ]
 

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -568,6 +568,21 @@ who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "1.0.23"
 
+[[audits.serde]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "1.0.202"
+
+[[audits.serde_bytes]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.11.14"
+
+[[audits.serde_derive]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "1.0.202"
+
 [[audits.sized-chunks]]
 who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -85,6 +85,7 @@ rocksdb = { git = "https://github.com/MaterializeInc/rust-rocksdb", branch = "ma
 seahash = "4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
+serde_bytes = { version = "0.11.14" }
 sha2 = "0.10.6"
 timely = { version = "0.12.0", default-features = false, features = [
     "bincode",

--- a/src/storage/src/upsert/types.rs
+++ b/src/storage/src/upsert/types.rs
@@ -189,6 +189,7 @@ pub enum Value<O> {
 /// A value as produced during consolidation of a snapshot.
 #[derive(Clone, Default, serde::Serialize, serde::Deserialize, Debug)]
 pub struct Snapshotting {
+    #[serde(with = "serde_bytes")]
     value_xor: Vec<u8>,
     len_sum: Wrapping<i64>,
     checksum_sum: Wrapping<i64>,
@@ -360,7 +361,7 @@ impl<O: Default> StateValue<O> {
 
     /// Merge an existing StateValue into this one, using the same method described in `merge_update`.
     /// See the docstring above for more information on correctness and robustness.
-    pub fn merge_update_state(&mut self, other: &Self) -> bool {
+    pub fn merge_update_state(&mut self, other: &Self) {
         match (self, other) {
             (
                 Self::Snapshotting(Snapshotting {
@@ -383,7 +384,6 @@ impl<O: Default> StateValue<O> {
                 {
                     *acc ^= val;
                 }
-                diff_sum.0 == 0 && checksum_sum.0 == 0 && value_xor.iter().all(|&x| x == 0)
             }
             _ => panic!("`merge_update_state` called with non-snapshotting state"),
         }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Follow up improvement to #27064 - this uses https://docs.rs/serde_bytes/latest/serde_bytes/ to improve serialization performance of the snapshot state in the upsert operator. The merge operator added for RocksDB uses this implicitly when values are serialized using https://docs.rs/bincode/latest/bincode/ when written to and read from RocksDB.

I also discovered and fixed the upsert load generator mzcompose workflow, and ran a few test cases to do a rough performance test:

```
***On present main:***

repeat = 100 * 1024
updates_count = 20
Scenario default took [datetime.timedelta(seconds=11, microseconds=774000)] ms
Scenario RocksDB Merge Operator took [datetime.timedelta(seconds=11, microseconds=112000)] ms

***On this branch:***

repeat = 100 * 1024
updates_count = 20
Scenario default took [datetime.timedelta(seconds=10, microseconds=955000)] ms
Scenario RocksDB Merge Operator took [datetime.timedelta(seconds=9, microseconds=659000)] ms

repeat = 250 * 1024
updates_count = 5
Scenario default took [datetime.timedelta(seconds=13, microseconds=633000)] ms
Scenario RocksDB Merge Operator took [datetime.timedelta(seconds=12, microseconds=595000)] ms

repeat = 250 * 1024
updates_count = 2
Scenario default took [datetime.timedelta(seconds=5, microseconds=346000)] ms
Scenario RocksDB Merge Operator took [datetime.timedelta(seconds=4, microseconds=332000)] ms
```

With this change there appears to be a more noticeable improvement when using the merge operator implementation.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
