### PR TITLE
tests: kafka-sink-topic-config.td: disable status check when using Redpanda

### DIFF
--- a/test/cloudtest/test_full_testdrive.py
+++ b/test/cloudtest/test_full_testdrive.py
@@ -30,4 +30,4 @@ def test_full_testdrive(mz: MaterializeApplication) -> None:
     # TODO: #26392 (test requires fivetran running in cloudtest)
     mz.testdrive.delete("/workdir/testdrive/fivetran-destination.td")
 
-    mz.testdrive.run(f"testdrive/{file_pattern}")
+    mz.testdrive.run("--var=uses-redpanda=True", f"testdrive/{file_pattern}")

--- a/test/testdrive/kafka-sink-topic-config.td
+++ b/test/testdrive/kafka-sink-topic-config.td
@@ -74,5 +74,8 @@ $ kafka-verify-topic sink=materialize.public.topic_config partition-count=1 topi
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
+$ skip-if
+SELECT '${arg.uses-redpanda}'::BOOL
+
 > SELECT status, error FROM mz_internal.mz_sink_statuses WHERE name = 'topic_config_unknown';
 stalled "kafka: Error creating topic testdrive-kafka-config-unknown-${testdrive.seed} for sink: Admin operation error: InvalidConfig (Broker: Configuration is invalid)"

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -95,6 +95,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         external_minio=True,
         fivetran_destination=True,
         fivetran_destination_files_path="/share/tmp",
+        entrypoint_extra=[f"--var=uses-redpanda={args.redpanda}"],
     )
 
     sysparams = args.system_param


### PR DESCRIPTION
This should fix https://github.com/MaterializeInc/materialize/issues/27648.

Nightly: https://buildkite.com/materialize/nightly/builds/8133