### PR TITLE
doc/user: patch CREATE MATERIALIZED VIEW grammar

### DIFF
--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -28,7 +28,9 @@ _view&lowbar;name_ | A name for the materialized view.
 _cluster&lowbar;name_ | The cluster to maintain this materialized view. If not specified, defaults to the active cluster.
 _select&lowbar;stmt_ | The [`SELECT` statement](../select) whose results you want to maintain incrementally updated.
 
-### `WITH` options
+#### `with_options`
+
+{{< diagram "with-options.svg" >}}
 
 | Field      | Value     | Description                                                                                                                                                       |
 | ---------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/doc/user/layouts/partials/sql-grammar/with-options.svg
+++ b/doc/user/layouts/partials/sql-grammar/with-options.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="463" height="97">
+<svg xmlns="http://www.w3.org/2000/svg" width="503" height="129">
    <polygon points="9 61 1 57 1 65"/>
    <polygon points="17 61 9 57 9 65"/>
    <rect x="51" y="47" width="58" height="32" rx="10"/>
@@ -20,17 +20,17 @@
    <rect x="195" y="47" width="48" height="32"/>
    <rect x="193" y="45" width="48" height="32" class="nonterminal"/>
    <text class="nonterminal" x="203" y="65">field</text>
-   <rect x="263" y="47" width="28" height="32" rx="10"/>
-   <rect x="261"
-         y="45"
+   <rect x="283" y="79" width="28" height="32" rx="10"/>
+   <rect x="281"
+         y="77"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="271" y="65">=</text>
-   <rect x="311" y="47" width="38" height="32"/>
-   <rect x="309" y="45" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="319" y="65">val</text>
+   <text class="terminal" x="291" y="97">=</text>
+   <rect x="351" y="47" width="38" height="32"/>
+   <rect x="349" y="45" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="359" y="65">val</text>
    <rect x="195" y="3" width="24" height="32" rx="10"/>
    <rect x="193"
          y="1"
@@ -39,16 +39,16 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="203" y="21">,</text>
-   <rect x="389" y="47" width="26" height="32" rx="10"/>
-   <rect x="387"
+   <rect x="429" y="47" width="26" height="32" rx="10"/>
+   <rect x="427"
          y="45"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="397" y="65">)</text>
+   <text class="terminal" x="437" y="65">)</text>
    <path class="line"
-         d="m17 61 h2 m20 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="453 61 461 57 461 65"/>
-   <polygon points="453 61 445 57 445 65"/>
+         d="m17 61 h2 m20 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m20 0 h10 m0 0 h38 m-68 0 h20 m48 0 h20 m-88 0 q10 0 10 10 m68 0 q0 -10 10 -10 m-78 10 v12 m68 0 v-12 m-68 12 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m20 -32 h10 m38 0 h10 m-234 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m214 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-214 0 h10 m24 0 h10 m0 0 h170 m20 44 h10 m26 0 h10 m-444 0 h20 m424 0 h20 m-464 0 q10 0 10 10 m444 0 q0 -10 10 -10 m-454 10 v46 m444 0 v-46 m-444 46 q0 10 10 10 m424 0 q10 0 10 -10 m-434 10 h10 m0 0 h414 m23 -66 h-3"/>
+   <polygon points="493 61 501 57 501 65"/>
+   <polygon points="493 61 485 57 485 65"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -603,7 +603,7 @@ cte_binding ::=
 recursive_cte_binding ::=
   cte_ident '(' col_ident col_type ( ',' col_ident col_type )* ')' 'AS' '(' select_stmt ')'
 with_options ::=
-  ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
+  ('WITH' '(' ( field '='? val ) ( ( ',' field '='? val ) )* ')')?
 with_options_aws ::= 'WITH' '('
     (
       static_credentials


### PR DESCRIPTION
Follow-up to #27325.

@ggevay, I missed adding the shortcode that pulled in the `WITH` options `.svg` — thanks for noticing it! Here's what it'll look like after this PR:

<img width="823" alt="Screenshot 2024-06-18 at 11 40 06" src="https://github.com/MaterializeInc/materialize/assets/23521087/832ff0e1-528f-42e0-b3b6-7cbd5d318cb2">
