### PR TITLE
dbt-materialize: add create/drop cluster macros

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-* Add `create_cluster` and `drop_cluster` macros to manage the creation and
-  deletion of clusters, respectively in CI/CD workflows.
+* Add the `create_cluster` and `drop_cluster` macros, which allow managing the
+  creation and deletion of clusters in workflows requiring transient
+  infrastructure (e.g. CI/CD).
 
 ## 1.8.1 - 2024-06-08
 

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,10 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Add `create_cluster` and `drop_cluster` macros to manage the creation and
+  deletion of clusters, respectively in CI/CD workflows.
+
 ## 1.8.1 - 2024-06-08
 
 * Add support for overriding the `generate_cluster_name` macro to customize the

--- a/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
@@ -1,0 +1,116 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{#
+-- This macro creates a new cluster for a given name, size, and replication factor.
+-- Parameters:
+--   cluster_name (str): The name of the cluster to create.
+--   size (str): The size of the cluster, default is '50cc' (optional).
+--   replication_factor (int): The replication factor of the cluster, default is 1 (optional).
+--   ignore_existing_objects (bool): Whether to ignore existing objects in the cluster, default is False (optional).
+--   force_deploy_suffix (bool): Whether to add _dbt_deploy suffix to the cluster name, default is False (optional).
+#}
+{% macro create_cluster(cluster_name, size='50cc', replication_factor=1, ignore_existing_objects=False, force_deploy_suffix=False) %}
+
+{%- if cluster_name -%}
+
+  {% set deploy_cluster = adapter.generate_final_cluster_name(cluster_name, force_deploy_suffix=force_deploy_suffix) %}
+
+  {% if cluster_exists(deploy_cluster) %}
+
+    {{ log("Cluster " ~ deploy_cluster ~ " already exists", info=True) }}
+
+    {% set cluster_empty %}
+      WITH dataflows AS (
+          SELECT mz_indexes.id
+          FROM mz_indexes
+          JOIN mz_clusters ON mz_indexes.cluster_id = mz_clusters.id
+          WHERE mz_clusters.name = {{ dbt.string_literal(deploy_cluster) }}
+
+          UNION ALL
+
+          SELECT mz_materialized_views.id
+          FROM mz_materialized_views
+          JOIN mz_clusters ON mz_materialized_views.cluster_id = mz_clusters.id
+          WHERE mz_clusters.name = {{ dbt.string_literal(deploy_cluster) }}
+
+          UNION ALL
+
+          SELECT mz_sources.id
+          FROM mz_sources
+          JOIN mz_clusters ON mz_clusters.id = mz_sources.cluster_id
+          WHERE mz_clusters.name = {{ dbt.string_literal(deploy_cluster) }}
+
+          UNION ALL
+
+          SELECT mz_sinks.id
+          FROM mz_sinks
+          JOIN mz_clusters ON mz_clusters.id = mz_sinks.cluster_id
+          WHERE mz_clusters.name = {{ dbt.string_literal(deploy_cluster) }}
+      )
+
+      SELECT count(*)
+      FROM dataflows
+      WHERE id LIKE 'u%'
+    {% endset %}
+
+    {% set cluster_object_count = run_query(cluster_empty) %}
+
+    {% if execute %}
+      {% if cluster_object_count and cluster_object_count.columns[0] and cluster_object_count.rows[0][0] > 0 %}
+        {% if check_cluster_ci_tag(deploy_cluster) %}
+          {{ log("Cluster " ~ deploy_cluster ~ " was already created for this pull request", info=True) }}
+        {% elif ignore_existing_objects %}
+          {{ log("[Warning] Deployment cluster " ~ deploy_cluster ~ " is not empty", info=True) }}
+          {{ log("[Warning] Confirm the objects it contains are expected before deployment", info=True) }}
+        {% else %}
+          {{ exceptions.raise_compiler_error("""
+            Deployment cluster """ ~ deploy_cluster ~ """ already exists and is not empty.
+            This is potentially dangerous as you may end up deploying objects to production you
+            do not intend.
+
+            If you are certain the objects in this cluster are supposed to exist, you can ignore this
+            error by setting ignore_existing_objects to True.
+
+            dbt run-operation create_cluster --args '{cluster_name: <cluster_name>, ignore_existing_objects: true}'
+          """) }}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+
+  {% else %}
+
+    {{ log("Creating cluster " ~ deploy_cluster ~ " with size " ~ size ~ " and replication factor " ~ replication_factor, info=True) }}
+
+    {% set create_cluster_query %}
+      CREATE CLUSTER {{ deploy_cluster }} (
+          SIZE = {{ dbt.string_literal(size) }},
+          REPLICATION FACTOR = {{ replication_factor }}
+      );
+    {% endset %}
+
+    {{ run_query(create_cluster_query) }}
+    {{ set_cluster_ci_tag(deploy_cluster) }}
+    {{ log("Cluster " ~ deploy_cluster ~ " created successfully.", info=True) }}
+
+  {% endif %}
+
+{%- else -%}
+
+  {{ exceptions.raise_compiler_error("Invalid arguments. Missing cluster name!") }}
+
+{%- endif %}
+
+{% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/ci/drop_cluster.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/ci/drop_cluster.sql
@@ -1,0 +1,39 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{#
+-- This macro drops a cluster used in CI.
+-- Parameters:
+--   cluster_name (str): The name of the cluster to drop.
+#}
+{% macro drop_cluster(cluster_name) %}
+
+{%- if cluster_name -%}
+
+  {{ log("Dropping cluster " ~ cluster_name ~ "...", info=True) }}
+
+  {% call statement('drop_cluster') -%}
+      DROP CLUSTER IF EXISTS {{ cluster_name }} CASCADE
+  {%- endcall -%}
+
+  {{ log("Cluster " ~ cluster_name ~ " dropped.", info=True) }}
+
+{%- else -%}
+
+  {{ exceptions.raise_compiler_error("Invalid arguments. Missing cluster name!") }}
+
+{%- endif -%}
+
+{% endmacro %}

--- a/misc/dbt-materialize/tests/adapter/test_ci.py
+++ b/misc/dbt-materialize/tests/adapter/test_ci.py
@@ -1,0 +1,153 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dbt.tests.util import run_dbt
+
+
+class TestClusterOps:
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self, project):
+        project.run_sql("DROP CLUSTER IF EXISTS test_cluster CASCADE")
+        project.run_sql("DROP CLUSTER IF EXISTS test_cluster_dbt_deploy CASCADE")
+
+    def test_create_and_drop_cluster(self, project):
+        # Test creating a cluster
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+
+        # Verify cluster creation
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'test_cluster_dbt_deploy'",
+            fetch="one",
+        )
+        assert result is not None, "Cluster was not created successfully"
+
+        # Test dropping the cluster
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster_dbt_deploy"}',
+            ]
+        )
+
+        # Verify cluster dropping
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'test_cluster_dbt_deploy'",
+            fetch="one",
+        )
+        assert result is None, "Cluster was not dropped successfully"
+
+    def test_create_existing_cluster(self, project):
+        # Create the cluster for the first time
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+
+        # Try creating the same cluster again
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+
+        # Verify the cluster exists
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'test_cluster_dbt_deploy'",
+            fetch="one",
+        )
+        assert (
+            result is not None
+        ), "Cluster should exist after attempting to create it again"
+
+        # Cleanup
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster_dbt_deploy"}',
+            ]
+        )
+
+    def test_drop_nonexistent_cluster(self, project):
+        # Attempt to drop a nonexistent cluster
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "nonexistent_cluster"}',
+            ]
+        )
+
+        # Verify no cluster exists
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'nonexistent_cluster'",
+            fetch="one",
+        )
+        assert result is None, "Nonexistent cluster should not exist"
+
+    def test_create_cluster_with_objects(self, project):
+        # Create a cluster and add an object to it
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+        project.run_sql("CREATE MATERIALIZED VIEW test_view AS SELECT 1")
+
+        # Attempt to create the same cluster without ignoring existing objects
+        with pytest.raises(Exception):
+            run_dbt(
+                [
+                    "run-operation",
+                    "create_cluster",
+                    "--args",
+                    '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": false, "force_deploy_suffix": true}',
+                ],
+                expect_pass=False,
+            )
+
+        # Cleanup
+        project.run_sql("DROP MATERIALIZED VIEW IF EXISTS test_view")
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster_dbt_deploy"}',
+            ]
+        )


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Abstracting the cluster create logic into its own macro which can later on be used in CI/CD workflows similar to what has already been outlined in @morsapaes' [dbt-ci-templates](https://github.com/morsapaes/dbt-ci-templates) project.