### PR TITLE
bump k8s-openapi feature to v1_28

### DIFF
--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.68"
-k8s-openapi = { version = "0.20.0", features = ["schemars", "v1_26"] }
+k8s-openapi = { version = "0.20.0", features = ["schemars", "v1_28"] }
 kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "ws"] }
 chrono = { version = "0.4.35", default-features = false }
 futures = "0.3.25"

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -21,7 +21,7 @@ mz-cloud-resources = { path = "../cloud-resources" }
 mz-orchestrator = { path = "../orchestrator" }
 mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }
-k8s-openapi = { version = "0.20.0", features = ["v1_26"] }
+k8s-openapi = { version = "0.20.0", features = ["v1_28"] }
 kube = { version = "0.87.1", default-features = false, features = ["client", "runtime", "ws"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -57,7 +57,7 @@ hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 insta = { version = "1.33.0", features = ["json"] }
 itertools = { version = "0.10.5" }
-k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_26"] }
+k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_28"] }
 kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
 kube-client = { version = "0.87.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
 kube-core = { version = "0.87.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
@@ -180,7 +180,7 @@ hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 insta = { version = "1.33.0", features = ["json"] }
 itertools = { version = "0.10.5" }
-k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_26"] }
+k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_28"] }
 kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
 kube-client = { version = "0.87.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
 kube-core = { version = "0.87.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }


### PR DESCRIPTION
bump k8s-openapi feature to v1_28

### Motivation

We're upgrading the k8s clusters to kubernetes 1.28, so we should update our clients to match.

### Tips for reviewer

I tried also updating the kube and k8s-openapi versions, but that pulled in a new tokio, which has a new method on their mpsc channels which conflicts with an extension we made to add a method with the same name (`recv_many`). This is sufficient for now, but we should upgrade tokio and switch to their method eventually.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  - Not a release blocker, but we'll need to update the cloud Cargo.toml files the same way when updating the submodule. That PR will come after this is merged, as we don't know the commit to bump the submodule to until then.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No user-facing behavior changes.
