### PR TITLE
DRAFT: Add RTR combined test

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -688,6 +688,17 @@ steps:
     agents:
       queue: linux-aarch64-small
 
+  - id: rtr-combined
+    label: RTR with all sources
+    depends_on: build-aarch64
+    timeout_in_minutes: 30
+    inputs: [test/rtr-combined]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: rtr-combined
+    agents:
+      queue: linux-aarch64-small
+
   - id: skip-version-upgrade
     label: "Skip Version Upgrade"
     depends_on: build-aarch64

--- a/test/rtr-combined/mzcompose
+++ b/test/rtr-combined/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/rtr-combined/mzcompose.py
+++ b/test/rtr-combined/mzcompose.py
@@ -1,0 +1,92 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+import threading
+import time
+
+from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.services.kafka import Kafka
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mysql import MySql
+from materialize.mzcompose.services.postgres import Postgres
+from materialize.mzcompose.services.schema_registry import SchemaRegistry
+from materialize.mzcompose.services.testdrive import Testdrive
+from materialize.mzcompose.services.zookeeper import Zookeeper
+from materialize.util import PropagatingThread
+
+SERVICES = [
+    Zookeeper(),
+    Kafka(),
+    SchemaRegistry(),
+    MySql(),
+    Postgres(),
+    Materialized(),
+    Testdrive(
+        entrypoint_extra=[
+            f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
+        ],
+    ),
+]
+
+#
+# Test that real-time recency works w/ slow ingest of upstream data.
+#
+def workflow_default(c: Composition) -> None:
+    c.down(destroy_volumes=True)
+    c.up("zookeeper", "kafka", "schema-registry", "postgres", "mysql", "materialized")
+    seed = random.getrandbits(16)
+    c.run_testdrive_files(
+        "--no-reset",
+        "--max-errors=1",
+        f"--seed={seed}",
+        "rtr/mz-setup.td",
+    )
+
+    running = True
+
+    def query():
+        with c.sql_cursor() as cursor:
+            cursor.execute("SET TRANSACTION_ISOLATION = 'STRICT SERIALIZABLE'")
+            cursor.execute("SET REAL_TIME_RECENCY TO TRUE")
+            queries = [
+                """SELECT sum(count) FROM (
+                SELECT count(*) FROM table_mysql
+                UNION ALL SELECT count(*) FROM table_pg
+                UNION ALL SELECT count(*) FROM input_kafka)""",
+                "SELECT sum FROM sum",
+            ]
+            thread_name = threading.current_thread().getName()
+            while running:
+                for query in queries:
+                    start_time = time.time()
+                    cursor.execute(query)
+                    result = cursor.fetchone()[0]
+                    runtime = time.time() - start_time
+                    print(f"{thread_name}: {result} ({runtime} s)")
+
+    threads = [PropagatingThread(target=query, name=f"verify{i}") for i in range(10)]
+    for thread in threads:
+        thread.start()
+
+    while True:
+        # Only reaches one execution every 4 seconds currently, instead of the targetted 1 second, so probably need to parallelize this
+        start_time = time.time()
+        c.run_testdrive_files(
+            "--no-reset",
+            "--max-errors=1",
+            f"--seed={seed}",
+            "rtr/ingest.td",
+        )
+        runtime = time.time() - start_time
+        print(f"ingest: {runtime} s")
+
+    running = False
+    for thread in threads:
+        thread.join()

--- a/test/rtr-combined/rtr/ingest.td
+++ b/test/rtr-combined/rtr/ingest.td
@@ -1,0 +1,21 @@
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# It might be more interesting to have 1000 events at different times instead of all at the same timestamp
+$ kafka-ingest topic=input format=bytes repeat=1000
+"${kafka-ingest.iteration}"
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO table_pg SELECT generate_series(0, 1000);
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+$ mysql-execute name=mysql
+USE public;
+INSERT INTO table_mysql SELECT 1 FROM mysql.time_zone t1, mysql.time_zone t2 LIMIT 1000;

--- a/test/rtr-combined/rtr/mz-setup.td
+++ b/test/rtr-combined/rtr/mz-setup.td
@@ -1,0 +1,82 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_mysql_source = true
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public;
+CREATE DATABASE public;
+USE public;
+CREATE TABLE table_mysql (a int);
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+
+> CREATE CONNECTION mysql_conn TO MYSQL (
+    HOST mysql,
+    PORT 3306,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+> CREATE SOURCE mysql_source
+  FROM MYSQL CONNECTION mysql_conn
+  FOR TABLES (public.table_mysql);
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+CREATE TABLE table_pg (a int);
+ALTER TABLE table_pg REPLICA IDENTITY FULL;
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SECRET pgpass AS 'postgres'
+
+> CREATE CONNECTION pg_conn TO POSTGRES (
+    HOST postgres,
+    PORT 5432,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+> CREATE SOURCE pg_source
+  FROM POSTGRES CONNECTION pg_conn (PUBLICATION 'mz_source')
+  FOR TABLES (table_pg);
+
+$ kafka-create-topic topic=input
+
+$ kafka-ingest topic=input format=bytes repeat=1
+0
+
+> CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER 'kafka:9092', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE SOURCE input_kafka (a)
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-${testdrive.seed}')
+  FORMAT CSV WITH 1 COLUMNS
+
+> CREATE MATERIALIZED VIEW sum AS
+  SELECT sum(count)
+  FROM (
+      SELECT count(*) FROM table_mysql
+      UNION ALL SELECT count(*) FROM table_pg
+      UNION ALL SELECT count(*) FROM input_kafka
+  ) AS x;
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET allow_real_time_recency = true


### PR DESCRIPTION
To verify that we can hit expected performance for RTR

See also https://www.notion.so/materialize/Real-Time-Recency-RTR-5882e14f745b4854a22390bacdeda10e#2694be4a9e854d1cb71814d7a879af69

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
