### PR TITLE
tests: Fix frontegg-mock parameters

### DIFF
--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -33,6 +33,7 @@ USERS = {
     ADMIN_USER: {
         "email": ADMIN_USER,
         "password": str(uuid.uuid4()),
+        "id": str(uuid.uuid4()),
         "tenant_id": TENANT_ID,
         "initial_api_tokens": [
             {
@@ -45,6 +46,7 @@ USERS = {
     OTHER_USER: {
         "email": OTHER_USER,
         "password": str(uuid.uuid4()),
+        "id": str(uuid.uuid4()),
         "tenant_id": TENANT_ID,
         "initial_api_tokens": [
             {

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1524,13 +1524,13 @@ class WebhookSources(Generator):
 
 TENANT_ID = str(uuid.uuid4())
 ADMIN_USER = "u1@example.com"
-OTHER_USER = "u2@example.com"
 ADMIN_ROLE = "MaterializePlatformAdmin"
 OTHER_ROLE = "MaterializePlatform"
 USERS = {
     ADMIN_USER: {
         "email": ADMIN_USER,
         "password": str(uuid.uuid4()),
+        "id": str(uuid.uuid4()),
         "tenant_id": TENANT_ID,
         "initial_api_tokens": [
             {


### PR DESCRIPTION
id became a required parameter in https://github.com/MaterializeInc/materialize/pull/27533 Tests are now failing: https://buildkite.com/materialize/nightly/builds/8065
```
frontegg-mock: fatal: decoding --users: missing field `id` at line 1 column 324
```
Relevant test run: https://buildkite.com/materialize/nightly/builds/8078
### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
