### PR TITLE
ci: Always upload latest heap profile too, overwriting previous

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -84,23 +84,13 @@ fi
 
 rm -f prof-*.gz
 
-if is_truthy "${CI_HEAP_PROFILES:-}"; then
-    (while true; do
-        sleep 5
-        # faketty because otherwise docker will complain about not being inside
-        # of a TTY when run in a background job
-        faketty bin/ci-builder run stable bin/ci-upload-heap-profiles "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
-    done
-    ) &
-else
-    (while true; do
-        sleep 5
-        # faketty because otherwise docker will complain about not being inside
-        # of a TTY when run in a background job
-        faketty bin/ci-builder run stable bin/ci-upload-heap-profiles --no-upload "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
-    done
-    ) &
-fi
+(while true; do
+    sleep 5
+    # faketty because otherwise docker will complain about not being inside
+    # of a TTY when run in a background job
+    faketty bin/ci-builder run stable bin/ci-upload-heap-profiles "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
+done
+) &
 
 ci_uncollapsed_heading ":docker: Running \`bin/mzcompose --find $BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION run ${run_args[*]}\`"
 

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -82,12 +82,22 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
     mzcompose --mz-quiet cp balancerd:/usr/local/bin/balancerd coverage/ || true
 fi
 
+rm -f prof-*.gz
+
 if is_truthy "${CI_HEAP_PROFILES:-}"; then
     (while true; do
         sleep 5
         # faketty because otherwise docker will complain about not being inside
         # of a TTY when run in a background job
         faketty bin/ci-builder run stable bin/ci-upload-heap-profiles "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
+    done
+    ) &
+else
+    (while true; do
+        sleep 5
+        # faketty because otherwise docker will complain about not being inside
+        # of a TTY when run in a background job
+        faketty bin/ci-builder run stable bin/ci-upload-heap-profiles --no-upload "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
     done
     ) &
 fi

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -71,6 +71,7 @@ for i in prof-*.pb.gz; do
     gzip -d "$i" || true
 done
 rm -f heap-profiles.tar.zstd
+rm -f prof-*latest.pb
 tar -I "zstd -19" -cvpf heap-profiles.tar.zstd prof-*.pb || true
 rm -f prof-*.pb || true
 

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -67,7 +67,14 @@ rm -rf cores
 
 bin/ci-builder run stable zstd --rm parallel-workload-queries.log || true
 
-mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nnetstat-ant.log\nnetstat-panelot.log\nps-aux.log\ndocker-ps-a.log\ndocker-inspect.log\n"; find . -name 'junit_*.xml')
+for i in prof-*.pb.gz; do
+    gzip -d "$i" || true
+done
+rm -f heap-profiles.tar.zstd
+tar -I "zstd -19" -cvpf heap-profiles.tar.zstd prof-*.pb || true
+rm -f prof-*.pb || true
+
+mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nnetstat-ant.log\nnetstat-panelot.log\nps-aux.log\ndocker-ps-a.log\ndocker-inspect.log\n"; find . -name 'junit_*.xml' -o -name 'heap-profiles.tar.zstd')
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 buildkite-agent artifact upload "$artifacts_str"
 bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}"

--- a/misc/python/materialize/cli/ci_upload_heap_profiles.py
+++ b/misc/python/materialize/cli/ci_upload_heap_profiles.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# ci_upload_heap_profiles.py - Upload memory heap profiles during an mzcompose run
+# ci_upload_heap_profiles.py - Record and upload memory heap profiles during an mzcompose run
 
 import argparse
 import json
@@ -26,7 +26,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         prog="ci-upload-heap-profiles",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="ci-upload-heap-profiles uploads memory heap profiles during an mzcompose run",
+        description="ci-upload-heap-profiles records and uploads memory heap profiles during an mzcompose run",
     )
 
     parser.add_argument("composition", type=str)

--- a/misc/python/materialize/cli/ci_upload_heap_profiles.py
+++ b/misc/python/materialize/cli/ci_upload_heap_profiles.py
@@ -11,6 +11,7 @@
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -50,6 +51,9 @@ def main() -> int:
         filename = f"prof-{service}{suffix}-{time_str}.pb.gz"
         with open(filename, "wb") as f:
             f.write(heap_profile)
+        filename_latest = f"prof-{service}{suffix}-latest.pb.gz"
+        with open(filename_latest, "wb") as f:
+            f.write(heap_profile)
         if args.upload:
             subprocess.run(
                 [
@@ -58,9 +62,10 @@ def main() -> int:
                     "upload",
                     "--log-level",
                     "error",
-                    filename,
+                    filename_latest,
                 ]
             )
+        os.remove(filename_latest)
 
     services = json.loads(
         subprocess.run(


### PR DESCRIPTION
Depends on Buildkite implementing only showing the latest upload in UI
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
