### PR TITLE
adapter: remove already applied loadgen source migration

### DIFF
--- a/misc/python/materialize/checks/all_checks/load_generator.py
+++ b/misc/python/materialize/checks/all_checks/load_generator.py
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.mz_version import MzVersion
+
+
+class LoadGeneratorAsOfUpTo(Check):
+    def _can_run(self, e: Executor) -> bool:
+        return self.base_version >= MzVersion.parse_mz("v0.101.0")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+            > CREATE SOURCE counter1 FROM LOAD GENERATOR COUNTER (AS OF 100, UP TO 200);
+        """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+            > CREATE SOURCE counter2 FROM LOAD GENERATOR COUNTER (AS OF 1100, UP TO 1200);
+                """,
+                """
+            > CREATE SOURCE counter3 FROM LOAD GENERATOR COUNTER (AS OF 11100, UP TO 11200);
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT COUNT(*) FROM counter1;
+                200
+                > SELECT COUNT(*) FROM counter2;
+                1200
+                > SELECT COUNT(*) FROM counter3;
+                11200
+            """
+            )
+        )

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -99,7 +99,7 @@ pub(crate) async fn migrate(
         catalog_version
     );
 
-    rewrite_ast_items(tx, |_tx, _id, stmt| {
+    rewrite_ast_items(tx, |_tx, _id, _stmt| {
         let _catalog_version = catalog_version.clone();
         Box::pin(async move {
             // Add per-item AST migrations below.
@@ -110,7 +110,6 @@ pub(crate) async fn migrate(
             //
             // Migration functions may also take `tx` as input to stage
             // arbitrary changes to the catalog.
-            ast_rewrite_create_source_loadgen_options_0_92_0(stmt)?;
             Ok(())
         })
     })
@@ -430,52 +429,6 @@ fn add_to_audit_log(
     let event =
         mz_audit_log::VersionedEvent::new(id, event_type, object_type, details, None, occurred_at);
     tx.insert_audit_log_event(event);
-    Ok(())
-}
-
-fn ast_rewrite_create_source_loadgen_options_0_92_0(
-    stmt: &mut Statement<Raw>,
-) -> Result<(), anyhow::Error> {
-    use mz_sql::ast::{
-        CreateSourceConnection, CreateSourceStatement, LoadGenerator, LoadGeneratorOptionName::*,
-    };
-
-    struct Rewriter;
-
-    impl<'ast> VisitMut<'ast, Raw> for Rewriter {
-        fn visit_create_source_statement_mut(
-            &mut self,
-            node: &'ast mut CreateSourceStatement<Raw>,
-        ) {
-            match &mut node.connection {
-                CreateSourceConnection::LoadGenerator { generator, options } => {
-                    let permitted_options: &[_] = match generator {
-                        LoadGenerator::Auction => &[TickInterval],
-                        LoadGenerator::Counter => &[TickInterval, MaxCardinality],
-                        LoadGenerator::Marketing => &[TickInterval],
-                        LoadGenerator::Datums => &[TickInterval],
-                        LoadGenerator::Tpch => &[TickInterval, ScaleFactor],
-                        LoadGenerator::KeyValue => &[
-                            TickInterval,
-                            Keys,
-                            SnapshotRounds,
-                            TransactionalSnapshot,
-                            ValueSize,
-                            Seed,
-                            Partitions,
-                            BatchSize,
-                        ],
-                    };
-
-                    options.retain(|o| permitted_options.contains(&o.name));
-                }
-                _ => {}
-            }
-        }
-    }
-
-    Rewriter.visit_statement_mut(stmt);
-
     Ok(())
 }
 


### PR DESCRIPTION
This also fixes #27638 which is caused by this migration deleting the `AS OF` and `UP TO` options from load generator sources.

Fixes https://github.com/MaterializeInc/incidents-and-escalations/issues/45#issuecomment-2167043869.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
