### PR TITLE
ci: annotate errors: uploading build results should not cause the build to fail

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -59,8 +59,6 @@ ERROR_RE = re.compile(
     | SUMMARY:\ .*Sanitizer
     # for miri test summary
     | (FAIL|TIMEOUT)\s+\[\s*\d+\.\d+s\]
-    # test history database
-    | Uploading\ results\ failed
     )
     .* $
     """,


### PR DESCRIPTION
This must not cause the build fail, in particular in the test pipeline. 