### PR TITLE
cargo tests: use higher concurrency

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -270,9 +270,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                         "--profile=ci",
                         "--cargo-profile=ci",
                         f"--partition=count:{partition}/{total}",
-                        # TODO(def-) Reenable when #19931 is fixed
                         # Most tests don't use 100% of a CPU core, so run two tests per CPU.
-                        # f"--test-threads={cpu_count * 2}",
+                        f"--test-threads={cpu_count * 2}",
                         *args.args,
                     ],
                     env=env,


### PR DESCRIPTION
This addresses -- if it works -- https://buildkite.com/materialize/nightly/builds/8174#0190356c-8390-40cd-80fd-e7416e5d0ddc, which references https://github.com/MaterializeInc/materialize/issues/19931.

### Test runs to check whether it is stable
* This build ❌ ✅ ✅
* https://buildkite.com/materialize/test/builds/84244 ✅ ✅ ✅
* https://buildkite.com/materialize/test/builds/84245 ✅ ✅ ✅
* https://buildkite.com/materialize/test/builds/84246 ✅ ✅ ✅
* https://buildkite.com/materialize/test/builds/84247 ❌ ✅ ✅