### PR TITLE
catalog: Remove replica statuses from state

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1074,6 +1074,14 @@ impl Catalog {
         self.state.get_cluster_replica(cluster_id, replica_id)
     }
 
+    pub fn try_get_cluster_replica(
+        &self,
+        cluster_id: ClusterId,
+        replica_id: ReplicaId,
+    ) -> Option<&ClusterReplica> {
+        self.state.try_get_cluster_replica(cluster_id, replica_id)
+    }
+
     pub fn user_cluster_replicas(&self) -> impl Iterator<Item = &ClusterReplica> {
         self.user_clusters().flat_map(|cluster| cluster.replicas())
     }

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -31,8 +31,8 @@ use mz_catalog::builtin::{
 use mz_catalog::config::AwsPrincipalContext;
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
-    CatalogItem, ClusterVariant, Connection, DataSourceDesc, Func, Index, MaterializedView, Sink,
-    Table, Type, View,
+    CatalogItem, ClusterReplicaProcessStatus, ClusterVariant, Connection, DataSourceDesc, Func,
+    Index, MaterializedView, Sink, Table, Type, View,
 };
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_controller::clusters::{
@@ -364,14 +364,14 @@ impl CatalogState {
         updates
     }
 
-    pub(super) fn pack_cluster_replica_status_update(
+    // TODO(jkosh44) This should not be a builtin table, it should be a builtin source.
+    pub(crate) fn pack_cluster_replica_status_update(
         &self,
-        cluster_id: ClusterId,
         replica_id: ReplicaId,
         process_id: ProcessId,
+        event: &ClusterReplicaProcessStatus,
         diff: Diff,
     ) -> BuiltinTableUpdate {
-        let event = self.get_cluster_status(cluster_id, replica_id, process_id);
         let status = event.status.as_kebab_case_str();
 
         let not_ready_reason = match event.status {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1639,6 +1639,7 @@ impl Coordinator {
                 )
             })
             .collect();
+        let now = self.now_datetime();
         for (cluster_id, replica_statuses) in cluster_statuses {
             self.cluster_replica_statuses
                 .initialize_cluster_statuses(cluster_id);
@@ -1648,7 +1649,7 @@ impl Coordinator {
                         cluster_id,
                         replica_id,
                         num_processes,
-                        self.now_datetime(),
+                        now,
                     );
             }
         }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -571,12 +571,13 @@ impl Coordinator {
                 }
             }
         }
+        let now = to_datetime((catalog.config().now)());
         for (cluster_id, replica_id, num_processes) in cluster_replicas_to_create {
             cluster_replica_statuses.initialize_cluster_replica_statuses(
                 cluster_id,
                 replica_id,
                 num_processes,
-                to_datetime((catalog.config().now)()),
+                now,
             );
             for (process_id, status) in
                 cluster_replica_statuses.get_cluster_replica_statuses(cluster_id, replica_id)

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -30,6 +30,7 @@ use mz_controller_types::{ClusterId, ReplicaId};
 use mz_ore::error::ErrorExt;
 use mz_ore::future::InTask;
 use mz_ore::instrument;
+use mz_ore::now::to_datetime;
 use mz_ore::retry::Retry;
 use mz_ore::str::StrExt;
 use mz_ore::task;
@@ -199,6 +200,8 @@ impl Coordinator {
         let mut cluster_replicas_to_drop = vec![];
         let mut compute_sinks_to_drop = BTreeMap::new();
         let mut peeks_to_drop = vec![];
+        let mut clusters_to_create = vec![];
+        let mut cluster_replicas_to_create = vec![];
         let mut update_tracing_config = false;
         let mut update_compute_config = false;
         let mut update_storage_config = false;
@@ -377,6 +380,21 @@ impl Coordinator {
                     });
                     webhook_sources_to_restart.extend(webhook_sources);
                 }
+                catalog::Op::CreateCluster { id, .. } => {
+                    clusters_to_create.push(*id);
+                }
+                catalog::Op::CreateClusterReplica {
+                    cluster_id,
+                    id,
+                    config,
+                    ..
+                } => {
+                    cluster_replicas_to_create.push((
+                        *cluster_id,
+                        *id,
+                        config.location.num_processes(),
+                    ));
+                }
                 _ => (),
             }
         }
@@ -497,17 +515,81 @@ impl Coordinator {
             catalog,
             active_conns,
             controller,
+            cluster_replica_statuses,
             ..
         } = self;
         let catalog = Arc::make_mut(catalog);
         let conn = conn_id.map(|id| active_conns.get(id).expect("connection must exist"));
 
         let TransactionResult {
-            builtin_table_updates,
+            mut builtin_table_updates,
             audit_events,
         } = catalog
             .transact(Some(&mut *controller.storage), oracle_write_ts, conn, ops)
             .await?;
+
+        // Update in-memory cluster replica statuses.
+        // TODO(jkosh44) All the builtin table updates should be handled as a builtin source
+        // updates elsewhere.
+        for (cluster_id, replica_id) in &cluster_replicas_to_drop {
+            let replica_statuses =
+                cluster_replica_statuses.remove_cluster_replica_statuses(cluster_id, replica_id);
+            for (process_id, status) in replica_statuses {
+                let builtin_table_update = catalog.state().pack_cluster_replica_status_update(
+                    *replica_id,
+                    process_id,
+                    &status,
+                    -1,
+                );
+                builtin_table_updates.push(builtin_table_update);
+            }
+        }
+        for cluster_id in &clusters_to_drop {
+            let cluster_statuses = cluster_replica_statuses.remove_cluster_statuses(cluster_id);
+            for (replica_id, replica_statuses) in cluster_statuses {
+                for (process_id, status) in replica_statuses {
+                    let builtin_table_update = catalog
+                        .state()
+                        .pack_cluster_replica_status_update(replica_id, process_id, &status, -1);
+                    builtin_table_updates.push(builtin_table_update);
+                }
+            }
+        }
+        for cluster_id in clusters_to_create {
+            cluster_replica_statuses.initialize_cluster_statuses(cluster_id);
+            for (replica_id, replica_statuses) in
+                cluster_replica_statuses.get_cluster_statuses(cluster_id)
+            {
+                for (process_id, status) in replica_statuses {
+                    let builtin_table_update = catalog.state().pack_cluster_replica_status_update(
+                        *replica_id,
+                        *process_id,
+                        status,
+                        1,
+                    );
+                    builtin_table_updates.push(builtin_table_update);
+                }
+            }
+        }
+        for (cluster_id, replica_id, num_processes) in cluster_replicas_to_create {
+            cluster_replica_statuses.initialize_cluster_replica_statuses(
+                cluster_id,
+                replica_id,
+                num_processes,
+                to_datetime((catalog.config().now)()),
+            );
+            for (process_id, status) in
+                cluster_replica_statuses.get_cluster_replica_statuses(cluster_id, replica_id)
+            {
+                let builtin_table_update = catalog.state().pack_cluster_replica_status_update(
+                    replica_id,
+                    *process_id,
+                    status,
+                    1,
+                );
+                builtin_table_updates.push(builtin_table_update);
+            }
+        }
 
         // Append our builtin table updates, then return the notify so we can run other tasks in
         // parallel.
@@ -1322,13 +1404,12 @@ impl Coordinator {
                 | Op::UpdateOwner { .. }
                 | Op::RevokeRole { .. }
                 | Op::UpdateClusterConfig { .. }
-                | Op::UpdateClusterReplicaStatus { .. }
                 | Op::UpdateStorageUsage { .. }
                 | Op::UpdateSystemConfiguration { .. }
                 | Op::ResetSystemConfiguration { .. }
                 | Op::ResetAllSystemConfiguration { .. }
                 | Op::Comment { .. }
-                | Op::SshTunnelConnectionsUpdates { .. }
+                | Op::WeirdBuiltinTableUpdates { .. }
                 | Op::TransactionDryRun => {}
             }
         }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -670,7 +670,7 @@ impl Coordinator {
                 &public_key_set,
                 1,
             );
-            ops.push(catalog::Op::SshTunnelConnectionsUpdates {
+            ops.push(catalog::Op::WeirdBuiltinTableUpdates {
                 builtin_table_update,
             });
         }
@@ -1594,7 +1594,7 @@ impl Coordinator {
                     .collect(),
             )))
             .chain(ssh_tunnel_updates.into_iter().map(|builtin_table_update| {
-                catalog::Op::SshTunnelConnectionsUpdates {
+                catalog::Op::WeirdBuiltinTableUpdates {
                     builtin_table_update,
                 }
             }))
@@ -3357,10 +3357,10 @@ impl Coordinator {
             1,
         );
         let ops = vec![
-            catalog::Op::SshTunnelConnectionsUpdates {
+            catalog::Op::WeirdBuiltinTableUpdates {
                 builtin_table_update: builtin_table_retraction,
             },
-            catalog::Op::SshTunnelConnectionsUpdates {
+            catalog::Op::WeirdBuiltinTableUpdates {
                 builtin_table_update: builtin_table_addition,
             },
         ];


### PR DESCRIPTION
Previously, cluster replica statuses were stored in memory in the
`CatalogState` struct. However, this information is not stored durably
in the durable catalog, it's ephemeral information. This presents a
challenge for having a multi-subscriber catalog that listens to durable
updates. The catalog has no way of learning about changes to the
replica statuses. The in-memory statuses will likely become
inconsistent after any changes and present incorrect information to
anyone subscribing to the catalog.

This commit fixes the above issue by removing the statuses from
the `CatalogState` struct and moving to to the `Coordinator`. These
statuses are only used in two places:

  1. In the `Coordinator` when processing cluster status update
  messages.
  2. To update the builtin table `mz_cluster_replica_statuses`.

The first usage makes the `Coordinator` a good place to put the
statuses. The second usage should be removed and
`mz_cluster_replica_statuses` should be a `BuiltinSource` instead of
a `BuiltinTable`. That work is saved for a future commit.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
