### PR TITLE
adapter: refactor select to sequence staged

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1004,14 +1004,6 @@ impl Coordinator {
             }
         }
 
-        // Cancel commands waiting on a real time recency timestamp. There is at most one  per session.
-        if let Some(real_time_recency_context) =
-            self.pending_real_time_recency_timestamp.remove(&conn_id)
-        {
-            let ctx = real_time_recency_context.take_context();
-            maybe_ctx = Some(ctx);
-        }
-
         // Cancel reads waiting on being linearized. There is at most one linearized read per
         // session.
         if let Some(pending_read_txn) = self.pending_linearize_read_txns.remove(&conn_id) {

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -17,8 +17,7 @@ use maplit::btreemap;
 use mz_controller_types::ClusterId;
 use mz_expr::{CollectionPlan, ResultSpec};
 use mz_ore::cast::CastFrom;
-use mz_ore::tracing::OpenTelemetryContext;
-use mz_ore::{instrument, task};
+use mz_ore::instrument;
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
 use mz_repr::{Datum, GlobalId, RowArena, Timestamp};
@@ -30,8 +29,9 @@ use mz_sql::plan::QueryWhen;
 use mz_sql::plan::{self, HirScalarExpr};
 use mz_sql::session::metadata::SessionMetadata;
 use mz_transform::EmptyStatisticsOracle;
-use tracing::Instrument;
-use tracing::{event, warn, Level};
+use tokio::sync::oneshot;
+use tracing::warn;
+use tracing::{Instrument, Span};
 
 use crate::active_compute_sink::{ActiveComputeSink, ActiveCopyTo};
 use crate::command::ExecuteResponse;
@@ -46,8 +46,7 @@ use crate::coord::{
     Coordinator, CopyToContext, ExecuteContext, ExplainContext, ExplainPlanContext, Message,
     PeekStage, PeekStageCopyTo, PeekStageExplainPlan, PeekStageExplainPushdown, PeekStageFinish,
     PeekStageLinearizeTimestamp, PeekStageOptimize, PeekStageRealTimeRecency,
-    PeekStageTimestampReadHold, PeekStageValidate, PlanValidity, RealTimeRecencyContext,
-    TargetCluster, WatchSetResponse,
+    PeekStageTimestampReadHold, PlanValidity, StageResult, Staged, TargetCluster, WatchSetResponse,
 };
 use crate::error::AdapterError;
 use crate::explain::insights::PlanInsightsContext;
@@ -57,6 +56,58 @@ use crate::optimize::dataflows::{prep_scalar_expr, EvalTime, ExprPrepStyle};
 use crate::optimize::{self, Optimize};
 use crate::session::{RequireLinearization, Session, TransactionOps, TransactionStatus};
 use crate::statement_logging::StatementLifecycleEvent;
+
+impl Staged for PeekStage {
+    fn validity(&mut self) -> &mut PlanValidity {
+        match self {
+            PeekStage::LinearizeTimestamp(stage) => &mut stage.validity,
+            PeekStage::RealTimeRecency(stage) => &mut stage.validity,
+            PeekStage::TimestampReadHold(stage) => &mut stage.validity,
+            PeekStage::Optimize(stage) => &mut stage.validity,
+            PeekStage::Finish(stage) => &mut stage.validity,
+            PeekStage::ExplainPlan(stage) => &mut stage.validity,
+            PeekStage::ExplainPushdown(stage) => &mut stage.validity,
+            PeekStage::CopyTo(stage) => &mut stage.validity,
+        }
+    }
+
+    async fn stage(
+        self,
+        coord: &mut Coordinator,
+        ctx: &mut ExecuteContext,
+    ) -> Result<StageResult<Box<Self>>, AdapterError> {
+        match self {
+            PeekStage::LinearizeTimestamp(stage) => {
+                coord.peek_linearize_timestamp(ctx.session(), stage).await
+            }
+            PeekStage::RealTimeRecency(stage) => {
+                coord.peek_real_time_recency(ctx.session(), stage).await
+            }
+            PeekStage::TimestampReadHold(stage) => {
+                coord.peek_timestamp_read_hold(ctx.session_mut(), stage)
+            }
+            PeekStage::Optimize(stage) => coord.peek_optimize(ctx.session(), stage).await,
+            PeekStage::Finish(stage) => coord.peek_finish(ctx, stage).await,
+            PeekStage::ExplainPlan(stage) => coord.peek_explain_plan(ctx.session(), stage).await,
+            PeekStage::ExplainPushdown(stage) => {
+                coord.peek_explain_pushdown(ctx.session(), stage).await
+            }
+            PeekStage::CopyTo(stage) => coord.peek_copy_to_dataflow(ctx, stage).await,
+        }
+    }
+
+    fn message(self, ctx: ExecuteContext, span: Span) -> Message {
+        Message::PeekStageReady {
+            ctx,
+            span,
+            stage: self,
+        }
+    }
+
+    fn cancel_enabled(&self) -> bool {
+        true
+    }
+}
 
 impl Coordinator {
     /// Sequence a peek, determining a timestamp and the most efficient dataflow interaction.
@@ -72,8 +123,6 @@ impl Coordinator {
         plan: plan::SelectPlan,
         target_cluster: TargetCluster,
     ) {
-        event!(Level::TRACE, plan = format!("{:?}", plan));
-
         let explain_ctx = if ctx.session().vars().emit_plan_insights_notice() {
             let optimizer_trace = OptimizerTrace::new(ExplainStage::PlanInsights.paths());
             ExplainContext::PlanInsightsNotice(optimizer_trace)
@@ -81,17 +130,11 @@ impl Coordinator {
             ExplainContext::None
         };
 
-        self.execute_peek_stage(
-            ctx,
-            OpenTelemetryContext::obtain(),
-            PeekStage::Validate(PeekStageValidate {
-                plan,
-                target_cluster,
-                copy_to_ctx: None,
-                explain_ctx,
-            }),
-        )
-        .await;
+        let stage = return_if_err!(
+            self.peek_validate(ctx.session(), plan, target_cluster, None, explain_ctx),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
     }
 
     #[instrument]
@@ -136,13 +179,12 @@ impl Coordinator {
 
         let uri = return_if_err!(eval_uri(to), ctx);
 
-        self.execute_peek_stage(
-            ctx,
-            OpenTelemetryContext::obtain(),
-            PeekStage::Validate(PeekStageValidate {
-                plan: select_plan,
+        let stage = return_if_err!(
+            self.peek_validate(
+                ctx.session(),
+                select_plan,
                 target_cluster,
-                copy_to_ctx: Some(CopyToContext {
+                Some(CopyToContext {
                     desc,
                     uri,
                     connection,
@@ -152,10 +194,11 @@ impl Coordinator {
                     // This will be set in `peek_stage_validate` stage below.
                     output_batch_count: None,
                 }),
-                explain_ctx: ExplainContext::None,
-            }),
-        )
-        .await;
+                ExplainContext::None,
+            ),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
     }
 
     #[instrument]
@@ -185,14 +228,13 @@ impl Coordinator {
         // executing the optimizer pipeline.
         let optimizer_trace = OptimizerTrace::new(stage.paths());
 
-        self.execute_peek_stage(
-            ctx,
-            OpenTelemetryContext::obtain(),
-            PeekStage::Validate(PeekStageValidate {
+        let stage = return_if_err!(
+            self.peek_validate(
+                ctx.session(),
                 plan,
                 target_cluster,
-                copy_to_ctx: None,
-                explain_ctx: ExplainContext::Plan(ExplainPlanContext {
+                None,
+                ExplainContext::Plan(ExplainPlanContext {
                     broken,
                     config,
                     format,
@@ -200,106 +242,23 @@ impl Coordinator {
                     replan: None,
                     desc: Some(desc),
                     optimizer_trace,
-                }),
-            }),
-        )
-        .await;
-    }
-
-    /// Processes as many `peek` stages as possible.
-    #[instrument]
-    pub(crate) async fn execute_peek_stage(
-        &mut self,
-        mut ctx: ExecuteContext,
-        root_otel_ctx: OpenTelemetryContext,
-        mut stage: PeekStage,
-    ) {
-        use PeekStage::*;
-
-        // Process the current stage and allow for processing the next.
-        loop {
-            event!(Level::TRACE, stage = format!("{:?}", stage));
-
-            // Always verify peek validity. This is cheap, and prevents programming errors
-            // if we move any stages off thread.
-            if let Some(validity) = stage.validity() {
-                if let Err(err) = validity.check(self.catalog()) {
-                    ctx.retire(Err(err));
-                    return;
-                }
-            }
-
-            (ctx, stage) = match stage {
-                Validate(stage) => {
-                    let next =
-                        return_if_err!(self.peek_stage_validate(ctx.session_mut(), stage), ctx);
-
-                    (ctx, PeekStage::LinearizeTimestamp(next))
-                }
-                LinearizeTimestamp(stage) => {
-                    self.peek_stage_linearize_timestamp(ctx, root_otel_ctx.clone(), stage)
-                        .await;
-                    return;
-                }
-                RealTimeRecency(stage) => {
-                    match self
-                        .peek_stage_real_time_recency(ctx, root_otel_ctx.clone(), stage)
-                        .await
-                    {
-                        Some((ctx, next)) => (ctx, PeekStage::TimestampReadHold(next)),
-                        // This branch includes propagating real-time-recency
-                        // errors and retiring the context. We can't do that
-                        // easily in the return because the caller takes
-                        // ownership of the ctx.
-                        None => return,
-                    }
-                }
-                TimestampReadHold(stage) => {
-                    let next = return_if_err!(
-                        self.peek_stage_timestamp_read_hold(ctx.session_mut(), stage),
-                        ctx
-                    );
-                    (ctx, PeekStage::Optimize(next))
-                }
-                Optimize(stage) => {
-                    self.peek_stage_optimize(ctx, root_otel_ctx.clone(), stage)
-                        .await;
-                    return;
-                }
-                Finish(stage) => {
-                    let res = self.peek_stage_finish(&mut ctx, stage).await;
-                    ctx.retire(res);
-                    return;
-                }
-                CopyTo(stage) => {
-                    self.peek_stage_copy_to_dataflow(ctx, stage).await;
-                    return;
-                }
-                ExplainPlan(stage) => {
-                    let result = self.peek_stage_explain_plan(&mut ctx, stage).await;
-                    ctx.retire(result);
-                    return;
-                }
-                ExplainPushdown(stage) => {
-                    self.peek_stage_explain_pushdown(ctx, stage).await;
-                    return;
-                }
-            }
-        }
+                })
+            ),
+            ctx
+        );
+        self.sequence_staged(ctx, Span::current(), stage).await;
     }
 
     /// Do some simple validation. We must defer most of it until after any off-thread work.
     #[instrument]
-    fn peek_stage_validate(
-        &mut self,
+    pub fn peek_validate(
+        &self,
         session: &Session,
-        PeekStageValidate {
-            plan,
-            target_cluster,
-            copy_to_ctx,
-            explain_ctx,
-        }: PeekStageValidate,
-    ) -> Result<PeekStageLinearizeTimestamp, AdapterError> {
+        plan: mz_sql::plan::SelectPlan,
+        target_cluster: TargetCluster,
+        copy_to_ctx: Option<CopyToContext>,
+        explain_ctx: ExplainContext,
+    ) -> Result<PeekStage, AdapterError> {
         // Collect optimizer parameters.
         let catalog = self.owned_catalog();
         let cluster = catalog.resolve_target_cluster(target_cluster, session)?;
@@ -406,7 +365,7 @@ impl Coordinator {
             role_metadata: session.role_metadata().clone(),
         };
 
-        Ok(PeekStageLinearizeTimestamp {
+        Ok(PeekStage::LinearizeTimestamp(PeekStageLinearizeTimestamp {
             validity,
             plan,
             source_ids,
@@ -414,15 +373,14 @@ impl Coordinator {
             timeline_context,
             optimizer,
             explain_ctx,
-        })
+        }))
     }
 
     /// Possibly linearize a timestamp from a `TimestampOracle`.
     #[instrument]
-    async fn peek_stage_linearize_timestamp(
-        &mut self,
-        ctx: ExecuteContext,
-        root_otel_ctx: OpenTelemetryContext,
+    async fn peek_linearize_timestamp(
+        &self,
+        session: &Session,
         PeekStageLinearizeTimestamp {
             validity,
             source_ids,
@@ -432,13 +390,11 @@ impl Coordinator {
             optimizer,
             explain_ctx,
         }: PeekStageLinearizeTimestamp,
-    ) {
-        let isolation_level = ctx.session.vars().transaction_isolation().clone();
+    ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
+        let isolation_level = session.vars().transaction_isolation().clone();
         let timeline = Coordinator::get_timeline(&timeline_context);
         let needs_linearized_read_ts =
             Coordinator::needs_linearized_read_ts(&isolation_level, &plan.when);
-
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
 
         let build_stage = move |oracle_read_ts: Option<Timestamp>| PeekStageRealTimeRecency {
             validity,
@@ -458,36 +414,29 @@ impl Coordinator {
                 // We ship the timestamp oracle off to an async task, so that we
                 // don't block the main task while we wait.
 
-                let span = tracing::debug_span!("linearized timestamp task");
-                mz_ore::task::spawn(|| "linearized timestamp task", async move {
-                    let oracle_read_ts = oracle.read_ts().instrument(span).await;
-                    let stage = build_stage(Some(oracle_read_ts));
-
-                    let stage = PeekStage::RealTimeRecency(stage);
-                    // Ignore errors if the coordinator has shut down.
-                    let _ = internal_cmd_tx.send(Message::PeekStageReady {
-                        ctx,
-                        otel_ctx: root_otel_ctx,
-                        stage,
-                    });
-                });
+                let span = Span::current();
+                Ok(StageResult::Handle(mz_ore::task::spawn(
+                    || "linearize timestamp",
+                    async move {
+                        let oracle_read_ts = oracle.read_ts().await;
+                        let stage = build_stage(Some(oracle_read_ts));
+                        let stage = PeekStage::RealTimeRecency(stage);
+                        Ok(Box::new(stage))
+                    }
+                    .instrument(span),
+                )))
             }
             Some(_) | None => {
                 let stage = build_stage(None);
                 let stage = PeekStage::RealTimeRecency(stage);
-                // Ignore errors if the coordinator has shut down.
-                let _ = internal_cmd_tx.send(Message::PeekStageReady {
-                    ctx,
-                    otel_ctx: root_otel_ctx,
-                    stage,
-                });
+                Ok(StageResult::Immediate(Box::new(stage)))
             }
         }
     }
 
     /// Determine a read timestamp and create appropriate read holds.
     #[instrument]
-    fn peek_stage_timestamp_read_hold(
+    fn peek_timestamp_read_hold(
         &mut self,
         session: &mut Session,
         PeekStageTimestampReadHold {
@@ -501,7 +450,7 @@ impl Coordinator {
             optimizer,
             explain_ctx,
         }: PeekStageTimestampReadHold,
-    ) -> Result<PeekStageOptimize, AdapterError> {
+    ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
         let cluster_id = match optimizer.as_ref() {
             Either::Left(optimizer) => optimizer.cluster_id(),
             Either::Right(optimizer) => optimizer.cluster_id(),
@@ -526,7 +475,7 @@ impl Coordinator {
             (&explain_ctx).into(),
         )?;
 
-        Ok(PeekStageOptimize {
+        let stage = PeekStage::Optimize(PeekStageOptimize {
             validity,
             plan,
             source_ids,
@@ -535,14 +484,14 @@ impl Coordinator {
             determination,
             optimizer,
             explain_ctx,
-        })
+        });
+        Ok(StageResult::Immediate(Box::new(stage)))
     }
 
     #[instrument]
-    async fn peek_stage_optimize(
-        &mut self,
-        ctx: ExecuteContext,
-        root_otel_ctx: OpenTelemetryContext,
+    async fn peek_optimize(
+        &self,
+        session: &Session,
         PeekStageOptimize {
             validity,
             plan,
@@ -553,22 +502,15 @@ impl Coordinator {
             mut optimizer,
             explain_ctx,
         }: PeekStageOptimize,
-    ) {
+    ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
         // Generate data structures that can be moved to another task where we will perform possibly
         // expensive optimizations.
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
-
         let timestamp_context = determination.timestamp_context.clone();
         let stats = self
-            .statistics_oracle(
-                ctx.session(),
-                &source_ids,
-                &timestamp_context.antichain(),
-                true,
-            )
+            .statistics_oracle(session, &source_ids, &timestamp_context.antichain(), true)
             .await
             .unwrap_or_else(|_| Box::new(EmptyStatisticsOracle));
-        let session = ctx.session().meta();
+        let session = session.meta();
         let now = self.catalog().config().now.clone();
         let catalog = self.owned_catalog();
         let mut compute_instances = BTreeMap::new();
@@ -581,45 +523,47 @@ impl Coordinator {
             }
         }
 
-        mz_ore::task::spawn_blocking(
+        let span = Span::current();
+        Ok(StageResult::Handle(mz_ore::task::spawn_blocking(
             || "optimize peek",
             move || {
-                let pipeline = || -> Result<Either<optimize::peek::GlobalLirPlan, optimize::copy_to::GlobalLirPlan>, AdapterError> {
-                    let _dispatch_guard = explain_ctx.dispatch_guard();
+                span.in_scope(|| {
+                    let pipeline = || -> Result<Either<optimize::peek::GlobalLirPlan, optimize::copy_to::GlobalLirPlan>, AdapterError> {
+                        let _dispatch_guard = explain_ctx.dispatch_guard();
 
-                    let raw_expr = plan.source.clone();
+                        let raw_expr = plan.source.clone();
 
-                    match optimizer.as_mut() {
-                        // Optimize SELECT statement.
-                        Either::Left(optimizer) => {
-                            // HIR ⇒ MIR lowering and MIR optimization (local)
-                            let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
-                            // Attach resolved context required to continue the pipeline.
-                            let local_mir_plan = local_mir_plan.resolve(timestamp_context.clone(), &session, stats);
-                            // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
-                            let global_lir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
+                        match optimizer.as_mut() {
+                            // Optimize SELECT statement.
+                            Either::Left(optimizer) => {
+                                // HIR ⇒ MIR lowering and MIR optimization (local)
+                                let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
+                                // Attach resolved context required to continue the pipeline.
+                                let local_mir_plan = local_mir_plan.resolve(timestamp_context.clone(), &session, stats);
+                                // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
+                                let global_lir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
 
-                            Ok(Either::Left(global_lir_plan))
+                                Ok(Either::Left(global_lir_plan))
+                            }
+                            // Optimize COPY TO statement.
+                            Either::Right(optimizer) => {
+                                // HIR ⇒ MIR lowering and MIR optimization (local and global)
+                                let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
+                                // Attach resolved context required to continue the pipeline.
+                                let local_mir_plan = local_mir_plan.resolve(timestamp_context.clone(), &session, stats);
+                                // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
+                                let global_lir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
+
+                                Ok(Either::Right(global_lir_plan))
+                            }
                         }
-                        // Optimize COPY TO statement.
-                        Either::Right(optimizer) => {
-                            // HIR ⇒ MIR lowering and MIR optimization (local and global)
-                            let local_mir_plan = optimizer.catch_unwind_optimize(raw_expr)?;
-                            // Attach resolved context required to continue the pipeline.
-                            let local_mir_plan = local_mir_plan.resolve(timestamp_context.clone(), &session, stats);
-                            // MIR optimization (global), MIR ⇒ LIR lowering, and LIR optimization (global)
-                            let global_lir_plan = optimizer.catch_unwind_optimize(local_mir_plan)?;
+                    };
 
-                            Ok(Either::Right(global_lir_plan))
-                        }
-                    }
-                };
+                    let optimization_finished_at = (now)();
 
-                let optimization_finished_at = (now)();
-
-                let stage = match pipeline() {
-                    Ok(Either::Left(global_lir_plan)) => {
-                        let optimizer = optimizer.unwrap_left();
+                    let stage = match pipeline() {
+                        Ok(Either::Left(global_lir_plan)) => {
+                            let optimizer = optimizer.unwrap_left();
                         // Enable fast path cluster calculation for slow path plans.
                         let needs_plan_insights = explain_ctx.needs_plan_insights();
                         // Disable anything that uses the optimizer if we only want the notice and
@@ -643,19 +587,33 @@ impl Coordinator {
                             index_id: optimizer.index_id(),
                             enable_re_optimize,
                         });
-                        match explain_ctx {
-                            ExplainContext::Plan(explain_ctx) => {
-                                let (_, df_meta, _) = global_lir_plan.unapply();
-                                PeekStage::ExplainPlan(PeekStageExplainPlan {
-                                    validity,
-                                    optimizer,
-                                    df_meta,
-                                    explain_ctx,
+                            match explain_ctx {
+                                ExplainContext::Plan(explain_ctx) => {
+                                    let (_, df_meta, _) = global_lir_plan.unapply();
+                                    PeekStage::ExplainPlan(PeekStageExplainPlan {
+                                        validity,
+                                        optimizer,
+                                        df_meta,
+                                        explain_ctx,
                                     insights_ctx,
-                                })
-                            }
-                            ExplainContext::PlanInsightsNotice(optimizer_trace) => {
-                                PeekStage::Finish(PeekStageFinish {
+                                    })
+                                }
+                                ExplainContext::PlanInsightsNotice(optimizer_trace) => {
+                                    PeekStage::Finish(PeekStageFinish {
+                                        validity,
+                                        plan,
+                                        id_bundle,
+                                        target_replica,
+                                        source_ids,
+                                        determination,
+                                        optimizer,
+                                        plan_insights_optimizer_trace: Some(optimizer_trace),
+                                        global_lir_plan,
+                                        optimization_finished_at,
+                                    insights_ctx,
+                                    })
+                                }
+                                ExplainContext::None => PeekStage::Finish(PeekStageFinish {
                                     validity,
                                     plan,
                                     id_bundle,
@@ -663,104 +621,84 @@ impl Coordinator {
                                     source_ids,
                                     determination,
                                     optimizer,
-                                    plan_insights_optimizer_trace: Some(optimizer_trace),
+                                    plan_insights_optimizer_trace: None,
                                     global_lir_plan,
                                     optimization_finished_at,
-                                    insights_ctx,
-                                })
+                                insights_ctx,
+                                }),
+                                ExplainContext::Pushdown => {
+                                    let (plan, _, _) = global_lir_plan.unapply();
+                                    let imports = match plan {
+                                        PeekPlan::SlowPath(plan) => plan
+                                            .desc
+                                            .source_imports
+                                            .into_iter()
+                                            .filter_map(|(id, (desc, _))| {
+                                                desc.arguments.operators.map(|mfp| (id, mfp))
+                                            })
+                                            .collect(),
+                                        PeekPlan::FastPath(_) => BTreeMap::default(),
+                                    };
+                                    PeekStage::ExplainPushdown(PeekStageExplainPushdown {
+                                        validity,
+                                        determination,
+                                        imports,
+                                    })
+                                }
                             }
-                            ExplainContext::None => PeekStage::Finish(PeekStageFinish {
+                        }
+                        Ok(Either::Right(global_lir_plan)) => {
+                            let optimizer = optimizer.unwrap_right();
+                            PeekStage::CopyTo(PeekStageCopyTo {
                                 validity,
-                                plan,
-                                id_bundle,
-                                target_replica,
-                                source_ids,
-                                determination,
                                 optimizer,
-                                plan_insights_optimizer_trace: None,
                                 global_lir_plan,
                                 optimization_finished_at,
-                                insights_ctx,
-                            }),
-                            ExplainContext::Pushdown => {
-                                let (plan, _, _) = global_lir_plan.unapply();
-                                let imports = match plan {
-                                    PeekPlan::SlowPath(plan) => plan
-                                        .desc
-                                        .source_imports
-                                        .into_iter()
-                                        .filter_map(|(id, (desc, _))| {
-                                            desc.arguments.operators.map(|mfp| (id, mfp))
-                                        })
-                                        .collect(),
-                                    PeekPlan::FastPath(_) => BTreeMap::default(),
-                                };
-                                PeekStage::ExplainPushdown(PeekStageExplainPushdown {
+                            })
+                        }
+                        // Internal optimizer errors are handled differently
+                        // depending on the caller.
+                        Err(err) => {
+                            let Some(optimizer) = optimizer.left() else {
+                                // In `COPY TO` contexts, immediately retire the
+                                // execution with the error.
+                                return Err(err);
+                            };
+                            let ExplainContext::Plan(explain_ctx) = explain_ctx else {
+                                // In `sequence_~` contexts, immediately retire the
+                                // execution with the error.
+                                return Err(err);
+                            };
+
+                            if explain_ctx.broken {
+                                // In `EXPLAIN BROKEN` contexts, just log the error
+                                // and move to the next stage with default
+                                // parameters.
+                                tracing::error!("error while handling EXPLAIN statement: {}", err);
+                                PeekStage::ExplainPlan(PeekStageExplainPlan {
                                     validity,
-                                    determination,
-                                    imports,
-                                })
+                                    optimizer,
+                                    df_meta: Default::default(),
+                                    explain_ctx,
+                                    insights_ctx: None,
+                            })
+                            } else {
+                                // In regular `EXPLAIN` contexts, immediately retire
+                                // the execution with the error.
+                                return Err(err);
                             }
                         }
-                    }
-                    Ok(Either::Right(global_lir_plan)) => {
-                        let optimizer = optimizer.unwrap_right();
-                        PeekStage::CopyTo(PeekStageCopyTo {
-                            validity,
-                            optimizer,
-                            global_lir_plan,
-                            optimization_finished_at,
-                        })
-                    }
-                    // Internal optimizer errors are handled differently
-                    // depending on the caller.
-                    Err(err) => {
-                        let Some(optimizer) = optimizer.left() else {
-                            // In `COPY TO` contexts, immediately retire the
-                            // execution with the error.
-                            return ctx.retire(Err(err.into()));
-                        };
-                        let ExplainContext::Plan(explain_ctx) = explain_ctx else {
-                            // In `sequence_~` contexts, immediately retire the
-                            // execution with the error.
-                            return ctx.retire(Err(err.into()));
-                        };
-
-                        if explain_ctx.broken {
-                            // In `EXPLAIN BROKEN` contexts, just log the error
-                            // and move to the next stage with default
-                            // parameters.
-                            tracing::error!("error while handling EXPLAIN statement: {}", err);
-                            PeekStage::ExplainPlan(PeekStageExplainPlan {
-                                validity,
-                                optimizer,
-                                df_meta: Default::default(),
-                                explain_ctx,
-                                insights_ctx: None,
-                            })
-                        } else {
-                            // In regular `EXPLAIN` contexts, immediately retire
-                            // the execution with the error.
-                            return ctx.retire(Err(err.into()));
-                        }
-                    }
-                };
-
-                // Ignore errors if the coordinator has shut down.
-                let _ = internal_cmd_tx.send(Message::PeekStageReady {
-                    ctx,
-                    otel_ctx: root_otel_ctx,
-                    stage,
-                });
+                    };
+                    Ok(Box::new(stage))
+                })
             },
-        );
+        )))
     }
 
     #[instrument]
-    async fn peek_stage_real_time_recency(
+    async fn peek_real_time_recency(
         &mut self,
-        ctx: ExecuteContext,
-        root_otel_ctx: OpenTelemetryContext,
+        session: &Session,
         PeekStageRealTimeRecency {
             validity,
             plan,
@@ -771,53 +709,36 @@ impl Coordinator {
             optimizer,
             explain_ctx,
         }: PeekStageRealTimeRecency,
-    ) -> Option<(ExecuteContext, PeekStageTimestampReadHold)> {
-        let fut = match self
-            .determine_real_time_recent_timestamp(ctx.session(), source_ids.iter().cloned())
-            .await
-        {
-            Ok(f) => f,
-            Err(e) => {
-                ctx.retire(Err(e.into()));
-                return None;
-            }
-        };
+    ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
+        let fut = self
+            .determine_real_time_recent_timestamp(session, source_ids.iter().cloned())
+            .await?;
 
         match fut {
             Some(fut) => {
-                let internal_cmd_tx = self.internal_cmd_tx.clone();
-                let conn_id = ctx.session().conn_id().clone();
-                self.pending_real_time_recency_timestamp.insert(
-                    conn_id.clone(),
-                    RealTimeRecencyContext::Peek {
-                        ctx,
-                        plan,
-                        root_otel_ctx,
-                        target_replica,
-                        timeline_context,
-                        oracle_read_ts: oracle_read_ts.clone(),
-                        source_ids,
-                        optimizer,
-                        explain_ctx,
-                    },
-                );
-                task::spawn(|| "real_time_recency_peek", async move {
-                    let real_time_recency_ts = fut.await;
-                    // It is not an error for these results to be ready after `internal_cmd_rx` has been dropped.
-                    let result = internal_cmd_tx.send(Message::RealTimeRecencyTimestamp {
-                        conn_id: conn_id.clone(),
-                        real_time_recency_ts,
-                        validity,
-                    });
-                    if let Err(e) = result {
-                        warn!("internal_cmd_rx dropped before we could send: {:?}", e);
+                let span = Span::current();
+                Ok(StageResult::Handle(mz_ore::task::spawn(
+                    || "peek real time recency",
+                    async move {
+                        let real_time_recency_ts = fut.await?;
+                        let stage = PeekStage::TimestampReadHold(PeekStageTimestampReadHold {
+                            validity,
+                            plan,
+                            target_replica,
+                            timeline_context,
+                            source_ids,
+                            optimizer,
+                            explain_ctx,
+                            oracle_read_ts,
+                            real_time_recency_ts: Some(real_time_recency_ts),
+                        });
+                        Ok(Box::new(stage))
                     }
-                });
-                None
+                    .instrument(span),
+                )))
             }
-            None => Some((
-                ctx,
-                PeekStageTimestampReadHold {
+            None => Ok(StageResult::Immediate(Box::new(
+                PeekStage::TimestampReadHold(PeekStageTimestampReadHold {
                     validity,
                     plan,
                     target_replica,
@@ -827,13 +748,13 @@ impl Coordinator {
                     explain_ctx,
                     oracle_read_ts,
                     real_time_recency_ts: None,
-                },
-            )),
+                }),
+            ))),
         }
     }
 
     #[instrument]
-    async fn peek_stage_finish(
+    async fn peek_finish(
         &mut self,
         ctx: &mut ExecuteContext,
         PeekStageFinish {
@@ -849,7 +770,7 @@ impl Coordinator {
             optimization_finished_at,
             insights_ctx,
         }: PeekStageFinish,
-    ) -> Result<ExecuteResponse, AdapterError> {
+    ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
         if let Some(id) = ctx.extra.contents() {
             self.record_statement_lifecycle_event(
                 &id,
@@ -967,26 +888,27 @@ impl Coordinator {
                 .add_notice(AdapterNotice::QueryTimestamp { explanation });
         }
 
-        match plan.copy_to {
-            None => Ok(resp),
-            Some(format) => Ok(ExecuteResponse::CopyTo {
+        let resp = match plan.copy_to {
+            None => resp,
+            Some(format) => ExecuteResponse::CopyTo {
                 format,
                 resp: Box::new(resp),
-            }),
-        }
+            },
+        };
+        Ok(StageResult::Response(resp))
     }
 
     #[instrument]
-    async fn peek_stage_copy_to_dataflow(
+    async fn peek_copy_to_dataflow(
         &mut self,
-        ctx: ExecuteContext,
+        ctx: &ExecuteContext,
         PeekStageCopyTo {
             validity,
             optimizer,
             global_lir_plan,
             optimization_finished_at,
         }: PeekStageCopyTo,
-    ) {
+    ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
         if let Some(id) = ctx.extra.contents() {
             self.record_statement_lifecycle_event(
                 &id,
@@ -1003,12 +925,14 @@ impl Coordinator {
         self.emit_optimizer_notices(ctx.session(), &df_meta.optimizer_notices);
 
         // Callback for the active copy to.
+        let (tx, rx) = oneshot::channel();
         let active_copy_to = ActiveCopyTo {
-            ctx,
+            conn_id: ctx.session().conn_id().clone(),
+            tx,
             cluster_id,
             depends_on: validity.dependency_ids.clone(),
         };
-        // Add metadata for the new COPY TO.
+        // Add metadata for the new COPY TO. CopyTo returns a `ready` future, so it is safe to drop.
         drop(
             self.add_active_compute_sink(sink_id, ActiveComputeSink::CopyTo(active_copy_to))
                 .await,
@@ -1016,12 +940,25 @@ impl Coordinator {
 
         // Ship dataflow.
         self.ship_dataflow(df_desc, cluster_id).await;
+
+        let span = Span::current();
+        Ok(StageResult::HandleRetire(mz_ore::task::spawn(
+            || "peek copy to dataflow",
+            async {
+                let res = rx.await;
+                match res {
+                    Ok(res) => res,
+                    Err(_) => Err(AdapterError::Internal("copy to sender dropped".into())),
+                }
+            }
+            .instrument(span),
+        )))
     }
 
     #[instrument]
-    async fn peek_stage_explain_plan(
-        &mut self,
-        ctx: &mut ExecuteContext,
+    async fn peek_explain_plan(
+        &self,
+        session: &Session,
         PeekStageExplainPlan {
             optimizer,
             insights_ctx,
@@ -1037,10 +974,10 @@ impl Coordinator {
                 },
             ..
         }: PeekStageExplainPlan,
-    ) -> Result<ExecuteResponse, AdapterError> {
+    ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
         let desc = desc.expect("RelationDesc for SelectPlan in EXPLAIN mode");
 
-        let session_catalog = self.catalog().for_session(ctx.session());
+        let session_catalog = self.catalog().for_session(session);
         let expr_humanizer = {
             let transient_items = btreemap! {
                 optimizer.select_id() => TransientItem::new(
@@ -1075,15 +1012,15 @@ impl Coordinator {
             )
             .await?;
 
-        Ok(Self::send_immediate_rows(rows))
+        Ok(StageResult::Response(Self::send_immediate_rows(rows)))
     }
 
     #[instrument]
-    async fn peek_stage_explain_pushdown(
-        &mut self,
-        ctx: ExecuteContext,
+    async fn peek_explain_pushdown(
+        &self,
+        session: &Session,
         stage: PeekStageExplainPushdown,
-    ) {
+    ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
         let as_of = stage.determination.timestamp_context.antichain();
         let mz_now = stage
             .determination
@@ -1091,9 +1028,14 @@ impl Coordinator {
             .timestamp()
             .map(|t| ResultSpec::value(Datum::MzTimestamp(*t)))
             .unwrap_or_else(ResultSpec::value_all);
-
-        self.render_explain_pushdown(ctx, as_of, mz_now, None, stage.imports)
-            .await
+        let fut = self
+            .render_explain_pushdown_prepare(session, as_of, mz_now, stage.imports)
+            .await;
+        let span = Span::current();
+        Ok(StageResult::HandleRetire(mz_ore::task::spawn(
+            || "peek explain pushdown",
+            fut.instrument(span),
+        )))
     }
 
     /// Determines the query timestamp and acquires read holds on dependent sources

--- a/src/environmentd/tests/tracing.rs
+++ b/src/environmentd/tests/tracing.rs
@@ -28,8 +28,8 @@ async fn test_expected_spans() {
         ("create_view_finish", "CREATE VIEW V AS SELECT 1"),
         ("create_index_finish", "CREATE DEFAULT INDEX i ON v"),
         ("subscribe_finish", "SUBSCRIBE (SELECT 1)"),
-        ("peek_stage_finish", "SELECT 1"),
-        ("peek_stage_explain_plan", "EXPLAIN SELECT 1"),
+        ("peek_finish", "SELECT 1"),
+        ("peek_explain_plan", "EXPLAIN SELECT 1"),
     ];
 
     let server = test_util::TestHarness::default()


### PR DESCRIPTION
This required changing the RTR and ActiveCopyTo APIs to no longer take full ownership of the `ExecuteContext`. In the RTR case, this was the last usage of that API and it could be removed completely.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

   * Last commit only, others are from #27689.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a