### PR TITLE
Docs: Add section in troubleshooting user docs on hydration

### DIFF
--- a/doc/user/content/transform-data/troubleshooting.md
+++ b/doc/user/content/transform-data/troubleshooting.md
@@ -220,16 +220,19 @@ To detect and address stalled sources, follow the [`Ingest data` troubleshooting
 guide.
 
 ### Hydrating upstream objects
-When a source, materialized view, or index is created or updated, the underlying cluster must first do an
-initial processing for the object over all the existing data. We call this process hydration. Queries that depend on hydrating objects will block until hydration is
-complete.
 
-Hydration takes time proportional to data volume and query complexity. Indexes and materialized views with large amounts of data will take longer to hydrate than indexes and materialized views with small amounts of data. Similarly, indexes and materialized views for complex queries will take longer to hydrate than indexes and materialized views for simple queries.
+When a source, materialized view, or index is created or updated, it must first
+be backfilled with any pre-existing data — a process known as _hydration_.
 
-Hydration also happens every time a cluster is restarted or sized up, including during
+Queries that depend objects that are still hydrating will **block until
+hydration is complete**. To see whether an object is still hydrating, navigate
+to the [workflow graph](#detect) for the object in the Materialize console.
+
+Hydration time is proportional to data volume and query complexity. This means
+that you should expect objects with large volumes of data and/or complex
+queries to take longer to hydrate. You should also expect hydration to be
+triggered every time a cluster is restarted or sized up, including during
 [Materialize's routine maintenance window](/releases#schedule).
-
-To see whether an object is still hydrating, use the [workflow graph in the Materialize console](#detect) for the object.
 
 ### Unhealthy cluster
 

--- a/doc/user/content/transform-data/troubleshooting.md
+++ b/doc/user/content/transform-data/troubleshooting.md
@@ -200,6 +200,7 @@ WHERE c.name = <CLUSTER_NAME>;
 The most common reasons for query hanging are:
 
 * An upstream source is stalled
+* An upstream object is still hydrating
 * Your cluster is unhealthy
 
 Each of these reasons requires a different approach for troubleshooting. Follow
@@ -217,6 +218,18 @@ guidance.
 <!-- TODO: update this to use the query history UI once it's available -->
 To detect and address stalled sources, follow the [`Ingest data` troubleshooting](/ingest-data/troubleshooting)
 guide.
+
+### Hydrating upstream objects
+When a source, materialized view, or index is created or updated, the underlying cluster must first do an
+initial processing for the object over all the existing data. We call this process hydration. Queries that depend on hydrating objects will block until hydration is
+complete.
+
+Hydration takes time proportional to data volume and query complexity. Indexes and materialized views with large amounts of data will take longer to hydrate than indexes and materialized views with small amounts of data. Similarly, indexes and materialized views for complex queries will take longer to hydrate than indexes and materialized views for simple queries.
+
+Hydration also happens every time a cluster is restarted or sized up, including during
+[Materialize's routine maintenance window](/releases#schedule).
+
+To see whether an object is still hydrating, use the [workflow graph in the Materialize console](#detect) for the object.
 
 ### Unhealthy cluster
 


### PR DESCRIPTION
We want to add "waiting for hydration" as a query plan insight, and I realized there's nothing in our troubleshooting docs around it currently, so decided to add a section.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
