### PR TITLE
adapter: introspection subscribes (coordinator-managed)

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -70,6 +70,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_eager_delta_joins": "true",
     "enable_envelope_debezium_in_subscribe": "true",
     "enable_expressions_in_limit_syntax": "true",
+    "enable_introspection_subscribes": "true",
     "enable_logical_compaction_window": "true",
     "enable_multi_worker_storage_persist_sink": "true",
     "enable_mysql_source": "true",

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -32,6 +32,13 @@ pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
     "Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.",
 );
 
+/// Enable installation of introspection subscribes.
+pub const ENABLE_INTROSPECTION_SUBSCRIBES: Config<bool> = Config::new(
+    "enable_introspection_subscribes",
+    false,
+    "Enable installation of introspection subscribes.",
+);
+
 /// The plan insights notice will not investigate fast path clusters if plan optimization took longer than this.
 pub const PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION: Config<Duration> = Config::new(
     "plan_insights_notice fast_path_clusters_optimize_duration",
@@ -50,5 +57,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ALLOW_USER_SESSIONS)
         .add(&ENABLE_0DT_DEPLOYMENT)
         .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
+        .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)
 }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -301,6 +301,8 @@ pub enum ExecuteResponse {
     CreatedClusterReplica,
     /// The requested index was created.
     CreatedIndex,
+    /// The requested introspection subscribe was created.
+    CreatedIntrospectionSubscribe,
     /// The requested secret was created.
     CreatedSecret,
     /// The requested sink was created.
@@ -509,6 +511,9 @@ impl TryInto<ExecuteResponse> for ExecuteResponseKind {
             ExecuteResponseKind::Updated => Err(()),
             ExecuteResponseKind::ValidatedConnection => Ok(ExecuteResponse::ValidatedConnection),
             ExecuteResponseKind::SendingRowsImmediate => Err(()),
+            ExecuteResponseKind::CreatedIntrospectionSubscribe => {
+                Ok(ExecuteResponse::CreatedIntrospectionSubscribe)
+            }
         }
     }
 }
@@ -576,6 +581,7 @@ impl ExecuteResponse {
             TransactionRolledBack { .. } => Some("ROLLBACK".into()),
             Updated(n) => Some(format!("UPDATE {}", n)),
             ValidatedConnection => Some("VALIDATE CONNECTION".into()),
+            CreatedIntrospectionSubscribe => Some("CREATE INTROSPECTION SUBSCRIBE".into()),
         }
     }
 

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -793,6 +793,9 @@ impl Coordinator {
             }
             self.builtin_table_update().background(updates);
         }
+
+        self.drop_introspection_subscribes(replica_id);
+
         self.controller
             .drop_replica(cluster_id, replica_id)
             .await

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -1,0 +1,502 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Support for unified compute introspection.
+//!
+//! Unified compute introspection is the process of collecting introspection data exported by
+//! individual replicas through their logging indexes and then writing that data, tagged with the
+//! respective replica ID, to "unified" storage collections. These storage collections then allow
+//! querying introspection data across all replicas and regardless of the health of individual
+//! replicas.
+//!
+//! # Lifecycle of Introspection Subscribes
+//!
+//! * After a new replica was created, the coordinator calls `install_introspection_subscribes` to
+//!   install all defined introspection subscribes on the new replica.
+//! * The coordinator calls `handle_introspection_subscribe_batch` for each response it receives
+//!   from an introspection subscribe, to write received updates to their corresponding
+//!   storage-managed collection.
+//! * Before a replica is dropped, the coordinator calls `drop_introspection_subscribes` to drop
+//!   all introspection subscribes previously installed on the replica.
+//! * When a replica disconnects without being dropped (e.g. because of a crash or network
+//!   failure), `handle_introspection_subscribe_batch` reacts on the corresponding error responses
+//!   by reinstalling the failed introspection subscribes.
+
+use anyhow::bail;
+use mz_cluster_client::ReplicaId;
+use mz_compute_client::controller::error::ERROR_TARGET_REPLICA_FAILED;
+use mz_compute_client::protocol::response::SubscribeBatch;
+use mz_controller_types::ClusterId;
+use mz_ore::collections::CollectionExt;
+use mz_ore::soft_panic_or_log;
+use mz_repr::fixed_length::ToDatumIter;
+use mz_repr::optimize::OverrideFrom;
+use mz_repr::{Datum, GlobalId, Row};
+use mz_sql::catalog::SessionCatalog;
+use mz_sql::plan::{Params, Plan, SubscribePlan};
+use mz_sql::session::metadata::SessionMetadata;
+use mz_sql::session::user::{RoleMetadata, MZ_SYSTEM_ROLE_ID};
+use mz_storage_client::controller::IntrospectionType;
+use tokio::sync::{mpsc, oneshot};
+use tracing::{info, Span};
+
+use crate::coord::{
+    Coordinator, IntrospectionSubscribeFinish, IntrospectionSubscribeOptimizeMir,
+    IntrospectionSubscribeStage, IntrospectionSubscribeTimestampOptimizeLir, Message, PlanValidity,
+    StageResult, Staged,
+};
+use crate::optimize::Optimize;
+use crate::session::Session;
+use crate::util::ClientTransmitter;
+use crate::{optimize, AdapterError, ExecuteContext, ExecuteContextExtra, ExecuteResponse};
+
+// State tracked about an active introspection subscribe.
+#[derive(Debug, Clone)]
+pub(super) struct IntrospectionSubscribe {
+    /// The ID of the targeted cluster.
+    cluster_id: ClusterId,
+    /// The ID of the targeted replica.
+    replica_id: ReplicaId,
+    /// The spec from which this subscribe was created.
+    spec: &'static SubscribeSpec,
+}
+
+impl Coordinator {
+    /// Installs introspection subscribes on all existing replicas.
+    ///
+    /// Meant to be invoked during coordinator bootstrapping.
+    pub(super) async fn bootstrap_introspection_subscribes(&mut self) {
+        let mut cluster_replicas = Vec::new();
+        for cluster in self.catalog.clusters() {
+            for replica in cluster.replicas() {
+                cluster_replicas.push((cluster.id, replica.replica_id));
+            }
+        }
+
+        for (cluster_id, replica_id) in cluster_replicas {
+            self.install_introspection_subscribes(cluster_id, replica_id)
+                .await;
+        }
+    }
+
+    /// Installs introspection subscribes on the given replica.
+    pub(super) async fn install_introspection_subscribes(
+        &mut self,
+        cluster_id: ClusterId,
+        replica_id: ReplicaId,
+    ) {
+        for spec in SUBSCRIBES {
+            self.install_introspection_subscribe(cluster_id, replica_id, spec)
+                .await;
+        }
+    }
+
+    async fn install_introspection_subscribe(
+        &mut self,
+        cluster_id: ClusterId,
+        replica_id: ReplicaId,
+        spec: &'static SubscribeSpec,
+    ) {
+        let id = self.allocate_transient_id();
+        info!(
+            %id,
+            %replica_id,
+            type_ = ?spec.introspection_type,
+            "installing introspection subscribe",
+        );
+
+        // Sequencing is performed asynchronously, and the target replica may be dropped before it
+        // completes. To ensure the subscribe does not leak in this case, we need to already add it
+        // to the coordinator state here, rather than at the end of sequencing.
+        let subscribe = IntrospectionSubscribe {
+            cluster_id,
+            replica_id,
+            spec,
+        };
+        self.introspection_subscribes.insert(id, subscribe);
+
+        self.sequence_introspection_subscribe(id, spec, cluster_id, replica_id)
+            .await;
+    }
+
+    async fn sequence_introspection_subscribe(
+        &mut self,
+        subscribe_id: GlobalId,
+        spec: &'static SubscribeSpec,
+        cluster_id: ClusterId,
+        replica_id: ReplicaId,
+    ) {
+        let (tx, rx) = oneshot::channel();
+        let client_tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
+        let ctx = ExecuteContext::from_parts(
+            client_tx,
+            self.internal_cmd_tx.clone(),
+            Session::dummy(),
+            Default::default(),
+        );
+
+        // If we just dropped the response `rx`, the coordinator would fail to send the response
+        // at the end of sequencing and proceed with trying to terminate the client connection,
+        // which would panic since there is no actual client connection. To prevent this we make
+        // sure that the `rx` gets properly drained.
+        mz_ore::task::spawn(|| "introspection-subscribe-response-drain", rx);
+
+        let catalog = self.catalog().for_system_session();
+        let plan = spec.to_plan(&catalog).expect("valid spec");
+
+        let role_metadata = RoleMetadata {
+            authenticated_role: MZ_SYSTEM_ROLE_ID,
+            session_role: MZ_SYSTEM_ROLE_ID,
+            current_role: MZ_SYSTEM_ROLE_ID,
+        };
+        let validity = PlanValidity {
+            transient_revision: self.catalog.transient_revision(),
+            dependency_ids: plan.from.depends_on(),
+            cluster_id: Some(cluster_id),
+            replica_id: Some(replica_id),
+            role_metadata,
+        };
+
+        let stage = IntrospectionSubscribeStage::OptimizeMir(IntrospectionSubscribeOptimizeMir {
+            validity,
+            plan,
+            subscribe_id,
+        });
+        self.sequence_staged(ctx, Span::current(), stage).await;
+    }
+
+    fn sequence_introspection_subscribe_optimize_mir(
+        &mut self,
+        session: &Session,
+        stage: IntrospectionSubscribeOptimizeMir,
+    ) -> Result<StageResult<Box<IntrospectionSubscribeStage>>, AdapterError> {
+        let IntrospectionSubscribeOptimizeMir {
+            mut validity,
+            plan,
+            subscribe_id,
+        } = stage;
+
+        let cluster_id = validity.cluster_id.expect("always set");
+        let compute_instance = self.instance_snapshot(cluster_id).expect("must exist");
+        let view_id = self.allocate_transient_id();
+
+        let vars = self.catalog().system_config();
+        let overrides = self.catalog.get_cluster(cluster_id).config.features();
+        let optimizer_config = optimize::OptimizerConfig::from(vars).override_from(&overrides);
+
+        let mut optimizer = optimize::subscribe::Optimizer::new(
+            self.owned_catalog(),
+            compute_instance,
+            view_id,
+            subscribe_id,
+            session.conn_id().clone(),
+            plan.with_snapshot,
+            None,
+            format!("introspection-subscribe-{subscribe_id}"),
+            optimizer_config,
+            self.optimizer_metrics(),
+        );
+
+        let span = Span::current();
+        Ok(StageResult::Handle(mz_ore::task::spawn_blocking(
+            || "optimize introspection subscribe (mir)",
+            move || {
+                span.in_scope(|| {
+                    // MIR ⇒ MIR optimization (global)
+                    let global_mir_plan = optimizer.catch_unwind_optimize(plan.from)?;
+                    // Add introduced indexes as validity dependencies.
+                    let id_bundle = global_mir_plan.id_bundle(cluster_id);
+                    validity.dependency_ids.extend(id_bundle.iter());
+
+                    let stage = IntrospectionSubscribeStage::TimestampOptimizeLir(
+                        IntrospectionSubscribeTimestampOptimizeLir {
+                            validity,
+                            optimizer,
+                            global_mir_plan,
+                        },
+                    );
+                    Ok(Box::new(stage))
+                })
+            },
+        )))
+    }
+
+    fn sequence_introspection_subscribe_timestamp_optimize_lir(
+        &mut self,
+        stage: IntrospectionSubscribeTimestampOptimizeLir,
+    ) -> Result<StageResult<Box<IntrospectionSubscribeStage>>, AdapterError> {
+        let IntrospectionSubscribeTimestampOptimizeLir {
+            validity,
+            mut optimizer,
+            global_mir_plan,
+        } = stage;
+
+        let cluster_id = validity.cluster_id.expect("always set");
+
+        // Timestamp selection.
+        let id_bundle = global_mir_plan.id_bundle(cluster_id);
+        let read_holds = self.acquire_read_holds(&id_bundle);
+        let as_of = read_holds.least_valid_read();
+
+        let global_mir_plan = global_mir_plan.resolve(as_of);
+
+        let span = Span::current();
+        Ok(StageResult::Handle(mz_ore::task::spawn_blocking(
+            || "optimize introspection subscribe (lir)",
+            move || {
+                span.in_scope(|| {
+                    // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+                    let global_lir_plan =
+                        optimizer.catch_unwind_optimize(global_mir_plan.clone())?;
+
+                    let stage = IntrospectionSubscribeStage::Finish(IntrospectionSubscribeFinish {
+                        validity,
+                        global_lir_plan,
+                        read_holds,
+                    });
+                    Ok(Box::new(stage))
+                })
+            },
+        )))
+    }
+
+    async fn sequence_introspection_subscribe_finish(
+        &mut self,
+        stage: IntrospectionSubscribeFinish,
+    ) -> Result<StageResult<Box<IntrospectionSubscribeStage>>, AdapterError> {
+        let IntrospectionSubscribeFinish {
+            validity,
+            global_lir_plan,
+            read_holds,
+        } = stage;
+
+        let cluster_id = validity.cluster_id.expect("always set");
+        let replica_id = validity.replica_id.expect("always set");
+        let subscribe_id = global_lir_plan.sink_id();
+
+        // The subscribe may already have been dropped, in which case we must not install a
+        // dataflow for it.
+        if self.introspection_subscribes.contains_key(&subscribe_id) {
+            let (df_desc, _df_meta) = global_lir_plan.unapply();
+            self.ship_dataflow(df_desc, cluster_id).await;
+
+            self.controller
+                .compute
+                .set_subscribe_target_replica(cluster_id, subscribe_id, replica_id)
+                .expect("cannot fail");
+        }
+
+        drop(read_holds);
+
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let resp = ExecuteResponse::Subscribing {
+            rx,
+            ctx_extra: ExecuteContextExtra::default(),
+            instance_id: cluster_id,
+        };
+        Ok(StageResult::Response(resp))
+    }
+
+    /// Drops the introspection subscribes installed on the given replica.
+    ///
+    /// Dropping an introspection subscribe entails:
+    ///  * removing it from [`Coordinator::introspection_subscribes`]
+    ///  * dropping its compute collection
+    ///  * retracting any rows previously omitted by it from its corresponding storage-managed
+    ///    collection
+    pub(super) fn drop_introspection_subscribes(&mut self, replica_id: ReplicaId) {
+        let to_drop: Vec<_> = self
+            .introspection_subscribes
+            .iter()
+            .filter(|(_, s)| s.replica_id == replica_id)
+            .map(|(id, _)| *id)
+            .collect();
+
+        for id in to_drop {
+            self.drop_introspection_subscribe(id);
+        }
+    }
+
+    fn drop_introspection_subscribe(&mut self, id: GlobalId) {
+        let Some(subscribe) = self.introspection_subscribes.remove(&id) else {
+            soft_panic_or_log!("attempt to remove unknown introspection subscribe (id={id})");
+            return;
+        };
+
+        info!(
+            %id,
+            replica_id = %subscribe.replica_id,
+            type_ = ?subscribe.spec.introspection_type,
+            "dropping introspection subscribe",
+        );
+
+        // This can fail if the sequencing hasn't finished yet for the subscribe. In this case,
+        // `sequence_introspection_subscribe_finish` will skip installing the compute collection in
+        // the first place.
+        let _ = self
+            .controller
+            .compute
+            .drop_collections(subscribe.cluster_id, vec![id]);
+
+        let target_replica = subscribe.replica_id.to_string();
+        let _filter = Box::new(move |row: &Row| {
+            let replica_id = row.unpack_first();
+            replica_id == Datum::String(&target_replica)
+        });
+        // TODO(#26730) send introspection updates
+        //self.controller
+        //    .storage
+        //    .update_introspection_collection(
+        //        subscribe.spec.introspection_type,
+        //        StorageWriteOp::Delete { filter },
+        //    )
+        //    .await;
+    }
+
+    async fn reinstall_introspection_subscribe(&mut self, id: GlobalId) {
+        let Some(subscribe) = self.introspection_subscribes.get(&id) else {
+            soft_panic_or_log!("attempt to reinstall unknown introspection subscribe (id={id})");
+            return;
+        };
+
+        let subscribe = subscribe.clone();
+
+        self.drop_introspection_subscribe(id);
+        self.install_introspection_subscribe(
+            subscribe.cluster_id,
+            subscribe.replica_id,
+            subscribe.spec,
+        )
+        .await;
+    }
+
+    /// Processes a batch returned by an introspection subscribe.
+    ///
+    /// Depending on the contents of the batch, this either appends received updates to the
+    /// corresponding storage-managed collection, or reinstalls a disconnected subscribe.
+    pub(super) async fn handle_introspection_subscribe_batch(
+        &mut self,
+        id: GlobalId,
+        batch: SubscribeBatch,
+    ) {
+        let Some(subscribe) = self.introspection_subscribes.get(&id) else {
+            soft_panic_or_log!("updates for unknown introspection subscribe (id={id})");
+            return;
+        };
+
+        let updates = match batch.updates {
+            Ok(updates) if updates.is_empty() => return,
+            Ok(updates) => updates,
+            Err(error) if error == ERROR_TARGET_REPLICA_FAILED => {
+                // The target replica disconnected, reinstall the subscribe.
+                self.reinstall_introspection_subscribe(id).await;
+                return;
+            }
+            Err(error) => {
+                soft_panic_or_log!(
+                    "introspection subscribe produced an error: {error} \
+                     (id={id}, subscribe={subscribe:?})",
+                );
+                return;
+            }
+        };
+
+        // Prepend the `replica_id` to each row.
+        let replica_id = subscribe.replica_id.to_string();
+        let mut new_updates = Vec::with_capacity(updates.len());
+        let mut new_row = Row::default();
+        for (_time, row, diff) in updates {
+            let mut packer = new_row.packer();
+            packer.push(Datum::String(&replica_id));
+            packer.extend(row.to_datum_iter());
+            new_updates.push((new_row.clone(), diff));
+        }
+
+        // TODO(#26730) send introspection updates
+        //self.controller
+        //    .storage
+        //    .update_introspection_collection(
+        //        subscribe.spec.introspection_type,
+        //        StorageWriteOp::Append {
+        //            updates: new_updates
+        //        },
+        //    )
+        //    .await;
+    }
+}
+
+impl Staged for IntrospectionSubscribeStage {
+    fn validity(&mut self) -> &mut PlanValidity {
+        match self {
+            Self::OptimizeMir(stage) => &mut stage.validity,
+            Self::TimestampOptimizeLir(stage) => &mut stage.validity,
+            Self::Finish(stage) => &mut stage.validity,
+        }
+    }
+
+    async fn stage(
+        self,
+        coord: &mut Coordinator,
+        ctx: &mut ExecuteContext,
+    ) -> Result<StageResult<Box<Self>>, AdapterError> {
+        match self {
+            Self::OptimizeMir(stage) => {
+                coord.sequence_introspection_subscribe_optimize_mir(ctx.session(), stage)
+            }
+            Self::TimestampOptimizeLir(stage) => {
+                coord.sequence_introspection_subscribe_timestamp_optimize_lir(stage)
+            }
+            Self::Finish(stage) => coord.sequence_introspection_subscribe_finish(stage).await,
+        }
+    }
+
+    fn message(self, ctx: ExecuteContext, span: Span) -> super::Message {
+        Message::IntrospectionSubscribeStageReady {
+            ctx,
+            span,
+            stage: self,
+        }
+    }
+
+    fn cancel_enabled(&self) -> bool {
+        false
+    }
+}
+
+/// The specification for an introspection subscribe.
+#[derive(Debug)]
+pub(super) struct SubscribeSpec {
+    /// An [`IntrospectionType`] identifying the storage-managed collection to which updates
+    /// received from subscribes instantiated from this spec are written.
+    #[allow(dead_code)] // TODO(#26730)
+    introspection_type: IntrospectionType,
+    /// The SQL definition of the subscribe.
+    sql: &'static str,
+}
+
+impl SubscribeSpec {
+    fn to_plan(&self, catalog: &dyn SessionCatalog) -> Result<SubscribePlan, anyhow::Error> {
+        let parsed = mz_sql::parse::parse(self.sql)?.into_element();
+        let (stmt, resolved_ids) = mz_sql::names::resolve(catalog, parsed.ast)?;
+        let plan = mz_sql::plan::plan(None, catalog, stmt, &Params::empty(), &resolved_ids)?;
+        match plan {
+            Plan::Subscribe(plan) => Ok(plan),
+            _ => bail!("unexpected plan type: {plan:?}"),
+        }
+    }
+}
+
+const SUBSCRIBES: &[SubscribeSpec] = &[SubscribeSpec {
+    introspection_type: IntrospectionType::ComputeErrorCounts,
+    sql: "SUBSCRIBE (
+        SELECT export_id, sum(count)
+        FROM mz_internal.mz_compute_error_counts_raw
+        GROUP BY export_id
+    )",
+}];

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -29,6 +29,7 @@
 //!   by reinstalling the failed introspection subscribes.
 
 use anyhow::bail;
+use mz_adapter_types::dyncfgs::ENABLE_INTROSPECTION_SUBSCRIBES;
 use mz_cluster_client::ReplicaId;
 use mz_compute_client::controller::error::ERROR_TARGET_REPLICA_FAILED;
 use mz_compute_client::protocol::response::SubscribeBatch;
@@ -91,6 +92,11 @@ impl Coordinator {
         cluster_id: ClusterId,
         replica_id: ReplicaId,
     ) {
+        let dyncfgs = self.catalog().system_config().dyncfgs();
+        if !ENABLE_INTROSPECTION_SUBSCRIBES.get(dyncfgs) {
+            return;
+        }
+
         for spec in SUBSCRIBES {
             self.install_introspection_subscribe(cluster_id, replica_id, spec)
                 .await;

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -21,8 +21,8 @@ use mz_controller::clusters::{ClusterEvent, ClusterStatus};
 use mz_controller::ControllerResponse;
 use mz_ore::now::EpochMillis;
 use mz_ore::option::OptionExt;
-use mz_ore::task;
 use mz_ore::tracing::OpenTelemetryContext;
+use mz_ore::{soft_assert_no_log, task};
 use mz_persist_client::usage::ShardsUsageReferenced;
 use mz_sql::ast::Statement;
 use mz_sql::names::ResolvedIds;
@@ -177,6 +177,13 @@ impl Coordinator {
                     self.sequence_staged(ctx, span, stage).await;
                 }
                 Message::SubscribeStageReady {
+                    ctx,
+                    span,
+                    stage,
+                } => {
+                    self.sequence_staged(ctx, span, stage).await;
+                }
+                Message::IntrospectionSubscribeStageReady {
                     ctx,
                     span,
                     stage,
@@ -381,19 +388,27 @@ impl Coordinator {
                 self.send_peek_response(uuid, response, otel_ctx);
             }
             ControllerResponse::SubscribeResponse(sink_id, response) => {
-                match self.active_compute_sinks.get_mut(&sink_id) {
-                    Some(ActiveComputeSink::Subscribe(active_subscribe)) => {
-                        let finished = active_subscribe.process_response(response);
-                        if finished {
-                            self.retire_compute_sinks(btreemap! {
-                                sink_id => ActiveComputeSinkRetireReason::Finished,
-                            })
-                            .await;
-                        }
+                if let Some(ActiveComputeSink::Subscribe(active_subscribe)) =
+                    self.active_compute_sinks.get_mut(&sink_id)
+                {
+                    let finished = active_subscribe.process_response(response);
+                    if finished {
+                        self.retire_compute_sinks(btreemap! {
+                            sink_id => ActiveComputeSinkRetireReason::Finished,
+                        })
+                        .await;
                     }
-                    _ => {
-                        tracing::error!(%sink_id, "received SubscribeResponse for nonexistent subscribe");
-                    }
+
+                    soft_assert_or_log!(
+                        !self.introspection_subscribes.contains_key(&sink_id),
+                        "`sink_id` {sink_id} unexpectedly found in both `active_subscribes` \
+                         and `introspection_subscribes`",
+                    );
+                } else if self.introspection_subscribes.contains_key(&sink_id) {
+                    self.handle_introspection_subscribe_batch(sink_id, response)
+                        .await;
+                } else {
+                    tracing::error!(%sink_id, "received SubscribeResponse for nonexistent subscribe");
                 }
             }
             ControllerResponse::CopyToResponse(sink_id, response) => {

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -22,7 +22,7 @@ use mz_controller::ControllerResponse;
 use mz_ore::now::EpochMillis;
 use mz_ore::option::OptionExt;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_ore::{soft_assert_no_log, task};
+use mz_ore::{soft_assert_or_log, task};
 use mz_persist_client::usage::ShardsUsageReferenced;
 use mz_sql::ast::Statement;
 use mz_sql::names::ResolvedIds;
@@ -184,11 +184,10 @@ impl Coordinator {
                     self.sequence_staged(ctx, span, stage).await;
                 }
                 Message::IntrospectionSubscribeStageReady {
-                    ctx,
                     span,
                     stage,
                 } => {
-                    self.sequence_staged(ctx, span, stage).await;
+                    self.sequence_staged((), span, stage).await;
                 }
                 Message::ExplainTimestampStageReady {
                     ctx,

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -534,6 +534,11 @@ impl Coordinator {
             .create_replicas(replicas_to_start, enable_worker_core_affinity)
             .await
             .expect("creating replicas must not fail");
+
+        for (cluster_id, replica_id) in replicas {
+            self.install_introspection_subscribes(*cluster_id, *replica_id)
+                .await;
+        }
     }
 
     /// When this is called by the automated cluster scheduling, `scheduling_decision_reason` should

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -19,15 +19,16 @@ use mz_sql::{plan, session::metadata::SessionMetadata};
 use tracing::Span;
 
 use crate::catalog::ReplicaCreateDropReason;
-use crate::{
-    coord::{AlterCluster, ClusterStage, Coordinator, Message, PlanValidity, StageResult, Staged},
-    session::Session,
-    AdapterError, ExecuteContext, ExecuteResponse,
+use crate::coord::{
+    AlterCluster, ClusterStage, Coordinator, Message, PlanValidity, StageResult, Staged,
 };
+use crate::{session::Session, AdapterError, ExecuteContext, ExecuteResponse};
 
 use super::return_if_err;
 
 impl Staged for ClusterStage {
+    type Ctx = ExecuteContext;
+
     fn validity(&mut self) -> &mut PlanValidity {
         match self {
             Self::Alter(stage) => &mut stage.validity,
@@ -36,9 +37,9 @@ impl Staged for ClusterStage {
 
     async fn stage(
         self,
-        coord: &mut crate::coord::Coordinator,
-        ctx: &mut crate::ExecuteContext,
-    ) -> Result<crate::coord::StageResult<Box<Self>>, crate::AdapterError> {
+        coord: &mut Coordinator,
+        ctx: &mut ExecuteContext,
+    ) -> Result<StageResult<Box<Self>>, crate::AdapterError> {
         match self {
             Self::Alter(stage) => {
                 coord
@@ -48,7 +49,7 @@ impl Staged for ClusterStage {
         }
     }
 
-    fn message(self, ctx: crate::ExecuteContext, span: tracing::Span) -> crate::coord::Message {
+    fn message(self, ctx: ExecuteContext, span: tracing::Span) -> Message {
         Message::ClusterStageReady {
             ctx,
             span,

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -37,6 +37,8 @@ use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext, TimestampProvider};
 
 impl Staged for CreateIndexStage {
+    type Ctx = ExecuteContext;
+
     fn validity(&mut self) -> &mut PlanValidity {
         match self {
             Self::Optimize(stage) => &mut stage.validity,
@@ -53,7 +55,7 @@ impl Staged for CreateIndexStage {
         match self {
             CreateIndexStage::Optimize(stage) => coord.create_index_optimize(stage).await,
             CreateIndexStage::Finish(stage) => {
-                coord.create_index_finish(ctx.session_mut(), stage).await
+                coord.create_index_finish(ctx.session(), stage).await
             }
             CreateIndexStage::Explain(stage) => {
                 coord.create_index_explain(ctx.session(), stage).await
@@ -410,7 +412,7 @@ impl Coordinator {
     #[instrument]
     async fn create_index_finish(
         &mut self,
-        session: &mut Session,
+        session: &Session,
         CreateIndexFinish {
             exported_index_id,
             plan:

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -53,6 +53,8 @@ use crate::ReadHolds;
 use crate::{catalog, AdapterNotice, CollectionIdBundle, ExecuteContext, TimestampProvider};
 
 impl Staged for CreateMaterializedViewStage {
+    type Ctx = ExecuteContext;
+
     fn validity(&mut self) -> &mut PlanValidity {
         match self {
             Self::Optimize(stage) => &mut stage.validity,

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -37,6 +37,8 @@ use crate::session::Session;
 use crate::{catalog, AdapterNotice, ExecuteContext};
 
 impl Staged for CreateViewStage {
+    type Ctx = ExecuteContext;
+
     fn validity(&mut self) -> &mut PlanValidity {
         match self {
             Self::Optimize(stage) => &mut stage.validity,

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -29,6 +29,8 @@ use crate::session::{RequireLinearization, Session};
 use crate::{CollectionIdBundle, ExecuteContext, TimelineContext, TimestampExplanation};
 
 impl Staged for ExplainTimestampStage {
+    type Ctx = ExecuteContext;
+
     fn validity(&mut self) -> &mut PlanValidity {
         match self {
             ExplainTimestampStage::Optimize(stage) => &mut stage.validity,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -58,6 +58,8 @@ use crate::session::{RequireLinearization, Session, TransactionOps, TransactionS
 use crate::statement_logging::StatementLifecycleEvent;
 
 impl Staged for PeekStage {
+    type Ctx = ExecuteContext;
+
     fn validity(&mut self) -> &mut PlanValidity {
         match self {
             PeekStage::LinearizeTimestamp(stage) => &mut stage.validity,

--- a/src/adapter/src/coord/sequencer/inner/secret.rs
+++ b/src/adapter/src/coord/sequencer/inner/secret.rs
@@ -30,6 +30,8 @@ use crate::session::Session;
 use crate::{catalog, AdapterError, AdapterNotice, ExecuteContext, ExecuteResponse};
 
 impl Staged for SecretStage {
+    type Ctx = ExecuteContext;
+
     fn validity(&mut self) -> &mut crate::coord::PlanValidity {
         match self {
             SecretStage::CreateFinish(stage) => &mut stage.validity,
@@ -43,7 +45,7 @@ impl Staged for SecretStage {
     async fn stage(
         self,
         coord: &mut Coordinator,
-        ctx: &mut crate::ExecuteContext,
+        ctx: &mut ExecuteContext,
     ) -> Result<crate::coord::StageResult<Box<Self>>, AdapterError> {
         match self {
             SecretStage::CreateEnsure(stage) => {
@@ -60,7 +62,7 @@ impl Staged for SecretStage {
         }
     }
 
-    fn message(self, ctx: crate::ExecuteContext, span: tracing::Span) -> crate::coord::Message {
+    fn message(self, ctx: ExecuteContext, span: tracing::Span) -> Message {
         Message::SecretStageReady {
             ctx,
             span,

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -168,7 +168,7 @@ impl Coordinator {
         } = &plan;
 
         // Collect optimizer parameters.
-        let cluster_id = validity.cluster_id.expect("cluser_id");
+        let cluster_id = validity.cluster_id.expect("cluster_id");
         let compute_instance = self
             .instance_snapshot(cluster_id)
             .expect("compute instance does not exist");

--- a/src/adapter/src/coord/sequencer/inner/subscribe.rs
+++ b/src/adapter/src/coord/sequencer/inner/subscribe.rs
@@ -29,6 +29,8 @@ use crate::util::ResultExt;
 use crate::{optimize, AdapterNotice, ExecuteContext, TimelineContext};
 
 impl Staged for SubscribeStage {
+    type Ctx = ExecuteContext;
+
     fn validity(&mut self) -> &mut PlanValidity {
         match self {
             SubscribeStage::OptimizeMir(stage) => &mut stage.validity,
@@ -189,7 +191,7 @@ impl Coordinator {
             compute_instance,
             view_id,
             sink_id,
-            conn_id,
+            Some(conn_id),
             *with_snapshot,
             up_to,
             debug_name,

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -53,7 +53,7 @@ pub struct Optimizer {
     /// `SUBSCRIBE FROM <SELECT>` variants.
     view_id: GlobalId,
     /// The id of the session connection in which the optimizer will run.
-    conn_id: ConnectionId,
+    conn_id: Option<ConnectionId>,
     /// Should the plan produce an initial snapshot?
     with_snapshot: bool,
     /// Sink timestamp.
@@ -87,7 +87,7 @@ impl Optimizer {
         compute_instance: ComputeInstanceSnapshot,
         view_id: GlobalId,
         sink_id: GlobalId,
-        conn_id: ConnectionId,
+        conn_id: Option<ConnectionId>,
         with_snapshot: bool,
         up_to: Option<Timestamp>,
         debug_name: String,
@@ -199,7 +199,7 @@ impl Optimize<SubscribeFrom> for Optimizer {
                         &self
                             .catalog
                             .state()
-                            .resolve_full_name(from.name(), Some(&self.conn_id)),
+                            .resolve_full_name(from.name(), self.conn_id.as_ref()),
                     )
                     .expect("subscribes can only be run on items with descs")
                     .into_owned();

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -197,6 +197,7 @@ impl From<&ExecuteResponse> for StatementEndedExecutionReason {
             | ExecuteResponse::CreatedCluster
             | ExecuteResponse::CreatedClusterReplica
             | ExecuteResponse::CreatedIndex
+            | ExecuteResponse::CreatedIntrospectionSubscribe
             | ExecuteResponse::CreatedSecret
             | ExecuteResponse::CreatedSink
             | ExecuteResponse::CreatedSource

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -22,6 +22,10 @@ use thiserror::Error;
 
 use crate::controller::{instance, ComputeInstanceId, ReplicaId};
 
+/// The error returned by replica-targeted peeks and subscribes when the target replica
+/// disconnects.
+pub const ERROR_TARGET_REPLICA_FAILED: &str = "target replica failed or was dropped";
+
 /// Error returned in response to a reference to an unknown compute instance.
 #[derive(Error, Debug)]
 #[error("instance does not exist: {0}")]

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -43,7 +43,7 @@ use timely::progress::{Antichain, ChangeBatch};
 use timely::{Container, PartialOrder};
 use uuid::Uuid;
 
-use crate::controller::error::CollectionMissing;
+use crate::controller::error::{CollectionMissing, ERROR_TARGET_REPLICA_FAILED};
 use crate::controller::replica::{ReplicaClient, ReplicaConfig};
 use crate::controller::{
     CollectionState, ComputeControllerResponse, ComputeControllerTimestamp, IntrospectionUpdates,
@@ -902,7 +902,7 @@ where
                 SubscribeBatch {
                     lower: subscribe.frontier.clone(),
                     upper: subscribe.frontier,
-                    updates: Err("target replica failed or was dropped".into()),
+                    updates: Err(ERROR_TARGET_REPLICA_FAILED.into()),
                 },
             );
             self.deliver_response(response);
@@ -917,7 +917,7 @@ where
         for (uuid, peek) in self.peeks_targeting(id) {
             peek_responses.push(ComputeControllerResponse::PeekResponse(
                 uuid,
-                PeekResponse::Error("target replica failed or was dropped".into()),
+                PeekResponse::Error(ERROR_TARGET_REPLICA_FAILED.into()),
                 peek.otel_ctx.clone(),
             ));
             to_drop.push(uuid);

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1192,6 +1192,7 @@ async fn execute_stmt<S: ResultSender>(
         | ExecuteResponse::CreatedClusterReplica { .. }
         | ExecuteResponse::CreatedTable { .. }
         | ExecuteResponse::CreatedIndex { .. }
+        | ExecuteResponse::CreatedIntrospectionSubscribe
         | ExecuteResponse::CreatedSecret { .. }
         | ExecuteResponse::CreatedSource { .. }
         | ExecuteResponse::CreatedSink { .. }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1711,6 +1711,7 @@ where
             | ExecuteResponse::CreatedConnection { .. }
             | ExecuteResponse::CreatedDatabase { .. }
             | ExecuteResponse::CreatedIndex { .. }
+            | ExecuteResponse::CreatedIntrospectionSubscribe
             | ExecuteResponse::CreatedMaterializedView { .. }
             | ExecuteResponse::CreatedRole
             | ExecuteResponse::CreatedSchema { .. }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -87,6 +87,7 @@ pub enum IntrospectionType {
     ComputeHydrationStatus,
     ComputeOperatorHydrationStatus,
     ComputeMaterializedViewRefreshes,
+    ComputeErrorCounts,
 
     // Written by the Adapter for tracking AWS PrivateLink Connection Status History
     PrivatelinkConnectionStatusHistory,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -988,7 +988,8 @@ where
                         IntrospectionType::ComputeDependencies
                         | IntrospectionType::ComputeHydrationStatus
                         | IntrospectionType::ComputeOperatorHydrationStatus
-                        | IntrospectionType::ComputeMaterializedViewRefreshes => {
+                        | IntrospectionType::ComputeMaterializedViewRefreshes
+                        | IntrospectionType::ComputeErrorCounts => {
                             self.collection_manager.register_differential_collection(id, read_handle_fn);
                             // Differential collections start with an empty
                             // desired state. No need to manually reset.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2480,7 +2480,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_commands_total("allow_compaction")
     assert count > 0, f"got {count}"
     count = metrics.get_commands_total("create_dataflow")
-    assert count == 3, f"got {count}"
+    assert count >= 3, f"got {count}"
     count = metrics.get_commands_total("peek")
     assert count == 2, f"got {count}"
     count = metrics.get_commands_total("cancel_peek")
@@ -2514,7 +2514,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_responses_total("peek_response")
     assert count == 2, f"got {count}"
     count = metrics.get_responses_total("subscribe_response")
-    assert count == 0, f"got {count}"
+    assert count > 0, f"got {count}"
 
     # mz_compute_response_message_bytes_total
     count = metrics.get_response_bytes_total("frontiers")
@@ -2522,7 +2522,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_response_bytes_total("peek_response")
     assert count > 0, f"got {count}"
     count = metrics.get_response_bytes_total("subscribe_response")
-    assert count == 0, f"got {count}"
+    assert count > 0, f"got {count}"
 
     count = metrics.get_value("mz_compute_controller_replica_count")
     assert count == 1, f"got {count}"
@@ -2533,7 +2533,7 @@ def workflow_test_compute_controller_metrics(c: Composition) -> None:
     count = metrics.get_value("mz_compute_controller_peek_count")
     assert count == 0, f"got {count}"
     count = metrics.get_value("mz_compute_controller_subscribe_count")
-    assert count == 0, f"got {count}"
+    assert count > 0, f"got {count}"
     count = metrics.get_value("mz_compute_controller_command_queue_size")
     assert count < 10, f"got {count}"
     count = metrics.get_value("mz_compute_controller_response_queue_size")

--- a/test/testdrive/dataflow-cleanup.td
+++ b/test/testdrive/dataflow-cleanup.td
@@ -13,6 +13,10 @@
 # This test relies on testdrive's automatic retries, since it queries
 # introspection sources that take a while to update.
 
+# Introspection subscribes add noise to the introspection sources, so disable them.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_introspection_subscribes = false
+
 # Create a clean replica to inspect dataflow state on.
 
 > DROP CLUSTER IF EXISTS test

--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -14,6 +14,13 @@
 # sources. This also serves to verify that logging is correctly cleaned up under
 # active dataflow cancellation.
 
+# Introspection subscribes add noise to the introspection sources, so disable them.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_introspection_subscribes = false
+
+> CREATE CLUSTER test SIZE '1';
+> SET cluster = test;
+
 > CREATE VIEW divergent AS
   WITH MUTUALLY RECURSIVE
       flip(x int) AS (VALUES(1) EXCEPT ALL SELECT * FROM flip)
@@ -24,9 +31,6 @@
   WITH MUTUALLY RECURSIVE
       flip(x int) AS (VALUES(1) EXCEPT ALL SELECT * FROM flip)
   SELECT * FROM flip
-
-# In case the environment has other replicas
-> SET cluster_replica = r1
 
 # Ensure the dataflow was successfully installed.
 > SELECT count(*)
@@ -130,3 +134,6 @@ true
 # This source never sees retractions.
 > SELECT count(*) > 0 FROM mz_internal.mz_scheduling_parks_histogram_raw
 true
+
+# Cleanup.
+> DROP CLUSTER test CASCADE

--- a/test/testdrive/github-21031.td
+++ b/test/testdrive/github-21031.td
@@ -12,14 +12,13 @@
 # This test confirms that subscribes that advance to the empty frontier are
 # fully cleaned up.
 #
-
-# This test uses introspection queries that need to be targeted to a replica
-> SET cluster_replica = r1
-
 # This test relies on testdrive's automatic retries, since it queries
 # introspection sources that take a while to update.
 
 $ set-regex match=\d{13,20} replacement=<TIMESTAMP>
+
+# This test uses introspection queries that need to be targeted to a replica
+> SET cluster_replica = r1
 
 # Create a collection with an empty frontier to subscribe from.
 > CREATE MATERIALIZED VIEW mv AS SELECT 1 AS a
@@ -46,5 +45,9 @@ $ set-regex match=\d{13,20} replacement=<TIMESTAMP>
 > SELECT count(*) FROM mz_internal.mz_subscriptions
 0
 
-> SELECT count(*) FROM mz_internal.mz_compute_exports e WHERE e.export_id LIKE 't%'
+> SELECT count(*)
+  FROM mz_internal.mz_compute_exports e
+  JOIN mz_internal.mz_dataflows d ON d.id = e.dataflow_id
+  WHERE e.export_id LIKE 't%' AND
+        d.name NOT LIKE '%introspection-subscribe%'
 0

--- a/test/testdrive/hydration-status.td
+++ b/test/testdrive/hydration-status.td
@@ -26,24 +26,27 @@
 > CREATE CLUSTER test REPLICAS (hydrated_test_1 (SIZE '1'))
 > SET cluster = test
 
-# Test that on an empty cluster only the introspection dataflows show up.
+# Test that on an empty cluster only the introspection dataflows (indexes and
+# subscribes) show up.
 
 > SELECT DISTINCT left(h.object_id, 1), h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   WHERE r.name LIKE 'hydrated_test%';
 s true
+t true
 
+# `mz_hydration_statuses` does not report on transient dataflows.
 > SELECT DISTINCT left(h.object_id, 1), h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   WHERE r.name LIKE 'hydrated_test%';
 s true
 
 # No operator-level hydration status logging for introspection dataflows.
 > SELECT DISTINCT left(h.object_id, 1), h.hydrated
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
   WHERE r.name LIKE 'hydrated_test%';
 
 # Test adding new compute dataflows.
@@ -55,8 +58,8 @@ s true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -66,8 +69,8 @@ mv_const hydrated_test_1 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -77,8 +80,8 @@ mv_const hydrated_test_1 true
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -93,8 +96,8 @@ mv_const hydrated_test_1 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -107,8 +110,8 @@ mv_const hydrated_test_2 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -124,8 +127,8 @@ mv_const hydrated_test_2 true
 # exist.
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -142,8 +145,8 @@ mv_const hydrated_test_1 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -153,8 +156,8 @@ mv_const hydrated_test_2 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -164,8 +167,8 @@ mv_const hydrated_test_2 true
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -177,24 +180,24 @@ mv       hydrated_test_2 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -206,8 +209,8 @@ mv       hydrated_test_2 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -217,8 +220,8 @@ mv_const hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -228,8 +231,8 @@ mv_const hydrated_test_3 true
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -242,8 +245,8 @@ mv       hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -251,8 +254,8 @@ mv  hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -260,8 +263,8 @@ mv  hydrated_test_3 true
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'
@@ -291,8 +294,8 @@ mv  hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -311,8 +314,8 @@ users         hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -323,8 +326,8 @@ users         hydrated_test_3 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -345,8 +348,8 @@ users         hydrated_test_4 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -380,8 +383,8 @@ users         hydrated_test_4 true
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_compute_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -391,8 +394,8 @@ mv_wmr_stuck hydrated_test_4 false
 
 > SELECT o.name, r.name, h.hydrated
   FROM mz_internal.mz_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%';
@@ -402,8 +405,8 @@ mv_wmr_stuck hydrated_test_4 false
 
 > SELECT o.name, r.name, bool_and(h.hydrated)
   FROM mz_internal.mz_compute_operator_hydration_statuses h
-  LEFT JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
-  LEFT JOIN mz_objects o ON (o.id = h.object_id)
+  JOIN mz_cluster_replicas r ON (r.id = h.replica_id)
+  JOIN mz_objects o ON (o.id = h.object_id)
   WHERE
       r.name LIKE 'hydrated_test%' AND
       o.id NOT LIKE 's%'

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -17,12 +17,13 @@ $ set-arg-default default-replica-size=1
 # Note that we count on the retry behavior of testdrive in this test
 # since introspection sources may take some time to catch up.
 
-# The contents of the introspection tables depend on the replica size
-$ skip-if
-SELECT '${arg.default-replica-size}' != '4-4'
+# Introspection subscribes add noise to the introspection sources, so disable them.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_introspection_subscribes = false
 
 # In case the environment has other replicas
-> SET cluster_replica = r1
+> CREATE CLUSTER test SIZE '4-4'
+> SET cluster = test
 
 > CREATE TABLE t (a int)
 
@@ -495,3 +496,6 @@ idx3_div_by_zero 3
   FROM mz_internal.mz_compute_error_counts c
   JOIN mz_objects o ON (c.export_id = o.id)
   ORDER BY name
+
+# Cleanup.
+> DROP CLUSTER test CASCADE

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -389,39 +389,43 @@ contains:upsert key could not be validated as unique
 # in memory consumptions and should be understood before adapting the values.
 > SET cluster_replica = r1
 
-> SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-"Arrange ReduceMinsMaxes"
-"Arrange ReduceMinsMaxes"
-"Arranged DistinctBy"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"Arranged MinsMaxesHierarchical input"
-"DistinctBy"
-DistinctByErrorCheck
-ReduceMinsMaxes
-ReduceMinsMaxes
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
-"Reduced Fallibly MinsMaxesHierarchical"
+> SELECT mdod.dataflow_name, mdod.name
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  JOIN mz_internal.mz_compute_exports USING (dataflow_id)
+  WHERE export_id LIKE 'u%'
+"Dataflow: materialize.public.input_keyed" "Arrange ReduceMinsMaxes"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_keyed" ReduceMinsMaxes
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_keyed_ab" "Arranged DistinctBy"
+"Dataflow: materialize.public.input_keyed_ab" DistinctBy
+"Dataflow: materialize.public.input_keyed_ab" DistinctByErrorCheck
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arrange ReduceMinsMaxes"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Arranged MinsMaxesHierarchical input"
+"Dataflow: materialize.public.input_with_deletions_keyed" ReduceMinsMaxes
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"
+"Dataflow: materialize.public.input_with_deletions_keyed" "Reduced Fallibly MinsMaxesHierarchical"

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -464,25 +464,29 @@ c    d
 # in memory consumptions and should be understood before adapting the values.
 > SET cluster_replica = r1
 
-> SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-AccumulableErrorCheck
-AccumulableErrorCheck
-AccumulableErrorCheck
-"ArrangeAccumulable [val: empty]"
-"ArrangeAccumulable [val: empty]"
-"ArrangeAccumulable [val: empty]"
-"ArrangeBy[[Column(0), Column(1)]]"
-"ArrangeBy[[Column(0), Column(1)]]"
-"ArrangeBy[[Column(0), Column(1)]]-errors"
-"ArrangeBy[[Column(0), Column(1)]]-errors"
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(1)]]
-ArrangeBy[[Column(1)]]-errors
-"ArrangeMonotonic [val: empty]"
-"ArrangeMonotonic [val: empty]"
-ReduceAccumulable
-ReduceAccumulable
-ReduceAccumulable
-ReduceMonotonic
-ReduceMonotonic
+> SELECT mdod.dataflow_name, mdod.name
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  JOIN mz_internal.mz_compute_exports USING (dataflow_id)
+  WHERE export_id LIKE 'u%'
+"Dataflow: materialize.public.data_view_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.data_view_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.data_view_primary_idx" "ArrangeBy[[Column(0), Column(1)]]"
+"Dataflow: materialize.public.data_view_primary_idx" "ArrangeBy[[Column(0), Column(1)]]-errors"
+"Dataflow: materialize.public.mat_data_idx3" ArrangeBy[[Column(1)]]
+"Dataflow: materialize.public.mat_data_idx3" ArrangeBy[[Column(1)]]-errors
+"Dataflow: materialize.public.mat_data_primary_idx" "ArrangeBy[[Column(0), Column(1)]]"
+"Dataflow: materialize.public.mat_data_primary_idx" "ArrangeBy[[Column(0), Column(1)]]-errors"
+"Dataflow: materialize.public.test1" AccumulableErrorCheck
+"Dataflow: materialize.public.test1" "ArrangeAccumulable [val: empty]"
+"Dataflow: materialize.public.test1" ReduceAccumulable
+"Dataflow: materialize.public.test2" AccumulableErrorCheck
+"Dataflow: materialize.public.test2" "ArrangeAccumulable [val: empty]"
+"Dataflow: materialize.public.test2" ReduceAccumulable
+"Dataflow: materialize.public.test4" "ArrangeMonotonic [val: empty]"
+"Dataflow: materialize.public.test4" ReduceMonotonic
+"Dataflow: materialize.public.test6" "ArrangeMonotonic [val: empty]"
+"Dataflow: materialize.public.test6" ReduceMonotonic
+"Dataflow: materialize.public.test7" AccumulableErrorCheck
+"Dataflow: materialize.public.test7" "ArrangeAccumulable [val: empty]"
+"Dataflow: materialize.public.test7" ReduceAccumulable

--- a/test/testdrive/monotonic.td
+++ b/test/testdrive/monotonic.td
@@ -203,27 +203,31 @@ Target cluster: quickstart
 # in memory consumptions and should be understood before adapting the values.
 > SET cluster_replica = r1
 
-> SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-"ArrangeBy[[Column(0), Column(1)]]"
-"ArrangeBy[[Column(0), Column(1)]]-errors"
-"ArrangeBy[[Column(0)]]"
-"ArrangeBy[[Column(0)]]"
-"ArrangeBy[[Column(0)]]"
-"ArrangeBy[[Column(0)]]"
-"ArrangeBy[[Column(0)]]"
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-"ArrangeMonotonic [val: empty]"
-"ArrangeMonotonic [val: empty]"
-"ArrangeMonotonic [val: empty]"
-"Arranged TopK input"
-ReduceMonotonic
-ReduceMonotonic
-ReduceMonotonic
-"Reduced TopK input"
+> SELECT mdod.dataflow_name, mdod.name
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  JOIN mz_internal.mz_compute_exports USING (dataflow_id)
+  WHERE export_id LIKE 'u%'
+"Dataflow: materialize.public.i1_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.i1_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.i4_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.i4_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.i6_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.i6_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.i6_primary_idx" "Arranged TopK input"
+"Dataflow: materialize.public.i6_primary_idx" "Reduced TopK input"
+"Dataflow: materialize.public.i8_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.i8_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.i9_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.i9_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.monotonic_fused" "ArrangeMonotonic [val: empty]"
+"Dataflow: materialize.public.monotonic_fused" ReduceMonotonic
+"Dataflow: materialize.public.monotonic_max" "ArrangeMonotonic [val: empty]"
+"Dataflow: materialize.public.monotonic_max" ReduceMonotonic
+"Dataflow: materialize.public.monotonic_min" "ArrangeMonotonic [val: empty]"
+"Dataflow: materialize.public.monotonic_min" ReduceMonotonic
+"Dataflow: materialize.public.non_dbz_data_indexed_primary_idx" "ArrangeBy[[Column(0), Column(1)]]"
+"Dataflow: materialize.public.non_dbz_data_indexed_primary_idx" "ArrangeBy[[Column(0), Column(1)]]-errors"
 
 # Propagating monotonicity analysis through materialized views
 

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -13,10 +13,14 @@ $ set-arg-default default-replica-size=1
 # increase unexpectedly. This is to prevent issues like this:
 # https://github.com/MaterializeInc/materialize/issues/20179
 
+# Introspection subscribes add noise to the introspection sources, so disable them.
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_introspection_subscribes = false
+
 # Run the majority of this test on its own cluster to ensure it doesn't
 # interfere with any other tests.
 > CREATE CLUSTER arrangement_sharing REPLICAS (r1 (SIZE '${arg.default-replica-size}'))
-> SET CLUSTER TO arrangement_sharing
+> SET cluster TO arrangement_sharing
 > SET cluster_replica = r1
 
 # from attributes/mir_unique_keys.slt
@@ -700,9 +704,14 @@ ReduceMinsMaxes
 > DROP TABLE t CASCADE
 
 # Check mz_catalog_server
-> SET CLUSTER TO mz_catalog_server
+> SET cluster TO mz_catalog_server
 
-> SELECT name, count(*) FROM (SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name) GROUP BY name;
+> SELECT mdod.name, count(*)
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  WHERE mdod.dataflow_name NOT LIKE '%introspection-subscribe%'
+  GROUP BY mdod.name
+  ORDER BY mdod.name;
 "AccumulableErrorCheck"                       8
 "Arrange export iterative err"                1
 "Arrange export iterative"                    1
@@ -756,13 +765,11 @@ ArrangeBy[[Column(13)]]                       1
 "ReduceMinsMaxes"                             1
 "Threshold local"                             4
 
-> SET CLUSTER TO arrangement_sharing
+> SET cluster TO arrangement_sharing
 
 # Check dataflows of our logging infrastructure with log_logging
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET log_filter = 'debug'
-ALTER CLUSTER arrangement_sharing SET (MANAGED = false);
-CREATE CLUSTER REPLICA arrangement_sharing.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
+> ALTER CLUSTER arrangement_sharing SET (MANAGED = false);
+> CREATE CLUSTER REPLICA arrangement_sharing.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
 
 > SET cluster_replica = replica;
 
@@ -796,5 +803,23 @@ CREATE CLUSTER REPLICA arrangement_sharing.replica SIZE = '2', INTROSPECTION DEB
 "Arrange Timely(Operates)"
 "Arrange Timely(Parks)"
 
+# Check dataflows installed by introspection subscribes.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET log_filter = 'info'
+ALTER SYSTEM SET enable_introspection_subscribes = true
+
+# Flipping `enable_introspection_subscribes` affects new replicas, so force a
+# restart.
+> DROP CLUSTER REPLICA arrangement_sharing.replica
+> ALTER CLUSTER arrangement_sharing SET (MANAGED = true)
+> ALTER CLUSTER arrangement_sharing SET (REPLICATION FACTOR = 0)
+> ALTER CLUSTER arrangement_sharing SET (REPLICATION FACTOR = 1)
+> RESET cluster_replica
+
+> SELECT mdod.name, count(*)
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  GROUP BY mdod.name
+  ORDER BY mdod.name
+AccumulableErrorCheck 1
+"ArrangeAccumulable [val: empty]" 1
+ReduceAccumulable 1

--- a/test/testdrive/top-1-monotonic.td
+++ b/test/testdrive/top-1-monotonic.td
@@ -277,34 +277,38 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=5
 # in memory consumptions and should be understood before adapting the values.
 > SET cluster_replica = r1
 
-> SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-"ArrangeBy[[Column(0)]]"
-"ArrangeBy[[Column(0)]]"
-"Arranged DistinctBy"
-"Arranged DistinctBy"
-"Arranged DistinctBy"
-"Arranged DistinctBy"
-"Arranged MonotonicTop1 partial [val: empty]"
-"Arranged MonotonicTop1 partial [val: empty]"
-"Arranged MonotonicTop1 partial [val: empty]"
-"Arranged MonotonicTop1 partial [val: empty]"
-"Arranged MonotonicTop1 partial [val: empty]"
-"Arranged MonotonicTop1 partial [val: empty]"
-"DistinctBy"
-"DistinctBy"
-"DistinctBy"
-"DistinctBy"
-DistinctByErrorCheck
-DistinctByErrorCheck
-DistinctByErrorCheck
-DistinctByErrorCheck
-MonotonicTop1
-MonotonicTop1
-MonotonicTop1
-MonotonicTop1
-MonotonicTop1
-MonotonicTop1
+> SELECT mdod.dataflow_name, mdod.name
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  JOIN mz_internal.mz_compute_exports USING (dataflow_id)
+  WHERE export_id LIKE 'u%'
+"Dataflow: group_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_in_top_1" "Arranged DistinctBy"
+"Dataflow: group_by_in_top_1" "Arranged DistinctBy"
+"Dataflow: group_by_in_top_1" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: group_by_in_top_1" DistinctBy
+"Dataflow: group_by_in_top_1" DistinctBy
+"Dataflow: group_by_in_top_1" DistinctByErrorCheck
+"Dataflow: group_by_in_top_1" DistinctByErrorCheck
+"Dataflow: group_by_in_top_1" MonotonicTop1
+"Dataflow: group_by_limit" "Arranged DistinctBy"
+"Dataflow: group_by_limit" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: group_by_limit" DistinctBy
+"Dataflow: group_by_limit" DistinctByErrorCheck
+"Dataflow: group_by_limit" MonotonicTop1
+"Dataflow: group_by_order_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_order_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_order_by_in_top_1" ArrangeBy[[Column(0)]]
+"Dataflow: group_by_order_by_in_top_1" "Arranged DistinctBy"
+"Dataflow: group_by_order_by_in_top_1" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: group_by_order_by_in_top_1" DistinctBy
+"Dataflow: group_by_order_by_in_top_1" DistinctByErrorCheck
+"Dataflow: group_by_order_by_in_top_1" MonotonicTop1
+"Dataflow: limit_only" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: limit_only" MonotonicTop1
+"Dataflow: order_by_desc_limit" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: order_by_desc_limit" MonotonicTop1
+"Dataflow: order_by_limit" "Arranged MonotonicTop1 partial [val: empty]"
+"Dataflow: order_by_limit" MonotonicTop1

--- a/test/testdrive/top-k-monotonic.td
+++ b/test/testdrive/top-k-monotonic.td
@@ -278,8 +278,12 @@ a
 # in memory consumptions and should be understood before adapting the values.
 > SET cluster_replica = r1
 
-> SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-"ArrangeBy[[Column(0)]]"
-ArrangeBy[[Column(0)]]-errors
-"Arranged TopK input"
-"Reduced TopK input"
+> SELECT mdod.dataflow_name, mdod.name
+  FROM mz_internal.mz_arrangement_sharing mash
+  JOIN mz_internal.mz_dataflow_operator_dataflows mdod ON mash.operator_id = mdod.id
+  JOIN mz_internal.mz_compute_exports USING (dataflow_id)
+  WHERE export_id LIKE 'u%'
+"Dataflow: materialize.public.v_other_primary_idx" ArrangeBy[[Column(0)]]
+"Dataflow: materialize.public.v_other_primary_idx" ArrangeBy[[Column(0)]]-errors
+"Dataflow: materialize.public.v_other_primary_idx" "Arranged TopK input"
+"Dataflow: materialize.public.v_other_primary_idx" "Reduced TopK input"


### PR DESCRIPTION
This PR introduces the overall infrastructure for introspection subscribes, implemented by a new `coord::introspection` module that extends the coordinator with methods to install introspection subscribes and process updates for them.

The results of introspection subscribes are still discarded here. Follow-up PRs will add the final pieces that writes them to storage.

The relevant design doc is https://github.com/MaterializeInc/materialize/pull/27548, except that the design proposes to let the controller install the subscribes, to cut down on implementation effort. An implementation of the controller-managed approach is provided in https://github.com/MaterializeInc/materialize/pull/27709. This PR is an attempt to implement the coordinator-managed approach after all, which has two major benefits over the controller-managed one:

* Introspection subscribe queries can be written in SQL rather than in LIR, making the addition of new subscribes significantly easier.
* Introspection subscribes can read from all builtin sources, not just per-replica introspection sources.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/materialize/issues/26730

### Tips for reviewer

This seems to work, but I don't understand the coordinator code well enough to say whether it's a reasonable implementation.

I initially tried to re-use the existing `SUBSCRIBE` sequencing code, but couldn't get it to work. This code implicitly assumes the existence of a client connection and a transaction, and I wasn't able to work around that. So instead I introduced dedicated sequencing stages for the introspection subscribes, which take inspiration from the `SUBSCRIBE` ones but are kept simpler.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
