### PR TITLE
kafka-rtr test: Fix up verification

### DIFF
--- a/test/kafka-rtr/simple/verify-rtr.td
+++ b/test/kafka-rtr/simple/verify-rtr.td
@@ -81,26 +81,22 @@ A,B,0
 > SELECT sum FROM sum;
 5000207
 
-# Try subscribing
-> BEGIN
-> DECLARE c1 CURSOR FOR SELECT city FROM input_1 WHERE city = 'ABC'
-> DECLARE c2 CURSOR FOR SELECT city FROM input_2 WHERE city = 'DEF'
-
+# Try RTR with transactions: First SELECT determines timestamp
 $ kafka-ingest topic=input_1 format=bytes repeat=1
 ABC,B,0
 
 $ kafka-ingest topic=input_2 format=bytes repeat=1
 DEF,B,0
 
-> FETCH ALL c1
+> BEGIN
+
+> SELECT city FROM input_1 WHERE city = 'ABC';
 ABC
 
-# TODO(def-) Reenable rest of the test when #27393 is fixed
-# > FETCH ALL c2
-# DEF
-#
-# > DECLARE c3 CURSOR FOR SELECT sum FROM sum;
-# > FETCH ALL c3
-# 5000209
-#
-# > COMMIT
+> SELECT city FROM input_2 WHERE city = 'DEF';
+DEF
+
+> SELECT sum FROM sum;
+5000209
+
+> COMMIT


### PR DESCRIPTION
Based on discussion in
https://github.com/MaterializeInc/materialize/issues/27393 there seems to be no product issue.

The transaction's first SELECT will determine the timestamp for the rest of the transaction, so we have to run the ingestions before that. The SELECT+FETCH pattern is not useful at all.

Fixes: https://github.com/MaterializeInc/materialize/issues/27393

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
