### PR TITLE
Upgrade hugo

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -254,8 +254,8 @@ RUN if [ $ARCH_GCC = x86_64 ]; then \
     && echo '04d4be5097b98cd28de469f8856b3fbe82669f57b482a4cf3092a55e9e8e9e0d  htmltest.tar.gz' | sha256sum --check \
     && tar -xzf htmltest.tar.gz -C /usr/local/bin htmltest \
     && rm htmltest.tar.gz \
-    && curl -fsSL https://github.com/gohugoio/hugo/releases/download/v0.87.0/hugo_extended_0.87.0_Linux-64bit.tar.gz > hugo.tar.gz \
-    && echo 'f216af92c06809c03981296f513ce54d3d690715d3c9fdfaff802d4a6759a260  hugo.tar.gz' | sha256sum --check \
+    && curl -fsSL https://github.com/gohugoio/hugo/releases/download/v0.124.1/hugo_extended_0.124.1_Linux-64bit.tar.gz > hugo.tar.gz \
+    && echo '55f5a5f6a4c923457b2ed4e2b00c251eabfe43d8d4afbe2ada92d9759c5e0410 hugo.tar.gz' | sha256sum --check \
     && tar -xzf hugo.tar.gz -C /usr/local/bin hugo \
     && rm hugo.tar.gz; \
     fi

--- a/doc/user/content/stylesheet.md
+++ b/doc/user/content/stylesheet.md
@@ -96,7 +96,7 @@ This is a "full_width" CTA button
 Used for prominent messages. Optionally can include a primary and secondary CTA button using `primary_url`, `primary_text`, `secondary_url`, `secondary_text` in shortcode params.
 
 **Primary Only:**
-{{< callout primary_url="/docs/get-started/" primary_text="Get Started" >}}
+{{< callout primary_url="/get-started/" primary_text="Get Started" >}}
   # Header
 
   Some text and the closing button is specified in the shortcode top.

--- a/doc/user/layouts/_default/_markup/render-image.html
+++ b/doc/user/layouts/_default/_markup/render-image.html
@@ -1,1 +1,10 @@
-<img src="{{ .Destination | safeURL | relURL }}" alt="{{ .Text }}" {{ with .Title}} title="{{ . }}"{{ end }}>
+{{- $url := .Destination | safeURL -}}
+{{- $parentPath := partial "relative-link.html" . -}}
+<img src="
+  {{- if hasPrefix $url "/" -}}
+    {{- $parentPath }}{{ $url | relURL -}}
+  {{- else -}}
+    {{- $url | relURL -}}
+  {{- end -}}
+" alt="{{ .Text }}" {{ with .Title}} title="{{ . }}"{{ end }}>
+{{- /* Chomp trailing newline. */ -}}

--- a/doc/user/layouts/_default/_markup/render-link.html
+++ b/doc/user/layouts/_default/_markup/render-link.html
@@ -1,3 +1,10 @@
 {{- $url := .Destination | safeURL -}}
-<a href="{{if hasPrefix $url "/"}}{{$url | relURL}}{{else}}{{$url}}{{end}}"{{with .Title}} title="{{.}}"{{end}}>{{.Text | safeHTML}}</a>
+{{- $parentPath := partial "relative-link.html" . -}}
+<a href="
+  {{- if hasPrefix $url "/" -}}
+    {{- $parentPath }}{{ $url | relURL -}}
+  {{- else -}}
+    {{- $url -}}
+  {{- end -}}
+" {{with .Title}} title="{{.}}"{{end}}>{{.Text | safeHTML}}</a>
 {{- /* Chomp trailing newline. */ -}}

--- a/doc/user/layouts/partials/footer.html
+++ b/doc/user/layouts/partials/footer.html
@@ -33,9 +33,10 @@
       </svg>
     </button>
   </div>
+  {{ with .File }}
   <div>
     <a
-      href="//github.com/MaterializeInc/materialize/edit/main/doc/user/content/{{ .File.Path }}"
+      href="//github.com/MaterializeInc/materialize/edit/main/doc/user/content/{{ .Path }}"
       class="btn-ghost"
     >
       <svg
@@ -52,6 +53,7 @@
       Edit this page
     </a>
   </div>
+  {{ end }}
   <div class="footer-links">
     <a href="https://materialize.com">Home</a>
     <a href="https://status.materialize.com">Status</a>

--- a/doc/user/layouts/partials/relative-link.html
+++ b/doc/user/layouts/partials/relative-link.html
@@ -1,0 +1,10 @@
+{{- $baseURL := .Page.Site.BaseURL -}}
+{{- $parsedURL := urls.Parse $baseURL -}}
+{{/*
+  This is the subdirectory within which the docs are hosted. We prepend it to relative URLs
+  since Hugo versions > 0.87 changed how relative URLs are generated and we wish to maintain
+  the legacy behavior.
+  */}}
+{{- $parentPath := strings.TrimRight "/" $parsedURL.Path -}}
+{{- /* Chomp trailing newline. */ -}}
+{{ return $parentPath }}

--- a/doc/user/layouts/shortcodes/callout.html
+++ b/doc/user/layouts/shortcodes/callout.html
@@ -1,3 +1,4 @@
+{{- $parentPath := partial "relative-link.html" . -}}
 <div class="callout">
 
   <div>
@@ -5,12 +6,26 @@
 
     <p>
       {{ if and ($.Params) (isset $.Params "primary_text") }}
-      <a class="btn" {{ with .Get "primary_url" }} href="{{ . }}" {{ end }}>
+      <a class="btn" {{ with .Get "primary_url" }} href="
+        {{- $primaryURL := . | safeURL -}}
+          {{- if hasPrefix $primaryURL "/" -}}
+            {{- $parentPath }}{{ $primaryURL | relURL -}}
+          {{- else -}}
+            {{- $primaryURL -}}
+          {{- end -}}"
+        {{- end }}>
         {{ .Get "primary_text" }}
       </a>
       {{ end }}
       {{ if and ($.Params) (isset $.Params "secondary_text") }}
-      <a class="btn" {{ with .Get "secondary_url" }} href="{{ . }}" {{ end }}>
+      <a class="btn" {{ with .Get "secondary_url" }} href="
+        {{- $secondaryURL := . | safeURL -}}
+          {{- if hasPrefix $secondaryURL "/" -}}
+            {{- $parentPath }}{{ $secondaryURL | relURL -}}
+          {{- else -}}
+            {{- $secondaryURL -}}
+          {{- end -}}"
+        {{- end }}>
         {{ .Get "secondary_text" }}
       </a>
       {{ end }}

--- a/doc/user/layouts/shortcodes/cta.html
+++ b/doc/user/layouts/shortcodes/cta.html
@@ -1,3 +1,12 @@
-<a class="cta {{with .Get "full_width"}}full_width{{end}}" href="{{ .Get "href" | relURL }}" {{with .Get "target"}}target="{{.}}"{{end}}}>
+{{- $url := .Get "href" | safeURL -}}
+{{- $parentPath := partial "relative-link.html" . -}}
+<a class="cta {{with .Get "full_width"}}full_width{{end}}" href="
+  {{- if hasPrefix $url "/" -}}
+    {{- $parentPath }}{{ $url | relURL -}}
+  {{- else -}}
+    {{- $url -}}
+  {{- end -}}
+" {{with .Get "target"}}target="{{.}}"{{end}}>
   {{ .Inner | $.Page.RenderString }}
 </a>
+{{- /* Chomp trailing newline. */ -}}

--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -1,5 +1,5 @@
 {{/*  Converts data/sql_funcs.yml into table. */}}
-
+{{ $parentPath := partial "relative-link.html" . }}
 {{$releasedVersions := dict}}
 {{range (where $.Site.RegularPages "Section" "releases")}}
   {{$releasedVersions = merge $releasedVersions (dict .File.ContentBaseName .) }}
@@ -42,7 +42,7 @@
         {{ .description | $.Page.RenderString }}
 
         {{ if .url }}
-        <a href="{{ .url | relURL }}">(docs)</a>.
+        <a href="{{ $parentPath }}{{ .url | relURL }}">(docs)</a>.
         {{ end }}
 
       </p>
@@ -53,7 +53,7 @@
 
       {{ if .unmaterializable_unless_temporal_filter }}
         <p><b>Note:</b> This function is <a href="#unmaterializable-functions">unmaterializable</a>, but
-        can be used in limited contexts in materialized views as a <a href="{{ "/transform-data/patterns/temporal-filters/" | relURL }}">temporal filter</a>.</p>
+        can be used in limited contexts in materialized views as a <a href="{{ $parentPath }}{{ "/transform-data/patterns/temporal-filters/" | relURL }}">temporal filter</a>.</p>
       {{ end }}
 
       {{ if .known_time_zone_limitation_cast }}
@@ -70,7 +70,7 @@
         {{ if not $releasePage.Params.released }}
           <p>
             <b>Unreleased: </b> This function will be released in
-            <a href="{{ printf "/releases/%s" $versionAdded | relURL }}"><strong>{{$versionAdded}}</strong></a>.
+            <a href="{{ printf "%s/releases/%s" $parentPath $versionAdded | relURL }}"><strong>{{$versionAdded}}</strong></a>.
             It may not be available in your region yet.
             The release is scheduled to complete by <strong>{{dateFormat "January 2, 2006" $releasePage.Params.date}}</strong>.
           </p>


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

Our current version of Hugo is fairly out of date, and engineers are encountering issues trying to author docs. This upgrades us to a recent version of Hugo and makes the necessary changes to make the generated docs functional. Beyond the version bump this includes:

- Fixing a build issue around the footer object format changing
- Updating our path generation to account for a change in relative pathing. Newer versions of Hugo generate URLs relative to the host, not subdirectory, even when hosted within a subdirectory. Add logic to our templates shortcodes to read the path from the Hugo config and prepend it to any relative URL.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
