### PR TITLE
storage: deletion from differential storage-managed collections

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -49,7 +49,7 @@ use mz_ore::{soft_assert_or_log, soft_panic_or_log};
 use mz_repr::global_id::TransientIdGen;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{Datum, Diff, GlobalId, Row, TimestampManipulation};
-use mz_storage_client::controller::{IntrospectionType, StorageController};
+use mz_storage_client::controller::{IntrospectionType, StorageController, StorageWriteOp};
 use mz_storage_client::storage_collections::StorageCollections;
 use mz_storage_types::read_policy::ReadPolicy;
 use serde::{Deserialize, Serialize};
@@ -687,9 +687,8 @@ where
 
         for (type_, updates) in updates_by_type {
             if !updates.is_empty() {
-                storage
-                    .update_introspection_collection(type_, updates)
-                    .await;
+                let op = StorageWriteOp::Append { updates };
+                storage.update_introspection_collection(type_, op).await;
             }
         }
     }

--- a/src/storage-controller/src/statistics.rs
+++ b/src/storage-controller/src/statistics.rs
@@ -100,7 +100,7 @@ where
             current_metrics.extend(correction.iter().cloned());
 
             collection_mgmt
-                .update_desired(statistics_collection_id, correction)
+                .differential_append(statistics_collection_id, correction)
                 .await;
         }
 
@@ -152,7 +152,7 @@ where
                     if !correction.is_empty() {
                         current_metrics.extend(correction.iter().cloned());
                         collection_mgmt
-                            .update_desired(statistics_collection_id, correction)
+                            .differential_append(statistics_collection_id, correction)
                             .await;
                     }
                 }


### PR DESCRIPTION
This PR extends the storage controller with support for deleting contents of differential storage-managed collections. Instead of a list of updates to append, the storage controller now accepts a `StorageWriteOp` in its APIs to update these collections. In addition to the existing append functionality, a `StorageWriteOp` can also specify a deletion request based on a `Row` filter.

At the moment deletions are implemented simply by utilizing the `desired` state that is kept in memory for differential collections, making additional persist reads unnecessary. This will have to change once the `CollectionManager` becomes smart enough to only keep the diff between `desired` and the persisted collection contents.

### Motivation

  * This PR adds a known-desirable feature.

Part of #26730
Design: #27548 

### Tips for reviewer

The new capability is not utilized in this PR. For a usage example see https://github.com/MaterializeInc/materialize/pull/27767, from which this is split out.

No strong opinions on the naming of things, happy to accept alternative proposals!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A