### PR TITLE
adapter,controller: refactorings that facilitate more read-only work

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -199,6 +199,7 @@ impl Catalog {
         &mut self,
         config: mz_controller::ControllerConfig,
         envd_epoch: core::num::NonZeroI64,
+        read_only: bool,
         transient_id_gen: Arc<TransientIdGen>,
         builtin_migration_metadata: BuiltinMigrationMetadata,
         // Whether to use the new txn-wal tables implementation or the
@@ -218,6 +219,7 @@ impl Catalog {
             mz_controller::Controller::new(
                 config,
                 envd_epoch,
+                read_only,
                 transient_id_gen,
                 txn_wal_tables,
                 &read_only_tx,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2037,13 +2037,6 @@ impl Coordinator {
         // Announce the completion of initialization.
         self.controller.initialization_complete();
 
-        if !self.read_only_controllers {
-            // Allow controller to go out of read-only mode right away.
-            self.controller.allow_writes();
-        } else {
-            tracing::info!("starting controllers in read-only mode!");
-        }
-
         // Expose mapping from T-shirt sizes to actual sizes
         builtin_table_updates.extend(
             self.catalog().state().resolve_builtin_table_updates(
@@ -3381,6 +3374,7 @@ pub fn serve(
                         catalog.initialize_controller(
                             controller_config,
                             controller_envd_epoch,
+                            read_only_controllers,
                             Arc::clone(&transient_id_gen),
                             builtin_migration_metadata,
                             controller_txn_wal_tables,

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -254,10 +254,12 @@ impl Coordinator {
             (StatementLifecycleHistory, statement_lifecycle_updates),
             (SqlText, sql_text_updates),
         ] {
-            self.controller
-                .storage
-                .append_introspection_updates(type_, updates)
-                .await;
+            if !updates.is_empty() {
+                self.controller
+                    .storage
+                    .append_introspection_updates(type_, updates)
+                    .await;
+            }
         }
     }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -196,6 +196,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
         build_info: &'static BuildInfo,
         storage_collections: Arc<dyn StorageCollections<Timestamp = T>>,
         envd_epoch: NonZeroI64,
+        read_only: bool,
         transient_id_gen: Arc<TransientIdGen>,
         metrics_registry: MetricsRegistry,
     ) -> Self {
@@ -210,7 +211,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
             build_info,
             storage_collections,
             initialized: false,
-            read_only: true,
+            read_only,
             config: Default::default(),
             arrangement_exert_proportionality: 16,
             stashed_replica_response: None,

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -475,11 +475,6 @@ where
         }
     }
 
-    /// Reports whether the controller is in read only mode.
-    pub fn read_only(&self) -> bool {
-        self.read_only
-    }
-
     /// Wait until the controller is ready to do some processing.
     ///
     /// This method may block for an arbitrarily long time.

--- a/src/storage-controller/src/collection_status.rs
+++ b/src/storage-controller/src/collection_status.rs
@@ -83,14 +83,16 @@ where
         self.previous_statuses
             .extend(new.iter().map(|r| (r.id, r.status)));
 
-        self.collection_manager
-            .blind_write(
-                source_status_history_id,
-                new.into_iter()
-                    .map(|update| (Row::from(update), 1))
-                    .collect(),
-            )
-            .await;
+        if !new.is_empty() {
+            self.collection_manager
+                .blind_write(
+                    source_status_history_id,
+                    new.into_iter()
+                        .map(|update| (Row::from(update), 1))
+                        .collect(),
+                )
+                .await;
+        }
     }
 }
 


### PR DESCRIPTION
Work towards https://github.com/MaterializeInc/materialize/issues/27406

Please see individual commits for the reason behind the change.

cc @benesch this changes something that you recently added, around `allow_writes()` and cleanup of cluster processes/pods.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
