### PR TITLE
slt: Fix mztimestamp conversion errors

### DIFF
--- a/test/sqllogictest/mztimestamp.slt
+++ b/test/sqllogictest/mztimestamp.slt
@@ -89,11 +89,11 @@ SELECT '1 hour'::interval::mz_timestamp::timestamp, '1 hour'::interval::mz_times
 262142-12-31 07:00:00+00
 
 # Roughly `HIGH_DATE` + 1 day.
-query error db error: ERROR: timestamp out of range
+query error timestamp out of range
 SELECT 8210266898400000::mz_timestamp::timestamp
 
-query error db error: ERROR: timestamp out of range
+query error timestamp out of range
 SELECT 18446744073709551615::mz_timestamp::timestamp
 
-query error db error: ERROR: timestamp out of range
+query error timestamp out of range
 SELECT 8210266898400000::mz_timestamp::timestamptz


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/slt/builds/5947#018fe8ed-2cb6-4002-bd45-e7911dc7d916

Necessary because with --auto-index-selects the error message prefix is different.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
