### PR TITLE
catalog: Plumb timestamps into state updates

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -27,10 +27,10 @@ use mz_catalog::memory::objects::{
 };
 use mz_compute_client::controller::ComputeReplicaConfig;
 use mz_controller::clusters::{ReplicaConfig, ReplicaLogging};
-use mz_ore::instrument;
+use mz_ore::{instrument, soft_assert_no_log};
 use mz_pgrepr::oid::INVALID_OID;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, Timestamp};
 use mz_sql::catalog::{
     CatalogItem as SqlCatalogItem, CatalogItemType, CatalogSchema, CatalogType, NameReference,
 };
@@ -82,24 +82,30 @@ impl CatalogState {
         &mut self,
         updates: Vec<StateUpdate>,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        let mut apply_state = BootstrapApplyState::Updates(Vec::new());
-        let updates = sort_updates(updates);
         let mut builtin_table_updates = Vec::with_capacity(updates.len());
-        let mut retractions = InProgressRetractions::default();
+        let updates = sort_updates(updates);
 
-        for update in updates {
-            let next_apply_state = BootstrapApplyState::new(update);
-            let (next_apply_state, builtin_table_update) = apply_state
-                .step(next_apply_state, self, &mut retractions)
-                .await;
-            apply_state = next_apply_state;
+        let mut groups: Vec<Vec<_>> = Vec::new();
+        for (_, updates) in &updates.into_iter().group_by(|update| update.ts) {
+            groups.push(updates.collect());
+        }
+        for updates in groups {
+            let mut apply_state = BootstrapApplyState::Updates(Vec::new());
+            let mut retractions = InProgressRetractions::default();
+
+            for update in updates {
+                let next_apply_state = BootstrapApplyState::new(update);
+                let (next_apply_state, builtin_table_update) = apply_state
+                    .step(next_apply_state, self, &mut retractions)
+                    .await;
+                apply_state = next_apply_state;
+                builtin_table_updates.extend(builtin_table_update);
+            }
+
+            // Apply remaining state.
+            let builtin_table_update = apply_state.apply(self, &mut retractions).await;
             builtin_table_updates.extend(builtin_table_update);
         }
-
-        // Apply remaining state.
-        let builtin_table_update = apply_state.apply(self, &mut retractions).await;
-        builtin_table_updates.extend(builtin_table_update);
-
         builtin_table_updates
     }
 
@@ -111,9 +117,17 @@ impl CatalogState {
         &mut self,
         updates: Vec<StateUpdate>,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
-        let mut retractions = InProgressRetractions::default();
+        let mut builtin_table_updates = Vec::with_capacity(updates.len());
         let updates = sort_updates(updates);
-        self.apply_updates_inner(updates, &mut retractions)
+
+        for (_, updates) in &updates.into_iter().group_by(|update| update.ts) {
+            let mut retractions = InProgressRetractions::default();
+            let builtin_table_update =
+                self.apply_updates_inner(updates.collect(), &mut retractions);
+            builtin_table_updates.extend(builtin_table_update);
+        }
+
+        builtin_table_updates
     }
 
     #[must_use]
@@ -123,8 +137,15 @@ impl CatalogState {
         updates: Vec<StateUpdate>,
         retractions: &mut InProgressRetractions,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
+        soft_assert_no_log!(
+            updates
+                .windows(2)
+                .all(|window| window[0].ts == window[1].ts),
+            "all timestamps should be equal: {updates:?}"
+        );
+
         let mut builtin_table_updates = Vec::with_capacity(updates.len());
-        for StateUpdate { kind, diff } in updates {
+        for StateUpdate { kind, ts: _, diff } in updates {
             match diff {
                 StateDiff::Retraction => {
                     // We want the builtin table retraction to match the state of the catalog
@@ -895,7 +916,7 @@ impl CatalogState {
         updates: Vec<StateUpdate>,
     ) -> Vec<BuiltinTableUpdate> {
         let mut builtin_table_updates = Vec::new();
-        for StateUpdate { kind, diff } in updates {
+        for StateUpdate { kind, ts: _, diff } in updates {
             let builtin_table_update = self.generate_builtin_table_update(kind, diff);
             let builtin_table_update = self.resolve_builtin_table_updates(builtin_table_update);
             builtin_table_updates.extend(builtin_table_update);
@@ -974,8 +995,21 @@ impl CatalogState {
     }
 }
 
-/// Sort [`StateUpdate`]s in dependency order.
-fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
+/// Sort [`StateUpdate`]s in timestamp then dependency order
+fn sort_updates(mut updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
+    let mut sorted_updates = Vec::with_capacity(updates.len());
+
+    updates.sort_by_key(|update| update.ts);
+    for (_, updates) in &updates.into_iter().group_by(|update| update.ts) {
+        let sorted_ts_updates = sort_updates_inner(updates.collect());
+        sorted_updates.extend(sorted_ts_updates);
+    }
+
+    sorted_updates
+}
+
+/// Sort [`StateUpdate`]s in dependency order for a single timestamp.
+fn sort_updates_inner(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
     fn push_update<T>(
         update: T,
         diff: StateDiff,
@@ -987,6 +1021,13 @@ fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
             StateDiff::Addition => additions.push(update),
         }
     }
+
+    soft_assert_no_log!(
+        updates
+            .windows(2)
+            .all(|window| window[0].ts == window[1].ts),
+        "all timestamps should be equal: {updates:?}"
+    );
 
     // Partition updates by type so that we can weave different update types into the right spots.
     let mut pre_cluster_retractions = Vec::new();
@@ -1023,16 +1064,16 @@ fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
                 &mut cluster_additions,
             ),
             StateUpdateKind::SystemObjectMapping(system_object_mapping) => {
-                builtin_item_updates.push((system_object_mapping, update.diff))
+                builtin_item_updates.push((system_object_mapping, update.ts, update.diff))
             }
             StateUpdateKind::TemporaryItem(item) => push_update(
-                (item, update.diff),
+                (item, update.ts, update.diff),
                 diff,
                 &mut temp_item_retractions,
                 &mut temp_item_additions,
             ),
             StateUpdateKind::Item(item) => push_update(
-                (item, update.diff),
+                (item, update.ts, update.diff),
                 diff,
                 &mut item_retractions,
                 &mut item_additions,
@@ -1053,26 +1094,27 @@ fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
     // Sort builtin item updates by dependency.
     let builtin_item_updates = builtin_item_updates
         .into_iter()
-        .map(|(system_object_mapping, diff)| {
+        .map(|(system_object_mapping, ts, diff)| {
             let idx = BUILTIN_LOOKUP
                 .get(&system_object_mapping.description)
                 .expect("missing builtin")
                 .0;
-            (idx, system_object_mapping, diff)
+            (idx, system_object_mapping, ts, diff)
         })
-        .sorted_by_key(|(idx, _, _)| *idx)
-        .map(|(_, system_object_mapping, diff)| (system_object_mapping, diff));
+        .sorted_by_key(|(idx, _, _, _)| *idx)
+        .map(|(_, system_object_mapping, ts, diff)| (system_object_mapping, ts, diff));
 
     // Further partition builtin item updates.
     let mut other_builtin_retractions = Vec::new();
     let mut other_builtin_additions = Vec::new();
     let mut builtin_index_retractions = Vec::new();
     let mut builtin_index_additions = Vec::new();
-    for (builtin_item_update, diff) in builtin_item_updates {
+    for (builtin_item_update, ts, diff) in builtin_item_updates {
         match &builtin_item_update.description.object_type {
             CatalogItemType::Index => push_update(
                 StateUpdate {
                     kind: StateUpdateKind::SystemObjectMapping(builtin_item_update),
+                    ts,
                     diff,
                 },
                 diff,
@@ -1090,6 +1132,7 @@ fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
             | CatalogItemType::Connection => push_update(
                 StateUpdate {
                     kind: StateUpdateKind::SystemObjectMapping(builtin_item_update),
+                    ts,
                     diff,
                 },
                 diff,
@@ -1101,11 +1144,11 @@ fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
 
     /// Sort item updates by GlobalId.
     fn sort_item_updates(
-        item_updates: Vec<(mz_catalog::durable::Item, StateDiff)>,
-    ) -> VecDeque<(mz_catalog::durable::Item, StateDiff)> {
+        item_updates: Vec<(mz_catalog::durable::Item, Timestamp, StateDiff)>,
+    ) -> VecDeque<(mz_catalog::durable::Item, Timestamp, StateDiff)> {
         item_updates
             .into_iter()
-            .sorted_by_key(|(item, _diff)| item.id)
+            .sorted_by_key(|(item, _ts, _diff)| item.id)
             .collect()
     }
     let item_retractions = sort_item_updates(item_retractions);
@@ -1113,11 +1156,11 @@ fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
 
     /// Sort temporary item updates by GlobalId.
     fn sort_temp_item_updates(
-        temp_item_updates: Vec<(TemporaryItem, StateDiff)>,
-    ) -> VecDeque<(TemporaryItem, StateDiff)> {
+        temp_item_updates: Vec<(TemporaryItem, Timestamp, StateDiff)>,
+    ) -> VecDeque<(TemporaryItem, Timestamp, StateDiff)> {
         temp_item_updates
             .into_iter()
-            .sorted_by_key(|(item, _diff)| item.id)
+            .sorted_by_key(|(item, _ts, _diff)| item.id)
             .collect()
     }
     let temp_item_retractions = sort_temp_item_updates(temp_item_retractions);
@@ -1125,24 +1168,26 @@ fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
 
     /// Merge sorted temporary and non-temp items.
     fn merge_item_updates(
-        mut item_updates: VecDeque<(mz_catalog::durable::Item, StateDiff)>,
-        mut temp_item_updates: VecDeque<(TemporaryItem, StateDiff)>,
+        mut item_updates: VecDeque<(mz_catalog::durable::Item, Timestamp, StateDiff)>,
+        mut temp_item_updates: VecDeque<(TemporaryItem, Timestamp, StateDiff)>,
     ) -> Vec<StateUpdate> {
         let mut state_updates = Vec::with_capacity(item_updates.len() + temp_item_updates.len());
 
-        while let (Some((item, _)), Some((temp_item, _))) =
+        while let (Some((item, _, _)), Some((temp_item, _, _))) =
             (item_updates.front(), temp_item_updates.front())
         {
             if item.id < temp_item.id {
-                let (item, diff) = item_updates.pop_front().expect("non-empty");
+                let (item, ts, diff) = item_updates.pop_front().expect("non-empty");
                 state_updates.push(StateUpdate {
                     kind: StateUpdateKind::Item(item),
+                    ts,
                     diff,
                 });
             } else if item.id > temp_item.id {
-                let (temp_item, diff) = temp_item_updates.pop_front().expect("non-empty");
+                let (temp_item, ts, diff) = temp_item_updates.pop_front().expect("non-empty");
                 state_updates.push(StateUpdate {
                     kind: StateUpdateKind::TemporaryItem(temp_item),
+                    ts,
                     diff,
                 });
             } else {
@@ -1152,16 +1197,18 @@ fn sort_updates(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
             }
         }
 
-        while let Some((item, diff)) = item_updates.pop_front() {
+        while let Some((item, ts, diff)) = item_updates.pop_front() {
             state_updates.push(StateUpdate {
                 kind: StateUpdateKind::Item(item),
+                ts,
                 diff,
             });
         }
 
-        while let Some((temp_item, diff)) = temp_item_updates.pop_front() {
+        while let Some((temp_item, ts, diff)) = temp_item_updates.pop_front() {
             state_updates.push(StateUpdate {
                 kind: StateUpdateKind::TemporaryItem(temp_item),
+                ts,
                 diff,
             });
         }
@@ -1207,6 +1254,7 @@ impl BootstrapApplyState {
             StateUpdate {
                 kind: StateUpdateKind::SystemObjectMapping(system_object_mapping),
                 diff: StateDiff::Addition,
+                ..
             } if matches!(
                 system_object_mapping.description.object_type,
                 CatalogItemType::View

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -138,9 +138,7 @@ impl CatalogState {
         retractions: &mut InProgressRetractions,
     ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
         soft_assert_no_log!(
-            updates
-                .windows(2)
-                .all(|window| window[0].ts == window[1].ts),
+            updates.iter().map(|update| update.ts).all_equal(),
             "all timestamps should be equal: {updates:?}"
         );
 
@@ -1023,9 +1021,7 @@ fn sort_updates_inner(updates: Vec<StateUpdate>) -> Vec<StateUpdate> {
     }
 
     soft_assert_no_log!(
-        updates
-            .windows(2)
-            .all(|window| window[0].ts == window[1].ts),
+        updates.iter().map(|update| update.ts).all_equal(),
         "all timestamps should be equal: {updates:?}"
     );
 

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -85,7 +85,7 @@ pub(crate) async fn migrate(
     state: &CatalogState,
     tx: &mut Transaction<'_>,
     now: NowFn,
-    _boot_ts: Timestamp,
+    boot_ts: Timestamp,
     _connection_context: &ConnectionContext,
 ) -> Result<(), anyhow::Error> {
     let catalog_version = tx.get_catalog_content_version();
@@ -121,6 +121,7 @@ pub(crate) async fn migrate(
         .get_items()
         .map(|item| StateUpdate {
             kind: StateUpdateKind::Item(item),
+            ts: boot_ts,
             diff: StateDiff::Addition,
         })
         .collect();

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -350,7 +350,7 @@ impl Catalog {
                 txn.set_catalog_content_version(config.build_info.version.to_string())?;
                 // Throw the existing item updates away because they may have been re-written in
                 // the migration.
-                let item_updates = txn.get_items().map(|item| StateUpdate{kind: StateUpdateKind::Item(item), diff: StateDiff::Addition}).collect();
+                let item_updates = txn.get_items().map(|item| StateUpdate{kind: StateUpdateKind::Item(item), ts: config.boot_ts, diff: StateDiff::Addition}).collect();
                 let builtin_table_update = state.apply_updates_for_bootstrap(item_updates).await;
                 builtin_table_updates.extend(builtin_table_update);
             } else {
@@ -650,6 +650,7 @@ impl Catalog {
                     kind: StateUpdateKind::AuditLog(mz_catalog::durable::objects::AuditLog {
                         event,
                     }),
+                    ts: boot_ts,
                     diff: StateDiff::Addition,
                 })
                 .collect();
@@ -675,6 +676,7 @@ impl Catalog {
                     kind: StateUpdateKind::StorageUsage(
                         mz_catalog::durable::objects::StorageUsage { metric },
                     ),
+                    ts: boot_ts,
                     diff: StateDiff::Addition,
                 })
                 .collect();

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -496,6 +496,7 @@ impl Catalog {
                     .into_iter()
                     .map(|(item, diff)| StateUpdate {
                         kind: StateUpdateKind::TemporaryItem(item),
+                        ts: tx.op_id().into(),
                         diff,
                     });
 

--- a/src/catalog/src/durable/objects/state_update.rs
+++ b/src/catalog/src/durable/objects/state_update.rs
@@ -121,6 +121,7 @@ impl StateUpdate {
             txn_wal_shard,
             audit_log_updates,
             storage_usage_updates,
+            commit_ts: _,
         } = txn_batch;
         let databases = from_batch(databases, StateUpdateKind::Database);
         let schemas = from_batch(schemas, StateUpdateKind::Schema);
@@ -220,11 +221,11 @@ impl TryFrom<StateUpdate<StateUpdateKind>> for Option<memory::objects::StateUpda
     type Error = DurableCatalogError;
 
     fn try_from(
-        StateUpdate { kind, ts: _, diff }: StateUpdate<StateUpdateKind>,
+        StateUpdate { kind, ts, diff }: StateUpdate<StateUpdateKind>,
     ) -> Result<Self, Self::Error> {
         let kind: Option<memory::objects::StateUpdateKind> = TryInto::try_into(kind)?;
         let diff = diff.try_into().expect("invalid diff");
-        let update = kind.map(|kind| memory::objects::StateUpdate { kind, diff });
+        let update = kind.map(|kind| memory::objects::StateUpdate { kind, ts, diff });
         Ok(update)
     }
 }

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -27,7 +27,7 @@ use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
 use mz_repr::optimize::OptimizerFeatureOverrides;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::role_id::RoleId;
-use mz_repr::{Diff, GlobalId, RelationDesc};
+use mz_repr::{Diff, GlobalId, RelationDesc, Timestamp};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{Expr, Raw, Statement, UnresolvedItemName, Value, WithOptionValue};
 use mz_sql::catalog::{
@@ -2364,7 +2364,7 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
 #[derive(Debug)]
 pub struct StateUpdate {
     pub kind: StateUpdateKind,
-    // TODO(jkosh44) Add timestamps.
+    pub ts: Timestamp,
     pub diff: StateDiff,
 }
 


### PR DESCRIPTION
The in-memory catalog state updates are only processed for a single
timestamp at a time. Due to this, we previously omitted the timestamps
for convenience. Soon, we will want to be able to process updates for
multiple timestamps at once. In preparation for that, this commit
starts plumbing timestamps into the in-memory state updates.

Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer
The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
