### PR TITLE
catalog: Make diffs more ergonomic

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -303,12 +303,16 @@ impl CatalogState {
         for StateUpdate { kind, diff } in updates {
             match diff {
                 StateDiff::Retraction => {
+                    // We want the builtin table retraction to match the state of the catalog
+                    // before applying the update.
                     builtin_table_updates
                         .extend(self.generate_builtin_table_update(kind.clone(), diff));
                     self.apply_update(kind, diff);
                 }
                 StateDiff::Addition => {
                     self.apply_update(kind.clone(), diff);
+                    // We want the builtin table addition to match the state of the catalog
+                    // after applying the update.
                     builtin_table_updates
                         .extend(self.generate_builtin_table_update(kind.clone(), diff));
                 }

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 use futures::future::BoxFuture;
 use maplit::btreeset;
 use mz_catalog::durable::{Item, Transaction};
-use mz_catalog::memory::objects::{StateUpdate, StateUpdateKind};
+use mz_catalog::memory::objects::{StateDiff, StateUpdate, StateUpdateKind};
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_repr::{GlobalId, Timestamp};
@@ -122,7 +122,7 @@ pub(crate) async fn migrate(
         .get_items()
         .map(|item| StateUpdate {
             kind: StateUpdateKind::Item(item),
-            diff: 1,
+            diff: StateDiff::Addition,
         })
         .collect();
     // The catalog is temporary, so we can throw out the builtin updates.

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -30,7 +30,8 @@ use mz_catalog::durable::{
 };
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
-    CatalogEntry, CatalogItem, CommentsMap, DefaultPrivileges, StateUpdate, StateUpdateKind,
+    CatalogEntry, CatalogItem, CommentsMap, DefaultPrivileges, StateDiff, StateUpdate,
+    StateUpdateKind,
 };
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_cluster_client::ReplicaId;
@@ -346,7 +347,7 @@ impl Catalog {
                 txn.set_catalog_content_version(config.build_info.version.to_string())?;
                 // Throw the existing item updates away because they may have been re-written in
                 // the migration.
-                let item_updates = txn.get_items().map(|item| StateUpdate{kind: StateUpdateKind::Item(item), diff: 1}).collect();
+                let item_updates = txn.get_items().map(|item| StateUpdate{kind: StateUpdateKind::Item(item), diff: StateDiff::Addition}).collect();
                 let builtin_table_update = state.apply_updates_for_bootstrap(item_updates).await;
                 builtin_table_updates.extend(builtin_table_update);
             } else {
@@ -646,7 +647,7 @@ impl Catalog {
                     kind: StateUpdateKind::AuditLog(mz_catalog::durable::objects::AuditLog {
                         event,
                     }),
-                    diff: 1,
+                    diff: StateDiff::Addition,
                 })
                 .collect();
             builtin_table_updates.extend(catalog.state.generate_builtin_table_updates(audit_logs));
@@ -671,7 +672,7 @@ impl Catalog {
                     kind: StateUpdateKind::StorageUsage(
                         mz_catalog::durable::objects::StorageUsage { metric },
                     ),
-                    diff: 1,
+                    diff: StateDiff::Addition,
                 })
                 .collect();
             builtin_table_updates.extend(

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -223,6 +223,7 @@ impl TryFrom<StateUpdate<StateUpdateKind>> for Option<memory::objects::StateUpda
         StateUpdate { kind, ts: _, diff }: StateUpdate<StateUpdateKind>,
     ) -> Result<Self, Self::Error> {
         let kind: Option<memory::objects::StateUpdateKind> = TryInto::try_into(kind)?;
+        let diff = diff.try_into().expect("invalid diff");
         let update = kind.map(|kind| memory::objects::StateUpdate { kind, diff });
         Ok(update)
     }

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -54,7 +54,7 @@ use crate::durable::{
     SCHEMA_ID_ALLOC_KEY, SYSTEM_ITEM_ALLOC_KEY, SYSTEM_REPLICA_ID_ALLOC_KEY, USER_ITEM_ALLOC_KEY,
     USER_ROLE_ID_ALLOC_KEY,
 };
-use crate::memory::objects::{StateUpdate, StateUpdateKind};
+use crate::memory::objects::{StateDiff, StateUpdate, StateUpdateKind};
 
 type Timestamp = u64;
 
@@ -1777,7 +1777,10 @@ impl<'a> Transaction<'a> {
                 unfinalized_shards,
                 StateUpdateKind::UnfinalizedShard,
             ))
-            .map(|kind| StateUpdate { kind, diff: 1 })
+            .map(|kind| StateUpdate {
+                kind,
+                diff: StateDiff::Addition,
+            })
     }
 
     /// Returns the updates of the current op.
@@ -1786,7 +1789,7 @@ impl<'a> Transaction<'a> {
             table_txn: &'a TableTransaction<K, V>,
             kind_fn: impl Fn(T) -> StateUpdateKind + 'a,
             op: Timestamp,
-        ) -> impl Iterator<Item = (StateUpdateKind, Diff)> + 'a
+        ) -> impl Iterator<Item = (StateUpdateKind, StateDiff)> + 'a
         where
             K: Ord + Eq + Clone + Debug,
             V: Ord + Clone + Debug,
@@ -1800,7 +1803,7 @@ impl<'a> Transaction<'a> {
                     if v.ts == op {
                         let key = k.clone();
                         let value = v.value.clone();
-                        let diff = v.diff.clone();
+                        let diff = v.diff.clone().try_into().expect("invalid diff");
                         let update = DurableType::from_key_value(key, value);
                         let kind = kind_fn(update);
                         Some((kind, diff))
@@ -1814,7 +1817,7 @@ impl<'a> Transaction<'a> {
             collection: &'a Vec<(K, Diff, Timestamp)>,
             kind_fn: impl Fn(T) -> StateUpdateKind + 'a,
             op: Timestamp,
-        ) -> impl Iterator<Item = (StateUpdateKind, Diff)> + 'a
+        ) -> impl Iterator<Item = (StateUpdateKind, StateDiff)> + 'a
         where
             K: Ord + Eq + Clone + Debug,
             T: DurableType<K, ()>,
@@ -1822,7 +1825,7 @@ impl<'a> Transaction<'a> {
             collection.iter().filter_map(move |(k, diff, ts)| {
                 if *ts == op {
                     let key = k.clone();
-                    let diff = diff.clone();
+                    let diff = diff.clone().try_into().expect("invalid diff");
                     let update = DurableType::from_key_value(key, ());
                     let kind = kind_fn(update);
                     Some((kind, diff))


### PR DESCRIPTION
This commit adds the enum `StateDiff` which describes all valid diffs that may accompany a catalog state update diff. Specifically those are 1 (`StateDiff::Addition`) and -1 (`StateDiff::Retraction`). The numeric diff is converted to a `StateDiff` as early as possible to help avoid constantly checking that the diff is valid.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
