### PR TITLE
dbt-materialize: Stop adding aliases to subqueries with --empty

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for overriding the `generate_cluster_name` macro to customize the
   cluster name generation logic in user projects.
+* Stop adding aliases to subqueries when calling with `--empty` flag.
 
 ## 1.8.0 - 2024-05-23
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/relation.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/relation.py
@@ -44,6 +44,7 @@ class MaterializeRelationType(StrEnum):
 @dataclass(frozen=True, eq=False, repr=False)
 class MaterializeRelation(PostgresRelation):
     type: Optional[MaterializeRelationType] = None
+    require_alias: bool = False
 
     # Materialize does not have a 63-character limit for relation names, unlike
     # PostgreSQL (see dbt-core #2727). Instead, we set 255 as the maximum

--- a/misc/dbt-materialize/tests/adapter/test_empty.py
+++ b/misc/dbt-materialize/tests/adapter/test_empty.py
@@ -13,11 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dbt.tests.adapter.empty.test_empty import BaseTestEmpty, BaseTestEmptyInlineSourceRef
+from dbt.tests.adapter.empty.test_empty import (
+    BaseTestEmpty,
+    BaseTestEmptyInlineSourceRef,
+)
 
 
 class TestMaterializeEmpty(BaseTestEmpty):
     pass
+
 
 class TestMaterializeEmptyInlineSourceRef(BaseTestEmptyInlineSourceRef):
     pass

--- a/misc/dbt-materialize/tests/adapter/test_empty.py
+++ b/misc/dbt-materialize/tests/adapter/test_empty.py
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dbt.tests.adapter.empty.test_empty import BaseTestEmpty
+from dbt.tests.adapter.empty.test_empty import BaseTestEmpty, BaseTestEmptyInlineSourceRef
 
 
 class TestMaterializeEmpty(BaseTestEmpty):
+    pass
+
+class TestMaterializeEmptyInlineSourceRef(BaseTestEmptyInlineSourceRef):
     pass


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

As per this bug [here](https://github.com/dbt-labs/dbt-adapters/issues/124), the `--empty` flag doesn't work with relation that are already named and fails.

A quick repro:
* Create a simple model with: `SELECT * FROM {{ ref('my_upstream_model')}} some_alias`
* The generated SQL when using the `--empty` flag, looks like this:
```sql
as (
  SELECT * FROM (
    select * from "my_upstream_model" where false limit 0) _dbt_limit_subq_my_upstream_model alias
);
```

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
