### PR TITLE
tests: disable smoketest_packed_numeric_roundtrips in miri

### DIFF
--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -852,6 +852,7 @@ mod tests {
     }
 
     #[mz_ore::test]
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     fn smoketest_packed_numeric_roundtrips() {
         let og = PackedNumeric::from_value(Numeric::from(-42));
         let bytes = og.as_bytes();


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/8158#01902c67-2c5e-4569-a48d-aa5a33d8a10b.