### PR TITLE
test analytics: data version should be a number

### DIFF
--- a/misc/python/materialize/test_analytics/setup/structures/01-base-tables.sql
+++ b/misc/python/materialize/test_analytics/setup/structures/01-base-tables.sql
@@ -23,7 +23,7 @@ CREATE TABLE build (
    mz_version TEXT, -- should eventually be changed to NOT NULL (but will break on versions that do not set it)
    date TIMESTAMPTZ NOT NULL,
    build_url TEXT NOT NULL,
-   data_version TEXT, -- should eventually be changed to NOT NULL (but will break on versions that do not set it)
+   data_version TEXT, -- should eventually be changed to INT and NOT NULL (but will break on versions that do not set it)
    remarks TEXT
 );
 

--- a/misc/python/materialize/test_analytics/test_analytics_db.py
+++ b/misc/python/materialize/test_analytics/test_analytics_db.py
@@ -9,4 +9,4 @@
 
 """Test analytics database."""
 
-TEST_ANALYTICS_DATA_VERSION = "0.1.2"
+TEST_ANALYTICS_DATA_VERSION: int = 2


### PR DESCRIPTION
because
* we likely don't need semantic versioning
* it easens comparisons