### PR TITLE
docs: don't identify users by email

### DIFF
--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -295,8 +295,8 @@ $(function() {
                 .attr('title', 'Subscribed')
                 .text('✅');
             removeForms();
-            window.analytics && window.analytics.identify(email);
             window.analytics && window.analytics.track("Integration Status Subscribed", {
+                email: email,
                 subject: $(this).parents("tr").find('td').first().text()
             });
             e.preventDefault();


### PR DESCRIPTION
Everywhere else the user is identified by a UUID, either the segment anonymous ID, or the frontegg ID. Instead, we can include the email as an attribute on the track call, so it's still accessible to analytics, but not polluting the user ID field.

### Motivation

  * This PR fixes a previously unreported bug.

I discovered this while investigating an issue Matt [reported](https://materializeinc.slack.com/archives/C06GZ7GBKB5/p1717091663493629), which was fixed here: https://github.com/MaterializeInc/materialize/pull/27385.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Not user facing
