### PR TITLE
testdrive: Ignore unfinalized shards in catalog

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1007,7 +1007,7 @@ impl Catalog {
     /// that the serialized state for two identical catalogs will compare
     /// identically.
     pub fn dump(&self) -> Result<CatalogDump, Error> {
-        Ok(CatalogDump::new(self.state.dump()?))
+        Ok(CatalogDump::new(self.state.dump(None)?))
     }
 
     /// Checks the [`Catalog`]s internal consistency.

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -2027,7 +2027,11 @@ impl CatalogState {
     /// There are no guarantees about the format of the serialized state, except
     /// that the serialized state for two identical catalogs will compare
     /// identically.
-    pub fn dump(&self) -> Result<String, Error> {
+    ///
+    /// Some consumers would like the ability to overwrite the `unfinalized_shards` catalog field,
+    /// which they can accomplish by passing in a value of `Some` for the `unfinalized_shards`
+    /// argument.
+    pub fn dump(&self, unfinalized_shards: Option<BTreeSet<String>>) -> Result<String, Error> {
         // Dump the base catalog.
         let mut dump = serde_json::to_value(&self).map_err(|e| {
             Error::new(ErrorKind::Unstructured(format!(
@@ -2038,13 +2042,24 @@ impl CatalogState {
             )))
         })?;
 
+        let dump_obj = dump.as_object_mut().expect("state must have been dumped");
         // Stitch in system parameter defaults.
-        dump.as_object_mut()
-            .expect("state must have been dumped")
-            .insert(
-                "system_parameter_defaults".into(),
-                serde_json::json!(self.system_config().defaults()),
-            );
+        dump_obj.insert(
+            "system_parameter_defaults".into(),
+            serde_json::json!(self.system_config().defaults()),
+        );
+        // Potentially overwrite unfinalized shards.
+        if let Some(unfinalized_shards) = unfinalized_shards {
+            dump_obj
+                .get_mut("storage_metadata")
+                .expect("known to exist")
+                .as_object_mut()
+                .expect("storage_metadata is an object")
+                .insert(
+                    "unfinalized_shards".into(),
+                    serde_json::json!(unfinalized_shards),
+                );
+        }
 
         // Emit as pretty-printed JSON.
         Ok(serde_json::to_string_pretty(&dump).expect("cannot fail on serde_json::Value"))


### PR DESCRIPTION
Testdrive has a feature where it compares the state of the in-memory catalog to the state of the on-disk catalog and throws an error if there is a difference. The set of unfinalized shards in the catalog are updated asynchronously by background processes. As a result, the value may legitimately change after fetching the memory catalog but before fetching the disk catalog, causing the testdrive comparison to fail. This commit fixes the issue by ignoring the unfinalized shards in the catalog comparison to ignore false negatives. Unfortunately, we also end up ignoring true negatives.

Specifically the implementation sets the value of the disk catalog's unfinalized shards equal to the value of the memory catalog's unfinalized shards, so that the comparison never fails.

Fixes #27196

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
