### PR TITLE
compute: reconciliation of logging collections (preserving `SpecializedTraceHandle`)

### DIFF
--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -15,7 +15,8 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use differential_dataflow::lattice::{antichain_join, Lattice};
-use differential_dataflow::operators::arrange::{Arranged, ShutdownButton};
+use differential_dataflow::operators::arrange::{Arranged, ShutdownButton, TraceAgent};
+use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
 use differential_dataflow::trace::TraceReader;
 use mz_repr::{Diff, GlobalId, Timestamp};
 use timely::dataflow::operators::{probe, CapabilitySet, Probe};
@@ -23,6 +24,7 @@ use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 use timely::progress::frontier::{Antichain, AntichainRef};
 use timely::progress::timestamp::Refines;
+use timely::PartialOrder;
 
 use crate::metrics::TraceMetrics;
 use crate::render::context::MzArrangementImport;
@@ -98,8 +100,8 @@ impl TraceManager {
     }
 
     /// Removes the trace for `id`.
-    pub fn del_trace(&mut self, id: &GlobalId) -> bool {
-        self.traces.remove(id).is_some()
+    pub fn remove(&mut self, id: &GlobalId) -> Option<TraceBundle> {
+        self.traces.remove(id)
     }
 }
 
@@ -109,7 +111,13 @@ impl TraceManager {
 /// representation and layouts.
 #[derive(Clone)]
 pub enum SpecializedTraceHandle {
-    RowRow(RowRowAgent<Timestamp, Diff>),
+    RowRow(PaddedTrace<RowRowAgent<Timestamp, Diff>>),
+}
+
+impl From<RowRowAgent<Timestamp, Diff>> for SpecializedTraceHandle {
+    fn from(trace: RowRowAgent<Timestamp, Diff>) -> Self {
+        Self::RowRow(trace.into())
+    }
 }
 
 impl SpecializedTraceHandle {
@@ -170,6 +178,150 @@ impl SpecializedTraceHandle {
             }
         }
     }
+
+    /// Turns this trace into a padded version that reports empty data for all times less than the
+    /// trace's current logical compaction frontier.
+    fn into_padded(self) -> Self {
+        match self {
+            Self::RowRow(trace) => Self::RowRow(trace.into_padded()),
+        }
+    }
+}
+
+/// Handle to a trace that can be padded.
+///
+/// A padded trace contains empty data for all times greater than or equal to its `padded_since`
+/// and less than the logical compaction frontier of the inner `trace`.
+///
+/// This type is intentionally limited to only work with `mz_repr::Timestamp` times, because that
+/// is all that's required by `TraceManager`. It can be made to be more generic, at the cost of
+/// more complicated reasoning about the correct management of the involved frontiers.
+#[derive(Clone)]
+pub struct PaddedTrace<Tr>
+where
+    Tr: TraceReader<Time = Timestamp>,
+{
+    /// The wrapped trace.
+    trace: Tr,
+    /// The frontier from which the trace is padded, or `None` if it is not padded.
+    ///
+    /// Invariant: The contained frontier is less than the logical compaction frontier of `trace`.
+    ///
+    /// All methods of `PaddedTrace` are written to uphold this invariant. In particular,
+    /// `set_logical_compaction_frontier`  sets the `padded_since` to `None` if the new compaction
+    /// frontier is >= the previous compaction frontier of `trace`.
+    padded_since: Option<Antichain<Timestamp>>,
+}
+
+impl<Tr> From<Tr> for PaddedTrace<Tr>
+where
+    Tr: TraceReader<Time = Timestamp>,
+{
+    fn from(trace: Tr) -> Self {
+        Self {
+            trace,
+            padded_since: None,
+        }
+    }
+}
+
+impl<Tr> PaddedTrace<Tr>
+where
+    Tr: TraceReader<Time = Timestamp>,
+{
+    /// Turns this trace into a padded version that reports empty data for all times less than the
+    /// trace's current logical compaction frontier.
+    fn into_padded(mut self) -> Self {
+        let trace_since = self.trace.get_logical_compaction();
+        let minimum_frontier = Antichain::from_elem(Timestamp::MIN);
+        if PartialOrder::less_than(&minimum_frontier.borrow(), &trace_since) {
+            self.padded_since = Some(minimum_frontier);
+        }
+        self
+    }
+}
+
+impl<Tr> TraceReader for PaddedTrace<Tr>
+where
+    Tr: TraceReader<Time = Timestamp>,
+{
+    type Key<'a> = Tr::Key<'a>;
+    type Val<'a> = Tr::Val<'a>;
+    type Time = Tr::Time;
+    type TimeGat<'a> = Tr::TimeGat<'a>;
+    type Diff = Tr::Diff;
+    type DiffGat<'a> = Tr::DiffGat<'a>;
+    type Batch = Tr::Batch;
+    type Storage = Tr::Storage;
+    type Cursor = Tr::Cursor;
+
+    fn cursor_through(
+        &mut self,
+        upper: AntichainRef<Self::Time>,
+    ) -> Option<(Self::Cursor, Self::Storage)> {
+        self.trace.cursor_through(upper)
+    }
+
+    fn set_logical_compaction(&mut self, frontier: AntichainRef<Self::Time>) {
+        let Some(padded_since) = &mut self.padded_since else {
+            self.trace.set_logical_compaction(frontier);
+            return;
+        };
+
+        // If a padded trace is compacted to some frontier less than the inner trace's compaction
+        // frontier, advance the `padded_since`. Otherwise discard the padding and apply the
+        // compaction to the inner trace instead.
+        let trace_since = self.trace.get_logical_compaction();
+        if PartialOrder::less_than(&frontier, &trace_since) {
+            if PartialOrder::less_than(&padded_since.borrow(), &frontier) {
+                *padded_since = frontier.to_owned();
+            }
+        } else {
+            self.padded_since = None;
+            self.trace.set_logical_compaction(frontier);
+        }
+    }
+
+    fn get_logical_compaction(&mut self) -> AntichainRef<Self::Time> {
+        match &self.padded_since {
+            Some(since) => since.borrow(),
+            None => self.trace.get_logical_compaction(),
+        }
+    }
+
+    fn set_physical_compaction(&mut self, frontier: AntichainRef<Self::Time>) {
+        self.trace.set_physical_compaction(frontier);
+    }
+
+    fn get_physical_compaction(&mut self) -> AntichainRef<Self::Time> {
+        self.trace.get_logical_compaction()
+    }
+
+    fn map_batches<F: FnMut(&Self::Batch)>(&self, f: F) {
+        self.trace.map_batches(f)
+    }
+}
+
+impl<Tr> PaddedTrace<TraceAgent<Tr>>
+where
+    Tr: TraceReader<Time = Timestamp> + 'static,
+{
+    /// Import a trace restricted to a specific time interval `[since, until)`.
+    pub fn import_frontier_core<G>(
+        &mut self,
+        scope: &G,
+        name: &str,
+        since: Antichain<Tr::Time>,
+        until: Antichain<Tr::Time>,
+    ) -> (
+        Arranged<G, TraceFrontier<TraceAgent<Tr>>>,
+        ShutdownButton<CapabilitySet<Tr::Time>>,
+    )
+    where
+        G: Scope<Timestamp = Tr::Time>,
+    {
+        self.trace.import_frontier_core(scope, name, since, until)
+    }
 }
 
 /// Bundles together traces for the successful computations (`oks`), the
@@ -178,16 +330,20 @@ impl SpecializedTraceHandle {
 #[derive(Clone)]
 pub struct TraceBundle {
     oks: SpecializedTraceHandle,
-    errs: ErrAgent<Timestamp, Diff>,
+    errs: PaddedTrace<ErrAgent<Timestamp, Diff>>,
     to_drop: Option<Rc<dyn Any>>,
 }
 
 impl TraceBundle {
     /// Constructs a new trace bundle out of an `oks` trace and `errs` trace.
-    pub fn new(oks: SpecializedTraceHandle, errs: ErrAgent<Timestamp, Diff>) -> TraceBundle {
+    pub fn new<O, E>(oks: O, errs: E) -> TraceBundle
+    where
+        O: Into<SpecializedTraceHandle>,
+        E: Into<PaddedTrace<ErrAgent<Timestamp, Diff>>>,
+    {
         TraceBundle {
-            oks,
-            errs,
+            oks: oks.into(),
+            errs: errs.into(),
             to_drop: None,
         }
     }
@@ -209,7 +365,7 @@ impl TraceBundle {
     }
 
     /// Returns a mutable reference to the `errs` trace.
-    pub fn errs_mut(&mut self) -> &mut ErrAgent<Timestamp, Diff> {
+    pub fn errs_mut(&mut self) -> &mut PaddedTrace<ErrAgent<Timestamp, Diff>> {
         &mut self.errs
     }
 
@@ -224,5 +380,19 @@ impl TraceBundle {
             &self.oks.get_logical_compaction(),
             &self.errs.get_logical_compaction(),
         )
+    }
+
+    /// Turns this trace bundle into a padded version that reports empty data for all times less
+    /// than the traces' current logical compaction frontier.
+    ///
+    /// Note that the padded bundle represents a different TVC than the original one, it is unsound
+    /// to use it to "uncompact" an existing TVC. The only valid use of the padded bundle is to
+    /// initializa a new TVC.
+    pub fn into_padded(self) -> Self {
+        Self {
+            oks: self.oks.into_padded(),
+            errs: self.errs.into_padded(),
+            to_drop: self.to_drop,
+        }
     }
 }

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -20,7 +20,7 @@ use timely::communication::Allocate;
 use timely::logging::{Logger, TimelyEvent};
 use timely::progress::reachability::logging::TrackerEvent;
 
-use crate::arrangement::manager::{SpecializedTraceHandle, TraceBundle};
+use crate::arrangement::manager::TraceBundle;
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::logging::compute::ComputeEvent;
 use crate::logging::reachability::ReachabilityEvent;
@@ -131,11 +131,8 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
         collections
             .into_iter()
             .map(|(log, collection)| {
-                let bundle = TraceBundle::new(
-                    SpecializedTraceHandle::RowRow(collection.trace),
-                    errs.clone(),
-                )
-                .with_drop(collection.token);
+                let bundle =
+                    TraceBundle::new(collection.trace, errs.clone()).with_drop(collection.token);
                 (log, (bundle, collection.dataflow_index))
             })
             .collect()

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -346,7 +346,7 @@ where
     /// Obtains a `SpecializedTraceHandle` for the underlying arrangement.
     pub fn trace_handle(&self) -> SpecializedTraceHandle {
         match self {
-            MzArrangement::RowRow(inner) => SpecializedTraceHandle::RowRow(inner.trace.clone()),
+            MzArrangement::RowRow(inner) => inner.trace.clone().into(),
         }
     }
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -768,6 +768,25 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             // We must drop the subscribe response buffer as it is global across all subscribes.
             // If it were broken out by `GlobalId` then we could drop only those of dataflows we drop.
             compute_state.subscribe_response_buffer = Rc::new(RefCell::new(Vec::new()));
+
+            // The controller expects the logging collections to be readable from the minimum time
+            // initially. We cannot recreate the logging arrangements without restarting the
+            // instance, but we can pad the compacted times with empty data. Doing so is sound
+            // because logging collections from different replica incarnations are considered
+            // distinct TVCs, so the controller doesn't expect any historical consistency from
+            // these collections when it reconnects to a replica.
+            //
+            // TODO(#27730): Consider resolving this with controller-side reconciliation instead.
+            if let Some(config) = old_instance_config {
+                for id in config.logging.index_logs.values() {
+                    let trace = compute_state
+                        .traces
+                        .remove(id)
+                        .expect("logging trace exists");
+                    let padded = trace.into_padded();
+                    compute_state.traces.set(*id, padded);
+                }
+            }
         } else {
             todo_commands.clone_from(&new_commands);
         }


### PR DESCRIPTION
Upon reconnecting to a replica, the compute controller expects the logging collections to be uncompacted and readable from the minimum time. To ensure that we introduce the ability to "pad" traces in the `TraceManager` by filling up their compacted times with empty contents. This is implemented as a thin `TraceReader` wrapper that intercepts accesses to the trace's logical compaction frontier and otherwise passes requests through to the inner trace.

This is an alternative proposal to https://github.com/MaterializeInc/materialize/pull/27532 that does not remove the `SpecializedTraceHandle` type but works around it instead.

### Motivation

  * This PR fixes a previously unreported bug.

Compute reconciliation introduces a mismatch between the controller's expectation of the read frontiers of logging collections (`[0]`) and the actual read frontiers the respective arrangements have on the replica. This mismatch can let replicas crash when the controller tries to read the logging collections at a time before their physical read frontier.

### Tips for reviewer

There is one TODO comment left about how a padded `TraceHandle` should implement `TraceReader::map_batches`. The current implementation simply defers to the wrapped trace, but I'm not sure that is correct. Would callers of `map_batches` expect to see an empty batch containing the times from `padded_since` to `trace.get_compaction_frontier()`?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
