### PR TITLE
compute: remove `Active*` controller types

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1859,7 +1859,7 @@ impl Coordinator {
                             .extend(df_desc.export_ids());
 
                         self.controller
-                            .active_compute()
+                            .compute
                             .create_dataflow(idx.cluster_id, df_desc)
                             .unwrap_or_terminate("cannot fail to create dataflows");
 
@@ -2935,7 +2935,7 @@ impl Coordinator {
         let export_ids = dataflow.exported_index_ids().collect();
 
         self.controller
-            .active_compute()
+            .compute
             .create_dataflow(instance, dataflow)
             .unwrap_or_terminate("dataflow creation cannot fail");
 

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -629,7 +629,7 @@ impl Coordinator {
                 for (dropped_name, uuid) in peeks_to_drop {
                     if let Some(pending_peek) = self.remove_pending_peek(&uuid) {
                         self.controller
-                            .active_compute()
+                            .compute
                             .cancel_peek(pending_peek.cluster_id, uuid)
                             .unwrap_or_terminate("unable to cancel peek");
                         self.retire_execution(
@@ -852,8 +852,8 @@ impl Coordinator {
                 .push(sink_id);
             by_id.insert(sink_id, sink);
         }
-        let mut compute = self.controller.active_compute();
         for (cluster_id, ids) in by_cluster {
+            let compute = &mut self.controller.compute;
             // A cluster could have been dropped, so verify it exists.
             if compute.instance_exists(cluster_id) {
                 compute
@@ -926,8 +926,8 @@ impl Coordinator {
                 tracing::error!("Instructed to drop a non-index index");
             }
         }
-        let mut compute = self.controller.active_compute();
         for (cluster_id, ids) in by_cluster {
+            let compute = &mut self.controller.compute;
             // A cluster could have been dropped, so verify it exists.
             if compute.instance_exists(cluster_id) {
                 compute
@@ -947,8 +947,8 @@ impl Coordinator {
         }
 
         // Drop compute sinks.
-        let mut compute = self.controller.active_compute();
         for (cluster_id, ids) in by_cluster {
+            let compute = &mut self.controller.compute;
             // A cluster could have been dropped, so verify it exists.
             if compute.instance_exists(cluster_id) {
                 compute

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -562,7 +562,7 @@ impl crate::coord::Coordinator {
 
                 // Very important: actually create the dataflow (here, so we can destructure).
                 self.controller
-                    .active_compute()
+                    .compute
                     .create_dataflow(compute_instance, dataflow)
                     .unwrap_or_terminate("cannot fail to create dataflows");
                 self.initialize_compute_read_policies(
@@ -628,7 +628,7 @@ impl crate::coord::Coordinator {
         let (id, literal_constraints, timestamp, map_filter_project) = peek_command;
 
         self.controller
-            .active_compute()
+            .compute
             .peek(
                 compute_instance,
                 id,
@@ -683,14 +683,13 @@ impl crate::coord::Coordinator {
             for (uuid, compute_instance) in &uuids {
                 inverse.entry(*compute_instance).or_default().insert(*uuid);
             }
-            let mut compute = self.controller.active_compute();
             for (compute_instance, uuids) in inverse {
                 // It's possible that this compute instance no longer exists because it was dropped
                 // while the peek was in progress. In this case we ignore the error and move on
                 // because the dataflow no longer exists.
                 // TODO(jkosh44) Dropping a cluster should actively cancel all pending queries.
                 for uuid in uuids {
-                    let _ = compute.cancel_peek(compute_instance, uuid);
+                    let _ = self.controller.compute.cancel_peek(compute_instance, uuid);
                 }
             }
 

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -423,9 +423,10 @@ impl crate::coord::Coordinator {
                 stashed_storage_holds.push(storage_hold);
             }
             for (compute_instance, compute_ids) in id_bundle.compute_ids.iter() {
-                let compute = coord.controller.active_compute();
                 for id in compute_ids.iter() {
-                    let collection = compute
+                    let collection = coord
+                        .controller
+                        .compute
                         .collection(*compute_instance, *id)
                         .expect("collection does not exist");
                     let read_frontier = collection.read_capability().clone();
@@ -507,7 +508,7 @@ impl crate::coord::Coordinator {
         // Apply read capabilities.
         for (compute_instance, compute_policy_updates) in compute_policy_updates {
             self.controller
-                .active_compute()
+                .compute
                 .set_read_policy(compute_instance, compute_policy_updates)
                 .unwrap_or_terminate("cannot fail to set read policy");
         }
@@ -565,9 +566,10 @@ impl crate::coord::Coordinator {
                 }
 
                 for (compute_instance, compute_ids) in id_bundle.compute_ids {
-                    let compute = self.controller.active_compute();
                     for id in compute_ids {
-                        let collection = compute
+                        let collection = self
+                            .controller
+                            .compute
                             .collection(compute_instance, id)
                             .expect("id does not exist");
                         assert!(collection.read_capability().le(&new_time.borrow()),
@@ -609,9 +611,9 @@ impl crate::coord::Coordinator {
             .set_read_policy(storage_policy_changes);
 
         // Update COMPUTE read policies
-        let mut compute = self.controller.active_compute();
         for (compute_instance, compute_policy_changes) in compute_policy_changes {
-            compute
+            self.controller
+                .compute
                 .set_read_policy(compute_instance, compute_policy_changes)
                 .unwrap_or_terminate("cannot fail to set read policy");
         }
@@ -644,8 +646,9 @@ impl crate::coord::Coordinator {
                     None => {
                         // We didn't get an initial policy, so set the current
                         // since as a static policy.
-                        let compute = self.controller.active_compute();
-                        let collection = compute
+                        let collection = self
+                            .controller
+                            .compute
                             .collection(*instance_id, *id)
                             .expect("collection does not exist");
                         let read_frontier = collection.read_capability().clone();
@@ -733,7 +736,7 @@ impl crate::coord::Coordinator {
                 })
                 .collect::<Vec<_>>();
             self.controller
-                .active_compute()
+                .compute
                 .set_read_policy(cluster_id, group)
                 .unwrap_or_terminate("cannot fail to set read policy");
         }
@@ -801,9 +804,10 @@ impl crate::coord::Coordinator {
         }
 
         for (compute_instance, compute_ids) in id_bundle.compute_ids.iter() {
-            let compute = self.controller.active_compute();
             for id in compute_ids.iter() {
-                let collection = compute
+                let collection = self
+                    .controller
+                    .compute
                     .collection(*compute_instance, *id)
                     .expect("collection does not exist");
                 let read_frontier = collection.read_capability().clone();
@@ -826,9 +830,9 @@ impl crate::coord::Coordinator {
                 .push((*id, read_needs.policy()));
         }
 
-        let mut compute = self.controller.active_compute();
         for (compute_instance, policy_changes) in policy_changes {
-            compute
+            self.controller
+                .compute
                 .set_read_policy(compute_instance, policy_changes)
                 .unwrap_or_terminate("cannot fail to set read policy");
         }
@@ -883,8 +887,8 @@ impl crate::coord::Coordinator {
                 }
             }
         }
-        let mut compute = self.controller.active_compute();
         for (compute_instance, policy_changes) in policy_changes_per_instance {
+            let compute = &mut self.controller.compute;
             if compute.instance_exists(*compute_instance) {
                 compute
                     .set_read_policy(*compute_instance, policy_changes)

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -49,6 +49,7 @@ use mz_ore::{soft_assert_or_log, soft_panic_or_log};
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{Datum, Diff, GlobalId, Row, TimestampManipulation};
 use mz_storage_client::controller::{IntrospectionType, StorageController};
+use mz_storage_client::storage_collections::StorageCollections;
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::{AntichainRef, MutableAntichain};
@@ -62,7 +63,7 @@ use crate::controller::error::{
     InstanceExists, InstanceMissing, PeekError, ReadPolicyError, ReplicaCreationError,
     ReplicaDropError, SubscribeTargetError,
 };
-use crate::controller::instance::{ActiveInstance, Instance};
+use crate::controller::instance::Instance;
 use crate::controller::replica::ReplicaConfig;
 use crate::logging::{LogVariant, LoggingConfig};
 use crate::metrics::ComputeControllerMetrics;
@@ -143,6 +144,8 @@ impl ComputeReplicaLogging {
 pub struct ComputeController<T> {
     instances: BTreeMap<ComputeInstanceId, Instance<T>>,
     build_info: &'static BuildInfo,
+    /// A handle providing access to storage collections.
+    storage_collections: Arc<dyn StorageCollections<Timestamp = T>>,
     /// Set to `true` once `initialization_complete` has been called.
     initialized: bool,
     /// Compute configuration to apply to new instances.
@@ -150,7 +153,7 @@ pub struct ComputeController<T> {
     /// `arrangement_exert_proportionality` value passed to new replicas.
     arrangement_exert_proportionality: u32,
     /// A replica response to be handled by the corresponding `Instance` on a subsequent call to
-    /// `ActiveComputeController::process`.
+    /// [`ComputeController::process`].
     stashed_replica_response: Option<(ComputeInstanceId, ReplicaId, ComputeResponse<T>)>,
     /// A number that increases on every `environmentd` restart.
     envd_epoch: NonZeroI64,
@@ -163,7 +166,7 @@ pub struct ComputeController<T> {
     dyncfg: Arc<ConfigSet>,
 
     /// Receiver for responses produced by `Instance`s, to be delivered on subsequent calls to
-    /// `ActiveComputeController::process`.
+    /// [`ComputeController::process`].
     response_rx: crossbeam_channel::Receiver<ComputeControllerResponse<T>>,
     /// Response sender that's passed to new `Instance`s.
     response_tx: crossbeam_channel::Sender<ComputeControllerResponse<T>>,
@@ -182,6 +185,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
     /// Construct a new [`ComputeController`].
     pub fn new(
         build_info: &'static BuildInfo,
+        storage_collections: Arc<dyn StorageCollections<Timestamp = T>>,
         envd_epoch: NonZeroI64,
         metrics_registry: MetricsRegistry,
     ) -> Self {
@@ -194,6 +198,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
         Self {
             instances: BTreeMap::new(),
             build_info,
+            storage_collections,
             initialized: false,
             config: Default::default(),
             arrangement_exert_proportionality: 16,
@@ -258,17 +263,6 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
             .ok_or(CollectionLookupError::CollectionMissing(collection_id))
     }
 
-    /// Acquire an [`ActiveComputeController`] by supplying a storage connection.
-    pub fn activate<'a>(
-        &'a mut self,
-        storage: &'a mut dyn StorageController<Timestamp = T>,
-    ) -> ActiveComputeController<'a, T> {
-        ActiveComputeController {
-            compute: self,
-            storage,
-        }
-    }
-
     /// List compute collections that depend on the given collection.
     pub fn collection_reverse_dependencies(
         &self,
@@ -322,6 +316,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
         let Self {
             instances,
             build_info: _,
+            storage_collections: _,
             initialized,
             config: _,
             arrangement_exert_proportionality,
@@ -387,6 +382,7 @@ where
             id,
             Instance::new(
                 self.build_info,
+                Arc::clone(&self.storage_collections),
                 arranged_logs,
                 self.envd_epoch,
                 self.metrics.for_instance(id),
@@ -448,7 +444,7 @@ where
     ///
     /// This method may block for an arbitrarily long time.
     ///
-    /// When the method returns, the caller should call [`ActiveComputeController::process`].
+    /// When the method returns, the caller should call [`ComputeController::process`].
     ///
     /// This method is cancellation safe.
     pub async fn ready(&mut self) {
@@ -486,7 +482,7 @@ where
                     Err(_) => {
                         // There is nothing to do here. `recv` has already added the failed replica to
                         // `instance.failed_replicas`, so it will be rehydrated in the next call to
-                        // `ActiveComputeController::process`.
+                        // [`ComputeController::process`].
                     }
                 }
             },
@@ -510,42 +506,7 @@ where
             .set_subscribe_target_replica(subscribe_id, target_replica)?;
         Ok(())
     }
-}
 
-/// A wrapper around a [`ComputeController`] with a live connection to a storage controller.
-pub struct ActiveComputeController<'a, T> {
-    compute: &'a mut ComputeController<T>,
-    storage: &'a mut dyn StorageController<Timestamp = T>,
-}
-
-impl<T: ComputeControllerTimestamp> ActiveComputeController<'_, T> {
-    /// TODO(#25239): Add documentation.
-    pub fn instance_exists(&self, id: ComputeInstanceId) -> bool {
-        self.compute.instance_exists(id)
-    }
-
-    /// Return a read-only handle to the indicated collection.
-    pub fn collection(
-        &self,
-        instance_id: ComputeInstanceId,
-        collection_id: GlobalId,
-    ) -> Result<&CollectionState<T>, CollectionLookupError> {
-        self.compute.collection(instance_id, collection_id)
-    }
-
-    /// Return a handle to the indicated compute instance.
-    fn instance(&mut self, id: ComputeInstanceId) -> Result<ActiveInstance<T>, InstanceMissing> {
-        self.compute
-            .instance_mut(id)
-            .map(|c| c.activate(self.storage))
-    }
-}
-
-impl<T> ActiveComputeController<'_, T>
-where
-    T: ComputeControllerTimestamp,
-    ComputeGrpcClient: ComputeClient<T>,
-{
     /// Adds replicas of an instance.
     pub fn add_replica_to_instance(
         &mut self,
@@ -567,11 +528,11 @@ where
                 log_logging: config.logging.log_logging,
                 index_logs: Default::default(),
             },
-            arrangement_exert_proportionality: self.compute.arrangement_exert_proportionality,
-            grpc_client: self.compute.config.grpc_client.clone(),
+            arrangement_exert_proportionality: self.arrangement_exert_proportionality,
+            grpc_client: self.config.grpc_client.clone(),
         };
 
-        self.instance(instance_id)?
+        self.instance_mut(instance_id)?
             .add_replica(replica_id, replica_config)?;
         Ok(())
     }
@@ -582,7 +543,7 @@ where
         instance_id: ComputeInstanceId,
         replica_id: ReplicaId,
     ) -> Result<(), ReplicaDropError> {
-        self.instance(instance_id)?.remove_replica(replica_id)?;
+        self.instance_mut(instance_id)?.remove_replica(replica_id)?;
         Ok(())
     }
 
@@ -598,7 +559,7 @@ where
         instance_id: ComputeInstanceId,
         dataflow: DataflowDescription<mz_compute_types::plan::Plan<T>, (), T>,
     ) -> Result<(), DataflowCreationError> {
-        self.instance(instance_id)?.create_dataflow(dataflow)?;
+        self.instance_mut(instance_id)?.create_dataflow(dataflow)?;
         Ok(())
     }
 
@@ -609,7 +570,7 @@ where
         instance_id: ComputeInstanceId,
         collection_ids: Vec<GlobalId>,
     ) -> Result<(), CollectionUpdateError> {
-        self.instance(instance_id)?
+        self.instance_mut(instance_id)?
             .drop_collections(collection_ids)?;
         Ok(())
     }
@@ -627,7 +588,7 @@ where
         target_replica: Option<ReplicaId>,
         peek_target: PeekTarget,
     ) -> Result<(), PeekError> {
-        self.instance(instance_id)?.peek(
+        self.instance_mut(instance_id)?.peek(
             collection_id,
             literal_constraints,
             uuid,
@@ -654,7 +615,7 @@ where
         instance_id: ComputeInstanceId,
         uuid: Uuid,
     ) -> Result<(), InstanceMissing> {
-        self.instance(instance_id)?.cancel_peek(uuid);
+        self.instance_mut(instance_id)?.cancel_peek(uuid);
         Ok(())
     }
 
@@ -674,17 +635,20 @@ where
         instance_id: ComputeInstanceId,
         policies: Vec<(GlobalId, ReadPolicy<T>)>,
     ) -> Result<(), ReadPolicyError> {
-        self.instance(instance_id)?.set_read_policy(policies)?;
+        self.instance_mut(instance_id)?.set_read_policy(policies)?;
         Ok(())
     }
 
     #[mz_ore::instrument(level = "debug")]
-    async fn record_introspection_updates(&mut self) {
+    async fn record_introspection_updates(
+        &mut self,
+        storage: &mut dyn StorageController<Timestamp = T>,
+    ) {
         // We could record the contents of `introspection_rx` directly here, but to reduce the
         // pressure on persist we spend some effort consolidating first.
         let mut updates_by_type = BTreeMap::new();
 
-        for (type_, updates) in self.compute.introspection_rx.try_iter() {
+        for (type_, updates) in self.introspection_rx.try_iter() {
             updates_by_type
                 .entry(type_)
                 .or_insert_with(Vec::new)
@@ -696,25 +660,26 @@ where
 
         for (type_, updates) in updates_by_type {
             if !updates.is_empty() {
-                self.storage
-                    .record_introspection_updates(type_, updates)
-                    .await;
+                storage.record_introspection_updates(type_, updates).await;
             }
         }
     }
 
     /// Processes the work queued by [`ComputeController::ready`].
     #[mz_ore::instrument(level = "debug")]
-    pub async fn process(&mut self) -> Option<ComputeControllerResponse<T>> {
+    pub async fn process(
+        &mut self,
+        storage: &mut dyn StorageController<Timestamp = T>,
+    ) -> Option<ComputeControllerResponse<T>> {
         // Perform periodic maintenance work.
-        if self.compute.maintenance_scheduled {
-            self.maintain().await;
-            self.compute.maintenance_ticker.reset();
-            self.compute.maintenance_scheduled = false;
+        if self.maintenance_scheduled {
+            self.maintain(storage).await;
+            self.maintenance_ticker.reset();
+            self.maintenance_scheduled = false;
         }
 
         // Process pending ready responses.
-        match self.compute.response_rx.try_recv() {
+        match self.response_rx.try_recv() {
             Ok(response) => return Some(response),
             Err(crossbeam_channel::TryRecvError::Empty) => (),
             Err(crossbeam_channel::TryRecvError::Disconnected) => {
@@ -725,10 +690,8 @@ where
         }
 
         // Process pending responses from replicas.
-        if let Some((instance_id, replica_id, response)) =
-            self.compute.stashed_replica_response.take()
-        {
-            if let Ok(mut instance) = self.instance(instance_id) {
+        if let Some((instance_id, replica_id, response)) = self.stashed_replica_response.take() {
+            if let Some(instance) = self.instances.get_mut(&instance_id) {
                 return instance.handle_response(response, replica_id);
             } else {
                 warn!(
@@ -743,10 +706,10 @@ where
     }
 
     #[mz_ore::instrument(level = "debug")]
-    async fn maintain(&mut self) {
+    async fn maintain(&mut self, storage: &mut dyn StorageController<Timestamp = T>) {
         // Perform instance maintenance work.
-        for instance in self.compute.instances.values_mut() {
-            instance.activate(self.storage).maintain();
+        for instance in self.instances.values_mut() {
+            instance.maintain();
         }
 
         // Record pending introspection updates.
@@ -754,7 +717,7 @@ where
         // It's beneficial to do this as the last maintenance step because previous steps can cause
         // dropping of state, which can can cause introspection retractions, which lower the volume
         // of data we have to record.
-        self.record_introspection_updates().await;
+        self.record_introspection_updates(storage).await;
     }
 }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -29,11 +29,13 @@ use mz_compute_types::sources::SourceInstanceDesc;
 use mz_dyncfg::ConfigSet;
 use mz_expr::RowSetFinishing;
 use mz_ore::cast::CastFrom;
+use mz_ore::collections::CollectionExt;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{Datum, Diff, GlobalId, Row};
-use mz_storage_client::controller::{IntrospectionType, StorageController};
-use mz_storage_types::read_holds::ReadHoldError;
+use mz_storage_client::controller::IntrospectionType;
+use mz_storage_client::storage_collections::StorageCollections;
+use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::Serialize;
 use thiserror::Error;
@@ -151,6 +153,8 @@ pub(super) enum SubscribeTargetError {
 pub(super) struct Instance<T> {
     /// Build info for spawning replicas
     build_info: &'static BuildInfo,
+    /// A handle providing access to storage collections.
+    storage_collections: Arc<dyn StorageCollections<Timestamp = T>>,
     /// Whether instance initialization has been completed.
     initialized: bool,
     /// The replicas of this compute instance.
@@ -158,7 +162,7 @@ pub(super) struct Instance<T> {
     /// Currently installed compute collections.
     ///
     /// New entries are added for all collections exported from dataflows created through
-    /// [`ActiveInstance::create_dataflow`].
+    /// [`Instance::create_dataflow`].
     ///
     /// Entries are removed by [`Instance::cleanup_collections`]. See that method's documentation
     /// about the conditions for removing collection state.
@@ -167,7 +171,7 @@ pub(super) struct Instance<T> {
     log_sources: BTreeMap<LogVariant, GlobalId>,
     /// Currently outstanding peeks.
     ///
-    /// New entries are added for all peeks initiated through [`ActiveInstance::peek`].
+    /// New entries are added for all peeks initiated through [`Instance::peek`].
     ///
     /// The entry for a peek is only removed once all replicas have responded to the peek. This is
     /// currently required to ensure all replicas have stopped reading from the peeked collection's
@@ -177,7 +181,7 @@ pub(super) struct Instance<T> {
     /// Currently in-progress subscribes.
     ///
     /// New entries are added for all subscribes exported from dataflows created through
-    /// [`ActiveInstance::create_dataflow`].
+    /// [`Instance::create_dataflow`].
     ///
     /// The entry for a subscribe is removed once at least one replica has reported the subscribe
     /// to have advanced to the empty frontier or to have been dropped, implying that no further
@@ -191,7 +195,7 @@ pub(super) struct Instance<T> {
     /// Tracks all in-progress COPY TOs.
     ///
     /// New entries are added for all s3 oneshot sinks (corresponding to a COPY TO) exported from
-    /// dataflows created through [`ActiveInstance::create_dataflow`].
+    /// dataflows created through [`Instance::create_dataflow`].
     ///
     /// The entry for a copy to is removed once at least one replica has finished
     /// or the exporting collection is dropped.
@@ -344,6 +348,20 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         Some(replica)
     }
 
+    fn acquire_storage_read_hold_at(
+        &self,
+        id: GlobalId,
+        frontier: Antichain<T>,
+    ) -> Result<ReadHold<T>, ReadHoldError> {
+        let mut hold = self
+            .storage_collections
+            .acquire_read_holds(vec![id])?
+            .into_element();
+        hold.try_downgrade(frontier)
+            .map_err(|_| ReadHoldError::SinceViolation(id))?;
+        Ok(hold)
+    }
+
     /// Enqueue the given response for delivery to the controller clients.
     fn deliver_response(&mut self, response: ComputeControllerResponse<T>) {
         self.response_tx
@@ -360,17 +378,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         self.introspection_tx
             .send((type_, updates))
             .expect("global controller never drops");
-    }
-
-    /// Acquire an [`ActiveInstance`] by providing a storage controller.
-    pub fn activate<'a>(
-        &'a mut self,
-        storage_controller: &'a mut dyn StorageController<Timestamp = T>,
-    ) -> ActiveInstance<'a, T> {
-        ActiveInstance {
-            compute: self,
-            storage_controller,
-        }
     }
 
     /// Returns whether the identified replica exists.
@@ -584,6 +591,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         // Destructure `self` here so we don't forget to consider dumping newly added fields.
         let Self {
             build_info: _,
+            storage_collections: _,
             initialized,
             replicas,
             collections,
@@ -651,6 +659,7 @@ where
 {
     pub fn new(
         build_info: &'static BuildInfo,
+        storage: Arc<dyn StorageCollections<Timestamp = T>>,
         arranged_logs: BTreeMap<LogVariant, GlobalId>,
         envd_epoch: NonZeroI64,
         metrics: InstanceMetrics,
@@ -670,6 +679,7 @@ where
 
         let mut instance = Self {
             build_info,
+            storage_collections: storage,
             initialized: false,
             replicas: Default::default(),
             collections,
@@ -853,36 +863,23 @@ where
         subscribe.target_replica = Some(target_replica);
         Ok(())
     }
-}
 
-/// A wrapper around [`Instance`] with a live storage controller.
-#[derive(Debug)]
-pub(super) struct ActiveInstance<'a, T> {
-    compute: &'a mut Instance<T>,
-    storage_controller: &'a mut dyn StorageController<Timestamp = T>,
-}
-
-impl<'a, T> ActiveInstance<'a, T>
-where
-    T: ComputeControllerTimestamp,
-    ComputeGrpcClient: ComputeClient<T>,
-{
     /// Add a new instance replica, by ID.
     pub fn add_replica(
         &mut self,
         id: ReplicaId,
         mut config: ReplicaConfig,
     ) -> Result<(), ReplicaExists> {
-        if self.compute.replica_exists(id) {
+        if self.replica_exists(id) {
             return Err(ReplicaExists(id));
         }
 
-        config.logging.index_logs = self.compute.log_sources.clone();
+        config.logging.index_logs = self.log_sources.clone();
         let log_ids: BTreeSet<_> = config.logging.index_logs.values().collect();
 
         // Initialize frontier tracking for the new replica.
         let mut updates = BTreeMap::new();
-        for (compute_id, collection) in &mut self.compute.collections {
+        for (compute_id, collection) in &mut self.collections {
             // Skip log collections not maintained by this replica.
             if collection.log_collection && !log_ids.contains(compute_id) {
                 continue;
@@ -894,23 +891,23 @@ where
         self.update_replica_write_frontiers(id, &updates);
         self.update_replica_input_frontiers(id, &updates);
 
-        let replica_epoch = self.compute.replica_epochs.entry(id).or_default();
+        let replica_epoch = self.replica_epochs.entry(id).or_default();
         *replica_epoch += 1;
-        let metrics = self.compute.metrics.for_replica(id);
+        let metrics = self.metrics.for_replica(id);
         let client = ReplicaClient::spawn(
             id,
-            self.compute.build_info,
+            self.build_info,
             config.clone(),
-            ClusterStartupEpoch::new(self.compute.envd_epoch, *replica_epoch),
+            ClusterStartupEpoch::new(self.envd_epoch, *replica_epoch),
             metrics.clone(),
-            Arc::clone(&self.compute.dyncfg),
+            Arc::clone(&self.dyncfg),
         );
 
         // Take this opportunity to clean up the history we should present.
-        self.compute.history.reduce();
+        self.history.reduce();
 
         // Replay the commands at the client, creating new dataflow identifiers.
-        for command in self.compute.history.iter() {
+        for command in self.history.iter() {
             if client.send(command.clone()).is_err() {
                 // We swallow the error here. On the next send, we will fail again, and
                 // restart the connection as well as this rehydration.
@@ -920,16 +917,14 @@ where
         }
 
         // Add replica to tracked state.
-        self.compute.add_replica_state(id, client, config);
+        self.add_replica_state(id, client, config);
 
         Ok(())
     }
 
     /// Remove an existing instance replica, by ID.
     pub fn remove_replica(&mut self, id: ReplicaId) -> Result<(), ReplicaMissing> {
-        self.compute
-            .remove_replica_state(id)
-            .ok_or(ReplicaMissing(id))?;
+        self.remove_replica_state(id).ok_or(ReplicaMissing(id))?;
 
         // Remove frontier tracking for this replica.
         self.remove_replica_frontiers(id);
@@ -937,9 +932,9 @@ where
         // Subscribes targeting this replica either won't be served anymore (if the replica is
         // dropped) or might produce inconsistent output (if the target collection is an
         // introspection index). We produce an error to inform upstream.
-        let to_drop: Vec<_> = self.compute.subscribes_targeting(id).collect();
+        let to_drop: Vec<_> = self.subscribes_targeting(id).collect();
         for subscribe_id in to_drop {
-            let subscribe = self.compute.subscribes.remove(&subscribe_id).unwrap();
+            let subscribe = self.subscribes.remove(&subscribe_id).unwrap();
             let response = ComputeControllerResponse::SubscribeResponse(
                 subscribe_id,
                 SubscribeBatch {
@@ -948,7 +943,7 @@ where
                     updates: Err("target replica failed or was dropped".into()),
                 },
             );
-            self.compute.deliver_response(response);
+            self.deliver_response(response);
         }
 
         // Peeks targeting this replica might not be served anymore (if the replica is dropped).
@@ -957,7 +952,7 @@ where
         // is consistent with how we handle targeted subscribes above.
         let mut peek_responses = Vec::new();
         let mut to_drop = Vec::new();
-        for (uuid, peek) in self.compute.peeks_targeting(id) {
+        for (uuid, peek) in self.peeks_targeting(id) {
             peek_responses.push(ComputeControllerResponse::PeekResponse(
                 uuid,
                 PeekResponse::Error("target replica failed or was dropped".into()),
@@ -966,7 +961,7 @@ where
             to_drop.push(uuid);
         }
         for response in peek_responses {
-            self.compute.deliver_response(response);
+            self.deliver_response(response);
         }
         to_drop.into_iter().for_each(|uuid| self.remove_peek(uuid));
 
@@ -979,7 +974,7 @@ where
     ///
     /// Panics if the specified replica does not exist.
     fn rehydrate_replica(&mut self, id: ReplicaId) {
-        let config = self.compute.replicas[&id].config.clone();
+        let config = self.replicas[&id].config.clone();
         self.remove_replica(id).expect("replica must exist");
         let result = self.add_replica(id, config);
 
@@ -991,7 +986,7 @@ where
 
     /// Rehydrate any failed replicas of this instance.
     fn rehydrate_failed_replicas(&mut self) {
-        let replicas = self.compute.replicas.iter();
+        let replicas = self.replicas.iter();
         let failed_replicas: Vec<_> = replicas
             .filter_map(|(id, replica)| replica.failed.then_some(*id))
             .collect();
@@ -1044,9 +1039,7 @@ where
 
         // Validate sources have `since.less_equal(as_of)`.
         for source_id in dataflow.source_imports.keys() {
-            let storage_read_hold = self
-                .storage_controller
-                .acquire_read_hold_at_time(*source_id, as_of.clone())?;
+            let storage_read_hold = self.acquire_storage_read_hold_at(*source_id, as_of.clone())?;
 
             storage_dependencies.push(*source_id);
             replica_input_frontier.join_assign(storage_read_hold.since());
@@ -1057,7 +1050,7 @@ where
         // Validate indexes have `since.less_equal(as_of)`.
         // TODO(mcsherry): Instead, return an error from the constructing method.
         for index_id in dataflow.index_imports.keys() {
-            let collection = self.compute.collection(*index_id)?;
+            let collection = self.collection(*index_id)?;
             let since = collection.read_capabilities.frontier();
             if !(timely::order::PartialOrder::less_equal(&since, &as_of.borrow())) {
                 Err(DataflowCreationError::SinceViolation(*index_id))?;
@@ -1093,7 +1086,7 @@ where
             .iter()
             .map(|id| (*id, changes.clone()))
             .collect();
-        self.storage_controller
+        self.storage_collections
             .update_read_capabilities(&mut storage_read_updates);
         // Drop the acquired read holds after we installed our old-style, manual
         // read capabilities.
@@ -1109,7 +1102,7 @@ where
         // Install collection state for each of the exports.
         for export_id in dataflow.export_ids() {
             let write_only = dataflow.sink_exports.contains_key(&export_id);
-            self.compute.add_collection(
+            self.add_collection(
                 export_id,
                 as_of.clone(),
                 storage_dependencies.clone(),
@@ -1129,7 +1122,7 @@ where
             .export_ids()
             .map(|id| (id, replica_input_frontier.clone()))
             .collect();
-        let replica_ids: Vec<_> = self.compute.replica_ids().collect();
+        let replica_ids: Vec<_> = self.replica_ids().collect();
         for replica_id in replica_ids {
             self.update_replica_write_frontiers(replica_id, &replica_write_frontier_updates);
             self.update_replica_input_frontiers(replica_id, &replica_input_frontier_updates);
@@ -1137,14 +1130,12 @@ where
 
         // Initialize tracking of subscribes.
         for subscribe_id in dataflow.subscribe_ids() {
-            self.compute
-                .subscribes
-                .insert(subscribe_id, ActiveSubscribe::new());
+            self.subscribes.insert(subscribe_id, ActiveSubscribe::new());
         }
 
         // Initialize tracking of copy tos.
         for copy_to_id in dataflow.copy_to_ids() {
-            self.compute.copy_tos.insert(copy_to_id);
+            self.copy_tos.insert(copy_to_id);
         }
 
         // Here we augment all imported sources and all exported sinks with the appropriate
@@ -1152,7 +1143,7 @@ where
         let mut source_imports = BTreeMap::new();
         for (id, (si, monotonic)) in dataflow.source_imports {
             let collection_metadata = self
-                .storage_controller
+                .storage_collections
                 .collection_metadata(id)
                 .map_err(|_| DataflowCreationError::CollectionMissing(id))?;
 
@@ -1169,7 +1160,7 @@ where
             let connection = match se.connection {
                 ComputeSinkConnection::Persist(conn) => {
                     let metadata = self
-                        .storage_controller
+                        .storage_collections
                         .collection_metadata(id)
                         .map_err(|_| DataflowCreationError::CollectionMissing(id))?
                         .clone();
@@ -1249,8 +1240,7 @@ where
             );
         } else {
             let collections: Vec<_> = augmented_dataflow.export_ids().collect();
-            self.compute
-                .send(ComputeCommand::CreateDataflow(augmented_dataflow));
+            self.send(ComputeCommand::CreateDataflow(augmented_dataflow));
 
             for id in collections {
                 self.maybe_schedule_collection(id);
@@ -1266,7 +1256,7 @@ where
     ///
     /// Panics if the identified collection does not exist.
     fn maybe_schedule_collection(&mut self, id: GlobalId) {
-        let collection = self.compute.expect_collection(id);
+        let collection = self.expect_collection(id);
 
         // Don't schedule collections twice.
         if collection.scheduled {
@@ -1294,15 +1284,15 @@ where
             // than the `as_of`, i.e., all input data up to and including the
             // `as_of` has been sealed.
             let compute_frontiers = collection.compute_dependencies.iter().map(|id| {
-                let dep = &self.compute.expect_collection(*id);
+                let dep = &self.expect_collection(*id);
                 &dep.write_frontier
             });
 
             let storage_frontiers = self
-                .storage_controller
+                .storage_collections
                 .collections_frontiers(collection.storage_dependencies.clone())
                 .expect("must exist");
-            let storage_frontiers = storage_frontiers.iter().map(|(_id, _since, upper)| upper);
+            let storage_frontiers = storage_frontiers.iter().map(|f| &f.write_frontier);
 
             let ready = compute_frontiers
                 .chain(storage_frontiers)
@@ -1312,15 +1302,15 @@ where
         };
 
         if ready {
-            self.compute.send(ComputeCommand::Schedule(id));
-            let collection = self.compute.expect_collection_mut(id);
+            self.send(ComputeCommand::Schedule(id));
+            let collection = self.expect_collection_mut(id);
             collection.scheduled = true;
         }
     }
 
     /// Schedule any unscheduled collections that are ready.
     fn schedule_collections(&mut self) {
-        let ids: Vec<_> = self.compute.collections.keys().copied().collect();
+        let ids: Vec<_> = self.collections.keys().copied().collect();
         for id in ids {
             self.maybe_schedule_collection(id);
         }
@@ -1332,7 +1322,7 @@ where
         let mut read_capability_updates = BTreeMap::new();
 
         for id in &ids {
-            let collection = self.compute.collection_mut(*id)?;
+            let collection = self.collection_mut(*id)?;
 
             // Mark the collection as dropped to allow it to be removed from the controller state.
             collection.dropped = true;
@@ -1348,10 +1338,10 @@ where
 
             // If the collection is a subscribe, stop tracking it. This ensures that the controller
             // ceases to produce `SubscribeResponse`s for this subscribe.
-            self.compute.subscribes.remove(id);
+            self.subscribes.remove(id);
             // If the collection is a copy to, stop tracking it. This ensures that the controller
             // ceases to produce `CopyToResponse`s` for this copy to.
-            self.compute.copy_tos.remove(id);
+            self.copy_tos.remove(id);
         }
 
         if !read_capability_updates.is_empty() {
@@ -1379,23 +1369,22 @@ where
         let mut maybe_storage_read_hold = None;
         match &peek_target {
             PeekTarget::Index { .. } => {
-                let since = self.compute.collection(id)?.read_capabilities.frontier();
+                let since = self.collection(id)?.read_capabilities.frontier();
                 if !since.less_equal(&timestamp) {
                     return Err(PeekError::SinceViolation(id));
                 }
             }
 
             PeekTarget::Persist { .. } => {
-                let storage_read_hold = self
-                    .storage_controller
-                    .acquire_read_hold_at_time(id, Antichain::from_elem(timestamp.clone()))?;
+                let storage_read_hold =
+                    self.acquire_storage_read_hold_at(id, Antichain::from_elem(timestamp.clone()))?;
 
                 maybe_storage_read_hold = Some(storage_read_hold);
             }
         }
 
         if let Some(target) = target_replica {
-            if !self.compute.replica_exists(target) {
+            if !self.replica_exists(target) {
                 return Err(PeekError::ReplicaMissing(target));
             }
         }
@@ -1406,7 +1395,7 @@ where
         match &peek_target {
             PeekTarget::Index { .. } => self.update_read_capabilities(updates),
             PeekTarget::Persist { .. } => self
-                .storage_controller
+                .storage_collections
                 .update_read_capabilities(&mut updates),
         };
 
@@ -1415,7 +1404,7 @@ where
         drop(maybe_storage_read_hold);
 
         let otel_ctx = OpenTelemetryContext::obtain();
-        self.compute.peeks.insert(
+        self.peeks.insert(
             uuid,
             PendingPeek {
                 target: peek_target.clone(),
@@ -1427,7 +1416,7 @@ where
             },
         );
 
-        self.compute.send(ComputeCommand::Peek(Peek {
+        self.send(ComputeCommand::Peek(Peek {
             literal_constraints,
             uuid,
             timestamp,
@@ -1444,23 +1433,20 @@ where
 
     /// Cancels an existing peek request.
     pub fn cancel_peek(&mut self, uuid: Uuid) {
-        let Some(peek) = self.compute.peeks.get_mut(&uuid) else {
+        let Some(peek) = self.peeks.get_mut(&uuid) else {
             tracing::warn!("did not find pending peek for {uuid}");
             return;
         };
 
         let response = PeekResponse::Canceled;
         let duration = peek.requested_at.elapsed();
-        self.compute
-            .metrics
-            .observe_peek_response(&response, duration);
+        self.metrics.observe_peek_response(&response, duration);
 
         // Enqueue the response to the cancellation.
         let otel_ctx = peek.otel_ctx.clone();
-        self.compute
-            .deliver_response(ComputeControllerResponse::PeekResponse(
-                uuid, response, otel_ctx,
-            ));
+        self.deliver_response(ComputeControllerResponse::PeekResponse(
+            uuid, response, otel_ctx,
+        ));
 
         // Remove the peek.
         // This will also propagate the cancellation to the replicas.
@@ -1486,7 +1472,7 @@ where
         // Do error checking upfront, to avoid introducing inconsistencies between a collection's
         // `implied_capability` and `read_capabilities`.
         for (id, _policy) in &policies {
-            let collection = self.compute.collection(*id)?;
+            let collection = self.collection(*id)?;
             if collection.read_policy.is_none() {
                 return Err(ReadPolicyError::WriteOnlyCollection(*id));
             }
@@ -1494,7 +1480,7 @@ where
 
         let mut read_capability_changes = BTreeMap::default();
         for (id, new_policy) in policies {
-            let collection = self.compute.expect_collection_mut(id);
+            let collection = self.expect_collection_mut(id);
 
             let old_capability = &collection.implied_capability;
             let new_capability = new_policy.frontier(collection.write_frontier.borrow());
@@ -1547,7 +1533,7 @@ where
         updates: &BTreeMap<GlobalId, Antichain<T>>,
     ) {
         for (id, new_upper) in updates {
-            let collection = self.compute.expect_collection_mut(*id);
+            let collection = self.expect_collection_mut(*id);
 
             let old_upper = collection
                 .replica_write_frontiers
@@ -1580,7 +1566,7 @@ where
         // input frontier advancements.
         let mut storage_read_capability_changes = BTreeMap::default();
         for (id, new_cap) in updates {
-            let collection = self.compute.expect_collection_mut(*id);
+            let collection = self.expect_collection_mut(*id);
 
             let old_cap = collection
                 .replica_input_frontiers
@@ -1612,7 +1598,7 @@ where
         storage_read_capability_changes.retain(|_key, update| !update.is_empty());
 
         if !storage_read_capability_changes.is_empty() {
-            self.storage_controller
+            self.storage_collections
                 .update_read_capabilities(&mut storage_read_capability_changes);
         }
     }
@@ -1621,7 +1607,7 @@ where
     #[mz_ore::instrument(level = "debug")]
     fn remove_replica_frontiers(&mut self, replica_id: ReplicaId) {
         let mut storage_read_capability_changes = BTreeMap::default();
-        for collection in self.compute.collections.values_mut() {
+        for collection in self.collections.values_mut() {
             // Remove the tracked write frontier.
             collection.replica_write_frontiers.remove(&replica_id);
 
@@ -1641,7 +1627,7 @@ where
         }
 
         if !storage_read_capability_changes.is_empty() {
-            self.storage_controller
+            self.storage_collections
                 .update_read_capabilities(&mut storage_read_capability_changes);
         }
     }
@@ -1659,7 +1645,7 @@ where
         // advancements.
         let mut read_capability_changes = BTreeMap::new();
         for (id, new_upper) in updates {
-            let collection = self.compute.expect_collection_mut(*id);
+            let collection = self.expect_collection_mut(*id);
 
             if !PartialOrder::less_than(&collection.write_frontier, new_upper) {
                 continue; // frontier has not advanced
@@ -1708,7 +1694,7 @@ where
         // That said, it is reasonable to assume that collections generally have greater IDs than
         // their dependencies, so starting with the largest is a useful optimization.
         while let Some((id, mut update)) = updates.pop_last() {
-            let Some(collection) = self.compute.collections.get_mut(&id) else {
+            let Some(collection) = self.collections.get_mut(&id) else {
                 tracing::error!(
                     %id, ?update,
                     "received read capability update for an unknown collection",
@@ -1764,15 +1750,14 @@ where
 
         // Produce `AllowCompaction` commands for collections that had read frontier downgrades.
         for id in compute_downgraded {
-            let collection = self.compute.expect_collection(id);
+            let collection = self.expect_collection(id);
             let frontier = collection.read_frontier().to_owned();
-            self.compute
-                .send(ComputeCommand::AllowCompaction { id, frontier });
+            self.send(ComputeCommand::AllowCompaction { id, frontier });
         }
 
         // Report storage read capability updates.
         if !storage_updates.is_empty() {
-            self.storage_controller
+            self.storage_collections
                 .update_read_capabilities(&mut storage_updates);
         }
     }
@@ -1785,20 +1770,20 @@ where
     ///    command.
     ///  * Remove the read hold for this peek, unblocking compaction that might have waited on it.
     fn remove_peek(&mut self, uuid: Uuid) {
-        let Some(peek) = self.compute.peeks.remove(&uuid) else {
+        let Some(peek) = self.peeks.remove(&uuid) else {
             return;
         };
 
         // NOTE: We need to send the `CancelPeek` command _before_ we release the peek's read hold,
         // to avoid the edge case that caused #16615.
-        self.compute.send(ComputeCommand::CancelPeek { uuid });
+        self.send(ComputeCommand::CancelPeek { uuid });
 
         let update = (peek.target.id(), ChangeBatch::new_from(peek.time, -1));
         let mut updates = [update].into();
         match &peek.target {
             PeekTarget::Index { .. } => self.update_read_capabilities(updates),
             PeekTarget::Persist { .. } => self
-                .storage_controller
+                .storage_collections
                 .update_read_capabilities(&mut updates),
         }
     }
@@ -1841,7 +1826,7 @@ where
         // According to the compute protocol, replicas are not allowed to send `Frontiers`
         // responses that regress frontiers they have reported previously. We still perform a check
         // here, rather than risking the controller becoming confused trying to handle regressions.
-        let Ok(coll) = self.compute.collection(id) else {
+        let Ok(coll) = self.collection(id) else {
             tracing::error!(
                %id, %replica_id, ?frontiers,
                "frontiers update for unknown collection",
@@ -1863,16 +1848,14 @@ where
 
             let old_global_frontier = coll.write_frontier.clone();
 
-            self.compute
-                .update_hydration_status(id, replica_id, &new_frontier);
-            self.compute
-                .collection_mut(id)
+            self.update_hydration_status(id, replica_id, &new_frontier);
+            self.collection_mut(id)
                 .expect("we know about the collection")
                 .collection_introspection
                 .frontier_update(&new_frontier);
             self.update_write_frontiers(replica_id, &[(id, new_frontier.clone())].into());
 
-            if let Ok(coll) = self.compute.collection(id) {
+            if let Ok(coll) = self.collection(id) {
                 if coll.write_frontier != old_global_frontier {
                     response = Some(ComputeControllerResponse::FrontierUpper {
                         id,
@@ -1899,7 +1882,7 @@ where
     ) -> Option<ComputeControllerResponse<T>> {
         // We might not be tracking this peek anymore, because we have served a response already or
         // because it was canceled. If this is the case, we ignore the response.
-        let peek = self.compute.peeks.get(&uuid)?;
+        let peek = self.peeks.get(&uuid)?;
 
         // If the peek is targeting a replica, ignore responses from other replicas.
         let target_replica = peek.target_replica.unwrap_or(replica_id);
@@ -1908,9 +1891,7 @@ where
         }
 
         let duration = peek.requested_at.elapsed();
-        self.compute
-            .metrics
-            .observe_peek_response(&response, duration);
+        self.metrics.observe_peek_response(&response, duration);
 
         self.remove_peek(uuid);
 
@@ -1929,7 +1910,7 @@ where
     ) -> Option<ComputeControllerResponse<T>> {
         // We might not be tracking this COPY TO because we have already returned a response
         // from one of the replicas. In that case, we ignore the response.
-        if self.compute.copy_tos.remove(&sink_id) {
+        if self.copy_tos.remove(&sink_id) {
             let result = match response {
                 CopyToResponse::RowCount(count) => Ok(count),
                 CopyToResponse::Error(error) => Err(anyhow::anyhow!(error)),
@@ -1958,7 +1939,7 @@ where
         response: SubscribeResponse<T>,
         replica_id: ReplicaId,
     ) -> Option<ComputeControllerResponse<T>> {
-        if !self.compute.collections.contains_key(&subscribe_id) {
+        if !self.collections.contains_key(&subscribe_id) {
             tracing::warn!(?replica_id, "Response for unknown subscribe {subscribe_id}",);
             tracing::error!("Replica sent a response for an unknown subscribe");
             return None;
@@ -1972,8 +1953,7 @@ where
             SubscribeResponse::DroppedAt(_) => Antichain::new(),
         };
 
-        self.compute
-            .update_hydration_status(subscribe_id, replica_id, &write_frontier);
+        self.update_hydration_status(subscribe_id, replica_id, &write_frontier);
 
         let write_frontier_updates = [(subscribe_id, write_frontier)].into();
         self.update_replica_write_frontiers(replica_id, &write_frontier_updates);
@@ -1985,7 +1965,7 @@ where
         self.update_replica_input_frontiers(replica_id, &write_frontier_updates);
 
         // If the subscribe is not tracked, or targets a different replica, there is nothing to do.
-        let mut subscribe = self.compute.subscribes.get(&subscribe_id)?.clone();
+        let mut subscribe = self.subscribes.get(&subscribe_id)?.clone();
         let replica_targeted = subscribe.target_replica.unwrap_or(replica_id) == replica_id;
         if !replica_targeted {
             return None;
@@ -2010,10 +1990,10 @@ where
 
                     if upper.is_empty() {
                         // This subscribe cannot produce more data. Stop tracking it.
-                        self.compute.subscribes.remove(&subscribe_id);
+                        self.subscribes.remove(&subscribe_id);
                     } else {
                         // This subscribe can produce more data. Update our tracking of it.
-                        self.compute.subscribes.insert(subscribe_id, subscribe);
+                        self.subscribes.insert(subscribe_id, subscribe);
                     }
 
                     if let Ok(updates) = updates.as_mut() {
@@ -2042,7 +2022,7 @@ where
                     frontier = ?frontier.elements(),
                     "received `DroppedAt` response for a tracked subscribe",
                 );
-                self.compute.subscribes.remove(&subscribe_id);
+                self.subscribes.remove(&subscribe_id);
                 None
             }
         }
@@ -2050,9 +2030,9 @@ where
 
     fn handle_status_response(&mut self, response: StatusResponse, replica_id: ReplicaId) {
         match response {
-            StatusResponse::OperatorHydration(status) => self
-                .compute
-                .update_operator_hydration_status(replica_id, status),
+            StatusResponse::OperatorHydration(status) => {
+                self.update_operator_hydration_status(replica_id, status)
+            }
         }
     }
 
@@ -2070,7 +2050,7 @@ where
     /// synchronous updates for compute dependencies, but we refrain from doing for simplicity.
     fn downgrade_warmup_capabilities(&mut self) {
         let mut new_capabilities = BTreeMap::new();
-        for (id, collection) in &self.compute.collections {
+        for (id, collection) in &self.collections {
             // For write-only collections that have advanced to the empty frontier, we can drop the
             // warmup capability entirely. There is no reason why we would need to hydrate those
             // collections again, so being able to warm them up is not useful.
@@ -2083,22 +2063,22 @@ where
             }
 
             let compute_frontiers = collection.compute_dependencies.iter().flat_map(|dep_id| {
-                let collection = self.compute.collections.get(dep_id);
+                let collection = self.collections.get(dep_id);
                 collection.map(|c| c.write_frontier.clone())
             });
 
             let existing_storage_dependencies = collection
                 .storage_dependencies
                 .iter()
-                .filter(|id| self.storage_controller.check_exists(**id).is_ok())
+                .filter(|id| self.storage_collections.check_exists(**id).is_ok())
                 .copied()
                 .collect::<Vec<_>>();
             let storage_frontiers = self
-                .storage_controller
+                .storage_collections
                 .collections_frontiers(existing_storage_dependencies)
                 .expect("missing storage collections")
                 .into_iter()
-                .map(|(_id, _since, upper)| upper);
+                .map(|f| f.write_frontier);
 
             let mut new_capability = Antichain::new();
             for frontier in compute_frontiers.chain(storage_frontiers) {
@@ -2114,7 +2094,7 @@ where
 
         let mut read_capability_changes = BTreeMap::new();
         for (id, new_capability) in new_capabilities {
-            let collection = self.compute.expect_collection_mut(id);
+            let collection = self.expect_collection_mut(id);
             let old_capability = &collection.warmup_capability;
 
             let mut update = ChangeBatch::new();
@@ -2138,8 +2118,8 @@ where
         self.rehydrate_failed_replicas();
         self.downgrade_warmup_capabilities();
         self.schedule_collections();
-        self.compute.cleanup_collections();
-        self.compute.refresh_state_metrics();
+        self.cleanup_collections();
+        self.refresh_state_metrics();
     }
 }
 

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -486,7 +486,7 @@ where
                 if let Some(jh) = metrics_task_join_handle {
                     self.metrics_tasks.insert(replica_id, jh);
                 }
-                self.active_compute().add_replica_to_instance(
+                self.compute.add_replica_to_instance(
                     cluster_id,
                     replica_id,
                     compute_location,
@@ -511,7 +511,7 @@ where
         self.deprovision_replica(cluster_id, replica_id).await?;
         self.metrics_tasks.remove(&replica_id);
 
-        self.active_compute().drop_replica(cluster_id, replica_id)?;
+        self.compute.drop_replica(cluster_id, replica_id)?;
         self.storage.drop_replica(cluster_id, replica_id);
         Ok(())
     }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -591,23 +591,6 @@ pub trait StorageController: Debug {
         Ok(hold)
     }
 
-    /// Acquires and returns a read hold at `desired_time`. Returns
-    /// [ReadHoldError::SinceViolation] when that is not possible.
-    fn acquire_read_hold_at_time(
-        &mut self,
-        id: GlobalId,
-        desired_hold: Antichain<Self::Timestamp>,
-    ) -> Result<ReadHold<Self::Timestamp>, ReadHoldError> {
-        let mut hold = self.acquire_read_holds(vec![id])?.into_element();
-
-        let res = match hold.try_downgrade(desired_hold) {
-            Ok(()) => Ok(hold),
-            Err(_e) => Err(ReadHoldError::SinceViolation(id)),
-        };
-
-        res
-    }
-
     /// Applies `updates` and sends any appropriate compaction command.
     fn update_read_capabilities(
         &mut self,


### PR DESCRIPTION
This PR removes the `ActiveComputeController` and `ActiveInstance` types which existed solely to wrap compute controller functionality that needs access to the storage controller.

Now that the shareable `StorageCollections` exists, the `ComputeController` and `Instance` types can each own an `Arc<StorageCollections>`, so the `activate` dance becomes unnecessary.

The only place where access to a `&mut StorageController` is still needed for now is when the `ComputeController` wants to record introspection updates. This is solved by passing a `&mut StorageController` into the `ComputeController::process` call and down to `record_introspection_updates`.

### Motivation

   * This PR refactors existing code.

Apart from simplifying things this is also a precondition for moving the `Instance` controllers into their own tasks.

### Tips for reviewer



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A