### PR TITLE
ci: Disable automatic retries for k8s node recovery

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -871,11 +871,6 @@ steps:
         label: "K8s recovery: storage on failing node"
         depends_on: build-aarch64
         timeout_in_minutes: 30
-        # TODO: #25108 (k8s node recovery tests flaky)
-        retry:
-          automatic:
-            - exit_status: 1
-              limit: 2
         agents:
           queue: linux-aarch64
         inputs:
@@ -894,12 +889,6 @@ steps:
         label: "K8s recovery: compute on failing node"
         depends_on: build-aarch64
         timeout_in_minutes: 30
-        # TODO: #25108 (k8s node recovery tests flaky)
-        retry:
-          automatic:
-            - exit_status: 1
-              limit:
-                1
         agents:
           queue: linux-aarch64
         inputs:
@@ -918,11 +907,6 @@ steps:
         label: "K8s recovery: replicated compute on failing node"
         depends_on: build-aarch64
         timeout_in_minutes: 30
-        # TODO: #25108 (k8s node recovery tests flaky)
-        retry:
-          automatic:
-            - exit_status: 1
-              limit: 1
         agents:
           queue: linux-aarch64
         inputs:
@@ -941,11 +925,6 @@ steps:
         label: "K8s recovery: envd on failing node"
         depends_on: build-aarch64
         timeout_in_minutes: 30
-        # TODO: #25108 (k8s node recovery tests flaky)
-        retry:
-          automatic:
-            - exit_status: 1
-              limit: 1
         agents:
           queue: linux-aarch64
         inputs:


### PR DESCRIPTION
Since the issue was closed

Seen in https://buildkite.com/materialize/nightly/builds/8058#019009a4-576f-4d0c-92f5-b3208346afc5

Verification in https://buildkite.com/materialize/nightly/builds/8060

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
