### PR TITLE
adapter: support cancellation in sequence_staged

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1026,6 +1026,9 @@ impl Coordinator {
         self.cancel_pending_peeks(&conn_id);
         self.cancel_pending_watchsets(&conn_id);
         self.cancel_compute_sinks_for_conn(&conn_id).await;
+        if let Some((tx, _rx)) = self.staged_cancellation.get_mut(&conn_id) {
+            let _ = tx.send(true);
+        }
     }
 
     /// Handle termination of a client session.

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -66,6 +66,10 @@ impl Staged for CreateIndexStage {
             stage: self,
         }
     }
+
+    fn cancel_enabled(&self) -> bool {
+        true
+    }
 }
 
 impl Coordinator {

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -87,6 +87,10 @@ impl Staged for CreateMaterializedViewStage {
             stage: self,
         }
     }
+
+    fn cancel_enabled(&self) -> bool {
+        true
+    }
 }
 
 impl Coordinator {

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -62,6 +62,10 @@ impl Staged for CreateViewStage {
             stage: self,
         }
     }
+
+    fn cancel_enabled(&self) -> bool {
+        true
+    }
 }
 
 impl Coordinator {

--- a/src/adapter/src/coord/sequencer/inner/secret.rs
+++ b/src/adapter/src/coord/sequencer/inner/secret.rs
@@ -67,6 +67,12 @@ impl Staged for SecretStage {
             stage: self,
         }
     }
+
+    fn cancel_enabled(&self) -> bool {
+        // Because secrets operations call out to external services and transact the catalog
+        // separately, disable cancellation.
+        false
+    }
 }
 
 impl Coordinator {

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -60,6 +60,10 @@ impl Staged for SubscribeStage {
             stage: self,
         }
     }
+
+    fn cancel_enabled(&self) -> bool {
+        true
+    }
 }
 
 impl Coordinator {

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -198,6 +198,7 @@ impl Coordinator {
 
     /// Clears coordinator state for a connection.
     pub(crate) async fn clear_connection(&mut self, conn_id: &ConnectionId) {
+        self.staged_cancellation.remove(conn_id);
         self.retire_compute_sinks_for_conn(conn_id, ActiveComputeSinkRetireReason::Finished)
             .await;
 


### PR DESCRIPTION
Allow safe off-thread tasks to listen for cancellation events from the coordinator.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a