### PR TITLE
sql: Fix renames with temporary dependents

### DIFF
--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -1796,7 +1796,7 @@ impl Catalog {
                             }))
                         })?;
 
-                    if !new_entry.item().is_temporary() {
+                    if !to_entry.item().is_temporary() {
                         tx.update_item(*id, to_entry.clone().into())?;
                     }
                     builtin_table_updates.extend(

--- a/test/sqllogictest/rename.slt
+++ b/test/sqllogictest/rename.slt
@@ -620,3 +620,24 @@ ALTER SOURCE users RENAME TO userz
 
 statement ok
 SELECT * FROM userz LIMIT 0
+
+statement ok
+CREATE TABLE non_temp_base(a INT);
+
+statement ok
+CREATE TEMPORARY VIEW temp_view AS SELECT * FROM non_temp_base;
+
+query TT
+SHOW CREATE VIEW temp_view;
+----
+materialize.public.temp_view
+CREATE VIEW "mz_temp"."temp_view" AS SELECT * FROM "materialize"."public"."non_temp_base"
+
+statement ok
+ALTER TABLE non_temp_base RENAME TO non_temp_table;
+
+query TT
+SHOW CREATE VIEW temp_view;
+----
+materialize.public.temp_view
+CREATE VIEW "mz_temp"."temp_view" AS SELECT * FROM "materialize"."public"."non_temp_table"

--- a/test/sqllogictest/rename.slt
+++ b/test/sqllogictest/rename.slt
@@ -630,8 +630,8 @@ CREATE TEMPORARY VIEW temp_view AS SELECT * FROM non_temp_base;
 query TT
 SHOW CREATE VIEW temp_view;
 ----
-materialize.public.temp_view
-CREATE VIEW "mz_temp"."temp_view" AS SELECT * FROM "materialize"."public"."non_temp_base"
+mz_temp.temp_view
+CREATE TEMPORARY VIEW "mz_temp"."temp_view" AS SELECT * FROM "materialize"."public_renamed"."non_temp_base"
 
 statement ok
 ALTER TABLE non_temp_base RENAME TO non_temp_table;
@@ -639,5 +639,5 @@ ALTER TABLE non_temp_base RENAME TO non_temp_table;
 query TT
 SHOW CREATE VIEW temp_view;
 ----
-materialize.public.temp_view
-CREATE VIEW "mz_temp"."temp_view" AS SELECT * FROM "materialize"."public"."non_temp_table"
+mz_temp.temp_view
+CREATE TEMPORARY VIEW "mz_temp"."temp_view" AS SELECT * FROM "materialize"."public_renamed"."non_temp_table"


### PR DESCRIPTION
Previously, renaming a non-temporary object with temporary dependents failed with a cryptic error. This commit fixes the issue, allowing users to rename non-temporary objects with temporary dependents.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
