### PR TITLE
test: force redpanda to produce an incompatible schema error

### DIFF
--- a/test/testdrive/alter-sink.td
+++ b/test/testdrive/alter-sink.td
@@ -9,9 +9,6 @@
 
 $ set-arg-default single-replica-cluster=quickstart
 
-$ set-sql-timeout duration=1s
-$ set-max-tries max-tries=30
-
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
@@ -19,7 +16,7 @@ $ set-max-tries max-tries=30
     URL '${testdrive.schema-registry-url}'
   );
 
-> CREATE TABLE pre_alter (pre_name string);
+> CREATE TABLE pre_alter (pre_name string NOT NULL);
 > INSERT INTO pre_alter VALUES ('fish');
 
 > CREATE TABLE post_alter (post_name string, post_value int);
@@ -57,7 +54,7 @@ $ kafka-verify-data format=json sink=materialize.public.sink key=false
     URL '${testdrive.schema-registry-url}'
   );
 
-> CREATE TABLE post_alter_incompatible (post_value int);
+> CREATE TABLE post_alter_incompatible (post_value int NOT NULL);
 
 > CREATE SINK incompatible_sink
   IN CLUSTER ${arg.single-replica-cluster}
@@ -67,7 +64,7 @@ $ kafka-verify-data format=json sink=materialize.public.sink key=false
   ENVELOPE DEBEZIUM
 
 $ kafka-verify-data format=avro sink=materialize.public.incompatible_sink sort-messages=true
-{"before": null, "after": {"row": {"pre_name": {"string": "fish"}}}}
+{"before": null, "after": {"row": {"pre_name": "fish"}}}
 
 > ALTER SINK incompatible_sink SET FROM post_alter_incompatible;
 


### PR DESCRIPTION
Fixes #27501

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
