### PR TITLE
compute: reconciliation of logging collections

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -508,7 +508,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             .expect("dropped untracked collection");
 
         // If this collection is an index, remove its trace.
-        self.compute_state.traces.del_trace(&id);
+        self.compute_state.traces.remove(&id);
         // If this collection is a sink, drop its sink token.
         collection.sink_token.take();
 

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -20,7 +20,7 @@ use timely::communication::Allocate;
 use timely::logging::{Logger, TimelyEvent};
 use timely::progress::reachability::logging::TrackerEvent;
 
-use crate::arrangement::manager::{SpecializedTraceHandle, TraceBundle};
+use crate::arrangement::manager::TraceBundle;
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::logging::compute::ComputeEvent;
 use crate::logging::reachability::ReachabilityEvent;
@@ -131,11 +131,8 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
         collections
             .into_iter()
             .map(|(log, collection)| {
-                let bundle = TraceBundle::new(
-                    SpecializedTraceHandle::RowRow(collection.trace),
-                    errs.clone(),
-                )
-                .with_drop(collection.token);
+                let bundle =
+                    TraceBundle::new(collection.trace, errs.clone()).with_drop(collection.token);
                 (log, (bundle, collection.dataflow_index))
             })
             .collect()

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -39,7 +39,6 @@ use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
 use tracing::error;
 
-use crate::arrangement::manager::SpecializedTraceHandle;
 use crate::compute_state::{ComputeState, HydrationEvent};
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::render::errors::ErrorLogger;
@@ -344,9 +343,9 @@ where
     S: ScopeParent<Timestamp = mz_repr::Timestamp>,
 {
     /// Obtains a `SpecializedTraceHandle` for the underlying arrangement.
-    pub fn trace_handle(&self) -> SpecializedTraceHandle {
+    pub fn trace_handle(&self) -> RowRowAgent<<S as ScopeParent>::Timestamp, Diff> {
         match self {
-            MzArrangement::RowRow(inner) => SpecializedTraceHandle::RowRow(inner.trace.clone()),
+            MzArrangement::RowRow(inner) => inner.trace.clone(),
         }
     }
 }


### PR DESCRIPTION
Upon reconnecting to a replica, the compute controller expects the logging collections to be uncompacted and readable from the minimum time. To ensure that we introduce the ability to "pad" traces in the `TraceManager` by filling up their compacted times with empty contents. This is implemented as a thin `TraceReader` wrapper that intercepts accesses to the trace's logical compaction frontier and otherwise passes requests through to the inner trace.

### Motivation

  * This PR fixes a previously unreported bug.

Compute reconciliation introduces a mismatch between the controller's expectation of the read frontiers of logging collections (`[0]`) and the actual read frontiers the respective arrangements have on the replica. This mismatch can let replicas crash when the controller tries to read the logging collections at a time before their physical read frontier.

### Tips for reviewer

Previous Slack discussions: [1](https://materializeinc.slack.com/archives/C0761MZ3QD9/p1717749427162899), [2](https://materializeinc.slack.com/archives/C0761MZ3QD9/p1717779890483119).

The first commit rips out the `SpecializedTraceHandle` as it gets in the way of implementing the new trace wrapper: It's annoying to write a `TraceHandle` that can wrap both `SpecializedTraceHandle` and `ErrAgent` because the former doesn't implement `TraceReader`. We can write more code to work around this of course, if people feel that keeping `SpecializedTraceHandle` around is worthwhile enough.

There is one TODO comment left about how a padded `TraceHandle` should implement `TraceReader::map_batches`. The current implementation simply defers to the wrapped trace, but I'm not sure that is correct. Would callers of `map_batches` expect to see an empty batch containing the times from `padded_since` to `trace.get_compaction_frontier()`?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
