### PR TITLE
frontegg-auth: support service app passwords

### DIFF
--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -23,7 +23,7 @@ use mz_frontegg_auth::{
     Authenticator as FronteggAuthentication, AuthenticatorConfig as FronteggConfig,
     DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
 };
-use mz_frontegg_mock::{FronteggMockServer, UserApiToken, UserConfig};
+use mz_frontegg_mock::{ApiToken, FronteggMockServer, UserConfig};
 use mz_ore::cast::CastFrom;
 use mz_ore::id_gen::{conn_id_org_uuid, org_id_conn_bits};
 use mz_ore::metrics::MetricsRegistry;
@@ -50,7 +50,7 @@ async fn test_balancer() {
     let password = Uuid::new_v4().to_string();
     let client_id = Uuid::new_v4();
     let secret = Uuid::new_v4();
-    let initial_api_tokens = vec![UserApiToken {
+    let initial_api_tokens = vec![ApiToken {
         client_id: client_id.clone(),
         secret: secret.clone(),
     }];
@@ -58,7 +58,7 @@ async fn test_balancer() {
     let users = BTreeMap::from([(
         email.clone(),
         UserConfig {
-            id: None,
+            id: Uuid::new_v4(),
             email,
             password,
             tenant_id,
@@ -82,6 +82,7 @@ async fn test_balancer() {
         encoding_key,
         decoding_key,
         users,
+        BTreeMap::new(),
         None,
         SYSTEM_TIME.clone(),
         EXPIRES_IN_SECS,

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -870,7 +870,7 @@ async fn auth(
                     user_id: claims.user_id,
                     admin: claims.is_admin,
                 });
-                (claims.email, Some(external_metadata_rx))
+                (claims.user, Some(external_metadata_rx))
             }
             Credentials::DefaultUser | Credentials::User(_) => {
                 return Err(AuthError::MissingHttpAuthentication)

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -35,7 +35,7 @@ use mz_frontegg_auth::{
     Authenticator as FronteggAuthentication, AuthenticatorConfig as FronteggConfig,
     DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
 };
-use mz_frontegg_mock::{FronteggMockServer, UserApiToken, UserConfig};
+use mz_frontegg_mock::{ApiToken, FronteggMockServer, UserConfig};
 use mz_ore::cast::CastFrom;
 use mz_ore::cast::CastLossy;
 use mz_ore::cast::TryCastFrom;
@@ -2023,6 +2023,7 @@ async fn test_max_connections_limits() {
         encoding_key,
         decoding_key,
         users,
+        BTreeMap::new(),
         None,
         SYSTEM_TIME.clone(),
         500,
@@ -4321,7 +4322,7 @@ async fn test_cert_reloading() {
     let password = Uuid::new_v4().to_string();
     let client_id = Uuid::new_v4();
     let secret = Uuid::new_v4();
-    let initial_api_tokens = vec![UserApiToken {
+    let initial_api_tokens = vec![ApiToken {
         client_id: client_id.clone(),
         secret: secret.clone(),
     }];
@@ -4329,7 +4330,7 @@ async fn test_cert_reloading() {
     let users = BTreeMap::from([(
         email.clone(),
         UserConfig {
-            id: None,
+            id: Uuid::new_v4(),
             email,
             password,
             tenant_id,
@@ -4353,6 +4354,7 @@ async fn test_cert_reloading() {
         encoding_key,
         decoding_key,
         users,
+        BTreeMap::new(),
         None,
         SYSTEM_TIME.clone(),
         EXPIRES_IN_SECS,

--- a/src/frontegg-auth/src/error.rs
+++ b/src/frontegg-auth/src/error.rs
@@ -22,14 +22,20 @@ pub enum Error {
     ReqwestError(Arc<reqwest::Error>),
     #[error("middleware programming error: {0}")]
     MiddlewareError(Arc<anyhow::Error>),
+    #[error("authentication token missing claims")]
+    MissingClaims,
     #[error("authentication token expired")]
     TokenExpired,
     #[error("unauthorized organization")]
     UnauthorizedTenant,
     #[error("the app password was not valid")]
     InvalidAppPassword,
-    #[error("email in access token did not match the expected email")]
-    WrongEmail,
+    #[error("user in access token did not match the expected user")]
+    WrongUser,
+    #[error("user name too long")]
+    UserNameTooLong,
+    #[error("user declared by tenant access token cannot be an email address")]
+    InvalidTenantApiTokenUser,
     #[error("request timeout")]
     Timeout(Arc<tokio::time::error::Elapsed>),
     #[error("internal error")]

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -16,8 +16,8 @@ mod metrics;
 use std::path::PathBuf;
 
 pub use auth::{
-    Authenticator, AuthenticatorConfig, Claims, DEFAULT_REFRESH_DROP_FACTOR,
-    DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
+    Authenticator, AuthenticatorConfig, ClaimMetadata, ClaimTokenType, Claims,
+    DEFAULT_REFRESH_DROP_FACTOR, DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
 };
 pub use client::tokens::{ApiTokenArgs, ApiTokenResponse};
 pub use client::Client;

--- a/src/frontegg-mock/src/main.rs
+++ b/src/frontegg-mock/src/main.rs
@@ -99,6 +99,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         .into_iter()
         .map(|user| (user.email.clone(), user))
         .collect();
+    let tenant_api_tokens = BTreeMap::new();
     let role_permissions = match &args.role_permissions {
         Some(s) => serde_json::from_str(s).with_context(|| "decoding --role-permissions")?,
         None => None,
@@ -115,6 +116,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         encoding_key,
         decoding_key,
         users,
+        tenant_api_tokens,
         role_permissions,
         SYSTEM_TIME.clone(),
         500,

--- a/src/mz/src/command/secret.rs
+++ b/src/mz/src/command/secret.rs
@@ -60,11 +60,11 @@ pub async fn create(
     // Retrieve information to open the psql shell sessions.
     let loading_spinner = cx.output_formatter().loading_spinner("Creating secret...");
 
-    let claims = cx.admin_client().claims();
+    let claims = cx.admin_client().claims().await?;
     let region_info = cx.get_region_info().await?;
-    let email = claims.await?.email;
+    let user = claims.user()?;
 
-    let mut client = cx.sql_client().shell(&region_info, email, None);
+    let mut client = cx.sql_client().shell(&region_info, user, None);
 
     // Build the queries to create the secret.
     let mut commands: Vec<String> = vec![];

--- a/src/mz/src/command/sql.rs
+++ b/src/mz/src/command/sql.rs
@@ -34,12 +34,12 @@ pub struct RunArgs {
 /// The SQL shell command is running `psql` behind the scenes.
 pub async fn run(cx: &RegionContext, RunArgs { cluster, psql_args }: RunArgs) -> Result<(), Error> {
     let sql_client = cx.sql_client();
-    let claims = cx.admin_client().claims();
+    let claims = cx.admin_client().claims().await?;
     let region_info = cx.get_region_info().await?;
-    let email = claims.await?.email;
+    let user = claims.user()?;
 
     let _error = sql_client
-        .shell(&region_info, email, cluster)
+        .shell(&region_info, user, cluster)
         .args(psql_args)
         .exec();
 

--- a/src/mz/src/error.rs
+++ b/src/mz/src/error.rs
@@ -32,6 +32,9 @@ pub enum Error {
     /// A Materialize Cloud API error from the [mz_cloud_api] crate.
     #[error(transparent)]
     ApiError(#[from] mz_cloud_api::error::Error),
+    /// A Frontegg authentication error.
+    #[error(transparent)]
+    AuthError(#[from] mz_frontegg_auth::Error),
     /// Indicates an error parsing an endpoint.
     #[error("Error parsing URL: {0}.\n\nTo resolve this issue, please verify the correctness of the URLs in the configuration file or the ones passed as parameters.")]
     UrlParseError(#[from] ParseError),


### PR DESCRIPTION
This commit teaches Materialize to authenticate service app passwords, as described in #20894.

Under the hood, a service app password is a tenant API token with the `user` claim set in its metadata. Authenticating with such an API token functions as a login to the specified user. To prevent impersonating Frontegg users, the `user` claim must not contain an `@` character.

Database privileges for service app passwords are managed by issuing the normal `GRANT` and `REVOKE` commands against the user associated with the app password.

Touches #20894.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds (part of) a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a (will write a dedicated changelog post when ready)
