### PR TITLE
dbt-materialize: allow docs generation for cross-db sources

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.2 - 2024-06-21
 
+<<<<<<< HEAD
 * Add support for sink cutover to the blue/green deployment workflow [#27557](https://github.com/MaterializeInc/materialize/pull/27557).
   Sinks **must** be created in a **dedicated schema and cluster**.
 
@@ -13,6 +14,9 @@
   Before, these clusters would be incorrectly recreated in the deployment
   environment with the `SCHEDULE` option set to `manual` (instead of
   `on-refresh`).
+=======
+* Enable cross-database references ([#27686](https://github.com/MaterializeInc/materialize/pull/27686)). Although cross-database references are not supported in `dbt-postgres`, databases in Materialize are purely used for namespacing, and therefore do not present the same constraint.
+>>>>>>> ab14c7ceb6 (Update misc/dbt-materialize/CHANGELOG.md)
 
 ## 1.8.1 - 2024-06-08
 

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,8 +1,11 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Enable cross-database references ([#27686](https://github.com/MaterializeInc/materialize/pull/27686)). Although cross-database references are not supported in `dbt-postgres`, databases in Materialize are purely used for namespacing, and therefore do not present the same constraint.
+
 ## 1.8.2 - 2024-06-21
 
-<<<<<<< HEAD
 * Add support for sink cutover to the blue/green deployment workflow [#27557](https://github.com/MaterializeInc/materialize/pull/27557).
   Sinks **must** be created in a **dedicated schema and cluster**.
 
@@ -14,9 +17,6 @@
   Before, these clusters would be incorrectly recreated in the deployment
   environment with the `SCHEDULE` option set to `manual` (instead of
   `on-refresh`).
-=======
-* Enable cross-database references ([#27686](https://github.com/MaterializeInc/materialize/pull/27686)). Although cross-database references are not supported in `dbt-postgres`, databases in Materialize are purely used for namespacing, and therefore do not present the same constraint.
->>>>>>> ab14c7ceb6 (Update misc/dbt-materialize/CHANGELOG.md)
 
 ## 1.8.1 - 2024-06-08
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/relations.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/relations.sql
@@ -1,0 +1,94 @@
+-- Copyright 2020 Josh Wills. All rights reserved.
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Most of this macro is direct copies of the PostgreSQL counterpart.
+-- Here we have included a minor change to fix the following error:
+-- column "referenced_schema.name" must appear in the GROUP BY clause or be used in an aggregate function
+-- See: https://github.com/dbt-labs/dbt-postgres/blob/main/dbt/include/postgres/macros/relations.sql
+
+{% macro materialize__get_relations() -%}
+
+  {%- call statement('relations', fetch_result=True) -%}
+    with relation as (
+        select
+            pg_rewrite.ev_class as class,
+            pg_rewrite.oid as id
+        from pg_rewrite
+    ),
+    class as (
+        select
+            oid as id,
+            relname as name,
+            relnamespace as schema,
+            relkind as kind
+        from pg_class
+    ),
+    dependency as (
+        select distinct
+            objid as id,
+            refobjid as ref
+        from pg_depend
+    ),
+    schema as (
+        select
+            oid as id,
+            nspname as name
+        from pg_namespace
+        where nspname != 'information_schema' and nspname not like 'pg\_%'
+    ),
+    referenced as (
+        select
+            relation.id AS id,
+            referenced_class.name,
+            referenced_class.schema,
+            referenced_class.kind
+        from relation
+        join class as referenced_class on relation.class=referenced_class.id
+        where referenced_class.kind in ('r', 'v', 'm')
+    ),
+    relationships as (
+        select
+            referenced.name as referenced_name,
+            referenced.schema as referenced_schema_id,
+            dependent_class.name as dependent_name,
+            dependent_class.schema as dependent_schema_id,
+            referenced.kind as kind
+        from referenced
+        join dependency on referenced.id=dependency.id
+        join class as dependent_class on dependency.ref=dependent_class.id
+        where
+            (referenced.name != dependent_class.name or
+             referenced.schema != dependent_class.schema)
+    )
+
+    select
+        referenced_schema.name as referenced_schema,
+        relationships.referenced_name as referenced_name,
+        dependent_schema.name as dependent_schema,
+        relationships.dependent_name as dependent_name
+    from relationships
+    join schema as dependent_schema on relationships.dependent_schema_id=dependent_schema.id
+    join schema as referenced_schema on relationships.referenced_schema_id=referenced_schema.id
+    group by referenced_schema.name, relationships.referenced_name, dependent_schema.name, relationships.dependent_name
+    order by referenced_schema.name, relationships.referenced_name, dependent_schema.name, relationships.dependent_name;
+  {%- endcall -%}
+
+  {{ return(load_result('relations').table) }}
+{% endmacro %}
+
+{% macro materialize_get_relations() %}
+  {{ return(materialize__get_relations()) }}
+{% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/relations.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/relations.sql
@@ -82,7 +82,7 @@
     from relationships
     join schema as dependent_schema on relationships.dependent_schema_id=dependent_schema.id
     join schema as referenced_schema on relationships.referenced_schema_id=referenced_schema.id
-    group by referenced_schema.name, relationships.referenced_name, dependent_schema.name, relationships.dependent_name
+    group by referenced_schema.name, referenced_name, dependent_schema.name, dependent_name
     order by referenced_schema, referenced_name, dependent_schema, dependent_name;
   {%- endcall -%}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/relations.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/relations.sql
@@ -14,9 +14,8 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
--- Most of this macro is direct copies of the PostgreSQL counterpart.
--- Here we have included a minor change to fix the following error:
--- column "referenced_schema.name" must appear in the GROUP BY clause or be used in an aggregate function
+-- Due to a PostgreSQL compatibility issue in processing aliases in the GROUP BY
+-- clause, we must override this macro.
 -- See: https://github.com/dbt-labs/dbt-postgres/blob/main/dbt/include/postgres/macros/relations.sql
 
 {% macro materialize__get_relations() -%}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/relations.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/relations.sql
@@ -83,7 +83,7 @@
     join schema as dependent_schema on relationships.dependent_schema_id=dependent_schema.id
     join schema as referenced_schema on relationships.referenced_schema_id=referenced_schema.id
     group by referenced_schema.name, relationships.referenced_name, dependent_schema.name, relationships.dependent_name
-    order by referenced_schema.name, relationships.referenced_name, dependent_schema.name, relationships.dependent_name;
+    order by referenced_schema, referenced_name, dependent_schema, dependent_name;
   {%- endcall -%}
 
   {{ return(load_result('relations').table) }}

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -97,6 +97,20 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                             sql=f"ALTER {what} OWNER TO materialize",
                         )
 
+                    # Create two databases that some tests rely on
+                    c.sql(
+                        service="materialized",
+                        user="materialize",
+                        sql=dedent(
+                            """
+                            CREATE DATABASE test_database_1;
+                            CREATE DATABASE test_database_2;
+                            CREATE TABLE test_database_1.public.table1 (id int);
+                            CREATE TABLE test_database_2.public.table2 (id int);
+                            """
+                        ),
+                    )
+
                     c.run(
                         "dbt",
                         "pytest",

--- a/misc/dbt-materialize/tests/adapter/test_persist_docs.py
+++ b/misc/dbt-materialize/tests/adapter/test_persist_docs.py
@@ -12,11 +12,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
+import os
 
+import pytest
 from dbt.tests.adapter.persist_docs.test_persist_docs import (
     BasePersistDocs,
     BasePersistDocsColumnMissing,
     BasePersistDocsCommentOnQuotedColumn,
+)
+from dbt.tests.util import run_dbt
+from fixtures import (
+    cross_database_reference_schema_yml,
+    cross_database_reference_sql,
 )
 
 
@@ -32,3 +40,29 @@ class TestPersistDocsCommentOnQuotedColumnMaterialize(
     BasePersistDocsCommentOnQuotedColumn
 ):
     pass
+
+
+class TestCrossDatabaseDocs:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cross_db_reference.sql": cross_database_reference_sql,
+            "schema.yml": cross_database_reference_schema_yml,
+        }
+
+    def test_cross_db_docs_generate(self, project):
+        results = run_dbt(["run"])
+
+        # Run dbt docs generate to generate documentation
+        results = run_dbt(["docs", "generate"])
+        assert results is not None
+
+        # Validate the generated documentation
+        with open(os.path.join(project.project_root, "target/catalog.json")) as f:
+            catalog = json.load(f)
+
+        assert "source.test.test_database_1.table1" in catalog["sources"]
+        assert "source.test.test_database_2.table2" in catalog["sources"]
+
+        cross_db_reference = catalog["nodes"]["model.test.cross_db_reference"]
+        assert "id" in cross_db_reference["columns"]


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR fixes the documentation generation for cross-db objects used as sources in models.