### PR TITLE
Revert "[persist/sources] Choose a resumption frontier in the source …

### DIFF
--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -113,59 +113,48 @@ where
         // shard has advanced too far.
         fail_point!("invalid_remap_as_of");
         assert!(
+            PartialOrder::less_equal(since, &as_of),
+            "invalid as_of: as_of({as_of:?}) < since({since:?}), \
+            source {id}, \
+            remap_shard: {:?}",
+            metadata.remap_shard
+        );
+
+        assert!(
             as_of.elements() == [IntoTime::minimum()] || PartialOrder::less_than(&as_of, upper),
             "invalid as_of: upper({upper:?}) <= as_of({as_of:?})",
         );
 
-        let events = if since.is_empty() {
-            // We never advance the since to empty in the source itself...
-            // this code is only reachable once the source has been dropped.
-            tracing::info!(
-                ?since,
-                ?as_of,
-                ?upper,
-                "{operator}({id}) {worker_id}/{worker_count} already dropped"
-            );
-            futures::stream::pending().boxed_local()
-        } else {
-            tracing::info!(
-                ?since,
-                ?as_of,
-                ?upper,
-                "{operator}({id}) {worker_id}/{worker_count} initializing PersistHandle"
-            );
-            assert!(
-                PartialOrder::less_equal(since, &as_of),
-                "invalid as_of: as_of({as_of:?}) < since({since:?}), \
-                source {id}, \
-                remap_shard: {:?}",
-                metadata.remap_shard
-            );
+        tracing::info!(
+            ?since,
+            ?as_of,
+            ?upper,
+            "{operator}({id}) {worker_id}/{worker_count} initializing PersistHandle"
+        );
 
-            use futures::stream;
-            stream::once(async move {
-                let updates = read_handle
-                    .snapshot_and_fetch(as_of.clone())
-                    .await
-                    .expect("since <= as_of asserted");
-                let snapshot = stream::once(std::future::ready(ListenEvent::Updates(updates)));
+        use futures::stream;
+        let events = stream::once(async move {
+            let updates = read_handle
+                .snapshot_and_fetch(as_of.clone())
+                .await
+                .expect("since <= as_of asserted");
+            let snapshot = stream::once(std::future::ready(ListenEvent::Updates(updates)));
 
-                let listener = read_handle
-                    .listen(as_of.clone())
-                    .await
-                    .expect("since <= as_of asserted");
+            let listener = read_handle
+                .listen(as_of.clone())
+                .await
+                .expect("since <= as_of asserted");
 
-                let listen_stream = stream::unfold(listener, |mut listener| async move {
-                    let events = stream::iter(listener.fetch_next().await);
-                    Some((events, listener))
-                })
-                .flatten();
-
-                snapshot.chain(listen_stream)
+            let listen_stream = stream::unfold(listener, |mut listener| async move {
+                let events = stream::iter(listener.fetch_next().await);
+                Some((events, listener))
             })
-            .flatten()
-            .boxed_local()
-        };
+            .flatten();
+
+            snapshot.chain(listen_stream)
+        })
+        .flatten()
+        .boxed_local();
 
         Ok(Self {
             events,

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -20,12 +20,11 @@ use std::sync::Arc;
 use differential_dataflow::lattice::Lattice;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::read::ListenEvent;
-use mz_persist_client::{Diagnostics, PersistClient};
+use mz_persist_client::Diagnostics;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::Codec64;
-use mz_repr::{Diff, GlobalId, Row, TimestampManipulation};
+use mz_repr::{Diff, GlobalId, Row};
 use mz_service::local::Activatable;
-use mz_storage_client::controller::PersistEpoch;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::sources::{
     GenericSourceConnection, IngestionDescription, KafkaSourceConnection,
@@ -186,7 +185,7 @@ where
     source_resume_uppers
 }
 
-impl<T: Timestamp + Lattice + Codec64 + Display + TimestampManipulation> AsyncStorageWorker<T> {
+impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
     /// Creates a new [`AsyncStorageWorker`].
     ///
     /// IMPORTANT: The passed in `activatable` is activated when new responses
@@ -224,15 +223,15 @@ impl<T: Timestamp + Lattice + Codec64 + Display + TimestampManipulation> AsyncSt
                         // arbitrarily hold back collections to perform historical queries and when
                         // the storage command protocol is updated such that these calculations are
                         // performed by the controller and not here.
-                        let mut resume_uppers = BTreeMap::new();
-
                         let mut as_of = Antichain::new();
+                        let mut resume_uppers = BTreeMap::new();
+                        let mut seen_remap_shard = None;
 
                         for (id, export) in ingestion_description.source_exports.iter() {
                             // Explicit destructuring to force a compile error when the metadata change
                             let CollectionMetadata {
                                 persist_location,
-                                remap_shard: _,
+                                remap_shard,
                                 data_shard,
                                 // The status shard only contains non-definite status updates
                                 status_shard: _,
@@ -248,51 +247,81 @@ impl<T: Timestamp + Lattice + Codec64 + Display + TimestampManipulation> AsyncSt
                                 .open(persist_location.clone())
                                 .await
                                 .expect("error creating persist client");
-                            let diagnostics = Diagnostics {
-                                shard_name: id.to_string(),
-                                handle_purpose: format!("resumption data {}", id),
-                            };
 
                             let mut write_handle = client
                                 .open_writer::<SourceData, (), T, Diff>(
                                     *data_shard,
                                     Arc::new(relation_desc.clone()),
                                     Arc::new(UnitSchema),
-                                    diagnostics.clone(),
+                                    Diagnostics {
+                                        shard_name: id.to_string(),
+                                        handle_purpose: format!("resumption data {}", id),
+                                    },
                                 )
                                 .await
                                 .unwrap();
                             let upper = write_handle.fetch_recent_upper().await;
-
-                            let read_handle = client
-                                .open_critical_since::<SourceData, (), T, Diff, PersistEpoch>(
-                                    *data_shard,
-                                    PersistClient::CONTROLLER_CRITICAL_SINCE,
-                                    diagnostics,
-                                )
-                                .await
-                                .expect("data shard");
-
-                            let export_as_of = {
-                                // Chose the largest frontier that we can without altering the mappings.
-                                // Generally speaking, we want to prevent the as-of from advancing past
-                                // the export's upper... or otherwise we'd risk remapping input data
-                                // to the wrong timestamp. However, if the overall since of the
-                                // export shard is past the upper, then nobody can observe the difference!
-                                // So we bound the as-of by the join of the two frontiers.
-                                let mut frontier: Antichain<_> = upper
-                                    .elements()
-                                    .iter()
-                                    .map(|t| t.step_back().unwrap_or(t.clone()))
-                                    .collect();
-                                frontier.join_assign(read_handle.since());
-                                frontier
-                            };
-
-                            as_of.meet_assign(&export_as_of);
-
                             resume_uppers.insert(*id, upper.clone());
                             write_handle.expire().await;
+
+                            // TODO(petrosagg): The as_of of the ingestion should normally be based
+                            // on the since frontiers of its outputs. Even though the storage
+                            // controller makes sure to make downgrade decisions in an organized
+                            // and ordered fashion, it then proceeds to persist them in an
+                            // asynchronous and disorganized fashion to persist. The net effect is
+                            // that upon restart, or upon observing the persist state like this
+                            // function, one can see non-sensical results like the since of A be in
+                            // advance of B even when B depends on A! This can happen because the
+                            // downgrade of B gets reordered and lost. Here is our best attempt at
+                            // playing detective of what the controller meant to do by blindly
+                            // assuming that the since of the remap shard is a suitable since
+                            // frontier without consulting the since frontier of the outputs. One
+                            // day we will enforce order to chaos and this comment will be deleted.
+                            if let Some(remap_shard) = remap_shard {
+                                match seen_remap_shard.as_ref() {
+                                    None => {
+                                        let read_handle = client
+                                            .open_leased_reader::<SourceData, (), T, Diff>(
+                                                *remap_shard,
+                                                Arc::new(
+                                                    ingestion_description
+                                                        .desc
+                                                        .connection
+                                                        .timestamp_desc(),
+                                                ),
+                                                Arc::new(UnitSchema),
+                                                Diagnostics {
+                                                    shard_name: ingestion_description
+                                                        .remap_collection_id
+                                                        .to_string(),
+                                                    handle_purpose: format!(
+                                                        "resumption data for {}",
+                                                        id
+                                                    ),
+                                                },
+                                                false,
+                                            )
+                                            .await
+                                            .unwrap();
+                                        as_of.clone_from(read_handle.since());
+                                        mz_ore::task::spawn(
+                                            move || "deferred_expire",
+                                            async move {
+                                                tokio::time::sleep(std::time::Duration::from_secs(
+                                                    300,
+                                                ))
+                                                .await;
+                                                read_handle.expire().await;
+                                            },
+                                        );
+                                        seen_remap_shard = Some(remap_shard.clone());
+                                    }
+                                    Some(shard) => assert_eq!(
+                                        shard, remap_shard,
+                                        "ingestion with multiple remap shards"
+                                    ),
+                                }
+                            }
                         }
 
                         /// Convenience function to convert `BTreeMap<GlobalId, Antichain<C>>` to


### PR DESCRIPTION
…based on the output upper, not the input since (#27314)"

This reverts commit 9576f999e9913c27e2904a7b38f55cc18a9cba01.

### Motivation

Resolves https://github.com/MaterializeInc/materialize/issues/27665

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
