### PR TITLE
catalog: Correctly handle matching updates

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -16,11 +16,13 @@ use std::fmt::Debug;
 use std::iter;
 
 use mz_catalog::builtin::{Builtin, BuiltinTable, BUILTIN_LOG_LOOKUP, BUILTIN_LOOKUP};
-use mz_catalog::durable::Item;
+use mz_catalog::durable::objects::{
+    ClusterKey, DatabaseKey, DurableType, ItemKey, RoleKey, SchemaKey,
+};
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
-    CatalogItem, Cluster, ClusterReplica, DataSourceDesc, Database, Func, Log, Role, Schema,
-    Source, StateDiff, StateUpdate, StateUpdateKind, Table, Type,
+    CatalogEntry, CatalogItem, Cluster, ClusterReplica, DataSourceDesc, Database, Func, Log, Role,
+    Schema, Source, StateDiff, StateUpdate, StateUpdateKind, Table, Type, UpdateFrom,
 };
 use mz_compute_client::controller::ComputeReplicaConfig;
 use mz_controller::clusters::{ReplicaConfig, ReplicaLogging};
@@ -30,8 +32,7 @@ use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
 use mz_repr::GlobalId;
 use mz_sql::catalog::{CatalogItemType, CatalogSchema, CatalogType, NameReference};
 use mz_sql::names::{
-    ItemQualifiers, QualifiedItemName, QualifiedSchemaName, ResolvedDatabaseSpecifier, ResolvedIds,
-    SchemaSpecifier,
+    ItemQualifiers, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds, SchemaSpecifier,
 };
 use mz_sql::rbac;
 use mz_sql::session::user::MZ_SYSTEM_ROLE_ID;
@@ -41,6 +42,38 @@ use mz_storage_types::sources::Timeline;
 use tracing::warn;
 
 use crate::catalog::{BuiltinTableUpdate, Catalog, CatalogState};
+
+/// Maintains the state of retractions while applying catalog state updates for a single timestamp.
+/// [`CatalogState`] maintains denormalized state for certain catalog objects. Updating an object
+/// results in applying a retraction for that object followed by applying an addition for that
+/// object. When applying those additions it can be extremely expensive to re-build that
+/// denormalized state from scratch. To avoid that issue we stash the denormalized state from
+/// retractions, so it can be used during additions.
+///
+/// Not all objects maintain denormalized state, so we only stash the retractions for the subset of
+/// objects that maintain denormalized state.
+// TODO(jkosh44) It might be simpler or more future proof to include all object types here, even if
+// the update step is a no-op for certain types.
+#[derive(Debug, Clone)]
+struct InProgressRetractions {
+    roles: BTreeMap<RoleKey, Role>,
+    databases: BTreeMap<DatabaseKey, Database>,
+    schemas: BTreeMap<SchemaKey, Schema>,
+    clusters: BTreeMap<ClusterKey, Cluster>,
+    items: BTreeMap<ItemKey, CatalogEntry>,
+}
+
+impl InProgressRetractions {
+    fn new() -> InProgressRetractions {
+        InProgressRetractions {
+            roles: BTreeMap::new(),
+            databases: BTreeMap::new(),
+            schemas: BTreeMap::new(),
+            clusters: BTreeMap::new(),
+            items: BTreeMap::new(),
+        }
+    }
+}
 
 /// Sort [`StateUpdate`]s in dependency order.
 fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
@@ -160,7 +193,9 @@ fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
     }
 
     // Sort item updates by GlobalId.
-    fn sort_item_updates(item_updates: Vec<(Item, StateDiff)>) -> Vec<StateUpdate> {
+    fn sort_item_updates(
+        item_updates: Vec<(mz_catalog::durable::Item, StateDiff)>,
+    ) -> Vec<StateUpdate> {
         item_updates
             .into_iter()
             .sorted_by_key(|(item, _diff)| item.id)
@@ -226,6 +261,7 @@ impl CatalogState {
         let mut state = ApplyState::Updates(Vec::new());
         let updates = sort_updates(updates);
         let mut builtin_table_updates = Vec::with_capacity(updates.len());
+        let mut retractions = InProgressRetractions::new();
 
         for update in updates {
             match (&mut state, update) {
@@ -241,7 +277,8 @@ impl CatalogState {
                 ) =>
                 {
                     // Apply updates and start batching builtin view additions.
-                    let builtin_table_update = self.apply_updates(std::mem::take(updates));
+                    let builtin_table_update =
+                        self.apply_updates(std::mem::take(updates), &mut retractions);
                     builtin_table_updates.extend(builtin_table_update);
                     let view_addition = lookup_builtin_view_addition(system_object_mapping);
                     state = ApplyState::BuiltinViewAdditions(vec![view_addition]);
@@ -278,7 +315,7 @@ impl CatalogState {
         // Apply remaining state.
         match state {
             ApplyState::Updates(updates) => {
-                let builtin_table_update = self.apply_updates(updates);
+                let builtin_table_update = self.apply_updates(updates, &mut retractions);
                 builtin_table_updates.extend(builtin_table_update);
             }
             ApplyState::BuiltinViewAdditions(builtin_view_additions) => {
@@ -298,6 +335,7 @@ impl CatalogState {
     pub(crate) fn apply_updates(
         &mut self,
         updates: Vec<StateUpdate>,
+        retractions: &mut InProgressRetractions,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
         let mut builtin_table_updates = Vec::with_capacity(updates.len());
         for StateUpdate { kind, diff } in updates {
@@ -307,10 +345,10 @@ impl CatalogState {
                     // before applying the update.
                     builtin_table_updates
                         .extend(self.generate_builtin_table_update(kind.clone(), diff));
-                    self.apply_update(kind, diff);
+                    self.apply_update(kind, diff, retractions);
                 }
                 StateDiff::Addition => {
-                    self.apply_update(kind.clone(), diff);
+                    self.apply_update(kind.clone(), diff, retractions);
                     // We want the builtin table addition to match the state of the catalog
                     // after applying the update.
                     builtin_table_updates
@@ -322,43 +360,52 @@ impl CatalogState {
     }
 
     #[instrument(level = "debug")]
-    fn apply_update(&mut self, kind: StateUpdateKind, diff: StateDiff) {
+    fn apply_update(
+        &mut self,
+        kind: StateUpdateKind,
+        diff: StateDiff,
+        retractions: &mut InProgressRetractions,
+    ) {
         match kind {
             StateUpdateKind::Role(role) => {
-                self.apply_role_update(role, diff);
+                self.apply_role_update(role, diff, retractions);
             }
             StateUpdateKind::Database(database) => {
-                self.apply_database_update(database, diff);
+                self.apply_database_update(database, diff, retractions);
             }
             StateUpdateKind::Schema(schema) => {
-                self.apply_schema_update(schema, diff);
+                self.apply_schema_update(schema, diff, retractions);
             }
             StateUpdateKind::DefaultPrivilege(default_privilege) => {
-                self.apply_default_privilege_update(default_privilege, diff);
+                self.apply_default_privilege_update(default_privilege, diff, retractions);
             }
             StateUpdateKind::SystemPrivilege(system_privilege) => {
-                self.apply_system_privilege_update(system_privilege, diff);
+                self.apply_system_privilege_update(system_privilege, diff, retractions);
             }
             StateUpdateKind::SystemConfiguration(system_configuration) => {
-                self.apply_system_configuration_update(system_configuration, diff);
+                self.apply_system_configuration_update(system_configuration, diff, retractions);
             }
             StateUpdateKind::Cluster(cluster) => {
-                self.apply_cluster_update(cluster, diff);
+                self.apply_cluster_update(cluster, diff, retractions);
             }
             StateUpdateKind::IntrospectionSourceIndex(introspection_source_index) => {
-                self.apply_introspection_source_index_update(introspection_source_index, diff);
+                self.apply_introspection_source_index_update(
+                    introspection_source_index,
+                    diff,
+                    retractions,
+                );
             }
             StateUpdateKind::ClusterReplica(cluster_replica) => {
-                self.apply_cluster_replica_update(cluster_replica, diff);
+                self.apply_cluster_replica_update(cluster_replica, diff, retractions);
             }
             StateUpdateKind::SystemObjectMapping(system_object_mapping) => {
-                self.apply_system_object_mapping_update(system_object_mapping, diff);
+                self.apply_system_object_mapping_update(system_object_mapping, diff, retractions);
             }
             StateUpdateKind::Item(item) => {
-                self.apply_item_update(item, diff);
+                self.apply_item_update(item, diff, retractions);
             }
             StateUpdateKind::Comment(comment) => {
-                self.apply_comment_update(comment, diff);
+                self.apply_comment_update(comment, diff, retractions);
             }
             StateUpdateKind::AuditLog(_audit_log) => {
                 // Audit logs are not stored in-memory.
@@ -367,95 +414,85 @@ impl CatalogState {
                 // Storage usage events are not stored in-memory.
             }
             StateUpdateKind::StorageCollectionMetadata(storage_collection_metadata) => {
-                self.apply_storage_collection_metadata_update(storage_collection_metadata, diff);
+                self.apply_storage_collection_metadata_update(
+                    storage_collection_metadata,
+                    diff,
+                    retractions,
+                );
             }
             StateUpdateKind::UnfinalizedShard(unfinalized_shard) => {
-                self.apply_unfinalized_shard_update(unfinalized_shard, diff);
+                self.apply_unfinalized_shard_update(unfinalized_shard, diff, retractions);
             }
         }
     }
 
     #[instrument(level = "debug")]
-    fn apply_role_update(&mut self, role: mz_catalog::durable::Role, diff: StateDiff) {
-        apply(
+    fn apply_role_update(
+        &mut self,
+        role: mz_catalog::durable::Role,
+        diff: StateDiff,
+        retractions: &mut InProgressRetractions,
+    ) {
+        apply_inverted_lookup(&mut self.roles_by_name, &role.name, role.id, diff);
+        apply_with_update(
             &mut self.roles_by_id,
-            role.id,
-            || Role {
-                name: role.name.clone(),
-                id: role.id,
-                oid: role.oid,
-                attributes: role.attributes,
-                membership: role.membership,
-                vars: role.vars,
-            },
+            role,
+            |role| role.id,
             diff,
+            &mut retractions.roles,
         );
-        apply(&mut self.roles_by_name, role.name, || role.id, diff);
     }
 
     #[instrument(level = "debug")]
-    fn apply_database_update(&mut self, database: mz_catalog::durable::Database, diff: StateDiff) {
-        apply(
-            &mut self.database_by_id,
-            database.id.clone(),
-            || Database {
-                name: database.name.clone(),
-                id: database.id.clone(),
-                oid: database.oid,
-                schemas_by_id: BTreeMap::new(),
-                schemas_by_name: BTreeMap::new(),
-                owner_id: database.owner_id,
-                privileges: PrivilegeMap::from_mz_acl_items(database.privileges),
-            },
-            diff,
-        );
-        apply(
+    fn apply_database_update(
+        &mut self,
+        database: mz_catalog::durable::Database,
+        diff: StateDiff,
+        retractions: &mut InProgressRetractions,
+    ) {
+        apply_inverted_lookup(
             &mut self.database_by_name,
-            database.name,
-            || database.id.clone(),
+            &database.name,
+            database.id,
             diff,
+        );
+        apply_with_update(
+            &mut self.database_by_id,
+            database,
+            |database| database.id,
+            diff,
+            &mut retractions.databases,
         );
     }
 
     #[instrument(level = "debug")]
-    fn apply_schema_update(&mut self, schema: mz_catalog::durable::Schema, diff: StateDiff) {
-        let (schemas_by_id, schemas_by_name, database_spec) = match &schema.database_id {
+    fn apply_schema_update(
+        &mut self,
+        schema: mz_catalog::durable::Schema,
+        diff: StateDiff,
+        retractions: &mut InProgressRetractions,
+    ) {
+        let (schemas_by_id, schemas_by_name) = match &schema.database_id {
             Some(database_id) => {
                 let db = self
                     .database_by_id
                     .get_mut(database_id)
                     .expect("catalog out of sync");
-                (
-                    &mut db.schemas_by_id,
-                    &mut db.schemas_by_name,
-                    ResolvedDatabaseSpecifier::Id(*database_id),
-                )
+                (&mut db.schemas_by_id, &mut db.schemas_by_name)
             }
             None => (
                 &mut self.ambient_schemas_by_id,
                 &mut self.ambient_schemas_by_name,
-                ResolvedDatabaseSpecifier::Ambient,
             ),
         };
-        apply(
+        apply_inverted_lookup(schemas_by_name, &schema.name, schema.id, diff);
+        apply_with_update(
             schemas_by_id,
-            schema.id.clone(),
-            || Schema {
-                name: QualifiedSchemaName {
-                    database: database_spec,
-                    schema: schema.name.clone(),
-                },
-                id: SchemaSpecifier::Id(schema.id.clone()),
-                oid: schema.oid,
-                items: BTreeMap::new(),
-                functions: BTreeMap::new(),
-                types: BTreeMap::new(),
-                owner_id: schema.owner_id,
-                privileges: PrivilegeMap::from_mz_acl_items(schema.privileges),
-            },
+            schema,
+            |schema| schema.id,
             diff,
+            &mut retractions.schemas,
         );
-        apply(schemas_by_name, schema.name.clone(), || schema.id, diff);
     }
 
     #[instrument(level = "debug")]
@@ -463,6 +500,7 @@ impl CatalogState {
         &mut self,
         default_privilege: mz_catalog::durable::DefaultPrivilege,
         diff: StateDiff,
+        _retractions: &mut InProgressRetractions,
     ) {
         match diff {
             StateDiff::Addition => self
@@ -475,7 +513,12 @@ impl CatalogState {
     }
 
     #[instrument(level = "debug")]
-    fn apply_system_privilege_update(&mut self, system_privilege: MzAclItem, diff: StateDiff) {
+    fn apply_system_privilege_update(
+        &mut self,
+        system_privilege: MzAclItem,
+        diff: StateDiff,
+        _retractions: &mut InProgressRetractions,
+    ) {
         match diff {
             StateDiff::Addition => self.system_privileges.grant(system_privilege),
             StateDiff::Retraction => self.system_privileges.revoke(&system_privilege),
@@ -487,6 +530,7 @@ impl CatalogState {
         &mut self,
         system_configuration: mz_catalog::durable::SystemConfiguration,
         diff: StateDiff,
+        _retractions: &mut InProgressRetractions,
     ) {
         let res = match diff {
             StateDiff::Addition => self.insert_system_configuration(
@@ -510,28 +554,19 @@ impl CatalogState {
     }
 
     #[instrument(level = "debug")]
-    fn apply_cluster_update(&mut self, cluster: mz_catalog::durable::Cluster, diff: StateDiff) {
-        apply(
+    fn apply_cluster_update(
+        &mut self,
+        cluster: mz_catalog::durable::Cluster,
+        diff: StateDiff,
+        retractions: &mut InProgressRetractions,
+    ) {
+        apply_inverted_lookup(&mut self.clusters_by_name, &cluster.name, cluster.id, diff);
+        apply_with_update(
             &mut self.clusters_by_id,
-            cluster.id,
-            || Cluster {
-                name: cluster.name.clone(),
-                id: cluster.id,
-                bound_objects: BTreeSet::new(),
-                log_indexes: BTreeMap::new(),
-                replica_id_by_name_: BTreeMap::new(),
-                replicas_by_id_: BTreeMap::new(),
-                owner_id: cluster.owner_id,
-                privileges: PrivilegeMap::from_mz_acl_items(cluster.privileges),
-                config: cluster.config.into(),
-            },
+            cluster,
+            |cluster| cluster.id,
             diff,
-        );
-        apply(
-            &mut self.clusters_by_name,
-            cluster.name,
-            || cluster.id,
-            diff,
+            &mut retractions.clusters,
         );
     }
 
@@ -540,10 +575,22 @@ impl CatalogState {
         &mut self,
         introspection_source_index: mz_catalog::durable::IntrospectionSourceIndex,
         diff: StateDiff,
+        _retractions: &mut InProgressRetractions,
     ) {
+        let cluster = self
+            .clusters_by_id
+            .get_mut(&introspection_source_index.cluster_id)
+            .expect("catalog out of sync");
         let log = BUILTIN_LOG_LOOKUP
             .get(introspection_source_index.name.as_str())
             .expect("missing log");
+        apply_inverted_lookup(
+            &mut cluster.log_indexes,
+            &log.variant,
+            introspection_source_index.index_id,
+            diff,
+        );
+
         match diff {
             StateDiff::Addition => {
                 self.insert_introspection_source_index(
@@ -557,16 +604,6 @@ impl CatalogState {
                 self.drop_item(introspection_source_index.index_id);
             }
         }
-        let cluster = self
-            .clusters_by_id
-            .get_mut(&introspection_source_index.cluster_id)
-            .expect("catalog out of sync");
-        apply(
-            &mut cluster.log_indexes,
-            log.variant,
-            || introspection_source_index.index_id,
-            diff,
-        );
     }
 
     #[instrument(level = "debug")]
@@ -574,6 +611,7 @@ impl CatalogState {
         &mut self,
         cluster_replica: mz_catalog::durable::ClusterReplica,
         diff: StateDiff,
+        _retractions: &mut InProgressRetractions,
     ) {
         let cluster = self
             .clusters_by_id
@@ -587,10 +625,22 @@ impl CatalogState {
             .clusters_by_id
             .get_mut(&cluster_replica.cluster_id)
             .expect("catalog out of sync");
-        apply(
-            &mut cluster.replicas_by_id_,
+        apply_inverted_lookup(
+            &mut cluster.replica_id_by_name_,
+            &cluster_replica.name,
             cluster_replica.replica_id,
-            || {
+            diff,
+        );
+        match diff {
+            StateDiff::Retraction => {
+                let prev = cluster.replicas_by_id_.remove(&cluster_replica.replica_id);
+                assert!(
+                    prev.is_some(),
+                    "retraction does not match existing value: {:?}",
+                    cluster_replica.replica_id
+                );
+            }
+            StateDiff::Addition => {
                 let logging = ReplicaLogging {
                     log_logging: cluster_replica.config.logging.log_logging,
                     interval: cluster_replica.config.logging.interval,
@@ -599,22 +649,23 @@ impl CatalogState {
                     location,
                     compute: ComputeReplicaConfig { logging },
                 };
-                ClusterReplica {
+                let mem_cluster_replica = ClusterReplica {
                     name: cluster_replica.name.clone(),
                     cluster_id: cluster_replica.cluster_id,
                     replica_id: cluster_replica.replica_id,
                     config,
                     owner_id: cluster_replica.owner_id,
-                }
-            },
-            diff,
-        );
-        apply(
-            &mut cluster.replica_id_by_name_,
-            cluster_replica.name,
-            || cluster_replica.replica_id,
-            diff,
-        );
+                };
+                let prev = cluster
+                    .replicas_by_id_
+                    .insert(cluster_replica.replica_id, mem_cluster_replica);
+                assert_eq!(
+                    prev, None,
+                    "values must be explicitly retracted before inserting a new value: {:?}",
+                    cluster_replica.replica_id
+                );
+            }
+        }
     }
 
     #[instrument(level = "debug")]
@@ -622,6 +673,7 @@ impl CatalogState {
         &mut self,
         system_object_mapping: mz_catalog::durable::SystemObjectMapping,
         diff: StateDiff,
+        _retractions: &mut InProgressRetractions,
     ) {
         let id = system_object_mapping.unique_identifier.id;
 
@@ -821,9 +873,15 @@ impl CatalogState {
     }
 
     #[instrument(level = "debug")]
-    fn apply_item_update(&mut self, item: mz_catalog::durable::Item, diff: StateDiff) {
+    fn apply_item_update(
+        &mut self,
+        item: mz_catalog::durable::Item,
+        diff: StateDiff,
+        retractions: &mut InProgressRetractions,
+    ) {
         match diff {
             StateDiff::Addition => {
+                let key = item.key();
                 let catalog_item = self
                     .deserialize_item(&item.create_sql)
                     .expect("invalid persisted SQL");
@@ -843,15 +901,40 @@ impl CatalogState {
                     item.owner_id,
                     PrivilegeMap::from_mz_acl_items(item.privileges),
                 );
+                // If there's a matching retraction, update the new item with denormalized state
+                // from the retraction.
+                if let Some(CatalogEntry {
+                    item: _,
+                    referenced_by,
+                    used_by,
+                    id,
+                    oid: _,
+                    name: _,
+                    owner_id: _,
+                    privileges: _,
+                }) = retractions.items.remove(&key)
+                {
+                    assert_eq!(id, item.id);
+                    let entry = self.entry_by_id.get_mut(&id).expect("just inserted");
+                    entry.referenced_by = referenced_by;
+                    entry.used_by = used_by;
+                }
             }
             StateDiff::Retraction => {
-                self.drop_item(item.id);
+                let entry = self.drop_item(item.id);
+                let key = item.into_key_value().0;
+                retractions.items.insert(key, entry);
             }
         }
     }
 
     #[instrument(level = "debug")]
-    fn apply_comment_update(&mut self, comment: mz_catalog::durable::Comment, diff: StateDiff) {
+    fn apply_comment_update(
+        &mut self,
+        comment: mz_catalog::durable::Comment,
+        diff: StateDiff,
+        _retractions: &mut InProgressRetractions,
+    ) {
         match diff {
             StateDiff::Addition => {
                 let prev = self.comments.update_comment(
@@ -884,11 +967,12 @@ impl CatalogState {
         &mut self,
         storage_collection_metadata: mz_catalog::durable::StorageCollectionMetadata,
         diff: StateDiff,
+        _retractions: &mut InProgressRetractions,
     ) {
-        apply(
+        apply_inverted_lookup(
             &mut self.storage_metadata.collection_metadata,
-            storage_collection_metadata.id,
-            || storage_collection_metadata.shard,
+            &storage_collection_metadata.id,
+            storage_collection_metadata.shard,
             diff,
         );
     }
@@ -898,6 +982,7 @@ impl CatalogState {
         &mut self,
         unfinalized_shard: mz_catalog::durable::UnfinalizedShard,
         diff: StateDiff,
+        _retractions: &mut InProgressRetractions,
     ) {
         match diff {
             StateDiff::Addition => {
@@ -1009,25 +1094,68 @@ impl CatalogState {
     }
 }
 
-/// Inserts `key` and `value` into `map` if `diff` is an addition, otherwise remove them from `map`
-/// if `diff` is a retraction.
-fn apply<K, V>(map: &mut BTreeMap<K, V>, key: K, value: impl FnOnce() -> V, diff: StateDiff)
+/// Helper method to updated inverted lookup maps. The keys are generally names and the values are
+/// generally IDs.
+///
+/// Importantly, when retracting it's expected that the existing value will match `value` exactly.
+fn apply_inverted_lookup<K, V>(map: &mut BTreeMap<K, V>, key: &K, value: V, diff: StateDiff)
 where
-    K: Ord + Debug,
+    K: Ord + Clone + Debug,
     V: PartialEq + Debug,
 {
     match diff {
         StateDiff::Retraction => {
-            let prev = map.remove(&key);
-            // We can't assert the exact contents of the previous value, since we don't know
-            // what it should look like.
-            assert!(
-                prev.is_some(),
+            let prev = map.remove(key);
+            assert_eq!(
+                prev,
+                Some(value),
                 "retraction does not match existing value: {key:?}"
             );
         }
         StateDiff::Addition => {
-            let prev = map.insert(key, value());
+            let prev = map.insert(key.clone(), value);
+            assert_eq!(
+                prev, None,
+                "values must be explicitly retracted before inserting a new value: {key:?}"
+            );
+        }
+    }
+}
+
+/// Helper method to update catalog state, that may need to be updated from a previously retracted
+/// object.
+fn apply_with_update<K, V, D>(
+    map: &mut BTreeMap<K, V>,
+    durable: D,
+    key_fn: impl FnOnce(&D) -> K,
+    diff: StateDiff,
+    retractions: &mut BTreeMap<D::Key, V>,
+) where
+    K: Ord,
+    V: UpdateFrom<D> + PartialEq + Debug,
+    D: DurableType,
+    D::Key: Ord,
+{
+    match diff {
+        StateDiff::Retraction => {
+            let mem_key = key_fn(&durable);
+            let value = map
+                .remove(&mem_key)
+                .expect("retraction does not match existing value: {key:?}");
+            let durable_key = durable.into_key_value().0;
+            retractions.insert(durable_key, value);
+        }
+        StateDiff::Addition => {
+            let mem_key = key_fn(&durable);
+            let durable_key = durable.key();
+            let value = match retractions.remove(&durable_key) {
+                Some(mut value) => {
+                    value.update_from(durable);
+                    value
+                }
+                None => durable.into(),
+            };
+            let prev = map.insert(mem_key, value);
             assert_eq!(
                 prev, None,
                 "values must be explicitly retracted before inserting a new value"

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1156,7 +1156,7 @@ impl CatalogState {
     }
 
     #[mz_ore::instrument(level = "trace")]
-    pub(super) fn drop_item(&mut self, id: GlobalId) {
+    pub(super) fn drop_item(&mut self, id: GlobalId) -> CatalogEntry {
         let metadata = self.entry_by_id.remove(&id).expect("catalog out of sync");
         info!(
             "drop {} {} ({})",
@@ -1209,6 +1209,8 @@ impl CatalogState {
                 );
             }
         }
+
+        metadata
     }
 
     pub(super) fn get_database(&self, database_id: &DatabaseId) -> &Database {

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1082,25 +1082,6 @@ impl CatalogState {
         owner_id: RoleId,
         privileges: PrivilegeMap,
     ) {
-        if !id.is_system() {
-            info!(
-                "create {} {} ({})",
-                item.typ(),
-                self.resolve_full_name(&name, None),
-                id
-            );
-        }
-
-        if !id.is_system() {
-            if let Some(cluster_id) = item.cluster_id() {
-                self.clusters_by_id
-                    .get_mut(&cluster_id)
-                    .expect("catalog out of sync")
-                    .bound_objects
-                    .insert(id);
-            };
-        }
-
         let entry = CatalogEntry {
             item,
             name,
@@ -1111,6 +1092,31 @@ impl CatalogState {
             owner_id,
             privileges,
         };
+
+        self.insert_entry(entry);
+    }
+
+    /// Associates a name, `GlobalId`, and entry.
+    pub(super) fn insert_entry(&mut self, entry: CatalogEntry) {
+        if !entry.id.is_system() {
+            info!(
+                "create {} {} ({})",
+                entry.item.typ(),
+                self.resolve_full_name(&entry.name, None),
+                entry.id
+            );
+        }
+
+        if !entry.id.is_system() {
+            if let Some(cluster_id) = entry.item.cluster_id() {
+                self.clusters_by_id
+                    .get_mut(&cluster_id)
+                    .expect("catalog out of sync")
+                    .bound_objects
+                    .insert(entry.id);
+            };
+        }
+
         for u in &entry.references().0 {
             match self.entry_by_id.get_mut(u) {
                 Some(metadata) => metadata.referenced_by.push(entry.id()),

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -525,6 +525,63 @@ impl From<CatalogEntry> for durable::Item {
     }
 }
 
+// `durable::Item` requires outside state to be converted into a `CatalogEntry`.
+impl From<(durable::Item, CatalogItem, QualifiedItemName)> for CatalogEntry {
+    fn from(
+        (
+            durable::Item {
+                id,
+                oid,
+                owner_id,
+                privileges,
+                // Converted externally into the `CatalogItem` and `QualifiedItemName`.
+                schema_id: _,
+                name: _,
+                create_sql: _,
+            },
+            catalog_item,
+            name,
+        ): (durable::Item, CatalogItem, QualifiedItemName),
+    ) -> Self {
+        CatalogEntry {
+            item: catalog_item,
+            referenced_by: Vec::new(),
+            used_by: Vec::new(),
+            id,
+            oid,
+            name,
+            owner_id,
+            privileges: PrivilegeMap::from_mz_acl_items(privileges),
+        }
+    }
+}
+impl UpdateFrom<(durable::Item, CatalogItem, QualifiedItemName)> for CatalogEntry {
+    fn update_from(
+        &mut self,
+        (
+            durable::Item {
+                id,
+                oid,
+                owner_id,
+                privileges,
+                // Converted externally into the `CatalogItem` and `QualifiedItemName`.
+                schema_id: _,
+                name: _,
+                create_sql: _,
+            },
+            catalog_item,
+            name,
+        ): (durable::Item, CatalogItem, QualifiedItemName),
+    ) {
+        self.item = catalog_item;
+        self.id = id;
+        self.oid = oid;
+        self.name = name;
+        self.owner_id = owner_id;
+        self.privileges = PrivilegeMap::from_mz_acl_items(privileges);
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct Table {
     pub create_sql: Option<String>,


### PR DESCRIPTION
The in-memory `CatalogState` maintains denormalized data for certain object types. For example, items maintain a list of all dependent items (other items that depend on it). Updates to an object, for example, updating the privileges on an object, is represented as a retraction of the object in its previous state, followed by an addition of the object in its new state, within a single timestamp.

Naively, we would apply these by removing the object from `CatalogState` when applying the retraction and then re-inserting it when applying the addition. The issue with this approach is that we lose all the denormalized state, which can be prohibitively expensive to regenerate.

This commit resolves this issue via the following process:

  1. When applying retractions, stash all removed objects in memory somewhere.
  2. When applying additions, see if there's a matching retraction, and if so restore its denormalized state.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
