### PR TITLE
dev docs: Update fast compile guide

### DIFF
--- a/doc/developer/fast-compiles.md
+++ b/doc/developer/fast-compiles.md
@@ -18,43 +18,32 @@ it's possible to get a rough sense of Materialize's performance on macOS,
 there have been more than a few occasions where apparent performance defects
 have disappeared when running the workload on Linux.
 
-## Use lld
+## Use mold
 
-Using lld instead of the standard linker will result in an impressive
-linking speedup.
+On Linux using mold instead of the standard linker will result in an impressive
+linking speedup. On macOS make sure to have an up-to-date system with at least
+Xcode 15 to use the new system linker, which is similarly fast.
 
 ### Installation
 
 #### Linux
 
-On Debian-based distros, you can install lld from the standard package
+On Debian-based distros, you can install mold from the standard package
 repository:
 
 ```shell
-sudo apt install lld
+sudo apt install mold
 ```
 
 You'll need to hunt down the equivalent instructions for your distribution if
 you don't use a Debian-based distribution.
 
-#### macOS
-
-lld is available on Homebrew as part of the `llvm` package.
-
-```shell
-brew install llvm
-```
-
-The `llvm` package is keg-only, so you'll have to add its bin folder to your
-PATH manually. Refer to the "Caveats" section in the output of the above
-`brew install` command for instructions.
-
 ### Configuration
 
-To tell Rust to use lld, set the following environment variable:
+To tell Rust to use mold, set the following environment variable:
 
 ```shell
-export RUSTFLAGS="-C link-arg=-fuse-ld=lld"
+export RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 ```
 
 Alternatively, you can configure the linker through a
@@ -62,17 +51,17 @@ Alternatively, you can configure the linker through a
 
 ```toml
 [build]
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 ```
 
 [cargo-config]: https://doc.rust-lang.org/cargo/reference/config.html#configuration
 
 ## Disable debug info
 
-The fastest known way to compile is with lld and disabling debug info:
+The fastest known way to compile is with mold and disabling debug info:
 
 ```shell
-export RUSTFLAGS="-C link-arg=-fuse-ld=lld -C debuginfo=0"
+export RUSTFLAGS="-C link-arg=-fuse-ld=mold -C debuginfo=0"
 ```
 
 Ideally, set that in your `~/.bashrc` or equivalent so that it applies


### PR DESCRIPTION
mold on Linux is more efficient (05:01 vs 05:04 for me, 05:34 for ld), Xcode 15 ld on macOS (08:03 vs 08:04 with lld)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
