### PR TITLE
orchestrator: in Process Orchestrator, disambiguate processes by deploy generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4598,6 +4598,7 @@ version = "0.0.0"
 dependencies = [
  "mz-cluster-client",
  "mz-compute-types",
+ "mz-dyncfg",
  "workspace-hack",
 ]
 
@@ -4625,6 +4626,7 @@ dependencies = [
  "mz-adapter-types",
  "mz-build-tools",
  "mz-compute-types",
+ "mz-controller-types",
  "mz-dyncfg",
  "mz-persist-client",
  "mz-storage-types",

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -261,7 +261,11 @@ class PreflightCheckContinue(Scenario):
             Validate(self),
             # A second restart while already on the new version
             KillMz(),
-            StartMz(self, tag=None),
+            StartMz(
+                self,
+                tag=None,
+                environment_extra=["MZ_DEPLOY_GENERATION=1"],
+            ),
             Validate(self),
         ]
 

--- a/misc/python/materialize/cloudtest/util/cluster.py
+++ b/misc/python/materialize/cloudtest/util/cluster.py
@@ -9,8 +9,8 @@
 
 
 def cluster_pod_name(cluster_id: str, replica_id: str, process: int = 0) -> str:
-    return f"pod/cluster-{cluster_id}-replica-{replica_id}-{process}"
+    return f"pod/cluster-{cluster_id}-replica-{replica_id}-gen-0-{process}"
 
 
 def cluster_service_name(cluster_id: str, replica_id: str) -> str:
-    return f"service/cluster-{cluster_id}-replica-{replica_id}"
+    return f"service/cluster-{cluster_id}-replica-{replica_id}-gen-0"

--- a/src/adapter/benches/catalog.rs
+++ b/src/adapter/benches/catalog.rs
@@ -24,7 +24,6 @@ fn bench_transact(c: &mut Criterion) {
                 PersistClient::new_for_tests().await,
                 Uuid::new_v4(),
                 SYSTEM_TIME.clone(),
-                None,
             )
             .await
             .unwrap()

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -496,6 +496,7 @@ async fn upgrade_check(
     cluster_replica_sizes: ClusterReplicaSizeMap,
     start: Instant,
 ) -> Result<(), anyhow::Error> {
+    let deploy_generation = 0;
     let now = SYSTEM_TIME.clone();
     let mut storage = openable_state
         .open_savepoint(
@@ -505,7 +506,7 @@ async fn upgrade_check(
                     "DEFAULT CLUSTER REPLICA SIZE IS ONLY USED FOR NEW ENVIRONMENTS".into(),
                 bootstrap_role: None,
             },
-            None,
+            deploy_generation,
             None,
         )
         .await?;

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -94,7 +94,7 @@ pub trait OpenableDurableCatalogState: Debug + Send {
         mut self: Box<Self>,
         initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
-        deploy_generation: Option<u64>,
+        deploy_generation: u64,
         epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError>;
 
@@ -119,7 +119,7 @@ pub trait OpenableDurableCatalogState: Debug + Send {
         mut self: Box<Self>,
         initial_ts: EpochMillis,
         bootstrap_args: &BootstrapArgs,
-        deploy_generation: Option<u64>,
+        deploy_generation: u64,
         epoch_lower_bound: Option<Epoch>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError>;
 
@@ -142,7 +142,7 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     async fn epoch(&mut self) -> Result<Epoch, CatalogError>;
 
     /// Get the deployment generation of this instance.
-    async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError>;
+    async fn get_deployment_generation(&mut self) -> Result<u64, CatalogError>;
 
     /// Reports if the remote configuration was synchronized at least once.
     async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError>;

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -84,7 +84,7 @@ pub(crate) async fn initialize(
     tx: &mut Transaction<'_>,
     options: &BootstrapArgs,
     initial_ts: EpochMillis,
-    deploy_generation: Option<u64>,
+    deploy_generation: u64,
 ) -> Result<(), CatalogError> {
     // Collect audit events so we can commit them once at the very end.
     let mut audit_events = vec![];
@@ -612,10 +612,7 @@ pub(crate) async fn initialize(
 
     for (key, value) in [
         (USER_VERSION_KEY.to_string(), CATALOG_VERSION),
-        (
-            DEPLOY_GENERATION.to_string(),
-            deploy_generation.unwrap_or(0),
-        ),
+        (DEPLOY_GENERATION.to_string(), deploy_generation),
         (SYSTEM_CONFIG_SYNCED_KEY.to_string(), 0),
     ] {
         tx.insert_config(key, value)?;

--- a/src/catalog/src/durable/persist/tests.rs
+++ b/src/catalog/src/durable/persist/tests.rs
@@ -21,6 +21,7 @@ async fn test_upgrade_shard() {
     let first_version = semver::Version::parse("0.10.0").expect("failed to parse version");
     let second_version = semver::Version::parse("0.11.0").expect("failed to parse version");
     let organization_id = Uuid::new_v4();
+    let deploy_generation = 0;
     let mut persist_cache = PersistClientCache::new_no_metrics();
     let upgrade_shard_id = shard_id(organization_id, UPGRADE_SEED);
 
@@ -43,7 +44,7 @@ async fn test_upgrade_shard() {
     .await
     .expect("failed to create persist catalog");
     let _persist_state = persist_openable_state
-        .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
+        .open(NOW_ZERO(), &test_bootstrap_args(), deploy_generation, None)
         .await
         .expect("failed to open persist catalog");
 
@@ -66,7 +67,7 @@ async fn test_upgrade_shard() {
     .await
     .expect("failed to create persist catalog");
     let _persist_state = persist_openable_state
-        .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), None, None)
+        .open_savepoint(NOW_ZERO(), &test_bootstrap_args(), deploy_generation, None)
         .await
         .expect("failed to open savepoint persist catalog");
 

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -134,8 +134,9 @@ async fn test_debug<'a>(
     );
 
     // Use `NOW_ZERO` for consistent timestamps in the snapshots.
+    let deploy_generation = 0;
     let _ = openable_state1
-        .open(NOW_ZERO(), &test_bootstrap_args(), None, None)
+        .open(NOW_ZERO(), &test_bootstrap_args(), deploy_generation, None)
         .await
         .unwrap();
 

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -43,14 +43,25 @@ async fn test_confirm_leadership(
     openable_state1: Box<dyn OpenableDurableCatalogState>,
     openable_state2: Box<dyn OpenableDurableCatalogState>,
 ) {
+    let deploy_generation = 0;
     let mut state1 = openable_state1
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+        .open(
+            SYSTEM_TIME(),
+            &test_bootstrap_args(),
+            deploy_generation,
+            None,
+        )
         .await
         .unwrap();
     assert!(state1.confirm_leadership().await.is_ok());
 
     let mut state2 = openable_state2
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+        .open(
+            SYSTEM_TIME(),
+            &test_bootstrap_args(),
+            deploy_generation,
+            None,
+        )
         .await
         .unwrap();
     assert!(state2.confirm_leadership().await.is_ok());
@@ -97,10 +108,16 @@ async fn test_get_and_prune_storage_usage(openable_state: Box<dyn OpenableDurabl
         size_bytes: 42,
         collection_timestamp: 20,
     });
+    let deploy_generation = 0;
     let boot_ts = mz_repr::Timestamp::new(23);
 
     let mut state = openable_state
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+        .open(
+            SYSTEM_TIME(),
+            &test_bootstrap_args(),
+            deploy_generation,
+            None,
+        )
         .await
         .unwrap();
     let mut txn = state.transaction().await.unwrap();
@@ -138,9 +155,15 @@ async fn test_persist_allocate_id() {
 }
 
 async fn test_allocate_id(openable_state: Box<dyn OpenableDurableCatalogState>) {
+    let deploy_generation = 0;
     let id_type = USER_ITEM_ALLOC_KEY;
     let mut state = openable_state
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+        .open(
+            SYSTEM_TIME(),
+            &test_bootstrap_args(),
+            deploy_generation,
+            None,
+        )
         .await
         .unwrap();
 
@@ -215,8 +238,14 @@ async fn test_audit_logs(openable_state: Box<dyn OpenableDurableCatalogState>) {
         }),
     ];
 
+    let deploy_generation = 0;
     let mut state = openable_state
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+        .open(
+            SYSTEM_TIME(),
+            &test_bootstrap_args(),
+            deploy_generation,
+            None,
+        )
         .await
         .unwrap();
     let mut txn = state.transaction().await.unwrap();
@@ -264,8 +293,14 @@ async fn test_items(openable_state: Box<dyn OpenableDurableCatalogState>) {
         },
     ];
 
+    let deploy_generation = 0;
     let mut state = openable_state
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+        .open(
+            SYSTEM_TIME(),
+            &test_bootstrap_args(),
+            deploy_generation,
+            None,
+        )
         .await
         .unwrap();
     let mut txn = state.transaction().await.unwrap();
@@ -310,8 +345,14 @@ async fn test_persist_schemas() {
 }
 
 async fn test_schemas(openable_state: Box<dyn OpenableDurableCatalogState>) {
+    let deploy_generation = 0;
     let mut state = openable_state
-        .open(SYSTEM_TIME(), &test_bootstrap_args(), None, None)
+        .open(
+            SYSTEM_TIME(),
+            &test_bootstrap_args(),
+            deploy_generation,
+            None,
+        )
         .await
         .unwrap();
     let mut txn = state.transaction().await.unwrap();

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -434,6 +434,11 @@ where
         }
     }
 
+    /// Returns the compute controller's config set.
+    pub fn dyncfg(&self) -> &Arc<ConfigSet> {
+        &self.dyncfg
+    }
+
     /// Update compute configuration.
     pub fn update_configuration(&mut self, config_params: ComputeParameters) {
         // Apply dyncfg updates.
@@ -467,6 +472,11 @@ where
         for instance in self.instances.values_mut() {
             instance.allow_writes();
         }
+    }
+
+    /// Reports whether the controller is in read only mode.
+    pub fn read_only(&self) -> bool {
+        self.read_only
     }
 
     /// Wait until the controller is ready to do some processing.

--- a/src/controller-types/Cargo.toml
+++ b/src/controller-types/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 mz-cluster-client = { path = "../cluster-client" }
 mz-compute-types = { path = "../compute-types" }
+mz-dyncfg = { path = "../dyncfg" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/controller-types/src/dyncfgs.rs
+++ b/src/controller-types/src/dyncfgs.rs
@@ -1,0 +1,26 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Dyncfgs used by the controller.
+
+use std::time::Duration;
+
+use mz_dyncfg::{Config, ConfigSet};
+
+/// The interval at which to retry cleaning replicas from past generatinos.
+pub const CONTROLLER_PAST_GENERATION_REPLICA_CLEANUP_RETRY_INTERVAL: Config<Duration> = Config::new(
+    "controller_past_generation_replica_cleanup_retry_interval",
+    Duration::from_secs(300),
+    "The interval at which to attempt to retry cleaning up replicas from past generations.",
+);
+
+/// Adds the full set of all controller `Config`s.
+pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
+    configs.add(&CONTROLLER_PAST_GENERATION_REPLICA_CLEANUP_RETRY_INTERVAL)
+}

--- a/src/controller-types/src/lib.rs
+++ b/src/controller-types/src/lib.rs
@@ -9,6 +9,8 @@
 
 //! Shared types for the `mz-controller` crate
 
+pub mod dyncfgs;
+
 /// Identifies a cluster.
 pub type ClusterId = mz_compute_types::ComputeInstanceId;
 

--- a/src/dyncfgs/Cargo.toml
+++ b/src/dyncfgs/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 mz-adapter-types = { path = "../adapter-types" }
 mz-compute-types = { path = "../compute-types" }
+mz-controller-types = { path = "../controller-types" }
 mz-dyncfg = { path = "../dyncfg" }
 mz-persist-client = { path = "../persist-client" }
 mz-storage-types = { path = "../storage-types" }

--- a/src/dyncfgs/src/lib.rs
+++ b/src/dyncfgs/src/lib.rs
@@ -31,5 +31,6 @@ pub fn all_dyncfgs() -> ConfigSet {
     configs = mz_compute_types::dyncfgs::all_dyncfgs(configs);
     configs = mz_adapter_types::dyncfgs::all_dyncfgs(configs);
     configs = mz_storage_types::dyncfgs::all_dyncfgs(configs);
+    configs = mz_controller_types::dyncfgs::all_dyncfgs(configs);
     configs
 }

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -881,6 +881,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         persist_clients: Arc::clone(&persist_clients),
         clusterd_image: args.clusterd_image.expect("clap enforced"),
         init_container_image: args.orchestrator_kubernetes_init_container_image,
+        deploy_generation: args.deploy_generation,
         now: SYSTEM_TIME.clone(),
         metrics_registry: metrics_registry.clone(),
         persist_pubsub_url: args.persist_pubsub_url,
@@ -935,7 +936,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 secrets_controller,
                 cloud_resource_controller,
                 txn_wal_tables_cli: args.persist_txn_tables,
-                deploy_generation: args.deploy_generation,
                 // Storage options.
                 storage_usage_collection_interval: args.storage_usage_collection_interval_sec,
                 storage_usage_retention_period: args.storage_usage_retention_period,

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -357,8 +357,8 @@ pub struct Args {
     ///
     /// This is incremented to request that the new process perform a graceful
     /// transition of power from the prior generation.
-    #[clap(long, env = "DEPLOY_GENERATION")]
-    deploy_generation: Option<u64>,
+    #[clap(long, env = "DEPLOY_GENERATION", default_value = "0")]
+    deploy_generation: u64,
 
     // === Storage options. ===
     /// Where the persist library should store its blob data.

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -474,6 +474,7 @@ impl Listeners {
                     orchestrator,
                     clusterd_image: "clusterd".into(),
                     init_container_image: None,
+                    deploy_generation: config.deploy_generation,
                     persist_location: PersistLocation {
                         blob_uri: format!("file://{}/persist/blob", data_directory.display()),
                         consensus_uri,
@@ -524,7 +525,6 @@ impl Listeners {
                 config_sync_timeout: Duration::from_secs(30),
                 config_sync_loop_interval: None,
                 bootstrap_role: config.bootstrap_role,
-                deploy_generation: config.deploy_generation,
                 http_host_name: Some(host_name),
                 internal_console_redirect_url: config.internal_console_redirect_url,
                 txn_wal_tables_cli: Some(TxnWalTablesImpl::Lazy),

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -102,7 +102,7 @@ pub struct TestHarness {
     // tracing.
     orchestrator_tracing_cli_args: TracingCliArgs,
     bootstrap_role: Option<String>,
-    deploy_generation: Option<u64>,
+    deploy_generation: u64,
     system_parameter_defaults: BTreeMap<String, String>,
     internal_console_redirect_url: Option<String>,
     metrics_registry: Option<MetricsRegistry>,
@@ -131,7 +131,7 @@ impl Default for TestHarness {
             propagate_crashes: false,
             enable_tracing: false,
             bootstrap_role: Some("materialize".into()),
-            deploy_generation: None,
+            deploy_generation: 0,
             // This and startup_log_filter below are both (?) needed to suppress clusterd messages.
             // If we need those in the future, we might need to change both.
             system_parameter_defaults: BTreeMap::from([(
@@ -278,7 +278,7 @@ impl TestHarness {
         self
     }
 
-    pub fn with_deploy_generation(mut self, deploy_generation: Option<u64>) -> Self {
+    pub fn with_deploy_generation(mut self, deploy_generation: u64) -> Self {
         self.deploy_generation = deploy_generation;
         self
     }

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -160,8 +160,8 @@ impl TestHarness {
     }
 
     /// Like [`TestHarness::start`] but can specify a cert reload trigger.
-    pub async fn start_with_trigger(self, reload_certs: ReloadTrigger) -> TestServer {
-        self.try_start_with_trigger(reload_certs)
+    pub async fn start_with_trigger(self, tls_reload_certs: ReloadTrigger) -> TestServer {
+        self.try_start_with_trigger(tls_reload_certs)
             .await
             .expect("Failed to start test Server")
     }
@@ -175,10 +175,10 @@ impl TestHarness {
     /// Like [`TestHarness::try_start`] but can specify a cert reload trigger.
     pub async fn try_start_with_trigger(
         self,
-        reload_certs: ReloadTrigger,
+        tls_reload_certs: ReloadTrigger,
     ) -> Result<TestServer, anyhow::Error> {
         let listeners = Listeners::new().await?;
-        listeners.serve_with_trigger(self, reload_certs).await
+        listeners.serve_with_trigger(self, tls_reload_certs).await
     }
 
     /// Starts a runtime and returns a [`TestServerWithRuntime`].
@@ -330,7 +330,7 @@ impl Listeners {
     pub async fn serve_with_trigger(
         self,
         config: TestHarness,
-        reload_certs: ReloadTrigger,
+        tls_reload_certs: ReloadTrigger,
     ) -> Result<TestServer, anyhow::Error> {
         let (data_directory, temp_dir) = match config.data_directory {
             None => {
@@ -528,7 +528,7 @@ impl Listeners {
                 http_host_name: Some(host_name),
                 internal_console_redirect_url: config.internal_console_redirect_url,
                 txn_wal_tables_cli: Some(TxnWalTablesImpl::Lazy),
-                reload_certs,
+                tls_reload_certs,
                 read_only_controllers: false,
             })
             .await?;

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2448,7 +2448,7 @@ async fn test_leader_promotion() {
         client.simple_query("SELECT 1").await.unwrap();
     }
     // propose a deploy generation for the first time.
-    let harness = harness.with_deploy_generation(Some(2));
+    let harness = harness.with_deploy_generation(2);
     {
         let listeners_2 = test_util::Listeners::new().await.unwrap();
         let internal_http_addr_2 = listeners_2.inner.internal_http_local_addr();
@@ -2506,7 +2506,7 @@ async fn test_leader_promotion() {
         client.simple_query("SELECT 1").await.unwrap();
     }
     // start with different deploy generation.
-    let harness = harness.with_deploy_generation(Some(3));
+    let harness = harness.with_deploy_generation(3);
     {
         let listeners_3 = test_util::Listeners::new().await.unwrap();
         let internal_http_addr_3 = listeners_3.inner.internal_http_local_addr();
@@ -2597,7 +2597,7 @@ async fn test_leader_promotion_always_using_deploy_generation() {
     let harness = test_util::TestHarness::default()
         .unsafe_mode()
         .data_directory(tmpdir.path())
-        .with_deploy_generation(Some(2));
+        .with_deploy_generation(2);
     {
         // propose a deploy generation for the first time
         let server = harness.clone().start().await;
@@ -2649,7 +2649,7 @@ async fn test_leader_promotion_mixed_code_version() {
     let harness = test_util::TestHarness::default()
         .unsafe_mode()
         .data_directory(tmpdir.path())
-        .with_deploy_generation(Some(1))
+        .with_deploy_generation(1)
         .with_code_version(this_version);
 
     // Query a server at the current version before we start a second server.
@@ -2662,7 +2662,7 @@ async fn test_leader_promotion_mixed_code_version() {
     let internal_http_addr_next = listeners_next.inner.internal_http_local_addr();
     let config_next = harness
         .clone()
-        .with_deploy_generation(Some(2))
+        .with_deploy_generation(2)
         .with_code_version(next_version.clone());
     let _server_next = mz_ore::task::spawn(|| "next version", async move {
         listeners_next.serve(config_next).await.unwrap()

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1074,7 +1074,7 @@ impl<'a> RunnerInner<'a> {
             config_sync_timeout: Duration::from_secs(30),
             config_sync_loop_interval: None,
             bootstrap_role: Some("materialize".into()),
-            deploy_generation: None,
+            deploy_generation: 0,
             http_host_name: Some(host_name),
             internal_console_redirect_url: None,
             txn_wal_tables_cli: Some(TxnWalTablesImpl::Lazy),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1078,7 +1078,7 @@ impl<'a> RunnerInner<'a> {
             http_host_name: Some(host_name),
             internal_console_redirect_url: None,
             txn_wal_tables_cli: Some(TxnWalTablesImpl::Lazy),
-            reload_certs: mz_server_core::cert_reload_never_reload(),
+            tls_reload_certs: mz_server_core::cert_reload_never_reload(),
             read_only_controllers: false,
         };
         // We need to run the server on its own Tokio runtime, which in turn

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1017,6 +1017,7 @@ impl<'a> RunnerInner<'a> {
                 orchestrator,
                 clusterd_image: "clusterd".into(),
                 init_container_image: None,
+                deploy_generation: 0,
                 persist_location: PersistLocation {
                     blob_uri: format!(
                         "file://{}/persist/blob",
@@ -1074,7 +1075,6 @@ impl<'a> RunnerInner<'a> {
             config_sync_timeout: Duration::from_secs(30),
             config_sync_loop_interval: None,
             bootstrap_role: Some("materialize".into()),
-            deploy_generation: 0,
             http_host_name: Some(host_name),
             internal_console_redirect_url: None,
             txn_wal_tables_cli: Some(TxnWalTablesImpl::Lazy),

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -112,8 +112,8 @@ def test_crash_environmentd(mz: MaterializeApplication) -> None:
 
     def get_replica() -> tuple[V1Pod, V1StatefulSet]:
         """Find the stateful set for the replica of the default cluster"""
-        compute_pod_name = "cluster-u1-replica-u1-0"
-        ss_name = "cluster-u1-replica-u1"
+        compute_pod_name = "cluster-u1-replica-u1-gen-0-0"
+        ss_name = "cluster-u1-replica-u1-gen-0"
         compute_pod = mz.environmentd.api().read_namespaced_pod(
             compute_pod_name, mz.environmentd.namespace()
         )

--- a/test/cloudtest/test_system_clusters.py
+++ b/test/cloudtest/test_system_clusters.py
@@ -31,5 +31,5 @@ def test_system_clusters(mz: MaterializeApplication) -> None:
     """Confirm that the system clusters have the expected labels and selectors"""
     mz.wait_replicas()
 
-    assert_pod_properties(mz, "cluster-s1-replica-s1-0")
-    assert_pod_properties(mz, "cluster-s2-replica-s2-0")
+    assert_pod_properties(mz, "cluster-s1-replica-s1-gen-0-0")
+    assert_pod_properties(mz, "cluster-s2-replica-s2-gen-0-0")


### PR DESCRIPTION
Touches https://github.com/MaterializeInc/materialize/issues/27406.

This is one of the things that we need in order to locally test read-only mode and eventually zero-downtime upgrades. After this change, you cannot run multiple deploy generations of `bin/environmentd` in parallel, but it is one of the necessary steps. We are now failing because of fencing and other things having to do with access to shared resources, like writing to tables and whatnot.

The change makes it so that multiple deploy generations of a single (local) environment can peacefully co-exist. Each one can spin up their cluster processes and their scratch directories (if any) don't clash.

~Crucially, this only changes the Process Orchestrator, which is used for local testing. The Kubernetes Orchestrator which is used in production "suffers" from the same problem and we eventually have to address that as well.~ This change now applies to both the process and Kubernetes orchestrators.

~Also, this does not touch the code around cleanup of orphaned processes. The Controller does this on bootstrap, but it only works with the Kubernetes Orchestrator, because each deployment generation has a global view of processes (pods, rather) and can deprovision them. The Process Orchestrator is only aware of the processes that it's specific instance has spawned, so cannot learn about or clean up orphaned processes.~

~NOTE: The Process Orchestrator _could_ probably be taught to know about all processes, by looking at the metadata/run dir, where we keep pids of live processes. It's just that we currently don't do that.~ The process orchestrator has been taught to do this.

**Usage:**

Start the first deploy generation:

```sh
$ bin/environmentd 
```

Then start second one in parallel:

```sh
bin/environmentd -- --deploy-generation=1 -- --sql-listen-addr 127.0.0.1:6975 --http-listen-addr 127.0.0.1:6976 --internal-sql-listen-addr 127.0.0.1:6977 --internal-http-listen-addr 127.0.0.1:6978 --internal-persist-pubsub-listen-addr 127.0.0.1:6979 --persist-pubsub-url "http://localhost:6979" --balancer-sql-listen-addr 127.0.0.1:6980 --balancer-http-listen-addr 127.0.0.1:6981
```

Though, as mentioned above, we cannot currently run multiple deployment generations in parallel, because of things that we have yet to address.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.


### Tips for reviewer

Go commit by commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
