### PR TITLE
RTR is not guaranteed in transactions

### DIFF
--- a/test/kafka-rtr/simple/verify-rtr.td
+++ b/test/kafka-rtr/simple/verify-rtr.td
@@ -80,23 +80,3 @@ A,B,0
 
 > SELECT sum FROM sum;
 5000207
-
-# Try RTR with transactions: First SELECT determines timestamp
-$ kafka-ingest topic=input_1 format=bytes repeat=1
-ABC,B,0
-
-$ kafka-ingest topic=input_2 format=bytes repeat=1
-DEF,B,0
-
-> BEGIN
-
-> SELECT city FROM input_1 WHERE city = 'ABC';
-ABC
-
-> SELECT city FROM input_2 WHERE city = 'DEF';
-DEF
-
-> SELECT sum FROM sum;
-5000209
-
-> COMMIT


### PR DESCRIPTION

### Motivation

Real time recency does not play well with interactive transactions where the system must commit to a timestamp to run statements at upfront but the set of sources on which the user intends to run queries on is revealed as the queries come in.

If a source that was not known at the time of the first query of a transaction is used in a subsequent query we have two options:
1. Run RTR and continue with the transaction if the timestamp we have already committed to is compatible (i.e contains all upstream changes)
2. Ignore RTR completely and run all queries at the timestamp determined in the beginning of the transaction.

Materialize currently does option 2, which may be surprising to users that have RTR enabled. We should think about whether option 1 would be preferable from a product pespective. That said, if the user is using frequently changing sources then option 1 would almost certainly raise a timestamp error.

In any case, this PR removes the test of RTR since it is incompatible with both options at the moment.

Fixes #27393

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
