### PR TITLE
bazel: Support setting `env` for `rust_test`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,3 +16,6 @@ build --copt=-Wno-error=deprecated-declarations
 #
 # This script gets run before every build, see the script for more info.
 build --workspace_status_command "python3 misc/bazel/build-info/workspace_status.py"
+
+# Stream all test output by default, otherwise Bazel captures it all.
+test --test_output=streamed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,7 +3520,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 [[package]]
 name = "librocksdb-sys"
 version = "0.11.0+8.3.2"
-source = "git+https://github.com/MaterializeInc/rust-rocksdb#ab3684f999a5586d7a5e94bd65defd78af15d40f"
+source = "git+https://github.com/MaterializeInc/rust-rocksdb?branch=master#ab3684f999a5586d7a5e94bd65defd78af15d40f"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -8188,7 +8188,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.21.0"
-source = "git+https://github.com/MaterializeInc/rust-rocksdb#ab3684f999a5586d7a5e94bd65defd78af15d40f"
+source = "git+https://github.com/MaterializeInc/rust-rocksdb?branch=master#ab3684f999a5586d7a5e94bd65defd78af15d40f"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,7 +3520,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 [[package]]
 name = "librocksdb-sys"
 version = "0.11.0+8.3.2"
-source = "git+https://github.com/MaterializeInc/rust-rocksdb?branch=master#ab3684f999a5586d7a5e94bd65defd78af15d40f"
+source = "git+https://github.com/MaterializeInc/rust-rocksdb#ab3684f999a5586d7a5e94bd65defd78af15d40f"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -8188,7 +8188,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.21.0"
-source = "git+https://github.com/MaterializeInc/rust-rocksdb?branch=master#ab3684f999a5586d7a5e94bd65defd78af15d40f"
+source = "git+https://github.com/MaterializeInc/rust-rocksdb#ab3684f999a5586d7a5e94bd65defd78af15d40f"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/misc/bazel/cargo-gazelle/src/config.rs
+++ b/misc/bazel/cargo-gazelle/src/config.rs
@@ -196,6 +196,9 @@ pub struct TestConfig {
     /// ["size"](https://bazel.build/reference/be/common-definitions#common-attributes-tests)
     /// of the test target, this defines how many resources Bazel provides to the test.
     size: Option<RustTestSize>,
+    /// Set of environment variables to set when the test is executed.
+    #[serde(default)]
+    env: BTreeMap<String, String>,
 }
 
 impl TestConfig {
@@ -205,6 +208,10 @@ impl TestConfig {
 
     pub fn size(&self) -> Option<&RustTestSize> {
         self.size.as_ref()
+    }
+
+    pub fn env(&self) -> &BTreeMap<String, String> {
+        &self.env
     }
 }
 

--- a/misc/bazel/cargo-gazelle/src/lib.rs
+++ b/misc/bazel/cargo-gazelle/src/lib.rs
@@ -306,11 +306,30 @@ impl<K, V> Dict<K, V> {
         }
     }
 
-    pub fn insert(&mut self, key: K, val: V)
+    pub fn empty() -> Self {
+        Dict {
+            items: BTreeMap::default(),
+        }
+    }
+
+    pub fn insert<M, N>(&mut self, key: M, val: N)
     where
+        M: Into<K>,
+        N: Into<V>,
         K: Ord,
     {
-        self.items.insert(key, val);
+        self.items.insert(key.into(), val.into());
+    }
+
+    pub fn extend<M, N, I>(&mut self, vals: I)
+    where
+        M: Into<K>,
+        N: Into<V>,
+        I: IntoIterator<Item = (M, N)>,
+        K: Ord,
+    {
+        self.items
+            .extend(vals.into_iter().map(|(k, v)| (k.into(), v.into())));
     }
 }
 

--- a/misc/bazel/cargo-gazelle/src/targets.rs
+++ b/misc/bazel/cargo-gazelle/src/targets.rs
@@ -194,6 +194,7 @@ pub struct RustTest {
     size: Field<RustTestSize>,
     data: Field<List<QuotedString>>,
     compile_data: Field<List<QuotedString>>,
+    env: Field<Dict<QuotedString, QuotedString>>,
     rustc_flags: Field<List<QuotedString>>,
     rustc_env: Field<Dict<QuotedString, QuotedString>>,
 }
@@ -254,6 +255,7 @@ impl RustTest {
         let (paths, globs) = test_common.compile_data();
         let compile_data = List::new(paths).concat_other(globs.map(Glob::new));
 
+        let env = Dict::new(test_config.env());
         let rustc_flags = List::new(test_common.rustc_flags());
         let rustc_env = Dict::new(test_common.rustc_env());
 
@@ -269,6 +271,7 @@ impl RustTest {
             size: Field::new("size", size),
             data: Field::new("data", data),
             compile_data: Field::new("compile_data", compile_data),
+            env: Field::new("env", env),
             rustc_flags: Field::new("rustc_flags", rustc_flags),
             rustc_env: Field::new("rustc_env", rustc_env),
         })
@@ -339,6 +342,7 @@ impl ToBazelDefinition for RustTest {
 
             self.compile_data.format(&mut w)?;
             self.data.format(&mut w)?;
+            self.env.format(&mut w)?;
             self.rustc_flags.format(&mut w)?;
             self.rustc_env.format(&mut w)?;
         }

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -87,3 +87,9 @@ default = ["mz-build-tools/default"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
+
+[package.metadata.cargo-gazelle.test.lib]
+data = ["src/snapshots/**"]
+
+[package.metadata.cargo-gazelle.test.lib.env]
+INSTA_WORKSPACE_ROOT = "."


### PR DESCRIPTION
This PR adds the `env` field as a configuration `cargo-gazelle` can auto-generate, which allows us to set environment variables for test executions. It also sets the default `test_output` to `streamed`, which mimics what `cargo test` does.

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/27381

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
