### PR TITLE
adapter: move explain timestamp to sequence staged

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -199,6 +199,13 @@ impl Coordinator {
                 } => {
                     self.sequence_staged(ctx, span, stage).await;
                 }
+                Message::ExplainTimestampStageReady {
+                    ctx,
+                    span,
+                    stage,
+                } => {
+                    self.sequence_staged(ctx, span, stage).await;
+                }
                 Message::SecretStageReady {
                     ctx,
                     span,
@@ -950,27 +957,6 @@ impl Coordinator {
         }
 
         match real_time_recency_context {
-            RealTimeRecencyContext::ExplainTimestamp {
-                mut ctx,
-                format,
-                cluster_id,
-                optimized_plan,
-                id_bundle,
-                when,
-            } => {
-                let result = self
-                    .sequence_explain_timestamp_finish(
-                        &mut ctx,
-                        format,
-                        cluster_id,
-                        optimized_plan,
-                        id_bundle,
-                        when,
-                        Some(real_time_recency_ts),
-                    )
-                    .await;
-                ctx.retire(result);
-            }
             RealTimeRecencyContext::Peek {
                 ctx,
                 root_otel_ctx,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -15,16 +15,14 @@
 use futures::future::LocalBoxFuture;
 use futures::FutureExt;
 use inner::return_if_err;
-use mz_controller_types::ClusterId;
-use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr, RowSetFinishing};
+use mz_expr::{MirRelationExpr, RowSetFinishing};
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::explain::ExplainFormat;
-use mz_repr::{Diff, GlobalId, RowCollection, Timestamp};
+use mz_repr::{Diff, GlobalId, RowCollection};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{
     self, AbortTransactionPlan, CommitTransactionPlan, CreateRolePlan, CreateSourcePlanBundle,
-    FetchPlan, MutationKind, Params, Plan, PlanKind, QueryWhen, RaisePlan,
+    FetchPlan, MutationKind, Params, Plan, PlanKind, RaisePlan,
 };
 use mz_sql::rbac;
 use mz_sql::session::metadata::SessionMetadata;
@@ -36,7 +34,6 @@ use tracing::{event, Instrument, Level, Span};
 
 use crate::catalog::Catalog;
 use crate::command::{Command, ExecuteResponse, Response};
-use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::{catalog_serving, Coordinator, Message, TargetCluster};
 use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
@@ -672,28 +669,6 @@ impl Coordinator {
         // not a user request, and the user name is still recorded in the plan, so we aren't losing
         // information.
         self.sequence_create_role(None, plan).await
-    }
-
-    pub(crate) async fn sequence_explain_timestamp_finish(
-        &mut self,
-        ctx: &mut ExecuteContext,
-        format: ExplainFormat,
-        cluster_id: ClusterId,
-        optimized_plan: OptimizedMirRelationExpr,
-        id_bundle: CollectionIdBundle,
-        when: QueryWhen,
-        real_time_recency_ts: Option<Timestamp>,
-    ) -> Result<ExecuteResponse, AdapterError> {
-        self.sequence_explain_timestamp_finish_inner(
-            ctx.session_mut(),
-            format,
-            cluster_id,
-            optimized_plan,
-            id_bundle,
-            when,
-            real_time_recency_ts,
-        )
-        .await
     }
 
     pub(crate) fn allocate_transient_id(&self) -> GlobalId {

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -1,0 +1,335 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use itertools::Itertools;
+use mz_controller_types::ClusterId;
+use mz_expr::CollectionPlan;
+use mz_ore::instrument;
+use mz_repr::explain::ExplainFormat;
+use mz_repr::{Datum, Row};
+use mz_sql::plan::{self};
+use mz_sql::session::metadata::SessionMetadata;
+use tracing::{Instrument, Span};
+
+use crate::coord::sequencer::inner::return_if_err;
+use crate::coord::timestamp_selection::{TimestampDetermination, TimestampSource};
+use crate::coord::{
+    Coordinator, ExplainTimestampFinish, ExplainTimestampOptimize, ExplainTimestampRealTimeRecency,
+    ExplainTimestampStage, Message, PlanValidity, StageResult, Staged, TargetCluster,
+};
+use crate::error::AdapterError;
+use crate::optimize::{self, Optimize};
+use crate::session::{RequireLinearization, Session};
+use crate::{CollectionIdBundle, ExecuteContext, TimelineContext, TimestampExplanation};
+
+impl Staged for ExplainTimestampStage {
+    fn validity(&mut self) -> &mut PlanValidity {
+        match self {
+            ExplainTimestampStage::Optimize(stage) => &mut stage.validity,
+            ExplainTimestampStage::RealTimeRecency(stage) => &mut stage.validity,
+            ExplainTimestampStage::Finish(stage) => &mut stage.validity,
+        }
+    }
+
+    async fn stage(
+        self,
+        coord: &mut Coordinator,
+        ctx: &mut ExecuteContext,
+    ) -> Result<StageResult<Box<Self>>, AdapterError> {
+        match self {
+            ExplainTimestampStage::Optimize(stage) => coord.explain_timestamp_optimize(stage),
+            ExplainTimestampStage::RealTimeRecency(stage) => {
+                coord
+                    .explain_timestamp_real_time_recency(ctx.session(), stage)
+                    .await
+            }
+            ExplainTimestampStage::Finish(stage) => {
+                coord
+                    .explain_timestamp_finish(ctx.session_mut(), stage)
+                    .await
+            }
+        }
+    }
+
+    fn message(self, ctx: ExecuteContext, span: Span) -> Message {
+        Message::ExplainTimestampStageReady {
+            ctx,
+            span,
+            stage: self,
+        }
+    }
+
+    fn cancel_enabled(&self) -> bool {
+        true
+    }
+}
+
+impl Coordinator {
+    #[instrument]
+    pub async fn sequence_explain_timestamp(
+        &mut self,
+        ctx: ExecuteContext,
+        plan: plan::ExplainTimestampPlan,
+        target_cluster: TargetCluster,
+    ) {
+        let stage = return_if_err!(
+            self.explain_timestamp_validity(ctx.session(), plan, target_cluster),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
+    }
+
+    #[instrument]
+    fn explain_timestamp_validity(
+        &self,
+        session: &Session,
+        plan: plan::ExplainTimestampPlan,
+        target_cluster: TargetCluster,
+    ) -> Result<ExplainTimestampStage, AdapterError> {
+        let cluster = self
+            .catalog()
+            .resolve_target_cluster(target_cluster, session)?;
+        let cluster_id = cluster.id;
+        let validity = PlanValidity {
+            transient_revision: self.catalog().transient_revision(),
+            dependency_ids: plan.raw_plan.depends_on(),
+            cluster_id: Some(cluster_id),
+            replica_id: None,
+            role_metadata: session.role_metadata().clone(),
+        };
+        Ok(ExplainTimestampStage::Optimize(ExplainTimestampOptimize {
+            validity,
+            plan,
+            cluster_id,
+        }))
+    }
+
+    #[instrument]
+    fn explain_timestamp_optimize(
+        &self,
+        ExplainTimestampOptimize {
+            validity,
+            plan,
+            cluster_id,
+        }: ExplainTimestampOptimize,
+    ) -> Result<StageResult<Box<ExplainTimestampStage>>, AdapterError> {
+        // Collect optimizer parameters.
+        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+
+        // Build an optimizer for this VIEW.
+        let mut optimizer = optimize::view::Optimizer::new(optimizer_config, None);
+
+        let span = Span::current();
+        Ok(StageResult::Handle(mz_ore::task::spawn_blocking(
+            || "optimize explain timestamp",
+            move || {
+                span.in_scope(|| {
+                    let plan::ExplainTimestampPlan {
+                        format,
+                        raw_plan,
+                        when,
+                    } = plan;
+
+                    // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
+                    let optimized_plan = optimizer.optimize(raw_plan)?;
+
+                    let stage =
+                        ExplainTimestampStage::RealTimeRecency(ExplainTimestampRealTimeRecency {
+                            validity,
+                            format,
+                            optimized_plan,
+                            cluster_id,
+                            when,
+                        });
+                    Ok(Box::new(stage))
+                })
+            },
+        )))
+    }
+
+    #[instrument]
+    async fn explain_timestamp_real_time_recency(
+        &mut self,
+        session: &Session,
+        ExplainTimestampRealTimeRecency {
+            validity,
+            format,
+            optimized_plan,
+            cluster_id,
+            when,
+        }: ExplainTimestampRealTimeRecency,
+    ) -> Result<StageResult<Box<ExplainTimestampStage>>, AdapterError> {
+        let source_ids = optimized_plan.depends_on();
+        let fut = self
+            .determine_real_time_recent_timestamp(session, source_ids.iter().cloned())
+            .await?;
+
+        match fut {
+            Some(fut) => {
+                let span = Span::current();
+                Ok(StageResult::Handle(mz_ore::task::spawn(
+                    || "explain timestamp real time recency",
+                    async move {
+                        let real_time_recency_ts = fut.await?;
+                        let stage = ExplainTimestampStage::Finish(ExplainTimestampFinish {
+                            validity,
+                            format,
+                            optimized_plan,
+                            cluster_id,
+                            source_ids,
+                            when,
+                            real_time_recency_ts: Some(real_time_recency_ts),
+                        });
+                        Ok(Box::new(stage))
+                    }
+                    .instrument(span),
+                )))
+            }
+            None => Ok(StageResult::Immediate(Box::new(
+                ExplainTimestampStage::Finish(ExplainTimestampFinish {
+                    validity,
+                    format,
+                    optimized_plan,
+                    cluster_id,
+                    source_ids,
+                    when,
+                    real_time_recency_ts: None,
+                }),
+            ))),
+        }
+    }
+
+    pub(crate) fn explain_timestamp(
+        &self,
+        session: &Session,
+        cluster_id: ClusterId,
+        id_bundle: &CollectionIdBundle,
+        determination: TimestampDetermination<mz_repr::Timestamp>,
+    ) -> TimestampExplanation<mz_repr::Timestamp> {
+        let mut sources = Vec::new();
+        {
+            let storage_ids = id_bundle.storage_ids.iter().cloned().collect_vec();
+            let frontiers = self
+                .controller
+                .storage
+                .collections_frontiers(storage_ids)
+                .expect("missing collection");
+
+            for (id, since, upper) in frontiers {
+                let name = self
+                    .catalog()
+                    .try_get_entry(&id)
+                    .map(|item| item.name())
+                    .map(|name| {
+                        self.catalog()
+                            .resolve_full_name(name, Some(session.conn_id()))
+                            .to_string()
+                    })
+                    .unwrap_or_else(|| id.to_string());
+                sources.push(TimestampSource {
+                    name: format!("{name} ({id}, storage)"),
+                    read_frontier: since.elements().to_vec(),
+                    write_frontier: upper.elements().to_vec(),
+                });
+            }
+        }
+        {
+            if let Some(compute_ids) = id_bundle.compute_ids.get(&cluster_id) {
+                let catalog = self.catalog();
+                for id in compute_ids {
+                    let state = self
+                        .controller
+                        .compute
+                        .collection(cluster_id, *id)
+                        .expect("id does not exist");
+                    let name = catalog
+                        .try_get_entry(id)
+                        .map(|item| item.name())
+                        .map(|name| {
+                            catalog
+                                .resolve_full_name(name, Some(session.conn_id()))
+                                .to_string()
+                        })
+                        .unwrap_or_else(|| id.to_string());
+                    sources.push(TimestampSource {
+                        name: format!("{name} ({id}, compute)"),
+                        read_frontier: state.read_capability().elements().to_vec(),
+                        write_frontier: state.write_frontier().to_vec(),
+                    });
+                }
+            }
+        }
+        let respond_immediately = determination.respond_immediately();
+        TimestampExplanation {
+            determination,
+            sources,
+            session_wall_time: session.pcx().wall_time,
+            respond_immediately,
+        }
+    }
+
+    #[instrument]
+    async fn explain_timestamp_finish(
+        &mut self,
+        session: &mut Session,
+        ExplainTimestampFinish {
+            validity: _,
+            format,
+            optimized_plan,
+            cluster_id,
+            source_ids,
+            when,
+            real_time_recency_ts,
+        }: ExplainTimestampFinish,
+    ) -> Result<StageResult<Box<ExplainTimestampStage>>, AdapterError> {
+        let id_bundle = self
+            .index_oracle(cluster_id)
+            .sufficient_collections(&source_ids);
+
+        let is_json = match format {
+            ExplainFormat::Text => false,
+            ExplainFormat::Json => true,
+            ExplainFormat::Dot => {
+                return Err(AdapterError::Unsupported("EXPLAIN TIMESTAMP AS DOT"));
+            }
+        };
+        let mut timeline_context = self.validate_timeline_context(source_ids.clone())?;
+        if matches!(timeline_context, TimelineContext::TimestampIndependent)
+            && optimized_plan.contains_temporal()
+        {
+            // If the source IDs are timestamp independent but the query contains temporal functions,
+            // then the timeline context needs to be upgraded to timestamp dependent. This is
+            // required because `source_ids` doesn't contain functions.
+            timeline_context = TimelineContext::TimestampDependent;
+        }
+
+        let oracle_read_ts = self.oracle_read_ts(session, &timeline_context, &when).await;
+
+        let determination = self.sequence_peek_timestamp(
+            session,
+            &when,
+            cluster_id,
+            timeline_context,
+            oracle_read_ts,
+            &id_bundle,
+            &source_ids,
+            real_time_recency_ts,
+            RequireLinearization::NotRequired,
+        )?;
+        let explanation = self.explain_timestamp(session, cluster_id, &id_bundle, determination);
+
+        let s = if is_json {
+            serde_json::to_string_pretty(&explanation).expect("failed to serialize explanation")
+        } else {
+            explanation.to_string()
+        };
+        let rows = vec![Row::pack_slice(&[Datum::from(s.as_str())])];
+        Ok(StageResult::Response(Self::send_immediate_rows(rows)))
+    }
+}


### PR DESCRIPTION
With the new support of cancelling for sequence staged, we can remove the detour that explain timestamp took through into the RTR handler.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

   * First commit is #27682

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
