### PR TITLE
envd: Rename BOOTSTRAP_BUILTIN_INTROSPECTION_CLUSTER_REPLICA_SIZE

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -408,13 +408,12 @@ pub struct Args {
     )]
     bootstrap_builtin_system_cluster_replica_size: String,
     /// The size of the builtin catalog server cluster replicas if bootstrapping.
-    // TODO(#26731): rename to `bootstrap_builtin_catalog_server_cluster_replica_size`
     #[clap(
         long,
-        env = "BOOTSTRAP_BUILTIN_INTROSPECTION_CLUSTER_REPLICA_SIZE",
+        env = "BOOTSTRAP_BUILTIN_CATALOG_SERVER_CLUSTER_REPLICA_SIZE",
         default_value = "1"
     )]
-    bootstrap_builtin_introspection_cluster_replica_size: String,
+    bootstrap_builtin_catalog_server_cluster_replica_size: String,
     /// The size of the builtin probe cluster replicas if bootstrapping.
     #[clap(
         long,
@@ -938,7 +937,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 bootstrap_builtin_system_cluster_replica_size: args
                     .bootstrap_builtin_system_cluster_replica_size,
                 bootstrap_builtin_catalog_server_cluster_replica_size: args
-                    .bootstrap_builtin_introspection_cluster_replica_size,
+                    .bootstrap_builtin_catalog_server_cluster_replica_size,
                 bootstrap_builtin_probe_cluster_replica_size: args
                     .bootstrap_builtin_probe_cluster_replica_size,
                 bootstrap_builtin_support_cluster_replica_size: args


### PR DESCRIPTION
to BOOTSTRAP_BUILTIN_CATALOG_SERVER_CLUSTER_REPLICA_SIZE

Follow-up to https://github.com/MaterializeInc/materialize/issues/26731

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
