### PR TITLE
bazel build: Remove insta dev dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,6 @@ dependencies = [
  "clap",
  "convert_case",
  "guppy",
- "insta",
  "once_cell",
  "proc-macro2",
  "protobuf-parse",

--- a/misc/bazel/cargo-gazelle/Cargo.toml
+++ b/misc/bazel/cargo-gazelle/Cargo.toml
@@ -30,9 +30,6 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 workspace-hack = { version = "0.0.0", path = "../../../src/workspace-hack", optional = true }
 
-[dev-dependencies]
-insta = "1.32"
-
 [features]
 default = ["workspace-hack"]
 


### PR DESCRIPTION
Unused dependency

Seen in https://buildkite.com/materialize/nightly/builds/8007#018fed53-d15a-491e-9ab3-951a87d41c46

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
