### PR TITLE
controller: remove disused storage stash URL argument

### DIFF
--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -61,7 +61,6 @@ export MZ_BALANCER_SQL_LISTEN_ADDR=${MZ_BALANCER_SQL_LISTEN_ADDR:-0.0.0.0:6880}
 export MZ_BALANCER_HTTP_LISTEN_ADDR=${MZ_BALANCER_HTTP_LISTEN_ADDR:-0.0.0.0:6881}
 export MZ_PERSIST_CONSENSUS_URL=${MZ_PERSIST_CONSENSUS_URL:-postgresql://root@$(hostname):26257?options=--search_path=consensus}
 export MZ_PERSIST_BLOB_URL=${MZ_PERSIST_BLOB_URL:-file:///mzdata/persist/blob}
-export MZ_STORAGE_STASH_URL=${MZ_STORAGE_STASH_URL:-postgresql://root@$(hostname):26257?options=--search_path=storage}
 export MZ_ADAPTER_STASH_URL=${MZ_ADAPTER_STASH_URL:-postgresql://root@$(hostname):26257?options=--search_path=adapter}
 export MZ_TIMESTAMP_ORACLE_URL=${MZ_TIMESTAMP_ORACLE_URL:-postgresql://root@$(hostname):26257?options=--search_path=tsoracle}
 export MZ_ORCHESTRATOR=${MZ_ORCHESTRATOR:-process}

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -240,7 +240,6 @@ def main() -> int:
                 f"--persist-consensus-url={args.postgres}?options=--search_path=consensus",
                 f"--persist-blob-url=file://{mzdata}/persist/blob",
                 f"--timestamp-oracle-url={args.postgres}?options=--search_path=tsoracle",
-                f"--storage-stash-url={args.postgres}?options=--search_path=storage",
                 f"--environment-id={environment_id}",
                 "--bootstrap-role=materialize",
                 *args.args,

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -192,7 +192,6 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             "--orchestrator-kubernetes-image-pull-policy=if-not-present",
             "--orchestrator-kubernetes-service-fs-group=999",
             f"--persist-consensus-url=postgres://root@cockroach.{self.cockroach_namespace}:26257?options=--search_path=consensus",
-            f"--storage-stash-url=postgres://root@cockroach.{self.cockroach_namespace}:26257?options=--search_path=storage",
             "--internal-sql-listen-addr=0.0.0.0:6877",
             "--internal-http-listen-addr=0.0.0.0:6878",
             "--unsafe-mode",

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -154,7 +154,6 @@ class Materialized(Service):
             address = "cockroach" if external_cockroach == True else external_cockroach
             depends_graph["cockroach"] = {"condition": "service_healthy"}
             command += [
-                f"--storage-stash-url=postgres://root@{address}:26257?options=--search_path=storage",
                 f"--persist-consensus-url=postgres://root@{address}:26257?options=--search_path=consensus",
             ]
             environment += [

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -86,8 +86,6 @@ pub struct ControllerConfig {
     /// PersistClient.
     /// This is intentionally shared between workers.
     pub persist_clients: Arc<PersistClientCache>,
-    /// The stash URL for the storage controller.
-    pub storage_stash_url: String,
     /// The clusterd image to use when starting new cluster processes.
     pub clusterd_image: String,
     /// The init container image to use for clusterd.

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -338,9 +338,6 @@ pub struct Args {
     /// Where the persist library should perform consensus.
     #[clap(long, env = "PERSIST_CONSENSUS_URL")]
     persist_consensus_url: Url,
-    /// The PostgreSQL URL for the storage stash.
-    #[clap(long, env = "STORAGE_STASH_URL", value_name = "POSTGRES_URL")]
-    storage_stash_url: String,
     /// The Persist PubSub URL.
     ///
     /// This URL is passed to `clusterd` for discovery of the Persist PubSub service.
@@ -879,7 +876,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             consensus_uri: args.persist_consensus_url.to_string(),
         },
         persist_clients: Arc::clone(&persist_clients),
-        storage_stash_url: args.storage_stash_url,
         clusterd_image: args.clusterd_image.expect("clap enforced"),
         init_container_image: args.orchestrator_kubernetes_init_container_image,
         now: SYSTEM_TIME.clone(),

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -344,7 +344,7 @@ impl Listeners {
             Some(data_directory) => (data_directory, None),
         };
         let scratch_dir = tempfile::tempdir()?;
-        let (consensus_uri, storage_stash_url, timestamp_oracle_url) = {
+        let (consensus_uri, timestamp_oracle_url) = {
             let seed = config.seed;
             let cockroach_url = env::var("COCKROACH_URL")
                 .map_err(|_| anyhow!("COCKROACH_URL environment variable is not set"))?;
@@ -357,13 +357,11 @@ impl Listeners {
             client
                 .batch_execute(&format!(
                     "CREATE SCHEMA IF NOT EXISTS consensus_{seed};
-                    CREATE SCHEMA IF NOT EXISTS storage_{seed};
                     CREATE SCHEMA IF NOT EXISTS tsoracle_{seed};"
                 ))
                 .await?;
             (
                 format!("{cockroach_url}?options=--search_path=consensus_{seed}"),
-                format!("{cockroach_url}?options=--search_path=storage_{seed}"),
                 format!("{cockroach_url}?options=--search_path=tsoracle_{seed}"),
             )
         };
@@ -481,7 +479,6 @@ impl Listeners {
                         consensus_uri,
                     },
                     persist_clients,
-                    storage_stash_url,
                     now: config.now.clone(),
                     metrics_registry: metrics_registry.clone(),
                     persist_pubsub_url: format!("http://localhost:{}", persist_pubsub_server_port),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -911,7 +911,7 @@ impl<'a> RunnerInner<'a> {
         let temp_dir = tempfile::tempdir()?;
         let scratch_dir = tempfile::tempdir()?;
         let environment_id = EnvironmentId::for_tests();
-        let (consensus_uri, storage_stash_url, timestamp_oracle_url) = {
+        let (consensus_uri, timestamp_oracle_url) = {
             let postgres_url = &config.postgres_url;
             info!(%postgres_url, "starting server");
             let (client, conn) = Retry::default()
@@ -933,16 +933,13 @@ impl<'a> RunnerInner<'a> {
             });
             client
                 .batch_execute(
-                    "DROP SCHEMA IF EXISTS sqllogictest_storage CASCADE;
-                     DROP SCHEMA IF EXISTS sqllogictest_tsoracle CASCADE;
+                    "DROP SCHEMA IF EXISTS sqllogictest_tsoracle CASCADE;
                      CREATE SCHEMA IF NOT EXISTS sqllogictest_consensus;
-                     CREATE SCHEMA sqllogictest_storage;
                      CREATE SCHEMA sqllogictest_tsoracle;",
                 )
                 .await?;
             (
                 format!("{postgres_url}?options=--search_path=sqllogictest_consensus"),
-                format!("{postgres_url}?options=--search_path=sqllogictest_storage"),
                 format!("{postgres_url}?options=--search_path=sqllogictest_tsoracle"),
             )
         };
@@ -1028,7 +1025,6 @@ impl<'a> RunnerInner<'a> {
                     consensus_uri,
                 },
                 persist_clients,
-                storage_stash_url,
                 now: SYSTEM_TIME.clone(),
                 metrics_registry: metrics_registry.clone(),
                 persist_pubsub_url: format!("http://localhost:{}", persist_pubsub_server_port),

--- a/test/crdb-restarts/mzcompose.py
+++ b/test/crdb-restarts/mzcompose.py
@@ -73,7 +73,6 @@ SERVICES = [
     Materialized(
         depends_on=[f"cockroach{id}" for id in range(CRDB_NODE_COUNT)],
         options=[
-            "--storage-stash-url=postgres://root@cockroach:26257?options=--search_path=storage",
             "--persist-consensus-url=postgres://root@cockroach:26257?options=--search_path=consensus",
             "--timestamp-oracle-url=postgres://root@cockroach:26257?options=--search_path=tsoracle",
         ],


### PR DESCRIPTION
We folded the storage stash into the catalog, but never cleaned up the now-unused storage stash URL argument.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
