### PR TITLE
compute: introspection subscribes (controller-managed)

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -64,6 +64,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_columnation_lgalloc": "true",
     "enable_comment": "true",
     "enable_compute_chunked_stack": "true",
+    "enable_compute_introspection_subscribes": "true",
     "enable_connection_validation_syntax": "true",
     "enable_copy_to_expr": "true",
     "enable_disk_cluster_replicas": "true",

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -73,6 +73,7 @@ use crate::protocol::response::{ComputeResponse, PeekResponse, SubscribeBatch};
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
 mod instance;
+mod introspection;
 mod replica;
 mod sequential_hydration;
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -21,6 +21,7 @@ use futures::{future, StreamExt};
 use mz_build_info::BuildInfo;
 use mz_cluster_client::client::{ClusterStartupEpoch, TimelyConfig};
 use mz_compute_types::dataflows::{BuildDesc, DataflowDescription};
+use mz_compute_types::dyncfgs::ENABLE_INTROSPECTION_SUBSCRIBES;
 use mz_compute_types::plan::flat_plan::FlatPlan;
 use mz_compute_types::plan::LirId;
 use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, PersistSinkConnection};
@@ -997,6 +998,10 @@ where
     }
 
     fn install_introspection_subscribes(&mut self, replica_id: ReplicaId) {
+        if !ENABLE_INTROSPECTION_SUBSCRIBES.get(&self.dyncfg) {
+            return;
+        }
+
         let subscribes = self
             .unified_introspection
             .init_subscribes_for_replica(replica_id);

--- a/src/compute-client/src/controller/introspection.rs
+++ b/src/compute-client/src/controller/introspection.rs
@@ -1,0 +1,370 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Support for unified compute introspection.
+//!
+//! Unified compute introspection is the process of collecting introspection data exported by
+//! individual replicas through their logging indexes and then writing that data, tagged with the
+//! respective replica ID, to "unified" storage collections. These storage collections then allow
+//! querying introspection data across all replicas and regardless of the health of individual
+//! replicas.
+//!
+//! # Lifecycle of Introspection Subscribes
+//!
+//! * When the controller adds a replica ([`Instance::add_replica`]) it calls
+//!   [`UnifiedIntrospection::init_subscribes_for_replica`] to initialize a new set of
+//!   introspection subscribes for the new replica. [`UnifiedIntrospection`] initializes tracking
+//!   for the new subscribes and returns to the controller a set of [`DataflowDescription`]s to
+//!   install.
+//! * Whenever the controller receives a response for an introspection subscribe, it forwards the
+//!   [`SubscribeBatch`] to [`UnifiedIntrospection::report_subscribe_updates`].
+//!   [`UnifiedIntrospection`] sends these updates through its `introspection_tx`, to get them
+//!   durably recorded.
+//! * When the controller removes a replica ([`Instance::remove_replica`]) it cancels all
+//!   replica-targeted subscribes. As part of doing so it calls
+//!   [`UnifiedIntrospection::drop_subscribe`] for each introspection subscribe.
+//!   [`UnifiedIntrospection`] removes tracking for the dropped subscribe and sends a deletion
+//!   request through its `introspection_tx`, to remove all updates previously recorded for this
+//!   subscribe.
+//!
+//! Subscribe errors are unexpected for introspection subscribes, except for
+//! [`ERROR_TARGET_REPLICA_FAILED`], which is produced by [`Instance::remove_replica`].
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use mz_compute_types::dataflows::{BuildDesc, DataflowDescription, IndexDesc, IndexImport};
+use mz_compute_types::plan::reduce::{AccumulablePlan, KeyValPlan, ReducePlan};
+use mz_compute_types::plan::{AvailableCollections, GetPlan, LirId, Plan};
+use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection};
+use mz_expr::{
+    permutation_for_arrangement, AggregateExpr, AggregateFunc, Id, MapFilterProject, MirScalarExpr,
+};
+use mz_ore::collections::CollectionExt;
+use mz_ore::id_gen::IdGen;
+use mz_ore::soft_panic_or_log;
+use mz_repr::fixed_length::ToDatumIter;
+use mz_repr::global_id::TransientIdGen;
+use mz_repr::{Datum, GlobalId, RelationDesc, RelationType, Row, ScalarType};
+use mz_storage_client::controller::IntrospectionType;
+use timely::progress::Timestamp;
+use tracing::info;
+
+use crate::controller::instance::ERROR_TARGET_REPLICA_FAILED;
+use crate::controller::{IntrospectionUpdates, ReplicaId};
+use crate::logging::{ComputeLog, LogVariant};
+use crate::protocol::response::SubscribeBatch;
+
+/// Managment state for unified introspection.
+#[derive(Debug)]
+pub(super) struct UnifiedIntrospection {
+    /// The tracked introspection subscribes.
+    subscribes: BTreeMap<GlobalId, IntrospectionSubscribe>,
+    /// Types of logging indexes and their assigned `GlobalId`s.
+    log_indexes: BTreeMap<LogVariant, GlobalId>,
+    /// Sender for introspection updates collected by introspection subscribes.
+    #[allow(dead_code)] // TODO(#26730)
+    introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
+    /// Generator for transient `GlobalId`s.
+    id_gen: Arc<TransientIdGen>,
+}
+
+impl UnifiedIntrospection {
+    pub fn new(
+        log_indexes: BTreeMap<LogVariant, GlobalId>,
+        introspection_tx: crossbeam_channel::Sender<IntrospectionUpdates>,
+        id_gen: Arc<TransientIdGen>,
+    ) -> Self {
+        Self {
+            subscribes: Default::default(),
+            log_indexes,
+            introspection_tx,
+            id_gen,
+        }
+    }
+
+    /// Returns whether the identified subscribe is a tracked introspection subscribe.
+    pub fn tracks_subscribe(&self, id: GlobalId) -> bool {
+        self.subscribes.contains_key(&id)
+    }
+
+    /// Initializes introspection subscribe tracking for the given replica.
+    ///
+    /// Returns the set of subscribe dataflows that should be installed on the replica and whose
+    /// results should be reported back via `absorb_subscribe_updates`.
+    pub fn init_subscribes_for_replica<T: Timestamp>(
+        &mut self,
+        replica_id: ReplicaId,
+    ) -> Vec<(GlobalId, DataflowDescription<Plan<T>, (), T>)> {
+        vec![self.init_subscribe(
+            replica_id,
+            IntrospectionType::ComputeErrorCounts,
+            build_subscribe_error_counts,
+        )]
+    }
+
+    fn init_subscribe<T, F>(
+        &mut self,
+        replica_id: ReplicaId,
+        introspection_type: IntrospectionType,
+        build: F,
+    ) -> (GlobalId, DataflowDescription<Plan<T>, (), T>)
+    where
+        F: Fn(SubscribeBuilder) -> DataflowDescription<Plan<T>, (), T>,
+    {
+        let sink_id = self.id_gen.allocate_id();
+        let view_id = self.id_gen.allocate_id();
+        let builder = SubscribeBuilder::new(&self.log_indexes, sink_id, view_id);
+        let dataflow = build(builder);
+
+        let subscribe = IntrospectionSubscribe {
+            replica_id: replica_id.to_string(),
+            introspection_type,
+        };
+        info!(%sink_id, ?subscribe, "initialized introspection subscribe");
+        self.subscribes.insert(sink_id, subscribe);
+
+        (sink_id, dataflow)
+    }
+
+    /// Drop an introspection subscribe.
+    pub fn drop_subscribe(&mut self, id: GlobalId) {
+        let Some(subscribe) = self.subscribes.remove(&id) else {
+            soft_panic_or_log!("attempt to drop unknown introspection subscribe (id={id})");
+            return;
+        };
+
+        let _filter = Box::new(|row: &Row| {
+            let replica_id = row.unpack_first();
+            replica_id == Datum::String(&subscribe.replica_id)
+        });
+        // TODO(#26730) send introspection deletions
+        //self.introspection_tx.send((
+        //    subscribe.introspection_type,
+        //    WriteCommand::Delete { filter },
+        //));
+
+        info!(%id, ?subscribe, "dropped introspection subscribe");
+    }
+
+    /// Report updates for an introspection subscribe.
+    pub fn report_subscribe_updates<T>(&mut self, id: GlobalId, batch: SubscribeBatch<T>) {
+        let Some(subscribe) = self.subscribes.get(&id) else {
+            soft_panic_or_log!("updates for unknown introspection subscribe (id={id})");
+            return;
+        };
+
+        let updates = match batch.updates {
+            Ok(updates) => updates,
+            // Errors caused by the target replica disconnecting are expected.
+            Err(error) if error == ERROR_TARGET_REPLICA_FAILED => return,
+            // All other errors are unexpected.
+            Err(error) => {
+                soft_panic_or_log!(
+                    "introspection subscribe produced an error: {error} \
+                     (id={id}, subscribe={subscribe:?})",
+                );
+                return;
+            }
+        };
+
+        // Prepend the `replica_id` to each row.
+        let _updates: Vec<_> = updates
+            .into_iter()
+            .map(|(_time, row, diff)| {
+                let datums = std::iter::once(Datum::String(&subscribe.replica_id))
+                    .chain(row.to_datum_iter());
+                let row = Row::pack(datums);
+                (row, diff)
+            })
+            .collect();
+
+        // TODO(#26730) send introspection updates
+        //self.introspection_tx.send((
+        //    subscribe.introspection_type,
+        //    WriteCommand::Append { updates },
+        //));
+    }
+}
+
+/// State tracked about an active introspection subscribe.
+#[derive(Debug)]
+struct IntrospectionSubscribe {
+    /// The ID of the targeted replica.
+    ///
+    /// Stored as a string to make packing into `Row`s more efficient.
+    replica_id: String,
+    /// The introspection type specifying the storage-managed collection to receive subscribe
+    /// updates.
+    #[allow(dead_code)] // TODO(#26730)
+    introspection_type: IntrospectionType,
+}
+
+/// A helper for building introspection subscribe dataflows.
+struct SubscribeBuilder<'a> {
+    /// Mapping from log variants to the IDs of their indexes.
+    index_ids: &'a BTreeMap<LogVariant, GlobalId>,
+    /// The ID used for the dataflow's sink export.
+    sink_id: GlobalId,
+    /// The ID used for the internal view that connects to the sink.
+    view_id: GlobalId,
+    /// A generator for [`LirId`]s.
+    lir_id_gen: IdGen,
+    /// Logging indexes that have been imported through `import_log`.
+    used_indexes: BTreeSet<LogVariant>,
+}
+
+impl<'a> SubscribeBuilder<'a> {
+    /// Creates a new `SubscribeBuilder` using the provided IDs.
+    fn new(
+        index_ids: &'a BTreeMap<LogVariant, GlobalId>,
+        sink_id: GlobalId,
+        view_id: GlobalId,
+    ) -> Self {
+        Self {
+            index_ids,
+            sink_id,
+            view_id,
+            lir_id_gen: Default::default(),
+            used_indexes: Default::default(),
+        }
+    }
+
+    /// Allocates a new [`LirId`].
+    fn allocate_lir_id(&mut self) -> LirId {
+        self.lir_id_gen.allocate_id()
+    }
+
+    /// Returns the key of the given index for the given [`LogVariant`].
+    fn log_key(log: LogVariant) -> Vec<MirScalarExpr> {
+        log.index_by()
+            .into_iter()
+            .map(MirScalarExpr::Column)
+            .collect()
+    }
+
+    /// Returns the relation type of the index for the given [`LogVariant`].
+    fn log_typ(log: LogVariant) -> RelationType {
+        log.desc().typ().clone()
+    }
+
+    /// Imports a logging index into the builder state, returns the corresponding `Get` plan.
+    fn import_log<T>(&mut self, log: LogVariant, mfp: MapFilterProject) -> Plan<T> {
+        self.used_indexes.insert(log);
+
+        let index_id = self.index_ids[&log];
+        let key = Self::log_key(log);
+        let column_types = Self::log_typ(log).column_types;
+        let arity = column_types.len();
+        let (permutation, thinning) = permutation_for_arrangement(&key, arity);
+
+        Plan::Get {
+            id: Id::Global(index_id),
+            keys: AvailableCollections::new_arranged(
+                vec![(key.clone(), permutation, thinning)],
+                Some(column_types),
+            ),
+            plan: GetPlan::Arrangement(key, None, mfp),
+            lir_id: self.allocate_lir_id(),
+        }
+    }
+
+    /// Transforms the given `plan` into a `DataflowDescription` for an introspection subscribe.
+    fn dataflow_description<T: Timestamp>(
+        &self,
+        plan: Plan<T>,
+        desc: RelationDesc,
+    ) -> DataflowDescription<Plan<T>, (), T> {
+        let mut index_imports = BTreeMap::new();
+        for log in &self.used_indexes {
+            let index_id = self.index_ids[log];
+            let import = IndexImport {
+                desc: IndexDesc {
+                    on_id: index_id,
+                    key: Self::log_key(*log),
+                },
+                typ: Self::log_typ(*log),
+                monotonic: false,
+            };
+            index_imports.insert(index_id, import);
+        }
+
+        let sink_desc = ComputeSinkDesc {
+            from: self.view_id,
+            from_desc: desc,
+            connection: ComputeSinkConnection::Subscribe(SubscribeSinkConnection {}),
+            with_snapshot: true,
+            up_to: Default::default(),
+            non_null_assertions: Default::default(),
+            refresh_schedule: None,
+        };
+
+        DataflowDescription {
+            source_imports: Default::default(),
+            index_imports,
+            objects_to_build: vec![BuildDesc {
+                id: self.view_id,
+                plan,
+            }],
+            index_exports: Default::default(),
+            sink_exports: [(self.sink_id, sink_desc)].into(),
+            as_of: None,
+            until: Default::default(),
+            initial_storage_as_of: None,
+            refresh_schedule: None,
+            debug_name: format!("introspection-subscribe-{}", self.sink_id),
+        }
+    }
+}
+
+/// Builds a dataflow for the `ComputeErrorCounts` subscribe.
+///
+/// The return dataflow corresponds to this SQL query:
+///
+/// ```sql
+/// SELECT export_id, sum(count)
+/// FROM <ComputeLog::ErrorCount>
+/// GROUP BY export_id
+/// ```
+fn build_subscribe_error_counts<T: Timestamp>(
+    mut builder: SubscribeBuilder,
+) -> DataflowDescription<Plan<T>, (), T> {
+    let desc = RelationDesc::empty()
+        .with_column("export_id", ScalarType::String.nullable(false))
+        .with_column("count", ScalarType::Int64.nullable(false))
+        .with_key(vec![0]);
+
+    // Import `ComputeLog::ErrorCount`, project away the `worker_id`.
+    let error_count = builder.import_log(
+        LogVariant::Compute(ComputeLog::ErrorCount),
+        MapFilterProject::new(3).project([0, 2]),
+    );
+
+    // Group by `export_id`, sum up `count`s.
+    let group_key = [MirScalarExpr::Column(0)];
+    let aggregates = [AggregateExpr {
+        func: AggregateFunc::SumInt64,
+        expr: MirScalarExpr::Column(1),
+        distinct: false,
+    }];
+    let reduce = Plan::Reduce {
+        input: Box::new(error_count),
+        key_val_plan: KeyValPlan::new(2, &group_key, &aggregates, None),
+        plan: ReducePlan::Accumulable(AccumulablePlan {
+            full_aggrs: aggregates.to_vec(),
+            simple_aggrs: vec![(0, 0, aggregates.into_element())],
+            distinct_aggrs: Default::default(),
+        }),
+        input_key: None,
+        mfp_after: MapFilterProject::new(2),
+        lir_id: builder.allocate_lir_id(),
+    };
+
+    builder.dataflow_description(reduce, desc)
+}

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -125,6 +125,13 @@ pub const PERSIST_SINK_OBEY_READ_ONLY: Config<bool> = Config::new(
     "Whether the compute persist_sink obeys read-only mode.",
 );
 
+/// Whether the compute controller should install introspection subscribes.
+pub const ENABLE_INTROSPECTION_SUBSCRIBES: Config<bool> = Config::new(
+    "enable_compute_introspection_subscribes",
+    false,
+    "Whether the compute controller should install introspection subscribes.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -142,4 +149,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&COPY_TO_S3_ARROW_BUILDER_BUFFER_RATIO)
         .add(&COPY_TO_S3_MULTIPART_PART_SIZE_BYTES)
         .add(&PERSIST_SINK_OBEY_READ_ONLY)
+        .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
 }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -87,6 +87,7 @@ pub enum IntrospectionType {
     ComputeHydrationStatus,
     ComputeOperatorHydrationStatus,
     ComputeMaterializedViewRefreshes,
+    ComputeErrorCounts,
 
     // Written by the Adapter for tracking AWS PrivateLink Connection Status History
     PrivatelinkConnectionStatusHistory,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -988,7 +988,8 @@ where
                         IntrospectionType::ComputeDependencies
                         | IntrospectionType::ComputeHydrationStatus
                         | IntrospectionType::ComputeOperatorHydrationStatus
-                        | IntrospectionType::ComputeMaterializedViewRefreshes => {
+                        | IntrospectionType::ComputeMaterializedViewRefreshes
+                        | IntrospectionType::ComputeErrorCounts => {
                             self.collection_manager.register_differential_collection(id, read_handle_fn);
                             // Differential collections start with an empty
                             // desired state. No need to manually reset.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2480,7 +2480,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_commands_total("allow_compaction")
     assert count > 0, f"got {count}"
     count = metrics.get_commands_total("create_dataflow")
-    assert count == 3, f"got {count}"
+    assert count >= 3, f"got {count}"
     count = metrics.get_commands_total("peek")
     assert count == 2, f"got {count}"
     count = metrics.get_commands_total("cancel_peek")
@@ -2514,7 +2514,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_responses_total("peek_response")
     assert count == 2, f"got {count}"
     count = metrics.get_responses_total("subscribe_response")
-    assert count == 0, f"got {count}"
+    assert count > 0, f"got {count}"
 
     # mz_compute_response_message_bytes_total
     count = metrics.get_response_bytes_total("frontiers")
@@ -2522,7 +2522,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_response_bytes_total("peek_response")
     assert count > 0, f"got {count}"
     count = metrics.get_response_bytes_total("subscribe_response")
-    assert count == 0, f"got {count}"
+    assert count > 0, f"got {count}"
 
     count = metrics.get_value("mz_compute_controller_replica_count")
     assert count == 1, f"got {count}"
@@ -2533,7 +2533,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_value("mz_compute_controller_peek_count")
     assert count == 0, f"got {count}"
     count = metrics.get_value("mz_compute_controller_subscribe_count")
-    assert count == 0, f"got {count}"
+    assert count > 0, f"got {count}"
     count = metrics.get_value("mz_compute_controller_command_queue_size")
     assert count < 10, f"got {count}"
     count = metrics.get_value("mz_compute_controller_response_queue_size")

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -429,6 +429,23 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             user="mz_system",
         )
 
+        if ArrangedIntro in disruption.compaction_checks:
+            # Disable introspection subscribes because they break the
+            # `ArrangedIntro` check by disabling compaction of logging indexes
+            # on all replicas if one of the replicas is failing. That's because
+            # of a defect of replica-targeted subscribes: They get installed on
+            # all replicas but only the targeted replica can drive the write
+            # frontier forward. If the targeted replica is crashing, the write
+            # frontier cannot advance and thus the read frontier cannot either.
+            #
+            # TODO(#27399): Fix this by installing targeted subscribes only on the
+            #               targeted replica.
+            c.sql(
+                "ALTER SYSTEM SET enable_compute_introspection_subscribes = false;",
+                port=6877,
+                user="mz_system",
+            )
+
         c.sql(
             """
             CREATE CLUSTER cluster1 REPLICAS (

--- a/test/testdrive/dataflow-cleanup.td
+++ b/test/testdrive/dataflow-cleanup.td
@@ -13,6 +13,10 @@
 # This test relies on testdrive's automatic retries, since it queries
 # introspection sources that take a while to update.
 
+# Introspection subscribes add noise to the introspection sources, so disable them.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_compute_introspection_subscribes = false
+
 # Create a clean replica to inspect dataflow state on.
 
 > DROP CLUSTER IF EXISTS test

--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -14,6 +14,13 @@
 # sources. This also serves to verify that logging is correctly cleaned up under
 # active dataflow cancellation.
 
+# Introspection subscribes add noise to the introspection sources, so disable them.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_compute_introspection_subscribes = false
+
+> CREATE CLUSTER test SIZE '1';
+> SET cluster = test;
+
 > CREATE VIEW divergent AS
   WITH MUTUALLY RECURSIVE
       flip(x int) AS (VALUES(1) EXCEPT ALL SELECT * FROM flip)
@@ -24,9 +31,6 @@
   WITH MUTUALLY RECURSIVE
       flip(x int) AS (VALUES(1) EXCEPT ALL SELECT * FROM flip)
   SELECT * FROM flip
-
-# In case the environment has other replicas
-> SET cluster_replica = r1
 
 # Ensure the dataflow was successfully installed.
 > SELECT count(*)
@@ -130,3 +134,6 @@ true
 # This source never sees retractions.
 > SELECT count(*) > 0 FROM mz_internal.mz_scheduling_parks_histogram_raw
 true
+
+# Cleanup.
+> DROP CLUSTER test CASCADE

--- a/test/testdrive/github-21031.td
+++ b/test/testdrive/github-21031.td
@@ -12,14 +12,13 @@
 # This test confirms that subscribes that advance to the empty frontier are
 # fully cleaned up.
 #
-
-# This test uses introspection queries that need to be targeted to a replica
-> SET cluster_replica = r1
-
 # This test relies on testdrive's automatic retries, since it queries
 # introspection sources that take a while to update.
 
 $ set-regex match=\d{13,20} replacement=<TIMESTAMP>
+
+# This test uses introspection queries that need to be targeted to a replica
+> SET cluster_replica = r1
 
 # Create a collection with an empty frontier to subscribe from.
 > CREATE MATERIALIZED VIEW mv AS SELECT 1 AS a
@@ -46,5 +45,9 @@ $ set-regex match=\d{13,20} replacement=<TIMESTAMP>
 > SELECT count(*) FROM mz_internal.mz_subscriptions
 0
 
-> SELECT count(*) FROM mz_internal.mz_compute_exports e WHERE e.export_id LIKE 't%'
+> SELECT count(*)
+  FROM mz_internal.mz_compute_exports e
+  JOIN mz_internal.mz_dataflows d ON d.id = e.dataflow_id
+  WHERE e.export_id LIKE 't%' AND
+        d.name NOT LIKE '%introspection-subscribe%'
 0

--- a/test/testdrive/hydration-status.td
+++ b/test/testdrive/hydration-status.td
@@ -26,24 +26,27 @@
 > CREATE CLUSTER test REPLICAS (hydrated_test_1 (SIZE '1'))
 > SET cluster = test
 
-# Test that on an empty cluster only the introspection dataflows show up.
+# Test that on an empty cluster only the introspection dataflows (indexes and
+# subscribes) show up.
 
 > SELECT DISTINCT left(h.object_id, 1), h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   WHERE r.name LIKE 'hydrated_test%';
 s true
+t true
 
+# `mz_hydration_statuses` does not report on transient dataflows.
 > SELECT DISTINCT left(h.object_id, 1), h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   WHERE r.name LIKE 'hydrated_test%';
 s true
 
 # No operator-level hydration status logging for introspection dataflows.
 > SELECT DISTINCT left(h.object_id, 1), h.hydrated
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   WHERE r.name LIKE 'hydrated_test%';
 
 # Test adding new compute dataflows.
@@ -55,8 +58,8 @@ s true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -66,8 +69,8 @@ mv_const hydrated_test_1 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -77,8 +80,8 @@ mv_const hydrated_test_1 true
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -93,8 +96,8 @@ mv_const hydrated_test_1 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -107,8 +110,8 @@ mv_const hydrated_test_2 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -124,8 +127,8 @@ mv_const hydrated_test_2 true
 # exist.
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -142,8 +145,8 @@ mv_const hydrated_test_1 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -153,8 +156,8 @@ mv_const hydrated_test_2 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -164,8 +167,8 @@ mv_const hydrated_test_2 true
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -177,24 +180,24 @@ mv       hydrated_test_2 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -206,8 +209,8 @@ mv       hydrated_test_2 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -217,8 +220,8 @@ mv_const hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -228,8 +231,8 @@ mv_const hydrated_test_3 true
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -242,8 +245,8 @@ mv       hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -251,8 +254,8 @@ mv  hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -260,8 +263,8 @@ mv  hydrated_test_3 true
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -291,8 +294,8 @@ mv  hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -311,8 +314,8 @@ users         hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -323,8 +326,8 @@ users         hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -345,8 +348,8 @@ users         hydrated_test_4 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -380,8 +383,8 @@ users         hydrated_test_4 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -391,8 +394,8 @@ mv_wmr_stuck hydrated_test_4 false
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -402,8 +405,8 @@ mv_wmr_stuck hydrated_test_4 false
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -17,12 +17,13 @@ $ set-arg-default default-replica-size=1
 # Note that we count on the retry behavior of testdrive in this test
 # since introspection sources may take some time to catch up.
 
-# The contents of the introspection tables depend on the replica size
-$ skip-if
-SELECT '${arg.default-replica-size}' != '4-4'
+# Introspection subscribes add noise to the introspection sources, so disable them.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_compute_introspection_subscribes = false
 
 # In case the environment has other replicas
-> SET cluster_replica = r1
+> CREATE CLUSTER test SIZE '4-4'
+> SET cluster = test
 
 > CREATE TABLE t (a int)
 
@@ -495,3 +496,6 @@ idx3_div_by_zero 3
   FROM mz_internal.mz_compute_error_counts c
   JOIN mz_objects o ON (c.export_id = o.id)
   ORDER BY name
+
+# Cleanup.
+> DROP CLUSTER test CASCADE

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -389,39 +389,43 @@ contains:upsert key could not be validated as unique
 # in memory consumptions and should be understood before adapting the values.
 > SET cluster_replica = r1
 
-> SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-"Arrange ReduceMinsMaxes"
-"Arrange ReduceMinsMaxes"
-"Arranged DistinctBy"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"DistinctBy"
-DistinctByErrorCheck
-ReduceMinsMaxes
-ReduceMinsMaxes
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
+> SELECT mdod.dataflow_name, mdod.name
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  JOIN mz_internal.mz_compute_exports USING (dataflow_id)
+  WHERE export_id LIKE 'u%'
+"Dataflow: materialize.public.input_keyed" "Arrange ReduceMinsMaxes"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" ReduceMinsMaxes
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed_ab" "Arranged DistinctBy"
+"Dataflow: materialize.public.input_keyed_ab" DistinctBy
+"Dataflow: materialize.public.input_keyed_ab" DistinctByErrorCheck
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arrange ReduceMinsMaxes"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" ReduceMinsMaxes
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -464,25 +464,29 @@ c    d
 # in memory consumptions and should be understood before adapting the values.
 > SET cluster_replica = r1
 
-> SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-AccumulableErrorCheck
-AccumulableErrorCheck
-AccumulableErrorCheck
-"ArrangeAccumulable [val: empty]"
-"ArrangeAccumulable [val: empty]"
-"ArrangeAccumulable [val: empty]"
-"ArrangeBy[[Column(0), Column(1)]]"
-"ArrangeBy[[Column(0), Column(1)]]"
-"ArrangeBy[[Column(0), Column(1)]]-errors"
-"ArrangeBy[[Column(0), Column(1)]]-errors"
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(1)]]
-ArrangeBy[[Column(1)]]-errors
-"ArrangeMonotonic [val: empty]"
-"ArrangeMonotonic [val: empty]"
-ReduceAccumulable
-ReduceAccumulable
-ReduceAccumulable
-ReduceMonotonic
-ReduceMonotonic
+> SELECT mdod.dataflow_name, mdod.name
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  JOIN mz_internal.mz_compute_exports USING (dataflow_id)
+  WHERE export_id LIKE 'u%'
+"Dataflow: materialize.public.data_view_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.data_view_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.data_view_primary_idx" "ArrangeBy[[Column(0), Column(1)]]"
+"Dataflow: materialize.public.data_view_primary_idx" "ArrangeBy[[Column(0), Column(1)]]-errors"
+"Dataflow: materialize.public.mat_data_idx3" ArrangeBy[[Column(1)]]
+"Dataflow: materialize.public.mat_data_idx3" ArrangeBy[[Column(1)]]-errors
+"Dataflow: materialize.public.mat_data_primary_idx" "ArrangeBy[[Column(0), Column(1)]]"
+"Dataflow: materialize.public.mat_data_primary_idx" "ArrangeBy[[Column(0), Column(1)]]-errors"
+"Dataflow: materialize.public.test1" AccumulableErrorCheck
+"Dataflow: materialize.public.test1" "ArrangeAccumulable [val: empty]"
+"Dataflow: materialize.public.test1" ReduceAccumulable
+"Dataflow: materialize.public.test2" AccumulableErrorCheck
+"Dataflow: materialize.public.test2" "ArrangeAccumulable [val: empty]"
+"Dataflow: materialize.public.test2" ReduceAccumulable
+"Dataflow: materialize.public.test4" "ArrangeMonotonic [val: empty]"
+"Dataflow: materialize.public.test4" ReduceMonotonic
+"Dataflow: materialize.public.test6" "ArrangeMonotonic [val: empty]"
+"Dataflow: materialize.public.test6" ReduceMonotonic
+"Dataflow: materialize.public.test7" AccumulableErrorCheck
+"Dataflow: materialize.public.test7" "ArrangeAccumulable [val: empty]"
+"Dataflow: materialize.public.test7" ReduceAccumulable

--- a/test/testdrive/monotonic.td
+++ b/test/testdrive/monotonic.td
@@ -203,27 +203,31 @@ Target cluster: quickstart
 # in memory consumptions and should be understood before adapting the values.
 > SET cluster_replica = r1
 
-> SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-"ArrangeBy[[Column(0), Column(1)]]"
-"ArrangeBy[[Column(0), Column(1)]]-errors"
-"ArrangeBy[[Column(0)]]"
-"ArrangeBy[[Column(0)]]"
-"ArrangeBy[[Column(0)]]"
-"ArrangeBy[[Column(0)]]"
-"ArrangeBy[[Column(0)]]"
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-"ArrangeMonotonic [val: empty]"
-"ArrangeMonotonic [val: empty]"
-"ArrangeMonotonic [val: empty]"
-"Arranged TopK input"
-ReduceMonotonic
-ReduceMonotonic
-ReduceMonotonic
-"Reduced TopK input"
+> SELECT mdod.dataflow_name, mdod.name
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  JOIN mz_internal.mz_compute_exports USING (dataflow_id)
+  WHERE export_id LIKE 'u%'
+"Dataflow: materialize.public.i1_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.i1_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.i4_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.i4_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.i6_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.i6_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.i6_primary_idx" "Arranged TopK input"
+"Dataflow: materialize.public.i6_primary_idx" "Reduced TopK input"
+"Dataflow: materialize.public.i8_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.i8_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.i9_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.i9_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.monotonic_fused" "ArrangeMonotonic [val: empty]"
+"Dataflow: materialize.public.monotonic_fused" ReduceMonotonic
+"Dataflow: materialize.public.monotonic_max" "ArrangeMonotonic [val: empty]"
+"Dataflow: materialize.public.monotonic_max" ReduceMonotonic
+"Dataflow: materialize.public.monotonic_min" "ArrangeMonotonic [val: empty]"
+"Dataflow: materialize.public.monotonic_min" ReduceMonotonic
+"Dataflow: materialize.public.non_dbz_data_indexed_primary_idx" "ArrangeBy[[Column(0), Column(1)]]"
+"Dataflow: materialize.public.non_dbz_data_indexed_primary_idx" "ArrangeBy[[Column(0), Column(1)]]-errors"
 
 # Propagating monotonicity analysis through materialized views
 

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -13,10 +13,14 @@ $ set-arg-default default-replica-size=1
 # increase unexpectedly. This is to prevent issues like this:
 # https://github.com/MaterializeInc/materialize/issues/20179
 
+# Introspection subscribes add noise to the introspection sources, so disable them.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_compute_introspection_subscribes = false
+
 # Run the majority of this test on its own cluster to ensure it doesn't
 # interfere with any other tests.
 > CREATE CLUSTER arrangement_sharing REPLICAS (r1 (SIZE '${arg.default-replica-size}'))
-> SET CLUSTER TO arrangement_sharing
+> SET cluster TO arrangement_sharing
 > SET cluster_replica = r1
 
 # from attributes/mir_unique_keys.slt
@@ -700,9 +704,14 @@ ReduceMinsMaxes
 > DROP TABLE t CASCADE
 
 # Check mz_catalog_server
-> SET CLUSTER TO mz_catalog_server
+> SET cluster TO mz_catalog_server
 
-> SELECT name, count(*) FROM (SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name) GROUP BY name;
+> SELECT mdod.name, count(*)
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  WHERE mdod.dataflow_name NOT LIKE '%introspection-subscribe%'
+  GROUP BY mdod.name
+  ORDER BY mdod.name;
 "AccumulableErrorCheck"                       8
 "Arrange export iterative err"                1
 "Arrange export iterative"                    1
@@ -756,13 +765,11 @@ ArrangeBy[[Column(13)]]                       1
 "ReduceMinsMaxes"                             1
 "Threshold local"                             4
 
-> SET CLUSTER TO arrangement_sharing
+> SET cluster TO arrangement_sharing
 
 # Check dataflows of our logging infrastructure with log_logging
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET log_filter = 'debug'
-ALTER CLUSTER arrangement_sharing SET (MANAGED = false);
-CREATE CLUSTER REPLICA arrangement_sharing.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
+> ALTER CLUSTER arrangement_sharing SET (MANAGED = false);
+> CREATE CLUSTER REPLICA arrangement_sharing.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
 
 > SET cluster_replica = replica;
 
@@ -796,5 +803,23 @@ CREATE CLUSTER REPLICA arrangement_sharing.replica SIZE = '2', INTROSPECTION DEB
 "Arrange Timely(Operates)"
 "Arrange Timely(Parks)"
 
+# Check dataflows installed by introspection subscribes.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET log_filter = 'info'
+ALTER SYSTEM SET enable_compute_introspection_subscribes = true
+
+# Flipping `enable_compute_introspection_subscribes` affects new replicas, so
+# force a restart.
+> DROP CLUSTER REPLICA arrangement_sharing.replica
+> ALTER CLUSTER arrangement_sharing SET (MANAGED = true)
+> ALTER CLUSTER arrangement_sharing SET (REPLICATION FACTOR = 0)
+> ALTER CLUSTER arrangement_sharing SET (REPLICATION FACTOR = 1)
+> RESET cluster_replica
+
+> SELECT mdod.name, count(*)
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  GROUP BY mdod.name
+  ORDER BY mdod.name
+AccumulableErrorCheck 1
+"ArrangeAccumulable [val: empty]" 1
+ReduceAccumulable 1

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -180,7 +180,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             # without mzcompose
             for file in args.files:
                 c.run_testdrive_files(
-                    f"--junit-report={junit_report}",
+                    # f"--junit-report={junit_report}",
                     *non_default_testdrive_vars,
                     *passthrough_args,
                     file,

--- a/test/testdrive/top-1-monotonic.td
+++ b/test/testdrive/top-1-monotonic.td
@@ -277,34 +277,38 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=5
 # in memory consumptions and should be understood before adapting the values.
 > SET cluster_replica = r1
 
-> SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-"ArrangeBy[[Column(0)]]"
-"ArrangeBy[[Column(0)]]"
-"Arranged DistinctBy"
-"Arranged DistinctBy"
-"Arranged DistinctBy"
-"Arranged DistinctBy"
-"Arranged MonotonicTop1 partial [val: empty]"
-"Arranged MonotonicTop1 partial [val: empty]"
-"Arranged MonotonicTop1 partial [val: empty]"
-"Arranged MonotonicTop1 partial [val: empty]"
-"Arranged MonotonicTop1 partial [val: empty]"
-"Arranged MonotonicTop1 partial [val: empty]"
-"DistinctBy"
-"DistinctBy"
-"DistinctBy"
-"DistinctBy"
-DistinctByErrorCheck
-DistinctByErrorCheck
-DistinctByErrorCheck
-DistinctByErrorCheck
-MonotonicTop1
-MonotonicTop1
-MonotonicTop1
-MonotonicTop1
-MonotonicTop1
-MonotonicTop1
+> SELECT mdod.dataflow_name, mdod.name
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  JOIN mz_internal.mz_compute_exports USING (dataflow_id)
+  WHERE export_id LIKE 'u%'
+"Dataflow: group_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_in_top_1" "Arranged DistinctBy"
+"Dataflow: group_by_in_top_1" "Arranged DistinctBy"
+"Dataflow: group_by_in_top_1" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: group_by_in_top_1" DistinctBy
+"Dataflow: group_by_in_top_1" DistinctBy
+"Dataflow: group_by_in_top_1" DistinctByErrorCheck
+"Dataflow: group_by_in_top_1" DistinctByErrorCheck
+"Dataflow: group_by_in_top_1" MonotonicTop1
+"Dataflow: group_by_limit" "Arranged DistinctBy"
+"Dataflow: group_by_limit" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: group_by_limit" DistinctBy
+"Dataflow: group_by_limit" DistinctByErrorCheck
+"Dataflow: group_by_limit" MonotonicTop1
+"Dataflow: group_by_order_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_order_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_order_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_order_by_in_top_1" "Arranged DistinctBy"
+"Dataflow: group_by_order_by_in_top_1" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: group_by_order_by_in_top_1" DistinctBy
+"Dataflow: group_by_order_by_in_top_1" DistinctByErrorCheck
+"Dataflow: group_by_order_by_in_top_1" MonotonicTop1
+"Dataflow: limit_only" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: limit_only" MonotonicTop1
+"Dataflow: order_by_desc_limit" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: order_by_desc_limit" MonotonicTop1
+"Dataflow: order_by_limit" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: order_by_limit" MonotonicTop1

--- a/test/testdrive/top-k-monotonic.td
+++ b/test/testdrive/top-k-monotonic.td
@@ -278,8 +278,12 @@ a
 # in memory consumptions and should be understood before adapting the values.
 > SET cluster_replica = r1
 
-> SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-"ArrangeBy[[Column(0)]]"
-ArrangeBy[[Column(0)]]-errors
-"Arranged TopK input"
-"Reduced TopK input"
+> SELECT mdod.dataflow_name, mdod.name
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  JOIN mz_internal.mz_compute_exports USING (dataflow_id)
+  WHERE export_id LIKE 'u%'
+"Dataflow: materialize.public.v_other_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.v_other_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.v_other_primary_idx" "Arranged TopK input"
+"Dataflow: materialize.public.v_other_primary_idx" "Reduced TopK input"


### PR DESCRIPTION
This PR introduces the overall infrastructure for introspection subscribes, as described in the [design doc](https://github.com/MaterializeInc/materialize/pull/27548), implemented by a new `UnifiedIntrospection` type that gets called by compute `Instance` controllers. It also introduces a first introspection subscribe that surfaces dataflow error counts, as the first user of this infrastructure.

The results of introspection subscribes are still discarded here. Follow-up PRs (#27768, #27767) will add the final piece that writes them to storage.

### Motivation

  * This PR adds a known-desirable feature.

Part of #26730 

### Tips for reviewer

I picked dataflow error counts as the test case for introspection subscribes because this data is both low-volume and useful. LMK if a different query seems more useful to you!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A