### PR TITLE
k8s: fix detection of OOM kills

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -19,9 +19,9 @@ use cloud_resource_controller::KubernetesResourceReader;
 use futures::stream::{BoxStream, StreamExt};
 use k8s_openapi::api::apps::v1::{StatefulSet, StatefulSetSpec};
 use k8s_openapi::api::core::v1::{
-    Affinity, Capabilities, Container, ContainerPort, ContainerState, EnvVar, EnvVarSource,
-    EphemeralVolumeSource, NodeAffinity, NodeSelector, NodeSelectorRequirement, NodeSelectorTerm,
-    ObjectFieldSelector, ObjectReference, PersistentVolumeClaim, PersistentVolumeClaimSpec,
+    Affinity, Capabilities, Container, ContainerPort, EnvVar, EnvVarSource, EphemeralVolumeSource,
+    NodeAffinity, NodeSelector, NodeSelectorRequirement, NodeSelectorTerm, ObjectFieldSelector,
+    ObjectReference, PersistentVolumeClaim, PersistentVolumeClaimSpec,
     PersistentVolumeClaimTemplate, Pod, PodAffinity, PodAffinityTerm, PodAntiAffinity,
     PodSecurityContext, PodSpec, PodTemplateSpec, PreferredSchedulingTerm, ResourceRequirements,
     SeccompProfile, Secret, SecurityContext, Service as K8sService, ServicePort, ServiceSpec,
@@ -1392,35 +1392,24 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 .ok_or_else(|| anyhow!("missing label: {service_id_label}"))?
                 .clone();
 
-            fn is_state_oom(state: &ContainerState) -> bool {
-                state
-                    .terminated
-                    .as_ref()
-                    // 137 is the exit code corresponding to OOM in Kubernetes.
-                    // It'd be a bit clearer to compare the reason to "OOMKilled",
-                    // but this doesn't work in Kind for some reason, preventing us from
-                    // writing automated tests.
-                    .map(|terminated| terminated.exit_code == 137)
-                    .unwrap_or(false)
-            }
             let oomed = pod
                 .status
                 .as_ref()
                 .and_then(|status| status.container_statuses.as_ref())
                 .map(|container_statuses| {
                     container_statuses.iter().any(|cs| {
-                        // We check whether the current _or_ the last state
-                        // is an OOM kill. The reason for this is that after a kill,
-                        // the state toggles from "Terminated" to "Waiting" very quickly,
-                        // at which point the OOM error appears int he last state,
-                        // not the current one.
-                        //
-                        // This "oomed" value is ignored later on if the pod is ready,
-                        // so there is no risk that we will go directly from "Terminated"
-                        // to "Running" and incorrectly report that we are currently
-                        // oom-killed.
-                        cs.last_state.as_ref().map(is_state_oom).unwrap_or(false)
-                            || cs.state.as_ref().map(is_state_oom).unwrap_or(false)
+                        // The container might have already transitioned from "terminated" to
+                        // "waiting"/"running" state, in which case we need to check its previous
+                        // state to find out why it terminated.
+                        let current_state = cs.state.as_ref().and_then(|s| s.terminated.as_ref());
+                        let last_state = cs.last_state.as_ref().and_then(|s| s.terminated.as_ref());
+                        let termination_state = current_state.or(last_state);
+
+                        // 137 is the exit code corresponding to OOM in Kubernetes. It'd be a bit
+                        // clearer to compare the reason to "OOMKilled", but this doesn't work in
+                        // Kind for some reason, preventing us from writing automated tests.
+                        let exit_code = termination_state.map(|s| s.exit_code);
+                        exit_code == Some(137)
                     })
                 })
                 .unwrap_or(false);


### PR DESCRIPTION
The code detecting an OOM-kill when reporting a replica status update would unconditionally check the replicas `last_state` before checking its current state. It could thus incorrectly report an OOM-kill when the replica oom'd previously, even when the current crash was due to something else than an OOM.

This is fixed here by adjusting the logic to only look at `last_state` if the current state is something else than "terminated" (i.e. "waiting" or "running").

This PR also changes to logic to detect exit code 135 (SIGBUS, observed during OOD kills) as an OOM-kill as well.

### Motivation

  * This PR fixes a recognized bug.

Fixes #27602 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
