### PR TITLE
bazel: Support `rust_binary` in cargo-gazelle

### DIFF
--- a/misc/bazel/cargo-gazelle/src/config.rs
+++ b/misc/bazel/cargo-gazelle/src/config.rs
@@ -75,6 +75,10 @@ pub struct CrateConfig {
     #[serde(alias = "test")]
     #[serde(default)]
     tests: BTreeMap<String, TestConfig>,
+    /// Extra config for any binary targets.
+    #[serde(alias = "binary")]
+    #[serde(default)]
+    binaries: BTreeMap<String, BinaryConfig>,
 }
 
 impl CrateConfig {
@@ -115,6 +119,11 @@ impl CrateConfig {
     pub fn test(&self, name: &str) -> &TestConfig {
         static EMPTY_TEST: Lazy<TestConfig> = Lazy::new(TestConfig::default);
         self.tests.get(name).unwrap_or(&*EMPTY_TEST)
+    }
+
+    pub fn binary(&self, name: &str) -> &BinaryConfig {
+        static EMPTY_BINARY: Lazy<BinaryConfig> = Lazy::new(BinaryConfig::default);
+        self.binaries.get(name).unwrap_or(&*EMPTY_BINARY)
     }
 }
 
@@ -208,6 +217,29 @@ impl TestConfig {
 
     pub fn size(&self) -> Option<&RustTestSize> {
         self.size.as_ref()
+    }
+
+    pub fn env(&self) -> &BTreeMap<String, String> {
+        &self.env
+    }
+}
+
+/// Extra configuration for a [`RustBinary`] target.
+///
+/// [`RustBinary`]: crate::targets::RustBinary
+#[derive(Default, Debug, serde::Deserialize)]
+pub struct BinaryConfig {
+    #[serde(flatten)]
+    common: CommonConfig,
+
+    /// Additional environment variables that get set when invoked by `bazel run`.
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+}
+
+impl BinaryConfig {
+    pub fn common(&self) -> &CommonConfig {
+        &self.common
     }
 
     pub fn env(&self) -> &BTreeMap<String, String> {

--- a/misc/bazel/cargo-gazelle/src/rules.rs
+++ b/misc/bazel/cargo-gazelle/src/rules.rs
@@ -18,6 +18,7 @@ pub enum Rule {
     RustProcMacro,
     RustTest,
     RustDocTest,
+    RustBinary,
     CargoBuildScript,
     // TODO(parkmycar): Include these rules. The tricky part is they need to
     // get imported from the crates_universe repository that is created.
@@ -28,9 +29,11 @@ pub enum Rule {
 impl Rule {
     pub fn module(&self) -> Module {
         match self {
-            Rule::RustLibrary | Rule::RustProcMacro | Rule::RustTest | Rule::RustDocTest => {
-                Module::Rust
-            }
+            Rule::RustLibrary
+            | Rule::RustProcMacro
+            | Rule::RustTest
+            | Rule::RustDocTest
+            | Rule::RustBinary => Module::Rust,
             Rule::CargoBuildScript => Module::Cargo,
         }
     }
@@ -43,6 +46,7 @@ impl ToBazelDefinition for Rule {
             Rule::RustProcMacro => "rust_proc_macro",
             Rule::RustTest => "rust_test",
             Rule::RustDocTest => "rust_doc_test",
+            Rule::RustBinary => "rust_binary",
             Rule::CargoBuildScript => "cargo_build_script",
         };
         let s = QuotedString::new(s);


### PR DESCRIPTION
This PR adds support for auto-generating `rust_binary` rules in `cargo-gazelle`. 

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/27381

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
