### PR TITLE
.*: Upgrade Rust to v1.79

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.78.0"
+rust-version = "1.79.0"
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-NIGHTLY_RUST_DATE=2024-04-19
+NIGHTLY_RUST_DATE=2024-06-20
 
 cd "$(dirname "$0")/.."
 

--- a/bin/lint-versions
+++ b/bin/lint-versions
@@ -11,5 +11,5 @@
 #
 # lint-versions - Check rust version
 
-grep "rust-version = " Cargo.toml | grep -q "1\.78\.0" || \
+grep "rust-version = " Cargo.toml | grep -q "1\.79\.0" || \
 (echo "Please validate new Rust versions for compilation time performance regressions or ask Team Testing to do so. Afterwards change the tested version in bin/lint-versions" && exit 1)

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -27,7 +27,7 @@ hex = "0.4.3"
 http = "0.2.8"
 itertools = "0.10.5"
 once_cell = "1.16.0"
-launchdarkly-server-sdk = { version = "1.0.0", default_features = false, features = [
+launchdarkly-server-sdk = { version = "1.0.0", default-features = false, features = [
     "hypertls",
 ] }
 maplit = "1.0.2"

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -109,7 +109,6 @@ impl BuiltinMigrationMetadata {
 pub enum CatalogItemRebuilder {
     SystemSource(CatalogItem),
     Object {
-        id: GlobalId,
         sql: String,
         is_retained_metrics_object: bool,
         custom_logical_compaction_window: Option<CompactionWindow>,
@@ -134,7 +133,6 @@ impl CatalogItemRebuilder {
                 .ast;
             mz_sql::ast::transform::create_stmt_replace_ids(&mut create_stmt, ancestor_ids);
             Self::Object {
-                id,
                 sql: create_stmt.to_ast_string_stable(),
                 is_retained_metrics_object: entry.item().is_retained_metrics_object(),
                 custom_logical_compaction_window: entry.item().custom_logical_compaction_window(),
@@ -146,7 +144,6 @@ impl CatalogItemRebuilder {
         match self {
             Self::SystemSource(item) => item,
             Self::Object {
-                id: _,
                 sql,
                 is_retained_metrics_object,
                 custom_logical_compaction_window,

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -26,7 +26,7 @@ use mz_adapter::session::{Session, DEFAULT_DATABASE_NAME};
 use mz_catalog::memory::objects::{CatalogItem, Table};
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_repr::RelationDesc;
-use mz_sql::ast::{Expr, Statement};
+use mz_sql::ast::Statement;
 use mz_sql::catalog::CatalogDatabase;
 use mz_sql::names::{
     self, ItemQualifiers, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds,
@@ -95,7 +95,7 @@ async fn datadriven() {
                                                 test_case.input.trim_end()
                                             )),
                                             desc: RelationDesc::empty(),
-                                            defaults: vec![Expr::null(); 0],
+                                            defaults: vec![],
                                             conn_id: None,
                                             resolved_ids: ResolvedIds(BTreeSet::new()),
                                             custom_logical_compaction_window: None,

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -329,6 +329,7 @@ pub struct SchemaResolver<'a> {
     pub writer_to_reader_names: BTreeMap<usize, usize>,
     pub reader_to_writer_names: BTreeMap<usize, usize>,
     pub reader_to_resolved_names: BTreeMap<usize, usize>,
+    #[allow(dead_code)]
     pub reader_fullnames: BTreeMap<usize, &'a FullName>,
     pub reader_schema: &'a Schema,
 }

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -831,14 +831,10 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "ascii"]
     fn ascii<'a>(a: &'a str) -> i32 {
-        match a
-            .chars()
+        a.chars()
             .next()
             .and_then(|c| i32::try_from(u32::from(c)).ok())
-        {
-            None => 0,
-            Some(v) => v,
-        }
+            .unwrap_or(0)
     }
 );
 

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.68"
-chrono = { version = "0.4.35", default_features = false, features = ["clock"] }
+chrono = { version = "0.4.35", default-features = false, features = ["clock"] }
 futures = "0.3.25"
 hex = "0.4.3"
 itertools = "0.10.5"

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = "1.0.66"
 async-trait = "0.1.68"
 bytesize = "1.1.0"
-chrono = { version = "0.4.35", default_features = false, features = ["serde"] }
+chrono = { version = "0.4.35", default-features = false, features = ["serde"] }
 derivative = "2.2.0"
 futures-core = "0.3.21"
 mz-ore = { path = "../ore"}

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -856,7 +856,7 @@ mod tests {
     fn smoketest_packed_numeric_roundtrips() {
         let og = PackedNumeric::from_value(Numeric::from(-42));
         let bytes = og.as_bytes();
-        let rnd = PackedNumeric::from_bytes(&bytes).expect("valid");
+        let rnd = PackedNumeric::from_bytes(bytes).expect("valid");
         assert_eq!(og, rnd);
 
         // Returns an error if the size of the slice is invalid.

--- a/src/repr/src/explain/tracing.rs
+++ b/src/repr/src/explain/tracing.rs
@@ -9,8 +9,6 @@
 
 //! Tracing utilities for explainable plans.
 
-#![cfg(feature = "tracing_")]
-
 use std::fmt::{Debug, Display};
 use std::sync::Mutex;
 

--- a/src/storage-types/src/stats.rs
+++ b/src/storage-types/src/stats.rs
@@ -395,7 +395,7 @@ mod tests {
                     .typ()
                     .columns()
                     .iter()
-                    .map(|ct| arb_datum_for_column(ct))
+                    .map(arb_datum_for_column)
                     .collect::<Vec<_>>()
                     .prop_map(|datums| Row::pack(datums.iter().map(Datum::from)));
                 proptest::collection::vec(rows, 1..max_rows)

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -21,7 +21,7 @@ mz-ore = { path = "../ore", features = ["async", "process", "tracing_", "test"] 
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "time"] }
 num-traits = "0.2"
-ahash = { version = "0.8.11", default_features = false }
+ahash = { version = "0.8.11", default-features = false }
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 
 [package.metadata.cargo-udeps.ignore]


### PR DESCRIPTION
This PR updates the version of Rust we use to v1.79 and fixes a few clippy lints.

### Motivation

Upgrade to the latest stable version of Rust

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Materialize is now built with v1.79 of Rust
