### PR TITLE
catalog: Clean up unnecessary schema method

### DIFF
--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -1498,14 +1498,7 @@ impl Catalog {
                                         .unwrap_or(&SYSTEM_CONN_ID),
                                 );
                                 update_privilege_fn(&mut schema.privileges);
-                                let database_id = match &database_spec {
-                                    ResolvedDatabaseSpecifier::Ambient => None,
-                                    ResolvedDatabaseSpecifier::Id(id) => Some(*id),
-                                };
-                                tx.update_schema(
-                                    schema_id,
-                                    schema.clone().into_durable_schema(database_id),
-                                )?;
+                                tx.update_schema(schema_id, schema.clone().into())?;
                                 builtin_table_updates.push(state.resolve_builtin_table_update(
                                     state.pack_schema_update(database_spec, &schema_id, 1),
                                 ));
@@ -1937,7 +1930,7 @@ impl Catalog {
                 let schema = state.get_schema_mut(&database_spec, &schema_spec, conn_id);
                 let old_name = schema.name().schema.clone();
                 schema.name.schema.clone_from(&new_name);
-                let new_schema = schema.clone().into_durable_schema(database_spec.id());
+                let new_schema = schema.clone().into();
                 tx.update_schema(schema_id, new_schema)?;
 
                 // Update the references to this schema.
@@ -2072,14 +2065,7 @@ impl Catalog {
                             new_owner,
                         );
                         schema.owner_id = new_owner;
-                        let database_id = match database_spec {
-                            ResolvedDatabaseSpecifier::Ambient => None,
-                            ResolvedDatabaseSpecifier::Id(id) => Some(id),
-                        };
-                        tx.update_schema(
-                            schema_id,
-                            schema.clone().into_durable_schema(database_id.copied()),
-                        )?;
+                        tx.update_schema(schema_id, schema.clone().into())?;
                         builtin_table_updates.push(state.resolve_builtin_table_update(
                             state.pack_schema_update(database_spec, &schema_id, 1),
                         ));

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -98,15 +98,15 @@ pub struct Schema {
     pub privileges: PrivilegeMap,
 }
 
-impl Schema {
-    pub fn into_durable_schema(self, database_id: Option<DatabaseId>) -> durable::Schema {
+impl From<Schema> for durable::Schema {
+    fn from(schema: Schema) -> durable::Schema {
         durable::Schema {
-            id: self.id.into(),
-            oid: self.oid,
-            name: self.name.schema,
-            database_id,
-            owner_id: self.owner_id,
-            privileges: self.privileges.into_all_values().collect(),
+            id: schema.id.into(),
+            oid: schema.oid,
+            name: schema.name.schema,
+            database_id: schema.name.database.id(),
+            owner_id: schema.owner_id,
+            privileges: schema.privileges.into_all_values().collect(),
         }
     }
 }


### PR DESCRIPTION
### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
