### PR TITLE
adapter: show RTR timestamp in EXPLAIN TIMESTAMP

### DIFF
--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -432,6 +432,7 @@ pub trait TimestampProvider {
             largest_not_in_advance_of_upper,
             oracle_read_ts,
             session_oracle_read_ts,
+            real_time_recency_ts,
         };
 
         Ok((determination, read_holds))
@@ -690,6 +691,8 @@ pub struct TimestampDetermination<T> {
     pub oracle_read_ts: Option<T>,
     /// The value of the session local timestamp's oracle timestamp, if used.
     pub session_oracle_read_ts: Option<T>,
+    /// The value of the real time recency timestamp, if used.
+    pub real_time_recency_ts: Option<T>,
 }
 
 impl<T: TimestampManipulation> TimestampDetermination<T> {
@@ -791,6 +794,13 @@ impl<T: fmt::Display + fmt::Debug + DisplayableInTimeline + TimestampManipulatio
                 f,
                 "  session oracle read timestamp: {}",
                 session_oracle_read_ts.display(timeline)
+            )?;
+        }
+        if let Some(real_time_recency_ts) = &self.determination.real_time_recency_ts {
+            writeln!(
+                f,
+                "    real time recency timestamp: {}",
+                real_time_recency_ts.display(timeline)
             )?;
         }
         writeln!(

--- a/test/kafka-rtr/simple/verify-rtr.td
+++ b/test/kafka-rtr/simple/verify-rtr.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-regex match=(s\d+|\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\)) replacement=<>
+
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET allow_real_time_recency = true
 
@@ -80,3 +82,7 @@ A,B,0
 
 > SELECT sum FROM sum;
 5000207
+
+# RTR timestamp should be present.
+> EXPLAIN TIMESTAMP FOR SELECT sum FROM sum
+"                query timestamp: <> <>\n          oracle read timestamp: <> <>\n    real time recency timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: true\n                       timeline: Some(EpochMilliseconds)\n              session wall time: <> <>\n\nsource materialize.public.sum (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"

--- a/test/testdrive/explain-timestamps.td
+++ b/test/testdrive/explain-timestamps.td
@@ -28,7 +28,7 @@ $ set-regex match=(s\d+|\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\d\d\d\
 > SET TRANSACTION_ISOLATION = 'STRICT SERIALIZABLE';
 > SET REAL_TIME_RECENCY TO TRUE
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
-"                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: true\n                       timeline: Some(EpochMilliseconds)\n              session wall time: <> <>\n\nsource materialize.public.t1 (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"
+"                query timestamp: <> <>\n          oracle read timestamp: <> <>\n    real time recency timestamp:             0 <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: true\n                       timeline: Some(EpochMilliseconds)\n              session wall time: <> <>\n\nsource materialize.public.t1 (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"
 
 # Test autorouting explain timestamp queries
 > EXPLAIN TIMESTAMP FOR SELECT * from mz_internal.mz_cluster_replica_metrics


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a