### PR TITLE
ci: Disable heap profiling for all benchmarks

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -92,8 +92,8 @@ if is_truthy "${CI_HEAP_PROFILES:-}"; then
         faketty bin/ci-builder run stable bin/ci-upload-heap-profiles "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
     done
     ) &
-# TODO: Remove exceptions when #27639 is fixed
-elif [ "$BUILDKITE_STEP_KEY" != "scalability-benchmark-dml-dql" ] && [ "$BUILDKITE_STEP_KEY" != "kafka-matrix" ]; then
+# We don't want any performance impact on benchmarks. Kafka-matrix goes OoM, might be close to its memory limit anyway.
+elif [[ "$BUILDKITE_STEP_KEY" != scalability-benchmark-* ]] && [[ "$BUILDKITE_STEP_KEY" != feature-benchmark-* ]] && [ "$BUILDKITE_STEP_KEY" != "kafka-matrix" ]; then
     (while true; do
         sleep 5
         # faketty because otherwise docker will complain about not being inside


### PR DESCRIPTION


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
