### PR TITLE
catalog: Refactor builtin table update generation

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1129,7 +1129,8 @@ impl Catalog {
     }
 
     pub fn pack_item_update(&self, id: GlobalId, diff: Diff) -> Vec<BuiltinTableUpdate> {
-        self.state.pack_item_update(id, diff)
+        self.state
+            .resolve_builtin_table_updates(self.state.pack_item_update(id, diff))
     }
 
     pub fn system_config(&self) -> &SystemVars {

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -932,7 +932,7 @@ impl CatalogState {
     /// durable catalog.
     #[instrument]
     pub(crate) fn generate_builtin_table_updates(
-        &mut self,
+        &self,
         updates: Vec<StateUpdate>,
     ) -> Vec<BuiltinTableUpdate> {
         let mut builtin_table_updates = Vec::new();
@@ -948,7 +948,7 @@ impl CatalogState {
     /// durable catalog.
     #[instrument(level = "debug")]
     fn generate_builtin_table_update(
-        &mut self,
+        &self,
         kind: StateUpdateKind,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -125,7 +125,8 @@ pub(crate) async fn migrate(
             diff: 1,
         })
         .collect();
-    state.apply_updates_for_bootstrap(item_updates).await;
+    // The catalog is temporary, so we can throw out the builtin updates.
+    let _ = state.apply_updates_for_bootstrap(item_updates).await;
 
     info!("migrating from catalog version {:?}", catalog_version);
 

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -592,7 +592,7 @@ impl Catalog {
             let (state, builtin_migration_metadata, mut builtin_table_updates, last_seen_version) =
                 Self::initialize_state(config.state, &mut storage).await?;
 
-            let mut catalog = Catalog {
+            let catalog = Catalog {
                 state,
                 plans: CatalogPlans::default(),
                 transient_revision: 1,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -2230,7 +2230,8 @@ impl CatalogState {
         };
         let id = tx.allocate_audit_log_id()?;
         let event = VersionedEvent::new(id, event_type, object_type, details, user, occurred_at);
-        builtin_table_updates.push(self.pack_audit_log_update(&event, 1)?);
+        builtin_table_updates
+            .push(self.resolve_builtin_table_update(self.pack_audit_log_update(&event, 1)?));
         audit_events.push(event.clone());
         tx.insert_audit_log_event(event);
         Ok(())
@@ -2248,7 +2249,8 @@ impl CatalogState {
             tx.get_and_increment_id(mz_catalog::durable::STORAGE_USAGE_ID_ALLOC_KEY.to_string())?;
 
         let details = VersionedStorageUsage::new(id, shard_id, size_bytes, collection_timestamp);
-        builtin_table_updates.push(self.pack_storage_usage_update(&details, 1));
+        builtin_table_updates
+            .push(self.resolve_builtin_table_update(self.pack_storage_usage_update(&details, 1)));
         tx.insert_storage_usage_event(details);
         Ok(())
     }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1672,6 +1672,10 @@ impl Coordinator {
                         .catalog()
                         .state()
                         .pack_cluster_replica_status_update(*replica_id, *process_id, status, 1);
+                    let builtin_table_update = self
+                        .catalog()
+                        .state()
+                        .resolve_builtin_table_update(builtin_table_update);
                     builtin_table_updates.push(builtin_table_update);
                 }
             }
@@ -2005,7 +2009,11 @@ impl Coordinator {
         }
 
         // Expose mapping from T-shirt sizes to actual sizes
-        builtin_table_updates.extend(self.catalog().state().pack_all_replica_size_updates());
+        builtin_table_updates.extend(
+            self.catalog().state().resolve_builtin_table_updates(
+                self.catalog().state().pack_all_replica_size_updates(),
+            ),
+        );
 
         // Advance all tables to the current timestamp
         debug!("coordinator init: advancing all tables to current timestamp");

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -297,6 +297,7 @@ impl Coordinator {
                     authenticated_role: role_id,
                 };
                 let update = self.catalog().state().pack_session_update(&conn, 1);
+                let update = self.catalog().state().resolve_builtin_table_update(update);
                 self.begin_session_for_statement_logging(&conn);
                 self.active_conns.insert(conn_id.clone(), conn);
 
@@ -1062,6 +1063,7 @@ impl Coordinator {
         // this to prevent blocking the Coordinator in the case that a lot of connections are
         // closed at once, which occurs regularly in some workflows.
         let update = self.catalog().state().pack_session_update(&conn, -1);
+        let update = self.catalog().state().resolve_builtin_table_update(update);
         let _builtin_update_notify = self.builtin_table_update().defer(vec![update]);
     }
 

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -541,6 +541,9 @@ impl Coordinator {
                     &status,
                     -1,
                 );
+                let builtin_table_update = catalog
+                    .state()
+                    .resolve_builtin_table_update(builtin_table_update);
                 builtin_table_updates.push(builtin_table_update);
             }
         }
@@ -551,6 +554,9 @@ impl Coordinator {
                     let builtin_table_update = catalog
                         .state()
                         .pack_cluster_replica_status_update(replica_id, process_id, &status, -1);
+                    let builtin_table_update = catalog
+                        .state()
+                        .resolve_builtin_table_update(builtin_table_update);
                     builtin_table_updates.push(builtin_table_update);
                 }
             }
@@ -567,6 +573,9 @@ impl Coordinator {
                         status,
                         1,
                     );
+                    let builtin_table_update = catalog
+                        .state()
+                        .resolve_builtin_table_update(builtin_table_update);
                     builtin_table_updates.push(builtin_table_update);
                 }
             }
@@ -588,6 +597,9 @@ impl Coordinator {
                     status,
                     1,
                 );
+                let builtin_table_update = catalog
+                    .state()
+                    .resolve_builtin_table_update(builtin_table_update);
                 builtin_table_updates.push(builtin_table_update);
             }
         }
@@ -769,11 +781,15 @@ impl Coordinator {
         {
             let mut updates = vec![];
             if let Some(metrics) = metrics {
-                let retraction = self
+                let retractions = self
                     .catalog()
                     .state()
                     .pack_replica_metric_updates(replica_id, &metrics, -1);
-                updates.extend(retraction.into_iter());
+                let retractions = self
+                    .catalog()
+                    .state()
+                    .resolve_builtin_table_updates(retractions);
+                updates.extend(retractions);
             }
             self.builtin_table_update().background(updates);
         }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -430,6 +430,10 @@ impl Coordinator {
                     } else {
                         insertions
                     };
+                    let updates = self
+                        .catalog()
+                        .state()
+                        .resolve_builtin_table_updates(updates);
                     self.builtin_table_update().background(updates);
                 }
             }
@@ -717,6 +721,10 @@ impl Coordinator {
                     old_process_status,
                     -1,
                 );
+            let builtin_table_retraction = self
+                .catalog()
+                .state()
+                .resolve_builtin_table_update(builtin_table_retraction);
 
             let new_process_status = ClusterReplicaProcessStatus {
                 status: event.status,
@@ -728,6 +736,10 @@ impl Coordinator {
                 &new_process_status,
                 1,
             );
+            let builtin_table_addition = self
+                .catalog()
+                .state()
+                .resolve_builtin_table_update(builtin_table_addition);
             self.cluster_replica_statuses.ensure_cluster_status(
                 event.cluster_id,
                 event.replica_id,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -678,6 +678,10 @@ impl Coordinator {
                 &public_key_set,
                 1,
             );
+            let builtin_table_update = self
+                .catalog()
+                .state()
+                .resolve_builtin_table_update(builtin_table_update);
             ops.push(catalog::Op::WeirdBuiltinTableUpdates {
                 builtin_table_update,
             });
@@ -1579,6 +1583,10 @@ impl Coordinator {
                 .catalog()
                 .state()
                 .pack_ssh_tunnel_connection_update(ssh_conn, &key_set, -1);
+            let ssh_tunnel_update = self
+                .catalog()
+                .state()
+                .resolve_builtin_table_update(ssh_tunnel_update);
             ssh_tunnel_updates.push(ssh_tunnel_update);
         }
 
@@ -3459,11 +3467,19 @@ impl Coordinator {
             &previous_key_set.public_keys(),
             -1,
         );
+        let builtin_table_retraction = self
+            .catalog()
+            .state()
+            .resolve_builtin_table_update(builtin_table_retraction);
         let builtin_table_addition = self.catalog().state().pack_ssh_tunnel_connection_update(
             id,
             &new_key_set.public_keys(),
             1,
         );
+        let builtin_table_addition = self
+            .catalog()
+            .state()
+            .resolve_builtin_table_update(builtin_table_addition);
         let ops = vec![
             catalog::Op::WeirdBuiltinTableUpdates {
                 builtin_table_update: builtin_table_retraction,

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -235,6 +235,7 @@ impl Coordinator {
                     .catalog()
                     .state()
                     .pack_subscribe_update(id, active_subscribe, 1);
+                let update = self.catalog().state().resolve_builtin_table_update(update);
 
                 self.metrics
                     .active_subscribes
@@ -281,6 +282,7 @@ impl Coordinator {
                         self.catalog()
                             .state()
                             .pack_subscribe_update(id, active_subscribe, -1);
+                    let update = self.catalog().state().resolve_builtin_table_update(update);
                     self.builtin_table_update().blocking(vec![update]).await;
 
                     self.metrics

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -520,7 +520,7 @@ async fn upgrade_check(
         .clone();
 
     let boot_ts = now().into();
-    let (_catalog, _, last_catalog_version) = Catalog::initialize_state(
+    let (_catalog, _, _, last_catalog_version) = Catalog::initialize_state(
         StateConfig {
             unsafe_mode: true,
             all_features: false,

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2238,7 +2238,7 @@ pub struct StateUpdate {
 /// The contents of a single state update.
 ///
 /// Variants are listed in dependency order.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum StateUpdateKind {
     Role(durable::objects::Role),
     Database(durable::objects::Database),


### PR DESCRIPTION
Previously, opening the catalog did the following two steps in order (among many other omitted steps):

  1. Load in-memory state from durable state.
  2. Generate builtin table updates from durable state.

Ideally these would be done at the same time; for each change to durable state we load it into memory and generate the corresponding builtin table update(s). It's much more obvious that the builtin table update(s) exactly reflect the durable change that caused it, instead of some other later durable change that overwrote the value (Note: builtin table updates are generated by looking at the in-memory catalog).

However, during startup there is a chicken and egg problem. We don't know what table to write to until we've loaded that table. For example when loading a schema, we don't know what table to update until we've loaded the `mz_schemas` table, which happens after loading schemas.

This commit solves the chicken and egg issue by breaking builtin table update generation into two steps.

  1. Generate builtin table update with a reference to the table name.
  2. Resolve the name in the builtin table update to an ID.

With this approach, we can perform step (1) at the same time as we update the in-memory state. Unfortunately, builtin table update generation is now much more verbose.

Works towards resolving #24844

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
