### PR TITLE
feature benchmark: fix ignore entry

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -34,7 +34,7 @@ def get_ancestor_overrides_for_performance_regressions(
     if scenario_class_name == "SwapSchema":
         # PR#27607 (catalog: Listen for updates in transactions) increased wallclock
         min_ancestor_mz_version_per_commit[
-            "d5388cccbcd860b04486573f632fb9337e7335a2"
+            "eef900de75d25fe854524dff9feeed8057e4bf79"
         ] = MzVersion.parse_mz("v0.105.0")
 
     if scenario_class_name == "MySqlInitialLoad":


### PR DESCRIPTION
This addresses the build failure in https://buildkite.com/materialize/nightly/builds/8174#0190356c-8398-400c-beab-ea7b3b68d451.

```
Docker compose failed: docker compose -f/dev/fd/3 --project-directory /var/lib/buildkite-agent/builds/buildkite-large-aarch64-e5872a3-i-082fa1e5905b9baf9-1/materialize/nightly/test/feature-benchmark up --detach --wait cockroach materialized clusterd
```

I learnt that the override commit needs to be directly on the main line (otherwise no image will exist).