### PR TITLE
revert "storage: wire up new reclock implementation"

### DIFF
--- a/src/storage/src/metrics/source.rs
+++ b/src/storage/src/metrics/source.rs
@@ -35,6 +35,7 @@ pub(crate) struct GeneralSourceMetricDefs {
     // Source metrics
     pub(crate) capability: UIntGaugeVec,
     pub(crate) resume_upper: IntGaugeVec,
+    pub(crate) inmemory_remap_bindings: UIntGaugeVec,
     pub(crate) commit_upper_ready_times: UIntGaugeVec,
     pub(crate) commit_upper_accepted_times: UIntGaugeVec,
 
@@ -67,6 +68,11 @@ impl GeneralSourceMetricDefs {
                 // TODO(guswynn): should this also track the resumption frontier operator?
                 help: "The timestamp-domain resumption frontier chosen for a source's ingestion",
                 var_labels: ["source_id"],
+            )),
+            inmemory_remap_bindings: registry.register(metric!(
+                name: "mz_source_inmemory_remap_bindings",
+                help: "The number of in-memory remap bindings that reclocking a time needs to iterate over.",
+                var_labels: ["source_id", "worker_id"],
             )),
             commit_upper_ready_times: registry.register(metric!(
                 name: "mz_source_commit_upper_ready_times",
@@ -124,6 +130,8 @@ pub(crate) struct SourceMetrics {
     pub(crate) capability: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     /// The resume_upper for a source.
     pub(crate) resume_upper: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
+    /// The number of in-memory remap bindings that reclocking a time needs to iterate over.
+    pub(crate) inmemory_remap_bindings: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     /// The number of ready remap bindings that are held in the reclock commit upper operator.
     pub(crate) commit_upper_ready_times: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     /// The number of accepted remap bindings that are held in the reclock commit upper operator.
@@ -148,6 +156,9 @@ impl SourceMetrics {
             resume_upper: defs
                 .resume_upper
                 .get_delete_on_drop_gauge(vec![source_id.to_string()]),
+            inmemory_remap_bindings: defs
+                .inmemory_remap_bindings
+                .get_delete_on_drop_gauge(vec![source_id.to_string(), worker_id.to_string()]),
             commit_upper_ready_times: defs
                 .commit_upper_ready_times
                 .get_delete_on_drop_gauge(vec![source_id.to_string(), worker_id.to_string()]),

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -7,20 +7,412 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! An operator (`ReclockOperator`) that observes the progress of a stream that is
-//! timestamped with some source time `FromTime` and generates bindings that describe how the
-//! collection should evolve in target time `IntoTime`.
+//! Operators that transform collections that evolve with some timestamp `FromTime` into a
+//! collections that evolve with some other timestamp `IntoTime.
+//!
+//! Reclocking happens in two separate phases, implemented by [ReclockOperator] and
+//! [ReclockFollower] respectively.
+//!
+/// For the first phase, the `ReclockOperator` observes the progress of a stream that is
+/// timestamped with some source time `FromTime` and generates bindings that describe how the
+/// collection should evolve in target time `IntoTime`.
+///
+/// For the second phase, the `ReclockFollower` observes both the data and the progress of a
+/// collection as it evolves in the `FromTime` domain and reclocks it into a collection that
+/// evolves in `IntoTime` according to the reclock decisions that have been taken by the
+/// `ReclockOperator`.
+use std::cell::RefCell;
+use std::fmt::Display;
+use std::rc::Rc;
+
 use differential_dataflow::consolidation;
+use differential_dataflow::difference::Abelian;
 use differential_dataflow::lattice::Lattice;
 use futures::{FutureExt, StreamExt};
 use mz_persist_client::error::UpperMismatch;
 use mz_repr::Diff;
 use mz_storage_client::util::remap_handle::RemapHandle;
-use timely::order::PartialOrder;
+use mz_timely_util::antichain::AntichainExt;
+use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::frontier::{Antichain, AntichainRef, MutableAntichain};
 use timely::progress::Timestamp;
 
 pub mod compat;
+
+/// A "follower" for the ReclockOperator, that maintains a trace based on the results of reclocking
+/// and data from the source. It provides the `reclock` method, which produces messages with their
+/// associated timestamps.
+///
+/// Shareable with `.share()`
+pub struct ReclockFollower<FromTime: Timestamp, IntoTime: Timestamp + Lattice + Display> {
+    /// The `since` maintained by the local handle. This may be beyond the shared `since`
+    since: Antichain<IntoTime>,
+    pub inner: Rc<RefCell<ReclockFollowerInner<FromTime, IntoTime>>>,
+}
+
+#[derive(Debug)]
+pub struct ReclockFollowerInner<FromTime: Timestamp, IntoTime: Timestamp + Lattice + Display> {
+    /// A dTVC trace of the remap collection containing all updates at `t: since <= t < upper`.
+    // NOTE(petrosagg): Once we write this as a timely operator this should just be an arranged
+    // trace of the remap collection
+    remap_trace: Vec<(FromTime, IntoTime, Diff)>,
+    /// Since frontier of the partial remap trace
+    since: MutableAntichain<IntoTime>,
+    /// Upper frontier of the partial remap trace
+    upper: Antichain<IntoTime>,
+    /// The upper frontier in terms of `FromTime`. Any attempt to reclock messages beyond this
+    /// frontier will result in an error.
+    source_upper: MutableAntichain<FromTime>,
+}
+
+impl<FromTime, IntoTime> ReclockFollower<FromTime, IntoTime>
+where
+    FromTime: Timestamp,
+    IntoTime: Timestamp + Lattice + Display,
+{
+    /// Constructs a new [ReclockFollower]
+    pub fn new(as_of: Antichain<IntoTime>) -> Self {
+        let mut since = MutableAntichain::new();
+        since.update_iter(as_of.iter().map(|t| (t.clone(), 1)));
+
+        Self {
+            since: as_of,
+            inner: Rc::new(RefCell::new(ReclockFollowerInner {
+                remap_trace: Vec::new(),
+                since,
+                upper: Antichain::from_elem(IntoTime::minimum()),
+                source_upper: MutableAntichain::new(),
+            })),
+        }
+    }
+
+    pub fn source_upper(&self) -> Antichain<FromTime> {
+        self.inner.borrow().source_upper.frontier().to_owned()
+    }
+
+    pub fn initialized(&self) -> bool {
+        let inner = self.inner.borrow();
+        PartialOrder::less_than(&inner.since.frontier(), &inner.upper.borrow())
+    }
+
+    /// Pushes a new trace batch into this [`ReclockFollower`].
+    pub fn push_trace_batch(&mut self, mut batch: ReclockBatch<FromTime, IntoTime>) {
+        let mut inner = self.inner.borrow_mut();
+        // Ensure we only add consolidated batches to our trace
+        consolidation::consolidate_updates(&mut batch.updates);
+        inner.remap_trace.extend(batch.updates.iter().cloned());
+        inner.source_upper.update_iter(
+            batch
+                .updates
+                .into_iter()
+                .map(|(src_ts, _ts, diff)| (src_ts, diff)),
+        );
+        inner.upper = batch.upper;
+    }
+
+    /// Reclocks a batch of messages timestamped with `FromTime` and returns an iterator of
+    /// messages timestamped with `IntoTime`.
+    ///
+    /// Each item of the resulting iterator will be associated with either the time it should be
+    /// reclocked to or an error indicating that a reclocking decision could not be taken with the
+    /// data that we have at hand.
+    ///
+    /// This method is most efficient when the to be reclocked iterator presents data in contiguous
+    /// runs with the same `FromTime`.
+    pub fn reclock<'a, M: 'a>(
+        &'a self,
+        batch: impl IntoIterator<Item = (M, FromTime)> + 'a,
+    ) -> impl Iterator<Item = (M, Result<IntoTime, ReclockError<FromTime>>)> + 'a
+    where
+        IntoTime: TotalOrder,
+    {
+        let mut memo: Option<(FromTime, Result<IntoTime, ReclockError<FromTime>>)> = None;
+        batch.into_iter().map(move |(msg, src_ts)| {
+            let result = match &memo {
+                Some((prev_src_ts, result)) if prev_src_ts == &src_ts => result.clone(),
+                _ => {
+                    let result = self.reclock_time_total(&src_ts);
+                    memo.insert((src_ts, result)).1.clone()
+                }
+            };
+            (msg, result)
+        })
+    }
+
+    /// Reclocks a single `FromTime` timestamp into the `IntoTime` time domain.
+    pub fn reclock_time(
+        &self,
+        src_ts: &FromTime,
+    ) -> Result<Antichain<IntoTime>, ReclockError<FromTime>> {
+        if !self.initialized() {
+            return Err(ReclockError::Uninitialized);
+        }
+        let inner = self.inner.borrow();
+        if inner.source_upper.less_equal(src_ts) {
+            return Err(ReclockError::BeyondUpper(src_ts.clone()));
+        }
+
+        // In order to understand the logic of the following section let's first consider an
+        // example of trying to reclock the FromTime D from this partial ordering:
+        //
+        //     ,--B----D
+        //    /              ,-------F----.
+        //   A              /              \
+        //    `---C--------E---------G------H
+        //
+        // ..into a target time domain where the remap collection varies according to this IntoTime
+        // partial ordering:
+        //
+        //   *----*--.---------------*------*
+        //   t0   t1  \              t2     t3
+        //             `--------------------*
+        //                                  t4
+        // ..and the FromTime frontiers at times t0, t1, t2, t3, t4 accumulate to:
+        //
+        // t0: Antichain{A}
+        // t1: Antichain{B, C}
+        // t2: Antichain{F, G}
+        // t3: Antichain{H}
+        // t4: Antichain{H}
+        //
+        // In the example above the correct answer is {t2, t4}, because this is the smallest
+        // antichain of IntoTime times such that the remap collection accumulates at each one of
+        // them to a FromTime frontier `f` such that D is not beyond `f`.
+        //
+        // We need to compute the answer by iterating over the consolidated remap trace which will
+        // present to us one diff at a time. We know that by construction at any given IntoTime
+        // time the remap collection accumulates to a well formed antichain. That is, it contains
+        // exactly one copy of mutually incomparable FromTime elements.
+        //
+        // We also know that `src_ts` is beyond the since frontier, therefore there exist witness
+        // timestamps `from_ts` that are less than or equal to `src_ts` and occur at IntoTime times
+        // with a positive diff. We also know that `src_ts` is not beyond the upper frontier,
+        // therefore all the positive diffs of the witness times must be retracted at subsequent
+        // IntoTime times.
+        //
+        // This cycle may be repeated an arbitrary amount of times until the final retraction. The
+        // IntoTime times at which the final retraction happens are the times that `src_ts` should
+        // be reclocked to.
+        //
+        // Therefore, if we filter the remap trace for witness timestamps and construct a
+        // MutableAntichain of the IntoTime times the witnesses occur at with a negated diff we'll
+        // end up computing a frontier of all the IntoTime times such that the remap collection
+        // accumulates to a frontier `f` such that `src_ts` is not beyond `f`, since the witness
+        // has been retracted.
+        //
+        // For our example above the remap trace would look like this:
+        //
+        // (A, t0, +1)
+        //
+        // (A, t1, -1)
+        // (B, t1, +1)
+        // (C, t1, +1)
+        //
+        // (B, t2, -1)
+        // (C, t2, -1)
+        // (F, t2, +1)
+        // (G, t2, +1)
+        //
+        // (F, t3, -1)
+        // (G, t3, -1)
+        // (H, t3, +1)
+        //
+        // (B, t4, -1)
+        // (C, t4, -1)
+        // (H, t4, +1)
+        //
+        // We are interested in reclocking the FromTime D so if we filter the trace for witnesses
+        // (i.e triplets such that `from_ts` is less than or equal to D) we are left with:
+        //
+        // (A, t0, +1)
+        // (A, t1, -1)
+        // (B, t1, +1)
+        // (B, t2, -1)
+        // (B, t4, -1)
+        //
+        // Keeping the IntoTime component and negating the diffs we have the following collection:
+        //
+        // (t0, -1)
+        // (t1, +1)
+        // (t1, -1)
+        // (t2, +1)
+        // (t4, +1)
+        //
+        // Processing this through a MutableAntichain will give as the desired frontier {t2, t4}
+        // since the diffs for t1 cancel out and t0 has a negative diff.
+        //
+        // While IntoTime is a partially ordered time and in the example above the answer was two
+        // separate times, we force that there is actually only one such time by requiring the
+        // ticker stream to provide a single timestamp per tick and advance its upper on each tick.
+        // This is just limitation of having the API function signatures from the original reclock
+        // implementation require a single IntoTime result. We should ideally lift that and make
+        // the reclock operators fully general.
+        let mut into_times = MutableAntichain::new();
+
+        let mut minimum = IntoTime::minimum();
+        minimum.advance_by(inner.since.frontier());
+        into_times.update_iter([(minimum, 1)]);
+
+        into_times.update_iter(
+            inner
+                .remap_trace
+                .iter()
+                .filter(|(from_ts, _, _)| PartialOrder::less_equal(from_ts, src_ts))
+                .map(|(_, into_ts, diff)| {
+                    let mut diff = *diff;
+                    diff.negate();
+                    (into_ts.clone(), diff)
+                }),
+        );
+        Ok(into_times.frontier().to_owned())
+    }
+
+    /// Reclocks a single `FromTime` timestamp into a totally ordered `IntoTime` time domain.
+    pub fn reclock_time_total(&self, src_ts: &FromTime) -> Result<IntoTime, ReclockError<FromTime>>
+    where
+        IntoTime: TotalOrder,
+    {
+        Ok(self
+            .reclock_time(src_ts)?
+            .into_option()
+            .expect("reclock_time produced the empty antichain"))
+    }
+
+    /// Reclocks a `FromTime` frontier into a `IntoTime` frontier.
+    ///
+    /// The conversion has the property that all messages that are beyond the provided `FromTime`
+    /// frontier will be relocked at times that will be beyond the returned `IntoTime` frontier.
+    /// This can be used to drive a `IntoTime` capability forward when the caller knows that a
+    /// `FromTime` frontier has advanced.
+    ///
+    /// The method returns an error if the `FromTime` frontier is not beyond the since frontier.
+    /// The error will contain the offending `FromTime`.
+    pub fn reclock_frontier(
+        &self,
+        source_frontier: AntichainRef<'_, FromTime>,
+    ) -> Result<Antichain<IntoTime>, ReclockError<FromTime>> {
+        let mut dest_frontier = self.inner.borrow().upper.clone();
+
+        for src_ts in source_frontier.iter() {
+            match self.reclock_time(src_ts) {
+                Ok(dest_ts) => {
+                    dest_frontier.extend(dest_ts);
+                }
+                Err(ReclockError::BeyondUpper(_)) => {}
+                Err(err @ ReclockError::Uninitialized) => return Err(err),
+            }
+        }
+
+        Ok(dest_frontier)
+    }
+
+    /// Reclocks an `IntoTime` frontier into a `FromTime` frontier.
+
+    /// The conversion has the property that all messages that would be reclocked to times beyond
+    /// the provided `IntoTime` frontier will be beyond the returned `FromTime` frontier. This can
+    /// be used to compute a safe starting point to resume producing an `IntoTime` collection at a
+    /// particular frontier.
+    pub fn source_upper_at_frontier<'a>(
+        &self,
+        frontier: AntichainRef<'a, IntoTime>,
+    ) -> Result<Antichain<FromTime>, ReclockError<AntichainRef<'a, IntoTime>>> {
+        let inner = self.inner.borrow();
+        if PartialOrder::less_equal(&frontier, &inner.since.frontier()) {
+            return Ok(Antichain::from_elem(FromTime::minimum()));
+        }
+        if !PartialOrder::less_than(&frontier, &inner.upper.borrow()) {
+            if PartialOrder::less_equal(&frontier, &inner.upper.borrow()) {
+                return Ok(inner.source_upper.frontier().to_owned());
+            } else if frontier.is_empty() {
+                return Ok(Antichain::new());
+            } else {
+                return Err(ReclockError::BeyondUpper(frontier));
+            }
+        }
+        let mut source_upper = MutableAntichain::new();
+
+        source_upper.update_iter(inner.remap_trace.iter().filter_map(|(src_ts, ts, diff)| {
+            if frontier
+                .iter()
+                .any(|dest_ts| PartialOrder::less_than(ts, dest_ts))
+            {
+                Some((src_ts.clone(), *diff))
+            } else {
+                None
+            }
+        }));
+        Ok(source_upper.frontier().to_owned())
+    }
+
+    /// Compacts the trace held by this reclock follower to the specified frontier.
+    ///
+    /// Reclocking has the property that it commutes with compaction. What this means is that
+    /// reclocking a collection and then compacting the result to some frontier F will produce
+    /// exactly the same result with first compacting the remap trace to frontier F and then
+    /// reclocking the collection.
+    pub fn compact(&mut self, new_since: Antichain<IntoTime>) {
+        let inner = &mut *self.inner.borrow_mut();
+        if !PartialOrder::less_equal(&self.since, &new_since) {
+            panic!(
+                "ReclockFollower: new_since={} is not beyond self.since={}. inner.since={}",
+                new_since.pretty(),
+                self.since.pretty(),
+                inner.since.pretty(),
+            );
+        }
+        inner.since.update_iter(
+            self.since
+                .iter()
+                .map(|t| (t.clone(), -1))
+                .chain(new_since.iter().map(|t| (t.clone(), 1))),
+        );
+        self.since = new_since;
+
+        // Compact the remap trace according to the computed frontier
+        for (_src_ts, ts, _diff) in inner.remap_trace.iter_mut() {
+            ts.advance_by(inner.since.frontier());
+        }
+        // And then consolidate
+        consolidation::consolidate_updates(&mut inner.remap_trace);
+    }
+
+    #[allow(dead_code)]
+    pub fn since(&self) -> AntichainRef<'_, IntoTime> {
+        self.since.borrow()
+    }
+
+    #[allow(dead_code)]
+    pub fn share(&self) -> Self {
+        self.inner
+            .borrow_mut()
+            .since
+            .update_iter(self.since.iter().map(|t| (t.clone(), 1)));
+        Self {
+            since: self.since.clone(),
+            inner: Rc::clone(&self.inner),
+        }
+    }
+
+    /// The number of remap bindings in the trace
+    pub fn size(&self) -> usize {
+        self.inner.borrow().remap_trace.len()
+    }
+}
+
+impl<FromTime: Timestamp, IntoTime: Timestamp + Lattice + Display> Drop
+    for ReclockFollower<FromTime, IntoTime>
+{
+    fn drop(&mut self) {
+        // Release read hold
+        self.compact(Antichain::new());
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReclockError<T> {
+    Uninitialized,
+    BeyondUpper(T),
+}
 
 /// The `ReclockOperator` is responsible for observing progress in the `FromTime` domain and
 /// consume messages from a ticker of progress in the `IntoTime` domain. When the source frontier
@@ -53,7 +445,7 @@ pub struct ReclockOperator<
     clock_stream: Clock,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Debug)]
 pub struct ReclockBatch<FromTime, IntoTime> {
     pub updates: Vec<(FromTime, IntoTime, Diff)>,
     pub upper: Antichain<IntoTime>,
@@ -231,19 +623,20 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::rc::Rc;
+    use std::collections::BTreeSet;
     use std::sync::Arc;
     use std::time::Duration;
 
     use futures::Stream;
+    use itertools::Itertools;
     use mz_build_info::DUMMY_BUILD_INFO;
     use mz_ore::metrics::MetricsRegistry;
     use mz_ore::now::SYSTEM_TIME;
     use mz_persist_client::cache::PersistClientCache;
     use mz_persist_client::cfg::PersistConfig;
     use mz_persist_client::rpc::PubSubClientConnection;
-    use mz_persist_client::{PersistLocation, ShardId};
+    use mz_persist_client::{Diagnostics, PersistClient, PersistLocation, ShardId};
+    use mz_persist_types::codec_impls::UnitSchema;
     use mz_repr::{GlobalId, RelationDesc, ScalarType, Timestamp};
     use mz_storage_client::util::remap_handle::RemapHandle;
     use mz_storage_types::controller::CollectionMetadata;
@@ -290,7 +683,7 @@ mod tests {
             impl RemapHandle<FromTime = kafka::KafkaTimestamp, IntoTime = Timestamp>,
             impl Stream<Item = (Timestamp, Antichain<Timestamp>)>,
         >,
-        ReclockBatch<kafka::KafkaTimestamp, Timestamp>,
+        ReclockFollower<kafka::KafkaTimestamp, Timestamp>,
     ) {
         let metadata = CollectionMetadata {
             persist_location: PersistLocation {
@@ -329,17 +722,22 @@ mod tests {
 
         let (mut operator, initial_batch) = ReclockOperator::new(remap_handle, clock_stream).await;
 
-        // In the tests we always reclock the minimum source frontier to the minimum target
-        // frontier, which we do in this step.
-        let initial_batch = if *initial_batch.upper == [Timestamp::minimum()] {
-            operator
-                .mint(Antichain::from_elem(Partitioned::minimum()).borrow())
-                .await
-        } else {
-            initial_batch
-        };
+        let mut follower = ReclockFollower::new(as_of);
 
-        (operator, initial_batch)
+        // Push any updates that might already exist in the persist shard to the follower.
+        if *initial_batch.upper == [Timestamp::minimum()] {
+            // In the tests we always reclock the minimum source frontier to the minimum target
+            // frontier, which we do in this step.
+            follower.push_trace_batch(
+                operator
+                    .mint(Antichain::from_elem(Partitioned::minimum()).borrow())
+                    .await,
+            );
+        } else {
+            follower.push_trace_batch(initial_batch);
+        }
+
+        (operator, follower)
     }
 
     /// Generates a [`kafka::NativeFrontier`] antichain where all the provided
@@ -371,55 +769,634 @@ mod tests {
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     async fn test_basic_usage() {
-        let (mut operator, initial_batch) =
+        let (mut operator, mut follower) =
             make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
-        let expected = ReclockBatch {
-            updates: vec![(
-                Partitioned::new_range(RangeBound::NegInfinity, RangeBound::PosInfinity, 0.into()),
-                0.into(),
-                1,
-            )],
-            upper: Antichain::from_elem(1.into()),
-        };
-        assert_eq!(expected, initial_batch);
 
         // Reclock offsets 1 and 3 to timestamp 1000
+        let batch = vec![
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+        ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(4))]);
-        let batch = operator.mint(source_upper.borrow()).await;
-        let expected = ReclockBatch {
-            updates: vec![
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(
+            reclocked_msgs,
+            &[(1, 1000.into()), (1, 1000.into()), (3, 1000.into())]
+        );
+
+        // This will return the antichain containing 1000 because that's where future messages will
+        // offset 1 will be reclocked to
+        let query = partitioned_frontier([(0, MzOffset::from(1))]);
+        assert_eq!(
+            Ok(Antichain::from_elem(1000.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+
+        // Reclock more messages for offsets 3 to the same timestamp
+        let batch = vec![
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+        ];
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(3, 1000.into()), (3, 1000.into())]);
+
+        // We're done with offset 3. Now reclocking the source upper will result to the overall
+        // target upper (1001) because any new bindings will be minted beyond that timestamp.
+        let query = partitioned_frontier([(0, MzOffset::from(4))]);
+
+        assert_eq!(
+            Ok(Antichain::from_elem(1001.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    async fn test_reclock_frontier() {
+        let persist_location = PersistLocation {
+            blob_uri: "mem://".to_owned(),
+            consensus_uri: "mem://".to_owned(),
+        };
+
+        let remap_shard = ShardId::new();
+
+        let persist_client = PERSIST_CACHE
+            .open(persist_location)
+            .await
+            .expect("error creating persist client");
+
+        let mut remap_read_handle = persist_client
+            .open_critical_since::<SourceData, (), Timestamp, Diff, u64>(
+                remap_shard,
+                PersistClient::CONTROLLER_CRITICAL_SINCE,
+                Diagnostics::from_purpose("test_since_hold"),
+            )
+            .await
+            .expect("error opening persist shard");
+
+        let (mut operator, mut follower) =
+            make_test_operator(remap_shard, Antichain::from_elem(0.into())).await;
+
+        let query = Antichain::from_elem(Partitioned::minimum());
+        // This is the initial source frontier so we should get the initial ts upper
+        assert_eq!(
+            Ok(Antichain::from_elem(1.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+
+        // Mint a couple of bindings for multiple partitions
+        follower.push_trace_batch(
+            operator
+                .mint(partitioned_frontier([(1, MzOffset::from(10))]).borrow())
+                .await,
+        );
+
+        follower.push_trace_batch(
+            operator
+                .mint(
+                    partitioned_frontier([(1, MzOffset::from(10)), (2, MzOffset::from(10))])
+                        .borrow(),
+                )
+                .await,
+        );
+
+        let mut remap_trace = BTreeSet::new();
+        remap_trace.extend(follower.inner.borrow().remap_trace.clone());
+        assert_eq!(
+            remap_trace,
+            BTreeSet::from_iter([
+                // Initial state
                 (
                     Partitioned::new_range(
                         RangeBound::NegInfinity,
-                        RangeBound::before(0),
-                        0.into(),
+                        RangeBound::PosInfinity,
+                        MzOffset::from(0)
+                    ),
+                    0.into(),
+                    1
+                ),
+                // updates from first mint
+                (
+                    Partitioned::new_range(
+                        RangeBound::NegInfinity,
+                        RangeBound::before(1),
+                        MzOffset::from(0)
                     ),
                     1000.into(),
-                    1,
-                ),
-                (
-                    Partitioned::new_range(RangeBound::after(0), RangeBound::PosInfinity, 0.into()),
-                    1000.into(),
-                    1,
-                ),
-                (
-                    Partitioned::new_singleton(RangeBound::exact(0), 4.into()),
-                    1000.into(),
-                    1,
+                    1
                 ),
                 (
                     Partitioned::new_range(
                         RangeBound::NegInfinity,
                         RangeBound::PosInfinity,
-                        0.into(),
+                        MzOffset::from(0)
                     ),
                     1000.into(),
-                    -1,
+                    -1
                 ),
-            ],
-            upper: Antichain::from_elem(1001.into()),
+                (
+                    Partitioned::new_range(
+                        RangeBound::after(1),
+                        RangeBound::PosInfinity,
+                        MzOffset::from(0)
+                    ),
+                    1000.into(),
+                    1
+                ),
+                (
+                    Partitioned::new_singleton(RangeBound::exact(1), MzOffset::from(10)),
+                    1000.into(),
+                    1
+                ),
+                // updates from second mint
+                (
+                    Partitioned::new_range(
+                        RangeBound::after(1),
+                        RangeBound::before(2),
+                        MzOffset::from(0)
+                    ),
+                    2000.into(),
+                    1
+                ),
+                (
+                    Partitioned::new_range(
+                        RangeBound::after(1),
+                        RangeBound::PosInfinity,
+                        MzOffset::from(0)
+                    ),
+                    2000.into(),
+                    -1
+                ),
+                (
+                    Partitioned::new_range(
+                        RangeBound::after(2),
+                        RangeBound::PosInfinity,
+                        MzOffset::from(0)
+                    ),
+                    2000.into(),
+                    1
+                ),
+                (
+                    Partitioned::new_singleton(RangeBound::exact(2), MzOffset::from(10)),
+                    2000.into(),
+                    1
+                ),
+            ])
+        );
+
+        // The initial frontier should now map to the minimum between the two partitions
+        let query = Antichain::from_elem(Partitioned::minimum());
+        assert_eq!(
+            Ok(Antichain::from_elem(1000.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+
+        // Map a frontier that advances only one of the partitions
+        let query = partitioned_frontier([(1, MzOffset::from(9))]);
+        assert_eq!(
+            Ok(Antichain::from_elem(1000.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+        let query = partitioned_frontier([(1, MzOffset::from(10))]);
+        assert_eq!(
+            Ok(Antichain::from_elem(2000.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+        // A frontier that is the upper of both partitions should map to the timestamp upper
+        let query = partitioned_frontier([(1, MzOffset::from(10)), (2, MzOffset::from(10))]);
+        assert_eq!(
+            Ok(Antichain::from_elem(2001.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+
+        // Advance the operator and confirm that we get to the next timestamp
+        follower.push_trace_batch(operator.advance().await);
+        let query = partitioned_frontier([(1, MzOffset::from(10)), (2, MzOffset::from(10))]);
+        assert_eq!(
+            Ok(Antichain::from_elem(3001.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+
+        // Compact but not enough to change the bindings
+        remap_read_handle
+            .compare_and_downgrade_since(&0, (&0, &Antichain::from_elem(900.into())))
+            .await
+            .unwrap();
+        follower.compact(Antichain::from_elem(900.into()));
+        let query = partitioned_frontier([(1, MzOffset::from(9))]);
+        assert_eq!(
+            Ok(Antichain::from_elem(1000.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+
+        // Compact enough to compact bindings
+        remap_read_handle
+            .compare_and_downgrade_since(&0, (&0, &Antichain::from_elem(1500.into())))
+            .await
+            .unwrap();
+        follower.compact(Antichain::from_elem(1500.into()));
+        let query = partitioned_frontier([(1, MzOffset::from(9))]);
+        // Now reclocking the same offset maps to the compacted binding, which is the same result
+        // as if we had reclocked offset 9 with the uncompacted bindings and then compacted that.
+        assert_eq!(
+            Ok(Antichain::from_elem(1500.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+        let query = partitioned_frontier([(1, MzOffset::from(10))]);
+        assert_eq!(
+            Ok(Antichain::from_elem(2000.into())),
+            follower.reclock_frontier(query.borrow())
+        );
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    async fn test_reclock() {
+        let (mut operator, mut follower) =
+            make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
+
+        // Reclock offsets 1 and 2 to timestamp 1000
+        let batch = vec![
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
+        ];
+        let source_upper = partitioned_frontier([(0, MzOffset::from(3))]);
+
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(1, 1000.into()), (2, 1000.into())]);
+
+        // Reclock offsets 3 and 4 to timestamp 2000
+        let batch = vec![
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
+        ];
+        let source_upper = partitioned_frontier([(0, MzOffset::from(5))]);
+
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(3, 2000.into()), (4, 2000.into())]);
+
+        // Reclock the same offsets again
+        let batch = vec![
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
+        ];
+
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(1, 1000.into()), (2, 1000.into())]);
+
+        // Reclock a batch with offsets that spans multiple bindings
+        let batch = vec![
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
+        ];
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(
+            reclocked_msgs,
+            &[
+                (1, 1000.into()),
+                (2, 1000.into()),
+                (3, 2000.into()),
+                (4, 2000.into()),
+            ]
+        );
+
+        // Reclock a batch that contains multiple messages having the same offset
+        let batch = vec![
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+        ];
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(
+            reclocked_msgs,
+            &[
+                (1, 1000.into()),
+                (1, 1000.into()),
+                (3, 2000.into()),
+                (3, 2000.into()),
+            ]
+        );
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    async fn test_reclock_gh16318() {
+        let (mut operator, mut follower) =
+            make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
+
+        // First mint bindings for 0 at timestamp 1000
+        let source_upper = partitioned_frontier([(0, MzOffset::from(50))]);
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+
+        // Then only for 1 at timestamp 2000
+        let source_upper = partitioned_frontier([(0, MzOffset::from(50)), (1, MzOffset::from(50))]);
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+
+        // Then again only for 0 at timestamp 3000
+        let source_upper =
+            partitioned_frontier([(0, MzOffset::from(100)), (1, MzOffset::from(50))]);
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+
+        // Reclockng (0, 50) must ignore the updates on the FromTime frontier that happened at
+        // timestamp 2000 since those are completely unrelated
+        let batch = vec![(
+            50,
+            Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(50)),
+        )];
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(50, 3000.into())]);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    async fn test_compaction() {
+        let persist_location = PersistLocation {
+            blob_uri: "mem://".to_owned(),
+            consensus_uri: "mem://".to_owned(),
         };
-        assert_eq!(expected, batch);
+
+        let remap_shard = ShardId::new();
+
+        let persist_client = PERSIST_CACHE
+            .open(persist_location)
+            .await
+            .expect("error creating persist client");
+
+        let mut remap_read_handle = persist_client
+            .open_critical_since::<SourceData, (), Timestamp, Diff, u64>(
+                remap_shard,
+                PersistClient::CONTROLLER_CRITICAL_SINCE,
+                Diagnostics::from_purpose("test_since_hold"),
+            )
+            .await
+            .expect("error opening persist shard");
+
+        let (mut operator, mut follower) =
+            make_test_operator(remap_shard, Antichain::from_elem(0.into())).await;
+
+        // Reclock offsets 1 and 2 to timestamp 1000
+        let batch = vec![
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
+        ];
+        let source_upper = partitioned_frontier([(0, MzOffset::from(3))]);
+
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(1, 1000.into()), (2, 1000.into())]);
+
+        // Reclock offsets 3 and 4 to timestamp 2000
+        let batch = vec![
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
+        ];
+        let source_upper = partitioned_frontier([(0, MzOffset::from(5))]);
+
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(3, 2000.into()), (4, 2000.into())]);
+
+        // Compact enough so that offsets >= 3 remain uncompacted
+        remap_read_handle
+            .compare_and_downgrade_since(&0, (&0, &Antichain::from_elem(1000.into())))
+            .await
+            .unwrap();
+        follower.compact(Antichain::from_elem(1000.into()));
+
+        // Reclock offsets 3 and 4 again to see we get the uncompacted result
+        let batch = vec![
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
+        ];
+
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(3, 2000.into()), (4, 2000.into())]);
+
+        // Attempting to reclock offset 2 should return compacted bindings
+        let src_ts = Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2));
+        let batch = vec![(2, src_ts.clone())];
+
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(2, 1000.into())]);
+
+        // Starting a new operator with an `as_of` is the same as having compacted
+        let (_operator, follower) =
+            make_test_operator(remap_shard, Antichain::from_elem(1000.into())).await;
+
+        // Reclocking offsets 3 and 4 should succeed
+        let batch = vec![
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
+        ];
+
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(3, 2000.into()), (4, 2000.into())]);
+
+        // But attempting to reclock offset 2 should return an error
+        let batch = vec![(
+            2,
+            Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+        )];
+
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(2, 1000.into())]);
+    }
+
+    #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    fn test_gh_22128() {
+        let mut follower: ReclockFollower<u32, u32> = ReclockFollower::new(Antichain::from_elem(0));
+
+        assert!(!follower.initialized());
+
+        // Create a follower and drop it immediately
+        let follower2 = follower.share();
+        drop(follower2);
+
+        // Now initialize the original follower and verify that it correctly compacts bindings
+        let batch = ReclockBatch {
+            updates: vec![(10, 0, 1), (15, 20, 1), (10, 20, -1)],
+            upper: Antichain::from_elem(40),
+        };
+        follower.push_trace_batch(batch);
+
+        // Sanity check that reclocking works. FromTime 12 maps to IntoTime 20
+        let msgs = vec![("foo", 12)];
+        let reclocked_msgs = follower
+            .reclock(msgs)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[("foo", 20)]);
+
+        follower.compact(Antichain::from_elem(30));
+
+        // Now there should only be one binding in memory
+        assert_eq!(follower.size(), 1);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    async fn test_sharing() {
+        let (mut operator, mut follower) =
+            make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
+
+        // Install a since hold
+        let shared_follower = follower.share();
+
+        // First mint bindings for partition 0 offset 1 at timestamp 1000
+        let source_upper = partitioned_frontier([(0, MzOffset::from(1))]);
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+
+        // Advance the since frontier on one of the handles at a timestamp that is less than 1000
+        // to leave the previously minted binding intact. Since we have an active since hold
+        // through `shared_follower` nothing in the trace is actually compacted.
+        follower.compact(Antichain::from_elem(500.into()));
+
+        // This will release since hold of {0} through `shared_follower` and the overall since
+        // frontier will become {500} which must now actually compact the in-memory trace.
+        drop(shared_follower);
+
+        // Verify that we reclock partition 0 offset 0 correctly
+        let batch = vec![(
+            0,
+            Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(0)),
+        )];
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(0, 1000.into())]);
     }
 
     #[mz_ore::test(tokio::test)]
@@ -427,112 +1404,316 @@ mod tests {
     async fn test_concurrency() {
         // Create two operators pointing to the same shard
         let shared_shard = ShardId::new();
-        let (mut op_a, initial_batch_a) =
+        let (mut op_a, mut follower_a) =
             make_test_operator(shared_shard, Antichain::from_elem(0.into())).await;
-        let (mut op_b, initial_batch_b) =
+        let (mut op_b, mut follower_b) =
             make_test_operator(shared_shard, Antichain::from_elem(0.into())).await;
-        let expected = ReclockBatch {
-            updates: vec![(
-                Partitioned::new_range(RangeBound::NegInfinity, RangeBound::PosInfinity, 0.into()),
-                0.into(),
-                1,
-            )],
-            upper: Antichain::from_elem(1.into()),
-        };
-        assert_eq!(expected, initial_batch_a);
-        assert_eq!(expected, initial_batch_b);
 
+        // Reclock a batch from one of the operators
         // Reclock offsets 1 and 2 to timestamp 1000 from operator A
+        let batch = vec![
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
+        ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(3))]);
-        let batch = op_a.mint(source_upper.borrow()).await;
-        let expected = ReclockBatch {
-            updates: vec![
-                (
-                    Partitioned::new_range(
-                        RangeBound::NegInfinity,
-                        RangeBound::before(0),
-                        0.into(),
-                    ),
-                    1000.into(),
-                    1,
-                ),
-                (
-                    Partitioned::new_range(RangeBound::after(0), RangeBound::PosInfinity, 0.into()),
-                    1000.into(),
-                    1,
-                ),
-                (
-                    Partitioned::new_singleton(RangeBound::exact(0), 3.into()),
-                    1000.into(),
-                    1,
-                ),
-                (
-                    Partitioned::new_range(
-                        RangeBound::NegInfinity,
-                        RangeBound::PosInfinity,
-                        0.into(),
-                    ),
-                    1000.into(),
-                    -1,
-                ),
-            ],
-            upper: Antichain::from_elem(1001.into()),
-        };
-        assert_eq!(expected, batch);
 
-        // Advance the time of operator B by 10 seconds
+        follower_a.push_trace_batch(op_a.mint(source_upper.borrow()).await);
+        let reclocked_msgs = follower_a
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(1, 1000.into()), (2, 1000.into())]);
+
+        follower_a.compact(Antichain::from_elem(1000.into()));
+
+        // Advance the time by a lot
         op_b.clock_stream.by_ref().take(10).count().await;
 
-        // Mint from operator B that doesn't yet know about the mint that happened from operator A.
-        // Operator B should attempt to mint in one go, fail, re-sync, and retry the mint and
-        // return the combined bindings.
+        // Reclock a batch that includes messages from the bindings already minted
+        let batch = vec![
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
+        ];
         let source_upper = partitioned_frontier([(0, MzOffset::from(5))]);
-        let batch = op_b.mint(source_upper.borrow()).await;
-        let expected = ReclockBatch {
-            updates: vec![
-                // Previous bindings discovered
-                (
-                    Partitioned::new_range(
-                        RangeBound::NegInfinity,
-                        RangeBound::before(0),
-                        0.into(),
-                    ),
-                    1000.into(),
-                    1,
-                ),
-                (
-                    Partitioned::new_range(RangeBound::after(0), RangeBound::PosInfinity, 0.into()),
-                    1000.into(),
-                    1,
-                ),
-                (
-                    Partitioned::new_singleton(RangeBound::exact(0), 3.into()),
-                    1000.into(),
-                    1,
-                ),
-                (
-                    Partitioned::new_range(
-                        RangeBound::NegInfinity,
-                        RangeBound::PosInfinity,
-                        0.into(),
-                    ),
-                    1000.into(),
-                    -1,
-                ),
-                // New bindings produced
-                (
-                    Partitioned::new_singleton(RangeBound::exact(0), 3.into()),
-                    11000.into(),
-                    -1,
-                ),
-                (
-                    Partitioned::new_singleton(RangeBound::exact(0), 5.into()),
-                    11000.into(),
-                    1,
-                ),
-            ],
-            upper: Antichain::from_elem(11001.into()),
+        // This operator should attempt to mint in one go, fail, re-sync, and retry only for the
+        // bindings that still need minting
+        follower_b.push_trace_batch(op_b.mint(source_upper.borrow()).await);
+        let reclocked_msgs = follower_b
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(
+            reclocked_msgs,
+            &[
+                (1, 1000.into()),
+                (2, 1000.into()),
+                (3, 11000.into()),
+                (4, 11000.into())
+            ]
+        );
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    async fn test_inversion() {
+        let persist_location = PersistLocation {
+            blob_uri: "mem://".to_owned(),
+            consensus_uri: "mem://".to_owned(),
         };
-        assert_eq!(expected, batch);
+
+        let remap_shard = ShardId::new();
+
+        let persist_client = PERSIST_CACHE
+            .open(persist_location)
+            .await
+            .expect("error creating persist client");
+
+        let mut remap_read_handle = persist_client
+            .open_critical_since::<SourceData, (), Timestamp, Diff, u64>(
+                remap_shard,
+                PersistClient::CONTROLLER_CRITICAL_SINCE,
+                Diagnostics::from_purpose("test_since_hold"),
+            )
+            .await
+            .expect("error opening persist shard");
+
+        let (mut operator, mut follower) =
+            make_test_operator(remap_shard, Antichain::from_elem(0.into())).await;
+
+        // SETUP
+        // Reclock offsets 1 and 2 to timestamp 1000
+        let batch = vec![
+            (
+                1,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(1)),
+            ),
+            (
+                2,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(2)),
+            ),
+        ];
+        let source_upper = partitioned_frontier([(0, MzOffset::from(3))]);
+
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(1, 1000.into()), (2, 1000.into())]);
+        // Reclock offsets 3 and 4 to timestamp 2000
+        let batch = vec![
+            (
+                3,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(3)),
+            ),
+            (
+                4,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(4)),
+            ),
+        ];
+        let source_upper = partitioned_frontier([(0, MzOffset::from(5))]);
+
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(3, 2000.into()), (4, 2000.into())]);
+        // Reclock offsets 5 and 6 to timestamp 3000
+        let batch = vec![
+            (
+                5,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(5)),
+            ),
+            (
+                6,
+                Partitioned::new_singleton(RangeBound::exact(0), MzOffset::from(6)),
+            ),
+        ];
+        let source_upper = partitioned_frontier([(0, MzOffset::from(7))]);
+
+        follower.push_trace_batch(operator.mint(source_upper.borrow()).await);
+        let reclocked_msgs = follower
+            .reclock(batch)
+            .map(|(m, ts)| (m, ts.unwrap()))
+            .collect_vec();
+        assert_eq!(reclocked_msgs, &[(5, 3000.into()), (6, 3000.into())]);
+
+        // END SETUP
+        //
+
+        // If we source_upper_at_frontier at the current `upper`, we should get the offset
+        // upper (strictly greater!!) back!
+        assert_eq!(
+            follower
+                .source_upper_at_frontier(Antichain::from_elem(3001.into()).borrow())
+                .unwrap(),
+            partitioned_frontier([(0, MzOffset::from(7))])
+        );
+        // Check out "upper strictly greater is correct
+        assert_eq!(
+            follower
+                .source_upper_at_frontier(Antichain::from_elem(3000.into()).borrow())
+                .unwrap(),
+            // Note this is the UPPER offset for the previous part of
+            // the trace.
+            partitioned_frontier([(0, MzOffset::from(5))])
+        );
+        // random time in the middle of 2 pieces of the trace
+        assert_eq!(
+            follower
+                .source_upper_at_frontier(Antichain::from_elem(2500.into()).borrow())
+                .unwrap(),
+            // Note this is the UPPER offset for the previous part of
+            // the trace.
+            partitioned_frontier([(0, MzOffset::from(5))])
+        );
+
+        // Check startup edge-case (the since is still 0 here) doesn't panic.
+        assert_eq!(
+            follower
+                .source_upper_at_frontier(Antichain::from_elem(Timestamp::minimum()).borrow())
+                .unwrap(),
+            Antichain::from_elem(Partitioned::minimum())
+        );
+
+        // Similarly, for an earlier part of the trace,
+        // we get the upper for that section of the trace
+        assert_eq!(
+            follower
+                .source_upper_at_frontier(Antichain::from_elem(2001.into()).borrow())
+                .unwrap(),
+            partitioned_frontier([(0, MzOffset::from(5))])
+        );
+        // upper logic, as before
+        assert_eq!(
+            follower
+                .source_upper_at_frontier(Antichain::from_elem(2000.into()).borrow())
+                .unwrap(),
+            partitioned_frontier([(0, MzOffset::from(3))])
+        );
+
+        // After compaction it should still work
+        remap_read_handle
+            .compare_and_downgrade_since(&0, (&0, &Antichain::from_elem(1000.into())))
+            .await
+            .unwrap();
+        follower.compact(Antichain::from_elem(1000.into()));
+        assert_eq!(
+            follower
+                .source_upper_at_frontier(Antichain::from_elem(2001.into()).borrow())
+                .unwrap(),
+            partitioned_frontier([(0, MzOffset::from(5))])
+        );
+        // compact as close as we can
+        remap_read_handle
+            .compare_and_downgrade_since(&0, (&0, &Antichain::from_elem(2000.into())))
+            .await
+            .unwrap();
+        follower.compact(Antichain::from_elem(2000.into()));
+        assert_eq!(
+            follower
+                .source_upper_at_frontier(Antichain::from_elem(2001.into()).borrow())
+                .unwrap(),
+            partitioned_frontier([(0, MzOffset::from(5))])
+        );
+
+        // If we compact too far, we get an error. Note we compact
+        // to the previous UPPER we were checking.
+        remap_read_handle
+            .compare_and_downgrade_since(&0, (&0, &Antichain::from_elem(3000.into())))
+            .await
+            .unwrap();
+        follower.compact(Antichain::from_elem(2001.into()));
+
+        assert_eq!(
+            follower.source_upper_at_frontier(Antichain::from_elem(2001.into()).borrow()),
+            Ok(Antichain::from_elem(Partitioned::minimum()))
+        );
+    }
+
+    // Regression test for
+    // https://github.com/MaterializeInc/materialize/issues/14740.
+    #[mz_ore::test(tokio::test(start_paused = true))]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
+    async fn test_since_hold() {
+        let binding_shard = ShardId::new();
+
+        let (mut operator, _follower) =
+            make_test_operator(binding_shard, Antichain::from_elem(0.into())).await;
+
+        // We do multiple rounds of minting. This will downgrade the since of
+        // the internal listen. If we didn't make sure to also heartbeat the
+        // internal handle that holds back the overall remap since the checks
+        // below would fail.
+        //
+        // We do two rounds and advance the time by half the lease timeout in
+        // between so that the "listen handle" will not timeout but the internal
+        // handle used for holding back the since will timeout.
+
+        tokio::time::advance(PERSIST_READER_LEASE_TIMEOUT_MS / 2 + Duration::from_millis(1)).await;
+        let source_upper = partitioned_frontier([(0, MzOffset::from(3))]);
+        let _ = operator.mint(source_upper.borrow()).await;
+
+        tokio::time::advance(PERSIST_READER_LEASE_TIMEOUT_MS / 2 + Duration::from_millis(1)).await;
+        let source_upper = partitioned_frontier([(0, MzOffset::from(5))]);
+        let _ = operator.mint(source_upper.borrow()).await;
+
+        // Allow time for background maintenance work, which does lease
+        // expiration. 1 ms is enough here, we just need to yield to allow the
+        // background task to be "scheduled".
+        tokio::time::sleep(Duration::from_millis(1)).await;
+
+        // Starting a new operator with an `as_of` of `0`, to verify that
+        // holding back the `since` of the remap shard works as expected.
+        let (_operator, _follower) =
+            make_test_operator(binding_shard, Antichain::from_elem(0.into())).await;
+
+        // Also manually assert the since of the remap shard.
+        let persist_location = PersistLocation {
+            blob_uri: "mem://".to_owned(),
+            consensus_uri: "mem://".to_owned(),
+        };
+
+        let persist_client = PERSIST_CACHE
+            .open(persist_location)
+            .await
+            .expect("error creating persist client");
+
+        let read_handle = persist_client
+            .open_leased_reader::<SourceData, (), Timestamp, Diff>(
+                binding_shard,
+                Arc::new(PROGRESS_DESC.clone()),
+                Arc::new(UnitSchema),
+                Diagnostics::from_purpose("test_since_hold"),
+                true,
+            )
+            .await
+            .expect("error opening persist shard");
+
+        assert_eq!(
+            Antichain::from_elem(0.into()),
+            read_handle.since().to_owned()
+        );
     }
 }

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
+use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use futures::stream::StreamExt;
@@ -43,6 +44,7 @@ use mz_ore::channel::{InstrumentedChannelMetric, InstrumentedUnboundedReceiver};
 use mz_ore::collections::CollectionExt;
 use mz_ore::error::ErrorExt;
 use mz_ore::now::NowFn;
+use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
 use mz_storage_types::configuration::StorageConfiguration;
@@ -53,17 +55,14 @@ use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
-use mz_timely_util::capture::{PusherCapture, UnboundedTokioCapture};
+use mz_timely_util::capture::UnboundedTokioCapture;
 use mz_timely_util::operator::StreamExt as _;
-use mz_timely_util::reclock::reclock;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::capture::capture::Capture;
 use timely::dataflow::operators::capture::Event;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use timely::dataflow::operators::{
-    Broadcast, CapabilitySet, Concat, Inspect, Leave, Map, Partition,
-};
+use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, Leave, Partition};
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream};
 use timely::order::TotalOrder;
@@ -76,7 +75,7 @@ use tracing::{info, trace};
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate};
 use crate::metrics::source::SourceMetrics;
 use crate::metrics::StorageMetrics;
-use crate::source::reclock::ReclockOperator;
+use crate::source::reclock::{ReclockBatch, ReclockFollower, ReclockOperator};
 use crate::source::types::{SourceMessage, SourceOutput, SourceReaderError, SourceRender};
 use crate::statistics::SourceStatistics;
 
@@ -179,6 +178,14 @@ where
 
     let mut tokens = vec![];
 
+    let reclock_follower = ReclockFollower::new(config.as_of.clone());
+
+    let (source_tx, source_rx) = config.metrics.get_instrumented_source_channel(
+        config.id,
+        config.worker_id,
+        config.worker_count,
+        "source_data",
+    );
     let (source_upper_tx, source_upper_rx) = config.metrics.get_instrumented_source_channel(
         config.id,
         config.worker_id,
@@ -192,25 +199,23 @@ where
             .get_source_metrics(&config.name, id, worker_id),
     );
 
-    let timestamp_desc = source_connection.timestamp_desc();
-
-    let (remap_collection, remap_token) =
-        remap_operator(scope, config.clone(), source_upper_rx, timestamp_desc);
+    let (remap_stream, remap_token) = remap_operator(
+        scope,
+        config.clone(),
+        source_upper_rx,
+        source_connection.timestamp_desc(),
+    );
     // Need to broadcast the remap changes to all workers.
-    let remap_collection = remap_collection.inner.broadcast().as_collection();
+    let remap_stream = remap_stream.inner.broadcast().as_collection();
     tokens.push(remap_token);
 
-    let committed_upper = reclock_committed_upper(
-        &remap_collection,
+    let reclocked_resume_stream = reclock_committed_upper(
+        &remap_stream,
         config.as_of.clone(),
         committed_upper,
         id,
         Arc::clone(&source_metrics),
     );
-
-    let (reclock_pusher, reclocked) = reclock(&remap_collection, config.as_of.clone());
-
-    let streams = demux_subsources(config.clone(), reclocked);
 
     let (health, source_tokens) = {
         let config = config.clone();
@@ -219,36 +224,28 @@ where
                 scope,
                 config.clone(),
                 source_connection,
-                committed_upper,
+                reclocked_resume_stream,
                 start_signal,
             );
 
-            source
-                .inner
-                .map(move |((output, result), from_time, diff)| {
-                    let result = match result {
-                        Ok(msg) => Ok(SourceOutput {
-                            key: msg.key,
-                            value: msg.value,
-                            metadata: msg.metadata,
-                            from_time: from_time.clone(),
-                        }),
-                        Err(SourceReaderError { inner }) => Err(SourceError {
-                            source_id: id,
-                            error: inner,
-                        }),
-                    };
-                    ((output, result), from_time, diff)
-                })
-                .capture_into(PusherCapture(reclock_pusher));
             // The use of an _unbounded_ queue here is justified as it matches the unbounded
             // buffers that lie between ordinary timely operators.
+            source.inner.capture_into(UnboundedTokioCapture(source_tx));
             source_upper.capture_into(UnboundedTokioCapture(source_upper_tx));
 
             (health_stream.leave(), source_tokens)
         })
     };
     tokens.extend(source_tokens);
+
+    let streams = reclock_operator(
+        scope,
+        config,
+        reclock_follower,
+        source_rx,
+        remap_stream,
+        source_metrics,
+    );
 
     (streams, health, tokens)
 }
@@ -561,20 +558,38 @@ where
     (remap_stream.as_collection(), button.press_on_drop())
 }
 
-/// Demultiplexes a combined stream of all subsources into individual collections per subsource
-fn demux_subsources<G, FromTime>(
+/// Receives un-timestamped batches from the source reader and updates to the
+/// remap trace on a second input. This operator takes the remap information,
+/// reclocks incoming batches and sends them forward.
+fn reclock_operator<G, FromTime, D, M>(
+    scope: &G,
     config: RawSourceCreationConfig,
-    input: Collection<G, (usize, Result<SourceOutput<FromTime>, SourceError>), Diff>,
+    mut timestamper: ReclockFollower<FromTime, mz_repr::Timestamp>,
+    mut source_rx: InstrumentedUnboundedReceiver<
+        Event<
+            FromTime,
+            Vec<(
+                (usize, Result<SourceMessage, SourceReaderError>),
+                FromTime,
+                D,
+            )>,
+        >,
+        M,
+    >,
+    remap_trace_updates: Collection<G, FromTime, Diff>,
+    source_metrics: Arc<SourceMetrics>,
 ) -> Vec<(
-    Collection<G, SourceOutput<FromTime>, Diff>,
+    Collection<G, SourceOutput<FromTime>, D>,
     Collection<G, SourceError, Diff>,
 )>
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
     FromTime: SourceTimestamp,
+    D: Semigroup + Into<Diff> + 'static,
+    M: InstrumentedChannelMetric + 'static,
 {
     let RawSourceCreationConfig {
-        name,
+        name: _,
         id,
         source_exports,
         worker_id,
@@ -595,42 +610,209 @@ where
 
     // TODO(guswynn): expose function
     let bytes_read_counter = metrics.source_defs.bytes_read.clone();
-    let source_metrics = metrics.get_source_metrics(&name, id, worker_id);
 
-    // Compute the overall resume upper to report for the ingestion
-    let resume_upper = Antichain::from_iter(resume_uppers.values().flat_map(|f| f.iter().cloned()));
-    source_metrics
-        .resume_upper
-        .set(mz_persist_client::metrics::encode_ts_metric(&resume_upper));
+    let operator_name = format!("reclock({})", id);
+    let mut reclock_op = AsyncOperatorBuilder::new(operator_name, scope.clone());
+    let (mut reclocked_output, reclocked_stream) = reclock_op.new_output();
+    let mut remap_input = reclock_op.new_disconnected_input(&remap_trace_updates.inner, Pipeline);
 
-    let input = input.inner.inspect_core(move |event| match event {
-        Ok((_, data)) => {
-            for ((_idx, result), _time, _diff) in data.iter() {
-                if let Ok(msg) = result {
-                    bytes_read_counter.inc_by(u64::cast_from(msg.key.byte_len()));
-                    bytes_read_counter.inc_by(u64::cast_from(msg.value.byte_len()));
+    reclock_op.build(move |capabilities| async move {
+        // The capability of the output after reclocking the source frontier
+        let mut cap_set = CapabilitySet::from_elem(capabilities.into_element());
+
+        // Compute the overall resume upper to report for the ingestion
+        let resume_upper = Antichain::from_iter(resume_uppers.values().flat_map(|f| f.iter().cloned()));
+        source_metrics.resume_upper.set(mz_persist_client::metrics::encode_ts_metric(&resume_upper));
+
+        let mut source_upper = MutableAntichain::new_bottom(FromTime::minimum());
+
+        // Stash of batches that have not yet been timestamped.
+        type Batch<T, D> = Vec<((usize, Result<SourceMessage, SourceReaderError>), T, D)>;
+        let mut untimestamped_batches: Vec<(FromTime, Batch<FromTime, D>)> = Vec::new();
+
+        // Stash of reclock updates that are still beyond the upper frontier
+        let mut remap_updates_stash = vec![];
+        let work_to_do = tokio::sync::Notify::new();
+        loop {
+            tokio::select! {
+                biased;
+                Some(event) = remap_input.next() => match event {
+                    AsyncEvent::Data(_cap, mut data) => remap_updates_stash.append(&mut data),
+                    // If the remap frontier advanced it's time to carve out a batch that includes
+                    // all updates not beyond the upper
+                    AsyncEvent::Progress(remap_upper) => {
+                        let remap_trace_batch = ReclockBatch {
+                            updates: remap_updates_stash
+                                .drain_filter_swapping(|(_, ts, _)| !remap_upper.less_equal(ts))
+                                .collect(),
+                            upper: remap_upper.to_owned(),
+                        };
+                        trace!(
+                            "timely-{worker_id} reclock({id}) \
+                            received remap batch: updates={:?} upper={}",
+                            &remap_trace_batch.updates,
+                            remap_upper.pretty()
+                        );
+                        timestamper.push_trace_batch(remap_trace_batch);
+                        work_to_do.notify_one();
+                    }
+                },
+                Some(event) = source_rx.recv() => match event {
+                    Event::Progress(changes) => {
+                        // In some sense, this is the core place where we connect the two scopes
+                        // (the source-timestamp one, and the `mz_repr::Timestamp` one).
+                        //
+                        // The source reader produces messages using normal capabilities, which are
+                        // `Capture::capture`'d into the sender-side of the `source_rx` channel.
+                        // While `Messages` may be received out of order, timely ensures that
+                        // `Progress` messages represent frontiers that later `Messages` are never
+                        // beyond (note that these times can be, and in our case ARE, partially
+                        // ordered).
+                        //
+                        // This is in fact the _core_ behavior that timely frontier tracking
+                        // offers, and it allows us to in some sense, "not think" about timestamps
+                        // here, and simply update the `MutableAntichain`, which will be
+                        // interpreted by the `ReclockFollower`.
+                        //
+                        // Effectively, we let timely and the `reclock` module worry about partial
+                        // orders, and simply write "classic" timely code here, whereby we store
+                        // messages until we see frontiers progress.
+                        source_upper.update_iter(changes);
+                        trace!(
+                            "timely-{worker_id} reclock({id}) \
+                            received source progress: source_upper={}",
+                            source_upper.pretty()
+                        );
+                        work_to_do.notify_one();
+                    }
+                    Event::Messages(time, batch) => {
+                        untimestamped_batches.push((time, batch));
+                        work_to_do.notify_one();
+                    }
+                },
+                _ = work_to_do.notified(), if timestamper.initialized() => {
+                    source_metrics.inmemory_remap_bindings.set(u64::cast_from(timestamper.size()));
+
+                    // Drain all messages that can be reclocked from all the batches
+                    let total_buffered: usize = untimestamped_batches.iter().map(|(_, b)| b.len()).sum();
+                    let reclock_source_upper = timestamper.source_upper();
+
+                    // Peel as many consequtive reclockable items as possible. It is not benefitial
+                    // to go further even if theoretically there may be more messages ready to be
+                    // reclocked further along because in the common case the message order is
+                    // correleated with time and therefore in the common case we would be wasting
+                    // work trying to compare all the buffered messages with the frontier.
+                    let mut reclockable_count = untimestamped_batches
+                        .iter()
+                        .flat_map(|(_, batch)| batch)
+                        .take_while(|(_, ts, _)| !reclock_source_upper.less_equal(ts))
+                        .count();
+
+                    let msgs = untimestamped_batches
+                        .iter_mut()
+                        .flat_map(|(_, batch)| {
+                            let drain_count = std::cmp::min(batch.len(), reclockable_count);
+                            reclockable_count = reclockable_count.saturating_sub(drain_count);
+                            batch.drain(0..drain_count)
+                        })
+                        .map(|(data, time, diff)| ((data, time.clone(), diff), time));
+
+                    // Accumulate updates to bytes_read for Prometheus metrics collection
+                    let mut bytes_read = 0;
+
+                    let mut total_processed = 0;
+                    for (((idx, msg), from_ts, diff), into_ts) in timestamper.reclock(msgs) {
+                        let into_ts = into_ts.expect("reclock for update not beyond upper failed");
+                        let output = match msg {
+                            Ok(message) => {
+                                bytes_read += message.key.byte_len() + message.value.byte_len();
+                                let ok = SourceOutput {
+                                    key: message.key,
+                                    value: message.value,
+                                    metadata: message.metadata,
+                                    from_time: from_ts,
+                                };
+                                (idx, Ok(ok))
+                            }
+                            Err(SourceReaderError { inner }) => {
+                                let err = SourceError {
+                                    source_id: id,
+                                    error: inner,
+                                };
+                                (idx, Err(err))
+                            }
+                        };
+
+                        let ts_cap = cap_set.delayed(&into_ts);
+                        reclocked_output.give(&ts_cap, (output, into_ts, diff)).await;
+                        total_processed += 1;
+                    }
+                    // The loop above might have completely emptied batches. We can now remove them
+                    untimestamped_batches.retain(|(_, batch)| !batch.is_empty());
+
+                    let total_skipped = total_buffered - total_processed;
+                    trace!(
+                        "timely-{worker_id} reclock({id}): processed {}, skipped {} messages",
+                        total_processed,
+                        total_skipped
+                    );
+
+                    bytes_read_counter.inc_by(u64::cast_from(bytes_read));
+
+                    // This is correct for totally ordered times because there can be at
+                    // most one entry in the `CapabilitySet`. If this ever changes we
+                    // need to rethink how we surface this in metrics. We will notice
+                    // when that happens because the `expect()` will fail.
+                    source_metrics.capability.set(
+                        cap_set
+                            .iter()
+                            .at_most_one()
+                            .expect("there can be at most one element for totally ordered times")
+                            .map(|c| c.time())
+                            .cloned()
+                            .unwrap_or(mz_repr::Timestamp::MAX)
+                            .into(),
+                    );
+
+
+                    // We must downgrade our capability to the meet of the timestamper frontier,
+                    // the source frontier, and the lower timestamp of all the pending batches
+                    // because it's only when both advance past some time `t` that we are
+                    // guaranteed that we'll not need to produce more data at time `t`.
+                    let mut ready_upper = reclock_source_upper;
+                    ready_upper.extend(
+                        source_upper.frontier().iter().cloned()
+                        .chain(untimestamped_batches.iter().map(|(time, _)| time.clone()))
+                    );
+
+                    let into_ready_upper = timestamper
+                        .reclock_frontier(ready_upper.borrow())
+                        .expect("uninitialized reclock follower");
+                    trace!(
+                        "timely-{worker_id} reclock({id}) downgrading timestamper: since={}",
+                        into_ready_upper.pretty()
+                    );
+
+                    cap_set.downgrade(into_ready_upper.elements());
+                    timestamper.compact(into_ready_upper.clone());
+                    if into_ready_upper.is_empty() {
+                        return;
+                    }
                 }
             }
         }
-        Err([time]) => source_metrics.capability.set(time.into()),
-        Err([]) => source_metrics
-            .capability
-            .set(mz_repr::Timestamp::MAX.into()),
-        // `mz_repr::Timestamp` is totally ordered and so there can be at most one element in the
-        // frontier. If this ever changes we need to rethink how we surface this in metrics. We
-        // will notice when that happens because the `expect()` will fail.
-        Err(_) => unreachable!("there can be at most one element for totally ordered times"),
     });
 
     // TODO(petrosagg): output the two streams directly
     type CB<C> = CapacityContainerBuilder<C>;
-    let (ok_muxed_stream, err_muxed_stream) = input.map_fallible::<CB<_>, CB<_>, _, _, _>(
-        "reclock-demux-ok-err",
-        |((output, r), ts, diff)| match r {
-            Ok(ok) => Ok(((output, ok), ts, diff)),
-            Err(err) => Err(((output, err), ts, diff.into())),
-        },
-    );
+    let (ok_muxed_stream, err_muxed_stream) = reclocked_stream
+        .map_fallible::<CB<_>, CB<_>, _, _, _>(
+            "reclock-demux-ok-err",
+            |((output, r), ts, diff)| match r {
+                Ok(ok) => Ok(((output, ok), ts, diff)),
+                Err(err) => Err(((output, err), ts, diff.into())),
+            },
+        );
 
     // We use the output index from the source export to route values to its ok
     // and err streams. There is one partition per source export; however,

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -103,7 +103,7 @@ pub struct SourceMessage {
 }
 
 /// A record produced by a source
-#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Debug, Deserialize)]
 pub struct SourceOutput<FromTime> {
     /// The record's key (or some empty/default value for sources without the concept of key)
     pub key: Row,

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -33,10 +33,10 @@ use mz_storage_types::sources::{
     SourceConnection, SourceData, SourceEnvelope, SourceTimestamp,
 };
 use timely::order::PartialOrder;
-use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, Timestamp};
 use tokio::sync::mpsc;
 
+use crate::source::reclock::{ReclockBatch, ReclockFollower};
 use crate::source::types::SourceRender;
 
 /// A worker that can execute commands that come in on a channel and returns
@@ -168,28 +168,20 @@ where
         }
     }
 
-    remap_updates.sort_unstable_by(|a, b| a.1.cmp(&b.1));
+    // This cannot be instantiated earlier because `AsyncStorageWorker` then needs to be `+ Send +
+    // Sync` and capturing the timestamper in the Future makes it non-Send since it contains an Rc.
+    let mut timestamper = ReclockFollower::new(as_of);
+    timestamper.push_trace_batch(ReclockBatch {
+        updates: remap_updates,
+        upper: remap_upper.clone(),
+    });
 
-    // The conversion of an IntoTime frontier to a FromTime frontier has the property that all
-    // messages that would be reclocked to times beyond the provided `IntoTime` frontier will be
-    // beyond the returned `FromTime` frontier. This can be used to compute a safe starting point
-    // to resume producing an `IntoTime` collection at a particular frontier.
-    let mut source_upper = MutableAntichain::new();
     let mut source_resume_uppers = BTreeMap::new();
     for (id, upper) in resume_uppers {
-        let resume_upper = if PartialOrder::less_equal(upper, &as_of) {
-            Antichain::from_elem(Timestamp::minimum())
-        } else {
-            let idx = remap_updates.partition_point(|(_, t, _)| !upper.less_equal(t));
-            source_upper.clear();
-            source_upper.update_iter(
-                remap_updates[0..idx]
-                    .iter()
-                    .map(|(from_time, _, diff)| (from_time.clone(), *diff)),
-            );
-            source_upper.frontier().to_owned()
-        };
-        source_resume_uppers.insert(*id, resume_upper);
+        let source_upper = timestamper
+            .source_upper_at_frontier(upper.borrow())
+            .expect("enough data is loaded");
+        source_resume_uppers.insert(*id, source_upper);
     }
     source_resume_uppers
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

#27058 is the most likely culprit for the issues we're seeing in #27455, so better to revert it and investigate the failures off the critical path.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
