### PR TITLE
storage: make PostgreSQL source more robust to silent connection drops

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -43,6 +43,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             tcp_user_timeout: Some(config.pg_source_tcp_user_timeout()),
         },
         pg_source_snapshot_statement_timeout: config.pg_source_snapshot_statement_timeout(),
+        pg_source_wal_sender_timeout: config.pg_source_wal_sender_timeout(),
         mysql_source_timeouts: mz_mysql_util::TimeoutConfig::build(
             config.mysql_source_snapshot_max_execution_time(),
             config.mysql_source_snapshot_lock_wait_timeout(),

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -35,13 +35,12 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
 /// Return the current storage configuration, derived from the system configuration.
 pub fn storage_config(config: &SystemVars) -> StorageParameters {
     StorageParameters {
-        pg_source_tcp_timeouts: mz_postgres_util::TcpTimeoutConfig {
-            connect_timeout: Some(config.pg_source_connect_timeout()),
-            keepalives_retries: Some(config.pg_source_keepalives_retries()),
-            keepalives_idle: Some(config.pg_source_keepalives_idle()),
-            keepalives_interval: Some(config.pg_source_keepalives_interval()),
-            tcp_user_timeout: Some(config.pg_source_tcp_user_timeout()),
-        },
+        pg_source_connect_timeout: Some(config.pg_source_connect_timeout()),
+        pg_source_tcp_keepalives_retries: Some(config.pg_source_tcp_keepalives_retries()),
+        pg_source_tcp_keepalives_idle: Some(config.pg_source_tcp_keepalives_idle()),
+        pg_source_tcp_keepalives_interval: Some(config.pg_source_tcp_keepalives_interval()),
+        pg_source_tcp_user_timeout: Some(config.pg_source_tcp_user_timeout()),
+        pg_source_tcp_configure_server: config.pg_source_tcp_configure_server(),
         pg_source_snapshot_statement_timeout: config.pg_source_snapshot_statement_timeout(),
         pg_source_wal_sender_timeout: config.pg_source_wal_sender_timeout(),
         mysql_source_timeouts: mz_mysql_util::TimeoutConfig::build(

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -25,11 +25,7 @@ pub use schemas::{get_schemas, publication_info};
 #[cfg(feature = "tunnel")]
 pub mod tunnel;
 #[cfg(feature = "tunnel")]
-pub use tunnel::{
-    Config, TcpTimeoutConfig, TunnelConfig, DEFAULT_CONNECT_TIMEOUT, DEFAULT_KEEPALIVE_IDLE,
-    DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_KEEPALIVE_RETRIES, DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT,
-    DEFAULT_TCP_USER_TIMEOUT,
-};
+pub use tunnel::{Config, TunnelConfig, DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT};
 
 pub mod query;
 pub use query::simple_query_opt;

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1203,10 +1203,11 @@ impl SystemVars {
             &UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP,
             &ENABLE_RBAC_CHECKS,
             &PG_SOURCE_CONNECT_TIMEOUT,
-            &PG_SOURCE_KEEPALIVES_IDLE,
-            &PG_SOURCE_KEEPALIVES_INTERVAL,
-            &PG_SOURCE_KEEPALIVES_RETRIES,
+            &PG_SOURCE_TCP_KEEPALIVES_IDLE,
+            &PG_SOURCE_TCP_KEEPALIVES_INTERVAL,
+            &PG_SOURCE_TCP_KEEPALIVES_RETRIES,
             &PG_SOURCE_TCP_USER_TIMEOUT,
+            &PG_SOURCE_TCP_CONFIGURE_SERVER,
             &PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT,
             &PG_SOURCE_WAL_SENDER_TIMEOUT,
             &PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT,
@@ -1757,24 +1758,29 @@ impl SystemVars {
         *self.expect_value(&PG_SOURCE_CONNECT_TIMEOUT)
     }
 
-    /// Returns the `pg_source_keepalives_retries` configuration parameter.
-    pub fn pg_source_keepalives_retries(&self) -> u32 {
-        *self.expect_value(&PG_SOURCE_KEEPALIVES_RETRIES)
+    /// Returns the `pg_source_tcp_keepalives_retries` configuration parameter.
+    pub fn pg_source_tcp_keepalives_retries(&self) -> u32 {
+        *self.expect_value(&PG_SOURCE_TCP_KEEPALIVES_RETRIES)
     }
 
-    /// Returns the `pg_source_keepalives_idle` configuration parameter.
-    pub fn pg_source_keepalives_idle(&self) -> Duration {
-        *self.expect_value(&PG_SOURCE_KEEPALIVES_IDLE)
+    /// Returns the `pg_source_tcp_keepalives_idle` configuration parameter.
+    pub fn pg_source_tcp_keepalives_idle(&self) -> Duration {
+        *self.expect_value(&PG_SOURCE_TCP_KEEPALIVES_IDLE)
     }
 
-    /// Returns the `pg_source_keepalives_interval` configuration parameter.
-    pub fn pg_source_keepalives_interval(&self) -> Duration {
-        *self.expect_value(&PG_SOURCE_KEEPALIVES_INTERVAL)
+    /// Returns the `pg_source_tcp_keepalives_interval` configuration parameter.
+    pub fn pg_source_tcp_keepalives_interval(&self) -> Duration {
+        *self.expect_value(&PG_SOURCE_TCP_KEEPALIVES_INTERVAL)
     }
 
     /// Returns the `pg_source_tcp_user_timeout` configuration parameter.
     pub fn pg_source_tcp_user_timeout(&self) -> Duration {
         *self.expect_value(&PG_SOURCE_TCP_USER_TIMEOUT)
+    }
+
+    /// Returns the `pg_source_tcp_configure_server` configuration parameter.
+    pub fn pg_source_tcp_configure_server(&self) -> bool {
+        *self.expect_value(&PG_SOURCE_TCP_CONFIGURE_SERVER)
     }
 
     /// Returns the `pg_source_snapshot_statement_timeout` configuration parameter.
@@ -2180,10 +2186,11 @@ impl SystemVars {
     /// Returns whether the named variable is a storage configuration parameter.
     pub fn is_storage_config_var(&self, name: &str) -> bool {
         name == PG_SOURCE_CONNECT_TIMEOUT.name()
-            || name == PG_SOURCE_KEEPALIVES_IDLE.name()
-            || name == PG_SOURCE_KEEPALIVES_INTERVAL.name()
-            || name == PG_SOURCE_KEEPALIVES_RETRIES.name()
+            || name == PG_SOURCE_TCP_KEEPALIVES_IDLE.name()
+            || name == PG_SOURCE_TCP_KEEPALIVES_INTERVAL.name()
+            || name == PG_SOURCE_TCP_KEEPALIVES_RETRIES.name()
             || name == PG_SOURCE_TCP_USER_TIMEOUT.name()
+            || name == PG_SOURCE_TCP_CONFIGURE_SERVER.name()
             || name == PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT.name()
             || name == PG_SOURCE_WAL_SENDER_TIMEOUT.name()
             || name == PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT.name()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1208,6 +1208,7 @@ impl SystemVars {
             &PG_SOURCE_KEEPALIVES_RETRIES,
             &PG_SOURCE_TCP_USER_TIMEOUT,
             &PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT,
+            &PG_SOURCE_WAL_SENDER_TIMEOUT,
             &PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT,
             &PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT,
             &PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT,
@@ -1781,6 +1782,11 @@ impl SystemVars {
         *self.expect_value(&PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT)
     }
 
+    /// Returns the `pg_source_wal_sender_timeout` configuration parameter.
+    pub fn pg_source_wal_sender_timeout(&self) -> Option<Duration> {
+        *self.expect_value(&PG_SOURCE_WAL_SENDER_TIMEOUT)
+    }
+
     /// Returns the `pg_source_snapshot_collect_strict_count` configuration parameter.
     pub fn pg_source_snapshot_collect_strict_count(&self) -> bool {
         *self.expect_value(&PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT)
@@ -2179,6 +2185,7 @@ impl SystemVars {
             || name == PG_SOURCE_KEEPALIVES_RETRIES.name()
             || name == PG_SOURCE_TCP_USER_TIMEOUT.name()
             || name == PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT.name()
+            || name == PG_SOURCE_WAL_SENDER_TIMEOUT.name()
             || name == PG_SOURCE_SNAPSHOT_COLLECT_STRICT_COUNT.name()
             || name == PG_SOURCE_SNAPSHOT_FALLBACK_TO_STRICT_COUNT.name()
             || name == PG_SOURCE_SNAPSHOT_WAIT_FOR_COUNT.name()

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -26,7 +26,9 @@ use mz_repr::optimize::OptimizerFeatures;
 use mz_sql_parser::ast::Ident;
 use mz_sql_parser::ident;
 use mz_storage_types::controller::TxnWalTablesImpl;
-use mz_storage_types::parameters::STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT;
+use mz_storage_types::parameters::{
+    DEFAULT_PG_SOURCE_WAL_SENDER_TIMEOUT, STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT,
+};
 use mz_tracing::{CloneableEnvFilter, SerializableDirective};
 use once_cell::sync::Lazy;
 use uncased::UncasedStr;
@@ -958,6 +960,15 @@ pub static PG_SOURCE_SNAPSHOT_STATEMENT_TIMEOUT: VarDefinition = VarDefinition::
     "pg_source_snapshot_statement_timeout",
     value!(Duration; mz_postgres_util::DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT),
     "Sets the `statement_timeout` value to use during the snapshotting phase of PG sources (Materialize)",
+    true,
+);
+
+/// Sets the `wal_sender_timeout` value to use during the replication phase of
+/// PG sources.
+pub static PG_SOURCE_WAL_SENDER_TIMEOUT: VarDefinition = VarDefinition::new(
+    "pg_source_wal_sender_timeout",
+    value!(Option<Duration>; DEFAULT_PG_SOURCE_WAL_SENDER_TIMEOUT),
+    "Sets the `wal_sender_timeout` value to use during the replication phase of PG sources (Materialize)",
     true,
 );
 

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -27,6 +27,9 @@ use mz_sql_parser::ast::Ident;
 use mz_sql_parser::ident;
 use mz_storage_types::controller::TxnWalTablesImpl;
 use mz_storage_types::parameters::{
+    DEFAULT_PG_SOURCE_CONNECT_TIMEOUT, DEFAULT_PG_SOURCE_TCP_CONFIGURE_SERVER,
+    DEFAULT_PG_SOURCE_TCP_KEEPALIVES_IDLE, DEFAULT_PG_SOURCE_TCP_KEEPALIVES_INTERVAL,
+    DEFAULT_PG_SOURCE_TCP_KEEPALIVES_RETRIES, DEFAULT_PG_SOURCE_TCP_USER_TIMEOUT,
     DEFAULT_PG_SOURCE_WAL_SENDER_TIMEOUT, STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT,
 };
 use mz_tracing::{CloneableEnvFilter, SerializableDirective};
@@ -911,46 +914,55 @@ pub static COORD_SLOW_MESSAGE_WARN_THRESHOLD: VarDefinition = VarDefinition::new
 /// Controls the connect_timeout setting when connecting to PG via `mz_postgres_util`.
 pub static PG_SOURCE_CONNECT_TIMEOUT: VarDefinition = VarDefinition::new(
     "pg_source_connect_timeout",
-    value!(Duration; mz_postgres_util::DEFAULT_CONNECT_TIMEOUT),
+    value!(Duration; DEFAULT_PG_SOURCE_CONNECT_TIMEOUT),
     "Sets the timeout applied to socket-level connection attempts for PG \
-    replication connections. (Materialize)",
+    replication connections (Materialize).",
     true,
 );
 
 /// Sets the maximum number of TCP keepalive probes that will be sent before dropping a connection
 /// when connecting to PG via `mz_postgres_util`.
-pub static PG_SOURCE_KEEPALIVES_RETRIES: VarDefinition = VarDefinition::new(
-    "pg_source_keepalives_retries",
-    value!(u32; mz_postgres_util::DEFAULT_KEEPALIVE_RETRIES),
+pub static PG_SOURCE_TCP_KEEPALIVES_RETRIES: VarDefinition = VarDefinition::new(
+    "pg_source_tcp_keepalives_retries",
+    value!(u32; DEFAULT_PG_SOURCE_TCP_KEEPALIVES_RETRIES),
     "Sets the maximum number of TCP keepalive probes that will be sent before dropping \
-    a connection when connecting to PG via `mz_postgres_util`. (Materialize)",
+    a connection when connecting to PG via `mz_postgres_util` (Materialize).",
     true,
 );
 
 /// Sets the amount of idle time before a keepalive packet is sent on the connection when connecting
 /// to PG via `mz_postgres_util`.
-pub static PG_SOURCE_KEEPALIVES_IDLE: VarDefinition = VarDefinition::new(
-    "pg_source_keepalives_idle",
-    value!(Duration; mz_postgres_util::DEFAULT_KEEPALIVE_IDLE),
+pub static PG_SOURCE_TCP_KEEPALIVES_IDLE: VarDefinition = VarDefinition::new(
+    "pg_source_tcp_keepalives_idle",
+    value!(Duration; DEFAULT_PG_SOURCE_TCP_KEEPALIVES_IDLE),
     "Sets the amount of idle time before a keepalive packet is sent on the connection \
-        when connecting to PG via `mz_postgres_util`. (Materialize)",
+        when connecting to PG via `mz_postgres_util` (Materialize).",
     true,
 );
 
 /// Sets the time interval between TCP keepalive probes when connecting to PG via `mz_postgres_util`.
-pub static PG_SOURCE_KEEPALIVES_INTERVAL: VarDefinition = VarDefinition::new(
-    "pg_source_keepalives_interval",
-    value!(Duration; mz_postgres_util::DEFAULT_KEEPALIVE_INTERVAL),
+pub static PG_SOURCE_TCP_KEEPALIVES_INTERVAL: VarDefinition = VarDefinition::new(
+    "pg_source_tcp_keepalives_interval",
+    value!(Duration; DEFAULT_PG_SOURCE_TCP_KEEPALIVES_INTERVAL),
     "Sets the time interval between TCP keepalive probes when connecting to PG via \
-        replication. (Materialize)",
+        replication (Materialize).",
     true,
 );
 
 /// Sets the TCP user timeout when connecting to PG via `mz_postgres_util`.
 pub static PG_SOURCE_TCP_USER_TIMEOUT: VarDefinition = VarDefinition::new(
     "pg_source_tcp_user_timeout",
-    value!(Duration; mz_postgres_util::DEFAULT_TCP_USER_TIMEOUT),
-    "Sets the TCP user timeout when connecting to PG via `mz_postgres_util`. (Materialize)",
+    value!(Duration; DEFAULT_PG_SOURCE_TCP_USER_TIMEOUT),
+    "Sets the TCP user timeout when connecting to PG via `mz_postgres_util` (Materialize).",
+    true,
+);
+
+/// Sets whether to apply the TCP configuration parameters on the server when
+/// connecting to PG via `mz_postgres_util`.
+pub static PG_SOURCE_TCP_CONFIGURE_SERVER: VarDefinition = VarDefinition::new(
+    "pg_source_tcp_configure_server",
+    value!(bool; DEFAULT_PG_SOURCE_TCP_CONFIGURE_SERVER),
+    "Sets whether to apply the TCP configuration parameters on the server when connecting to PG via `mz_postgres_util` (Materialize).",
     true,
 );
 

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -1361,6 +1361,18 @@ impl PostgresConnection<InlinedConnection> {
             config.ssl_cert(cert.as_bytes()).ssl_key(key.as_bytes());
         }
 
+        let mut options = vec![];
+        if let Some(wal_sender_timeout) = storage_configuration
+            .parameters
+            .pg_source_wal_sender_timeout
+        {
+            options.push(format!(
+                "--wal_sender_timeout={}",
+                wal_sender_timeout.as_millis()
+            ));
+        };
+        config.options(options.join(" ").as_str());
+
         let tunnel = match &self.tunnel {
             Tunnel::Direct => {
                 // Ensure any host we connect to is resolved to an external address.

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -18,7 +18,7 @@ import "service/src/params.proto";
 package mz_storage_types.parameters;
 
 message ProtoStorageParameters {
-    reserved 1, 2, 3, 25, 12, 26, 31;
+    reserved 1, 2, 3, 25, 12, 16, 26, 31;
     uint64 keep_n_source_status_history_entries = 4;
     mz_rocksdb_types.config.ProtoRocksDbTuningParameters upsert_rocksdb_tuning_config = 5;
     bool finalize_shards = 6;
@@ -29,7 +29,6 @@ message ProtoStorageParameters {
     mz_service.params.ProtoGrpcClientParameters grpc_client = 11;
     uint64 shrink_upsert_unused_buffers_by_ratio = 13;
     reserved 14, 15;
-    ProtoPgSourceTcpTimeouts pg_source_tcp_timeouts = 16;
     mz_proto.ProtoDuration pg_source_snapshot_statement_timeout = 17;
     bool record_namespaced_errors = 18;
     uint64 keep_n_privatelink_status_history_entries = 19;
@@ -41,19 +40,17 @@ message ProtoStorageParameters {
     mz_proto.ProtoDuration user_storage_managed_collections_batch_duration = 28;
     ProtoMySqlSourceTimeouts mysql_source_timeouts = 29;
     mz_proto.ProtoDuration pg_source_wal_sender_timeout = 32;
+    optional mz_proto.ProtoDuration pg_source_connect_timeout = 33;
+    optional uint32 pg_source_tcp_keepalives_retries = 34;
+    optional mz_proto.ProtoDuration pg_source_tcp_keepalives_idle = 35;
+    optional mz_proto.ProtoDuration pg_source_tcp_keepalives_interval = 36;
+    optional mz_proto.ProtoDuration pg_source_tcp_user_timeout = 37;
+    bool pg_source_tcp_configure_server = 38;
 
     mz_dyncfg.ConfigUpdates dyncfg_updates = 30;
 
     reserved 27;
     reserved "enable_dependency_read_hold_asserts";
-}
-
-message ProtoPgSourceTcpTimeouts {
-    optional mz_proto.ProtoDuration connect_timeout = 1;
-    optional uint32 keepalives_retries = 2;
-    optional mz_proto.ProtoDuration keepalives_idle = 3;
-    optional mz_proto.ProtoDuration keepalives_interval = 4;
-    optional mz_proto.ProtoDuration tcp_user_timeout = 5;
 }
 
 message ProtoPgSourceSnapshotConfig {

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -40,6 +40,7 @@ message ProtoStorageParameters {
     ProtoPgSourceSnapshotConfig pg_snapshot_config = 24;
     mz_proto.ProtoDuration user_storage_managed_collections_batch_duration = 28;
     ProtoMySqlSourceTimeouts mysql_source_timeouts = 29;
+    mz_proto.ProtoDuration pg_source_wal_sender_timeout = 32;
 
     mz_dyncfg.ConfigUpdates dyncfg_updates = 30;
 

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -20,6 +20,22 @@ use serde::{Deserialize, Serialize};
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage_types.parameters.rs"));
 
+// Some of these defaults were recommended by @ph14
+// https://github.com/MaterializeInc/materialize/pull/18644#discussion_r1160071692
+pub const DEFAULT_PG_SOURCE_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+pub const DEFAULT_PG_SOURCE_TCP_KEEPALIVES_INTERVAL: Duration = Duration::from_secs(10);
+pub const DEFAULT_PG_SOURCE_TCP_KEEPALIVES_IDLE: Duration = Duration::from_secs(10);
+pub const DEFAULT_PG_SOURCE_TCP_KEEPALIVES_RETRIES: u32 = 5;
+// This is meant to be DEFAULT_KEEPALIVE_IDLE
+// + DEFAULT_KEEPALIVE_RETRIES * DEFAULT_KEEPALIVE_INTERVAL
+pub const DEFAULT_PG_SOURCE_TCP_USER_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Whether to apply TCP settings to the server as well as the client.
+///
+/// These option are generally considered something that the upstream DBA should
+/// configure, so we don't override them by default.
+pub const DEFAULT_PG_SOURCE_TCP_CONFIGURE_SERVER: bool = false;
+
 // The default value for the `wal_sender_timeout` option for PostgreSQL sources.
 //
 // See: <https://www.postgresql.org/docs/current/runtime-config-replication.html>
@@ -34,7 +50,15 @@ pub const DEFAULT_PG_SOURCE_WAL_SENDER_TIMEOUT: Option<Duration> = None;
 /// Unset parameters should be interpreted to mean "use the previous value".
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct StorageParameters {
-    pub pg_source_tcp_timeouts: mz_postgres_util::TcpTimeoutConfig,
+    pub pg_source_connect_timeout: Option<Duration>,
+    pub pg_source_tcp_keepalives_retries: Option<u32>,
+    pub pg_source_tcp_keepalives_idle: Option<Duration>,
+    pub pg_source_tcp_keepalives_interval: Option<Duration>,
+    pub pg_source_tcp_user_timeout: Option<Duration>,
+    /// Whether to apply the configuration on the server as well.
+    ///
+    /// By default, the timeouts are only applied on the client.
+    pub pg_source_tcp_configure_server: bool,
     pub pg_source_snapshot_statement_timeout: Duration,
     pub pg_source_wal_sender_timeout: Option<Duration>,
     pub mysql_source_timeouts: mz_mysql_util::TimeoutConfig,
@@ -93,10 +117,15 @@ pub const STORAGE_MANAGED_COLLECTIONS_BATCH_DURATION_DEFAULT: Duration = Duratio
 impl Default for StorageParameters {
     fn default() -> Self {
         Self {
-            pg_source_tcp_timeouts: Default::default(),
+            pg_source_connect_timeout: Some(DEFAULT_PG_SOURCE_CONNECT_TIMEOUT),
+            pg_source_tcp_keepalives_retries: Some(DEFAULT_PG_SOURCE_TCP_KEEPALIVES_RETRIES),
+            pg_source_tcp_keepalives_idle: Some(DEFAULT_PG_SOURCE_TCP_KEEPALIVES_IDLE),
+            pg_source_tcp_keepalives_interval: Some(DEFAULT_PG_SOURCE_TCP_KEEPALIVES_INTERVAL),
+            pg_source_tcp_user_timeout: Some(DEFAULT_PG_SOURCE_TCP_USER_TIMEOUT),
             pg_source_snapshot_statement_timeout:
                 mz_postgres_util::DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT,
             pg_source_wal_sender_timeout: DEFAULT_PG_SOURCE_WAL_SENDER_TIMEOUT,
+            pg_source_tcp_configure_server: DEFAULT_PG_SOURCE_TCP_CONFIGURE_SERVER,
             mysql_source_timeouts: Default::default(),
             keep_n_source_status_history_entries: Default::default(),
             keep_n_sink_status_history_entries: Default::default(),
@@ -193,7 +222,12 @@ impl StorageParameters {
     pub fn update(
         &mut self,
         StorageParameters {
-            pg_source_tcp_timeouts,
+            pg_source_connect_timeout,
+            pg_source_tcp_keepalives_retries,
+            pg_source_tcp_keepalives_idle,
+            pg_source_tcp_keepalives_interval,
+            pg_source_tcp_user_timeout,
+            pg_source_tcp_configure_server,
             pg_source_snapshot_statement_timeout,
             pg_source_wal_sender_timeout,
             mysql_source_timeouts,
@@ -217,7 +251,12 @@ impl StorageParameters {
             dyncfg_updates,
         }: StorageParameters,
     ) {
-        self.pg_source_tcp_timeouts = pg_source_tcp_timeouts;
+        self.pg_source_connect_timeout = pg_source_connect_timeout;
+        self.pg_source_tcp_keepalives_retries = pg_source_tcp_keepalives_retries;
+        self.pg_source_tcp_keepalives_idle = pg_source_tcp_keepalives_idle;
+        self.pg_source_tcp_keepalives_interval = pg_source_tcp_keepalives_interval;
+        self.pg_source_tcp_user_timeout = pg_source_tcp_user_timeout;
+        self.pg_source_tcp_configure_server = pg_source_tcp_configure_server;
         self.pg_source_snapshot_statement_timeout = pg_source_snapshot_statement_timeout;
         self.pg_source_wal_sender_timeout = pg_source_wal_sender_timeout;
         self.mysql_source_timeouts = mysql_source_timeouts;
@@ -249,10 +288,15 @@ impl StorageParameters {
 impl RustType<ProtoStorageParameters> for StorageParameters {
     fn into_proto(&self) -> ProtoStorageParameters {
         ProtoStorageParameters {
-            pg_source_tcp_timeouts: Some(self.pg_source_tcp_timeouts.into_proto()),
+            pg_source_connect_timeout: self.pg_source_connect_timeout.into_proto(),
+            pg_source_tcp_keepalives_retries: self.pg_source_tcp_keepalives_retries,
+            pg_source_tcp_keepalives_idle: self.pg_source_tcp_keepalives_idle.into_proto(),
+            pg_source_tcp_keepalives_interval: self.pg_source_tcp_keepalives_interval.into_proto(),
+            pg_source_tcp_user_timeout: self.pg_source_tcp_user_timeout.into_proto(),
             pg_source_snapshot_statement_timeout: Some(
                 self.pg_source_snapshot_statement_timeout.into_proto(),
             ),
+            pg_source_tcp_configure_server: self.pg_source_tcp_configure_server,
             pg_source_wal_sender_timeout: self.pg_source_wal_sender_timeout.into_proto(),
             mysql_source_timeouts: Some(self.mysql_source_timeouts.into_proto()),
             keep_n_source_status_history_entries: u64::cast_from(
@@ -291,9 +335,14 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
 
     fn from_proto(proto: ProtoStorageParameters) -> Result<Self, TryFromProtoError> {
         Ok(Self {
-            pg_source_tcp_timeouts: proto
-                .pg_source_tcp_timeouts
-                .into_rust_if_some("ProtoStorageParameters::pg_source_tcp_timeouts")?,
+            pg_source_connect_timeout: proto.pg_source_connect_timeout.into_rust()?,
+            pg_source_tcp_keepalives_retries: proto.pg_source_tcp_keepalives_retries,
+            pg_source_tcp_keepalives_idle: proto.pg_source_tcp_keepalives_idle.into_rust()?,
+            pg_source_tcp_keepalives_interval: proto
+                .pg_source_tcp_keepalives_interval
+                .into_rust()?,
+            pg_source_tcp_user_timeout: proto.pg_source_tcp_user_timeout.into_rust()?,
+            pg_source_tcp_configure_server: proto.pg_source_tcp_configure_server,
             pg_source_snapshot_statement_timeout: proto
                 .pg_source_snapshot_statement_timeout
                 .into_rust_if_some(
@@ -357,28 +406,6 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             dyncfg_updates: proto.dyncfg_updates.ok_or_else(|| {
                 TryFromProtoError::missing_field("ProtoStorageParameters::dyncfg_updates")
             })?,
-        })
-    }
-}
-
-impl RustType<ProtoPgSourceTcpTimeouts> for mz_postgres_util::TcpTimeoutConfig {
-    fn into_proto(&self) -> ProtoPgSourceTcpTimeouts {
-        ProtoPgSourceTcpTimeouts {
-            connect_timeout: self.connect_timeout.into_proto(),
-            keepalives_retries: self.keepalives_retries,
-            keepalives_idle: self.keepalives_idle.into_proto(),
-            keepalives_interval: self.keepalives_interval.into_proto(),
-            tcp_user_timeout: self.tcp_user_timeout.into_proto(),
-        }
-    }
-
-    fn from_proto(proto: ProtoPgSourceTcpTimeouts) -> Result<Self, TryFromProtoError> {
-        Ok(mz_postgres_util::TcpTimeoutConfig {
-            connect_timeout: proto.connect_timeout.into_rust()?,
-            keepalives_retries: proto.keepalives_retries,
-            keepalives_idle: proto.keepalives_idle.into_rust()?,
-            keepalives_interval: proto.keepalives_interval.into_rust()?,
-            tcp_user_timeout: proto.tcp_user_timeout.into_rust()?,
         })
     }
 }

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -155,10 +155,11 @@ CREATE PUBLICATION another_publication FOR TABLE another_schema.another_table;
 # TODO: enable once we land #24586
 # $ postgres-verify-slot connection=postgres://postgres:postgres@postgres slot=materialize_% active=false
 
-# Sneak in a test for pg_source_snapshot_statement_timeout
+# Sneak in a test for pg_source_snapshot_statement_timeout, pg_source_wal_sender_timeout
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET pg_source_snapshot_statement_timeout = 1000
+ALTER SYSTEM SET pg_source_snapshot_statement_timeout = 1000;
+ALTER SYSTEM SET pg_source_wal_sender_timeout = 0;
 
 > CREATE SOURCE "test_slot_source"
   IN CLUSTER cdc_cluster


### PR DESCRIPTION
Details in commit messages.

Slack context: https://materializeinc.slack.com/archives/C0761MZ3QD9/p1718382044937969

### Motivation

  * This PR adds a feature that has not yet been specified.

### Post merge

Update the naming of the keepalives parameters in LD.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
