### PR TITLE
tests: mysql-cdc: test add sub source after corruption

### DIFF
--- a/test/mysql-cdc-resumption/alter-source-add-subsource.td
+++ b/test/mysql-cdc-resumption/alter-source-add-subsource.td
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> ALTER SOURCE mz_source ADD SUBSOURCE public.t3;

--- a/test/mysql-cdc-resumption/mzcompose.py
+++ b/test/mysql-cdc-resumption/mzcompose.py
@@ -103,7 +103,10 @@ def workflow_bin_log_manipulations(c: Composition) -> None:
     with c.override(
         Materialized(sanity_restart=False),
     ):
-        scenarios = [reset_master_gtid, corrupt_bin_log]
+        scenarios = [
+            reset_master_gtid,
+            corrupt_bin_log_to_stall_source,
+        ]
         for scenario in scenarios:
             print(f"--- Running scenario {scenario.__name__}")
             initialize(c)
@@ -417,7 +420,7 @@ def reset_master_gtid(c: Composition) -> None:
     )
 
 
-def corrupt_bin_log(c: Composition) -> None:
+def corrupt_bin_log_to_stall_source(c: Composition) -> None:
     """
     Switch off mz, modify data in mysql, and purge the bin-log so that mz hasn't seen all entries in the replication
     stream.

--- a/test/mysql-cdc-resumption/mzcompose.py
+++ b/test/mysql-cdc-resumption/mzcompose.py
@@ -450,6 +450,8 @@ def corrupt_bin_log_and_add_sub_source(c: Composition) -> None:
 
 
 def _corrupt_bin_log(c: Composition) -> None:
+    run_testdrive_files(c, "wait-for-snapshot.td")
+
     c.kill("materialized")
 
     mysql_conn = create_mysql_connection(c)

--- a/test/mysql-cdc-resumption/mzcompose.py
+++ b/test/mysql-cdc-resumption/mzcompose.py
@@ -106,6 +106,7 @@ def workflow_bin_log_manipulations(c: Composition) -> None:
         scenarios = [
             reset_master_gtid,
             corrupt_bin_log_to_stall_source,
+            corrupt_bin_log_and_add_sub_source,
         ]
         for scenario in scenarios:
             print(f"--- Running scenario {scenario.__name__}")
@@ -430,6 +431,21 @@ def corrupt_bin_log_to_stall_source(c: Composition) -> None:
     run_testdrive_files(
         c,
         "verify-source-stalled.td",
+    )
+
+
+def corrupt_bin_log_and_add_sub_source(c: Composition) -> None:
+    """
+    Corrupt the bin log, add a sub source, and expect it to be working.
+    """
+
+    _corrupt_bin_log(c)
+
+    run_testdrive_files(
+        c,
+        "populate-table-t3.td",
+        "alter-source-add-subsource.td",
+        "verify-t3.td",
     )
 
 

--- a/test/mysql-cdc-resumption/populate-table-t3.td
+++ b/test/mysql-cdc-resumption/populate-table-t3.td
@@ -1,0 +1,18 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ mysql-connect name=mysql url=mysql://root@${arg.mysql-host} password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+USE public;
+
+DROP TABLE IF EXISTS t3;
+CREATE TABLE t3 (f1 INTEGER NOT NULL);
+
+INSERT INTO t3 VALUES (1);

--- a/test/mysql-cdc-resumption/verify-t3.td
+++ b/test/mysql-cdc-resumption/verify-t3.td
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT * FROM t3;
+1


### PR DESCRIPTION
>  Create a source, purge the bin log, add a sub source?

This adds testing for https://github.com/MaterializeInc/materialize/pull/27507.