### PR TITLE
ci: Fix github invalid regex detection

### DIFF
--- a/misc/python/materialize/github.py
+++ b/misc/python/materialize/github.py
@@ -86,9 +86,9 @@ def get_known_issues_from_github() -> (
                 issues_with_invalid_regex.append(
                     GitHubIssueWithInvalidRegexp(
                         internal_error_type="GITHUB_INVALID_REGEXP",
-                        issue_url=issue.info["html_url"],
-                        issue_title=issue.info["title"],
-                        issue_number=issue.info["number"],
+                        issue_url=issue["html_url"],
+                        issue_title=issue["title"],
+                        issue_number=issue["number"],
                         regex_pattern=match.strip(),
                     )
                 )


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/test/builds/83914#01901791-e03e-454c-8b41-5a0d8b2c1edd

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
