### PR TITLE
.*: Upgrade `protobuf-native` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7755,9 +7755,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-native"
-version = "0.3.0+26.1"
+version = "0.3.1+26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf69c1af460fb26c23df5eb1e4f6a73d3cc32442e08089e15f65f8df874ec328"
+checksum = "28d044214db6b29e30fa2d8f9dfb5234e13383a2577330eb06e3763495e4a466"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -1071,7 +1071,7 @@ version = "0.11.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.protobuf-native]]
-version = "0.3.0+26.1"
+version = "0.3.1+26.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.psm]]

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -65,7 +65,7 @@ mz-txn-wal = { path = "../txn-wal" }
 num_enum = "0.5.7"
 paste = "1.0"
 postgres_array = { version = "0.11.0" }
-protobuf-native = "0.3.0"
+protobuf-native = "0.3.1"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }


### PR DESCRIPTION
This PR upgrades our `protobuf-native` dependency

### Motivation

Pull in https://github.com/MaterializeInc/rust-protobuf-native/pull/16 for Bazel

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
