### PR TITLE
Update user docs on webhook source creation to use an alias for the CHECK statement secret

### DIFF
--- a/doc/user/content/ingest-data/amazon-eventbridge.md
+++ b/doc/user/content/ingest-data/amazon-eventbridge.md
@@ -61,8 +61,11 @@ FROM WEBHOOK
   -- Include all headers, but filter out the secret.
   INCLUDE HEADERS ( NOT 'x-mz-api-key' )
   CHECK (
-    WITH ( HEADERS, SECRET eventbridge_webhook_secret)
-    constant_time_eq(headers->'x-mz-api-key', secret)
+    WITH ( HEADERS, SECRET eventbridge_webhook_secret AS validation_secret)
+    -- The constant_time_eq validation function **does not support** fully
+    -- qualified secret names. We recommend always aliasing the secret name
+    -- for ease of use.
+    constant_time_eq(headers->'x-mz-api-key', validation_secret)
   );
 ```
 

--- a/doc/user/content/ingest-data/hubspot.md
+++ b/doc/user/content/ingest-data/hubspot.md
@@ -59,9 +59,12 @@ CREATE SOURCE hubspot_source
       WITH (
         HEADERS,
         BODY AS body,
-        SECRET hubspot_webhook_secret
+        SECRET hubspot_webhook_secret AS validation_secret
       )
-      constant_time_eq(headers->'authorization', hubspot_webhook_secret)
+      -- The constant_time_eq validation function **does not support** fully
+      -- qualified secret names. We recommend always aliasing the secret name
+      -- for ease of use.
+      constant_time_eq(headers->'authorization', validation_secret)
 );
 ```
 

--- a/doc/user/content/ingest-data/rudderstack.md
+++ b/doc/user/content/ingest-data/rudderstack.md
@@ -59,9 +59,12 @@ CREATE SOURCE rudderstack_source
       WITH (
         HEADERS,
         BODY AS request_body,
-        SECRET rudderstack_webhook_secret
+        SECRET rudderstack_webhook_secret AS validation_secret
       )
-      constant_time_eq(headers->'authorization', rudderstack_webhook_secret)
+      -- The constant_time_eq validation function **does not support** fully
+      -- qualified secret names. We recommend always aliasing the secret name
+      -- for ease of use.
+      constant_time_eq(headers->'authorization', validation_secret)
 );
 ```
 

--- a/doc/user/content/ingest-data/segment.md
+++ b/doc/user/content/ingest-data/segment.md
@@ -58,8 +58,11 @@ CREATE SOURCE segment_source IN CLUSTER webhooks_cluster FROM WEBHOOK
   INCLUDE HEADER 'event-type' AS event_type
   INCLUDE HEADERS
   CHECK (
-    WITH ( BODY BYTES, HEADERS, SECRET segment_webhook_secret BYTES)
-    constant_time_eq(decode(headers->'x-signature', 'hex'), hmac(body, segment_webhook_secret, 'sha1'))
+    WITH ( BODY BYTES, HEADERS, SECRET segment_webhook_secret BYTES AS validation_secret)
+    -- The constant_time_eq validation function **does not support** fully
+    -- qualified secret names. We recommend always aliasing the secret name
+    -- for ease of use.
+    constant_time_eq(decode(headers->'x-signature', 'hex'), hmac(body, validation_secret, 'sha1'))
   );
 ```
 

--- a/doc/user/content/ingest-data/snowcatcloud.md
+++ b/doc/user/content/ingest-data/snowcatcloud.md
@@ -59,9 +59,12 @@ CREATE SOURCE snowcat_source IN CLUSTER webhooks_cluster
       WITH (
         HEADERS,
         BODY AS body,
-        SECRET snowcat_webhook_secret
+        SECRET snowcat_webhook_secret AS validation_secret
       )
-      constant_time_eq(headers->'authorization', snowcat_webhook_secret)
+      -- The constant_time_eq validation function **does not support** fully
+      -- qualified secret names. We recommend always aliasing the secret name
+      -- for ease of use.
+      constant_time_eq(headers->'authorization', validation_secret)
 );
 ```
 

--- a/doc/user/content/ingest-data/webhook-quickstart.md
+++ b/doc/user/content/ingest-data/webhook-quickstart.md
@@ -46,9 +46,12 @@ CREATE SOURCE webhook_demo FROM WEBHOOK
     WITH (
       HEADERS,
       BODY AS request_body,
-      SECRET demo_webhook
+      SECRET demo_webhook AS validation_secret
     )
-    constant_time_eq(headers->'x-api-key', demo_webhook)
+    -- The constant_time_eq validation function **does not support** fully
+    -- qualified secret names. We recommend always aliasing the secret name
+    -- for ease of use.
+    constant_time_eq(headers->'x-api-key', validation_secret)
   );
 ```
 

--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -370,9 +370,9 @@ FROM WEBHOOK
       WITH (
         HEADERS,
         BODY AS request_body,
-        SECRET basic_hook_auth
+        SECRET basic_hook_auth AS validation_secret
       )
-      constant_time_eq(headers->'authorization', basic_hook_auth)
+      constant_time_eq(headers->'authorization', validation_secret)
     );
 ```
 

--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -24,7 +24,7 @@ Webhook sources expose a [public URL](#webhook-url) that allows your application
 
 Field                            | Use
 ---------------------------------|--------------------------
-  _src_name_                     | The name for the source
+  _src_name_                     | The name for the source.
  **IN CLUSTER** _cluster_name_   | The [cluster](/sql/create-cluster) to maintain this source.
  **INCLUDE HEADER**              | Map a header value from a request into a column.
  **INCLUDE HEADERS**             | Include a column named `'headers'` of type `map[text => text]` containing the headers of the request.
@@ -34,9 +34,9 @@ Field                            | Use
 
 Field                  | Type                | Description
 -----------------------|---------------------|--------------
-`BODY`                 | `text` or `bytea`   | Provide a `body` column to the check expression. The column can be renamed with the optional **AS** _alias_ statement, and the type can be changed to `bytea` with the optional **BYTES** keyword.
-`HEADERS`              | `map[text=>text]` or `map[text=>bytea]` | Provide a column `'headers'` to the check expression. The column can be renamed with the optional **AS** _alias_ statement, and the type can be changed to `map[text => bytea]` with the optional **BYTES** keyword.
-`SECRET` _secret_name_ | `text` or `bytea`    | Provide a _secret_name_ column to the check expression, with the value of the [`SECRET`](/sql/create-secret). The column can be renamed with the optional **AS** _alias_ statement, and the type can be changed to `bytea` with the optional **BYTES** keyword.
+`BODY`                 | `text` or `bytea`   | Provide a `body` column to the check expression. The column can be renamed with the optional **AS** _alias_ statement, and the data type can be changed to `bytea` with the optional **BYTES** keyword.
+`HEADERS`              | `map[text=>text]` or `map[text=>bytea]` | Provide a column `'headers'` to the check expression. The column can be renamed with the optional **AS** _alias_ statement, and the data type can be changed to `map[text => bytea]` with the optional **BYTES** keyword.
+`SECRET` _secret_name_ | `text` or `bytea`    | Securely provide a [`SECRET`](/sql/create-secret) to the check expression. The `constant_time_eq` validation function **does not support** fully qualified secret names: if the secret is in a different namespace to the source, the column can be renamed with the optional **AS** _alias_ statement. The data type can also be changed to `bytea` using the optional **BYTES** keyword.
 
 ## Supported formats
 
@@ -152,11 +152,14 @@ CREATE SOURCE my_webhook_source FROM WEBHOOK
   CHECK (
     WITH (
       HEADERS, BODY AS request_body,
-      SECRET my_webhook_shared_secret
+      SECRET my_webhook_shared_secret AS validation_secret
     )
+    -- The constant_time_eq validation function **does not support** fully
+    -- qualified secret names. We recommend always aliasing the secret name
+    -- for ease of use.
     constant_time_eq(
         decode(headers->'x-signature', 'base64'),
-        hmac(request_body, my_webhook_shared_secret, 'sha256')
+        hmac(request_body, validation_secret, 'sha256')
     )
   );
 ```
@@ -372,6 +375,9 @@ FROM WEBHOOK
         BODY AS request_body,
         SECRET basic_hook_auth AS validation_secret
       )
+      -- The constant_time_eq validation function **does not support** fully
+      -- qualified secret names. We recommend always aliasing the secret name
+      -- for ease of use.
       constant_time_eq(headers->'authorization', validation_secret)
     );
 ```


### PR DESCRIPTION
Docs counterpart to https://github.com/MaterializeInc/console/pull/2537.
Tested this example out in staging and it worked.

cc @arusahni 

### Motivation

This PR adds a feature that has not yet been specified.

The CHECK statement syntax can be confusing to people. One aspect that is challenging is that you cannot use a fully qualified name for the secret in the constant_time_eq call. Let's encourage users to alias the secret, then use the alias in the constant_time_eq call. 


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
