### PR TITLE
use sequence_staged for alter cluster ddl

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -279,6 +279,11 @@ pub enum Message<T = mz_repr::Timestamp> {
         span: Span,
         stage: SecretStage,
     },
+    ClusterStageReady {
+        ctx: ExecuteContext,
+        span: Span,
+        stage: ClusterStage,
+    },
     ExplainTimestampStageReady {
         ctx: ExecuteContext,
         span: Span,
@@ -342,6 +347,7 @@ impl Message {
             }
             Message::SubscribeStageReady { .. } => "subscribe_stage_ready",
             Message::SecretStageReady { .. } => "secret_stage_ready",
+            Message::ClusterStageReady { .. } => "cluster_stage_ready",
             Message::DrainStatementLog => "drain_statement_log",
             Message::AlterConnectionValidationReady(..) => "alter_connection_validation_ready",
             Message::PrivateLinkVpcEndpointEvents(_) => "private_link_vpc_endpoint_events",
@@ -615,6 +621,17 @@ pub struct ExplainTimestampFinish {
     source_ids: BTreeSet<GlobalId>,
     when: QueryWhen,
     real_time_recency_ts: Option<Timestamp>,
+}
+
+#[derive(Debug)]
+pub enum ClusterStage {
+    Alter(AlterCluster),
+}
+
+#[derive(Debug)]
+pub struct AlterCluster {
+    validity: PlanValidity,
+    plan: plan::AlterClusterPlan,
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -197,6 +197,13 @@ impl Coordinator {
                 } => {
                     self.sequence_staged(ctx, span, stage).await;
                 }
+                Message::ClusterStageReady{
+                    ctx,
+                    span,
+                    stage,
+                } => {
+                    self.sequence_staged(ctx, span, stage).await;
+                }
                 Message::DrainStatementLog => {
                     self.drain_statement_log().await;
                 }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -348,8 +348,7 @@ impl Coordinator {
                     ctx.retire(Ok(ExecuteResponse::AlteredObject(plan.object_type)));
                 }
                 Plan::AlterCluster(plan) => {
-                    let result = self.sequence_alter_cluster(ctx.session(), plan).await;
-                    ctx.retire(result);
+                    self.sequence_alter_cluster_staged(ctx, plan).await;
                 }
                 Plan::AlterClusterRename(plan) => {
                     let result = self

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -115,6 +115,7 @@ use crate::session::{
 use crate::util::{viewable_variables, ClientTransmitter, ResultExt};
 use crate::{guard_write_critical_section, PeekResponseUnary, ReadHolds};
 
+mod cluster;
 mod create_index;
 mod create_materialized_view;
 mod create_view;

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -1,0 +1,247 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeSet;
+
+use mz_catalog::memory::objects::ClusterVariantManaged;
+use mz_controller::clusters::ReplicaLogging;
+use mz_controller_types::DEFAULT_REPLICA_LOGGING_INTERVAL;
+use mz_ore::instrument;
+use mz_sql::catalog::ObjectType;
+use mz_sql::plan::{AlterClusterPlan, AlterOptionParameter};
+use mz_sql::{plan, session::metadata::SessionMetadata};
+use tracing::Span;
+
+use crate::catalog::ReplicaCreateDropReason;
+use crate::{
+    coord::{AlterCluster, ClusterStage, Coordinator, Message, PlanValidity, StageResult, Staged},
+    session::Session,
+    AdapterError, ExecuteContext, ExecuteResponse,
+};
+
+use super::return_if_err;
+
+impl Staged for ClusterStage {
+    fn validity(&mut self) -> &mut PlanValidity {
+        match self {
+            Self::Alter(stage) => &mut stage.validity,
+        }
+    }
+
+    async fn stage(
+        self,
+        coord: &mut crate::coord::Coordinator,
+        ctx: &mut crate::ExecuteContext,
+    ) -> Result<crate::coord::StageResult<Box<Self>>, crate::AdapterError> {
+        match self {
+            Self::Alter(stage) => {
+                coord
+                    .sequence_alter_cluster(ctx.session(), stage.plan.clone())
+                    .await
+            }
+        }
+    }
+
+    fn message(self, ctx: crate::ExecuteContext, span: tracing::Span) -> crate::coord::Message {
+        Message::ClusterStageReady {
+            ctx,
+            span,
+            stage: self,
+        }
+    }
+
+    fn cancel_enabled(&self) -> bool {
+        // Cluster create and alter are not yet cancelable
+        false
+    }
+}
+
+impl Coordinator {
+    #[instrument]
+    pub(crate) async fn sequence_alter_cluster_staged(
+        &mut self,
+        ctx: ExecuteContext,
+        plan: plan::AlterClusterPlan,
+    ) {
+        let stage = return_if_err!(self.alter_cluster_validate(ctx.session(), plan).await, ctx);
+        self.sequence_staged(ctx, Span::current(), stage).await;
+    }
+
+    #[instrument]
+    async fn alter_cluster_validate(
+        &mut self,
+        session: &Session,
+        plan: plan::AlterClusterPlan,
+    ) -> Result<ClusterStage, AdapterError> {
+        let validity = PlanValidity {
+            transient_revision: self.catalog().transient_revision(),
+            dependency_ids: BTreeSet::new(),
+            cluster_id: Some(plan.id.clone()),
+            replica_id: None,
+            role_metadata: session.role_metadata().clone(),
+        };
+        Ok(ClusterStage::Alter(AlterCluster { validity, plan }))
+    }
+
+    pub(super) async fn sequence_alter_cluster(
+        &mut self,
+        session: &Session,
+        AlterClusterPlan {
+            id: cluster_id,
+            name: _,
+            options,
+        }: AlterClusterPlan,
+    ) -> Result<StageResult<Box<ClusterStage>>, AdapterError> {
+        use mz_catalog::memory::objects::ClusterVariant::*;
+
+        let config = self.catalog.get_cluster(cluster_id).config.clone();
+        let mut new_config = config.clone();
+
+        match (&new_config.variant, &options.managed) {
+            (Managed(_), AlterOptionParameter::Reset)
+            | (Managed(_), AlterOptionParameter::Unchanged)
+            | (Managed(_), AlterOptionParameter::Set(true)) => {}
+            (Managed(_), AlterOptionParameter::Set(false)) => new_config.variant = Unmanaged,
+            (Unmanaged, AlterOptionParameter::Unchanged)
+            | (Unmanaged, AlterOptionParameter::Set(false)) => {}
+            (Unmanaged, AlterOptionParameter::Reset)
+            | (Unmanaged, AlterOptionParameter::Set(true)) => {
+                // Generate a minimal correct configuration
+
+                // Size and disk adjusted later when sequencing the actual configuration change.
+                let size = "".to_string();
+                let disk = false;
+                let logging = ReplicaLogging {
+                    log_logging: false,
+                    interval: Some(DEFAULT_REPLICA_LOGGING_INTERVAL),
+                };
+                new_config.variant = Managed(ClusterVariantManaged {
+                    size,
+                    availability_zones: Default::default(),
+                    logging,
+                    replication_factor: 1,
+                    disk,
+                    optimizer_feature_overrides: Default::default(),
+                    schedule: Default::default(),
+                });
+            }
+        }
+
+        match &mut new_config.variant {
+            Managed(ClusterVariantManaged {
+                size,
+                availability_zones,
+                logging,
+                replication_factor,
+                disk,
+                optimizer_feature_overrides: _,
+                schedule,
+            }) => {
+                use AlterOptionParameter::*;
+                match &options.size {
+                    Set(s) => size.clone_from(s),
+                    Reset => coord_bail!("SIZE has no default value"),
+                    Unchanged => {}
+                }
+                match &options.disk {
+                    Set(d) => *disk = *d,
+                    Reset => *disk = self.catalog.system_config().disk_cluster_replicas_default(),
+                    Unchanged => {}
+                }
+                match &options.availability_zones {
+                    Set(az) => availability_zones.clone_from(az),
+                    Reset => *availability_zones = Default::default(),
+                    Unchanged => {}
+                }
+                match &options.introspection_debugging {
+                    Set(id) => logging.log_logging = *id,
+                    Reset => logging.log_logging = false,
+                    Unchanged => {}
+                }
+                match &options.introspection_interval {
+                    Set(ii) => logging.interval = ii.0,
+                    Reset => logging.interval = Some(DEFAULT_REPLICA_LOGGING_INTERVAL),
+                    Unchanged => {}
+                }
+                match &options.replication_factor {
+                    Set(rf) => *replication_factor = *rf,
+                    Reset => *replication_factor = 1,
+                    Unchanged => {}
+                }
+                match &options.schedule {
+                    Set(new_schedule) => {
+                        *schedule = new_schedule.clone();
+                    }
+                    Reset => *schedule = Default::default(),
+                    Unchanged => {}
+                }
+                if !matches!(options.replicas, Unchanged) {
+                    coord_bail!("Cannot change REPLICAS of managed clusters");
+                }
+            }
+            Unmanaged => {
+                use AlterOptionParameter::*;
+                if !matches!(options.size, Unchanged) {
+                    coord_bail!("Cannot change SIZE of unmanaged clusters");
+                }
+                if !matches!(options.availability_zones, Unchanged) {
+                    coord_bail!("Cannot change AVAILABILITY ZONES of unmanaged clusters");
+                }
+                if !matches!(options.introspection_debugging, Unchanged) {
+                    coord_bail!("Cannot change INTROSPECTION DEGUBBING of unmanaged clusters");
+                }
+                if !matches!(options.introspection_interval, Unchanged) {
+                    coord_bail!("Cannot change INTROSPECTION INTERVAL of unmanaged clusters");
+                }
+                if !matches!(options.replication_factor, Unchanged) {
+                    coord_bail!("Cannot change REPLICATION FACTOR of unmanaged clusters");
+                }
+            }
+        }
+
+        if new_config == config {
+            return Ok(StageResult::Response(ExecuteResponse::AlteredObject(
+                ObjectType::Cluster,
+            )));
+        }
+
+        match (&config.variant, new_config.variant) {
+            (Managed(config), Managed(new_config)) => {
+                self.sequence_alter_cluster_managed_to_managed(
+                    Some(session),
+                    cluster_id,
+                    config,
+                    new_config,
+                    ReplicaCreateDropReason::Manual,
+                )
+                .await?;
+            }
+            (Unmanaged, Managed(new_config)) => {
+                self.sequence_alter_cluster_unmanaged_to_managed(
+                    session, cluster_id, new_config, options,
+                )
+                .await?;
+            }
+            (Managed(_), Unmanaged) => {
+                self.sequence_alter_cluster_managed_to_unmanaged(session, cluster_id)
+                    .await?;
+            }
+            (Unmanaged, Unmanaged) => {
+                self.sequence_alter_cluster_unmanaged_to_unmanaged(
+                    session,
+                    cluster_id,
+                    options.replicas,
+                )?;
+            }
+        }
+        Ok(StageResult::Response(ExecuteResponse::AlteredObject(
+            ObjectType::Cluster,
+        )))
+    }
+}

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1035,7 +1035,7 @@ pub struct AlterSinkPlan {
     pub in_cluster: ClusterId,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AlterClusterPlan {
     pub id: ClusterId,
     pub name: String,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This refactor should have no functional change, but will prepare us to implement [graceful reconfigure](https://github.com/MaterializeInc/materialize/issues/20010) using `sequence_staged`

Graceful reconfiguration will require sleeps or long running checks inside of the `alter cluster` ddl. We want these waits to be
cancelable and moved off the main coord thread. This is perfect for `sequence_staged` to handle.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
