### PR TITLE
.*: Upgrade `rust-rocksdb`, `mysql_common`, and `postgres*` dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,7 +18,7 @@ rustflags = [
     "-Clink-arg=-fuse-ld=lld",
     "-Csymbol-mangling-version=v0",
     "-Ctarget-cpu=x86-64-v3",
-    "-Ctarget-feature=+aes",
+    "-Ctarget-feature=+aes,+pclmulqdq",
     "--cfg=tokio_unstable",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,17 +968,16 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cexpr",
  "clang-sys",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
- "prettyplease 0.2.4",
  "proc-macro2",
  "quote",
  "regex",
@@ -3519,8 +3518,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.11.0+8.3.2"
-source = "git+https://github.com/MaterializeInc/rust-rocksdb?branch=master#ab3684f999a5586d7a5e94bd65defd78af15d40f"
+version = "0.16.0+8.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -3529,7 +3529,6 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
- "rustflags",
  "zstd-sys",
 ]
 
@@ -3820,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.32.1"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a60cb978c0a1d654edcc1460f8d6092dacf21346ed6017d81fb76a23ef5a8de"
+checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
 dependencies = [
  "base64 0.21.5",
  "bindgen",
@@ -7238,12 +7237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pem"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7582,16 +7575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
-dependencies = [
- "proc-macro2",
- "syn 2.0.63",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7697,7 +7680,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease 0.1.25",
+ "prettyplease",
  "prost",
  "prost-types",
  "regex",
@@ -8188,8 +8171,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.21.0"
-source = "git+https://github.com/MaterializeInc/rust-rocksdb?branch=master#ab3684f999a5586d7a5e94bd65defd78af15d40f"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -8246,12 +8230,6 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
-
-[[package]]
-name = "rustflags"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74f1ec0cda1aea3a3a6c0df066cd67acac62e24064532b871e8eafb0ec6c126"
 
 [[package]]
 name = "rustix"
@@ -9702,7 +9680,7 @@ name = "tonic-build"
 version = "0.9.2"
 source = "git+https://github.com/MaterializeInc/tonic?rev=0d86e360ab45779770ca150c8487fe7940c299a9#0d86e360ab45779770ca150c8487fe7940c299a9"
 dependencies = [
- "prettyplease 0.1.25",
+ "prettyplease",
  "proc-macro2",
  "prost-build",
  "quote",
@@ -10592,6 +10570,7 @@ dependencies = [
  "indexmap 1.9.1",
  "insta",
  "itertools 0.10.5",
+ "itertools 0.12.1",
  "k8s-openapi",
  "kube",
  "kube-client",

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -89,7 +89,7 @@ esac
 # might miss.
 #
 # Sync: This list of features should be kept in sync with the one in xcompile and .cargo/config.
-x86_64_target_features="+aes"
+x86_64_target_features="+aes,+pclmulqdq"
 aaarch64_target_features="+aes,+sha2"
 
 rust_target_features=""

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -277,6 +277,7 @@ RUN if [ $ARCH_GO = arm64 ]; then echo 'bdad4d3063ddb7bfa5ecf17fb8b029d5d81d7d4e
 # Install Bazel.
 #
 # TODO(parkmycar): Run Bazel in Docker image that does not have access to clang/gcc or any other tools.
+# TODO(parkmycar): Should we use bazelisk and maintain a central Bazel version number?
 
 ARG BAZEL_VERSION="7.1.1"
 

--- a/ci/test/lint-slow.sh
+++ b/ci/test/lint-slow.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
+echo "$RUSTFLAGS"
+
 try cargo clippy --all-targets -- -D warnings
 
 try bin/doc

--- a/ci/test/lint-slow.sh
+++ b/ci/test/lint-slow.sh
@@ -15,8 +15,6 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-echo "$RUSTFLAGS"
-
 try cargo clippy --all-targets -- -D warnings
 
 try bin/doc

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -121,6 +121,11 @@ who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.1.9"
 
+[[audits.bindgen]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.69.4"
+
 [[audits.bitmaps]]
 who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
@@ -343,6 +348,11 @@ who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.2.8"
 
+[[audits.librocksdb-sys]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.16.0+8.10.0"
+
 [[audits.memchr]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
@@ -357,6 +367,11 @@ version = "0.34.1"
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.32.1"
+
+[[audits.mysql_common]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.32.4"
 
 [[audits.nested]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"
@@ -578,6 +593,11 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 delta = "0.16.20 -> 0.17.7"
 
+[[audits.rocksdb]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.22.0"
+
 [[audits.rustls-pemfile]]
 who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
@@ -691,6 +711,11 @@ version = "0.12.0@git:0c26e5e4198085d6c90db11930f2dba52e9f32cc"
 [[audits.tokio-postgres]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
+version = "0.7.8@git:02336bebb28507665184c21566e5d1dc8de1dd7d"
+
+[[audits.tokio-postgres]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
 version = "0.7.8@git:02336bebb28507665184c21566e5d1dc8de1dd7d"
 
 [[audits.tokio-postgres]]

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -742,10 +742,6 @@ criteria = "safe-to-deploy"
 version = "0.7.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.librocksdb-sys]]
-version = "0.11.0+8.3.2@git:ab3684f999a5586d7a5e94bd65defd78af15d40f"
-criteria = "safe-to-deploy"
-
 [[exemptions.libz-sys]]
 version = "1.1.8"
 criteria = "safe-to-deploy"
@@ -1144,10 +1140,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rlimit]]
 version = "0.8.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.rocksdb]]
-version = "0.21.0@git:ab3684f999a5586d7a5e94bd65defd78af15d40f"
 criteria = "safe-to-deploy"
 
 [[exemptions.ropey]]

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -629,13 +629,6 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
-[[publisher.rustflags]]
-version = "0.1.4"
-when = "2023-07-15"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
 [[publisher.rustix]]
 version = "0.37.15"
 when = "2023-04-26"

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -78,7 +78,7 @@ def target_features(arch: Arch) -> list[str]:
     Sync: This list of features should be kept in sync with the one in ci-builder and .cargo/config.
     """
     if arch == Arch.X86_64:
-        return ["+aes"]
+        return ["+aes", "+pclmulqdq"]
     elif arch == Arch.AARCH64:
         return ["+aes", "+sha2"]
     else:

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -31,7 +31,7 @@ mz-txn-wal = { path = "../txn-wal" }
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 regex = "1.7.0"
-rocksdb = { git = "https://github.com/MaterializeInc/rust-rocksdb", branch = "master", default-features = false, features = ["snappy", "zstd", "lz4"] }
+rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", "zstd", "lz4"] }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -19,7 +19,7 @@ mz-ore = { path = "../ore", features = ["async"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ssh-util = { path = "../ssh-util" }
-mysql_common = { version = "0.32.1", default-features = false, features = ["chrono"] }
+mysql_common = { version = "0.32.4", default-features = false, features = ["chrono"] }
 mysql_async = { version = "0.34.1", default-features = false, features = ["minimal", "tracing"] }
 once_cell = "1.16.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -32,7 +32,7 @@ tracing = "0.1.37"
 # https://github.com/google/snappy/blob/main/COPYING
 # https://github.com/lz4/lz4/blob/dev/LICENSE
 # https://github.com/facebook/zstd
-rocksdb = { git = "https://github.com/MaterializeInc/rust-rocksdb", branch = "master", default-features = false, features = ["snappy", "zstd", "lz4"] }
+rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", "zstd", "lz4"] }
 uncased = "0.9.7"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/rocksdb/src/config.rs
+++ b/src/rocksdb/src/config.rs
@@ -200,8 +200,8 @@ fn fmt_write_buffer_manager(
 ) -> Result<(), std::fmt::Error> {
     fmt.debug_struct("WriteBufferManager")
         .field("enabled", &buf.enabled())
-        .field("buffer_size", &buf.buffer_size())
-        .field("memory_usage", &buf.memory_usage())
+        .field("buffer_size", &buf.get_buffer_size())
+        .field("memory_usage", &buf.get_usage())
         .finish()
 }
 
@@ -361,7 +361,7 @@ pub(crate) fn get_write_buffer_manager(
         let write_buffer_manager_bytes = current_cluster_max_buffer_limit
             .or(*write_buffer_manager_memory_bytes)
             .unwrap();
-        Some(WriteBufferManager::new_with_allow_stall(
+        Some(WriteBufferManager::new_write_buffer_manager(
             write_buffer_manager_bytes,
             *write_buffer_manager_allow_stall,
         ))
@@ -413,7 +413,7 @@ mod test {
         let write_buffer_manager = write_buffer_manager.unwrap();
         assert!(write_buffer_manager.enabled());
         assert_eq!(
-            write_buffer_manager.buffer_size(),
+            write_buffer_manager.get_buffer_size(),
             config.write_buffer_manager_memory_bytes.unwrap()
         )
     }
@@ -433,6 +433,6 @@ mod test {
         let write_buffer_manager = write_buffer_manager.unwrap();
         assert!(write_buffer_manager.enabled());
         // the limit should be 50% of 2000 i.e. 1000
-        assert_eq!(write_buffer_manager.buffer_size(), 1000)
+        assert_eq!(write_buffer_manager.get_buffer_size(), 1000)
     }
 }

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -343,7 +343,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
         // Arc will be dropped by the end of this scope
         let buf = shared_write_buffer_manager.get().unwrap();
         assert!(buf.enabled());
-        assert_eq!(write_buffer_memory_bytes, buf.buffer_size());
+        assert_eq!(write_buffer_memory_bytes, buf.get_buffer_size());
     }
 
     let updated_bytes = 20000;
@@ -371,7 +371,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
     {
         let buf = shared_write_buffer_manager.get().unwrap();
         assert!(buf.enabled());
-        assert_eq!(write_buffer_memory_bytes, buf.buffer_size());
+        assert_eq!(write_buffer_memory_bytes, buf.get_buffer_size());
     }
 
     instance2.close().await?;
@@ -398,7 +398,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
         let buf = shared_write_buffer_manager.get().unwrap();
         assert!(buf.enabled());
         // The new instance will now use the updated write buffer manager
-        assert_eq!(updated_bytes, buf.buffer_size());
+        assert_eq!(updated_bytes, buf.get_buffer_size());
     }
 
     instance3.close().await?;

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -35,7 +35,7 @@ indexmap = { version = "2.0.0", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
 maplit = "1.0.2"
 mysql_async = { version = "0.34.1", default-features = false, features = ["minimal", "binlog"] }
-mysql_common = { version = "0.32.1", default-features = false, features = ["chrono"] }
+mysql_common = { version = "0.32.4", default-features = false, features = ["chrono"] }
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-build-info = { path = "../build-info" }
@@ -77,11 +77,7 @@ rdkafka = { version = "0.29.0", features = [
     "zstd",
 ] }
 regex = { version = "1.7.0" }
-rocksdb = { git = "https://github.com/MaterializeInc/rust-rocksdb", branch = "master", default-features = false, features = [
-    "snappy",
-    "zstd",
-    "lz4",
-] }
+rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", "zstd", "lz4"] }
 seahash = "4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -56,7 +56,8 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 insta = { version = "1.33.0", features = ["json"] }
-itertools = { version = "0.10.5" }
+itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12.1" }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10.5" }
 k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_28"] }
 kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
 kube-client = { version = "0.87.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
@@ -69,7 +70,7 @@ mime_guess = { version = "2.0.3" }
 minimal-lexical = { version = "0.2.1", default-features = false, features = ["std"] }
 mio = { version = "0.8.11", features = ["net", "os-ext"] }
 mysql_async = { git = "https://github.com/MaterializeInc/mysql_async", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
-mysql_common = { version = "0.32.1", default-features = false, features = ["binlog", "chrono"] }
+mysql_common = { version = "0.32.4", default-features = false, features = ["binlog", "chrono"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
@@ -179,7 +180,8 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 hyper = { version = "0.14.27", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 insta = { version = "1.33.0", features = ["json"] }
-itertools = { version = "0.10.5" }
+itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12.1" }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10.5" }
 k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_28"] }
 kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
 kube-client = { version = "0.87.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
@@ -192,7 +194,7 @@ mime_guess = { version = "2.0.3" }
 minimal-lexical = { version = "0.2.1", default-features = false, features = ["std"] }
 mio = { version = "0.8.11", features = ["net", "os-ext"] }
 mysql_async = { git = "https://github.com/MaterializeInc/mysql_async", default-features = false, features = ["binlog", "minimal", "native-tls-tls", "tracing"] }
-mysql_common = { version = "0.32.1", default-features = false, features = ["binlog", "chrono"] }
+mysql_common = { version = "0.32.4", default-features = false, features = ["binlog", "chrono"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
@@ -276,6 +278,7 @@ pathdiff = { version = "0.2.1", default-features = false, features = ["camino"] 
 ring = { version = "0.17.7", features = ["std"] }
 
 [target.x86_64-apple-darwin.dependencies]
+bitflags = { version = "2.4.1", default-features = false, features = ["std"] }
 camino = { version = "1.1.7", default-features = false, features = ["serde1"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 pathdiff = { version = "0.2.1", default-features = false, features = ["camino"] }
@@ -283,6 +286,7 @@ ring = { version = "0.17.7", features = ["std"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
+bitflags = { version = "2.4.1", default-features = false, features = ["std"] }
 camino = { version = "1.1.7", default-features = false, features = ["serde1"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 pathdiff = { version = "0.2.1", default-features = false, features = ["camino"] }


### PR DESCRIPTION
This PR upgrades our `rust-rocksdb` dependency to use the upstream version instead of our fork since the changes in our fork related to the `WriteBufferManager` have been released. 

Note: we do lose the changes to `rust-rocksdb` that [specify the CPU type](https://github.com/MaterializeInc/rust-rocksdb/pull/2) when building `librocksdb`, but there was never any concrete evidence that this improved performance. It's also something we can easily re-introduce with Bazel if need be. If this is deemed important, I did make branch of our fork that [merges upstream](https://github.com/MaterializeInc/rust-rocksdb/pull/3).

To prevent a duplicate dependency of `bindgen` I also upgraded `mysql_common` which also resulted in various `postgres` crates getting updated with changes @benesch recently pushed to our fork.

### Motivation

I wanted to upgrade `rust-rocksdb` so we could build in Bazel with `cmake` instead of having to write a custom build target that includes our extensions.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
