### PR TITLE
catalog: Optimize item updates

### DIFF
--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -525,63 +525,6 @@ impl From<CatalogEntry> for durable::Item {
     }
 }
 
-// `durable::Item` requires outside state to be converted into a `CatalogEntry`.
-impl From<(durable::Item, CatalogItem, QualifiedItemName)> for CatalogEntry {
-    fn from(
-        (
-            durable::Item {
-                id,
-                oid,
-                owner_id,
-                privileges,
-                // Converted externally into the `CatalogItem` and `QualifiedItemName`.
-                schema_id: _,
-                name: _,
-                create_sql: _,
-            },
-            catalog_item,
-            name,
-        ): (durable::Item, CatalogItem, QualifiedItemName),
-    ) -> Self {
-        CatalogEntry {
-            item: catalog_item,
-            referenced_by: Vec::new(),
-            used_by: Vec::new(),
-            id,
-            oid,
-            name,
-            owner_id,
-            privileges: PrivilegeMap::from_mz_acl_items(privileges),
-        }
-    }
-}
-impl UpdateFrom<(durable::Item, CatalogItem, QualifiedItemName)> for CatalogEntry {
-    fn update_from(
-        &mut self,
-        (
-            durable::Item {
-                id,
-                oid,
-                owner_id,
-                privileges,
-                // Converted externally into the `CatalogItem` and `QualifiedItemName`.
-                schema_id: _,
-                name: _,
-                create_sql: _,
-            },
-            catalog_item,
-            name,
-        ): (durable::Item, CatalogItem, QualifiedItemName),
-    ) {
-        self.item = catalog_item;
-        self.id = id;
-        self.oid = oid;
-        self.name = name;
-        self.owner_id = owner_id;
-        self.privileges = PrivilegeMap::from_mz_acl_items(privileges);
-    }
-}
-
 #[derive(Debug, Clone, Serialize)]
 pub struct Table {
     pub create_sql: Option<String>,


### PR DESCRIPTION
Updating an item through the `apply_updates` machinery requires
updating the item durably, reading it back in from disk, and finally
parsing, planning, and optimizing the item's CREATE SQL. The parsing,
planning, and optimizing is potentially wasteful for updates that don't
modify the item's SQL such as privilege updates. This commit optimizes
item updating by skipping parsing, planning, and optimizing when the
SQL has not changed. Applying items no longer fits nicely into the
`UpdateFrom` trait, so the code's a bit uglier, but the structure is
still the same.

Works towards resolving #24844

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
