### PR TITLE
Fix Delta join 1st input index usage annotation

### DIFF
--- a/src/compute-types/src/plan/join/delta_join.rs
+++ b/src/compute-types/src/plan/join/delta_join.rs
@@ -224,6 +224,7 @@ impl DeltaJoinPlan {
 
         // Pick the "first" (by `Ord`) key for the source relation of each path.
         // (This matches the probably arbitrary historical practice from `mod render`.)
+        // This needs to be kept in sync with `IndexUsageContext::add_keys`!
         let mut source_keys = vec![None; number_of_inputs];
         for source_relation in 0..number_of_inputs {
             for (lookup_relation, lookup_key, _characteristics) in &join_orders[source_relation] {

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -4977,7 +4977,7 @@ WHERE a = c and d = e and b = f
                                     "User": 9
                                   },
                                   {
-                                    "DeltaJoin": false
+                                    "DeltaJoin": "Lookup"
                                   }
                                 ],
                                 [
@@ -4985,7 +4985,7 @@ WHERE a = c and d = e and b = f
                                     "User": 10
                                   },
                                   {
-                                    "DeltaJoin": false
+                                    "DeltaJoin": "Lookup"
                                   }
                                 ]
                               ]
@@ -5378,7 +5378,7 @@ WHERE b = c and d = e
                                     "User": 12
                                   },
                                   {
-                                    "DeltaJoin": true
+                                    "DeltaJoin": "FirstInputFullScan"
                                   }
                                 ]
                               ]
@@ -5423,7 +5423,7 @@ WHERE b = c and d = e
                                     "User": 9
                                   },
                                   {
-                                    "DeltaJoin": false
+                                    "DeltaJoin": "Lookup"
                                   }
                                 ],
                                 [
@@ -5431,7 +5431,7 @@ WHERE b = c and d = e
                                     "User": 10
                                   },
                                   {
-                                    "DeltaJoin": false
+                                    "DeltaJoin": "Lookup"
                                   }
                                 ]
                               ]
@@ -5481,7 +5481,7 @@ WHERE b = c and d = e
                                     "User": 11
                                   },
                                   {
-                                    "DeltaJoin": false
+                                    "DeltaJoin": "Lookup"
                                   }
                                 ]
                               ]

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -891,6 +891,38 @@ Target cluster: quickstart
 
 EOF
 
+# Test a delta join where the first input has both a full scan and a lookup.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(join implementations) AS TEXT FOR
+SELECT a, b, c, d, e, f
+FROM t, u, v
+WHERE a = c and b = e
+----
+Explained Query:
+  Project (#0, #1, #0, #3, #1, #5)
+    Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+      Join on=(#0 = #2 AND #1 = #4) type=delta
+        implementation
+          %0:t » %1:u[#0]KA » %2:v[#0]KA
+          %1:u » %0:t[#0]KA » %2:v[#0]KA
+          %2:v » %0:t[#1]KA » %1:u[#0]KA
+        ArrangeBy keys=[[#0], [#1]]
+          ReadIndex on=t t_a_idx=[delta join 1st input (full scan)] t_b_idx=[delta join lookup]
+        ArrangeBy keys=[[#0]]
+          ReadIndex on=u u_c_idx=[delta join lookup]
+        ArrangeBy keys=[[#0]]
+          ReadIndex on=v v_e_idx=[delta join lookup]
+
+Used Indexes:
+  - materialize.public.t_a_idx (delta join 1st input (full scan))
+  - materialize.public.u_c_idx (delta join lookup)
+  - materialize.public.v_e_idx (delta join lookup)
+  - materialize.public.t_b_idx (delta join lookup)
+
+Target cluster: quickstart
+
+EOF
+
 # Test an IndexedFilter join.
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(humanized expressions) AS TEXT FOR

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -628,7 +628,7 @@ Explained Query:
               %4:country » %3:city[#3]KA » %2:person[#8]KA » %1:forum[#3]KA » %0:message[#10]KA » %5[#0]UKA
               %5 » %0:message[#1]KA » %1:forum[#1]KA » %2:person[#1]KA » %3:city[#0]KA » %4:country[#0]KAef
             ArrangeBy keys=[[#1{messageid}], [#10{containerforumid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join 1st input (full scan)] message_containerforumid=[delta join 1st input (full scan)] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join 1st input (full scan)] message_containerforumid=[delta join lookup] // { arity: 13 }
             ArrangeBy keys=[[#1{id}], [#3{moderatorpersonid}]] // { arity: 4 }
               ReadIndex on=forum forum_id=[delta join lookup] forum_moderatorpersonid=[delta join lookup] // { arity: 4 }
             ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
@@ -666,7 +666,7 @@ Used Indexes:
   - materialize.public.city_partofcountryid (delta join lookup)
   - materialize.public.message_hastag_tag_tagid (delta join lookup)
   - materialize.public.message_messageid (delta join 1st input (full scan))
-  - materialize.public.message_containerforumid (delta join 1st input (full scan))
+  - materialize.public.message_containerforumid (delta join lookup)
 
 Target cluster: quickstart
 
@@ -1893,7 +1893,7 @@ Explained Query:
               %2:country » %1:city[#3]KA » %0:person[#8]KA » %3:person_knows_person[#1]KAiif
               %3:person_knows_person » %0:person[#1]KA » %1:city[#0]KA » %2:country[#0]KAef
             ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
-              ReadIndex on=person person_id=[delta join 1st input (full scan)] person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
+              ReadIndex on=person person_id=[delta join 1st input (full scan)] person_locationcityid=[delta join lookup] // { arity: 11 }
             ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
               ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
             ArrangeBy keys=[[#0{id}]] // { arity: 4 }
@@ -1903,7 +1903,7 @@ Explained Query:
 
 Used Indexes:
   - materialize.public.person_id (delta join 1st input (full scan))
-  - materialize.public.person_locationcityid (delta join 1st input (full scan))
+  - materialize.public.person_locationcityid (delta join lookup)
   - materialize.public.person_knows_person_person1id (delta join lookup)
   - materialize.public.country_id (delta join lookup)
   - materialize.public.city_id (delta join lookup)
@@ -2640,7 +2640,7 @@ Explained Query:
               %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
               %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
             ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
+              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
             ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
               Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
                 ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
@@ -2652,7 +2652,7 @@ Explained Query:
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
   - materialize.public.person_knows_person_person1id (*** full scan ***, delta join 1st input (full scan))
-  - materialize.public.person_knows_person_person2id (delta join 1st input (full scan))
+  - materialize.public.person_knows_person_person2id (delta join lookup)
   - materialize.public.message_messageid (*** full scan ***)
 
 Target cluster: quickstart
@@ -3061,7 +3061,7 @@ Explained Query:
             %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
             %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
           ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
+            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
           ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
             Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
@@ -3073,7 +3073,7 @@ Explained Query:
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
   - materialize.public.person_knows_person_person1id (*** full scan ***, delta join 1st input (full scan))
-  - materialize.public.person_knows_person_person2id (delta join 1st input (full scan))
+  - materialize.public.person_knows_person_person2id (delta join lookup)
   - materialize.public.message_messageid (*** full scan ***)
 
 Target cluster: quickstart

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -635,7 +635,7 @@ Explained Query:
               %4:country » %3:city[#3]KA » %2:person[#8]KA » %1:forum[#3]KA » %0:message[#10]KA » %5[#0]UKA
               %5 » %0:message[#1]KA » %1:forum[#1]KA » %2:person[#1]KA » %3:city[#0]KA » %4:country[#0]KAef
             ArrangeBy keys=[[#1{messageid}], [#10{containerforumid}]] // { arity: 13 }
-              ReadIndex on=message message_messageid=[delta join 1st input (full scan)] message_containerforumid=[delta join 1st input (full scan)] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join 1st input (full scan)] message_containerforumid=[delta join lookup] // { arity: 13 }
             ArrangeBy keys=[[#1{id}], [#3{moderatorpersonid}]] // { arity: 4 }
               ReadIndex on=forum forum_id=[delta join lookup] forum_moderatorpersonid=[delta join lookup] // { arity: 4 }
             ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
@@ -673,7 +673,7 @@ Used Indexes:
   - materialize.public.city_partofcountryid (delta join lookup)
   - materialize.public.message_hastag_tag_tagid (delta join lookup)
   - materialize.public.message_messageid (delta join 1st input (full scan))
-  - materialize.public.message_containerforumid (delta join 1st input (full scan))
+  - materialize.public.message_containerforumid (delta join lookup)
 
 Target cluster: quickstart
 
@@ -1900,7 +1900,7 @@ Explained Query:
               %2:country » %1:city[#3]KA » %0:person[#8]KA » %3:person_knows_person[#1]KAiif
               %3:person_knows_person » %0:person[#1]KA » %1:city[#0]KA » %2:country[#0]KAef
             ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
-              ReadIndex on=person person_id=[delta join 1st input (full scan)] person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
+              ReadIndex on=person person_id=[delta join 1st input (full scan)] person_locationcityid=[delta join lookup] // { arity: 11 }
             ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
               ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
             ArrangeBy keys=[[#0{id}]] // { arity: 4 }
@@ -1910,7 +1910,7 @@ Explained Query:
 
 Used Indexes:
   - materialize.public.person_id (delta join 1st input (full scan))
-  - materialize.public.person_locationcityid (delta join 1st input (full scan))
+  - materialize.public.person_locationcityid (delta join lookup)
   - materialize.public.person_knows_person_person1id (delta join lookup)
   - materialize.public.country_id (delta join lookup)
   - materialize.public.city_id (delta join lookup)
@@ -2647,7 +2647,7 @@ Explained Query:
               %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
               %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
             ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
+              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
             ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
               Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
                 ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
@@ -2659,7 +2659,7 @@ Explained Query:
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
   - materialize.public.person_knows_person_person1id (*** full scan ***, delta join 1st input (full scan))
-  - materialize.public.person_knows_person_person2id (delta join 1st input (full scan))
+  - materialize.public.person_knows_person_person2id (delta join lookup)
   - materialize.public.message_messageid (*** full scan ***)
 
 Target cluster: quickstart
@@ -3068,7 +3068,7 @@ Explained Query:
             %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
             %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
           ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join 1st input (full scan)] // { arity: 3 }
+            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
           ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
             Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
@@ -3080,7 +3080,7 @@ Explained Query:
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
   - materialize.public.person_knows_person_person1id (*** full scan ***, delta join 1st input (full scan))
-  - materialize.public.person_knows_person_person2id (delta join 1st input (full scan))
+  - materialize.public.person_knows_person_person2id (delta join lookup)
   - materialize.public.message_messageid (*** full scan ***)
 
 Target cluster: quickstart

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -183,6 +183,7 @@ def compileFastSltConfig() -> SltRunConfig:
         "test/sqllogictest/cockroach/aggregate.slt",
         "test/sqllogictest/cockroach/distinct_on.slt",
         "test/sqllogictest/cockroach/subquery_correlated.slt",
+        "test/sqllogictest/transform/notice/*.slt",
     }
 
     tests_without_views = {

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -519,7 +519,7 @@ materialize.public.q05:
             %4:nation » %5:region[#0]KAef » %0:customer[#3]KA » %1:orders[#1]KAiif » %2:lineitem[#0]KA » %3:supplier[#0, #1]KK
             %5:region » %4:nation[#2]KA » %0:customer[#3]KA » %1:orders[#1]KAiif » %2:lineitem[#0]KA » %3:supplier[#0, #1]KK
           ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
-            ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
+            ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
           ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}], [#0{l_orderkey}, #1{l_suppkey}]] // { arity: 4 }
@@ -540,7 +540,7 @@ Used Indexes:
   - materialize.public.pk_region_regionkey (delta join lookup)
   - materialize.public.pk_supplier_suppkey (*** full scan ***)
   - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
-  - materialize.public.fk_customer_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_customer_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
   - materialize.public.fk_orders_custkey (delta join lookup)
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
@@ -667,7 +667,7 @@ materialize.public.q07:
                 %4:l0 » %0:supplier[#3]KA » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                 %5:l0 » %3:customer[#3]KA » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
               ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-                ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
+                ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
               ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
               ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
@@ -684,7 +684,7 @@ materialize.public.q07:
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
   - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
-  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
   - materialize.public.pk_customer_custkey (delta join lookup)
   - materialize.public.fk_customer_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
@@ -947,7 +947,7 @@ materialize.public.q10:
               %2:lineitem » %1:orders[#0]KAiiif » %0:customer[#0]KA » %3:nation[#0]KA
               %3:nation » %0:customer[#3]KA » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef
             ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
-              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
+              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
             ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
             ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
@@ -958,7 +958,7 @@ materialize.public.q10:
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
   - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
-  - materialize.public.fk_customer_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_customer_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
   - materialize.public.fk_orders_custkey (delta join lookup)
   - materialize.public.fk_lineitem_orderkey (delta join lookup)
@@ -1933,7 +1933,7 @@ materialize.public.q21:
               %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
               %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
             ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
+              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
             ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
@@ -1944,7 +1944,7 @@ materialize.public.q21:
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
   - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
-  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
   - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
   - materialize.public.fk_lineitem_suppkey (delta join lookup)

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -471,7 +471,7 @@ materialize.public.q05:
             %4:nation » %5:region[#0]KAef » %0:customer[#3]KA » %1:orders[#1]KAiif » %2:lineitem[#0]KA » %3:supplier[#0, #1]KK
             %5:region » %4:nation[#2]KA » %0:customer[#3]KA » %1:orders[#1]KAiif » %2:lineitem[#0]KA » %3:supplier[#0, #1]KK
           ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
-            ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
+            ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
           ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}], [#0{l_orderkey}, #1{l_suppkey}]] // { arity: 4 }
@@ -492,7 +492,7 @@ Used Indexes:
   - materialize.public.pk_region_regionkey (delta join lookup)
   - materialize.public.pk_supplier_suppkey (*** full scan ***)
   - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
-  - materialize.public.fk_customer_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_customer_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
   - materialize.public.fk_orders_custkey (delta join lookup)
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
@@ -601,7 +601,7 @@ materialize.public.q07:
                 %4:l0 » %0:supplier[#3]KA » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                 %5:l0 » %3:customer[#3]KA » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
               ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-                ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
+                ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
               ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
               ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
@@ -618,7 +618,7 @@ materialize.public.q07:
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
   - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
-  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
   - materialize.public.pk_customer_custkey (delta join lookup)
   - materialize.public.fk_customer_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
@@ -854,7 +854,7 @@ materialize.public.q10:
               %2:lineitem » %1:orders[#0]KAiiif » %0:customer[#0]KA » %3:nation[#0]KA
               %3:nation » %0:customer[#3]KA » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef
             ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
-              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
+              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
             ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
             ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
@@ -865,7 +865,7 @@ materialize.public.q10:
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
   - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
-  - materialize.public.fk_customer_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_customer_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
   - materialize.public.fk_orders_custkey (delta join lookup)
   - materialize.public.fk_lineitem_orderkey (delta join lookup)
@@ -1744,7 +1744,7 @@ materialize.public.q21:
               %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
               %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
             ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
+              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
             ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
@@ -1755,7 +1755,7 @@ materialize.public.q21:
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
   - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
-  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
   - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
   - materialize.public.fk_lineitem_suppkey (delta join lookup)

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -470,7 +470,7 @@ Explained Query:
               %4:nation » %5:region[#0]KAef » %0:customer[#3]KA » %1:orders[#1]KAiif » %2:lineitem[#0]KA » %3:supplier[#0, #1]KK
               %5:region » %4:nation[#2]KA » %0:customer[#3]KA » %1:orders[#1]KAiif » %2:lineitem[#0]KA » %3:supplier[#0, #1]KK
             ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
-              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
+              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
             ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
             ArrangeBy keys=[[#0{l_orderkey}], [#0{l_orderkey}, #1{l_suppkey}]] // { arity: 4 }
@@ -491,7 +491,7 @@ Used Indexes:
   - materialize.public.pk_region_regionkey (delta join lookup)
   - materialize.public.pk_supplier_suppkey (*** full scan ***)
   - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
-  - materialize.public.fk_customer_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_customer_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
   - materialize.public.fk_orders_custkey (delta join lookup)
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
@@ -599,7 +599,7 @@ Explained Query:
                   %4:l0 » %0:supplier[#3]KA » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                   %5:l0 » %3:customer[#3]KA » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
                 ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-                  ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
+                  ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
                 ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
                   ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
                 ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
@@ -616,7 +616,7 @@ Explained Query:
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
   - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
-  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
   - materialize.public.pk_customer_custkey (delta join lookup)
   - materialize.public.fk_customer_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
@@ -852,7 +852,7 @@ Explained Query:
                 %2:lineitem » %1:orders[#0]KAiiif » %0:customer[#0]KA » %3:nation[#0]KA
                 %3:nation » %0:customer[#3]KA » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef
               ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
-                ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
+                ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
               ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
               ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
@@ -863,7 +863,7 @@ Explained Query:
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
   - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
-  - materialize.public.fk_customer_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_customer_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
   - materialize.public.fk_orders_custkey (delta join lookup)
   - materialize.public.fk_lineitem_orderkey (delta join lookup)
@@ -1739,7 +1739,7 @@ Explained Query:
                 %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
                 %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
               ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
-                ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
+                ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
               ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
               ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
@@ -1750,7 +1750,7 @@ Explained Query:
 Used Indexes:
   - materialize.public.pk_nation_nationkey (delta join lookup)
   - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
-  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
   - materialize.public.pk_orders_orderkey (delta join lookup)
   - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
   - materialize.public.fk_lineitem_suppkey (delta join lookup)


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/27324: Now we figure out which of the arrangements on the first input of a Delta join we'll scan, and which we'll just do lookups into.

### Motivation

  * This PR fixes a recognized bug: Fixes https://github.com/MaterializeInc/materialize/issues/27324

### Tips for reviewer

The first commit is just a minor test change, discussed [here](https://github.com/MaterializeInc/materialize/pull/27279#issuecomment-2129315229) with @nrainer-materialize.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
