### PR TITLE
postgres consistency: extend and adjust ignores

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -465,7 +465,7 @@ class PgPostExecutionInconsistencyIgnoreFilter(
             )
 
         if query_template.matches_any_expression(
-            partial(matches_fun_by_name, function_name_in_lower_case="COALESCE"), True
+            partial(matches_fun_by_name, function_name_in_lower_case="coalesce"), True
         ):
             return YesIgnore(
                 "Postgres resolves all arguments, possibly resulting in an evaluation error"

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -289,6 +289,12 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("#24578: different representation")
 
+        if db_operation.pattern == "$ % $" and (
+            ExpressionCharacteristics.MAX_VALUE in all_involved_characteristics
+            or ExpressionCharacteristics.TINY_VALUE in all_involved_characteristics
+        ):
+            return YesIgnore("#27634: modulo with large / tiny values")
+
         if db_operation.is_tagged(TAG_REGEX):
             return YesIgnore(
                 "Materialize regular expressions are similar to, but not identical to, PostgreSQL regular expressions."


### PR DESCRIPTION
This addresses
* https://buildkite.com/materialize/nightly/builds/8083#019011c6-9f22-46fa-bd99-484a37f78cb7
* https://buildkite.com/materialize/nightly/builds/8084#019011ca-54f6-4321-a1a3-50eb934b2a32

Nightly: https://buildkite.com/materialize/nightly/builds/8085