### PR TITLE
bazel: Update BUILD files for `rocksdb` and `librdkafka`

### DIFF
--- a/misc/bazel/c_deps/BUILD.openssl.bazel
+++ b/misc/bazel/c_deps/BUILD.openssl.bazel
@@ -152,3 +152,14 @@ select_file(
     subpath = "include",
     visibility = ["//visibility:public"],
 )
+
+copy_to_directory(
+    name = "openssl_root",
+    srcs = [
+        ":libssl_copy",
+        ":libcrypto_copy",
+        ":openssl_include",
+    ],
+    root_paths = [".", "openssl"],
+    visibility = ["//visibility:public"],
+)

--- a/misc/bazel/c_deps/rust-sys/BUILD.librdkafka.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.librdkafka.bazel
@@ -31,11 +31,43 @@ cmake(
     lib_source = ":all_srcs",
     build_args = ["-j8"],
     generate_args = [
+        # Features enabled by the Rust `rdkafka-sys` crate.
         "-DRDKAFKA_BUILD_STATIC=1",
         "-DRDKAFKA_BUILD_TESTS=0",
         "-DRDKAFKA_BUILD_EXAMPLES=0",
         "-DCMAKE_INSTALL_LIBDIR=lib",
+        "-DWITH_ZLIB=1",
+        "-DWITH_ZSTD=1",
+        "-DWITH_SSL=1",
+        "-DWITH_SASL_SCRAM=1",
+        "-DWITH_SASL_OAUTHBEARER=1",
+        # Additional features of librdkafka that we disable.
+        "-DWITH_CURL=0",
+        "-DWITH_SASL=0",
+        "-DENABLE_LZ4_EXT=0",
+        # `cmake` tries _very_ hard to find libraries to link against, and it
+        # generally prefers dynamic libraries in the sysroot, which is exactly
+        # what we don't want because it breaks hermeticity.
+        #
+        # We set a number of options here to limit what `cmake` will search for
+        # so we link against our static libraries.
+        "-DCMAKE_POLICY_DEFAULT_CMP0074=NEW",
+        "-DCMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH=0",
+        "-DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=0",
+        "-DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=0",
+        # Uncomment this if you ever need to debug what library cmake is resolving.
+        # "-DCMAKE_FIND_DEBUG_MODE=TRUE",
     ],
+    env = {
+        # Note: casing here is important.
+        "OpenSSL_ROOT": "$(execpath @openssl//:openssl_root)",
+    },
+    deps = [
+        "@zlib//:zlib",
+        "@openssl//:openssl",
+        "@zstd//:zstd",
+    ],
+    build_data = ["@openssl//:openssl_root"],
     out_static_libs = ["librdkafka.a"],
 )
 

--- a/misc/bazel/c_deps/rust-sys/BUILD.rocksdb.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.rocksdb.bazel
@@ -129,25 +129,31 @@ cmake(
         "-DWITH_SNAPPY=1",
         "-DWITH_LZ4=1",
         "-DWITH_ZSTD=1",
-        "-DWITH_ZLIB=1",
-        "-DWITH_BZIP2=1",
         "-DWITH_GFLAGS=OFF",
         "-DWITH_ALL_TESTS=OFF",
         "-DWITH_TESTS=OFF",
         "-DWITH_TOOLS=OFF",
         "-DUSE_RTTI=1",
         "-DROCKSDB_BUILD_SHARED=OFF",
+        # `cmake` tries _very_ hard to find libraries to link against, and it
+        # generally prefers dynamic libraries in the sysroot, which is exactly
+        # what we don't want because it breaks hermeticity.
+        #
+        # We set a number of options here to limit what `cmake` will search for
+        # so we link against our static libraries.
+        "-DCMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH=0",
+        "-DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=0",
+        "-DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=0",
+        # Uncomment this if you ever need to debug what library cmake is resolving.
+        # "-DCMAKE_FIND_DEBUG_MODE=TRUE",
     ],
     lib_source = ":rocksdb_srcs",
     targets = ["rocksdb"],
     out_static_libs = ["librocksdb.a"],
     deps = [
         ":snappy",
-        "@jemalloc//:jemalloc",
         "@lz4//:lz4",
         "@zstd//:zstd",
-        "@zlib//:zlib",
-        "@bzip2//:bzip2",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This PR updates the build targets for `rocksdb` and `librdkafka` to align with their respective Rust build scripts, and make sure `cmake` is linking against the correct libraries.

When getting an end-to-end build of `environmentd` and `clusterd` to work, we were failing at the last linking step because of missing symbols. The issue turned out to be that `cmake` was preferring the version of OpenSSLv3 that existed on my local machine as opposed to the OpenSSLv1.1.1w that we build with Bazel. We set some specific flags for `cmake` to prevent it from searching the system, and instead provide an OpenSSL root path.

For `rocksdb` we were failing to find the symbols from our `c_api_extension.h` that includes support `WriteBufferManager`. This is totally an oversight on my part because the `rocksdb` Cmake rules know nothing about our fork's extensions. In https://github.com/MaterializeInc/materialize/pull/27698 we upgrade `rocksdb` to the upstream version that now includes support for the `WriteBufferManager` which fixes the issue. We also set the same flags as `librdkafka` to make sure we're linking against the correct external libraries.

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/26796

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
