### PR TITLE
compute: prevent as-of regressions by persist peeks

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1797,13 +1797,14 @@ where
         // to avoid the edge case that caused #16615.
         self.send(ComputeCommand::CancelPeek { uuid });
 
-        let update = (peek.target.id(), ChangeBatch::new_from(peek.time, -1));
-        let mut updates = [update].into();
+        let change = ChangeBatch::new_from(peek.time, -1);
         match &peek.target {
-            PeekTarget::Index { .. } => self.update_read_capabilities(updates),
-            PeekTarget::Persist { .. } => self
-                .storage_collections
-                .update_read_capabilities(&mut updates),
+            PeekTarget::Index { id } => self.update_read_capabilities([(*id, change)].into()),
+            PeekTarget::Persist { id, .. } => {
+                let mut updates = [(*id, change)].into();
+                self.storage_collections
+                    .update_read_capabilities(&mut updates);
+            }
         }
     }
 

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -63,8 +63,6 @@ message ProtoPersistTarget {
 }
 
 message ProtoPeek {
-    // TODO(bkirwi) remove this now-redundant field once persist peeks are locked in
-    mz_repr.global_id.ProtoGlobalId id = 1;
     repeated mz_repr.row.ProtoRow key = 2;
     mz_proto.ProtoU128 uuid = 3;
     uint64 timestamp = 4;

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -486,16 +486,6 @@ pub enum PeekTarget {
     },
 }
 
-impl PeekTarget {
-    /// TODO(#25239): Add documentation.
-    pub fn id(&self) -> GlobalId {
-        match self {
-            PeekTarget::Index { id, .. } => *id,
-            PeekTarget::Persist { id, .. } => *id,
-        }
-    }
-}
-
 /// Peek a collection, either in an arrangement or Persist.
 ///
 /// This request elicits data from the worker, by naming the
@@ -537,7 +527,6 @@ pub struct Peek<T = mz_repr::Timestamp> {
 impl RustType<ProtoPeek> for Peek {
     fn into_proto(&self) -> ProtoPeek {
         ProtoPeek {
-            id: Some(self.target.id().into_proto()),
             key: match &self.literal_constraints {
                 // In the Some case, the vector is never empty, so it's safe to encode None as an
                 // empty vector, and Some(vector) as just the vector.
@@ -589,12 +578,12 @@ impl RustType<ProtoPeek> for Peek {
                     id: target.id.into_rust_if_some("ProtoIndexTarget::id")?,
                 },
                 Some(proto_peek::Target::Persist(target)) => PeekTarget::Persist {
-                    id: target.id.into_rust_if_some("ProtoIndexTarget::id")?,
-                    metadata: target.metadata.into_rust_if_some("ProtoPeek::target")?,
+                    id: target.id.into_rust_if_some("ProtoPersistTarget::id")?,
+                    metadata: target
+                        .metadata
+                        .into_rust_if_some("ProtoPersistTarget::metadata")?,
                 },
-                None => PeekTarget::Index {
-                    id: x.id.into_rust_if_some("ProtoPeek::id")?,
-                },
+                None => return Err(TryFromProtoError::missing_field("ProtoPeek::target")),
             },
         })
     }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -831,12 +831,12 @@ impl PendingPeek {
     /// Produces a corresponding log event.
     pub fn as_log_event(&self, installed: bool) -> ComputeEvent {
         let peek = self.peek();
-        let peek_type = match self {
-            PendingPeek::Index(_) => logging::compute::PeekType::Index,
-            PendingPeek::Persist(_) => logging::compute::PeekType::Persist,
+        let (id, peek_type) = match &peek.target {
+            PeekTarget::Index { id } => (id, logging::compute::PeekType::Index),
+            PeekTarget::Persist { id, .. } => (id, logging::compute::PeekType::Persist),
         };
         ComputeEvent::Peek {
-            peek: logging::compute::Peek::new(peek.target.id(), peek.timestamp, peek.uuid),
+            peek: logging::compute::Peek::new(*id, peek.timestamp, peek.uuid),
             peek_type,
             installed,
         }


### PR DESCRIPTION
This PR fixes a bug in `ComputeCommandHistory::reduce`. It contained this code:

```rust
        // Determine the required antichains to support live peeks;
        let mut live_peek_frontiers = std::collections::BTreeMap::new();
        for Peek {
            target, timestamp, ..
        } in live_peeks.values()
        {
            // Introduce `time` as a constraint on the `as_of` frontier of `id`.
            live_peek_frontiers
                .entry(target.id())
                .or_insert_with(Antichain::new)
                .insert(timestamp.clone());
        }
```

`live_peek_frontiers` would then be used to hold back the as-ofs of `CreateDataflow` commands, to ensure that the peeks can be fulfilled by the respective created dataflows. The bug here is the missing differentiation between index peeks and persist peeks. Persist peeks are not reading from the compute dataflow with the same ID, but from the persist shard that dataflow sinks into. So there is no need to hold back the as-of frontier of the compute dataflow for persist peeks, as that frontier is independent from the target shard's frontier.

Holding back dataflow as-ofs for persist peeks like this can cause the as-ofs to regress because it is valid to issue a persist peek at a time that's less than the read frontier of the sink dataflow (as long as it's not less than the read frontier of the persist shard). Regressing dataflow as-ofs are not something the controller expects and so they can lead to all kinds of frontier tracking bugs, like https://github.com/MaterializeInc/materialize/issues/27484.

The most straightforward fix is to ignore persist peeks in the code cited above. But we can also observe that the compute history doesn't need to worry about holding back frontiers for peek commands, since that's already the controller's job. The compute history is not concerned about holding back frontiers to satisfy the read requirements of dependent dataflows (which is also the controller's job), so it seems arbitrary that it is concerned with the read requirements of peeks. So instead of trying to fix the above code, the approach taken here is to simply remove it.

The second commit is an attempt of avoiding similar issues in the future by removing the `PeekTarget::id` method and forcing all users to destructure the `PeekTarget` enum to get at the ID. The hope is that this causes more awareness about the type of the peeked collection and makes mix-ups less likely.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/27484

### Tips for reviewer

The usefulness of the second commit may be debatable. I'm fine with dropping it if people don't consider it worthwhile.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A