### PR TITLE
persist: Refactor stats away from `Box<dyn DynStats>` and instead use an enum

### DIFF
--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -11,10 +11,10 @@
 
 //! Aggregate statistics about data stored in persist.
 
-use std::any::Any;
 use std::fmt::Debug;
 
 use arrow::array::Array;
+use mz_ore::cast::CastFrom;
 use mz_ore::metric;
 use mz_ore::metrics::{IntCounter, MetricsRegistry};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
@@ -44,6 +44,141 @@ pub use structured::StructStats;
 
 include!(concat!(env!("OUT_DIR"), "/mz_persist_types.stats.rs"));
 
+/// Statistics for a single column of data.
+#[derive(Debug, Clone)]
+pub struct ColumnarStats {
+    /// Expected to be `None` if the associated column is non-nullable.
+    pub nulls: Option<ColumnNullStats>,
+    /// Statistics on the values of the column.
+    pub values: ColumnStatKinds,
+}
+
+impl ColumnarStats {
+    /// Downcast this instasnce of [`ColumnarStats`] into `T::Stats`, if the
+    /// inner type is a `T::Stats`.
+    pub fn downcast<T: Data>(&self) -> Option<T::Stats> {
+        T::Stats::downcast(self)
+    }
+}
+
+impl DynStats for ColumnarStats {
+    fn debug_json(&self) -> serde_json::Value {
+        let value_json = self.values.debug_json();
+
+        match (&self.nulls, value_json) {
+            (Some(nulls), serde_json::Value::Object(mut x)) => {
+                if nulls.count > 0 {
+                    x.insert("nulls".to_owned(), nulls.count.into());
+                }
+                serde_json::Value::Object(x)
+            }
+            (Some(nulls), x) => {
+                serde_json::json!({"nulls": nulls.count, "not nulls": x})
+            }
+            (None, x) => x,
+        }
+    }
+
+    fn into_columnar_stats(self) -> ColumnarStats {
+        self
+    }
+}
+
+/// Statistics about the null values in a column.
+#[derive(Debug, Copy, Clone)]
+pub struct ColumnNullStats {
+    /// Number of nulls in the column.
+    pub count: usize,
+}
+
+impl RustType<ProtoOptionStats> for ColumnNullStats {
+    fn into_proto(&self) -> ProtoOptionStats {
+        ProtoOptionStats {
+            none: u64::cast_from(self.count),
+        }
+    }
+
+    fn from_proto(proto: ProtoOptionStats) -> Result<Self, TryFromProtoError> {
+        Ok(ColumnNullStats {
+            count: usize::cast_from(proto.none),
+        })
+    }
+}
+
+/// All of the kinds of statistics that we support.
+#[derive(Debug, Clone)]
+pub enum ColumnStatKinds {
+    /// Primitive stats that maintin just an upper and lower bound.
+    Primitive(PrimitiveStatsVariants),
+    /// Statistics for objects with multiple fields.
+    Struct(StructStats),
+    /// Statistics about a column of binary data.
+    Bytes(BytesStats),
+    /// Maintain no statistics for a given column.
+    None,
+}
+
+impl DynStats for ColumnStatKinds {
+    fn debug_json(&self) -> serde_json::Value {
+        match self {
+            ColumnStatKinds::Primitive(prim) => prim.debug_json(),
+            ColumnStatKinds::Struct(x) => x.debug_json(),
+            ColumnStatKinds::Bytes(bytes) => bytes.debug_json(),
+            ColumnStatKinds::None => NoneStats.debug_json(),
+        }
+    }
+
+    fn into_columnar_stats(self) -> ColumnarStats {
+        ColumnarStats {
+            nulls: None,
+            values: self,
+        }
+    }
+}
+
+impl RustType<proto_dyn_stats::Kind> for ColumnStatKinds {
+    fn into_proto(&self) -> proto_dyn_stats::Kind {
+        match self {
+            ColumnStatKinds::Primitive(prim) => {
+                proto_dyn_stats::Kind::Primitive(RustType::into_proto(prim))
+            }
+            ColumnStatKinds::Struct(x) => proto_dyn_stats::Kind::Struct(RustType::into_proto(x)),
+            ColumnStatKinds::Bytes(bytes) => {
+                proto_dyn_stats::Kind::Bytes(RustType::into_proto(bytes))
+            }
+            ColumnStatKinds::None => proto_dyn_stats::Kind::None(()),
+        }
+    }
+
+    fn from_proto(proto: proto_dyn_stats::Kind) -> Result<Self, TryFromProtoError> {
+        let stats = match proto {
+            proto_dyn_stats::Kind::Primitive(prim) => ColumnStatKinds::Primitive(prim.into_rust()?),
+            proto_dyn_stats::Kind::Struct(x) => ColumnStatKinds::Struct(x.into_rust()?),
+            proto_dyn_stats::Kind::Bytes(bytes) => ColumnStatKinds::Bytes(bytes.into_rust()?),
+            proto_dyn_stats::Kind::None(_) => ColumnStatKinds::None,
+        };
+        Ok(stats)
+    }
+}
+
+impl<T: Into<PrimitiveStatsVariants>> From<T> for ColumnStatKinds {
+    fn from(value: T) -> Self {
+        ColumnStatKinds::Primitive(value.into())
+    }
+}
+
+impl From<StructStats> for ColumnStatKinds {
+    fn from(value: StructStats) -> Self {
+        ColumnStatKinds::Struct(value)
+    }
+}
+
+impl From<BytesStats> for ColumnStatKinds {
+    fn from(value: BytesStats) -> Self {
+        ColumnStatKinds::Bytes(value)
+    }
+}
+
 /// Metrics for [PartStats].
 #[derive(Debug)]
 pub struct PartStatsMetrics {
@@ -66,7 +201,7 @@ impl PartStatsMetrics {
 /// If Custom is used, the DynStats returned must be a`<T as Data>::Stats`.
 pub enum StatsFn {
     Default,
-    Custom(fn(&DynColumnRef, ValidityRef) -> Result<Box<dyn DynStats>, String>),
+    Custom(fn(&DynColumnRef, ValidityRef) -> Result<ColumnarStats, String>),
 }
 
 #[cfg(debug_assertions)]
@@ -75,10 +210,8 @@ impl PartialEq for StatsFn {
         match (self, other) {
             (StatsFn::Default, StatsFn::Default) => true,
             (StatsFn::Custom(s), StatsFn::Custom(o)) => {
-                let s: fn(&'static DynColumnRef, ValidityRef) -> Result<Box<dyn DynStats>, String> =
-                    *s;
-                let o: fn(&'static DynColumnRef, ValidityRef) -> Result<Box<dyn DynStats>, String> =
-                    *o;
+                let s: fn(&'static DynColumnRef, ValidityRef) -> Result<ColumnarStats, String> = *s;
+                let o: fn(&'static DynColumnRef, ValidityRef) -> Result<ColumnarStats, String> = *o;
                 // I think this is not always correct, but it's only used in
                 // debug_assertions so as long as CI is happy with it, probably
                 // good enough.
@@ -117,6 +250,15 @@ pub trait ColumnStats<T: Data>: DynStats {
     fn upper<'a>(&'a self) -> Option<T::Ref<'a>>;
     /// The number of `None`s if this column is optional or 0 if it isn't.
     fn none_count(&self) -> usize;
+
+    /// Downcast an instance of [`ColumnarStats`] into `Self`, if
+    /// [`ColumnarStats`] contains `Self`.
+    ///
+    /// Note: This method is intended to help bridge the gap between [`Data`]
+    /// and [`crate::Schema2`].
+    fn downcast(stats: &ColumnarStats) -> Option<Self>
+    where
+        Self: Sized;
 }
 
 /// A source of aggregate statistics about a column of data.
@@ -133,16 +275,16 @@ pub trait StatsFrom<T> {
 
 /// Type-erased aggregate statistics about a column of data.
 pub trait DynStats: Debug + Send + Sync + 'static {
-    /// Returns self as a `dyn Any` for downcasting.
-    fn as_any(&self) -> &dyn Any;
     /// Returns the name of the erased type for use in error messages.
     fn type_name(&self) -> &'static str {
         std::any::type_name::<Self>()
     }
-    /// See [mz_proto::RustType::into_proto].
-    fn into_proto(&self) -> ProtoDynStats;
+
     /// Formats these statistics for use in `INSPECT SHARD` and debugging.
     fn debug_json(&self) -> serde_json::Value;
+
+    /// Return `self` as [`ColumnarStats`].
+    fn into_columnar_stats(self) -> ColumnarStats;
 }
 
 /// Trim, possibly in a lossy way, statistics to reduce the serialization costs.
@@ -192,19 +334,6 @@ impl<T: DynStats> Debug for OptionStats<T> {
 }
 
 impl<T: DynStats> DynStats for OptionStats<T> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn into_proto(&self) -> ProtoDynStats {
-        let mut ret = self.some.into_proto();
-        // This prevents us from serializing `OptionStats<OptionStats<T>>`, but
-        // that's intentionally out of scope. See the comment on ProtoDynStats.
-        assert!(ret.option.is_none());
-        ret.option = Some(ProtoOptionStats {
-            none: self.none.into_proto(),
-        });
-        ret
-    }
     fn debug_json(&self) -> serde_json::Value {
         match self.some.debug_json() {
             serde_json::Value::Object(mut x) => {
@@ -218,6 +347,16 @@ impl<T: DynStats> DynStats for OptionStats<T> {
             }
         }
     }
+
+    fn into_columnar_stats(self) -> ColumnarStats {
+        let inner = self.some.into_columnar_stats();
+        assert!(inner.nulls.is_none(), "we don't support nested OptionStats");
+
+        ColumnarStats {
+            nulls: Some(ColumnNullStats { count: self.none }),
+            values: inner.values,
+        }
+    }
 }
 
 /// Empty set of statistics.
@@ -226,19 +365,15 @@ impl<T: DynStats> DynStats for OptionStats<T> {
 pub struct NoneStats;
 
 impl DynStats for NoneStats {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn into_proto(&self) -> ProtoDynStats {
-        ProtoDynStats {
-            option: None,
-            kind: Some(proto_dyn_stats::Kind::None(RustType::into_proto(self))),
-        }
-    }
-
     fn debug_json(&self) -> serde_json::Value {
         serde_json::Value::String(format!("{self:?}"))
+    }
+
+    fn into_columnar_stats(self) -> ColumnarStats {
+        ColumnarStats {
+            nulls: None,
+            values: ColumnStatKinds::None,
+        }
     }
 }
 
@@ -253,6 +388,19 @@ impl<T: Data> ColumnStats<T> for NoneStats {
 
     fn none_count(&self) -> usize {
         0
+    }
+
+    fn downcast(stats: &ColumnarStats) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if stats.nulls.is_some() {
+            return None;
+        }
+        match &stats.values {
+            ColumnStatKinds::None => Some(NoneStats),
+            _ => None,
+        }
     }
 }
 
@@ -270,6 +418,20 @@ where
 
     fn none_count(&self) -> usize {
         self.none
+    }
+
+    fn downcast(stats: &ColumnarStats) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        let inner = match &stats.values {
+            ColumnStatKinds::None => NoneStats,
+            _ => return None,
+        };
+        Some(OptionStats {
+            some: inner,
+            none: stats.nulls.as_ref().map_or(0, |n| n.count),
+        })
     }
 }
 
@@ -487,121 +649,59 @@ fn trim_to_budget_jsonb(
     stats.elements.extend(stats_to_keep);
 }
 
-impl RustType<ProtoDynStats> for Box<dyn DynStats> {
+impl RustType<ProtoDynStats> for ColumnarStats {
     fn into_proto(&self) -> ProtoDynStats {
-        DynStats::into_proto(self.as_ref())
+        let option = self.nulls.as_ref().map(|n| n.into_proto());
+        let kind = RustType::into_proto(&self.values);
+
+        ProtoDynStats {
+            option,
+            kind: Some(kind),
+        }
     }
 
-    fn from_proto(mut proto: ProtoDynStats) -> Result<Self, TryFromProtoError> {
-        struct BoxFn;
-        impl DynStatsFn<Box<dyn DynStats>> for BoxFn {
-            fn call<T: DynStats>(self, t: T) -> Result<Box<dyn DynStats>, TryFromProtoError> {
-                Ok(Box::new(t))
-            }
-        }
-        struct OptionStatsFn<F>(usize, F);
-        impl<R, F: DynStatsFn<R>> DynStatsFn<R> for OptionStatsFn<F> {
-            fn call<T: DynStats>(self, some: T) -> Result<R, TryFromProtoError> {
-                let OptionStatsFn(none, f) = self;
-                f.call(OptionStats { none, some })
-            }
-        }
+    fn from_proto(proto: ProtoDynStats) -> Result<Self, TryFromProtoError> {
+        let kind = proto
+            .kind
+            .ok_or_else(|| TryFromProtoError::missing_field("ProtoDynStats::kind"))?;
 
-        match proto.option.take() {
-            Some(option) => {
-                let none = option.none.into_rust()?;
-                dyn_from_proto(proto, OptionStatsFn(none, BoxFn))
-            }
-            None => dyn_from_proto(proto, BoxFn),
-        }
+        Ok(ColumnarStats {
+            nulls: proto.option.into_rust()?,
+            values: kind.into_rust()?,
+        })
     }
 }
 
-/// Basically `FnOnce<T: DynStats>(self, t: T) -> R`, if rust would let us
-/// type that.
-///
-/// We use this in `dyn_from_proto` so that OptionStats can hold a `some: T`
-/// instead of a `Box<dyn DynStats>`.
-trait DynStatsFn<R> {
-    fn call<T: DynStats>(self, t: T) -> Result<R, TryFromProtoError>;
-}
-
-fn dyn_from_proto<R, F: DynStatsFn<R>>(proto: ProtoDynStats, f: F) -> Result<R, TryFromProtoError> {
-    assert!(proto.option.is_none());
-    let kind = proto
-        .kind
-        .ok_or_else(|| TryFromProtoError::missing_field("ProtoDynStats::kind"))?;
-    match kind {
-        // Sniff the type of x.lower and use that to determine which type of
-        // PrimitiveStats to decode it as.
-        proto_dyn_stats::Kind::Primitive(x) => match x.lower {
-            Some(proto_primitive_stats::Lower::LowerBool(_)) => {
-                f.call(PrimitiveStats::<bool>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerU8(_)) => {
-                f.call(PrimitiveStats::<u8>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerU16(_)) => {
-                f.call(PrimitiveStats::<u16>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerU32(_)) => {
-                f.call(PrimitiveStats::<u32>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerU64(_)) => {
-                f.call(PrimitiveStats::<u64>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerI8(_)) => {
-                f.call(PrimitiveStats::<i8>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerI16(_)) => {
-                f.call(PrimitiveStats::<i16>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerI32(_)) => {
-                f.call(PrimitiveStats::<i32>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerI64(_)) => {
-                f.call(PrimitiveStats::<i64>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerF32(_)) => {
-                f.call(PrimitiveStats::<f32>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerF64(_)) => {
-                f.call(PrimitiveStats::<f64>::from_proto(x)?)
-            }
-            Some(proto_primitive_stats::Lower::LowerString(_)) => {
-                f.call(PrimitiveStats::<String>::from_proto(x)?)
-            }
-            None => Err(TryFromProtoError::missing_field("ProtoPrimitiveStats::min")),
-        },
-        proto_dyn_stats::Kind::Struct(x) => f.call(StructStats::from_proto(x)?),
-        proto_dyn_stats::Kind::Bytes(x) => f.call(BytesStats::from_proto(x)?),
-        proto_dyn_stats::Kind::None(x) => f.call(NoneStats::from_proto(x)?),
-    }
-}
-
-/// Returns a [`Strategy`] that generates arbitrary `Box<dyn DynStats>`.
-pub(crate) fn any_box_dyn_stats() -> impl Strategy<Value = Box<dyn DynStats>> {
-    fn into_box_dyn_stats<T: DynStats>(x: T) -> Box<dyn DynStats> {
-        let x: Box<dyn DynStats> = Box::new(x);
-        x
-    }
+/// Returns a [`Strategy`] that generates arbitrary [`ColumnarStats`].
+pub(crate) fn any_columnar_stats() -> impl Strategy<Value = ColumnarStats> {
     let leaf = Union::new(vec![
         any_primitive_stats::<bool>()
-            .prop_map(into_box_dyn_stats)
+            .prop_map(|s| ColumnStatKinds::Primitive(s.into()))
             .boxed(),
         any_primitive_stats::<i64>()
-            .prop_map(into_box_dyn_stats)
+            .prop_map(|s| ColumnStatKinds::Primitive(s.into()))
             .boxed(),
         any_primitive_stats::<String>()
-            .prop_map(into_box_dyn_stats)
+            .prop_map(|s| ColumnStatKinds::Primitive(s.into()))
             .boxed(),
-        any_bytes_stats().prop_map(into_box_dyn_stats).boxed(),
-    ]);
+        any_bytes_stats().prop_map(ColumnStatKinds::Bytes).boxed(),
+    ])
+    .prop_map(|values| ColumnarStats {
+        nulls: None,
+        values,
+    });
+
     leaf.prop_recursive(2, 10, 3, |inner| {
         (
             any::<usize>(),
             proptest::collection::btree_map(any::<String>(), inner, 0..3),
         )
-            .prop_map(|(len, cols)| into_box_dyn_stats(StructStats { len, cols }))
+            .prop_map(|(len, cols)| {
+                let values = ColumnStatKinds::Struct(StructStats { len, cols });
+                ColumnarStats {
+                    nulls: None,
+                    values,
+                }
+            })
     })
 }

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -261,19 +261,11 @@ pub trait ColumnStats<T: Data>: DynStats {
         Self: Sized;
 }
 
-/// A source of aggregate statistics about a column of data.
-pub trait StatsFrom<T> {
-    /// Computes statistics from a column of data.
-    ///
-    /// The validity, if given, indicates which values in the columns are and
-    /// are not used for stats. This allows us to model non-nullable columns in
-    /// a nullable struct. For optional columns (i.e. ones with their own
-    /// validity) it _must be a subset_ of the column's validity, otherwise this
-    /// panics.
-    fn stats_from(col: &T, validity: ValidityRef) -> Self;
-}
-
-/// Type-erased aggregate statistics about a column of data.
+/// Type that can be used to represent some [`ColumnStats`].
+///
+/// This is a separate trait than [`ColumnStats`] because its implementations
+/// generally don't care about what kind of stats they contain, whereas
+/// [`ColumnStats`] is generic over the inner type of statistics.
 pub trait DynStats: Debug + Send + Sync + 'static {
     /// Returns the name of the erased type for use in error messages.
     fn type_name(&self) -> &'static str {
@@ -285,6 +277,18 @@ pub trait DynStats: Debug + Send + Sync + 'static {
 
     /// Return `self` as [`ColumnarStats`].
     fn into_columnar_stats(self) -> ColumnarStats;
+}
+
+/// A source of aggregate statistics about a column of data.
+pub trait StatsFrom<T> {
+    /// Computes statistics from a column of data.
+    ///
+    /// The validity, if given, indicates which values in the columns are and
+    /// are not used for stats. This allows us to model non-nullable columns in
+    /// a nullable struct. For optional columns (i.e. ones with their own
+    /// validity) it _must be a subset_ of the column's validity, otherwise this
+    /// panics.
+    fn stats_from(col: &T, validity: ValidityRef) -> Self;
 }
 
 /// Trim, possibly in a lossy way, statistics to reduce the serialization costs.

--- a/src/persist-types/src/stats/bytes.rs
+++ b/src/persist-types/src/stats/bytes.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
 use std::fmt::Debug;
 
 use arrow::array::BinaryArray;
@@ -19,13 +18,12 @@ use crate::dyn_struct::ValidityRef;
 use crate::stats::json::{any_json_stats, JsonStats};
 use crate::stats::primitive::{any_primitive_vec_u8_stats, PrimitiveStats};
 use crate::stats::{
-    proto_bytes_stats, proto_dyn_stats, ColumnStats, DynStats, OptionStats, ProtoAtomicBytesStats,
-    ProtoBytesStats, ProtoDynStats, StatsFrom, TrimStats,
+    proto_bytes_stats, ColumnStatKinds, ColumnStats, ColumnarStats, DynStats, OptionStats,
+    ProtoAtomicBytesStats, ProtoBytesStats, StatsFrom, TrimStats,
 };
 
 /// `PrimitiveStats<Vec<u8>>` that cannot safely be trimmed.
-#[derive(Debug)]
-#[cfg_attr(any(test), derive(Clone))]
+#[derive(Debug, Clone)]
 pub struct AtomicBytesStats {
     /// See [PrimitiveStats::lower]
     pub lower: Vec<u8>,
@@ -59,6 +57,7 @@ impl RustType<ProtoAtomicBytesStats> for AtomicBytesStats {
 }
 
 /// Statistics about a column of `Vec<u8>`.
+#[derive(Clone)]
 pub enum BytesStats {
     Primitive(PrimitiveStats<Vec<u8>>),
     Json(JsonStats),
@@ -72,17 +71,6 @@ impl Debug for BytesStats {
 }
 
 impl DynStats for BytesStats {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn into_proto(&self) -> ProtoDynStats {
-        ProtoDynStats {
-            option: None,
-            kind: Some(proto_dyn_stats::Kind::Bytes(RustType::into_proto(self))),
-        }
-    }
-
     fn debug_json(&self) -> serde_json::Value {
         match self {
             BytesStats::Primitive(x) => x.debug_json(),
@@ -90,25 +78,44 @@ impl DynStats for BytesStats {
             BytesStats::Atomic(x) => x.debug_json(),
         }
     }
+
+    fn into_columnar_stats(self) -> ColumnarStats {
+        ColumnarStats {
+            nulls: None,
+            values: ColumnStatKinds::Bytes(self),
+        }
+    }
 }
 
 impl ColumnStats<Vec<u8>> for BytesStats {
     fn lower<'a>(&'a self) -> Option<<Vec<u8> as Data>::Ref<'a>> {
         match self {
-            BytesStats::Primitive(x) => x.lower(),
+            BytesStats::Primitive(x) => Some(x.lower.as_slice()),
             BytesStats::Json(_) => None,
             BytesStats::Atomic(x) => Some(&x.lower),
         }
     }
     fn upper<'a>(&'a self) -> Option<<Vec<u8> as Data>::Ref<'a>> {
         match self {
-            BytesStats::Primitive(x) => x.upper(),
+            BytesStats::Primitive(x) => Some(x.upper.as_slice()),
             BytesStats::Json(_) => None,
             BytesStats::Atomic(x) => Some(&x.upper),
         }
     }
     fn none_count(&self) -> usize {
         0
+    }
+    fn downcast(stats: &ColumnarStats) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if stats.nulls.is_some() {
+            return None;
+        }
+        match &stats.values {
+            ColumnStatKinds::Bytes(bytes) => Some(bytes.clone()),
+            _ => None,
+        }
     }
 }
 
@@ -121,6 +128,19 @@ impl ColumnStats<Option<Vec<u8>>> for OptionStats<BytesStats> {
     }
     fn none_count(&self) -> usize {
         self.none
+    }
+    fn downcast(stats: &ColumnarStats) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        let inner = match &stats.values {
+            ColumnStatKinds::Bytes(s) => s,
+            _ => return None,
+        };
+        Some(OptionStats {
+            some: inner.clone(),
+            none: stats.nulls.as_ref().map_or(0, |n| n.count),
+        })
     }
 }
 

--- a/src/persist-types/src/stats/bytes.rs
+++ b/src/persist-types/src/stats/bytes.rs
@@ -109,10 +109,7 @@ impl ColumnStats<Vec<u8>> for BytesStats {
     where
         Self: Sized,
     {
-        if stats.nulls.is_some() {
-            return None;
-        }
-        match &stats.values {
+        match stats.non_null_values()? {
             ColumnStatKinds::Bytes(bytes) => Some(bytes.clone()),
             _ => None,
         }

--- a/src/persist-types/src/stats/json.rs
+++ b/src/persist-types/src/stats/json.rs
@@ -26,7 +26,7 @@ use crate::stats::{
 // Each element could be any of a JsonNull, a bool, a string, a numeric, a list,
 // or a map/object. The column might be a single type but could also be a
 // mixture of any subset of these types.
-#[cfg_attr(any(test), derive(Clone))]
+#[derive(Clone)]
 pub enum JsonStats {
     /// A sentinel that indicates there were no elements.
     None,
@@ -55,8 +55,7 @@ pub enum JsonStats {
     Maps(BTreeMap<String, JsonMapElementStats>),
 }
 
-#[derive(Default)]
-#[cfg_attr(any(test), derive(Clone))]
+#[derive(Default, Clone)]
 pub struct JsonMapElementStats {
     pub len: usize,
     pub stats: JsonStats,

--- a/src/persist-types/src/stats/primitive.rs
+++ b/src/persist-types/src/stats/primitive.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
 use std::fmt::{self, Debug};
 
 use arrow::array::{Array, BinaryArray, BooleanArray, PrimitiveArray, StringArray};
@@ -21,9 +20,8 @@ use serde::Serialize;
 use crate::columnar::Data;
 use crate::dyn_struct::ValidityRef;
 use crate::stats::{
-    proto_bytes_stats, proto_dyn_stats, proto_primitive_stats, ColumnStats, DynStats, OptionStats,
-    ProtoBytesStats, ProtoDynStats, ProtoPrimitiveBytesStats, ProtoPrimitiveStats, StatsFrom,
-    TrimStats,
+    proto_primitive_stats, BytesStats, ColumnStatKinds, ColumnStats, ColumnarStats, DynStats,
+    OptionStats, ProtoPrimitiveBytesStats, ProtoPrimitiveStats, StatsFrom, TrimStats,
 };
 use crate::timestamp::try_parse_monotonic_iso8601_timestamp;
 
@@ -113,7 +111,7 @@ pub fn truncate_string(x: &str, max_len: usize, bound: TruncateBound) -> Option<
 }
 
 /// Statistics about a primitive non-optional column.
-#[cfg_attr(any(test), derive(Clone))]
+#[derive(Copy, Clone)]
 pub struct PrimitiveStats<T> {
     /// An inclusive lower bound on the data contained in the column.
     ///
@@ -150,49 +148,46 @@ impl Debug for PrimitiveStats<Vec<u8>> {
 
 impl<T: Serialize> DynStats for PrimitiveStats<T>
 where
-    PrimitiveStats<T>: RustType<ProtoPrimitiveStats> + Send + Sync + 'static,
+    PrimitiveStats<T>: RustType<ProtoPrimitiveStats>
+        + Into<PrimitiveStatsVariants>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn into_proto(&self) -> ProtoDynStats {
-        ProtoDynStats {
-            option: None,
-            kind: Some(proto_dyn_stats::Kind::Primitive(RustType::into_proto(self))),
-        }
-    }
     fn debug_json(&self) -> serde_json::Value {
         let l = serde_json::to_value(&self.lower).expect("valid json");
         let u = serde_json::to_value(&self.upper).expect("valid json");
         serde_json::json!({"lower": l, "upper": u})
     }
+
+    fn into_columnar_stats(self) -> ColumnarStats {
+        ColumnarStats {
+            nulls: None,
+            values: ColumnStatKinds::Primitive(self.into()),
+        }
+    }
 }
 
 impl DynStats for PrimitiveStats<Vec<u8>> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn into_proto(&self) -> ProtoDynStats {
-        ProtoDynStats {
-            option: None,
-            kind: Some(proto_dyn_stats::Kind::Bytes(ProtoBytesStats {
-                kind: Some(proto_bytes_stats::Kind::Primitive(RustType::into_proto(
-                    self,
-                ))),
-            })),
-        }
-    }
     fn debug_json(&self) -> serde_json::Value {
         serde_json::json!({
             "lower": hex::encode(&self.lower),
             "upper": hex::encode(&self.upper),
         })
     }
+
+    fn into_columnar_stats(self) -> ColumnarStats {
+        ColumnarStats {
+            nulls: None,
+            values: ColumnStatKinds::Bytes(BytesStats::Primitive(self)),
+        }
+    }
 }
 
 /// This macro implements the [`ColumnStats`] trait for all variants of [`PrimitiveStats`].
 macro_rules! stats_primitive {
-    ($data:ty, $ref:ident) => {
+    ($data:ty, $ref:ident, $variant:ident) => {
         impl ColumnStats<$data> for PrimitiveStats<$data> {
             fn lower<'a>(&'a self) -> Option<<$data as Data>::Ref<'a>> {
                 Some(self.lower.$ref())
@@ -202,6 +197,20 @@ macro_rules! stats_primitive {
             }
             fn none_count(&self) -> usize {
                 0
+            }
+            fn downcast(stats: &super::ColumnarStats) -> Option<Self>
+            where
+                Self: Sized,
+            {
+                if stats.nulls.is_some() {
+                    return None;
+                }
+                match &stats.values {
+                    ColumnStatKinds::Primitive(PrimitiveStatsVariants::$variant(prim)) => {
+                        Some(prim.clone())
+                    }
+                    _ => None,
+                }
             }
         }
 
@@ -215,23 +224,41 @@ macro_rules! stats_primitive {
             fn none_count(&self) -> usize {
                 self.none
             }
+            fn downcast(stats: &super::ColumnarStats) -> Option<Self>
+            where
+                Self: Sized,
+            {
+                let prim = match &stats.values {
+                    ColumnStatKinds::Primitive(PrimitiveStatsVariants::$variant(prim)) => prim,
+                    _ => return None,
+                };
+                Some(OptionStats {
+                    some: prim.clone(),
+                    none: stats.nulls.as_ref().map_or(0, |n| n.count),
+                })
+            }
+        }
+
+        impl From<PrimitiveStats<$data>> for PrimitiveStatsVariants {
+            fn from(value: PrimitiveStats<$data>) -> Self {
+                PrimitiveStatsVariants::$variant(value)
+            }
         }
     };
 }
 
-stats_primitive!(bool, clone);
-stats_primitive!(u8, clone);
-stats_primitive!(u16, clone);
-stats_primitive!(u32, clone);
-stats_primitive!(u64, clone);
-stats_primitive!(i8, clone);
-stats_primitive!(i16, clone);
-stats_primitive!(i32, clone);
-stats_primitive!(i64, clone);
-stats_primitive!(f32, clone);
-stats_primitive!(f64, clone);
-stats_primitive!(Vec<u8>, as_slice);
-stats_primitive!(String, as_str);
+stats_primitive!(bool, clone, Bool);
+stats_primitive!(u8, clone, U8);
+stats_primitive!(u16, clone, U16);
+stats_primitive!(u32, clone, U32);
+stats_primitive!(u64, clone, U64);
+stats_primitive!(i8, clone, I8);
+stats_primitive!(i16, clone, I16);
+stats_primitive!(i32, clone, I32);
+stats_primitive!(i64, clone, I64);
+stats_primitive!(f32, clone, F32);
+stats_primitive!(f64, clone, F64);
+stats_primitive!(String, as_str, String);
 
 impl StatsFrom<BooleanBuffer> for PrimitiveStats<bool> {
     fn stats_from(col: &BooleanBuffer, validity: ValidityRef) -> Self {
@@ -508,7 +535,7 @@ impl TrimStats for ProtoPrimitiveBytesStats {
 }
 
 /// Enum wrapper around [`PrimitiveStats`] for each variant that we support.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum PrimitiveStatsVariants {
     /// [`bool`]
     Bool(PrimitiveStats<bool>),
@@ -537,17 +564,6 @@ pub enum PrimitiveStatsVariants {
 }
 
 impl DynStats for PrimitiveStatsVariants {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn into_proto(&self) -> ProtoDynStats {
-        ProtoDynStats {
-            option: None,
-            kind: Some(proto_dyn_stats::Kind::Primitive(RustType::into_proto(self))),
-        }
-    }
-
     fn debug_json(&self) -> serde_json::Value {
         use PrimitiveStatsVariants::*;
 
@@ -564,6 +580,13 @@ impl DynStats for PrimitiveStatsVariants {
             F32(stats) => stats.debug_json(),
             F64(stats) => stats.debug_json(),
             String(stats) => stats.debug_json(),
+        }
+    }
+
+    fn into_columnar_stats(self) -> ColumnarStats {
+        ColumnarStats {
+            nulls: None,
+            values: ColumnStatKinds::Primitive(self),
         }
     }
 }
@@ -652,31 +675,6 @@ impl RustType<ProtoPrimitiveStats> for PrimitiveStatsVariants {
         Ok(stats)
     }
 }
-
-/// Small macro to help us convert `PrimitiveStats<T>` into
-/// [`PrimitiveStatsVariants`].
-macro_rules! primitive_stats_from {
-    ($native:ty, $variant:ident) => {
-        impl From<PrimitiveStats<$native>> for PrimitiveStatsVariants {
-            fn from(value: PrimitiveStats<$native>) -> Self {
-                PrimitiveStatsVariants::$variant(value)
-            }
-        }
-    };
-}
-
-primitive_stats_from!(bool, Bool);
-primitive_stats_from!(u8, U8);
-primitive_stats_from!(u16, U16);
-primitive_stats_from!(u32, U32);
-primitive_stats_from!(u64, U64);
-primitive_stats_from!(i8, I8);
-primitive_stats_from!(i16, I16);
-primitive_stats_from!(i32, I32);
-primitive_stats_from!(i64, I64);
-primitive_stats_from!(f32, F32);
-primitive_stats_from!(f64, F64);
-primitive_stats_from!(String, String);
 
 /// Returns a [`Strategy`] for generating arbitrary [`PrimitiveStats`].
 pub(crate) fn any_primitive_stats<T>() -> impl Strategy<Value = PrimitiveStats<T>>

--- a/src/persist-types/src/stats/primitive.rs
+++ b/src/persist-types/src/stats/primitive.rs
@@ -202,10 +202,7 @@ macro_rules! stats_primitive {
             where
                 Self: Sized,
             {
-                if stats.nulls.is_some() {
-                    return None;
-                }
-                match &stats.values {
+                match stats.non_null_values()? {
                     ColumnStatKinds::Primitive(PrimitiveStatsVariants::$variant(prim)) => {
                         Some(prim.clone())
                     }

--- a/src/persist-types/src/stats/structured.rs
+++ b/src/persist-types/src/stats/structured.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
 use std::collections::BTreeMap;
 
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
@@ -19,13 +18,13 @@ use serde::ser::{SerializeMap, SerializeStruct};
 use crate::columnar::Data;
 use crate::dyn_struct::{DynStruct, DynStructCol, ValidityRef};
 use crate::stats::{
-    any_box_dyn_stats, proto_dyn_stats, ColumnStats, DynStats, OptionStats, ProtoDynStats,
-    ProtoStructStats, StatsFrom, TrimStats,
+    any_columnar_stats, proto_dyn_stats, ColumnStatKinds, ColumnStats, ColumnarStats, DynStats,
+    OptionStats, ProtoStructStats, StatsFrom, TrimStats,
 };
 
 /// Statistics about a column of a struct type with a uniform schema (the same
 /// columns and associated `T: Data` types in each instance of the struct).
-#[derive(Arbitrary, Default)]
+#[derive(Arbitrary, Default, Clone)]
 pub struct StructStats {
     /// The count of structs in the column.
     pub len: usize,
@@ -34,7 +33,7 @@ pub struct StructStats {
     /// This will often be all of the columns, but it's not guaranteed. Persist
     /// reserves the right to prune statistics about some or all of the columns.
     #[proptest(strategy = "any_struct_stats_cols()")]
-    pub cols: BTreeMap<String, Box<dyn DynStats>>,
+    pub cols: BTreeMap<String, ColumnarStats>,
 }
 
 impl std::fmt::Debug for StructStats {
@@ -54,15 +53,6 @@ impl serde::Serialize for StructStats {
 }
 
 impl DynStats for StructStats {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn into_proto(&self) -> ProtoDynStats {
-        ProtoDynStats {
-            option: None,
-            kind: Some(proto_dyn_stats::Kind::Struct(RustType::into_proto(self))),
-        }
-    }
     fn debug_json(&self) -> serde_json::Value {
         let mut cols = serde_json::Map::new();
         cols.insert("len".to_owned(), self.len.into());
@@ -71,6 +61,12 @@ impl DynStats for StructStats {
         }
         cols.into()
     }
+    fn into_columnar_stats(self) -> ColumnarStats {
+        ColumnarStats {
+            nulls: None,
+            values: ColumnStatKinds::Struct(self),
+        }
+    }
 }
 
 impl StructStats {
@@ -78,11 +74,11 @@ impl StructStats {
     ///
     /// This will often be all of the columns, but it's not guaranteed. Persist
     /// reserves the right to prune statistics about some or all of the columns.
-    pub fn col<T: Data>(&self, name: &str) -> Result<Option<&T::Stats>, String> {
+    pub fn col<T: Data>(&self, name: &str) -> Result<Option<T::Stats>, String> {
         let Some(stats) = self.cols.get(name) else {
             return Ok(None);
         };
-        match stats.as_any().downcast_ref() {
+        match stats.downcast::<T>() {
             Some(x) => Ok(Some(x)),
             None => Err(format!(
                 "expected stats type {} got {}",
@@ -105,6 +101,18 @@ impl ColumnStats<DynStruct> for StructStats {
     fn none_count(&self) -> usize {
         0
     }
+    fn downcast(stats: &ColumnarStats) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        if stats.nulls.is_some() {
+            return None;
+        }
+        match &stats.values {
+            ColumnStatKinds::Struct(inner) => Some(inner.clone()),
+            _ => None,
+        }
+    }
 }
 
 impl ColumnStats<Option<DynStruct>> for OptionStats<StructStats> {
@@ -116,6 +124,19 @@ impl ColumnStats<Option<DynStruct>> for OptionStats<StructStats> {
     }
     fn none_count(&self) -> usize {
         self.none
+    }
+    fn downcast(stats: &ColumnarStats) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        let inner = match &stats.values {
+            ColumnStatKinds::Struct(inner) => inner,
+            _ => return None,
+        };
+        Some(OptionStats {
+            some: inner.clone(),
+            none: stats.nulls.as_ref().map_or(0, |n| n.count),
+        })
     }
 }
 
@@ -140,7 +161,7 @@ impl RustType<ProtoStructStats> for StructStats {
             cols: self
                 .cols
                 .iter()
-                .map(|(k, v)| (k.into_proto(), v.into_proto()))
+                .map(|(k, v)| (k.into_proto(), RustType::into_proto(v)))
                 .collect(),
         }
     }
@@ -173,7 +194,7 @@ impl TrimStats for ProtoStructStats {
     }
 }
 
-struct DynStatsCols<'a>(&'a BTreeMap<String, Box<dyn DynStats>>);
+struct DynStatsCols<'a>(&'a BTreeMap<String, ColumnarStats>);
 
 impl serde::Serialize for DynStatsCols<'_> {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
@@ -187,9 +208,8 @@ impl serde::Serialize for DynStatsCols<'_> {
 }
 
 /// Returns a [`Strategy`] for generating arbitrary [`StructStats`].
-pub(crate) fn any_struct_stats_cols() -> impl Strategy<Value = BTreeMap<String, Box<dyn DynStats>>>
-{
-    proptest::collection::btree_map(any::<String>(), any_box_dyn_stats(), 1..5)
+pub(crate) fn any_struct_stats_cols() -> impl Strategy<Value = BTreeMap<String, ColumnarStats>> {
+    proptest::collection::btree_map(any::<String>(), any_columnar_stats(), 1..5)
 }
 
 #[cfg(test)]
@@ -198,7 +218,7 @@ mod tests {
 
     use super::*;
     use crate::stats::primitive::PrimitiveStats;
-    use crate::stats::trim_to_budget;
+    use crate::stats::{trim_to_budget, BytesStats, ColumnNullStats, ColumnStatKinds};
 
     #[mz_ore::test]
     fn struct_trim_to_budget() {
@@ -207,10 +227,14 @@ mod tests {
             let cols = cols
                 .iter()
                 .map(|(key, cost)| {
-                    let stats: Box<dyn DynStats> = Box::new(PrimitiveStats {
+                    let stats = BytesStats::Primitive(PrimitiveStats {
                         lower: vec![],
                         upper: vec![0u8; *cost],
                     });
+                    let stats = ColumnarStats {
+                        nulls: None,
+                        values: ColumnStatKinds::Bytes(stats),
+                    };
                     ((*key).to_owned(), stats)
                 })
                 .collect();
@@ -240,19 +264,23 @@ mod tests {
     // Confirm that fields are being trimmed from largest to smallest.
     #[mz_ore::test]
     fn trim_order_regression() {
-        fn dyn_stats(lower: &'static str, upper: &'static str) -> Box<dyn DynStats> {
-            Box::new(PrimitiveStats {
+        fn column_stats(lower: &'static str, upper: &'static str) -> ColumnarStats {
+            let stats = PrimitiveStats {
                 lower: lower.to_owned(),
                 upper: upper.to_owned(),
-            })
+            };
+            ColumnarStats {
+                nulls: None,
+                values: ColumnStatKinds::Primitive(stats.into()),
+            }
         }
         let stats = StructStats {
             len: 2,
             cols: BTreeMap::from([
-                ("foo".to_owned(), dyn_stats("a", "b")),
+                ("foo".to_owned(), column_stats("a", "b")),
                 (
                     "bar".to_owned(),
-                    dyn_stats("aaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaab"),
+                    column_stats("aaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaab"),
                 ),
             ]),
         };
@@ -271,15 +299,17 @@ mod tests {
     // "err", and the real columns are all nested under "ok".
     #[mz_ore::test]
     fn stats_trim_to_budget_regression_recursion() {
-        fn str_stats(n: usize, l: &str, u: &str) -> Box<dyn DynStats> {
-            let stats: Box<dyn DynStats> = Box::new(OptionStats {
-                none: n,
-                some: PrimitiveStats {
-                    lower: l.to_owned(),
-                    upper: u.to_owned(),
-                },
-            });
-            stats
+        fn str_stats(n: usize, l: &str, u: &str) -> ColumnarStats {
+            ColumnarStats {
+                nulls: Some(ColumnNullStats { count: n }),
+                values: ColumnStatKinds::Primitive(
+                    PrimitiveStats {
+                        lower: l.to_owned(),
+                        upper: u.to_owned(),
+                    }
+                    .into(),
+                ),
+            }
         }
 
         const BIG: usize = 100;
@@ -297,7 +327,13 @@ mod tests {
             len: 2,
             cols: BTreeMap::from([
                 ("err".to_owned(), str_stats(2, "", "")),
-                ("ok".to_owned(), Box::new(StructStats { len: 2, cols })),
+                (
+                    "ok".to_owned(),
+                    ColumnarStats {
+                        nulls: None,
+                        values: ColumnStatKinds::Struct(StructStats { len: 2, cols }),
+                    },
+                ),
             ]),
         };
         let mut proto_stats = RustType::into_proto(&source_data_stats);

--- a/src/persist-types/src/stats/structured.rs
+++ b/src/persist-types/src/stats/structured.rs
@@ -105,10 +105,7 @@ impl ColumnStats<DynStruct> for StructStats {
     where
         Self: Sized,
     {
-        if stats.nulls.is_some() {
-            return None;
-        }
-        match &stats.values {
+        match stats.non_null_values()? {
             ColumnStatKinds::Struct(inner) => Some(inner.clone()),
             _ => None,
         }

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -461,7 +461,7 @@ impl TxnsCodec for TxnsCodecRow {
     }
 
     fn should_fetch_part(data_id: &ShardId, stats: &PartStats) -> Option<bool> {
-        fn col<'a, T: Data>(stats: &'a StructStats, col: &str) -> Option<&'a T::Stats> {
+        fn col<'a, T: Data>(stats: &'a StructStats, col: &str) -> Option<T::Stats> {
             stats
                 .col::<T>(col)
                 .map_err(|err| error!("unexpected stats type for col {}: {}", col, err))

--- a/src/storage-types/src/stats.rs
+++ b/src/storage-types/src/stats.rs
@@ -13,7 +13,7 @@ use mz_expr::{ColumnSpecs, Interpreter, MapFilterProject, ResultSpec, Unmaterial
 use mz_persist_types::columnar::Data;
 use mz_persist_types::dyn_struct::DynStruct;
 use mz_persist_types::stats::{
-    BytesStats, ColumnStats, DynStats, JsonStats, PartStats, PartStatsMetrics,
+    BytesStats, ColumnStats, ColumnarStats, DynStats, JsonStats, PartStats, PartStatsMetrics,
 };
 use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::{
@@ -47,13 +47,13 @@ impl<'a> RelationPartStats<'a> {
     }
 }
 
-fn downcast_stats<'a, T: Data>(
+fn downcast_stats<T: Data>(
     metrics: &PartStatsMetrics,
     name: &str,
     col_name: &str,
-    stats: &'a dyn DynStats,
-) -> Option<&'a T::Stats> {
-    match stats.as_any().downcast_ref::<T::Stats>() {
+    stats: &ColumnarStats,
+) -> Option<T::Stats> {
+    match stats.downcast::<T>() {
         Some(x) => Some(x),
         None => {
             // TODO: There is a known instance of this #22680. While we look
@@ -92,15 +92,15 @@ impl RelationPartStats<'_> {
         result.may_contain(Datum::True) || result.may_fail()
     }
 
-    fn json_spec<'a>(len: usize, stats: &'a JsonStats, arena: &'a RowArena) -> ResultSpec<'a> {
+    fn json_spec<'a>(len: usize, stats: JsonStats, arena: &'a RowArena) -> ResultSpec<'a> {
         match stats {
             JsonStats::JsonNulls => ResultSpec::value(Datum::JsonNull),
             JsonStats::Bools(bools) => {
                 ResultSpec::value_between(bools.lower.into(), bools.upper.into())
             }
             JsonStats::Strings(strings) => ResultSpec::value_between(
-                strings.lower.as_str().into(),
-                strings.upper.as_str().into(),
+                arena.make_datum(|r| r.push(Datum::String(strings.lower.as_str()))),
+                arena.make_datum(|r| r.push(Datum::String(strings.upper.as_str()))),
             ),
             JsonStats::Numerics(numerics) => ResultSpec::value_between(
                 arena.make_datum(|r| Jsonb::decode(&numerics.lower, r)),
@@ -110,13 +110,14 @@ impl RelationPartStats<'_> {
                 ResultSpec::map_spec(
                     maps.into_iter()
                         .map(|(k, v)| {
-                            let mut v_spec = Self::json_spec(v.len, &v.stats, arena);
+                            let mut v_spec = Self::json_spec(v.len, v.stats, arena);
                             if v.len != len {
                                 // This field is not always present, so assume
                                 // that accessing it might be null.
                                 v_spec = v_spec.union(ResultSpec::null());
                             }
-                            (k.as_str().into(), v_spec)
+                            let key = arena.make_datum(|r| r.push(Datum::String(k.as_str())));
+                            (key, v_spec)
                         })
                         .collect(),
                 )
@@ -150,7 +151,7 @@ impl RelationPartStats<'_> {
                 nullable: false,
             } => {
                 let byte_stats =
-                    downcast_stats::<Vec<u8>>(self.metrics, self.name, name.as_str(), &**stats)?;
+                    downcast_stats::<Vec<u8>>(self.metrics, self.name, name.as_str(), stats)?;
                 let value_range = match byte_stats {
                     BytesStats::Json(json_stats) => {
                         Self::json_spec(ok_stats.some.len, json_stats, arena)
@@ -167,13 +168,13 @@ impl RelationPartStats<'_> {
                     self.metrics,
                     self.name,
                     name.as_str(),
-                    &**stats,
+                    stats,
                 )?;
                 let null_range = match option_stats.none {
                     0 => ResultSpec::nothing(),
                     _ => ResultSpec::null(),
                 };
-                let value_range = match &option_stats.some {
+                let value_range = match option_stats.some {
                     BytesStats::Json(json_stats) => {
                         Self::json_spec(ok_stats.some.len, json_stats, arena)
                     }
@@ -209,15 +210,15 @@ impl RelationPartStats<'_> {
     }
 
     fn col_values<'a>(&'a self, idx: usize, arena: &'a RowArena) -> Option<ResultSpec> {
-        struct ColValues<'a>(
+        struct ColValues<'a, 's>(
             &'a PartStatsMetrics,
             &'a str,
             &'a str,
-            &'a dyn DynStats,
+            &'s ColumnarStats,
             &'a RowArena,
             Option<usize>,
         );
-        impl<'a> DatumToPersistFn<Option<ResultSpec<'a>>> for ColValues<'a> {
+        impl<'a, 's> DatumToPersistFn<Option<ResultSpec<'a>>> for ColValues<'a, 's> {
             fn call<T: DatumToPersist>(self) -> Option<ResultSpec<'a>> {
                 let ColValues(metrics, name, col_name, stats, arena, total_count) = self;
                 let stats = downcast_stats::<T::Data>(metrics, name, col_name, stats)?;
@@ -251,7 +252,7 @@ impl RelationPartStats<'_> {
             self.metrics,
             self.name,
             name.as_str(),
-            stats.as_ref(),
+            stats,
             arena,
             self.len(),
         ))?;
@@ -267,10 +268,7 @@ mod tests {
     use mz_persist_types::part::PartBuilder;
     use mz_persist_types::stats::PartStats;
     use mz_repr::{arb_datum_for_column, RelationType};
-    use mz_repr::{
-        ColumnType, Datum, DatumToPersist, DatumToPersistFn, RelationDesc, Row, RowArena,
-        ScalarType,
-    };
+    use mz_repr::{ColumnType, Datum, RelationDesc, Row, RowArena, ScalarType};
     use proptest::prelude::*;
     use proptest::strategy::ValueTree;
 
@@ -278,16 +276,6 @@ mod tests {
     use crate::sources::SourceData;
 
     fn validate_stats(column_type: &ColumnType, datums: &[Datum<'_>]) -> Result<(), String> {
-        struct ValidateStats<'a>(&'a RelationPartStats<'a>, &'a RowArena, Datum<'a>);
-        impl<'a> DatumToPersistFn<()> for ValidateStats<'a> {
-            fn call<T: DatumToPersist>(self) -> () {
-                let ValidateStats(stats, arena, datum) = self;
-                if let Some(spec) = stats.col_values(0, arena) {
-                    assert!(spec.may_contain(datum));
-                }
-            }
-        }
-
         let schema = RelationDesc::empty().with_column("col", column_type.clone());
 
         let mut builder = PartBuilder::new(&schema, &UnitSchema).expect("success");
@@ -310,7 +298,9 @@ mod tests {
 
         // Validate that the stats would include all of the provided datums.
         for datum in datums {
-            column_type.to_persist(ValidateStats(&stats, &arena, *datum));
+            if let Some(spec) = stats.col_values(0, &arena) {
+                assert!(spec.may_contain(*datum));
+            }
         }
 
         Ok(())


### PR DESCRIPTION
This PR refactors stats handling away from using `Box<dyn DynStats>` and to using a concrete type called `ColumnarStats`, which is structured very similar to the `ProtoDynStats` message type, i.e. it has an inner `enum` of all the stats types that we can match against.

It should not result in _any_ behavioral change, the `statistics_stability` test that asserts the generated statistics match a snapshot, is still passing.

Previously the flow worked like `ProtoDynStats` -> `Box<dyn DynStats>` -downcast-> `T::Stats`. The flow in this PR is still very similar, `ProtoDynStats` -> `ColumnarStats` -> `T::Stats`, but now `ColumnarStats` contains an enum `ColumnStatsKind` that we can match against in a follow up PR.

### Motivation

Related to https://github.com/MaterializeInc/materialize/issues/24830
Related to https://github.com/MaterializeInc/materialize/pull/27084

As we write structured data for all of our column types we'll evolve the kind of stats we keep. Currently the kind of stats are 1:1 with the implementation of `trait Data` that has an associated `type Stats`. Today we downcast a `Box<dyn DynStats>` to this associated `Stats` type, but this doesn't work if there are possibly two different kinds of stats that might exist for a column type. Also, I recently re-worked our column encoders away from the `Data` trait, and thus the associated `Stats` type as well.

We don't do it in this PR, but we're now setup to `match` a column type against a `ColumnStatsKind` enum which will make it easy to evolve stats over time.

#### Alternatives

There are two alternatives to `match`-ing between column type and stats type.

1. For a given column type, downcast to known stats types until we find a match. This works, but feels very non-Rusty.
2. Provide a version number with each `Part` and then given a version and column type, downcast to a specific kind of stats. This approach doesn't require a refactor but I think we'd still end up with a big `match` statement?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
