### PR TITLE
[persist] Allow using the critical since across the board

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -95,8 +95,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_txn_tables": "lazy",
     "persist_use_critical_since_catalog": "true",
     "persist_use_critical_since_snapshot": "true",
-    # TODO: change to true when #27219 is resolved
-    "persist_use_critical_since_source": "false",
+    "persist_use_critical_since_source": "true",
     "persist_part_decode_format": "row_with_validate",
     "statement_logging_default_sample_rate": "0.01",
     "statement_logging_max_sample_rate": "0.01",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -916,7 +916,7 @@ class FlipFlagsAction(Action):
         BOOLEAN_FLAG_VALUES = ["TRUE", "FALSE"]
 
         self.flags_with_values: dict[str, list[str]] = dict()
-        for flag in ["catalog", "snapshot", "txn"]:
+        for flag in ["catalog", "source", "snapshot", "txn"]:
             self.flags_with_values[f"persist_use_critical_since_{flag}"] = (
                 BOOLEAN_FLAG_VALUES
             )

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -278,7 +278,7 @@ where
     }
     impl<H: FnOnce(String) -> Pin<Box<dyn Future<Output = ()>>> + 'static> ErrorHandler<H> {
         /// Report the error and enforce that we never return.
-        async fn report_and_stop(self, error: String) {
+        async fn report_and_stop(self, error: String) -> ! {
             (self.inner)(error).await;
 
             // We cannot continue, and we cannot shut down. Otherwise downstream
@@ -372,8 +372,7 @@ where
                         .report_and_stop(format!(
                             "{name_owned}: {shard_id} cannot serve requested as_of {as_of:?}: {e:?}"
                         ))
-                        .await;
-                    unreachable!("error handler must diverge");
+                        .await
                 }
             },
             SnapshotMode::Exclude => vec![],
@@ -396,8 +395,7 @@ where
                     .report_and_stop(format!(
                         "{name_owned}: {shard_id} cannot serve requested as_of {as_of:?}: {e:?}"
                     ))
-                    .await;
-                unreachable!("error handler must diverge");
+                    .await
             }
         };
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -21,9 +21,9 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use futures::Stream;
 use mz_dyncfg::Config;
+use mz_ore::instrument;
 use mz_ore::now::EpochMillis;
 use mz_ore::task::{AbortOnDropHandle, JoinHandle, RuntimeExt};
-use mz_ore::{instrument, soft_assert_or_log};
 use mz_persist::location::{Blob, SeqNo};
 use mz_persist_types::{Codec, Codec64};
 use proptest_derive::Arbitrary;
@@ -686,13 +686,9 @@ where
     ) -> Result<Vec<LeasedBatchPart<T>>, Since<T>> {
         let batches = self.machine.snapshot(&as_of).await?;
 
-        soft_assert_or_log!(
-            PartialOrder::less_equal(self.since(), &as_of),
-            "ReadHandle::snapshot called with as_of {:?} not past the handle's since {:?}, \
-            though the read has succeeded. This implies the since is not being held back correctly.",
-            &as_of,
-            self.since()
-        );
+        if !PartialOrder::less_equal(self.since(), &as_of) {
+            return Err(Since(self.since().clone()));
+        }
 
         let filter = FetchBatchFilter::Snapshot { as_of };
         let mut leased_parts = Vec::new();

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -28,6 +28,7 @@ use mz_ore::instrument;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_ore::task::AbortOnDropHandle;
 use mz_persist_client::cache::PersistClientCache;
+use mz_persist_client::cfg::USE_CRITICAL_SINCE_SNAPSHOT;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
@@ -777,7 +778,7 @@ where
 
         // We create a new read handle every time someone requests a snapshot
         // and then immediately expire it instead of keeping a read handle
-        // permanently in our state to avoid having it heartbeat continously.
+        // permanently in our state to avoid having it heartbeat continually.
         // The assumption is that calls to snapshot are rare and therefore worth
         // it to always create a new handle.
         let read_handle = persist_client
@@ -789,7 +790,7 @@ where
                     shard_name: id.to_string(),
                     handle_purpose: format!("snapshot {}", id),
                 },
-                false,
+                USE_CRITICAL_SINCE_SNAPSHOT.get(&self.persist.cfg),
             )
             .await
             .expect("invalid persist usage");

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -654,7 +654,9 @@ where
                     &dep_collection.implied_capability,
                     collection_implied_capability
                 ),
-                "dependency since cannot be in advance of dependent's since"
+                "dependency since ({dep}@{:?}) cannot be in advance of dependent's since ({id}@{:?})",
+                dep_collection.implied_capability,
+                collection_implied_capability,
             );
         }
 

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -675,7 +675,7 @@ where
     /// Currently, collections have either 0 or 1 dependencies.
     fn determine_collection_dependencies(
         &self,
-        self_collections: &mut BTreeMap<GlobalId, CollectionState<T>>,
+        self_collections: &BTreeMap<GlobalId, CollectionState<T>>,
         data_source: &DataSource,
     ) -> Result<Vec<GlobalId>, StorageError<T>> {
         let dependencies = match &data_source {
@@ -1435,10 +1435,8 @@ where
             let data_shard_since = since_handle.since().clone();
 
             // Determine if this collection has any dependencies.
-            let storage_dependencies = self.determine_collection_dependencies(
-                &mut *self_collections,
-                &description.data_source,
-            )?;
+            let storage_dependencies = self
+                .determine_collection_dependencies(&*self_collections, &description.data_source)?;
 
             // Determine the intial since of the collection.
             let initial_since = match storage_dependencies

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1412,16 +1412,11 @@ where
         // Reorder in dependency order.
         to_register.sort_by_key(|(id, ..)| *id);
 
-        // New collections that are being created.
-        let mut new_collections = BTreeSet::new();
-
         // We hold this lock for a very short amount of time, just doing some
         // hashmap inserts and unbounded channel sends.
         let mut self_collections = self.collections.lock().expect("lock poisoned");
 
         for (id, mut description, write_handle, since_handle, metadata) in to_register {
-            new_collections.insert(id);
-
             // Ensure that the ingestion has an export for its primary source.
             // This is done in an akward spot to appease the borrow checker.
             if let DataSource::Ingestion(ingestion) = &mut description.data_source {


### PR DESCRIPTION
- Now all creators of leased readers can be configured to use the critical handles' since, and all are enabled in CI.
- Fix two lingering issues:
    - It's possible for ALTER SOURCE to add subsources that start behind the since of the remap shard, breaking our invariant. This branch advances the since to be past its input's since on collection create, which should always be safe and signals the correct thing to the source pipeline.
    - @aljoscha recently added code to restart the persist source in the Kafka sink on an as-of error, but the new check I added was an assert. Switch over to using the cool new error-reporting mechanism.

### Motivation

#26940

### Tips for reviewer

There are a ton of different ways to fix the sources issue, but this one seemed like the most principled. It may slow down collection creation, though - I haven't observed this yet, but I'm not sure if we have specific tests that would notice this?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
