### PR TITLE
Various fixes to nightlies

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -246,6 +246,10 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             args += [
                 f"--timestamp-oracle-url=postgres://root@cockroach.{self.cockroach_namespace}:26257?options=--search_path=tsoracle"
             ]
+        if not self._meets_minimum_version("0.105.0-dev"):
+            args += [
+                f"--storage-stash-url=postgres://root@cockroach.{self.cockroach_namespace}:26257?options=--search_path=storage"
+            ]
 
         return args + self.extra_args
 

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -387,7 +387,7 @@ def workflow_rocksdb_cleanup(c: Composition) -> None:
             where s.name ='{source_name}'"""
         )[0]
         prefix = "/scratch"
-        cluster_prefix = f"cluster-{cluster_id}-replica-{replica_id}"
+        cluster_prefix = f"cluster-{cluster_id}-replica-{replica_id}-gen-0"
         postfix = "storage/upsert"
         return (
             f"{prefix}/{cluster_prefix}/{postfix}",


### PR DESCRIPTION
See commit messages for details.

### Motivation

* Fix some nightly tests that I broke.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
