### PR TITLE
postgres consistency: improve ignores, add likely needed ones

### DIFF
--- a/misc/python/materialize/output_consistency/expression/expression.py
+++ b/misc/python/materialize/output_consistency/expression/expression.py
@@ -48,6 +48,11 @@ class Expression:
         raise NotImplementedError
 
     def resolve_return_type_spec(self) -> ReturnTypeSpec:
+        """
+        Ignore filters should favor #resolve_return_type_category over this method whenever possible because that method
+        resolves dynamic types.
+        :return: the return type spec
+        """
         raise NotImplementedError
 
     def resolve_return_type_category(self) -> DataTypeCategory:

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -342,10 +342,17 @@ class PgPreExecutionInconsistencyIgnoreFilter(
                 )
 
         if db_operation.is_tagged(TAG_EQUALITY_ORDERING):
-            return_type_category = expression.args[0].resolve_return_type_category()
-            if return_type_category == DataTypeCategory.STRING:
+            return_type_category_1 = expression.args[0].resolve_return_type_category()
+            return_type_category_2 = expression.args[1].resolve_return_type_category()
+            if DataTypeCategory.STRING in {
+                return_type_category_1,
+                return_type_category_2,
+            }:
                 return YesIgnore("#22002: ordering on text different (<, <=, ...)")
-            if return_type_category == DataTypeCategory.JSONB:
+            if DataTypeCategory.JSONB in {
+                return_type_category_1,
+                return_type_category_2,
+            }:
                 return YesIgnore("#26309: ordering on JSON different")
 
         if db_operation.pattern == "CAST ($ AS $)" and expression.matches(

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -56,14 +56,8 @@ from materialize.output_consistency.input_data.operations.jsonb_operations_provi
 from materialize.output_consistency.input_data.operations.string_operations_provider import (
     TAG_REGEX,
 )
-from materialize.output_consistency.input_data.return_specs.array_return_spec import (
-    ArrayReturnTypeSpec,
-)
 from materialize.output_consistency.input_data.return_specs.number_return_spec import (
     NumericReturnTypeSpec,
-)
-from materialize.output_consistency.input_data.return_specs.string_return_spec import (
-    StringReturnTypeSpec,
 )
 from materialize.output_consistency.input_data.types.number_types_provider import (
     DOUBLE_TYPE_IDENTIFIER,
@@ -208,13 +202,13 @@ class PgPreExecutionInconsistencyIgnoreFilter(
             return YesIgnore("#21997: lpad with negative")
 
         if db_function.function_name_in_lower_case in {"min", "max"}:
-            return_type_spec = expression.args[0].resolve_return_type_spec()
-            if isinstance(return_type_spec, StringReturnTypeSpec):
+            return_type_category = expression.args[0].resolve_return_type_category()
+            if return_type_category == DataTypeCategory.STRING:
                 return YesIgnore("#22002: ordering on text different (min/max)")
 
         if db_function.function_name_in_lower_case in {"min", "max"}:
-            return_type_spec = expression.args[0].resolve_return_type_spec()
-            if isinstance(return_type_spec, ArrayReturnTypeSpec):
+            return_type_category = expression.args[0].resolve_return_type_category()
+            if return_type_category == DataTypeCategory.ARRAY:
                 return YesIgnore("#27457: ordering on array different (min/max)")
 
         if db_function.function_name_in_lower_case == "replace":

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -59,9 +59,6 @@ from materialize.output_consistency.input_data.operations.string_operations_prov
 from materialize.output_consistency.input_data.return_specs.array_return_spec import (
     ArrayReturnTypeSpec,
 )
-from materialize.output_consistency.input_data.return_specs.jsonb_return_spec import (
-    JsonbReturnTypeSpec,
-)
 from materialize.output_consistency.input_data.return_specs.number_return_spec import (
     NumericReturnTypeSpec,
 )
@@ -345,10 +342,10 @@ class PgPreExecutionInconsistencyIgnoreFilter(
                 )
 
         if db_operation.is_tagged(TAG_EQUALITY_ORDERING):
-            return_type_spec = expression.args[0].resolve_return_type_spec()
-            if isinstance(return_type_spec, StringReturnTypeSpec):
+            return_type_category = expression.args[0].resolve_return_type_category()
+            if return_type_category == DataTypeCategory.STRING:
                 return YesIgnore("#22002: ordering on text different (<, <=, ...)")
-            if isinstance(return_type_spec, JsonbReturnTypeSpec):
+            if return_type_category == DataTypeCategory.JSONB:
                 return YesIgnore("#26309: ordering on JSON different")
 
         if db_operation.pattern == "CAST ($ AS $)" and expression.matches(

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -205,9 +205,8 @@ class PgPreExecutionInconsistencyIgnoreFilter(
             return_type_category = expression.args[0].resolve_return_type_category()
             if return_type_category == DataTypeCategory.STRING:
                 return YesIgnore("#22002: ordering on text different (min/max)")
-
-        if db_function.function_name_in_lower_case in {"min", "max"}:
-            return_type_category = expression.args[0].resolve_return_type_category()
+            if return_type_category == DataTypeCategory.JSONB:
+                return YesIgnore("#26309: ordering on JSON different (min/max)")
             if return_type_category == DataTypeCategory.ARRAY:
                 return YesIgnore("#27457: ordering on array different (min/max)")
 
@@ -347,7 +346,12 @@ class PgPreExecutionInconsistencyIgnoreFilter(
                 return_type_category_1,
                 return_type_category_2,
             }:
-                return YesIgnore("#26309: ordering on JSON different")
+                return YesIgnore("#26309: ordering on JSON different (<, <=, ...)")
+            if DataTypeCategory.ARRAY in {
+                return_type_category_1,
+                return_type_category_2,
+            }:
+                return YesIgnore("#27457: ordering on array different (<, <=, ...)")
 
         if db_operation.pattern == "CAST ($ AS $)" and expression.matches(
             partial(


### PR DESCRIPTION
This
* fixes https://buildkite.com/materialize/nightly/builds/7998#018fe974-4dab-4ed1-9001-7edbc2eee8fb
* improves other ignores
* adds likely needed additional ignores

As for the build failure with expression `(coalesce(right(varchar_8_val_2, int4_max)) < varchar_8_val_w_spaces)`, the ignore pattern for `TEXT < TEXT` was present but did not match because the first argument (`coalesce`) resolved to `DynamicReturnTypeSpec` while the filter was working on `StringReturnTypeSpec`.

### Commits
2bbce31225 postgres consistency: improve ignore to work properly with types only known at runtime
8578912c54 postgres consistency: extend ignore to also apply on less accurate type information
d63d41950c postgres consistency: rework other ignore
562001b20d postgres consistency: add likely needed ignores
b24e3d3886 output consistency: add comment
