### PR TITLE
dbt: adapt to mz_introspection rename

### DIFF
--- a/misc/dbt-materialize/dbt/adapters/materialize/connections.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/connections.py
@@ -38,10 +38,10 @@ logger = AdapterLogger("Materialize")
 # after the session is established.
 def connect(**kwargs):
     options = [
-        # Ensure that dbt's introspection queries get routed to the
-        # `mz_introspection` cluster, even if the server or role's default is
+        # Ensure that dbt's catalog queries get routed to the
+        # `mz_catalog_server` cluster, even if the server or role's default is
         # different.
-        "--auto_route_introspection_queries=on",
+        "--auto_route_catalog_queries=on",
         # dbt prints notices to stdout, which is very distracting because dbt
         # can establish many new connections during `dbt run`.
         "--welcome_message=off",

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/await_cluster_ready.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/await_cluster_ready.sql
@@ -20,7 +20,7 @@
         {{ return(true) }}
     {% endif %}
     -- Hydration takes time. Be a good
-    -- citizen and don't overwhelm mz_introspection
+    -- citizen and don't overwhelm mz_catalog_server
     {{ adapter.sleep(poll_interval) }}
 {% endfor %}
 {{ exceptions.raise_compiler_error("Cluster " ~ deploy_cluster ~ " failed to hydrate within a reasonable amount of time") }}


### PR DESCRIPTION
Now that the `mz_introspection` -> `mz_catalog_server` rename has been rolled out to production, adapt the dbt adapter to use the new names.

### Motivation

  * This PR adds a known-desirable feature.

Closes #26731 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A