### PR TITLE
Introduce MzContainerized, use in reachability logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#f051b828fc579efbf69c03ce669cb92fbe51a362"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#7760a903c9c451f7cf039a3978994251bafd8721"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -2019,7 +2019,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#f051b828fc579efbf69c03ce669cb92fbe51a362"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#7760a903c9c451f7cf039a3978994251bafd8721"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -5264,6 +5264,7 @@ dependencies = [
  "ctor",
  "derivative",
  "either",
+ "flatcontainer",
  "futures",
  "hibitset",
  "http 0.2.9",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -205,7 +205,7 @@ version = "1.0.5"
 [[audits.differential-dataflow]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:f051b828fc579efbf69c03ce669cb92fbe51a362"
+version = "0.12.0@git:7760a903c9c451f7cf039a3978994251bafd8721"
 
 [[audits.domain]]
 who = "Matt Jibson <matt.jibson@gmail.com>"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -30,7 +30,7 @@ mz-compute-types = { path = "../compute-types" }
 mz-dyncfg = { path = "../dyncfg" }
 mz-dyncfgs = { path = "../dyncfgs" }
 mz-expr = { path = "../expr" }
-mz-ore = { path = "../ore", features = ["async", "process", "tracing_"] }
+mz-ore = { path = "../ore", features = ["async", "flatcontainer", "process", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-repr = { path = "../repr" }

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -415,7 +415,7 @@ mod flatcontainer {
     use differential_dataflow::lattice::Lattice;
     use differential_dataflow::operators::arrange::Arranged;
     use differential_dataflow::trace::TraceReader;
-    use mz_ore::flatcontainer::MzContainerized;
+    use mz_ore::flatcontainer::MzRegionPreference;
     use timely::container::flatcontainer::{IntoOwned, Push, Region, ReserveItems};
     use timely::dataflow::Scope;
     use timely::progress::Timestamp;
@@ -428,7 +428,7 @@ mod flatcontainer {
     where
         Self: Clone,
         G: Scope<Timestamp = T::Owned>,
-        G::Timestamp: Lattice + Ord + MzContainerized,
+        G::Timestamp: Lattice + Ord + MzRegionPreference,
         K: Region
             + Clone
             + Push<<K as Region>::Owned>

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -415,9 +415,8 @@ mod flatcontainer {
     use differential_dataflow::lattice::Lattice;
     use differential_dataflow::operators::arrange::Arranged;
     use differential_dataflow::trace::TraceReader;
-    use differential_dataflow::Data;
-    use std::fmt::Debug;
-    use timely::container::flatcontainer::{Containerized, IntoOwned, Push, Region, ReserveItems};
+    use mz_ore::flatcontainer::MzContainerized;
+    use timely::container::flatcontainer::{IntoOwned, Push, Region, ReserveItems};
     use timely::dataflow::Scope;
     use timely::progress::Timestamp;
     use timely::PartialOrder;
@@ -428,46 +427,42 @@ mod flatcontainer {
     impl<G, K, V, T, R, C> ArrangementSize for Arranged<G, FlatKeyValAgent<K, V, T, R, C>>
     where
         Self: Clone,
-        G: Scope<Timestamp = T>,
-        G::Timestamp: Lattice + Ord + Containerized,
-        K: Data + Containerized,
-        K::Region: Clone
-            + Region<Owned = K>
-            + Push<K>
-            + for<'a> Push<<K::Region as Region>::ReadItem<'a>>
-            + for<'a> ReserveItems<<K::Region as Region>::ReadItem<'a>>,
-        for<'a> <K::Region as Region>::ReadItem<'a>: Copy + Debug + Ord,
-        V: Data + Containerized,
-        V::Region: Clone
-            + Push<V>
-            + for<'a> Push<<V::Region as Region>::ReadItem<'a>>
-            + Region<Owned = V>
-            + for<'a> ReserveItems<<V::Region as Region>::ReadItem<'a>>,
-        for<'a> <V::Region as Region>::ReadItem<'a>: Copy + Debug + Ord,
-        T: Containerized
-            + Lattice
-            + for<'a> PartialOrder<<T::Region as Region>::ReadItem<'a>>
-            + Timestamp,
-        T::Region: Clone
-            + Push<T>
-            + for<'a> Push<<T::Region as Region>::ReadItem<'a>>
-            + Region<Owned = T>
-            + for<'a> ReserveItems<<T::Region as Region>::ReadItem<'a>>,
-        for<'a> <T::Region as Region>::ReadItem<'a>:
-            Copy + Debug + IntoOwned<'a, Owned = T> + Ord + PartialOrder<T>,
-        R: Containerized
-            + Default
-            + Ord
-            + Semigroup
-            + for<'a> Semigroup<<R::Region as Region>::ReadItem<'a>>
+        G: Scope<Timestamp = T::Owned>,
+        G::Timestamp: Lattice + Ord + MzContainerized,
+        K: Region
+            + Clone
+            + Push<<K as Region>::Owned>
+            + for<'a> Push<<K as Region>::ReadItem<'a>>
+            + for<'a> ReserveItems<<K as Region>::ReadItem<'a>>
             + 'static,
-        R::Region: Clone
-            + Push<R>
-            + for<'a> Push<&'a R>
-            + for<'a> Push<<R::Region as Region>::ReadItem<'a>>
-            + Region<Owned = R>
-            + for<'a> ReserveItems<<R::Region as Region>::ReadItem<'a>>,
-        for<'a> <R::Region as Region>::ReadItem<'a>: Copy + Debug + IntoOwned<'a, Owned = R> + Ord,
+        V: Region
+            + Clone
+            + Push<<V as Region>::Owned>
+            + for<'a> Push<<V as Region>::ReadItem<'a>>
+            + for<'a> ReserveItems<<V as Region>::ReadItem<'a>>
+            + 'static,
+        T: Region
+            + Clone
+            + Push<<T as Region>::Owned>
+            + for<'a> Push<<T as Region>::ReadItem<'a>>
+            + for<'a> ReserveItems<<T as Region>::ReadItem<'a>>
+            + 'static,
+        R: Region
+            + Clone
+            + Push<<R as Region>::Owned>
+            + for<'a> Push<&'a <R as Region>::Owned>
+            + for<'a> Push<<R as Region>::ReadItem<'a>>
+            + for<'a> ReserveItems<<R as Region>::ReadItem<'a>>
+            + 'static,
+        K::Owned: Clone + Ord,
+        V::Owned: Clone + Ord,
+        T::Owned: Lattice + for<'a> PartialOrder<<T as Region>::ReadItem<'a>> + Timestamp,
+        R::Owned:
+            Default + Ord + Semigroup + for<'a> Semigroup<<R as Region>::ReadItem<'a>> + 'static,
+        for<'a> <K as Region>::ReadItem<'a>: Copy + Ord,
+        for<'a> <V as Region>::ReadItem<'a>: Copy + Ord,
+        for<'a> <T as Region>::ReadItem<'a>: Copy + IntoOwned<'a> + Ord + PartialOrder<T::Owned>,
+        for<'a> <R as Region>::ReadItem<'a>: Copy + IntoOwned<'a, Owned = R::Owned> + Ord,
         C: 'static,
     {
         fn log_arrangement_size(self) -> Self {

--- a/src/compute/src/logging.rs
+++ b/src/compute/src/logging.rs
@@ -15,13 +15,14 @@ mod initialize;
 mod reachability;
 mod timely;
 
+use ::timely::container::{CapacityContainerBuilder, ContainerBuilder, PushInto, SizableContainer};
+use ::timely::Container;
 use std::any::Any;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::time::Duration;
 
 use ::timely::dataflow::operators::capture::{Event, EventLink, EventPusher};
-use ::timely::logging::WorkerIdentifier;
 use ::timely::progress::Timestamp as TimelyTimestamp;
 use ::timely::scheduling::Activator;
 use mz_compute_client::logging::{ComputeLog, DifferentialLog, LogVariant, TimelyLog};
@@ -35,79 +36,45 @@ use crate::typedefs::RowRowAgent;
 pub use crate::logging::initialize::initialize;
 
 /// Logs events as a timely stream, with progress statements.
-struct BatchLogger<T, E, P>
+struct BatchLogger<CB, P>
 where
-    P: EventPusher<Timestamp, Vec<(Duration, E, T)>>,
+    CB: ContainerBuilder,
+    P: EventPusher<Timestamp, CB::Container>,
 {
     /// Time in milliseconds of the current expressed capability.
     time_ms: Timestamp,
     event_pusher: P,
-    _phantom: ::std::marker::PhantomData<(E, T)>,
     /// Each time is advanced to the strictly next millisecond that is a multiple of this interval.
     /// This means we should be able to perform the same action on timestamp capabilities, and only
     /// flush buffers when this timestamp advances.
-    interval_ms: u64,
+    interval_ms: u128,
     /// A stash for data that does not yet need to be sent.
-    buffer: Vec<(Duration, E, T)>,
+    builder: CB,
 }
 
-impl<T, E, P> BatchLogger<T, E, P>
+impl<CB, P> BatchLogger<CB, P>
 where
-    P: EventPusher<Timestamp, Vec<(Duration, E, T)>>,
+    CB: ContainerBuilder,
+    P: EventPusher<Timestamp, CB::Container>,
 {
-    /// Batch size in bytes for batches
-    const BATCH_SIZE_BYTES: usize = 1 << 13;
-
-    /// Calculate the default buffer size based on `(Duration, E, T)` tuples.
-    fn buffer_capacity() -> usize {
-        let size = ::std::mem::size_of::<(Duration, E, T)>();
-        if size == 0 {
-            Self::BATCH_SIZE_BYTES
-        } else if size <= Self::BATCH_SIZE_BYTES {
-            Self::BATCH_SIZE_BYTES / size
-        } else {
-            1
-        }
-    }
-
     /// Creates a new batch logger.
-    fn new(event_pusher: P, interval_ms: u64) -> Self {
+    fn new(event_pusher: P, interval_ms: u128) -> Self {
         BatchLogger {
             time_ms: Timestamp::minimum(),
             event_pusher,
-            _phantom: ::std::marker::PhantomData,
             interval_ms,
-            buffer: Vec::with_capacity(Self::buffer_capacity()),
+            builder: CB::default(),
         }
     }
 
-    /// Publishes a batch of logged events and advances the capability.
-    fn publish_batch(&mut self, time: &Duration, data: &mut Vec<(Duration, E, T)>) {
-        // TODO(benesch): avoid dangerous `as` conversion.
-        #[allow(clippy::as_conversions)]
-        let new_time_ms = Timestamp::try_from(
-            (((time.as_millis() as u64) / self.interval_ms) + 1) * self.interval_ms,
-        )
-        .expect("must fit");
-        if !data.is_empty() {
-            // If we don't need to grow our buffer, move
-            if data.len() > self.buffer.capacity() - self.buffer.len() {
-                self.event_pusher.push(Event::Messages(
-                    self.time_ms,
-                    self.buffer.drain(..).collect(),
-                ));
-            }
-
-            self.buffer.append(data);
-        }
+    fn flush_through(&mut self, time: &Duration) {
+        let time_ms = ((time.as_millis() / self.interval_ms) + 1) * self.interval_ms;
+        let new_time_ms: Timestamp = time_ms.try_into().expect("must fit");
         if self.time_ms < new_time_ms {
-            // Flush buffered events that may need to advance.
-            self.event_pusher.push(Event::Messages(
-                self.time_ms,
-                self.buffer.drain(..).collect(),
-            ));
-            if self.buffer.capacity() > Self::buffer_capacity() {
-                self.buffer = Vec::with_capacity(Self::buffer_capacity())
+            while let Some(finished) = self.builder.finish() {
+                let finished = std::mem::take(finished);
+                self.event_pusher
+                    .push(Event::Messages(self.time_ms, finished));
             }
 
             // In principle we can buffer up until this point, if that is appealing to us.
@@ -115,13 +82,46 @@ where
             // here, as the forward ticks would be that much less frequent.
             self.event_pusher
                 .push(Event::Progress(vec![(new_time_ms, 1), (self.time_ms, -1)]));
+            self.time_ms = new_time_ms;
         }
-        self.time_ms = new_time_ms;
+    }
+
+    fn extract_and_send(&mut self) {
+        while let Some(extracted) = self.builder.extract() {
+            let extracted = std::mem::take(extracted);
+            self.event_pusher
+                .push(Event::Messages(self.time_ms, extracted));
+        }
     }
 }
-impl<T, E, P> Drop for BatchLogger<T, E, P>
+
+impl<CB, P, D> PushInto<D> for BatchLogger<CB, P>
 where
-    P: EventPusher<Timestamp, Vec<(Duration, E, T)>>,
+    CB: ContainerBuilder + PushInto<D>,
+    P: EventPusher<Timestamp, CB::Container>,
+{
+    fn push_into(&mut self, item: D) {
+        self.builder.push_into(item);
+        self.extract_and_send();
+    }
+}
+
+impl<C, P> BatchLogger<CapacityContainerBuilder<C>, P>
+where
+    C: SizableContainer,
+    P: EventPusher<Timestamp, C>,
+{
+    /// Publishes a batch of logged events and advances the capability.
+    fn push_container(&mut self, data: &mut C) {
+        self.builder.push_container(data);
+        self.extract_and_send();
+    }
+}
+
+impl<CB, P> Drop for BatchLogger<CB, P>
+where
+    CB: ContainerBuilder,
+    P: EventPusher<Timestamp, CB::Container>,
 {
     fn drop(&mut self) {
         self.event_pusher
@@ -134,12 +134,12 @@ where
 /// This is just a bundle-type intended to make passing around its contents in the logging
 /// initialization code more convenient.
 #[derive(Clone)]
-struct EventQueue<E> {
-    link: Rc<EventLink<Timestamp, Vec<(Duration, WorkerIdentifier, E)>>>,
+struct EventQueue<C> {
+    link: Rc<EventLink<Timestamp, C>>,
     activator: RcActivator,
 }
 
-impl<E> EventQueue<E> {
+impl<C> EventQueue<C> {
     fn new(name: &str) -> Self {
         let activator_name = format!("{name}_activator");
         let activate_after = 128;

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -12,27 +12,23 @@
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::rc::Rc;
-use std::time::Duration;
 
 use mz_compute_client::logging::LoggingConfig;
 use mz_expr::{permutation_for_arrangement, MirScalarExpr};
 use mz_ore::cast::CastFrom;
+use mz_ore::flatcontainer::{MzContainerized, OwnedRegionMarker};
 use mz_ore::iter::IteratorExt;
 use mz_repr::{Datum, Diff, RowArena, SharedRow, Timestamp};
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
-use timely::container::flatcontainer::{Containerized, FlatStack};
+use timely::container::flatcontainer::FlatStack;
 use timely::container::CapacityContainerBuilder;
-use timely::dataflow::operators::core::Filter;
+use timely::dataflow::channels::pact::Pipeline;
 
 use crate::extensions::arrange::{MzArrange, MzArrangeCore};
+use crate::logging::initialize::ReachabilityRegion;
 use crate::logging::{EventQueue, LogCollection, LogVariant, TimelyLog};
-use crate::typedefs::{FlatKeyValSpine, RowRowSpine};
-
-pub(super) type ReachabilityEvent = (
-    Vec<usize>,
-    Vec<(usize, usize, bool, Option<Timestamp>, Diff)>,
-);
+use crate::typedefs::{FlatKeyValSpineDefault, RowRowSpine};
 
 /// Constructs the logging dataflow for reachability logs.
 ///
@@ -43,7 +39,7 @@ pub(super) type ReachabilityEvent = (
 pub(super) fn construct<A: Allocate>(
     worker: &mut timely::worker::Worker<A>,
     config: &LoggingConfig,
-    event_queue: EventQueue<ReachabilityEvent>,
+    event_queue: EventQueue<FlatStack<ReachabilityRegion>>,
 ) -> BTreeMap<LogVariant, LogCollection> {
     let interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_index = worker.index();
@@ -51,61 +47,44 @@ pub(super) fn construct<A: Allocate>(
 
     // A dataflow for multiple log-derived arrangements.
     let traces = worker.dataflow_named("Dataflow: timely reachability logging", move |scope| {
-        let (logs, token) = Some(event_queue.link).mz_replay::<_, CapacityContainerBuilder<_>>(
+        let enable_logging = config.enable_logging;
+        type UpdatesKey = (
+            bool,
+            OwnedRegionMarker<usize>,
+            usize,
+            usize,
+            Option<Timestamp>,
+        );
+        type UpdatesRegion = <((UpdatesKey, ()), Timestamp, Diff) as MzContainerized>::Region;
+
+        type CB = CapacityContainerBuilder<FlatStack<UpdatesRegion>>;
+        let (updates, token) = Some(event_queue.link).mz_replay::<_, CB, _>(
             scope,
             "reachability logs",
             config.interval,
             event_queue.activator,
+            move |mut session, data| {
+                // If logging is disabled, we still need to install the indexes, but we can leave them
+                // empty. We do so by immediately filtering all logs events.
+                if !enable_logging {
+                    return;
+                }
+                for (time, _worker, (addr, massaged)) in data.iter() {
+                    let time_ms = ((time.as_millis() / interval_ms) + 1) * interval_ms;
+                    let time_ms: Timestamp = time_ms.try_into().expect("must fit");
+                    for (source, port, update_type, ts, diff) in massaged {
+                        let datum = (update_type, addr, source, port, ts);
+                        session.give(((datum, ()), time_ms, diff));
+                    }
+                }
+            },
         );
-
-        type RLogs = <(Duration, usize, ReachabilityEvent) as Containerized>::Region;
-        let mut logs = logs.container::<FlatStack<RLogs>>();
-
-        // If logging is disabled, we still need to install the indexes, but we can leave them
-        // empty. We do so by immediately filtering all logs events.
-        if !config.enable_logging {
-            logs = logs.filter(|_| false);
-        }
-
-        use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 
         // Restrict results by those logs that are meant to be active.
         let logs_active = vec![LogVariant::Timely(TimelyLog::Reachability)];
 
-        let mut flatten = OperatorBuilder::new(
-            "Timely Reachability Logging Flatten ".to_string(),
-            scope.clone(),
-        );
-
-        use timely::dataflow::channels::pact::Pipeline;
-        let mut input = flatten.new_input(&logs, Pipeline);
-
-        type UpdatesKey = (bool, Vec<usize>, usize, usize, Option<Timestamp>);
-        type UpdatesRegion = <((UpdatesKey, ()), Timestamp, Diff) as Containerized>::Region;
-
-        let (mut updates_out, updates) =
-            flatten.new_output::<CapacityContainerBuilder<FlatStack<UpdatesRegion>>>();
-
-        flatten.build(move |_capability| {
-            move |_frontiers| {
-                let mut updates = updates_out.activate();
-
-                input.for_each(|cap, data| {
-                    let mut updates_session = updates.session_with_builder(&cap);
-                    for (time, _worker, (addr, massaged)) in data.iter() {
-                        let time_ms = ((time.as_millis() / interval_ms) + 1) * interval_ms;
-                        let time_ms: Timestamp = time_ms.try_into().expect("must fit");
-                        for (source, port, update_type, ts, diff) in massaged {
-                            let datum = (update_type, addr, source, port, ts);
-                            updates_session.give(((datum, ()), time_ms, diff));
-                        }
-                    }
-                });
-            }
-        });
-
         let updates = updates
-            .mz_arrange_core::<_, FlatKeyValSpine<UpdatesKey, (), Timestamp, Diff, _>>(
+            .mz_arrange_core::<_, FlatKeyValSpineDefault<UpdatesKey, (), Timestamp, Diff, _>>(
                 Pipeline,
                 "PreArrange Timely reachability",
             );
@@ -130,6 +109,7 @@ pub(super) fn construct<A: Allocate>(
                         let mut row_builder = binding.borrow_mut();
                         row_builder.packer().push_list(
                             addr.iter()
+                                .copied()
                                 .chain_one(source)
                                 .map(|id| Datum::UInt64(u64::cast_from(id))),
                         );

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -16,11 +16,13 @@ use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::trace::implementations::chunker::ColumnationChunker;
 use differential_dataflow::trace::implementations::merge_batcher::MergeBatcher;
 use differential_dataflow::trace::implementations::merge_batcher_col::ColumnationMerger;
-use differential_dataflow::trace::implementations::ord_neu::OrdValBatch;
+use differential_dataflow::trace::implementations::ord_neu::{FlatValSpine, OrdValBatch};
 use differential_dataflow::trace::wrappers::enter::TraceEnter;
 use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
+use mz_ore::flatcontainer::MzContainerized;
 use mz_repr::Diff;
 use mz_storage_types::errors::DataflowError;
+use timely::container::flatcontainer::impls::tuple::{TupleABCRegion, TupleABRegion};
 use timely::dataflow::ScopeParent;
 
 pub use crate::row_spine::{RowRowSpine, RowSpine, RowValSpine};
@@ -30,9 +32,8 @@ pub use crate::typedefs::spines::{ColKeySpine, ColValSpine};
 pub(crate) mod spines {
     use std::rc::Rc;
 
-    use differential_dataflow::trace::implementations::chunker::ContainerChunker;
-    use differential_dataflow::trace::implementations::merge_batcher::MergeBatcher;
-    use differential_dataflow::trace::implementations::merge_batcher_flat::FlatcontainerMerger;
+    use differential_dataflow::difference::Semigroup;
+    use differential_dataflow::lattice::Lattice;
     use differential_dataflow::trace::implementations::ord_neu::{
         OrdKeyBatch, OrdKeyBuilder, OrdValBatch, OrdValBuilder,
     };
@@ -41,7 +42,8 @@ pub(crate) mod spines {
     use differential_dataflow::trace::rc_blanket_impls::RcBuilder;
     use mz_timely_util::containers::stack::StackWrapper;
     use timely::container::columnation::{Columnation, TimelyStack};
-    use timely::container::flatcontainer::{Containerized, FlatStack, Push, Region};
+    use timely::container::flatcontainer::{FlatStack, Push, Region};
+    use timely::progress::Timestamp;
 
     use crate::row_spine::OffsetOptimized;
     use crate::typedefs::{KeyBatcher, KeyValBatcher};
@@ -81,55 +83,61 @@ pub(crate) mod spines {
     }
 
     /// A layout based on timely stacks
-    pub struct MzFlatLayout<U: Update> {
-        phantom: std::marker::PhantomData<U>,
+    pub struct MzFlatLayout<K, V, T, R> {
+        phantom: std::marker::PhantomData<(K, V, T, R)>,
     }
 
-    impl<U: Update> Layout for MzFlatLayout<U>
+    impl<K, V, T, R> Update for MzFlatLayout<K, V, T, R>
     where
-        U::Key: Containerized,
-        for<'a> <U::Key as Containerized>::Region:
-            Push<U::Key> + Push<<<U::Key as Containerized>::Region as Region>::ReadItem<'a>>,
-        for<'a> <<U::Key as Containerized>::Region as Region>::ReadItem<'a>: Copy + Ord,
-        U::Val: Containerized,
-        for<'a> <U::Val as Containerized>::Region:
-            Push<U::Val> + Push<<<U::Val as Containerized>::Region as Region>::ReadItem<'a>>,
-        for<'a> <<U::Val as Containerized>::Region as Region>::ReadItem<'a>: Copy + Ord,
-        U::Time: Containerized,
-        <U::Time as Containerized>::Region: Region<Owned = U::Time>,
-        for<'a> <U::Time as Containerized>::Region:
-            Push<U::Time> + Push<<<U::Time as Containerized>::Region as Region>::ReadItem<'a>>,
-        for<'a> <<U::Time as Containerized>::Region as Region>::ReadItem<'a>: Copy + Ord,
-        U::Diff: Containerized,
-        <U::Diff as Containerized>::Region: Region<Owned = U::Diff>,
-        for<'a> <U::Diff as Containerized>::Region:
-            Push<U::Diff> + Push<<<U::Diff as Containerized>::Region as Region>::ReadItem<'a>>,
-        for<'a> <<U::Diff as Containerized>::Region as Region>::ReadItem<'a>: Copy + Ord,
+        K: Region,
+        V: Region,
+        T: Region,
+        R: Region,
+        K::Owned: Ord + Clone + 'static,
+        V::Owned: Ord + Clone + 'static,
+        T::Owned: Ord + Clone + Lattice + Timestamp + 'static,
+        R::Owned: Ord + Semigroup + 'static,
     {
-        type Target = U;
-        type KeyContainer = FlatStack<<U::Key as Containerized>::Region>;
-        type ValContainer = FlatStack<<U::Val as Containerized>::Region>;
-        type TimeContainer = FlatStack<<U::Time as Containerized>::Region>;
-        type DiffContainer = FlatStack<<U::Diff as Containerized>::Region>;
+        type Key = K::Owned;
+        type Val = V::Owned;
+        type Time = T::Owned;
+        type Diff = R::Owned;
+    }
+
+    impl<K, V, T, R> Layout for MzFlatLayout<K, V, T, R>
+    where
+        K: Region
+            + Push<<K as Region>::Owned>
+            + for<'a> Push<<K as Region>::ReadItem<'a>>
+            + 'static,
+        V: Region
+            + Push<<V as Region>::Owned>
+            + for<'a> Push<<V as Region>::ReadItem<'a>>
+            + 'static,
+        T: Region
+            + Push<<T as Region>::Owned>
+            + for<'a> Push<<T as Region>::ReadItem<'a>>
+            + 'static,
+        R: Region
+            + Push<<R as Region>::Owned>
+            + for<'a> Push<<R as Region>::ReadItem<'a>>
+            + 'static,
+        K::Owned: Ord + Clone + 'static,
+        V::Owned: Ord + Clone + 'static,
+        T::Owned: Ord + Clone + Lattice + Timestamp + 'static,
+        R::Owned: Ord + Semigroup + 'static,
+        for<'a> K::ReadItem<'a>: Copy + Ord,
+        for<'a> V::ReadItem<'a>: Copy + Ord,
+        for<'a> T::ReadItem<'a>: Copy + Ord,
+        for<'a> R::ReadItem<'a>: Copy + Ord,
+    {
+        type Target = Self;
+        type KeyContainer = FlatStack<K>;
+        type ValContainer = FlatStack<V>;
+        type TimeContainer = FlatStack<T>;
+        type DiffContainer = FlatStack<R>;
         type OffsetContainer = OffsetOptimized;
     }
-
-    /// A trace implementation backed by flatcontainer storage.
-    pub type FlatValSpine<K, V, T, R, C> = Spine<
-        Rc<OrdValBatch<MzFlatLayout<((K, V), T, R)>>>,
-        MergeBatcher<
-            C,
-            ContainerChunker<FlatStack<<((K, V), T, R) as Containerized>::Region>>,
-            FlatcontainerMerger<T, R, <((K, V), T, R) as Containerized>::Region>,
-            T,
-        >,
-        RcBuilder<
-            OrdValBuilder<
-                MzFlatLayout<((K, V), T, R)>,
-                FlatStack<<((K, V), T, R) as Containerized>::Region>,
-            >,
-        >,
-    >;
 }
 
 // Spines are data structures that collect and maintain updates.
@@ -175,8 +183,16 @@ pub type KeyValBatcher<K, V, T, D> = MergeBatcher<
     T,
 >;
 
-pub type FlatKeyValBatch<K, V, T, R> = OrdValBatch<MzFlatLayout<((K, V), T, R)>>;
-pub type FlatKeyValSpine<K, V, T, R, C> = spines::FlatValSpine<K, V, T, R, C>;
+pub type FlatKeyValBatch<K, V, T, R> = OrdValBatch<MzFlatLayout<K, V, T, R>>;
+pub type FlatKeyValSpine<K, V, T, R, C> =
+    FlatValSpine<MzFlatLayout<K, V, T, R>, TupleABCRegion<TupleABRegion<K, V>, T, R>, C>;
+pub type FlatKeyValSpineDefault<K, V, T, R, C> = FlatKeyValSpine<
+    <K as MzContainerized>::Region,
+    <V as MzContainerized>::Region,
+    <T as MzContainerized>::Region,
+    <R as MzContainerized>::Region,
+    C,
+>;
 pub type FlatKeyValAgent<K, V, T, R, C> = TraceAgent<FlatKeyValSpine<K, V, T, R, C>>;
 pub type FlatKeyValEnter<K, V, T, R, C, TEnter> =
     TraceEnter<TraceFrontier<FlatKeyValAgent<K, V, T, R, C>>, TEnter>;

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -28,6 +28,7 @@ compact_bytes = { version = "0.1.2", optional = true }
 ctor = { version = "0.1.26", optional = true }
 derivative = { version = "2.2.0", optional = true }
 either = "1.8.0"
+flatcontainer = { version = "0.4.1", optional = true }
 futures = { version = "0.3.25", optional = true }
 hibitset = { version = "0.6.4", optional = true }
 lgalloc = { version = "0.3", optional = true }

--- a/src/ore/src/flatcontainer.rs
+++ b/src/ore/src/flatcontainer.rs
@@ -1,0 +1,121 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Flat container utilities
+
+use flatcontainer::{Push, Region, ReserveItems};
+
+/// Associate a type with a flat container region.
+pub trait MzContainerized: 'static {
+    /// The owned type of the container.
+    type Owned;
+    /// A region that can hold `Self`.
+    type Region: for<'a> Region<Owned = Self::Owned>
+        + Push<Self::Owned>
+        + for<'a> Push<<Self::Region as Region>::ReadItem<'a>>
+        + for<'a> ReserveItems<<Self::Region as Region>::ReadItem<'a>>;
+}
+
+/// Marker to indicate that the contents of a collection should be stored in an
+/// [`OwnedRegion`](flatcontainer::OwnedRegion). This is most useful to force types to a region
+/// that doesn't copy individual elements to a nested region, like the
+/// [`SliceRegion`](flatcontainer::SliceRegion) does.
+#[derive(Debug)]
+pub struct OwnedRegionMarker<T>(std::marker::PhantomData<T>);
+
+mod tuple {
+    use flatcontainer::impls::tuple::*;
+    use paste::paste;
+
+    use crate::flatcontainer::MzContainerized;
+
+    macro_rules! tuple_flatcontainer {
+        ($($name:ident)+) => (
+            paste! {
+                impl<$($name: MzContainerized),*> MzContainerized for ($($name,)*) {
+                    type Owned = ($($name::Owned,)*);
+                    type Region = [<Tuple $($name)* Region >]<$($name::Region,)*>;
+                }
+            }
+        )
+    }
+
+    tuple_flatcontainer!(A);
+    tuple_flatcontainer!(A B);
+    tuple_flatcontainer!(A B C);
+    tuple_flatcontainer!(A B C D);
+    tuple_flatcontainer!(A B C D E);
+}
+
+mod copy {
+    use flatcontainer::MirrorRegion;
+
+    use crate::flatcontainer::MzContainerized;
+
+    macro_rules! implement_for {
+        ($index_type:ty) => {
+            impl MzContainerized for $index_type {
+                type Owned = Self;
+                type Region = MirrorRegion<Self>;
+            }
+        };
+    }
+
+    implement_for!(());
+    implement_for!(bool);
+    implement_for!(char);
+
+    implement_for!(u8);
+    implement_for!(u16);
+    implement_for!(u32);
+    implement_for!(u64);
+    implement_for!(u128);
+    implement_for!(usize);
+
+    implement_for!(i8);
+    implement_for!(i16);
+    implement_for!(i32);
+    implement_for!(i64);
+    implement_for!(i128);
+    implement_for!(isize);
+
+    implement_for!(f32);
+    implement_for!(f64);
+
+    implement_for!(std::num::Wrapping<i8>);
+    implement_for!(std::num::Wrapping<i16>);
+    implement_for!(std::num::Wrapping<i32>);
+    implement_for!(std::num::Wrapping<i64>);
+    implement_for!(std::num::Wrapping<i128>);
+    implement_for!(std::num::Wrapping<isize>);
+
+    implement_for!(std::time::Duration);
+}
+
+mod vec {
+    use flatcontainer::OwnedRegion;
+
+    use crate::flatcontainer::{MzContainerized, OwnedRegionMarker};
+
+    impl<T: Clone + 'static> MzContainerized for OwnedRegionMarker<T> {
+        type Owned = Vec<T>;
+        type Region = OwnedRegion<T>;
+    }
+}
+
+impl<T: MzContainerized> MzContainerized for Option<T> {
+    type Owned = <flatcontainer::OptionRegion<T::Region> as Region>::Owned;
+    type Region = flatcontainer::OptionRegion<T::Region>;
+}

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -40,6 +40,8 @@ pub mod codegen;
 pub mod collections;
 pub mod env;
 pub mod error;
+#[cfg(feature = "flatcontainer")]
+pub mod flatcontainer;
 pub mod fmt;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "async")))]
 #[cfg(feature = "async")]

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -47,6 +47,7 @@ once_cell = "1.16.0"
 mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore", features = [
     "bytes_",
+    "flatcontainer",
     "id_gen",
     "smallvec",
     "region",

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -462,11 +462,11 @@ impl columnation::Columnation for Timestamp {
 
 mod flatcontainer {
     use flatcontainer::{IntoOwned, MirrorRegion};
-    use mz_ore::flatcontainer::MzContainerized;
+    use mz_ore::flatcontainer::MzRegionPreference;
 
     use crate::Timestamp;
 
-    impl MzContainerized for Timestamp {
+    impl MzRegionPreference for Timestamp {
         type Owned = Self;
         type Region = MirrorRegion<Timestamp>;
     }

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -461,11 +461,13 @@ impl columnation::Columnation for Timestamp {
 }
 
 mod flatcontainer {
-    use flatcontainer::{Containerized, IntoOwned, MirrorRegion};
+    use flatcontainer::{IntoOwned, MirrorRegion};
+    use mz_ore::flatcontainer::MzContainerized;
 
     use crate::Timestamp;
 
-    impl Containerized for Timestamp {
+    impl MzContainerized for Timestamp {
+        type Owned = Self;
         type Region = MirrorRegion<Timestamp>;
     }
 


### PR DESCRIPTION
Introduce a `MzContainerized` trait that associates types to regions, while allowing to specify a owned type that is different to `Self`. Switches reachability logging to send flat containers over dataflow edges. Changes `mz_replay` to accept a closure to produce data.

Related: #27741

Part of #13038

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
