### PR TITLE
postgres-inconsistency test: Ignore array order

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -56,6 +56,9 @@ from materialize.output_consistency.input_data.operations.jsonb_operations_provi
 from materialize.output_consistency.input_data.operations.string_operations_provider import (
     TAG_REGEX,
 )
+from materialize.output_consistency.input_data.return_specs.array_return_spec import (
+    ArrayReturnTypeSpec,
+)
 from materialize.output_consistency.input_data.return_specs.jsonb_return_spec import (
     JsonbReturnTypeSpec,
 )
@@ -211,6 +214,11 @@ class PgPreExecutionInconsistencyIgnoreFilter(
             return_type_spec = expression.args[0].resolve_return_type_spec()
             if isinstance(return_type_spec, StringReturnTypeSpec):
                 return YesIgnore("#22002: ordering on text different (min/max)")
+
+        if db_function.function_name_in_lower_case in {"min", "max"}:
+            return_type_spec = expression.args[0].resolve_return_type_spec()
+            if isinstance(return_type_spec, ArrayReturnTypeSpec):
+                return YesIgnore("#27457: ordering on array different (min/max)")
 
         if db_function.function_name_in_lower_case == "replace":
             # replace is not working properly with empty text; however, it is not possible to reliably determine if an


### PR DESCRIPTION
See https://github.com/MaterializeInc/materialize/issues/27457


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
