### PR TITLE
catalog: Fix get_op_updates transaction method

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -291,7 +291,7 @@ impl Catalog {
             let mut pre_item_updates = Vec::new();
             let mut item_updates = Vec::new();
             let mut post_item_updates = Vec::new();
-            for update in txn.get_updates() {
+            for update in txn.get_bootstrap_updates() {
                 match update.kind {
                     StateUpdateKind::Role(_)
                     | StateUpdateKind::Database(_)
@@ -578,7 +578,7 @@ impl Catalog {
                 .await
                 .transaction()
                 .await?
-                .get_updates()
+                .get_bootstrap_updates()
                 .collect();
             let mut builtin_table_updates = catalog.state.generate_builtin_table_updates(updates);
 


### PR DESCRIPTION
Previously the `get_op_updates` function in `Transaction` did not return updates for audit logs and storage usage events. This commit fixes that issue.

Works towards resolving #24844

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
