### PR TITLE
storage/sources: Add new 'VALUE DECODING ERRORS' option to ENVELOPE UPSERT sources

### DIFF
--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -730,6 +730,9 @@ impl Source {
                             // DEBEZIUM.
                             Some("debezium")
                         }
+                        mz_storage_types::sources::envelope::UpsertStyle::ValueErrInline {
+                            ..
+                        } => Some("upsert-value-err-inline"),
                     },
                     SourceEnvelope::CdcV2 => {
                         // TODO(aljoscha): Should we even report this? It's

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -320,7 +320,6 @@ Primary
 Privatelink
 Privileges
 Progress
-Propagate
 Protobuf
 Protocol
 Publication

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -117,6 +117,7 @@ Debugging
 Dec
 Decimal
 Declare
+Decoding
 Decorrelated
 Default
 Defaults
@@ -142,6 +143,7 @@ Endpoint
 Enforced
 Envelope
 Error
+Errors
 Escape
 Estimate
 Every
@@ -318,6 +320,7 @@ Primary
 Privatelink
 Privileges
 Progress
+Propagate
 Protobuf
 Protocol
 Publication

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -546,7 +546,6 @@ impl_display!(SourceIncludeMetadata);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SourceErrorPolicy {
     Inline,
-    Propagate,
 }
 
 impl AstDisplay for SourceErrorPolicy {
@@ -554,9 +553,6 @@ impl AstDisplay for SourceErrorPolicy {
         match self {
             Self::Inline => {
                 f.write_str("INLINE");
-            }
-            Self::Propagate => {
-                f.write_str("PROPAGATE");
             }
         }
     }

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -544,10 +544,32 @@ impl AstDisplay for SourceIncludeMetadata {
 impl_display!(SourceIncludeMetadata);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SourceErrorPolicy {
+    Inline,
+    Propagate,
+}
+
+impl AstDisplay for SourceErrorPolicy {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            Self::Inline => {
+                f.write_str("INLINE");
+            }
+            Self::Propagate => {
+                f.write_str("PROPAGATE");
+            }
+        }
+    }
+}
+impl_display!(SourceErrorPolicy);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SourceEnvelope {
     None,
     Debezium,
-    Upsert,
+    Upsert {
+        value_decode_err_policy: Vec<SourceErrorPolicy>,
+    },
     CdcV2,
 }
 
@@ -558,7 +580,7 @@ impl SourceEnvelope {
         match self {
             SourceEnvelope::None => false,
             SourceEnvelope::Debezium => false,
-            SourceEnvelope::Upsert => false,
+            SourceEnvelope::Upsert { .. } => false,
             SourceEnvelope::CdcV2 => true,
         }
     }
@@ -574,8 +596,16 @@ impl AstDisplay for SourceEnvelope {
             Self::Debezium => {
                 f.write_str("DEBEZIUM");
             }
-            Self::Upsert => {
-                f.write_str("UPSERT");
+            Self::Upsert {
+                value_decode_err_policy,
+            } => {
+                if value_decode_err_policy.is_empty() {
+                    f.write_str("UPSERT");
+                } else {
+                    f.write_str("UPSERT (VALUE DECODING ERRORS = (");
+                    f.write_node(&display::comma_separated(value_decode_err_policy));
+                    f.write_str("))")
+                }
             }
             Self::CdcV2 => {
                 f.write_str("MATERIALIZE");

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2201,12 +2201,9 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_source_error_policy_option(&mut self) -> Result<SourceErrorPolicy, ParserError> {
-        if self.parse_keyword(INLINE) {
-            Ok(SourceErrorPolicy::Inline)
-        } else if self.parse_keyword(PROPAGATE) {
-            Ok(SourceErrorPolicy::Propagate)
-        } else {
-            self.expected(self.peek_pos(), "INLINE, or PROPAGATE", self.peek_token())
+        match self.expect_one_of_keywords(&[INLINE])? {
+            INLINE => Ok(SourceErrorPolicy::Inline),
+            _ => unreachable!(),
         }
     }
 
@@ -2221,11 +2218,12 @@ impl<'a> Parser<'a> {
                 // we should extract this into a helper function.
                 self.expect_keywords(&[VALUE, DECODING, ERRORS])?;
                 let _ = self.consume_token(&Token::Eq);
-                self.expect_token(&Token::LParen)?;
-
+                let open_inner = self.consume_token(&Token::LParen);
                 let value_decode_err_policy =
                     self.parse_comma_separated(Parser::parse_source_error_policy_option)?;
-                self.expect_token(&Token::RParen)?;
+                if open_inner {
+                    self.expect_token(&Token::RParen)?;
+                }
                 self.expect_token(&Token::RParen)?;
                 value_decode_err_policy
             } else {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2200,13 +2200,41 @@ impl<'a> Parser<'a> {
         Ok(CsrConnectionProtobuf { connection, seed })
     }
 
+    fn parse_source_error_policy_option(&mut self) -> Result<SourceErrorPolicy, ParserError> {
+        if self.parse_keyword(INLINE) {
+            Ok(SourceErrorPolicy::Inline)
+        } else if self.parse_keyword(PROPAGATE) {
+            Ok(SourceErrorPolicy::Propagate)
+        } else {
+            self.expected(self.peek_pos(), "INLINE, or PROPAGATE", self.peek_token())
+        }
+    }
+
     fn parse_source_envelope(&mut self) -> Result<SourceEnvelope, ParserError> {
         let envelope = if self.parse_keyword(NONE) {
             SourceEnvelope::None
         } else if self.parse_keyword(DEBEZIUM) {
             SourceEnvelope::Debezium
         } else if self.parse_keyword(UPSERT) {
-            SourceEnvelope::Upsert
+            let value_decode_err_policy = if self.consume_token(&Token::LParen) {
+                // We only support the `VALUE DECODING ERRORS` option for now, but if we add another
+                // we should extract this into a helper function.
+                self.expect_keywords(&[VALUE, DECODING, ERRORS])?;
+                let _ = self.consume_token(&Token::Eq);
+                self.expect_token(&Token::LParen)?;
+
+                let value_decode_err_policy =
+                    self.parse_comma_separated(Parser::parse_source_error_policy_option)?;
+                self.expect_token(&Token::RParen)?;
+                self.expect_token(&Token::RParen)?;
+                value_decode_err_policy
+            } else {
+                vec![]
+            };
+
+            SourceEnvelope::Upsert {
+                value_decode_err_policy,
+            }
         } else if self.parse_keyword(MATERIALIZE) {
             SourceEnvelope::CdcV2
         } else {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2971,23 +2971,23 @@ CREATE SOURCE header2 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEX
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header2")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Header { key: "header1", alias: Ident("h1"), use_bytes: false }, Header { key: "header2", alias: Ident("h2"), use_bytes: true }], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
-CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (PROPAGATE))
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE))
 ----
-CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (PROPAGATE))
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE))
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Propagate] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
-CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE, PROPAGATE))
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = INLINE)
 ----
-CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE, PROPAGATE))
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE))
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline, Propagate] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS)
 ----
-error: Expected left parenthesis, found right parenthesis
+error: Expected one of INLINE, found right parenthesis
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS)
                                                                                                                                         ^
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -2304,7 +2304,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USI
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(Upsert), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(Upsert { value_decode_err_policy: [] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE MATERIALIZE
@@ -2968,7 +2968,28 @@ CREATE SOURCE header2 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT 
 ----
 CREATE SOURCE header2 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON INCLUDE HEADER 'header1' AS h1, HEADER 'header2' AS h2 BYTES ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header2")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Header { key: "header1", alias: Ident("h1"), use_bytes: false }, Header { key: "header2", alias: Ident("h2"), use_bytes: true }], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header2")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Header { key: "header1", alias: Ident("h1"), use_bytes: false }, Header { key: "header2", alias: Ident("h2"), use_bytes: true }], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+
+parse-statement
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (PROPAGATE))
+----
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (PROPAGATE))
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Propagate] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+
+parse-statement
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE, PROPAGATE))
+----
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE, PROPAGATE))
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline, Propagate] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+
+parse-statement
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS)
+----
+error: Expected left parenthesis, found right parenthesis
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS)
+                                                                                                                                        ^
 
 parse-statement
 CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (RETAIN HISTORY FOR '1s');

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1226,6 +1226,7 @@ pub fn plan_create_source(
             let style = if value_decode_err_policy.is_empty() {
                 UpsertStyle::Default(key_envelope)
             } else if value_decode_err_policy.contains(&SourceErrorPolicy::Inline) {
+                scx.require_feature_flag(&vars::ENABLE_ENVELOPE_UPSERT_INLINE_ERRORS)?;
                 UpsertStyle::ValueErrInline { key_envelope }
             } else {
                 bail_unsupported!("ENVELOPE UPSERT with unsupported value decode error policy")

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1222,18 +1222,11 @@ pub fn plan_create_source(
             if key_envelope == KeyEnvelope::None {
                 key_envelope = get_unnamed_key_envelope(key_encoding)?;
             }
-            // If the value decode error policy is not set or is just set to PROPAGATE
-            // then we can use the default upsert style.
-            let style = if value_decode_err_policy.is_empty()
-                || value_decode_err_policy == &[SourceErrorPolicy::Propagate]
-            {
+            // If the value decode error policy is not set we use the default upsert style.
+            let style = if value_decode_err_policy.is_empty() {
                 UpsertStyle::Default(key_envelope)
             } else if value_decode_err_policy.contains(&SourceErrorPolicy::Inline) {
-                UpsertStyle::ValueErrInline {
-                    key_envelope,
-                    propagate_errors: value_decode_err_policy
-                        .contains(&SourceErrorPolicy::Propagate),
-                }
+                UpsertStyle::ValueErrInline { key_envelope }
             } else {
                 bail_unsupported!("ENVELOPE UPSERT with unsupported value decode error policy")
             };

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -69,9 +69,10 @@ use mz_sql_parser::ast::{
     MaterializedViewOptionName, MySqlConfigOption, MySqlConfigOptionName, PgConfigOption,
     PgConfigOptionName, ProtobufSchema, QualifiedReplica, RefreshAtOptionValue,
     RefreshEveryOptionValue, RefreshOptionValue, ReplicaDefinition, ReplicaOption,
-    ReplicaOptionName, RoleAttribute, SetRoleVar, SourceIncludeMetadata, Statement,
-    TableConstraint, TableOption, TableOptionName, UnresolvedDatabaseName, UnresolvedItemName,
-    UnresolvedObjectName, UnresolvedSchemaName, Value, ViewDefinition, WithOptionValue,
+    ReplicaOptionName, RoleAttribute, SetRoleVar, SourceErrorPolicy, SourceIncludeMetadata,
+    Statement, TableConstraint, TableOption, TableOptionName, UnresolvedDatabaseName,
+    UnresolvedItemName, UnresolvedObjectName, UnresolvedSchemaName, Value, ViewDefinition,
+    WithOptionValue,
 };
 use mz_sql_parser::ident;
 use mz_sql_parser::parser::StatementParseResult;
@@ -709,7 +710,7 @@ pub fn plan_create_source(
             if !include_metadata.is_empty()
                 && !matches!(
                     envelope,
-                    ast::SourceEnvelope::Upsert
+                    ast::SourceEnvelope::Upsert { .. }
                         | ast::SourceEnvelope::None
                         | ast::SourceEnvelope::Debezium
                 )
@@ -1201,7 +1202,9 @@ pub fn plan_create_source(
                 style: UpsertStyle::Debezium { after_idx },
             }
         }
-        ast::SourceEnvelope::Upsert => {
+        ast::SourceEnvelope::Upsert {
+            value_decode_err_policy,
+        } => {
             let key_encoding = match encoding.as_ref().and_then(|e| e.key.as_ref()) {
                 None => {
                     if !key_envelope_no_encoding {
@@ -1219,9 +1222,22 @@ pub fn plan_create_source(
             if key_envelope == KeyEnvelope::None {
                 key_envelope = get_unnamed_key_envelope(key_encoding)?;
             }
-            UnplannedSourceEnvelope::Upsert {
-                style: UpsertStyle::Default(key_envelope),
-            }
+            // If the value decode error policy is not set or is just set to PROPAGATE
+            // then we can use the default upsert style.
+            let style = if value_decode_err_policy.is_empty()
+                || value_decode_err_policy == &[SourceErrorPolicy::Propagate]
+            {
+                UpsertStyle::Default(key_envelope)
+            } else if value_decode_err_policy.contains(&SourceErrorPolicy::Inline) {
+                UpsertStyle::ValueErrInline {
+                    key_envelope,
+                    propagate_errors: value_decode_err_policy
+                        .contains(&SourceErrorPolicy::Propagate),
+                }
+            } else {
+                bail_unsupported!("ENVELOPE UPSERT with unsupported value decode error policy")
+            };
+            UnplannedSourceEnvelope::Upsert { style }
         }
         ast::SourceEnvelope::CdcV2 => {
             scx.require_feature_flag(&vars::ENABLE_ENVELOPE_MATERIALIZE)?;
@@ -1823,7 +1839,7 @@ fn get_encoding(
 
     let requires_keyvalue = matches!(
         envelope,
-        ast::SourceEnvelope::Debezium | ast::SourceEnvelope::Upsert
+        ast::SourceEnvelope::Debezium | ast::SourceEnvelope::Upsert { .. }
     );
     let is_keyvalue = encoding.key.is_some();
     if requires_keyvalue && !is_keyvalue {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2109,6 +2109,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: true,
     },
+    {
+        name: enable_envelope_upsert_inline_errors,
+        desc: "The VALUE DECODING ERRORS = INLINE option on ENVELOPE UPSERT",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {

--- a/src/storage-types/src/sources/envelope.proto
+++ b/src/storage-types/src/sources/envelope.proto
@@ -49,8 +49,14 @@ message ProtoUpsertStyle {
         uint64 after_idx = 1;
     }
 
+    message ProtoValueErrInline {
+        ProtoKeyEnvelope key_envelope = 1;
+        bool propagate_errors = 2;
+    }
+
     oneof kind {
         ProtoKeyEnvelope default = 1;
         ProtoDebezium debezium = 2;
+        ProtoValueErrInline value_error_inline = 3;
     }
 }

--- a/src/storage-types/src/sources/envelope.proto
+++ b/src/storage-types/src/sources/envelope.proto
@@ -51,7 +51,6 @@ message ProtoUpsertStyle {
 
     message ProtoValueErrInline {
         ProtoKeyEnvelope key_envelope = 1;
-        bool propagate_errors = 2;
     }
 
     oneof kind {

--- a/src/storage-types/src/sources/envelope.rs
+++ b/src/storage-types/src/sources/envelope.rs
@@ -459,22 +459,13 @@ fn compute_envelope_value_desc(
                 ColumnType {
                     nullable: true,
                     scalar_type: ScalarType::Record {
-                        fields: vec![
-                            (
-                                "description".into(),
-                                ColumnType {
-                                    nullable: true,
-                                    scalar_type: ScalarType::String,
-                                },
-                            ),
-                            (
-                                "code".into(),
-                                ColumnType {
-                                    nullable: true,
-                                    scalar_type: ScalarType::String,
-                                },
-                            ),
-                        ],
+                        fields: vec![(
+                            "description".into(),
+                            ColumnType {
+                                nullable: true,
+                                scalar_type: ScalarType::String,
+                            },
+                        )],
                         custom_id: None,
                     },
                 },

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -606,11 +606,8 @@ fn upsert_commands<G: Scope, FromTime: Timestamp>(
                         packer.extend(key_row.iter());
                         // The 'value' column is null
                         packer.push(Datum::Null);
-                        // The 'error' column is a record with 'description' and 'code' columns
-                        // TODO(roshan): What should go into the 'code' column?
-                        packer.push_list(
-                            iter::once(Datum::String(&err_string)).chain(iter::once(Datum::Null)),
-                        );
+                        // The 'error' column is a record with a 'description' column
+                        packer.push_list(iter::once(Datum::String(&err_string)));
                         packer.extend(metadata.iter());
                         Some(Ok(row_buf.clone()))
                     }

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -648,8 +648,8 @@ val2:[1,2,
   ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE));
 
 > SELECT key, value::text, error::text FROM value_decode_error
-val1 <null> "(\"Bytes: Failed to decode JSON: {\"\"a\"\":,\"\"c\"\":\"\"d\"\"} (original bytes: [7b, 22, 61, 22, 3a, 2c, 22, 63, 22, 3a, 22, 64, 22, 7d])\",)"
-val2 <null> "(\"Bytes: Failed to decode JSON: [1,2, (original bytes: [5b, 31, 2c, 32, 2c])\",)"
+val1 <null> "(\"Bytes: Failed to decode JSON: {\"\"a\"\":,\"\"c\"\":\"\"d\"\"} (original bytes: [7b, 22, 61, 22, 3a, 2c, 22, 63, 22, 3a, 22, 64, 22, 7d])\")"
+val2 <null> "(\"Bytes: Failed to decode JSON: [1,2, (original bytes: [5b, 31, 2c, 32, 2c])\")"
 
 # replace the bad values with good ones
 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=inline-value-errors-1

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -639,6 +639,18 @@ val2:[1,2,
 
 > CREATE CLUSTER inline_error_cluster SIZE '${arg.default-storage-size}';
 
+# should error without the feature flag enabled
+! CREATE SOURCE value_decode_error
+  IN CLUSTER inline_error_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-inline-value-errors-1-${testdrive.seed}')
+  KEY FORMAT TEXT
+  VALUE FORMAT JSON
+  ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE));
+contains:The VALUE DECODING ERRORS = INLINE option on ENVELOPE UPSERT is not supported
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_envelope_upsert_inline_errors = true
+
 # This source will inline errors and not propagate them
 > CREATE SOURCE value_decode_error
   IN CLUSTER inline_error_cluster

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -625,3 +625,50 @@ $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json-
 "\"int\"" 99
 "\"object\"" "{\"y\":\"z\"}"
 "\"str\"" "\"bye\""
+
+
+#
+# Test Inline error handling with value decode failures
+#
+
+$ kafka-create-topic topic=inline-value-errors-1 partitions=1
+
+$ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=inline-value-errors-1
+val1:{"a":,"c":"d"}
+val2:[1,2,
+
+> CREATE CLUSTER inline_error_cluster SIZE '${arg.default-storage-size}';
+
+# This source will not inline errors and should propagate them
+> CREATE SOURCE value_decode_error
+  IN CLUSTER inline_error_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-inline-value-errors-1-${testdrive.seed}')
+  KEY FORMAT TEXT
+  VALUE FORMAT JSON
+  ENVELOPE UPSERT (VALUE DECODING ERRORS = (PROPAGATE));
+
+! SELECT * FROM value_decode_error
+contains:Envelope error: Upsert: Value error: Bytes: Failed to decode JSON:
+
+> DROP SOURCE value_decode_error
+
+# This source will inline errors only
+> CREATE SOURCE value_decode_error
+  IN CLUSTER inline_error_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-inline-value-errors-1-${testdrive.seed}')
+  KEY FORMAT TEXT
+  VALUE FORMAT JSON
+  ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE));
+
+> SELECT key, value::text, error::text FROM value_decode_error
+val1 <null> "(\"Bytes: Failed to decode JSON: {\"\"a\"\":,\"\"c\"\":\"\"d\"\"} (original bytes: [7b, 22, 61, 22, 3a, 2c, 22, 63, 22, 3a, 22, 64, 22, 7d])\",)"
+val2 <null> "(\"Bytes: Failed to decode JSON: [1,2, (original bytes: [5b, 31, 2c, 32, 2c])\",)"
+
+# replace the bad values with good ones
+$ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=inline-value-errors-1
+val1:{"a": 1,"c":"d"}
+val2:[1,2,3]
+
+> SELECT key, value::text, error::text FROM value_decode_error
+val1 "(\"{\"\"a\"\":1,\"\"c\"\":\"\"d\"\"}\")" <null>
+val2 "(\"[1,2,3]\")" <null>

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -639,20 +639,7 @@ val2:[1,2,
 
 > CREATE CLUSTER inline_error_cluster SIZE '${arg.default-storage-size}';
 
-# This source will not inline errors and should propagate them
-> CREATE SOURCE value_decode_error
-  IN CLUSTER inline_error_cluster
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-inline-value-errors-1-${testdrive.seed}')
-  KEY FORMAT TEXT
-  VALUE FORMAT JSON
-  ENVELOPE UPSERT (VALUE DECODING ERRORS = (PROPAGATE));
-
-! SELECT * FROM value_decode_error
-contains:Envelope error: Upsert: Value error: Bytes: Failed to decode JSON:
-
-> DROP SOURCE value_decode_error
-
-# This source will inline errors only
+# This source will inline errors and not propagate them
 > CREATE SOURCE value_decode_error
   IN CLUSTER inline_error_cluster
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-inline-value-errors-1-${testdrive.seed}')


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Implements the inline-errors component of https://github.com/MaterializeInc/materialize/pull/27540
Partially fixes https://github.com/MaterializeInc/materialize/issues/22430

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The linked design doc is not yet ratified so there is a chance the SQL syntax and behavior might need to be adjusted.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
