### PR TITLE
ore: make `halt!` use `_exit` to avoid exit handler races

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5271,6 +5271,7 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "lgalloc",
+ "libc",
  "mz-ore",
  "mz-ore-proc",
  "native-tls",

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -90,7 +90,6 @@ steps:
       timeout_in_minutes: 2880
       agents:
         queue: linux-aarch64-large
-      skip: "Reenable when #21751 is fixed"
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -46,7 +46,7 @@ mz-expr = { path = "../expr" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-mysql-util = { path = "../mysql-util" }
 mz-orchestrator = { path = "../orchestrator" }
-mz-ore = { path = "../ore", features = ["chrono", "async", "tracing_"] }
+mz-ore = { path = "../ore", features = ["chrono", "async", "process", "tracing_"] }
 mz-persist-types = { path = "../persist-types" }
 mz-persist-client = { path = "../persist-client" }
 mz-pgcopy = { path = "../pgcopy" }

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -20,7 +20,7 @@ differential-dataflow = "0.12.0"
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }
 mz-cluster-client = { path = "../cluster-client" }
-mz-ore = { path = "../ore", features = ["async", "tracing_"] }
+mz-ore = { path = "../ore", features = ["async", "process", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-pid-file = { path = "../pid-file" }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -30,7 +30,7 @@ mz-compute-types = { path = "../compute-types" }
 mz-dyncfg = { path = "../dyncfg" }
 mz-dyncfgs = { path = "../dyncfgs" }
 mz-expr = { path = "../expr" }
-mz-ore = { path = "../ore", features = ["async", "tracing_"] }
+mz-ore = { path = "../ore", features = ["async", "process", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-pid-file = { path = "../pid-file" }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -23,7 +23,7 @@ mz-orchestrator = { path = "../orchestrator" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["process"] }
 mz-repr = { path = "../repr" }
 mz-service = { path = "../service" }
 mz-storage-client = { path = "../storage-client" }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -57,7 +57,7 @@ mz-orchestrator = { path = "../orchestrator" }
 mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes" }
 mz-orchestrator-process = { path = "../orchestrator-process" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
-mz-ore = { path = "../ore", features = ["async", "tracing_"] }
+mz-ore = { path = "../ore", features = ["async", "process", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-pgwire = { path = "../pgwire" }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -31,6 +31,7 @@ either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
 hibitset = { version = "0.6.4", optional = true }
 lgalloc = { version = "0.3", optional = true }
+libc = { version = "0.2.138", optional = true }
 mz-ore-proc = { path = "../ore-proc", default-features = false }
 num = "0.4.0"
 once_cell = "1.16.0"
@@ -115,6 +116,7 @@ async = [
 ]
 bytes_ = ["bytes", "compact_bytes", "smallvec", "smallvec/const_generics", "region", "tracing_"]
 network = ["async", "bytes", "hyper", "smallvec", "tonic", "tracing"]
+process = ["libc"]
 region = ["lgalloc"]
 tracing_ = [
   "anyhow",

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -69,6 +69,7 @@ pub mod option;
 pub mod panic;
 pub mod path;
 pub mod permutations;
+#[cfg(feature = "process")]
 pub mod process;
 #[cfg(feature = "region")]
 pub mod region;

--- a/src/ore/src/process.rs
+++ b/src/ore/src/process.rs
@@ -42,6 +42,13 @@
 macro_rules! halt {
     ($($arg:expr),* $(,)?) => {{
         $crate::__private::tracing::warn!("halting process: {}", format!($($arg),*));
-            ::std::process::exit(2);
+        $crate::process::halt();
     }}
+}
+
+/// Helper for the `halt!` macro.
+///
+/// This function exists to avoid that all callers of `halt!` have to explicitly depend on `libc`.
+pub fn halt() -> ! {
+    unsafe { libc::_exit(2) };
 }

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -42,7 +42,7 @@ hex = "0.4.3"
 itertools = "0.10.5"
 mz-build-info = { path = "../build-info" }
 mz-dyncfg = { path = "../dyncfg" }
-mz-ore = { path = "../ore", features = ["bytes_", "test", "tracing_"] }
+mz-ore = { path = "../ore", features = ["bytes_", "process", "test", "tracing_"] }
 mz-persist = { path = "../persist" }
 mz-persist-proc = { path = "../persist-proc" }
 mz-persist-types = { path = "../persist-types" }

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -23,7 +23,7 @@ mz-ccsr = { path = "../ccsr" }
 mz-cluster-client = { path = "../cluster-client" }
 mz-dyncfgs = { path = "../dyncfgs" }
 mz-kafka-util = { path = "../kafka-util" }
-mz-ore = { path = "../ore", features = ["async", "tracing_"] }
+mz-ore = { path = "../ore", features = ["async", "process", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto", features = ["tokio-postgres"] }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -15,7 +15,7 @@ futures-util = "0.3.25"
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 serde = { version = "1.0.152", features = ["derive"] }
-mz-ore = { path = "../ore", features = ["async", "tracing_", "test"] }
+mz-ore = { path = "../ore", features = ["async", "process", "tracing_", "test"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "time"] }
 num-traits = "0.2"

--- a/src/txn-wal/Cargo.toml
+++ b/src/txn-wal/Cargo.toml
@@ -15,7 +15,7 @@ bytes = { version = "1.3.0" }
 differential-dataflow = "0.12.0"
 futures = "0.3.25"
 itertools = { version = "0.10.5" }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["process"] }
 mz-dyncfg = { path = "../dyncfg" }
 mz-persist-types = { path = "../persist-types" }
 mz-persist-client = { path = "../persist-client" }


### PR DESCRIPTION
This PR fixes a soundness hole introduced by multiple threads calling `halt!` at the same time, thereby invoking thread-unsafe the libc `exit` function concurrently, which would lead to use-after-frees and segfaults. The fix is to call `_exit` instead, which is thread-safe.

### Motivation

  * This PR fixes a recognized bug.

Fixes #21751

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A