### PR TITLE
catalog: Listen for updates in transactions

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -31,6 +31,12 @@ def get_ancestor_overrides_for_performance_regressions(
     # Commits must be ordered descending by their date.
     min_ancestor_mz_version_per_commit = dict()
 
+    if scenario_class_name == "SwapSchema":
+        # PR#27607 (catalog: Listen for updates in transactions) increased wallclock
+        min_ancestor_mz_version_per_commit[
+            "d5388cccbcd860b04486573f632fb9337e7335a2"
+        ] = MzVersion.parse_mz("v0.105.0")
+
     if scenario_class_name == "MySqlInitialLoad":
         # PR#27058 (storage: wire up new reclock implementation) increased memory usage
         min_ancestor_mz_version_per_commit[

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -182,9 +182,9 @@ impl Catalog {
             .await
             .map_err(mz_catalog::durable::DurableCatalogError::from)?;
 
-        // Ensure the state changes from initialization are visible in the
-        // state.
-        state.update_storage_metadata(&txn);
+        let updates = txn.get_op_updates().collect();
+        let builtin_updates = state.apply_updates(updates);
+        assert_eq!(builtin_updates, Vec::new());
         txn.commit().await?;
         drop(storage);
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -78,7 +78,7 @@ use crate::catalog::CatalogState;
 use crate::coord::ConnMeta;
 
 /// An update to a built-in table.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuiltinTableUpdate<T = GlobalId> {
     /// The reference of the table to update.
     pub id: T,

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -323,6 +323,9 @@ impl Catalog {
                     | StateUpdateKind::StorageUsage(_)
                     | StateUpdateKind::StorageCollectionMetadata(_)
                     | StateUpdateKind::UnfinalizedShard(_) => post_item_updates.push(update),
+                    StateUpdateKind::TemporaryItem(item) => {
+                        unreachable!("temporary items don't exist during startup: {item:?}")
+                    }
                 }
             }
 
@@ -1334,7 +1337,7 @@ mod builtin_migration_tests {
         ) -> (String, ItemNamespace, CatalogItem) {
             let item = match self.item {
                 SimplifiedItem::Table => CatalogItem::Table(Table {
-                    create_sql: Some("CREATE TABLE t ()".to_string()),
+                    create_sql: Some("CREATE TABLE materialize.public.t (a INT)".to_string()),
                     desc: RelationDesc::empty()
                         .with_column("a", ScalarType::Int32.nullable(true))
                         .with_key(vec![0]),
@@ -1345,11 +1348,19 @@ mod builtin_migration_tests {
                     is_retained_metrics_object: false,
                 }),
                 SimplifiedItem::MaterializedView { referenced_names } => {
-                    let table_list = referenced_names.iter().join(",");
+                    let table_list = referenced_names
+                        .iter()
+                        .map(|table| format!("materialize.public.{table}"))
+                        .join(",");
+                    let column_list = referenced_names
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, _)| format!("a{idx}"))
+                        .join(",");
                     let resolved_ids = convert_names_to_ids(referenced_names, id_mapping);
                     CatalogItem::MaterializedView(MaterializedView {
                         create_sql: format!(
-                            "CREATE MATERIALIZED VIEW mv AS SELECT * FROM {table_list}"
+                            "CREATE MATERIALIZED VIEW materialize.public.mv ({column_list}) AS SELECT * FROM {table_list}"
                         ),
                         raw_expr: mz_sql::plan::HirRelationExpr::constant(
                             Vec::new(),
@@ -1379,7 +1390,7 @@ mod builtin_migration_tests {
                 SimplifiedItem::Index { on } => {
                     let on_id = id_mapping[&on];
                     CatalogItem::Index(Index {
-                        create_sql: format!("CREATE INDEX idx ON {on} (a)"),
+                        create_sql: format!("CREATE INDEX idx ON materialize.public.{on} (a)"),
                         on: on_id,
                         keys: Vec::new(),
                         conn_id: None,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -19,15 +19,14 @@ use std::time::Instant;
 use itertools::Itertools;
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
-use mz_catalog::durable::Transaction;
 use mz_sql::session::metadata::SessionMetadata;
 use once_cell::sync::Lazy;
 use serde::Serialize;
 use timely::progress::Antichain;
 use tokio::sync::mpsc;
-use tracing::{info, warn};
+use tracing::warn;
 
-use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageUsage};
+use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent};
 use mz_build_info::DUMMY_BUILD_INFO;
 use mz_catalog::builtin::{
     Builtin, BuiltinCluster, BuiltinLog, BuiltinSource, BuiltinTable, BuiltinType, BUILTINS,
@@ -35,19 +34,19 @@ use mz_catalog::builtin::{
 use mz_catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap};
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
-    CatalogEntry, CatalogItem, Cluster, ClusterConfig, ClusterReplica, CommentsMap, Connection,
-    DataSourceDesc, Database, DefaultPrivileges, Index, MaterializedView, Role, Schema, Secret,
-    Sink, Source, Table, Type, View,
+    CatalogEntry, CatalogItem, Cluster, ClusterReplica, CommentsMap, Connection, DataSourceDesc,
+    Database, DefaultPrivileges, Index, MaterializedView, Role, Schema, Secret, Sink, Source,
+    Table, Type, View,
 };
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_controller::clusters::{
-    ManagedReplicaAvailabilityZones, ManagedReplicaLocation, ReplicaAllocation, ReplicaConfig,
-    ReplicaLocation, UnmanagedReplicaLocation,
+    ManagedReplicaAvailabilityZones, ManagedReplicaLocation, ReplicaAllocation, ReplicaLocation,
+    UnmanagedReplicaLocation,
 };
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_expr::MirScalarExpr;
 use mz_ore::collections::CollectionExt;
-use mz_ore::now::{EpochMillis, NOW_ZERO};
+use mz_ore::now::NOW_ZERO;
 use mz_ore::soft_assert_no_log;
 use mz_ore::str::StrExt;
 use mz_pgrepr::oid::INVALID_OID;
@@ -86,7 +85,7 @@ use mz_storage_types::connections::inline::{
 use mz_storage_types::connections::ConnectionContext;
 
 // DO NOT add any more imports from `crate` outside of `crate::catalog`.
-use crate::catalog::{BuiltinTableUpdate, ConnCatalog};
+use crate::catalog::ConnCatalog;
 use crate::coord::ConnMeta;
 use crate::optimize::{self, Optimize};
 use crate::session::Session;
@@ -684,17 +683,8 @@ impl CatalogState {
             .unwrap_or_else(|| panic!("unknown cluster {cluster_id}"))
     }
 
-    pub(super) fn get_cluster_mut(&mut self, cluster_id: ClusterId) -> &mut Cluster {
-        self.try_get_cluster_mut(cluster_id)
-            .unwrap_or_else(|| panic!("unknown cluster {cluster_id}"))
-    }
-
     pub(super) fn try_get_cluster(&self, cluster_id: ClusterId) -> Option<&Cluster> {
         self.clusters_by_id.get(&cluster_id)
-    }
-
-    pub(super) fn try_get_cluster_mut(&mut self, cluster_id: ClusterId) -> Option<&mut Cluster> {
-        self.clusters_by_id.get_mut(&cluster_id)
     }
 
     pub(super) fn try_get_role(&self, id: &RoleId) -> Option<&Role> {
@@ -713,10 +703,6 @@ impl CatalogState {
         self.roles_by_name
             .get(role_name)
             .map(|id| &self.roles_by_id[id])
-    }
-
-    pub(super) fn get_role_mut(&mut self, id: &RoleId) -> &mut Role {
-        self.roles_by_id.get_mut(id).expect("catalog out of sync")
     }
 
     pub(crate) fn collect_role_membership(&self, id: &RoleId) -> BTreeSet<RoleId> {
@@ -1072,15 +1058,6 @@ impl CatalogState {
     /// Associates a name, `GlobalId`, and entry.
     pub(super) fn insert_entry(&mut self, entry: CatalogEntry) {
         if !entry.id.is_system() {
-            info!(
-                "create {} {} ({})",
-                entry.item.typ(),
-                self.resolve_full_name(&entry.name, None),
-                entry.id
-            );
-        }
-
-        if !entry.id.is_system() {
             if let Some(cluster_id) = entry.item.cluster_id() {
                 self.clusters_by_id
                     .get_mut(&cluster_id)
@@ -1137,12 +1114,6 @@ impl CatalogState {
     #[mz_ore::instrument(level = "trace")]
     pub(super) fn drop_item(&mut self, id: GlobalId) -> CatalogEntry {
         let metadata = self.entry_by_id.remove(&id).expect("catalog out of sync");
-        info!(
-            "drop {} {} ({})",
-            metadata.item_type(),
-            self.resolve_full_name(metadata.name(), metadata.conn_id()),
-            id
-        );
         for u in &metadata.references().0 {
             if let Some(dep_metadata) = self.entry_by_id.get_mut(u) {
                 dep_metadata.referenced_by.retain(|u| *u != metadata.id())
@@ -1194,44 +1165,6 @@ impl CatalogState {
 
     pub(super) fn get_database(&self, database_id: &DatabaseId) -> &Database {
         &self.database_by_id[database_id]
-    }
-
-    pub(super) fn get_database_mut(&mut self, database_id: &DatabaseId) -> &mut Database {
-        self.database_by_id
-            .get_mut(database_id)
-            .expect("catalog out of sync")
-    }
-
-    pub(super) fn insert_cluster(
-        &mut self,
-        id: ClusterId,
-        name: String,
-        introspection_source_indexes: Vec<(&'static BuiltinLog, GlobalId, u32)>,
-        owner_id: RoleId,
-        privileges: PrivilegeMap,
-        config: ClusterConfig,
-    ) {
-        let mut log_indexes = BTreeMap::new();
-        for (log, index_id, oid) in introspection_source_indexes {
-            self.insert_introspection_source_index(id, log, index_id, oid);
-            log_indexes.insert(log.variant.clone(), index_id);
-        }
-
-        self.clusters_by_id.insert(
-            id,
-            Cluster {
-                name: name.clone(),
-                id,
-                bound_objects: BTreeSet::new(),
-                log_indexes,
-                replica_id_by_name_: BTreeMap::new(),
-                replicas_by_id_: BTreeMap::new(),
-                owner_id,
-                privileges,
-                config,
-            },
-        );
-        assert!(self.clusters_by_name.insert(name, id).is_none());
     }
 
     pub(super) fn insert_introspection_source_index(
@@ -1287,50 +1220,6 @@ impl CatalogState {
         );
     }
 
-    pub(super) fn rename_cluster(&mut self, id: ClusterId, to_name: String) {
-        let cluster = self.get_cluster_mut(id);
-        let old_name = std::mem::take(&mut cluster.name);
-        cluster.name.clone_from(&to_name);
-
-        assert!(self.clusters_by_name.remove(&old_name).is_some());
-        assert!(self.clusters_by_name.insert(to_name, id).is_none());
-    }
-
-    pub(super) fn insert_cluster_replica(
-        &mut self,
-        cluster_id: ClusterId,
-        replica_name: String,
-        replica_id: ReplicaId,
-        config: ReplicaConfig,
-        owner_id: RoleId,
-    ) {
-        let replica = ClusterReplica {
-            name: replica_name.clone(),
-            cluster_id,
-            replica_id,
-            config,
-            owner_id,
-        };
-        let cluster = self
-            .clusters_by_id
-            .get_mut(&cluster_id)
-            .expect("catalog out of sync");
-        cluster.insert_replica(replica);
-    }
-
-    /// Renames a cluster replica.
-    ///
-    /// Panics if the cluster or cluster replica does not exist.
-    pub(super) fn rename_cluster_replica(
-        &mut self,
-        cluster_id: ClusterId,
-        replica_id: ReplicaId,
-        to_name: String,
-    ) {
-        let cluster = self.get_cluster_mut(cluster_id);
-        cluster.rename_replica(replica_id, to_name);
-    }
-
     /// Gets a reference to the specified replica of the specified cluster.
     ///
     /// Returns `None` if either the cluster or the replica does not
@@ -1382,17 +1271,24 @@ impl CatalogState {
         Ok(self.system_configuration.set(name, value)?)
     }
 
+    /// Parse system configuration `name` with `value` int.
+    ///
+    /// Returns the parsed value as a string.
+    pub(super) fn parse_system_configuration(
+        &self,
+        name: &str,
+        value: VarInput,
+    ) -> Result<String, Error> {
+        let value = self.system_configuration.parse(name, value)?;
+        Ok(value.format())
+    }
+
     /// Reset system configuration `name`.
     ///
     /// Return a `bool` value indicating whether the configuration was modified
     /// by the call.
     pub(super) fn remove_system_configuration(&mut self, name: &str) -> Result<bool, Error> {
         Ok(self.system_configuration.reset(name)?)
-    }
-
-    /// Remove all system configurations.
-    pub(super) fn clear_system_configuration(&mut self) {
-        self.system_configuration.reset_all();
     }
 
     /// Gets the schema map for the database matching `database_spec`.
@@ -2201,13 +2097,12 @@ impl CatalogState {
     }
 
     // TODO(mjibson): Is there a way to make this a closure to avoid explicitly
-    // passing tx, session, and builtin_table_updates?
+    // passing tx, and session?
     pub(crate) fn add_to_audit_log(
-        &self,
+        system_configuration: &SystemVars,
         oracle_write_ts: mz_repr::Timestamp,
         session: Option<&ConnMeta>,
         tx: &mut mz_catalog::durable::Transaction,
-        builtin_table_updates: &mut Vec<BuiltinTableUpdate>,
         audit_events: &mut Vec<VersionedEvent>,
         event_type: EventType,
         object_type: ObjectType,
@@ -2217,37 +2112,14 @@ impl CatalogState {
 
         // unsafe_mock_audit_event_timestamp can only be set to Some when running in unsafe mode.
 
-        let occurred_at = match self
-            .system_configuration
-            .unsafe_mock_audit_event_timestamp()
-        {
+        let occurred_at = match system_configuration.unsafe_mock_audit_event_timestamp() {
             Some(ts) => ts.into(),
             _ => oracle_write_ts.into(),
         };
         let id = tx.allocate_audit_log_id()?;
         let event = VersionedEvent::new(id, event_type, object_type, details, user, occurred_at);
-        builtin_table_updates
-            .push(self.resolve_builtin_table_update(self.pack_audit_log_update(&event, 1)?));
         audit_events.push(event.clone());
         tx.insert_audit_log_event(event);
-        Ok(())
-    }
-
-    pub(super) fn add_to_storage_usage(
-        &self,
-        tx: &mut mz_catalog::durable::Transaction,
-        builtin_table_updates: &mut Vec<BuiltinTableUpdate>,
-        shard_id: Option<String>,
-        size_bytes: u64,
-        collection_timestamp: EpochMillis,
-    ) -> Result<(), Error> {
-        let id =
-            tx.get_and_increment_id(mz_catalog::durable::STORAGE_USAGE_ID_ALLOC_KEY.to_string())?;
-
-        let details = VersionedStorageUsage::new(id, shard_id, size_bytes, collection_timestamp);
-        builtin_table_updates
-            .push(self.resolve_builtin_table_update(self.pack_storage_usage_update(&details, 1)));
-        tx.insert_storage_usage_event(details);
         Ok(())
     }
 
@@ -2291,22 +2163,9 @@ impl CatalogState {
         }
     }
 
-    /// Synchronizes the local view of the [`StorageMetadata`] with the
-    /// [`Transaction`]'s.
-    ///
-    /// This must be called after any `Transaction` is given to the storage
-    /// controller, otherwise subsequent storage operations will have
-    /// inconsistent metadata.
-    pub(super) fn update_storage_metadata(&mut self, tx: &Transaction<'_>) {
-        use mz_storage_client::controller::StorageTxn;
-        self.storage_metadata.collection_metadata = tx.get_collection_metadata();
-        self.storage_metadata.unfinalized_shards = tx.get_unfinalized_shards();
-    }
-
     /// Returns a read-only view of the current [`StorageMetadata`].
     ///
-    /// To write to this struct, you must use a [`Transaction`], followed by a
-    /// call to `update_storage_metadata`.
+    /// To write to this struct, you must use a catalog transaction.
     pub fn storage_metadata(&self) -> &StorageMetadata {
         &self.storage_metadata
     }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -529,7 +529,7 @@ impl Coordinator {
             .await?;
 
         // Update in-memory cluster replica statuses.
-        // TODO(jkosh44) All the builtin table updates should be handled as a builtin source
+        // TODO(jkosh44) All these builtin table updates should be handled as a builtin source
         // updates elsewhere.
         for (cluster_id, replica_id) in &cluster_replicas_to_drop {
             let replica_statuses =

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -61,20 +61,19 @@ async fn datadriven() {
                     match test_case.directive.as_str() {
                         "add-table" => {
                             let id = catalog.allocate_user_id().await.unwrap();
-                            let database_id = catalog
-                                .resolve_database(DEFAULT_DATABASE_NAME)
-                                .unwrap()
-                                .id();
+                            let database = catalog.resolve_database(DEFAULT_DATABASE_NAME).unwrap();
+                            let database_name = database.name.clone();
+                            let database_id = database.id();
                             let database_spec = ResolvedDatabaseSpecifier::Id(database_id);
-                            let schema_spec = catalog
+                            let schema = catalog
                                 .resolve_schema_in_database(
                                     &database_spec,
                                     DEFAULT_SCHEMA,
                                     &SYSTEM_CONN_ID,
                                 )
-                                .unwrap()
-                                .id
-                                .clone();
+                                .unwrap();
+                            let schema_name = schema.name.schema.clone();
+                            let schema_spec = schema.id.clone();
                             catalog
                                 .transact(
                                     None,
@@ -91,7 +90,9 @@ async fn datadriven() {
                                         },
                                         item: CatalogItem::Table(Table {
                                             create_sql: Some(format!(
-                                                "CREATE TABLE {} ()",
+                                                "CREATE TABLE {}.{}.{} ()",
+                                                database_name,
+                                                schema_name,
                                                 test_case.input.trim_end()
                                             )),
                                             desc: RelationDesc::empty(),

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -120,7 +120,7 @@ pub struct BuiltinLog {
     pub access: Vec<MzAclItem>,
 }
 
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, PartialEq, Eq)]
 pub struct BuiltinTable {
     pub name: &'static str,
     pub schema: &'static str,


### PR DESCRIPTION
This commit updates the catalog transaction logic such that updates to
the in-memory catalog are made using the `apply_update` function. In
theory this puts us in a state where all updates to the in-memory
catalog that can be derived from the durable catalog, are done via the
`apply_update` function.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
