### PR TITLE
dev docs: Encourage git pushfwl

### DIFF
--- a/doc/developer/guide-changes.md
+++ b/doc/developer/guide-changes.md
@@ -873,6 +873,21 @@ rather than its internal details. Always use your best judgment.
 Our testing philosophy is covered in much greater detail in
 [Developer guide: testing](guide-testing.md).
 
+### Force-Pushing to your PR Branch
+
+There is a culture at Materialize of other developers fixing small issues in
+someone's pull request by pushing to the branch directly. QA also uses this to
+add tests for newly introduced or changed features. It is easy to accidentally
+overwrite such changes on your PR when you force-push to your branch using
+`git push --force`. To prevent this you should force-push only with a lease,
+which will prevent you from accidentally overwriting new changes your teammates
+may have added to your PR:
+
+```bash
+$ git config --global alias.pushfwl "push --force-with-lease"
+$ git pushfwl
+```
+
 ## Deviations from Google
 
 As mentioned at the start of this guide, much of the above advice derives from


### PR DESCRIPTION
See also https://materializeinc.slack.com/archives/CQY8LN96Y/p1713536183221339

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
