### PR TITLE
[skunk] Add a CLOCK load generator

### DIFF
--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -118,6 +118,21 @@ The organizations, users, and accounts are fixed at the time the source
 is created. Each tick interval, either a new auction is started, or a new bid
 is placed in the currently ongoing auction.
 
+### Clock
+
+{{< private-preview />}}
+
+The clock load generator tracks the system clock time, and can be used in
+contexts where the [`now()` function cannot](/sql/functions/now_and_mz_now/#limitations).
+On each tick interval, the source emits the system clock time. For example,
+configuring this load generator with `TICK INTERVAL '1 minute'` will cause the
+source to update every minute.
+
+Field | Type                         | Description
+----  | ---------------------------- | -------------
+time  | `timestamp with time zone`   | The system clock time.
+
+
 ### Marketing
 
 The marketing load generator simulates a marketing organization that is using a machine learning model to send coupons to potential leads. The marketing source will be automatically demuxed
@@ -302,6 +317,43 @@ SELECT * from bids;
  10 |  3844 |          1 |     59 | 2022-09-16 23:24:07.332+00
  11 |  1861 |          1 |     40 | 2022-09-16 23:24:08.332+00
  12 |  3338 |          1 |     97 | 2022-09-16 23:24:09.332+00
+```
+
+### Creating a clock load generator
+
+{{< private-preview />}}
+
+To create a load generator source that ticks over to a new time every second:
+
+```mzsql
+CREATE SOURCE clock
+  FROM LOAD GENERATOR CLOCK
+  (TICK INTERVAL '1s');
+```
+
+To display the created source:
+
+```mzsql
+SHOW SOURCES;
+```
+
+```nofmt
+      name      |      type      | size |  cluster
+----------------+----------------+------+-----------
+ clock          | load-generator | 1    | mz_system
+ clock_progress | progress       |      |
+```
+
+To check the current clock time:
+
+```mzsql
+SELECT * FROM clock;
+```
+
+```nofmt
+          time
+------------------------
+ 2024-07-02 16:25:06+00
 ```
 
 ### Creating a marketing load generator

--- a/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="555" height="687">
+<svg xmlns="http://www.w3.org/2000/svg" width="555" height="731">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -47,38 +47,46 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="56" y="261">AUCTION</text>
-   <rect x="48" y="287" width="88" height="32" rx="10"/>
+   <rect x="48" y="287" width="70" height="32" rx="10"/>
    <rect x="46"
          y="285"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="56" y="305">CLOCK</text>
+   <rect x="48" y="331" width="88" height="32" rx="10"/>
+   <rect x="46"
+         y="329"
          width="88"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="56" y="305">COUNTER</text>
-   <rect x="48" y="331" width="104" height="32" rx="10"/>
+   <text class="terminal" x="56" y="349">COUNTER</text>
+   <rect x="48" y="375" width="104" height="32" rx="10"/>
    <rect x="46"
-         y="329"
+         y="373"
          width="104"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="56" y="349">MARKETING</text>
-   <rect x="48" y="375" width="60" height="32" rx="10"/>
+   <text class="terminal" x="56" y="393">MARKETING</text>
+   <rect x="48" y="419" width="60" height="32" rx="10"/>
    <rect x="46"
-         y="373"
+         y="417"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="56" y="393">TPCH</text>
-   <rect x="48" y="419" width="100" height="32" rx="10"/>
+   <text class="terminal" x="56" y="437">TPCH</text>
+   <rect x="48" y="463" width="100" height="32" rx="10"/>
    <rect x="46"
-         y="417"
+         y="461"
          width="100"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="56" y="437">KEY VALUE</text>
+   <text class="terminal" x="56" y="481">KEY VALUE</text>
    <rect x="212" y="243" width="26" height="32" rx="10"/>
    <rect x="210"
          y="241"
@@ -106,46 +114,46 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="492" y="261">)</text>
-   <rect x="210" y="485" width="138" height="32" rx="10"/>
+   <rect x="210" y="529" width="138" height="32" rx="10"/>
    <rect x="208"
-         y="483"
+         y="527"
          width="138"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="218" y="503">FOR ALL TABLES</text>
-   <rect x="45" y="567" width="76" height="32" rx="10"/>
+   <text class="terminal" x="218" y="547">FOR ALL TABLES</text>
+   <rect x="45" y="611" width="76" height="32" rx="10"/>
    <rect x="43"
-         y="565"
+         y="609"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="585">EXPOSE</text>
-   <rect x="141" y="567" width="96" height="32" rx="10"/>
+   <text class="terminal" x="53" y="629">EXPOSE</text>
+   <rect x="141" y="611" width="96" height="32" rx="10"/>
    <rect x="139"
-         y="565"
+         y="609"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="149" y="585">PROGRESS</text>
-   <rect x="257" y="567" width="40" height="32" rx="10"/>
+   <text class="terminal" x="149" y="629">PROGRESS</text>
+   <rect x="257" y="611" width="40" height="32" rx="10"/>
    <rect x="255"
-         y="565"
+         y="609"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="265" y="585">AS</text>
-   <rect x="317" y="567" width="196" height="32"/>
-   <rect x="315" y="565" width="196" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="325" y="585">progress_subsource_name</text>
-   <rect x="405" y="653" width="102" height="32"/>
-   <rect x="403" y="651" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="413" y="671">with_options</text>
+   <text class="terminal" x="265" y="629">AS</text>
+   <rect x="317" y="611" width="196" height="32"/>
+   <rect x="315" y="609" width="196" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="325" y="629">progress_subsource_name</text>
+   <rect x="405" y="697" width="102" height="32"/>
+   <rect x="403" y="695" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="413" y="715">with_options</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-462 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-539 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m86 0 h10 m0 0 h18 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m88 0 h10 m0 0 h16 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m60 0 h10 m0 0 h44 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m100 0 h10 m0 0 h4 m40 -176 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-364 242 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m138 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-367 50 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-192 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m23 -32 h-3"/>
-   <polygon points="545 635 553 631 553 639"/>
-   <polygon points="545 635 537 631 537 639"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-462 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-539 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m86 0 h10 m0 0 h18 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m70 0 h10 m0 0 h34 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m88 0 h10 m0 0 h16 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m60 0 h10 m0 0 h44 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m100 0 h10 m0 0 h4 m40 -220 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-364 286 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m138 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-367 50 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-192 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m23 -32 h-3"/>
+   <polygon points="545 679 553 675 553 683"/>
+   <polygon points="545 679 537 675 537 683"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -195,7 +195,7 @@ create_source_kafka ::=
 create_source_load_generator ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   ('IN CLUSTER' cluster_name)?
-  'FROM LOAD GENERATOR' ('AUCTION' | 'COUNTER' | 'MARKETING' | 'TPCH' | 'KEY VALUE')
+  'FROM LOAD GENERATOR' ('AUCTION' | 'CLOCK' |   'COUNTER' | 'MARKETING' | 'TPCH' | 'KEY VALUE')
   ('(' (load_generator_option) ( ( ',' load_generator_option ) )* ')')?
   'FOR ALL TABLES'
   ('EXPOSE' 'PROGRESS' 'AS' progress_subsource_name)?

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -74,6 +74,7 @@ Characteristics
 Check
 Class
 Client
+Clock
 Close
 Cluster
 Clusters

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1204,6 +1204,7 @@ impl_display_t!(CreateSourceConnection);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum LoadGenerator {
+    Clock,
     Counter,
     Marketing,
     Auction,
@@ -1216,6 +1217,7 @@ impl AstDisplay for LoadGenerator {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Self::Counter => f.write_str("COUNTER"),
+            Self::Clock => f.write_str("CLOCK"),
             Self::Marketing => f.write_str("MARKETING"),
             Self::Auction => f.write_str("AUCTION"),
             Self::Datums => f.write_str("DATUMS"),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3230,9 +3230,10 @@ impl<'a> Parser<'a> {
             }
             LOAD => {
                 self.expect_keyword(GENERATOR)?;
-                let generator = match self
-                    .expect_one_of_keywords(&[COUNTER, MARKETING, AUCTION, TPCH, DATUMS, KEY])?
-                {
+                let generator = match self.expect_one_of_keywords(&[
+                    CLOCK, COUNTER, MARKETING, AUCTION, TPCH, DATUMS, KEY,
+                ])? {
+                    CLOCK => LoadGenerator::Clock,
                     COUNTER => LoadGenerator::Counter,
                     AUCTION => LoadGenerator::Auction,
                     TPCH => LoadGenerator::Tpch,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2522,6 +2522,13 @@ CREATE SOURCE lg FROM LOAD GENERATOR KEY VALUE (KEYS = 1, PARTITIONS = 2, TICK I
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: KeyValue, options: [LoadGeneratorOption { name: Keys, value: Some(Value(Number("1"))) }, LoadGeneratorOption { name: Partitions, value: Some(Value(Number("2"))) }, LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1m"))) }, LoadGeneratorOption { name: BatchSize, value: Some(Value(Number("100"))) }, LoadGeneratorOption { name: Seed, value: Some(Value(Number("200"))) }, LoadGeneratorOption { name: ValueSize, value: Some(Value(Number("150"))) }, LoadGeneratorOption { name: SnapshotRounds, value: Some(Value(Number("3"))) }, LoadGeneratorOption { name: TransactionalSnapshot, value: Some(Value(Boolean(false))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
+CREATE SOURCE clock FROM LOAD GENERATOR CLOCK (TICK INTERVAL '1s')
+----
+CREATE SOURCE clock FROM LOAD GENERATOR CLOCK (TICK INTERVAL = '1s')
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("clock")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Clock, options: [LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1s"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
+
+parse-statement
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1s', SCALE FACTOR 1, MAX CARDINALITY 100, UP TO 5, AS OF 5)
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL = '1s', SCALE FACTOR = 1, MAX CARDINALITY = 100, UP TO = 5, AS OF = 5)

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1470,6 +1470,7 @@ impl LoadGeneratorOptionExtracted {
 
         let permitted_options: &[_] = match loadgen {
             ast::LoadGenerator::Auction => &[TickInterval, AsOf, UpTo],
+            ast::LoadGenerator::Clock => &[TickInterval, AsOf, UpTo],
             ast::LoadGenerator::Counter => &[TickInterval, AsOf, UpTo, MaxCardinality],
             ast::LoadGenerator::Marketing => &[TickInterval, AsOf, UpTo],
             ast::LoadGenerator::Datums => &[TickInterval, AsOf, UpTo],
@@ -1517,6 +1518,10 @@ pub(crate) fn load_generator_ast_to_generator(
 
     let load_generator = match loadgen {
         ast::LoadGenerator::Auction => LoadGenerator::Auction,
+        ast::LoadGenerator::Clock => {
+            scx.require_feature_flag(&crate::session::vars::ENABLE_CLOCK_LOAD_GENERATOR)?;
+            LoadGenerator::Clock
+        }
         ast::LoadGenerator::Counter => {
             let LoadGeneratorOptionExtracted {
                 max_cardinality, ..

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2067,6 +2067,12 @@ feature_flags!(
         default: false,
         enable_for_item_parsing: true,
     },
+    {
+        name: enable_clock_load_generator,
+        desc: "Enable the clock load generator",
+        default: false,
+        enable_for_item_parsing: true,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {

--- a/src/storage-types/src/sources/load_generator.proto
+++ b/src/storage-types/src/sources/load_generator.proto
@@ -19,6 +19,7 @@ message ProtoLoadGeneratorSourceConnection {
     reserved 1;
     oneof kind {
         ProtoCounterLoadGenerator counter = 6;
+        google.protobuf.Empty clock = 11;
         google.protobuf.Empty auction = 3;
         ProtoTpchLoadGenerator tpch = 4;
         google.protobuf.Empty datums = 5;
@@ -46,7 +47,7 @@ message ProtoKeyValueLoadGenerator {
     uint64 keys = 1;
     uint64 snapshot_rounds = 2;
     bool transactional_snapshot = 3;
-    uint64 value_size= 4;
+    uint64 value_size = 4;
     uint64 partitions = 5;
     optional mz_proto.ProtoDuration tick_interval = 6;
     uint64 batch_size = 7;

--- a/src/storage/src/source/generator/clock.rs
+++ b/src/storage/src/source/generator/clock.rs
@@ -1,0 +1,70 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_ore::cast::CastFrom;
+use mz_ore::now::NowFn;
+use mz_repr::{Datum, Row};
+use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorOutput};
+use mz_storage_types::sources::MzOffset;
+use std::{iter, mem};
+
+pub struct Clock {
+    pub tick_ms: u64,
+    pub as_of_ms: u64,
+}
+
+impl Generator for Clock {
+    fn by_seed(
+        &self,
+        now: NowFn,
+        _seed: Option<u64>,
+        mut resume_offset: MzOffset,
+    ) -> Box<dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, i64)>)>> {
+        let interval_ms = self.tick_ms;
+        let floor = move |t| t / interval_ms * interval_ms;
+        let first_tick = floor(self.as_of_ms);
+        resume_offset = resume_offset.max(MzOffset::from(first_tick));
+
+        Box::new(
+            iter::from_fn(move || {
+                let next_offset = MzOffset::from(now() + 1).max(resume_offset);
+                let prev_offset = mem::replace(&mut resume_offset, next_offset);
+                Some((prev_offset, next_offset))
+            })
+            .flat_map(move |(lower, upper)| {
+                let row = move |tick: u64| {
+                    let now_dt = mz_ore::now::to_datetime(tick)
+                        .try_into()
+                        .expect("system time out of bounds");
+                    Row::pack_slice(&[Datum::TimestampTz(now_dt)])
+                };
+
+                let messages = (floor(lower.offset)..=floor(upper.offset))
+                    .step_by(usize::cast_from(interval_ms))
+                    .filter(move |&tick| lower.offset <= tick && tick < upper.offset)
+                    .flat_map(move |at_offset| {
+                        let last_offset = at_offset
+                            .checked_sub(interval_ms)
+                            .filter(move |&t| t >= first_tick);
+                        [last_offset.map(|t| (t, -1)), Some((at_offset, 1))]
+                            .into_iter()
+                            .flatten()
+                            .map(move |(time, diff)| {
+                                Event::Message(MzOffset::from(at_offset), (row(time), diff))
+                            })
+                    });
+                let progress = iter::once(Event::Progress(Some(upper)));
+
+                messages
+                    .chain(progress)
+                    .map(|e| (LoadGeneratorOutput::Default, e))
+            }),
+        )
+    }
+}

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -10,6 +10,9 @@
 $ set-arg-default default-replica-size=1
 $ set-arg-default single-replica-cluster=quickstart
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_clock_load_generator = true;
+
 > CREATE SOURCE counter_empty
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR COUNTER (AS OF 5, UP TO 5)
@@ -100,6 +103,18 @@ users                   subsource      ${arg.single-replica-cluster}
 # Show that AST of subsource contains REFERENCES option
 > SHOW CREATE SOURCE accounts
 materialize.public.accounts "CREATE SUBSOURCE \"materialize\".\"public\".\"accounts\" (\"id\" \"pg_catalog\".\"int8\" NOT NULL, \"org_id\" \"pg_catalog\".\"int8\" NOT NULL, \"balance\" \"pg_catalog\".\"int8\" NOT NULL, UNIQUE (\"id\")) OF SOURCE \"materialize\".\"public\".\"auction_house\" WITH (EXTERNAL REFERENCE = \"mz_load_generators\".\"auction\".\"accounts\")"
+
+# CLOCK load generator source
+
+> CREATE SOURCE clock
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR CLOCK (TICK INTERVAL '1s')
+
+> SELECT count(*) FROM clock;
+1
+
+> SELECT time < now() + INTERVAL '1s', time > now() - INTERVAL '1s' FROM clock
+true true
 
 # Check that non-append-only `COUNTER` sources reach the proper size
 


### PR DESCRIPTION
Add a load generator that is periodically updated to reflect the current time.

```
materialize=> CREATE SOURCE clock FROM LOAD GENERATOR CLOCK (TICK INTERVAL '1s');
CREATE SOURCE
materialize=> select * from clock;
     time      
---------------
 1718817919000
(1 row)

materialize=> copy(subscribe to (select time::timestamp from clock)) to stdout;
1718817931178	1	2024-06-19 17:25:29
1718817932000	-1	2024-06-19 17:25:29
1718817932000	1	2024-06-19 17:25:30
1718817933000	1	2024-06-19 17:25:31
1718817933000	-1	2024-06-19 17:25:30
1718817934000	1	2024-06-19 17:25:32
1718817934000	-1	2024-06-19 17:25:31
1718817935000	1	2024-06-19 17:25:33
1718817935000	-1	2024-06-19 17:25:32
1718817936000	1	2024-06-19 17:25:34
1718817936000	-1	2024-06-19 17:25:33
```

### Motivation

Inspired by [this blog post](https://github.com/frankmcsherry/blog/blob/master/posts/2024-05-19.md#operational-data-from-thin-air) -- the machinery there is very cool, but having a bit of support from a source would allow you to do things like:

```sql
CREATE VIEW moments AS
SELECT
  generate_series(time::timestamp - '3 hours', time::timestamp - '1 second', '1 second') AS moment
FROM clock;
```

Which feels more direct to me... and may be slightly more efficient, since it does not require eg. pre-generating the list of all years.

### Tips for reviewer

I've updated the impl to use tokio's ticking mechanism and have ticks roughly align with nice round wall-clock times. (So if we use a 1-minute tick interval the tick will happen roughly as the minute changes; and if it isn't polled for a few minutes for whatever reason, it would do a few extra ticks to keep up.) This is useful for the clock source, but I think it's better behaviour in general.

Note that the clock ticks don't necessarily align precisely with `mz_now()`, because we have no way to control the timestamp of the data after it's reclocked. (And in practice, due to the vagaries of the source pipeline, the ticks are reclocked slightly later than you'd want.) Fixing this is a much bigger project than this little PR, though!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
