### PR TITLE
ci: re-enable one automatic retry for k8s node recovery tests

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -836,6 +836,11 @@ steps:
         label: "K8s recovery: storage on failing node"
         depends_on: build-aarch64
         timeout_in_minutes: 30
+        # TODO: #25108 (k8s node recovery tests flaky)
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 2
         agents:
           queue: linux-aarch64
         inputs:
@@ -854,6 +859,12 @@ steps:
         label: "K8s recovery: compute on failing node"
         depends_on: build-aarch64
         timeout_in_minutes: 30
+        # TODO: #25108 (k8s node recovery tests flaky)
+        retry:
+          automatic:
+            - exit_status: 1
+              limit:
+                1
         agents:
           queue: linux-aarch64
         inputs:
@@ -872,6 +883,11 @@ steps:
         label: "K8s recovery: replicated compute on failing node"
         depends_on: build-aarch64
         timeout_in_minutes: 30
+        # TODO: #25108 (k8s node recovery tests flaky)
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 1
         agents:
           queue: linux-aarch64
         inputs:
@@ -890,6 +906,11 @@ steps:
         label: "K8s recovery: envd on failing node"
         depends_on: build-aarch64
         timeout_in_minutes: 30
+        # TODO: #25108 (k8s node recovery tests flaky)
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 1
         agents:
           queue: linux-aarch64
         inputs:


### PR DESCRIPTION
Observed two failures in https://buildkite.com/materialize/nightly/builds/8142.