### PR TITLE
Accept OFFSET and LIMIT/FETCH in any order

### DIFF
--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -79,7 +79,7 @@ error: multiple LIMIT/FETCH clauses not allowed
 parse-statement roundtrip
 (SELECT LIMIT 1) FETCH FIRST ROW
 ----
-error: Expected end of statement, found FETCH
+error: multiple LIMIT/FETCH clauses not allowed
 (SELECT LIMIT 1) FETCH FIRST ROW
                  ^
 

--- a/test/sqllogictest/cockroach/limit.slt
+++ b/test/sqllogictest/cockroach/limit.slt
@@ -57,10 +57,10 @@ SELECT generate_series FROM generate_series(1, 100) ORDER BY generate_series OFF
 ----
 4
 
-statement error Expected end of statement, found LIMIT
+statement error db error: ERROR: multiple LIMIT/FETCH clauses not allowed
 SELECT generate_series FROM generate_series(1, 100) FETCH NEXT ROW ONLY LIMIT 3;
 
-statement error Expected end of statement, found FETCH
+statement error db error: ERROR: multiple LIMIT/FETCH clauses not allowed
 SELECT generate_series FROM generate_series(1, 100) LIMIT 3 FETCH NEXT ROW ONLY;
 
 query I

--- a/test/sqllogictest/limit_expr.slt
+++ b/test/sqllogictest/limit_expr.slt
@@ -7,6 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# ---------------------------------------------------------
+# Non-literal expressions in LIMIT.
+# (For literals, see `order_by.slt`)
+# ---------------------------------------------------------
+
 mode cockroach
 
 simple conn=mz_system,user=mz_system

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -397,6 +397,136 @@ one  1
 two  2
 zero 0
 
+# LIMIT (or FETCH) and OFFSET should be accepted in any order. (Postgres also does, and Monte Carlo needs this.)
+query TI
+SELECT b, a
+FROM foo
+ORDER BY b
+LIMIT 2;
+----
+one  1
+two  2
+
+query TI
+SELECT b, a
+FROM foo
+ORDER BY b
+FETCH FIRST 2 ROWS ONLY;
+----
+one  1
+two  2
+
+query TI
+SELECT b, a
+FROM foo
+ORDER BY b
+LIMIT 2 OFFSET 1;
+----
+two  2
+zero  0
+
+query TI
+SELECT b, a
+FROM foo
+ORDER BY b
+FETCH FIRST 2 ROWS ONLY OFFSET 1;
+----
+two  2
+zero  0
+
+query TI
+SELECT b, a
+FROM foo
+ORDER BY b
+OFFSET 1 LIMIT 1;
+----
+two  2
+
+query TI
+SELECT b, a
+FROM foo
+ORDER BY b
+OFFSET 1;
+----
+two  2
+zero  0
+
+# FETCH FIRST and FETCH NEXT mean the same thing.
+query TI
+SELECT b, a
+FROM foo
+ORDER BY b
+OFFSET 1
+FETCH FIRST 1 ROWS ONLY;
+----
+two  2
+
+query TI
+SELECT b, a
+FROM foo
+ORDER BY b
+OFFSET 1
+FETCH NEXT 1 ROWS ONLY;
+----
+two  2
+
+# OFFSET can have optional ROW or ROWS (which doesn't mean anything)
+query TI
+SELECT b, a
+FROM foo
+ORDER BY b
+OFFSET 1 ROW LIMIT 3;
+----
+two  2
+zero  0
+
+query TI
+SELECT b, a
+FROM foo
+ORDER BY b
+OFFSET 1 ROWS LIMIT 3;
+----
+two  2
+zero  0
+
+# Multiple LIMIT/FETCH or multiple OFFSET not allowed
+query error multiple LIMIT/FETCH clauses not allowed
+SELECT b, a
+FROM foo
+ORDER BY b
+LIMIT 1 LIMIT 2;
+
+query error multiple LIMIT/FETCH clauses not allowed
+SELECT b, a
+FROM foo
+ORDER BY b
+LIMIT 1
+FETCH FIRST 3 ROWS ONLY;
+
+query error multiple OFFSET clauses not allowed
+SELECT b, a
+FROM foo
+ORDER BY b
+OFFSET 1 OFFSET 2;
+
+query error multiple LIMIT/FETCH clauses not allowed
+SELECT b, a
+FROM foo
+ORDER BY b
+LIMIT 1 OFFSET 1 LIMIT 2;
+
+query error multiple OFFSET clauses not allowed
+SELECT b, a
+FROM foo
+ORDER BY b
+OFFSET 1 LIMIT 3 OFFSET 2;
+
+query error multiple OFFSET clauses not allowed
+SELECT b, a
+FROM foo
+ORDER BY b
+OFFSET 1 OFFSET 2 LIMIT 3;
+
 ### sorts, limits, and offsets in subqueries ###
 
 # These tests have been designed to cover a wide range of situations where there


### PR DESCRIPTION
Fixes #27765

I've checked also the Monte Carlo query from the issue, and it works.

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/materialize/issues/27765

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
