### PR TITLE
timely-util: reclaim memory used for stash vec

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -31,12 +31,6 @@ def get_ancestor_overrides_for_performance_regressions(
     # Commits must be ordered descending by their date.
     min_ancestor_mz_version_per_commit = dict()
 
-    if scenario_class_name == "ParallelIngestion":
-        # PR#27058 (storage: wire up new reclock implementation) increased memory usage
-        min_ancestor_mz_version_per_commit[
-            "10abb1cca257ffc3d605c99ed961e037bbf3fa51"
-        ] = MzVersion.parse_mz("v0.103.0")
-
     if "OptbenchTPCH" in scenario_class_name:
         # PR#26652 (explain: fix tracing fast path regression) significantly increased wallclock for OptbenchTPCH
         min_ancestor_mz_version_per_commit[

--- a/src/timely-util/src/reclock.rs
+++ b/src/timely-util/src/reclock.rs
@@ -246,7 +246,6 @@ where
         // The frontier of the `events` input
         let mut source_frontier = MutableAntichain::new_bottom(FromTime::minimum());
 
-        let mut stash = Vec::new();
         let mut binding_buffer = Vec::new();
         let mut remap_buffer = Vec::new();
         let mut interesting_times = Vec::new();
@@ -298,6 +297,7 @@ where
             //         chains that results from sorting the updates by `FromTime`, and then
             //         segmenting the sequence at elements where the partial order on `FromTime` is
             //         violated.
+            let mut stash = Vec::new();
             while let Some(event) = events.pull() {
                 match event.as_mut() {
                     Event::Progress(changes) => {
@@ -307,7 +307,7 @@ where
                 }
             }
             stash.sort_unstable_by(|(_, t1, _): &(D, FromTime, R), (_, t2, _)| t1.cmp(t2));
-            let mut new_source_updates = ChainBatch::from_iter(stash.drain(..));
+            let mut new_source_updates = ChainBatch::from_iter(stash);
 
             // STEP 4: Reclock new and deferred updates
             //         We are now ready to step through the remap bindings in time order and


### PR DESCRIPTION
### Motivation

The current version of the reclock operator maintains a stash vector whose capacity only ratchets upwards as it's being used. This means that if the operator processes a spike of input the memory of that vector will spike too and will never be reclaimed.

This PR recycles the stash buffer every time the operator gets scheduled. A more complicated buffer management strategy might need to be considered in the future but for now all benchmarks seem happy with this change.

Fixes #27425

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
