### PR TITLE
persist: Update description on dyn cfg

### DIFF
--- a/src/persist-client/src/internal/cache.rs
+++ b/src/persist-client/src/internal/cache.rs
@@ -38,7 +38,7 @@ pub(crate) const BLOB_CACHE_MEM_LIMIT_BYTES: Config<usize> = Config::new(
     // help with multi-process replicas, but the memory usage seems
     // unobjectionable enough to have it for the cases that it does help.
     1024 * 1024,
-    "Capacity of in-mem blob cache in bytes. Only takes effect on restart (Materialize).",
+    "Capacity of in-mem blob cache in bytes (Materialize).",
 );
 
 impl BlobMemCache {


### PR DESCRIPTION
The flag takes effect immediately, not on restart

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
