### PR TITLE
bazel: Update cargo-gazelle to generate platform specific features and dependencies

### DIFF
--- a/misc/bazel/cargo-gazelle/src/lib.rs
+++ b/misc/bazel/cargo-gazelle/src/lib.rs
@@ -463,7 +463,7 @@ impl ToBazelDefinition for Glob {
 /// let features = [(PlatformVariant::Aarch64MacOS, features)];
 ///
 /// let select: Select<List<QuotedString>> = Select::new(features, List::empty());
-/// assert_eq!(select.to_bazel_definition(), "select({\n\t\"macos_arm\": [\"json\"],\n\t\"//conditions:default\": [],\n})");
+/// assert_eq!(select.to_bazel_definition(), "select({\n\t\"@//misc/bazel/platforms:macos_arm\": [\"json\"],\n\t\"//conditions:default\": [],\n})");
 /// ```
 #[derive(Debug)]
 pub struct Select<T> {

--- a/misc/bazel/cargo-gazelle/src/platforms.rs
+++ b/misc/bazel/cargo-gazelle/src/platforms.rs
@@ -1,0 +1,83 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use guppy::platform::{Platform, PlatformSpec, TargetFeatures, Triple};
+use once_cell::sync::Lazy;
+
+use crate::ToBazelDefinition;
+
+static AARCH64_MAC_OS: Lazy<PlatformSpec> = Lazy::new(|| {
+    let triple = Triple::new("aarch64-apple-darwin").unwrap();
+    PlatformSpec::Platform(Arc::new(Platform::from_triple(triple, TargetFeatures::All)))
+});
+static X86_64_MAC_OS: Lazy<PlatformSpec> = Lazy::new(|| {
+    let triple = Triple::new("x86_64-apple-darwin").unwrap();
+    PlatformSpec::Platform(Arc::new(Platform::from_triple(triple, TargetFeatures::All)))
+});
+static AARCH64_LINUX_GNU: Lazy<PlatformSpec> = Lazy::new(|| {
+    let triple = Triple::new("aarch64-unknown-linux-gnu").unwrap();
+    PlatformSpec::Platform(Arc::new(Platform::from_triple(triple, TargetFeatures::All)))
+});
+static X86_64_LINUX_GNU: Lazy<PlatformSpec> = Lazy::new(|| {
+    let triple = Triple::new("x86_64-unknown-linux-gnu").unwrap();
+    PlatformSpec::Platform(Arc::new(Platform::from_triple(triple, TargetFeatures::All)))
+});
+
+/// Defines the various platforms we support building for.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PlatformVariant {
+    /// `aarch64-apple-darwin`
+    Aarch64MacOS,
+    /// `x86_64-apple-darwin`
+    X86_64MacOS,
+    /// `aarch64-unknown-linux-gnu`
+    Aarch64Linux,
+    /// `x86_64-unknown-linux-gnu`
+    X86_64Linux,
+}
+
+impl PlatformVariant {
+    const ALL: &'static [PlatformVariant] = &[
+        PlatformVariant::Aarch64MacOS,
+        PlatformVariant::X86_64MacOS,
+        PlatformVariant::Aarch64Linux,
+        PlatformVariant::X86_64Linux,
+    ];
+
+    pub fn spec(&self) -> &PlatformSpec {
+        match self {
+            PlatformVariant::Aarch64MacOS => &*AARCH64_MAC_OS,
+            PlatformVariant::X86_64MacOS => &*X86_64_MAC_OS,
+            PlatformVariant::Aarch64Linux => &*AARCH64_LINUX_GNU,
+            PlatformVariant::X86_64Linux => &*X86_64_LINUX_GNU,
+        }
+    }
+
+    pub fn all() -> &'static [PlatformVariant] {
+        Self::ALL
+    }
+}
+
+impl ToBazelDefinition for PlatformVariant {
+    fn format(&self, writer: &mut dyn std::fmt::Write) -> Result<(), std::fmt::Error> {
+        use PlatformVariant::*;
+
+        // These names are defined in our own platform spec in `/misc/bazel/platforms`.
+        let s = match self {
+            Aarch64MacOS => "@//misc/bazel/platforms:macos_arm",
+            X86_64MacOS => "@//misc/bazel/platforms:macos_x86_64",
+            Aarch64Linux => "@//misc/bazel/platforms:linux_arm",
+            X86_64Linux => "@//misc/bazel/platforms:linux_x86_64",
+        };
+
+        write!(writer, "\"{s}\"")
+    }
+}


### PR DESCRIPTION
This PR updates cargo-gazelle to generate `crate-features` and `dependencies` based on platform. For example, the [`mz-alloc-default` crate](https://github.com/MaterializeInc/materialize/blob/main/src/alloc-default/Cargo.toml#L30-L31) enables the `jemalloc` feature on `alloc` if the platform is not `macos`.

After this PR we'll generate a `rust_library` target like:

```
rust_library(
	name = "mz_alloc",
	srcs = glob(["src/**/*.rs"]),
	crate_features = ["default"] + select({
		"@//misc/bazel/platforms:linux_arm": [
			"jemalloc",
			"mz-prof",
			"tikv-jemallocator",
		],
		"@//misc/bazel/platforms:linux_x86_64": [
			"jemalloc",
			"mz-prof",
			"tikv-jemallocator",
		],
		"//conditions:default": [],
	}),
	aliases = aliases(
		normal = True,
		proc_macro = True,
	),
	deps = [
		"//src/ore:mz_ore",
		"//src/prof-http:mz_prof_http",
		"//src/prof:mz_prof",
	] + all_crate_deps(normal = True),
	proc_macro_deps = [] + all_crate_deps(proc_macro = True),
	compile_data = [],
	data = [],
	rustc_flags = [],
	rustc_env = {},
)
```

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/27381

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
