### PR TITLE
mysql-cdc tests: Enable ALTER SOURCE depending scenarios

### DIFF
--- a/test/mysql-cdc-resumption/alter-mz.td
+++ b/test/mysql-cdc-resumption/alter-mz.td
@@ -7,6 +7,4 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TODO #24975 (support ALTER SOURCE)
-# Uncomment all calls to alter-mz.td in test/mysql-cdc-resumption/mzcompose.py
 > DROP SOURCE t0;

--- a/test/mysql-cdc-resumption/mzcompose.py
+++ b/test/mysql-cdc-resumption/mzcompose.py
@@ -311,7 +311,7 @@ def disconnect_mysql_during_snapshot(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
-        # "alter-mz.td",
+        "alter-mz.td",
     )
 
 
@@ -323,12 +323,12 @@ def restart_mysql_during_snapshot(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
-        # "alter-mz.td",
+        "alter-mz.td",
     )
 
 
 def restart_mz_during_snapshot(c: Composition) -> None:
-    # run_testdrive_files(c, "alter-mz.td")
+    run_testdrive_files(c, "alter-mz.td")
     restart_mz(c)
 
     run_testdrive_files(c, "delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
@@ -341,7 +341,7 @@ def disconnect_mysql_during_replication(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
-        # "alter-mz.td",
+        "alter-mz.td",
         "toxiproxy-close-connection.td",
         "toxiproxy-restore-connection.td",
     )
@@ -353,7 +353,7 @@ def restart_mysql_during_replication(c: Composition) -> None:
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "alter-table.td",
-        # "alter-mz.td",
+        "alter-mz.td",
     )
 
     restart_mysql(c)
@@ -367,7 +367,7 @@ def restart_mz_during_replication(c: Composition) -> None:
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "alter-table.td",
-        # "alter-mz.td",
+        "alter-mz.td",
     )
 
     restart_mz(c)
@@ -381,7 +381,7 @@ def fix_mysql_schema_while_mz_restarts(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
-        # "alter-mz.td",
+        "alter-mz.td",
         "verify-data.td",
         "alter-table-fix.td",
     )
@@ -401,7 +401,7 @@ def verify_no_snapshot_reingestion(c: Composition) -> None:
         "delete-rows-t1.td",
         "delete-rows-t2.td",
         "alter-table.td",
-        # "alter-mz.td",
+        "alter-mz.td",
     )
 
 
@@ -480,6 +480,7 @@ def transaction_with_rollback(c: Composition) -> None:
     run_testdrive_files(
         c,
         "alter-table.td",
+        "alter-mz.td",
     )
 
 
@@ -501,12 +502,7 @@ def mysql_out_of_disk_space(c: Composition) -> None:
     time.sleep(30)
     c.exec("mysql", "bash", "-c", f"rm {fill_file}")
 
-    run_testdrive_files(
-        c,
-        "delete-rows-t2.td",
-        "alter-table.td",
-        # "alter-mz.td"
-    )
+    run_testdrive_files(c, "delete-rows-t2.td", "alter-table.td", "alter-mz.td")
 
 
 def backup_restore_mysql(c: Composition) -> None:

--- a/test/mysql-cdc-resumption/verify-data.td
+++ b/test/mysql-cdc-resumption/verify-data.td
@@ -26,6 +26,5 @@ contains:incompatible schema change
 > SELECT COUNT(*) = 0 FROM mz_internal.mz_source_statuses WHERE error LIKE '%Connection refused%';
 true
 
-# TODO #24975 (support ALTER SOURCE)
-# ! SELECT * FROM t0
-# contains:unknown catalog item 't0'
+! SELECT * FROM t0
+contains:unknown catalog item 't0'

--- a/test/mysql-cdc/alter-column-irrelevant.td
+++ b/test/mysql-cdc/alter-column-irrelevant.td
@@ -58,7 +58,6 @@ $ mysql-execute name=mysql
 ALTER TABLE t1 ADD COLUMN f3 INTEGER FIRST;
 INSERT INTO t1 VALUES (3, 3, 3);
 
-# TODO #24975 (ordered column change requires ALTER SOURCE support)
 ! SELECT * FROM t1;
 contains:incompatible schema change
 


### PR DESCRIPTION
Since #24975 landed: https://buildkite.com/materialize/nightly/builds/7998#018fe974-4cd3-4db0-bcaa-61f44cbaff61

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
