### PR TITLE
ci: remove color from annotations

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -124,20 +124,7 @@ IGNORE_RE = re.compile(
     re.VERBOSE | re.MULTILINE,
 )
 
-TERMINAL_COLORS_RE = re.compile(
-    r"""
-    \x1B  # ESC
-    (?:   # 7-bit C1 Fe (except CSI)
-        [@-Z\\-_]
-    |     # or [ for CSI, followed by a control sequence
-        \[
-        [0-?]*  # Parameter bytes
-        [ -/]*  # Intermediate bytes
-        [@-~]   # Final byte
-    )
-""",
-    re.VERBOSE,
-)
+COLOR_FORMATTING_RE = re.compile(r"\[\d+m(.*?)\[0m")
 
 
 @dataclass
@@ -456,7 +443,7 @@ def _collect_service_panics_in_logs(data: Any, log_file_name: str) -> list[Error
 
 
 def sanitize_text(text: str, max_length: int = 4000) -> str:
-    text = TERMINAL_COLORS_RE.sub("", text)
+    text = COLOR_FORMATTING_RE.sub(r"\1", text)
 
     if len(text) > max_length:
         text = text[:max_length] + " [...]"

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -31,6 +31,7 @@ from materialize.buildkite_insights.steps.build_step import (
     BuildStepMatcher,
     extract_build_step_outcomes,
 )
+from materialize.terminal import remove_formattings
 
 CI_RE = re.compile("ci-regexp: (.*)")
 CI_APPLY_TO = re.compile("ci-apply-to: (.*)")
@@ -123,8 +124,6 @@ IGNORE_RE = re.compile(
     """,
     re.VERBOSE | re.MULTILINE,
 )
-
-COLOR_FORMATTING_RE = re.compile(r"\[\d+m(.*?)\[0m")
 
 
 @dataclass
@@ -443,7 +442,7 @@ def _collect_service_panics_in_logs(data: Any, log_file_name: str) -> list[Error
 
 
 def sanitize_text(text: str, max_length: int = 4000) -> str:
-    text = COLOR_FORMATTING_RE.sub(r"\1", text)
+    text = remove_formattings(text)
 
     if len(text) > max_length:
         text = text[:max_length] + " [...]"

--- a/misc/python/materialize/terminal.py
+++ b/misc/python/materialize/terminal.py
@@ -9,6 +9,7 @@
 
 """Terminal utilities."""
 
+import re
 
 COLOR_GREEN = "\033[92m"
 COLOR_RED = "\033[91m"
@@ -21,6 +22,8 @@ COLOR_BAD = COLOR_RED
 STYLE_BOLD = "\033[1m"
 _END_FORMATTING = "\033[0m"
 
+_COLOR_FORMATTING_RE = re.compile(r"\[\d+m(.*?)\[0m")
+
 
 def with_formatting(text: str, formatting: str) -> str:
     return with_formattings(text, [formatting])
@@ -29,3 +32,7 @@ def with_formatting(text: str, formatting: str) -> str:
 def with_formattings(text: str, formattings: list[str]) -> str:
     formatting = "".join(formattings)
     return f"{formatting}{text}{_END_FORMATTING}"
+
+
+def remove_formattings(text: str) -> str:
+    return _COLOR_FORMATTING_RE.sub(r"\1", text)


### PR DESCRIPTION
This improves https://github.com/MaterializeInc/materialize/pull/27431.

<s>I am aware that this is rather greedy and could potentially match things it should not...</s>

Reworked the approach.

The junit file contains:
```
----------------------------------------------------------------------------------------------------
Insert                              | wallclock |           1.400 |           1.440 |      no       | [92m2.7 pct   less/faster[0m
Insert                              | messages  |            None |            None |      no       | N/A
Insert                              | memory    |        3108.978 |        2728.462 |    !!YES!!    | [91m13.9 pct   more/slower[0m</error>
```