### PR TITLE
platform-checks: Add ALTER SINK test

### DIFF
--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -914,3 +914,78 @@ class SinkAutoCreatedTopicConfig(Check):
             """
             )
         )
+
+
+@externally_idempotent(False)
+class AlterSink(Check):
+    """Check ALTER SINK"""
+
+    def _can_run(self, e: Executor) -> bool:
+        return self.base_version >= MzVersion.parse_mz("v0.103.0")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            schemas()
+            + dedent(
+                """
+                > CREATE TABLE table_alter1 (x int, y string)
+                > CREATE TABLE table_alter2 (x int, y string)
+                > CREATE TABLE table_alter3 (x int, y string)
+                > CREATE SINK sink_alter FROM table_alter1
+                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'alter-sink')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE DEBEZIUM
+                > INSERT INTO table_alter1 VALUES (0, 'a')
+                > INSERT INTO table_alter2 VALUES (1, 'b')
+                > INSERT INTO table_alter3 VALUES (2, 'c')
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > ALTER SINK sink_alter SET FROM table_alter2;
+
+                # Wait for the actual restart to have occurred before inserting
+                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=4s
+
+                > INSERT INTO table_alter1 VALUES (10, 'aa')
+                > INSERT INTO table_alter2 VALUES (11, 'bb')
+                > INSERT INTO table_alter3 VALUES (12, 'cc')
+                """,
+                """
+                > ALTER SINK sink_alter SET FROM table_alter3;
+
+                # Wait for the actual restart to have occurred before inserting
+                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=4s
+
+                > INSERT INTO table_alter1 VALUES (100, 'aaa')
+                > INSERT INTO table_alter2 VALUES (101, 'bbb')
+                > INSERT INTO table_alter3 VALUES (102, 'ccc')
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                # We check the contents of the sink topics by re-ingesting them.
+
+                > CREATE SOURCE sink_alter_source
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'alter-sink')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE NONE
+
+                > SELECT before IS NULL, (after).x, (after).y FROM sink_alter_source
+                true 0 a
+                true 11 bb
+                true 102 ccc
+
+                > DROP SOURCE sink_alter_source CASCADE;
+            """
+            )
+        )


### PR DESCRIPTION
Locally I'm seeing wrong results: (Edit: Also in CI: https://buildkite.com/materialize/nightly/builds/8101)
```
> SELECT before IS NULL, (after).x, (after).y FROM sink_alter_source
rows didn't match; sleeping to see if dataflow catches up 50ms 75ms 113ms 169ms 253ms 380ms 570ms 854ms 1s 2s 3s 4s 6s 10s 15s 22s 33s 49s 74s 76s
^^^ +++
9:1: error: non-matching rows: expected:
[["true", "0", "a"], ["true", "102", "ccc"], ["true", "11", "bb"]]
got:
[["true", "0", "a"], ["true", "10", "aa"], ["true", "101", "bbb"]]
Poor diff:
+ true 10 aa
+ true 101 bbb
- true 102 ccc
- true 11 bb
```

Adding sleeps seems to fix them. But I'm worried because it looks like without the sleep the old data can end up in the sink even though we previously altered the sink to switch to a new table. @petrosagg Is this an issue or expected?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
