### PR TITLE
test utils: provide cloud hostname

### DIFF
--- a/ci/test/lint-main/checks/check-mzcompose-files.sh
+++ b/ci/test/lint-main/checks/check-mzcompose-files.sh
@@ -25,6 +25,7 @@ check_all_files_referenced_in_ci() {
         -not -wholename "./test/canary-environment/mzcompose.py" `# Only run manually` \
         -not -wholename "./test/console/mzcompose.py" `# Only run manually` \
         -not -wholename "./test/mzcompose_examples/mzcompose.py" `# Example only` \
+        -not -wholename "./test/get-cloud-hostname/mzcompose.py" `# Utility, no test` \
         | sed -e "s|.*/\([^/]*\)/mzcompose.py|\1|")
     while read -r composition; do
         if ! grep -q "composition: $composition" ci/*/pipeline.template.yml; then

--- a/misc/python/materialize/mz_env_util.py
+++ b/misc/python/materialize/mz_env_util.py
@@ -18,8 +18,9 @@ def get_cloud_hostname(
     app_password: str,
     region: str = "aws/us-east-1",
     environment: str = "production",
+    quiet: bool = False,
 ) -> str:
     with c.override(
         Mz(region=region, environment=environment, app_password=app_password)
     ):
-        return c.cloud_hostname()
+        return c.cloud_hostname(quiet=quiet)

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -1384,9 +1384,10 @@ class Composition:
         )
         self.up("materialized")
 
-    def cloud_hostname(self) -> str:
+    def cloud_hostname(self, quiet: bool = False) -> str:
         """Uses the mz command line tool to get the hostname of the cloud instance"""
-        print("Obtaining hostname of cloud instance ...")
+        if not quiet:
+            print("Obtaining hostname of cloud instance ...")
         region_status = self.run("mz", "region", "show", capture=True)
         sql_line = region_status.stdout.split("\n")[2]
         cloud_url = sql_line.split("\t")[1].strip()

--- a/test/get-cloud-hostname/README.md
+++ b/test/get-cloud-hostname/README.md
@@ -1,0 +1,3 @@
+# Get cloud hostname
+
+This prints the cloud hostname.

--- a/test/get-cloud-hostname/mzcompose
+++ b/test/get-cloud-hostname/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/get-cloud-hostname/mzcompose.py
+++ b/test/get-cloud-hostname/mzcompose.py
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.mz_env_util import get_cloud_hostname
+from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services.materialized import Materialized
+
+SERVICES = [
+    Materialized(),
+]
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    c.up("materialized")
+
+    parser.add_argument("--app-password", type=str)
+    args = parser.parse_args()
+
+    c.up("materialized")
+
+    hostname = get_cloud_hostname(c, app_password=args.app_password)
+
+    print(hostname)

--- a/test/get-cloud-hostname/mzcompose.py
+++ b/test/get-cloud-hostname/mzcompose.py
@@ -25,6 +25,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     c.up("materialized")
 
-    hostname = get_cloud_hostname(c, app_password=args.app_password)
+    hostname = get_cloud_hostname(c, app_password=args.app_password, quiet=True)
 
     print(hostname)


### PR DESCRIPTION
This replaces parts of https://github.com/MaterializeInc/materialize/pull/27512.

This will be tested in https://github.com/MaterializeInc/materialize/pull/27514 through https://buildkite.com/materialize/test/builds?branch=nrainer-materialize%3Atest-analytics%2Fstore-build-annotations-demo (build is expected to fail but the question is whether annotate-stuff will succeed).