### PR TITLE
mz-sql build: Remove unused postgres_array dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6016,7 +6016,6 @@ dependencies = [
  "num_enum",
  "once_cell",
  "paste",
- "postgres_array",
  "proptest",
  "proptest-derive",
  "prost",

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -64,7 +64,6 @@ mz-tracing = { path = "../tracing" }
 mz-txn-wal = { path = "../txn-wal" }
 num_enum = "0.5.7"
 paste = "1.0"
-postgres_array = { version = "0.11.0" }
 protobuf-native = "0.3.1"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/8088#019012a7-a173-416f-851b-5323804ce64e

Verification: https://buildkite.com/materialize/nightly/builds/8097

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
