### PR TITLE
feature-benchmark: Reduce scale for ManySmallUpdates

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -54,13 +54,13 @@ ERROR_RE = re.compile(
     | [Oo]ut\ [Oo]f\ [Mm]emory
     | cannot\ migrate\ from\ catalog
     | halting\ process: # Rust unwrap
-    | fatal runtime error: # stack overflow
+    | fatal\ runtime\ error: # stack overflow
     | \[SQLsmith\] # Unknown errors are logged
     | \[SQLancer\] # Unknown errors are logged
     | environmentd:\ fatal: # startup failure
     | clusterd:\ fatal: # startup failure
     | error:\ Found\ argument\ '.*'\ which\ wasn't\ expected,\ or\ isn't\ valid\ in\ this\ context
-    | environmentd .* unrecognized\ configuration\ parameter
+    | environmentd\ .*\ unrecognized\ configuration\ parameter
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
     | SUMMARY:\ .*Sanitizer
     # for miri test summary

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -25,7 +25,7 @@ SHA256_OF_FRAMEWORK["*"] = (
 # Consider increasing the scenario's class #version() if changes are expected to impact results!
 SHA256_BY_SCENARIO_FILE: dict[str, str] = {}
 SHA256_BY_SCENARIO_FILE["benchmark_main.py"] = (
-    "157215738cdde40abe92ae6409f6b0c568eeb8136e6a6e29e0e57846a37941f7"
+    "921157368504a54cefc56d23855af318e02c4154c38246381bbf05bd4066dc5a"
 )
 SHA256_BY_SCENARIO_FILE["concurrency.py"] = (
     "2e9c149c136b83b3853abc923a1adbdaf55a998ab4557712f8424c8b16f2adb1"

--- a/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/benchmark_main.py
@@ -25,6 +25,7 @@ from materialize.feature_benchmark.scenario import (
     ScenarioBig,
     ScenarioDisabled,
 )
+from materialize.feature_benchmark.scenario_version import ScenarioVersion
 from materialize.mz_version import MzVersion
 
 # for pdoc ignores
@@ -230,6 +231,8 @@ class Insert(DML):
 class ManySmallInserts(DML):
     """Measure the time it takes for several small INSERT statements to return."""
 
+    SCALE = 4
+
     def init(self) -> Action:
         return self.table_ten()
 
@@ -237,7 +240,7 @@ class ManySmallInserts(DML):
         random.seed(self.seed())
 
         statements = []
-        for _ in range(0, 10000):
+        for _ in range(0, self.n()):
             statements.append(f"> INSERT INTO t1 VALUES ({random.randint(0, 100000)})")
 
         insert_statements_str = "\n".join(statements)
@@ -338,6 +341,11 @@ class Update(DML):
 class ManySmallUpdates(DML):
     """Measure the time it takes for several small UPDATE statements to return to client"""
 
+    SCALE = 3  # runs > 4 hours with SCALE = 4
+
+    def version(self) -> ScenarioVersion:
+        return ScenarioVersion.create(1, 1, 0)
+
     def init(self) -> list[Action]:
         return [
             self.table_ten(),
@@ -356,7 +364,7 @@ class ManySmallUpdates(DML):
         random.seed(self.seed())
 
         statements = []
-        for _ in range(0, 10000):
+        for _ in range(0, self.n()):
             statements.append(
                 f"> UPDATE t1 SET f1 = {random.randint(0, 100000)}, f2 = {random.randint(0, 100000)} WHERE f1 % 10 = {random.randint(0, 10)}"
             )


### PR DESCRIPTION
Thanks to @bkirwi for noticing

Verification in https://buildkite.com/materialize/nightly/builds/8061

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
