### PR TITLE
adapter: allow blocking user sessions via feature flag

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -11,6 +11,12 @@
 
 use mz_dyncfg::{Config, ConfigSet};
 
+pub const ALLOW_USER_SESSIONS: Config<bool> = Config::new(
+    "allow_user_sessions",
+    true,
+    "Whether to allow user roles to create new sessions. When false, only system roles will be permitted to create new sessions.",
+);
+
 /// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.
 pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
     "enable_statement_lifecycle_logging",
@@ -20,5 +26,7 @@ pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
 
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
-    configs.add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
+    configs
+        .add(&ALLOW_USER_SESSIONS)
+        .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
 }

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -224,6 +224,8 @@ pub enum AdapterError {
     RtrDropFailure(String),
     /// The collection requested to be sinked cannot be read at any timestamp
     UnreadableSinkCollection,
+    /// User sessions have been blocked.
+    UserSessionsDisallowed,
 }
 
 impl AdapterError {
@@ -336,6 +338,7 @@ impl AdapterError {
             }
             AdapterError::RtrTimeout(name) => Some(format!("{name} failed to ingest data up to the real-time recency point")),
             AdapterError::RtrDropFailure(name) => Some(format!("{name} dropped before ingesting data to the real-time recency point")),
+            AdapterError::UserSessionsDisallowed => Some(format!("Your organization has been blocked. Please contact support.")),
             _ => None,
         }
     }
@@ -528,6 +531,7 @@ impl AdapterError {
             AdapterError::RtrTimeout(_) => SqlState::QUERY_CANCELED,
             AdapterError::RtrDropFailure(_) => SqlState::UNDEFINED_OBJECT,
             AdapterError::UnreadableSinkCollection => SqlState::from_code("MZ009"),
+            AdapterError::UserSessionsDisallowed => SqlState::from_code("MZ010"),
         }
     }
 
@@ -756,6 +760,7 @@ impl fmt::Display for AdapterError {
             AdapterError::UnreadableSinkCollection => {
                 write!(f, "collection is not readable at any time")
             }
+            AdapterError::UserSessionsDisallowed => write!(f, "login blocked"),
         }
     }
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1929,7 +1929,7 @@ fn test_max_connections_on_all_interfaces() {
         let status = res.status();
         let text = res.text().expect("no body?");
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(text, "creating connection would violate max_connections limit (desired: 2, limit: 1, current: 1)");
+        assert!(text.contains("creating connection would violate max_connections limit (desired: 2, limit: 1, current: 1)"));
     }
 
     {
@@ -1948,7 +1948,7 @@ fn test_max_connections_on_all_interfaces() {
             let res = Client::new().post(http_url.clone()).json(&json).send().unwrap();
             let status = res.status();
             if status == StatusCode::INTERNAL_SERVER_ERROR {
-                assert_eq!(res.text().expect("expect body"), "creating connection would violate max_connections limit (desired: 2, limit: 1, current: 1)");
+                assert!(res.text().expect("expect body").contains("creating connection would violate max_connections limit (desired: 2, limit: 1, current: 1)"));
                 return Err(());
             }
             assert_eq!(status, StatusCode::OK);
@@ -1992,7 +1992,7 @@ fn test_max_connections_on_all_interfaces() {
     let status = res.status();
     let text = res.text().expect("no body?");
     assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-    assert_eq!(text, "creating connection would violate max_connections limit (desired: 2, limit: 1, current: 1)");
+    assert!(text.contains("creating connection would violate max_connections limit (desired: 2, limit: 1, current: 1)"));
 }
 
 // Test max_connections and superuser_reserved_connections.


### PR DESCRIPTION
Introduce a new `allow_user_sessions` feature flag which, when false, blocks new user sessions (i.e., sessions for users other than mz_support or mz_system).

This flag be used to prevent expired trials and churned customers from accessing their Materialize region.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

    Discussed on Slack here: https://materializeinc.slack.com/archives/CL68GT3AT/p1717655925489429

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
