### PR TITLE
doc/user: convert all user docs to use mzsql highlighting where appropriate

### DIFF
--- a/doc/user/content/free-trial-faqs.md
+++ b/doc/user/content/free-trial-faqs.md
@@ -45,7 +45,7 @@ trial period.
 To see your current credit consumption rate, measured in credits per hour, run
 the following query against Materialize:
 
-```sql
+```mzsql
 SELECT sum(s.credits_per_hour) AS credit_consumption_rate
   FROM mz_cluster_replicas r
   JOIN mz_cluster_replica_sizes s ON r.size = s.size;
@@ -68,7 +68,7 @@ No, you cannot go over the rate limit of 4 credits per hour at any time during
 your free trial. If you try to add a replica that puts you over the limit,
 Materialize will return an error similar to:
 
-```sql
+```nofmt
 Error: creating cluster replica would violate max_credit_consumption_rate limit (desired: 6, limit: 4, current: 3)
 Hint: Drop an existing cluster replica or contact support to request a limit increase.
 ```

--- a/doc/user/content/get-started/isolation-level.md
+++ b/doc/user/content/get-started/isolation-level.md
@@ -35,11 +35,11 @@ Isolation level is a configuration parameter that can be set by the user on a se
 
 ## Examples
 
-```sql
+```mzsql
 SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
 ```
 
-```sql
+```mzsql
 SET TRANSACTION_ISOLATION TO 'STRICT SERIALIZABLE';
 ```
 

--- a/doc/user/content/ingest-data/amazon-eventbridge.md
+++ b/doc/user/content/ingest-data/amazon-eventbridge.md
@@ -29,7 +29,7 @@ scenarios, we recommend separating your workloads into multiple clusters for
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 
-```sql
+```mzsql
 CREATE CLUSTER webhooks_cluster (SIZE = '25cc');
 
 SET CLUSTER = webhooks_cluster;
@@ -40,7 +40,7 @@ SET CLUSTER = webhooks_cluster;
 To validate requests between Amazon EventBridge and Materialize, you must create
 a [secret](/sql/create-secret/):
 
-```sql
+```mzsql
 CREATE SECRET eventbridge_webhook_secret AS '<secret_value>';
 ```
 
@@ -54,7 +54,7 @@ in Materialize to ingest data from Amazon EventBridge. By default, the source
 will be created in the active cluster; to use a different cluster, use the `IN
 CLUSTER` clause.
 
-```sql
+```mzsql
 CREATE SOURCE eventbridge_source
 FROM WEBHOOK
   BODY FORMAT JSON
@@ -121,7 +121,7 @@ Amazon EventBridge, you can now query the incoming data:
 
 1. Use SQL queries to inspect and analyze the incoming data:
 
-    ```sql
+    ```mzsql
     SELECT * FROM eventbridge_source LIMIT 10;
     ```
 

--- a/doc/user/content/ingest-data/amazon-msk.md
+++ b/doc/user/content/ingest-data/amazon-msk.md
@@ -56,7 +56,7 @@ the TCP listeners (step 3) and the VPC endpoint service (step 5).
 
 In Materialize, create a source connection that uses the SSH tunnel connection you configured in the previous section:
 
-```sql
+```mzsql
 CREATE CONNECTION kafka_connection TO KAFKA (
   BROKER 'broker1:9092',
   SSH TUNNEL ssh_connection
@@ -201,7 +201,7 @@ The process to connect Materialize to Amazon MSK consists of the following steps
 
     e. Create a connection using the command below. The broker URL is what you copied in step c of this subsection. The `<topic-name>` is the name of the topic you created in Step 4. The `<your-username>` and `<your-password>` is from _Store a new secret_ under Step 2.
 
-      ```sql
+      ```mzsql
       CREATE SECRET msk_password AS '<your-password>';
 
       CREATE CONNECTION kafka_connection TO KAFKA (
@@ -226,7 +226,7 @@ multiple [`CREATE SOURCE`](/sql/create-source/kafka/) statements. By default,
 the source will be created in the active cluster; to use a different cluster,
 use the `IN CLUSTER` clause.
 
-```sql
+```mzsql
 CREATE SOURCE json_source
   FROM KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
   FORMAT JSON;

--- a/doc/user/content/ingest-data/cdc-sql-server.md
+++ b/doc/user/content/ingest-data/cdc-sql-server.md
@@ -154,7 +154,7 @@ information about upstream database operations, like the `before` and `after`
 values for each record. To create a source that interprets the
 [Debezium envelope](/sql/create-source/kafka/#using-debezium) in Materialize:
 
-```sql
+```mzsql
 CREATE SOURCE kafka_repl
     FROM KAFKA CONNECTION kafka_connection (TOPIC 'server1.testDB.tableName')
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
@@ -177,7 +177,7 @@ Any materialized view defined on top of this source will be incrementally
 updated as new change events stream in through Kafka, resulting from `INSERT`,
 `UPDATE`, and `DELETE` operations in the original SQL Server database.
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW cnt_table AS
     SELECT field1,
            COUNT(*) AS cnt

--- a/doc/user/content/ingest-data/confluent-cloud.md
+++ b/doc/user/content/ingest-data/confluent-cloud.md
@@ -88,7 +88,7 @@ of the following steps:
     Step 4. The `<your-api-key>` and `<your-api-secret>` are from the _Create
     an API Key_ step.
 
-    ```sql
+    ```mzsql
       CREATE SECRET confluent_username AS '<your-api-key>';
       CREATE SECRET confluent_password AS '<your-api-secret>';
 

--- a/doc/user/content/ingest-data/hubspot.md
+++ b/doc/user/content/ingest-data/hubspot.md
@@ -27,7 +27,7 @@ scenarios, we recommend separating your workloads into multiple clusters for
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 
-```sql
+```mzsql
 CREATE CLUSTER webhooks_cluster (SIZE = '25cc');
 
 SET CLUSTER = webhooks_cluster;
@@ -37,7 +37,7 @@ SET CLUSTER = webhooks_cluster;
 
 To validate requests between HubSpot and Materialize, you must create a [secret](/sql/create-secret/):
 
-```sql
+```mzsql
 CREATE SECRET hubspot_webhook_secret AS '<secret_value>';
 ```
 
@@ -51,7 +51,7 @@ in Materialize to ingest data from HubSpot. By default, the source will be
 created in the active cluster; to use a different cluster, use the `IN
 CLUSTER` clause.
 
-```sql
+```mzsql
 CREATE SOURCE hubspot_source
   FROM WEBHOOK
     BODY FORMAT JSON
@@ -159,7 +159,7 @@ HubSpot, you can now query the incoming data:
 
 1. Use SQL queries to inspect and analyze the incoming data:
 
-    ```sql
+    ```mzsql
     SELECT * FROM hubspot_source LIMIT 10;
     ```
 
@@ -171,7 +171,7 @@ Webhook data is ingested as a JSON blob. We recommend creating a parsing view on
 top of your webhook source that uses [`jsonb` operators](/sql/types/jsonb/#operators)
 to map the individual fields to columns with the required data types.
 
-```sql
+```mzsql
 CREATE VIEW parse_hubspot AS SELECT
     body->>'city' AS city,
     body->>'firstname' AS firstname,

--- a/doc/user/content/ingest-data/kafka-self-hosted.md
+++ b/doc/user/content/ingest-data/kafka-self-hosted.md
@@ -67,7 +67,7 @@ endpoint service (step 5).
 In Materialize, create a source connection that uses the SSH tunnel connection
 you configured in the previous section:
 
-```sql
+```mzsql
 CREATE CONNECTION kafka_connection TO KAFKA (
   BROKER 'broker1:9092',
   SSH TUNNEL ssh_connection
@@ -82,7 +82,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -92,7 +92,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 1. Create a [Kafka connection](/sql/create-connection/#kafka) that references
    your Kafka cluster:
 
-    ```sql
+    ```mzsql
     CREATE SECRET kafka_password AS '<your-password>';
 
     CREATE CONNECTION kafka_connection TO KAFKA (
@@ -112,7 +112,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 The Kafka connection created in the previous section can then be reused across
 multiple [`CREATE SOURCE`](/sql/create-source/kafka/) statements:
 
-```sql
+```mzsql
 CREATE SOURCE json_source
   FROM KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
   FORMAT JSON;

--- a/doc/user/content/ingest-data/mysql/amazon-aurora.md
+++ b/doc/user/content/ingest-data/mysql/amazon-aurora.md
@@ -71,7 +71,7 @@ Select the option that works best for you.
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -117,7 +117,7 @@ configuration of resources for an SSH tunnel. For more details, see the
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 

--- a/doc/user/content/ingest-data/mysql/amazon-rds.md
+++ b/doc/user/content/ingest-data/mysql/amazon-rds.md
@@ -60,13 +60,13 @@ binary logging.
    reasonable value. To check the current value of the [`binlog retention hours`](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql-stored-proc-configuring.html#mysql_rds_set_configuration-usage-notes.binlog-retention-hours)
    configuration parameter, connect to your RDS instance and run:
 
-   ```sql
+   ```mysql
    CALL mysql.rds_show_configuration;
    ```
 
    If the value returned is `NULL`, or less than `168` (i.e. 7 days), run:
 
-   ```sql
+   ```mysql
    CALL mysql.rds_set_configuration('binlog retention hours', 168);
    ```
 
@@ -78,12 +78,12 @@ binary logging.
 1. To validate that all configuration parameters are set to the expected values
    after the above configuration changes, run:
 
-    ```sql
+    ```mysql
     -- Validate "binlog retention hours" configuration parameter
     CALL mysql.rds_show_configuration;
     ```
 
-    ```sql
+    ```mysql
     -- Validate parameter group configuration parameters
     SHOW VARIABLES WHERE variable_name IN (
       'log_bin',
@@ -125,7 +125,7 @@ Select the option that works best for you.
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -171,7 +171,7 @@ configuration of resources for an SSH tunnel. For more details, see the
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 
@@ -232,12 +232,12 @@ available(also for PostgreSQL)."
 
 ## Step 6. Check the ingestion status
 
-{{% postgres-direct/check-the-ingestion-status %}}
+{{% mysql-direct/check-the-ingestion-status %}}
 
 ## Step 7. Right-size the cluster
 
-{{% postgres-direct/right-size-the-cluster %}}
+{{% mysql-direct/right-size-the-cluster %}}
 
 ## Next steps
 
-{{% postgres-direct/next-steps %}}
+{{% mysql-direct/next-steps %}}

--- a/doc/user/content/ingest-data/mysql/azure-db.md
+++ b/doc/user/content/ingest-data/mysql/azure-db.md
@@ -66,7 +66,7 @@ Select the option that works best for you.
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -98,7 +98,7 @@ to serve as your SSH bastion host.
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 

--- a/doc/user/content/ingest-data/mysql/debezium.md
+++ b/doc/user/content/ingest-data/mysql/debezium.md
@@ -34,7 +34,7 @@ As _root_:
 
 1. Check the `log_bin` and `binlog_format` settings:
 
-    ```sql
+    ```mysql
     SHOW VARIABLES
     WHERE variable_name IN ('log_bin', 'binlog_format');
     ```
@@ -51,7 +51,7 @@ As _root_:
 1. Grant enough privileges to the replication user to ensure Debezium can
    operate in the database:
 
-    ```sql
+    ```mysql
     GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO "user";
 
     FLUSH PRIVILEGES;
@@ -191,7 +191,7 @@ information about upstream database operations, like the `before` and `after`
 values for each record. To create a source that interprets the
 [Debezium envelope](/sql/create-source/kafka/#using-debezium) in Materialize:
 
-```sql
+```mzsql
 CREATE SOURCE kafka_repl
     FROM KAFKA CONNECTION kafka_connection (TOPIC 'dbserver1.db1.table1')
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
@@ -213,7 +213,7 @@ Any materialized view defined on top of this source will be incrementally
 updated as new change events stream in through Kafka, as a result of `INSERT`,
 `UPDATE` and `DELETE` operations in the original MySQL database.
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW cnt_table1 AS
     SELECT field1,
            COUNT(*) AS cnt

--- a/doc/user/content/ingest-data/mysql/google-cloud-sql.md
+++ b/doc/user/content/ingest-data/mysql/google-cloud-sql.md
@@ -60,7 +60,7 @@ Select the option that works best for you.
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -92,7 +92,7 @@ network to allow traffic from the bastion host.
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 

--- a/doc/user/content/ingest-data/mysql/self-hosted.md
+++ b/doc/user/content/ingest-data/mysql/self-hosted.md
@@ -61,7 +61,7 @@ Select the option that works best for you.
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -92,7 +92,7 @@ traffic from the bastion host.
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 

--- a/doc/user/content/ingest-data/network-security/ssh-tunnel.md
+++ b/doc/user/content/ingest-data/network-security/ssh-tunnel.md
@@ -19,7 +19,7 @@ In Materialize, create a source connection that uses the SSH tunnel connection y
 
 {{< tabs tabID="1" >}}
 {{< tab "Kafka">}}
-```sql
+```mzsql
 CREATE CONNECTION kafka_connection TO KAFKA (
     BROKER 'broker1:9092',
     SSH TUNNEL ssh_connection
@@ -29,7 +29,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 You can reuse this Kafka connection across multiple [`CREATE SOURCE`](/sql/create-source/kafka/)
 statements:
 
-```sql
+```mzsql
 CREATE SOURCE json_source
   FROM KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
   FORMAT JSON;
@@ -37,7 +37,7 @@ CREATE SOURCE json_source
 
 {{< /tab >}}
 {{< tab "PostgreSQL">}}
-```sql
+```mzsql
 CREATE SECRET pgpass AS '<POSTGRES_PASSWORD>';
 
 CREATE CONNECTION pg_connection TO POSTGRES (
@@ -54,7 +54,7 @@ CREATE CONNECTION pg_connection TO POSTGRES (
 You can reuse this PostgreSQL connection across multiple [`CREATE SOURCE`](/sql/create-source/postgres/)
 statements:
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
   FOR ALL TABLES;
@@ -62,7 +62,7 @@ CREATE SOURCE mz_source
 {{< /tab >}}
 
 {{< tab "MySQL">}}
-```sql
+```mzsql
 CREATE SECRET mysqlpass AS '<POSTGRES_PASSWORD>';
 
     CREATE CONNECTION mysql_connection TO MYSQL (
@@ -74,7 +74,7 @@ CREATE SECRET mysqlpass AS '<POSTGRES_PASSWORD>';
 You can reuse this MySQL connection across multiple [`CREATE SOURCE`](/sql/create-source/postgres/)
 statements:
 
-```sql
+```mzsql
     CREATE SOURCE mz_source
       FROM mysql CONNECTION mysql_connection
       FOR ALL TABLES;

--- a/doc/user/content/ingest-data/network-security/static-ips.md
+++ b/doc/user/content/ingest-data/network-security/static-ips.md
@@ -44,9 +44,11 @@ a region. We make every effort to provide advance notice of such changes.
 
 Show the static egress IPs associated with a region:
 
-```sql
+```mzsql
 SELECT * FROM mz_egress_ips;
 ```
+
+<p></p>
 
 ```nofmt
    egress_ip

--- a/doc/user/content/ingest-data/postgres/alloydb.md
+++ b/doc/user/content/ingest-data/postgres/alloydb.md
@@ -58,7 +58,7 @@ Materialize with AlloyDB:
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -91,7 +91,7 @@ network to allow traffic from the bastion host.
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 

--- a/doc/user/content/ingest-data/postgres/amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres/amazon-aurora.md
@@ -58,7 +58,7 @@ Select the option that works best for you.
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -202,7 +202,7 @@ configuration of resources for an SSH tunnel. For more details, see the
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 
@@ -252,7 +252,7 @@ start by selecting the relevant option.
    command to securely store the password for the `materialize` PostgreSQL user you
    created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -260,7 +260,7 @@ start by selecting the relevant option.
    connection object with access and authentication details for Materialize to
    use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -288,7 +288,7 @@ start by selecting the relevant option.
    to your Aurora instance and start ingesting data from the publication you
    created [earlier](#step-2-create-a-publication).
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
@@ -313,7 +313,7 @@ start by selecting the relevant option.
    client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#aws-privatelink)
    command to create an AWS PrivateLink connection:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
       SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0356210a8a432d9e9',
       AVAILABILITY ZONES ('use1-az1', 'use1-az2', 'use1-az3')
@@ -332,7 +332,7 @@ start by selecting the relevant option.
 
 1. Retrieve the AWS principal for the AWS PrivateLink connection you just created:
 
-    ```sql
+    ```mzsql
     SELECT principal
     FROM mz_aws_privatelink_connections plc
     JOIN mz_connections c ON plc.id = c.id
@@ -357,7 +357,7 @@ start by selecting the relevant option.
 1. Validate the AWS PrivateLink connection you created using the
    [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
-    ```sql
+    ```mzsql
     VALIDATE CONNECTION privatelink_svc;
     ```
 
@@ -366,7 +366,7 @@ start by selecting the relevant option.
 1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
    password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -374,7 +374,7 @@ start by selecting the relevant option.
 another connection object, this time with database access and authentication
 details for Materialize to use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -396,7 +396,7 @@ details for Materialize to use:
    to your Aurora instance via AWS PrivateLink and start ingesting data from the
    publication you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
@@ -417,7 +417,7 @@ details for Materialize to use:
    client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel)
    command to create an SSH tunnel connection:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (
         HOST '<SSH_BASTION_HOST>',
         PORT <SSH_BASTION_PORT>,
@@ -434,7 +434,7 @@ details for Materialize to use:
 1. Get Materialize's public keys for the SSH tunnel connection you just
    created:
 
-    ```sql
+    ```mzsql
     SELECT
         mz_connections.name,
         mz_ssh_tunnel_connections.*
@@ -459,7 +459,7 @@ details for Materialize to use:
    connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection)
    command:
 
-    ```sql
+    ```mzsql
     VALIDATE CONNECTION ssh_connection;
     ```
 
@@ -468,7 +468,7 @@ details for Materialize to use:
 1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
 password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -476,7 +476,7 @@ password for the `materialize` PostgreSQL user you created [earlier](#step-2-cre
    another connection object, this time with database access and authentication
    details for Materialize to use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -498,7 +498,7 @@ password for the `materialize` PostgreSQL user you created [earlier](#step-2-cre
    to your Aurora instance and start ingesting data from the publication you
    created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')

--- a/doc/user/content/ingest-data/postgres/amazon-rds.md
+++ b/doc/user/content/ingest-data/postgres/amazon-rds.md
@@ -32,7 +32,7 @@ As a first step, you need to make sure logical replication is enabled.
 
 1. Check if logical replication is enabled:
 
-    ``` sql
+    ```postgres
     SELECT name, setting
       FROM pg_settings
       WHERE name = 'rds.logical_replication';
@@ -70,7 +70,7 @@ As a first step, you need to make sure logical replication is enabled.
 1. Back in the SQL client connected to PostgreSQL, verify that replication is
    now enabled:
 
-    ``` sql
+    ```postgres
     SELECT name, setting
       FROM pg_settings
       WHERE name = 'rds.logical_replication';
@@ -113,7 +113,7 @@ Select the option that works best for you.
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -255,7 +255,7 @@ configuration of resources for an SSH tunnel. For more details, see the
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 
@@ -304,7 +304,7 @@ start by selecting the relevant option.
    command to securely store the password for the `materialize` PostgreSQL user you
    created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -312,7 +312,7 @@ start by selecting the relevant option.
    connection object with access and authentication details for Materialize to
    use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -334,7 +334,7 @@ start by selecting the relevant option.
    to your RDS instance and start ingesting data from the publication you created
    [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
@@ -359,7 +359,7 @@ start by selecting the relevant option.
    client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#aws-privatelink)
    command to create an AWS PrivateLink connection:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
       SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0356210a8a432d9e9',
       AVAILABILITY ZONES ('use1-az1', 'use1-az2', 'use1-az3')
@@ -379,7 +379,7 @@ start by selecting the relevant option.
 1. Retrieve the AWS principal for the AWS PrivateLink connection you just
    created:
 
-    ```sql
+    ```mzsql
     SELECT principal
     FROM mz_aws_privatelink_connections plc
     JOIN mz_connections c ON plc.id = c.id
@@ -404,7 +404,7 @@ start by selecting the relevant option.
 1. Validate the AWS PrivateLink connection you created using the
    [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
-    ```sql
+    ```mzsql
     VALIDATE CONNECTION privatelink_svc;
     ```
 
@@ -413,7 +413,7 @@ start by selecting the relevant option.
 1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
    password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -421,7 +421,7 @@ start by selecting the relevant option.
    another connection object, this time with database access and authentication
    details for Materialize to use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -443,7 +443,7 @@ start by selecting the relevant option.
    to your RDS instance via AWS PrivateLink and start ingesting data from the
    publication you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
@@ -464,7 +464,7 @@ start by selecting the relevant option.
    client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel)
    command to create an SSH tunnel connection:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (
         HOST '<SSH_BASTION_HOST>',
         PORT <SSH_BASTION_PORT>,
@@ -481,7 +481,7 @@ start by selecting the relevant option.
 1. Get Materialize's public keys for the SSH tunnel connection you just
    created:
 
-    ```sql
+    ```mzsql
     SELECT
         mz_connections.name,
         mz_ssh_tunnel_connections.*
@@ -504,7 +504,7 @@ start by selecting the relevant option.
 1. Back in the SQL client connected to Materialize, validate the SSH tunnel
    connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
-    ```sql
+    ```mzsql
     VALIDATE CONNECTION ssh_connection;
     ```
 
@@ -513,7 +513,7 @@ start by selecting the relevant option.
 1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
    password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -521,7 +521,7 @@ start by selecting the relevant option.
    another connection object, this time with database access and authentication
    details for Materialize to use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -543,7 +543,7 @@ start by selecting the relevant option.
    to your RDS instance and start ingesting data from the publication you created
    [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')

--- a/doc/user/content/ingest-data/postgres/azure-db.md
+++ b/doc/user/content/ingest-data/postgres/azure-db.md
@@ -51,7 +51,7 @@ Select the option that works best for you.
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -83,7 +83,7 @@ to serve as your SSH bastion host.
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 
@@ -124,7 +124,7 @@ start by selecting the relevant option.
    command to securely store the password for the `materialize` PostgreSQL user
    you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -132,7 +132,7 @@ start by selecting the relevant option.
    connection object with access and authentication details for Materialize to
    use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -152,7 +152,7 @@ start by selecting the relevant option.
 to your Azure instance and start ingesting data from the publication you
 created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
@@ -177,7 +177,7 @@ created [earlier](#step-2-create-a-publication):
    client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel)
    command to create an SSH tunnel connection:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (
         HOST '<SSH_BASTION_HOST>',
         PORT <SSH_BASTION_PORT>,
@@ -194,7 +194,7 @@ created [earlier](#step-2-create-a-publication):
 1. Get Materialize's public keys for the SSH tunnel connection you just
    created:
 
-    ```sql
+    ```mzsql
     SELECT
         mz_connections.name,
         mz_ssh_tunnel_connections.*
@@ -218,7 +218,7 @@ created [earlier](#step-2-create-a-publication):
    connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection)
    command:
 
-    ```sql
+    ```mzsql
     VALIDATE CONNECTION ssh_connection;
     ```
 
@@ -227,7 +227,7 @@ created [earlier](#step-2-create-a-publication):
 1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
    password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -235,7 +235,7 @@ created [earlier](#step-2-create-a-publication):
    another connection object, this time with database access and authentication
    details for Materialize to use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -255,7 +255,7 @@ created [earlier](#step-2-create-a-publication):
 to your Azure instance and start ingesting data from the publication you
 created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')

--- a/doc/user/content/ingest-data/postgres/cloud-sql.md
+++ b/doc/user/content/ingest-data/postgres/cloud-sql.md
@@ -51,7 +51,7 @@ Select the option that works best for you.
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -83,7 +83,7 @@ network to allow traffic from the bastion host.
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 

--- a/doc/user/content/ingest-data/postgres/debezium.md
+++ b/doc/user/content/ingest-data/postgres/debezium.md
@@ -35,7 +35,7 @@ As a _superuser_:
 1. Check the [`wal_level` configuration](https://www.postgresql.org/docs/current/wal-configuration.html)
    setting:
 
-    ```sql
+    ```postgres
     SHOW wal_level;
     ```
 
@@ -155,7 +155,7 @@ Once logical replication is enabled:
    has **no primary key** defined, you must set the replica identity value to
    `FULL`:
 
-    ```sql
+    ```postgres
     ALTER TABLE repl_table REPLICA IDENTITY FULL;
     ```
 
@@ -303,7 +303,7 @@ information about upstream database operations, like the `before` and `after`
 values for each record. To create a source that interprets the
 [Debezium envelope](/sql/create-source/kafka/#using-debezium) in Materialize:
 
-```sql
+```mzsql
 CREATE SOURCE kafka_repl
     FROM KAFKA CONNECTION kafka_connection (TOPIC 'pg_repl.public.table1')
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
@@ -329,7 +329,7 @@ Any materialized view defined on top of this source will be incrementally
 updated as new change events stream in through Kafka, as a result of `INSERT`,
 `UPDATE` and `DELETE` operations in the original Postgres database.
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW cnt_table1 AS
     SELECT field1,
            COUNT(*) AS cnt

--- a/doc/user/content/ingest-data/postgres/self-hosted.md
+++ b/doc/user/content/ingest-data/postgres/self-hosted.md
@@ -29,7 +29,7 @@ As a first step, you need to make sure logical replication is enabled.
 
 1. Check if logical replication is enabled:
 
-    ```sql
+    ```postgres
     SHOW wal_level;
     ```
 
@@ -43,7 +43,7 @@ As a first step, you need to make sure logical replication is enabled.
 1. Back in the SQL client connected to PostgreSQL, verify that replication is
    now enabled:
 
-    ```sql
+    ```postgres
     SHOW wal_level;
     ```
 
@@ -73,7 +73,7 @@ Select the option that works best for you.
    client connected to Materialize, find the static egress IP addresses for the
    Materialize region you are running in:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_egress_ips;
     ```
 
@@ -156,7 +156,7 @@ option.
      In Materialize, create a [`AWS PRIVATELINK`](/sql/create-connection/#aws-privatelink) connection that references the
      endpoint service that you created in the previous step.
 
-     ```sql
+     ```mzsql
     CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
         SERVICE NAME 'com.amazonaws.vpce.<region_id>.vpce-svc-<endpoint_service_id>',
         AVAILABILITY ZONES ('use1-az1', 'use1-az2', 'use1-az3')
@@ -171,7 +171,7 @@ option.
     Retrieve the AWS principal for the AWS PrivateLink connection you just
     created:
 
-    ```sql
+    ```mzsql
     SELECT principal
     FROM mz_aws_privatelink_connections plc
     JOIN mz_connections c ON plc.id = c.id
@@ -221,7 +221,7 @@ traffic from the bastion host.
        SQL client connected to Materialize, get the static egress IP addresses for
        the Materialize region you are running in:
 
-       ```sql
+       ```mzsql
        SELECT * FROM mz_egress_ips;
        ```
 
@@ -261,7 +261,7 @@ start by selecting the relevant option.
    command to securely store the password for the `materialize` PostgreSQL user you
    created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -269,7 +269,7 @@ start by selecting the relevant option.
    connection object with access and authentication details for Materialize to
    use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -289,7 +289,7 @@ start by selecting the relevant option.
    to your database and start ingesting data from the publication you created
    [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
@@ -310,7 +310,7 @@ start by selecting the relevant option.
    client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel)
    command to create an SSH tunnel connection:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (
         HOST '<SSH_BASTION_HOST>',
         PORT <SSH_BASTION_PORT>,
@@ -327,7 +327,7 @@ start by selecting the relevant option.
 1. Get Materialize's public keys for the SSH tunnel connection you just
    created:
 
-    ```sql
+    ```mzsql
     SELECT
         mz_connections.name,
         mz_ssh_tunnel_connections.*
@@ -351,7 +351,7 @@ start by selecting the relevant option.
    connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection)
    command:
 
-    ```sql
+    ```mzsql
     VALIDATE CONNECTION ssh_connection;
     ```
 
@@ -360,7 +360,7 @@ start by selecting the relevant option.
 1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the
    password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -368,7 +368,7 @@ start by selecting the relevant option.
    another connection object, this time with database access and authentication
    details for Materialize to use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -388,7 +388,7 @@ start by selecting the relevant option.
    to your Azure instance and start ingesting data from the publication you
    created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
@@ -413,7 +413,7 @@ start by selecting the relevant option.
    command to securely store the password for the `materialize` PostgreSQL user you
    created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -421,7 +421,7 @@ start by selecting the relevant option.
    another connection object, this time with database access and authentication
    details for Materialize to use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
         HOST '<host>',
         PORT 5432,
@@ -441,7 +441,7 @@ start by selecting the relevant option.
    to your database and start ingesting data from the publication you created
    [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')

--- a/doc/user/content/ingest-data/redpanda-cloud.md
+++ b/doc/user/content/ingest-data/redpanda-cloud.md
@@ -101,7 +101,7 @@ preferred SQL client, create a connection with your Redpanda Cloud cluster
 access and authentication details using the [`CREATE CONNECTION`](/sql/create-connection/)
 command:
 
-    ```sql
+    ```mzsql
       -- The credentials of your Redpanda Cloud user.
       CREATE SECRET redpanda_username AS '<your-username>';
       CREATE SECRET redpanda_password AS '<your-password>';
@@ -119,7 +119,7 @@ command:
    By default, the source will be created in the active cluster; to use a
    different cluster, use the `IN CLUSTER` clause.
 
-    ```sql
+    ```mzsql
     CREATE SOURCE rp_source
       -- The topic you want to read from.
       FROM KAFKA CONNECTION redpanda_cloud (TOPIC '<topic-name>')
@@ -200,7 +200,7 @@ preferred SQL client, create a [PrivateLink connection](/ingest-data/network-sec
 using the service name from the previous step. Be sure to specify **all
 availability zones** of your Redpanda Cloud cluster.
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION rp_privatelink TO AWS PRIVATELINK (
       SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-abcdefghijk',
       AVAILABILITY ZONES ('use1-az4','use1-az1','use1-az2')
@@ -210,7 +210,7 @@ availability zones** of your Redpanda Cloud cluster.
 1. Retrieve the AWS principal for the AWS PrivateLink connection you just
 created:
 
-    ```sql
+    ```mzsql
     SELECT principal
     FROM mz_aws_privatelink_connections plc
     JOIN mz_connections c ON plc.id = c.id
@@ -265,7 +265,7 @@ principal:
 1. In Materialize, validate the AWS PrivateLink connection you created using the
 [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
-    ```sql
+    ```mzsql
     VALIDATE CONNECTION rp_privatelink;
     ```
 
@@ -279,7 +279,7 @@ principal:
 1. Finally, create a connection to your Redpanda Cloud cluster using the AWS
 Privatelink connection you created earlier:
 
-    ```sql
+    ```mzsql
     -- The credentials of your Redpanda Cloud user.
     CREATE SECRET redpanda_username AS '<your-username>';
     CREATE SECRET redpanda_password AS '<your-password>';

--- a/doc/user/content/ingest-data/rudderstack.md
+++ b/doc/user/content/ingest-data/rudderstack.md
@@ -28,7 +28,7 @@ scenarios, we recommend separating your workloads into multiple clusters for
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 
-```sql
+```mzsql
 CREATE CLUSTER webhooks_cluster (SIZE = '25cc');
 
 SET CLUSTER = webhooks_cluster;
@@ -38,7 +38,7 @@ SET CLUSTER = webhooks_cluster;
 
 To validate requests between Rudderstack and Materialize, you must create a [secret](/sql/create-secret/):
 
-```sql
+```mzsql
 CREATE SECRET rudderstack_webhook_secret AS '<secret_value>';
 ```
 
@@ -51,7 +51,7 @@ in Materialize to ingest data from RudderStack. By default, the source will be
 created in the active cluster; to use a different cluster, use the `IN
 CLUSTER` clause.
 
-```sql
+```mzsql
 CREATE SOURCE rudderstack_source
   FROM WEBHOOK
     BODY FORMAT JSON
@@ -133,7 +133,7 @@ Rudderstack, you can now query the incoming data:
 
 1. Use SQL queries to inspect and analyze the incoming data:
 
-    ```sql
+    ```mzsql
     SELECT * FROM rudderstack_source LIMIT 10;
     ```
 
@@ -148,7 +148,7 @@ Webhook data is ingested as a JSON blob. We recommend creating a parsing view on
 top of your webhook source that uses [`jsonb` operators](https://materialize.com/docs/sql/types/jsonb/#operators)
 to map the individual fields to columns with the required data types.
 
-```sql
+```mzsql
 CREATE VIEW json_parsed AS
   SELECT
     (body -> '_metadata' ->> 'nodeVersion')::text AS nodeVersion,

--- a/doc/user/content/ingest-data/segment.md
+++ b/doc/user/content/ingest-data/segment.md
@@ -29,7 +29,7 @@ scenarios, we recommend separating your workloads into multiple clusters for
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 
-```sql
+```mzsql
 CREATE CLUSTER webhooks_cluster (SIZE = '25cc');
 
 SET CLUSTER = webhooks_cluster;
@@ -39,7 +39,7 @@ SET CLUSTER = webhooks_cluster;
 
 To validate requests between Segment and Materialize, you must create a [secret](/sql/create-secret/):
 
-```sql
+```mzsql
 CREATE SECRET segment_webhook_secret AS '<secret_value>';
 ```
 
@@ -52,7 +52,7 @@ in Materialize to ingest data from Segment. By default, the source will be
 created in the active cluster; to use a different cluster, use the `IN
 CLUSTER` clause.
 
-```sql
+```mzsql
 CREATE SOURCE segment_source IN CLUSTER webhooks_cluster FROM WEBHOOK
   BODY FORMAT JSON
   INCLUDE HEADER 'event-type' AS event_type
@@ -155,7 +155,7 @@ Segment, you can now query the incoming data:
 
 1. Use SQL queries to inspect and analyze the incoming data:
 
-    ```sql
+    ```mzsql
     SELECT * FROM segment_source LIMIT 10;
     ```
 
@@ -170,7 +170,7 @@ to map the individual fields to columns with the required data types.
 {{< tabs >}}
 
 {{< tab "Page">}}
-```sql
+```mzsql
 CREATE VIEW parse_segment AS SELECT
     body->>'anonymousId' AS anonymousId,
     body->>'channel' AS channel,
@@ -195,7 +195,7 @@ FROM segment_source;
 
 {{< tab "Track">}}
 
-```sql
+```mzsql
 CREATE VIEW parse_segment AS SELECT
     body->>'anonymousId' AS anonymous_id,
     body->'context'->'library'->>'name' AS context_library_name,
@@ -222,7 +222,7 @@ FROM segment_source;
 {{< /tab >}}
 
 {{< tab "Identity">}}
-```sql
+```mzsql
 CREATE VIEW parse_segment AS SELECT
     body->>'anonymousId' AS anonymous_id,
     body->>'channel' AS channel,

--- a/doc/user/content/ingest-data/snowcatcloud.md
+++ b/doc/user/content/ingest-data/snowcatcloud.md
@@ -28,7 +28,7 @@ scenarios, we recommend separating your workloads into multiple clusters for
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 
-```sql
+```mzsql
 CREATE CLUSTER webhooks_cluster (SIZE = '25cc');
 
 SET CLUSTER = webhooks_cluster;
@@ -38,7 +38,7 @@ SET CLUSTER = webhooks_cluster;
 
 To validate requests between SnowcatCloud and Materialize, you must create a [secret](/sql/create-secret/):
 
-```sql
+```mzsql
 CREATE SECRET snowcat_webhook_secret AS '<secret_value>';
 ```
 
@@ -51,7 +51,7 @@ in Materialize to ingest data from SnowcatCloud. By default, the source will be
 created in the active cluster; to use a different cluster, use the `IN
 CLUSTER` clause.
 
-```sql
+```mzsql
 CREATE SOURCE snowcat_source IN CLUSTER webhooks_cluster
   FROM WEBHOOK
     BODY FORMAT JSON
@@ -130,7 +130,7 @@ SnowcatCloud, you can now query the incoming data:
 
 1. Use SQL queries to inspect and analyze the incoming data:
 
-    ```sql
+    ```mzsql
     SELECT * FROM segment_source LIMIT 10;
     ```
 
@@ -146,7 +146,7 @@ to map the individual fields to columns with the required data types.
 To see what columns are available for your pipeline (enrichments), refer to
 the [SnowcatCloud documentation](https://docs.snowcatcloud.com/).
 
-```sql
+```mzsql
 CREATE VIEW events AS
 SELECT
     body ->> 'app_id' AS app_id,

--- a/doc/user/content/ingest-data/striim.md
+++ b/doc/user/content/ingest-data/striim.md
@@ -95,7 +95,7 @@ scenarios, we recommend separating your workloads into multiple clusters for
    command to create connection objects with access and authentication details
    to your Kafka cluster and schema registry:
 
-   ```sql
+   ```mzsql
     CREATE SECRET kafka_password AS '<your-password>';
     CREATE SECRET csr_password AS '<your-password>';
 
@@ -119,7 +119,7 @@ scenarios, we recommend separating your workloads into multiple clusters for
    Materialize to your Kafka broker and schema registry using the connections you
    created in the previous step.
 
-   ```sql
+   ```mzsql
    CREATE SOURCE src
      FROM KAFKA CONNECTION kafka_connection (TOPIC '<topic-name>')
      KEY FORMAT TEXT

--- a/doc/user/content/ingest-data/stripe.md
+++ b/doc/user/content/ingest-data/stripe.md
@@ -27,7 +27,7 @@ scenarios, we recommend separating your workloads into multiple clusters for
 
 To create a cluster in Materialize, use the [`CREATE CLUSTER` command](/sql/create-cluster):
 
-```sql
+```mzsql
 CREATE CLUSTER webhooks_cluster (SIZE = '25cc');
 
 SET CLUSTER = webhooks_cluster;
@@ -37,7 +37,7 @@ SET CLUSTER = webhooks_cluster;
 
 To validate requests between Stripe and Materialize, you must create a [secret](/sql/create-secret/):
 
-```sql
+```mzsql
 CREATE SECRET stripe_webhook_secret AS '<secret_value>';
 ```
 
@@ -50,7 +50,7 @@ in Materialize to ingest data from Stripe. By default, the source will be
 created in the active cluster; to use a different cluster, use the `IN
 CLUSTER` clause.
 
-```sql
+```mzsql
 CREATE SOURCE stripe_source IN CLUSTER webhooks_cluster
 FROM WEBHOOK
     BODY FORMAT JSON;
@@ -132,7 +132,7 @@ Stripe signing scheme, check out the [Stripe documentation](https://stripe.com/d
 
 1. Use SQL queries to inspect and analyze the incoming data:
 
-    ```sql
+    ```mzsql
     SELECT * FROM stripe_source LIMIT 10;
     ```
 
@@ -146,7 +146,7 @@ Webhook data is ingested as a JSON blob. We recommend creating a parsing view on
 top of your webhook source that uses [`jsonb` operators](https://materialize.com/docs/sql/types/jsonb/#operators)
 to map the individual fields to columns with the required data types.
 
-```sql
+```mzsql
 CREATE VIEW parse_stripe AS SELECT
     body->>'api_version' AS api_version,
     to_timestamp((body->'created')::int) AS created,

--- a/doc/user/content/ingest-data/troubleshooting.md
+++ b/doc/user/content/ingest-data/troubleshooting.md
@@ -29,7 +29,7 @@ Alternatively, you can get this information from the system catalog by querying
 the [`mz_source_statuses`](/sql/system-catalog/mz_internal/#mz_source_statuses)
 table:
 
-```sql
+```mzsql
 SELECT * FROM mz_internal.mz_source_statuses
 WHERE name = <SOURCE_NAME>;
 ```
@@ -60,7 +60,7 @@ To determine whether your source has completed ingesting the initial snapshot,
 you can query the [`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics)
 system catalog table:
 
-```sql
+```mzsql
 SELECT snapshot_committed
 FROM mz_internal.mz_source_statistics
 WHERE id = <SOURCE_ID>;
@@ -80,7 +80,7 @@ Repeatedly query the
 [`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics)
 table and look for ingestion statistics that advance over time:
 
-```sql
+```mzsql
 SELECT
     bytes_received,
     messages_received,

--- a/doc/user/content/ingest-data/upstash-kafka.md
+++ b/doc/user/content/ingest-data/upstash-kafka.md
@@ -107,7 +107,7 @@ steps:
     the name of the topic you created in Step 3. The `<your-username>` and
     `<your-password>` are from the _Create new credentials_ step.
 
-    ```sql
+    ```mzsql
       CREATE SECRET upstash_username AS '<your-username>';
       CREATE SECRET upstash_password AS '<your-password>';
 
@@ -146,7 +146,7 @@ steps:
 
     To create a sink, run the following command:
 
-    ```sql
+    ```mzsql
       CREATE SINK <sink-name>
         FROM <source, table or mview>
         INTO KAFKA CONNECTION <upstash_kafka> (TOPIC '<sink-topic-name>')

--- a/doc/user/content/ingest-data/warpstream.md
+++ b/doc/user/content/ingest-data/warpstream.md
@@ -89,14 +89,14 @@ Ensure you have the following:
 
     a. Save WarpStream credentials:
 
-    ```sql
+    ```mzsql
     CREATE SECRET warpstream_username AS '<username>';
     CREATE SECRET warpstream_password AS '<password>';
     ```
 
     b. Set up a connection to the WarpStream broker:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION warpstream_kafka TO KAFKA (
         BROKER '<CLUSTER_NAME>.fly.dev:9092',
         SASL MECHANISMS = "PLAIN",
@@ -109,7 +109,7 @@ Ensure you have the following:
     source will be created in the active cluster; to use a different cluster,
     use the `IN CLUSTER` clause.
 
-    ```sql
+    ```mzsql
     CREATE SOURCE warpstream_click_stream_source
         FROM KAFKA CONNECTION warpstream_kafka (TOPIC 'materialize_click_streams')
         FORMAT JSON;
@@ -117,13 +117,13 @@ Ensure you have the following:
 
     d. Verify the ingestion and query the data in Materialize:
 
-    ```sql
+    ```mzsql
     SELECT * FROM warpstream_click_stream_source LIMIT 10;
     ```
 
     e. Furthermore, create a materialized view to aggregate the data:
 
-    ```sql
+    ```mzsql
     CREATE MATERIALIZED VIEW warpstream_click_stream_aggregate AS
         SELECT
             user_id,
@@ -146,7 +146,7 @@ Ensure you have the following:
 
     g. Query the materialized view to monitor the real-time updates:
 
-    ```sql
+    ```mzsql
     SELECT * FROM warpstream_click_stream_aggregate;
     ```
 

--- a/doc/user/content/ingest-data/webhook-quickstart.md
+++ b/doc/user/content/ingest-data/webhook-quickstart.md
@@ -26,7 +26,7 @@ and pop open the SQL Shell.
 To validate requests between the webhook event generator and Materialize, you
 need a [secret](/sql/create-secret/):
 
-```sql
+```mzsql
 CREATE SECRET demo_webhook AS '<secret_value>';
 ```
 
@@ -39,7 +39,7 @@ Using the secret from the previous step, create a webhook source to ingest data
 from the webhook event generator. By default, the source will be created in the
 current cluster.
 
-```sql
+```mzsql
 CREATE SOURCE webhook_demo FROM WEBHOOK
   BODY FORMAT JSON
   CHECK (
@@ -70,7 +70,7 @@ to shape the events.
 
 In the SQL Shell, validate that the source is ingesting data:
 
-```sql
+```mzsql
 SELECT jsonb_pretty(body) AS body FROM webhook_demo LIMIT 1;
 ```
 
@@ -97,7 +97,7 @@ top of your webhook source that uses [jsonb operators](https://materialize.com/d
 to map the individual fields to columns with the required data types. Using the
 previous example:
 
-```sql
+```mzsql
 CREATE VIEW webhook_demo_parsed AS SELECT
     (body->'location'->>'latitude')::numeric AS location_latitude,
     (body->'location'->>'longitude')::numeric AS location_longitude,
@@ -112,7 +112,7 @@ FROM webhook_demo;
 To see results change over time, let’s [`SUBSCRIBE`](/sql/subscribe/) to the
 `webhook_demo_parsed ` view:
 
-```sql
+```mzsql
 SUBSCRIBE(SELECT * FROM webhook_demo_parsed) WITH (SNAPSHOT = FALSE);
 ```
 
@@ -124,7 +124,7 @@ cancel out of the `SUBSCRIBE` using **Stop streaming**.
 Once you’re done exploring the generated webhook data, remember to clean up your
 environment:
 
-```sql
+```mzsql
 DROP SOURCE webhook_demo CASCADE;
 
 DROP SECRET demo_webhook;

--- a/doc/user/content/integrations/golang.md
+++ b/doc/user/content/integrations/golang.md
@@ -192,7 +192,7 @@ An `MzDiff` value of `-1` indicates that Materialize is deleting one row with th
 
 To clean up the sources, views, and tables that we created, first connect to Materialize using a [PostgreSQL client](/integrations/sql-clients/) and then, run the following commands:
 
-```sql
+```mzsql
 DROP MATERIALIZED VIEW IF EXISTS counter_sum;
 DROP SOURCE IF EXISTS counter;
 DROP TABLE IF EXISTS countries;

--- a/doc/user/content/integrations/java-jdbc.md
+++ b/doc/user/content/integrations/java-jdbc.md
@@ -389,7 +389,7 @@ A `mz_diff` value of `-1` indicates that Materialize is deleting one row with th
 
 To clean up the sources, views, and tables that we created, first connect to Materialize using a [PostgreSQL client](/integrations/sql-clients/) and then, run the following commands:
 
-```sql
+```mzsql
 DROP MATERIALIZED VIEW IF EXISTS counter_sum;
 DROP SOURCE IF EXISTS counter;
 DROP TABLE IF EXISTS countries;

--- a/doc/user/content/integrations/node-js.md
+++ b/doc/user/content/integrations/node-js.md
@@ -263,7 +263,7 @@ client.connect((err, client) => {
 
 To clean up the sources, views, and tables that we created, first connect to Materialize using a [PostgreSQL client](/integrations/sql-clients/) and then, run the following commands:
 
-```sql
+```mzsql
 DROP MATERIALIZED VIEW IF EXISTS counter_sum;
 DROP SOURCE IF EXISTS counter;
 DROP TABLE IF EXISTS countries;

--- a/doc/user/content/integrations/php.md
+++ b/doc/user/content/integrations/php.md
@@ -212,7 +212,7 @@ An `mz_diff` value of `-1` indicates Materialize is deleting one row with the in
 
 To clean up the sources, views, and tables that we created, first connect to Materialize using a [PostgreSQL client](/integrations/sql-clients/) and then, run the following commands:
 
-```sql
+```mzsql
 DROP MATERIALIZED VIEW IF EXISTS counter_sum;
 DROP SOURCE IF EXISTS counter;
 DROP TABLE IF EXISTS countries;

--- a/doc/user/content/integrations/python.md
+++ b/doc/user/content/integrations/python.md
@@ -211,7 +211,7 @@ with conn.cursor() as cur:
 
 To clean up the sources, views, and tables that we created, first connect to Materialize using a [PostgreSQL client](/integrations/sql-clients/) and then, run the following commands:
 
-```sql
+```mzsql
 DROP MATERIALIZED VIEW IF EXISTS counter_sum;
 DROP SOURCE IF EXISTS counter;
 DROP TABLE IF EXISTS countries;

--- a/doc/user/content/integrations/ruby.md
+++ b/doc/user/content/integrations/ruby.md
@@ -180,7 +180,7 @@ An `mz_diff` value of `-1` indicates Materialize is deleting one row with the in
 
 To clean up the sources, views, and tables that we created, first connect to Materialize using a [PostgreSQL client](/integrations/sql-clients/) and then, run the following commands:
 
-```sql
+```mzsql
 DROP MATERIALIZED VIEW IF EXISTS counter_sum;
 DROP SOURCE IF EXISTS counter;
 DROP TABLE IF EXISTS countries;

--- a/doc/user/content/integrations/rust.md
+++ b/doc/user/content/integrations/rust.md
@@ -169,7 +169,7 @@ The [SUBSCRIBE output format](/sql/subscribe/#output) of the `counter_sum` view 
 
 To clean up the sources, views, and tables that we created, first connect to Materialize using a [PostgreSQL client](/integrations/sql-clients/) and then, run the following commands:
 
-```sql
+```mzsql
 DROP MATERIALIZED VIEW IF EXISTS counter_sum;
 DROP SOURCE IF EXISTS counter;
 DROP TABLE IF EXISTS countries;

--- a/doc/user/content/integrations/sql-clients.md
+++ b/doc/user/content/integrations/sql-clients.md
@@ -113,7 +113,7 @@ define a bootstrap query in the connection initialization settings.
 1. Under **Bootstrap queries**, click **Configure** and add a new SQL query that
 sets the active cluster for the connection:
 
-    ```sql
+    ```mzsql
     SET cluster = other_cluster;
     ```
 

--- a/doc/user/content/manage/access-control/_index.md
+++ b/doc/user/content/manage/access-control/_index.md
@@ -124,7 +124,7 @@ databases, or schemas. To modify the default privileges available to all other
 roles in a Materialize region, you can use the [`ALTER DEFAULT PRIVILEGES`](/sql/alter-default-privileges/)
 command.
 
-```sql
+```mzsql
 # Use SHOW ROLES to list existing roles in the system, which are 1:1 with invited users
 SHOW ROLES;
 
@@ -151,7 +151,7 @@ decide to roll out a RBAC strategy for your Materialize organization.
 As an alternative, you can approximate the set of privileges of a _superuser_ by
 instead modifying the default privileges to be wildly permissive:
 
-```sql
+```mzsql
 -- Use SHOW ROLES to list existing roles in the system, which are 1:1 with invited users
 SHOW ROLES;
 
@@ -192,7 +192,7 @@ If your Materialize user base is small and you don't expect it to grow
 significantly over time, you can grant and revoke privileges directly to/from
 user roles.
 
-```sql
+```mzsql
 -- Use SHOW ROLES to list existing roles in the system.
 SHOW ROLES;
 
@@ -222,7 +222,7 @@ As an example, Data Engineers might need a larger scope of permissions to create
 and evolve the data model, while Data Analysts might only need read permissions
 to query Materialize using BI tools.
 
-```sql
+```mzsql
 -- Use SHOW ROLES to list existing roles in the system, which are 1:1 with invited users
 SHOW ROLES;
 
@@ -283,7 +283,7 @@ roles from inheriting it. This means that users have to explicitly run e.g.,
 `SET ROLE production` before being able to run any commands in the specified
 environment.
 
-```sql
+```mzsql
 -- Step 1: create the dev and prod roles
 CREATE ROLE dev;
 CREATE ROLE prod NOINHERIT;

--- a/doc/user/content/manage/access-control/manage-privileges.md
+++ b/doc/user/content/manage/access-control/manage-privileges.md
@@ -14,7 +14,7 @@ This page outlines how to assign and manage role privileges.
 To grant privileges to a role, use the [`GRANT PRIVILEGE`](https://materialize.com/docs/sql/grant-privilege/) statement with the
 object you want to grant privileges to:
 
-```sql
+```mzsql
 GRANT USAGE ON <OBJECT_TYPE> <object_name> TO <role_name>;
 ```
 
@@ -49,7 +49,7 @@ For example, to allow a role to create a materialized view, you would
 give that role `CREATE` privileges on the cluster and the schema because the
 materialized view will be namespaced by the schema.
 
-```sql
+```mzsql
 GRANT CREATE ON CLUSTER <cluster_name> to <role_name>;
 GRANT CREATE ON <schema_name> to <role_name>;
 ```
@@ -58,6 +58,6 @@ GRANT CREATE ON <schema_name> to <role_name>;
 
 To remove privileges from a role, use the [`REVOKE`](https://materialize.com/docs/sql/revoke-privilege/) statement:
 
-```sql
+```mzsql
 REVOKE USAGE ON <OBJECT_TYPE> <object_name> FROM <role_name>;
 ```

--- a/doc/user/content/manage/access-control/manage-roles.md
+++ b/doc/user/content/manage/access-control/manage-roles.md
@@ -15,7 +15,7 @@ This page outlines how to create and manage roles in Materialize.
 
 To create a new role, use the [`CREATE ROLE`](https://materialize.com/docs/sql/create-role/) statement:
 
-```sql
+```mzsql
 CREATE ROLE <role_name> WITH <role_attribute>;
 ```
 
@@ -29,7 +29,7 @@ Materialize roles have the following available attributes:
 
 To change a role's attributes, use the [`ALTER ROLE`](https://materialize.com/docs/sql/alter-role/) statement:
 
-```sql
+```mzsql
 ALTER ROLE <role_name> WITH <ATTRIBUTE>;
 ```
 
@@ -37,7 +37,7 @@ ALTER ROLE <role_name> WITH <ATTRIBUTE>;
 
 To grant a role assignment to a user, use the [`GRANT`](https://materialize.com/docs/sql/grant-role/) statement:
 
-```sql
+```mzsql
 GRANT <role_name> to <user_name>;
 ```
 
@@ -45,7 +45,7 @@ GRANT <role_name> to <user_name>;
 
 To remove a user from a role, use the [`REVOKE`](https://materialize.com/docs/sql/revoke-role/) statement:
 
-```sql
+```mzsql
 REVOKE <role_name> FROM <user_name>;
 ```
 
@@ -53,7 +53,7 @@ REVOKE <role_name> FROM <user_name>;
 
 To remove a role, use the [`DROP ROLE`](https://materialize.com/docs/sql/drop-role/) statement:
 
-```sql
+```mzsql
 DROP ROLE <role_name>;
 ```
 

--- a/doc/user/content/manage/access-control/rbac-terraform-tutorial.md
+++ b/doc/user/content/manage/access-control/rbac-terraform-tutorial.md
@@ -46,9 +46,11 @@ In this scenario, you are a DevOps engineer responsible for managing your Materi
 
 3. Each role you create has default role attributes that determine how they can interact with Materialize objects. Let’s look at the role attributes of the role you created:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_roles WHERE name = 'dev_role';
     ```
+
+    <p></p>
 
     ```nofmt
     -[ RECORD 1 ]--+------
@@ -113,9 +115,11 @@ Your `dev_role` has the default system-level permissions and needs object-level 
 
 3. Now that our resources exist, we can query their privileges before they have been associated with our role created in step 1.
 
-    ```sql
+    ```mzsql
     SELECT name, privileges FROM mz_tables WHERE name = 'dev_table';
     ```
+
+    <p></p>
 
     ```nofmt
     name|privileges
@@ -160,9 +164,11 @@ In this example, let's say your `dev_role` needs the following permissions:
 
 3. We can now check the privileges on our table again
 
-    ```sql
+    ```mzsql
     SELECT name, privileges FROM mz_tables WHERE name = 'dev_table';
     ```
+
+    <p></p>
 
     ```nofmt
     name|privileges
@@ -224,7 +230,7 @@ The dev_role now has the acceptable privileges it needs. Let’s apply this role
 
 3. To review the permissions a roles, you can view the object data:
 
-    ```sql
+    ```mzsql
     SELECT name, privileges FROM mz_tables WHERE name = 'dev_table';
     ```
 
@@ -300,7 +306,7 @@ Your `dev_role` also needs access to `qa_db`. You can apply these privileges ind
 
 3. Review the privileges of `qa_role` and `dev_role`:
 
-   ```sql
+   ```mzsql
    SELECT name, privileges FROM mz_databases WHERE name='qa_db';
    ```
 
@@ -329,7 +335,7 @@ You can revoke certain privileges for each role, even if they are inherited from
 
     Because Terraform is responsible for maintaining the state of our project, removing this grant resource and running an `apply` is the equivalent of running a revoke statement:
 
-    ```sql
+    ```mzsql
     REVOKE CREATE ON DATABASE dev_table FROM dev_role;
     ```
 

--- a/doc/user/content/manage/access-control/rbac-tutorial.md
+++ b/doc/user/content/manage/access-control/rbac-tutorial.md
@@ -42,7 +42,7 @@ example.
 1. In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
    client connected to Materialize, create a new role:
 
-    ```sql
+    ```mzsql
     CREATE ROLE dev_role;
     ```
 
@@ -50,7 +50,7 @@ example.
     can interact with Materialize objects. Let's look at the role attributes of
     the role you created:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_roles WHERE name = 'dev_role';
    ```
 
@@ -87,27 +87,27 @@ privileges the role needs.
 1. In the SQL client connected to Materialize, create a new example cluster to
 avoid impacting other environments:
 
-   ```sql
+   ```mzsql
    CREATE CLUSTER dev_cluster (SIZE = '25cc');
    ```
 
 1. Change into the example cluster:
 
-   ```sql
+   ```mzsql
    SET CLUSTER TO dev_cluster;
    ```
 
 1. Create a new database, schema, and table:
 
-   ```sql
+   ```mzsql
    CREATE DATABASE dev_db;
    ```
 
-   ```sql
+   ```mzsql
    CREATE SCHEMA dev_db.schema;
    ```
 
-   ```sql
+   ```mzsql
    CREATE TABLE dev_table (a int, b text NOT NULL);
    ```
 
@@ -126,7 +126,7 @@ In this example, let's say your `dev_role` needs the following permissions:
 
 1. In your terminal, grant table-level privileges to the `dev_role`:
 
-   ```sql
+   ```mzsql
    GRANT SELECT, UPDATE, INSERT ON dev_table TO dev_role;
    ```
 
@@ -136,7 +136,7 @@ In this example, let's say your `dev_role` needs the following permissions:
 
 2. Grant schema privileges to the `dev_role`:
 
-   ```sql
+   ```mzsql
    GRANT USAGE ON SCHEMA dev_db.schema TO dev_role;
    ```
 
@@ -145,13 +145,13 @@ In this example, let's say your `dev_role` needs the following permissions:
 3. Grant database privileges to the `dev_role`. You can use the `GRANT ALL`
    statement to grant all available privileges on an object.
 
-   ```sql
+   ```mzsql
    GRANT ALL ON DATABASE dev_db TO dev_role;
    ```
 
 4. Grant cluster privileges to the `dev_role`:
 
-   ```sql
+   ```mzsql
    GRANT USAGE, CREATE ON CLUSTER dev_cluster TO dev_role;
    ```
 
@@ -166,13 +166,13 @@ to a user in your Materialize organization.
 
 1. In your terminal, use the `GRANT` statement to apply a role to your new user:
 
-   ```sql
+   ```mzsql
    GRANT dev_role TO <new_user>;
    ```
 
 1. To review the permissions a role has, you can view the object data:
 
-   ```sql
+   ```mzsql
    SELECT name, privileges FROM mz_tables WHERE name='dev_table';
    ```
 
@@ -196,13 +196,13 @@ privileges as needed.
 
 1. Create a second role your Materialize account:
 
-   ```sql
+   ```mzsql
    CREATE ROLE qa_role;
    ```
 
 2. Apply `CREATEDB` privileges to the `qa_role`
 
-   ```sql
+   ```mzsql
    GRANT CREATEDB ON SYSTEM TO qa_role;
    ```
 
@@ -210,13 +210,13 @@ privileges as needed.
 
 3. Create a new `qa_db` database:
 
-   ```sql
+   ```mzsql
    CREATE DATABASE qa_db;
    ```
 
 4. Apply `USAGE` and `CREATE` privileges to the `qa_role` role for the new database:
 
-   ```sql
+   ```mzsql
    GRANT USAGE, CREATE ON DATABASE qa_db TO qa_role;
    ```
 
@@ -228,7 +228,7 @@ permissions as the `qa_role`.
 
 1. Add `dev_role` as a member of `qa_role`:
 
-   ```sql
+   ```mzsql
    GRANT qa_role TO dev_role;
    ```
 
@@ -238,7 +238,7 @@ permissions as the `qa_role`.
 
 2. Review the privileges of `qa_role` and `dev_role`:
 
-   ```sql
+   ```mzsql
    SELECT name, privileges FROM mz_databases WHERE name='qa_db';
    ```
 
@@ -261,7 +261,7 @@ You can revoke certain privileges for each role, even if they are inherited from
 1. Let's say you decide `dev_role` no longer needs `CREATE` privileges on the
    `dev_table` object. You can revoke that privilege for the role:
 
-   ```sql
+   ```mzsql
    REVOKE CREATE ON DATABASE dev_table FROM dev_role;
    ```
 
@@ -277,7 +277,7 @@ You can revoke certain privileges for each role, even if they are inherited from
    If you need to revoke specific privileges from a role that have been
    inheritied from another role, you must revoke the role with those privileges.
 
-   ```sql
+   ```mzsql
    REVOKE qa_role FROM dev_role;
    ```
    In this example, when `dev_role` inherits from `qa_role`, `dev_role` always has
@@ -294,14 +294,14 @@ to destroy the objects you created for this guide.
 
 1. Drop the roles you created:
 
-   ```sql
+   ```mzsql
    DROP ROLE qa_role;
    DROP ROLE dev_role;
    ```
 
 1. Drop the other objects you created:
 
-   ```sql
+   ```mzsql
    DROP CLUSTER dev_cluster CASCADE;
    DROP DATABASE dev_db CASCADE;
    DROP TABLE dev_table;

--- a/doc/user/content/manage/blue-green.md
+++ b/doc/user/content/manage/blue-green.md
@@ -105,7 +105,7 @@ it is safe to cut over.
 
 3. Use the `SWAP` operation to atomically rename your objects in a way that is
 transparent to clients.
-    ```sql
+    ```mzsql
     BEGIN;
     ALTER SCHEMA prod SWAP WITH prod_deploy;
     ALTER CLUSTER prod SWAP WITH prod_deploy;
@@ -116,7 +116,7 @@ transparent to clients.
 
 4. Now that changes are running in `prod` and the legacy version is in
 `prod_deploy`, you can drop the prod_deploy compute objects and schema.
-    ```sql
+    ```mzsql
     DROP CLUSTER prod_deploy CASCADE;
     DROP SCHEMA prod_deploy CASCADE;
     ```
@@ -135,7 +135,7 @@ also use `ALTER...RENAME` operations on:
 - Materialized Views
 - Indexes
 
-  ```sql
+  ```mzsql
   BEGIN;
   -- Swap schemas
   ALTER SCHEMA prod RENAME TO temp;

--- a/doc/user/content/manage/dbt/_index.md
+++ b/doc/user/content/manage/dbt/_index.md
@@ -175,7 +175,7 @@ exposed** in dbt, and need to exist before you run any `source` models.
 Create a [Kafka source](/sql/create-source/kafka/).
 
 **Filename:** sources/kafka_topic_a.sql
-```sql
+```mzsql
 {{ config(materialized='source') }}
 
 FROM KAFKA CONNECTION kafka_connection (TOPIC 'topic_a')
@@ -193,7 +193,7 @@ database.schema.kafka_topic_a
 Create a [PostgreSQL source](/sql/create-source/postgres/).
 
 **Filename:** sources/pg.sql
-```sql
+```mzsql
 {{ config(materialized='source') }}
 
 FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
@@ -225,7 +225,7 @@ models in, you should additionally force a dependency on the parent source
 model (`pg`), as described in the [dbt documentation](https://docs.getdbt.com/reference/dbt-jinja-functions/ref#forcing-dependencies).
 
 **Filename:** staging/dep_subsources.sql
-```sql
+```mzsql
 -- depends_on: {{ ref('pg') }}
 {{ config(materialized='view') }}
 
@@ -251,7 +251,7 @@ database.schema.table_b
 Create a [MySQL source](/sql/create-source/mysql/).
 
 **Filename:** sources/mysql.sql
-```sql
+```mzsql
 {{ config(materialized='source') }}
 
 FROM MYSQL CONNECTION mysql_connection
@@ -283,7 +283,7 @@ models in, you should additionally force a dependency on the parent source
 model (`mysql`), as described in the [dbt documentation](https://docs.getdbt.com/reference/dbt-jinja-functions/ref#forcing-dependencies).
 
 **Filename:** staging/dep_subsources.sql
-```sql
+```mzsql
 -- depends_on: {{ ref('mysql') }}
 {{ config(materialized='view') }}
 
@@ -309,7 +309,7 @@ database.schema.table_b
 Create a [webhook source](/sql/create-source/webhook/).
 
 **Filename:** sources/webhook.sql
-```sql
+```mzsql
 {{ config(materialized='source') }}
 
 FROM WEBHOOK
@@ -352,7 +352,7 @@ in Materialize you can simply provide the SQL statement in the model (and skip
 the `materialized` configuration parameter).
 
 **Filename:** models/view_a.sql
-```sql
+```mzsql
 SELECT
     col_a, ...
 FROM {{ ref('kafka_topic_a') }}
@@ -370,7 +370,7 @@ databases), with [materialized views](/sql/create-materialized-view)
 that **continuously update** as the underlying data changes:
 
 **Filename:** models/materialized_view_a.sql
-```sql
+```mzsql
 {{ config(materialized='materialized_view') }}
 
 SELECT
@@ -394,7 +394,7 @@ can instruct dbt to create a sink using the custom `sink` materialization.
 Create a [Kafka sink](/sql/create-sink).
 
 **Filename:** sinks/kafka_topic_c.sql
-```sql
+```mzsql
 {{ config(materialized='sink') }}
 
 FROM {{ ref('materialized_view_a') }}
@@ -419,7 +419,7 @@ Use the `cluster` option to specify the [cluster](/sql/create-cluster/) in which
 a `materialized view`, `index`, `source`, or `sink` model is created. If
 unspecified, the default cluster for the connection is used.
 
-```sql
+```mzsql
 {{ config(materialized='materialized_view', cluster='cluster_a') }}
 ```
 
@@ -429,7 +429,7 @@ Use the `database` option to specify the [database](/sql/namespaces/#database-de
 in which a `source`, `view`, `materialized view` or `sink` is created. If
 unspecified, the default database for the connection is used.
 
-```sql
+```mzsql
 {{ config(materialized='materialized_view', database='database_a') }}
 ```
 
@@ -448,14 +448,14 @@ Component                            | Value     | Description
 
 ##### Creating a multi-column index
 
-```sql
+```mzsql
 {{ config(materialized='view',
           indexes=[{'columns': ['col_a','col_b'], 'cluster': 'cluster_a'}]) }}
 ```
 
 ##### Creating a default index
 
-```sql
+```mzsql
 {{ config(materialized='view',
     indexes=[{'default': True}]) }}
 ```
@@ -514,7 +514,7 @@ types are supported.
 A `not_null` constraint will be compiled to an [`ASSERT NOT NULL`](/sql/create-materialized-view/#non-null-assertions)
 option for the specified columns of the materialize view.
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW model_with_constraints
 WITH (
         ASSERT NOT NULL col_with_constraints
@@ -541,8 +541,13 @@ SELECT NULL AS col_with_constraints,
    SQL client connected to Materialize, double-check that all objects have been
    created:
 
-    ```sql
+    ```mzsql
     SHOW SOURCES [FROM database.schema];
+    ```
+
+    <p></p>
+
+    ```nofmt
            name
     -------------------
      mysql_table_a
@@ -550,13 +555,31 @@ SELECT NULL AS col_with_constraints,
      postgres_table_a
      postgres_table_b
      kafka_topic_a
+    ```
 
+    <p></p>
+
+    ```mzsql
     SHOW VIEWS;
+    ```
+
+    <p></p>
+
+    ```nofmt
            name
     -------------------
      view_a
+    ```
 
-     SHOW MATERIALIZED VIEWS;
+    <p></p>
+
+    ```mzsql
+    SHOW MATERIALIZED VIEWS;
+    ```
+
+    <p></p>
+
+    ```nofmt
            name
     -------------------
      materialized_view_a
@@ -633,14 +656,28 @@ trigger **real-time alerts** downstream.
    SQL client connected to Materialize, that the schema storing the tests has been
    created, as well as the test materialized views:
 
-    ```sql
+    ```mzsql
     SHOW SCHEMAS;
+    ```
+
+    <p></p>
+
+    ```nofmt
            name
     -------------------
      public
      public_etl_failure
+    ```
 
-    SHOW MATERIALIZED VIEWS FROM public_etl_failure;;
+    <p></p>
+
+    ```mzsql
+    SHOW MATERIALIZED VIEWS FROM public_etl_failure;
+    ```
+
+    <p></p>
+
+    ```nofmt
            name
     -------------------
      not_null_col_a
@@ -719,7 +756,7 @@ For "use-at-your-own-risk" workarounds, see [`dbt-core` #4226](https://github.co
 
     As an alternative, you can configure `persist-docs` in the config block of your models:
 
-    ```sql
+    ```mzsql
     {{ config(
         materialized=materialized_view,
         persist_docs={"relation": true, "columns": true}
@@ -730,8 +767,12 @@ For "use-at-your-own-risk" workarounds, see [`dbt-core` #4226](https://github.co
   files is persisted to Materialize in the [mz_internal.mz_comments](/sql/system-catalog/mz_internal/#mz_comments)
   system catalog table on every `dbt run`:
 
-    ```sql
+    ```mzsql
       SELECT * FROM mz_internal.mz_comments;
+    ```
+    <p></p>
+
+    ```nofmt
 
         id  |    object_type    | object_sub_id |              comment
       ------+-------------------+---------------+----------------------------------

--- a/doc/user/content/manage/dbt/development-workflows.md
+++ b/doc/user/content/manage/dbt/development-workflows.md
@@ -153,7 +153,7 @@ to hydrate before you can validate that it produces the expected results.
 1. As an example, imagine your dbt project includes the following models:
 
    **Filename:** _models/my_model_a.sql_
-   ```sql
+   ```mzsql
    SELECT
      1 AS a,
      1 AS id,
@@ -163,7 +163,7 @@ to hydrate before you can validate that it produces the expected results.
    ```
 
    **Filename:** _models/my_model_b.sql_
-   ```sql
+   ```mzsql
    SELECT
      2 as b,
      1 as id,
@@ -172,7 +172,7 @@ to hydrate before you can validate that it produces the expected results.
    ```
 
    **Filename:** models/my_model.sql
-   ```sql
+   ```mzsql
    SELECT
      a+b AS c,
      CONCAT(string_a, string_b) AS string_c,

--- a/doc/user/content/overview/timelines.md
+++ b/doc/user/content/overview/timelines.md
@@ -33,7 +33,7 @@ This can be used to allow multiple CDC sources, or a CDC source and system time 
 
 For example, to create two CDC sources that are joinable:
 
-```sql
+```mzsql
 CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'broker');
 
 CREATE SOURCE source_1
@@ -58,7 +58,7 @@ the `mz_epoch_ms` timeline.
 You **must** ensure that the `time` field's units are milliseconds since the Unix epoch.
 Joining this source to other system time sources will result in query delays until the timestamps being received are close to wall-clock `now()`.
 
-```sql
+```mzsql
 CREATE SOURCE source_3
   FROM KAFKA CONDITION kafka_conn (TOPIC 'topic-3')
   FORMAT AVRO USING SCHEMA 'schema'

--- a/doc/user/content/quickstarts/data-applications.md
+++ b/doc/user/content/quickstarts/data-applications.md
@@ -32,12 +32,12 @@ Materialize provides public Kafka topics and a Confluent Schema Registry for its
 
 1. In your `psql` terminal, create a new schema:
 
-    ```sql
+    ```mzsql
     CREATE SCHEMA shop;
     ```
 
 1. Create [a connection](/sql/create-connection/#confluent-schema-registry) to the Confluent Schema Registry:
-    ```sql
+    ```mzsql
     CREATE SECRET IF NOT EXISTS shop.csr_username AS '<TBD>';
     CREATE SECRET IF NOT EXISTS shop.csr_password AS '<TBD>';
 
@@ -50,7 +50,7 @@ Materialize provides public Kafka topics and a Confluent Schema Registry for its
 
 1. Create [a connection](/sql/create-connection/#kafka) to the Kafka broker:
 
-    ```sql
+    ```mzsql
     CREATE SECRET shop.kafka_password AS '<TBD>';
 
     CREATE CONNECTION shop.kafka_connection TO KAFKA (
@@ -63,7 +63,7 @@ Materialize provides public Kafka topics and a Confluent Schema Registry for its
 
 1. Create the sources, one per Kafka topic:
 
-    ```sql
+    ```mzsql
     CREATE SOURCE purchases
     FROM KAFKA CONNECTION shop.kafka_connection (TOPIC 'purchases')
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION shop.csr_basic_http
@@ -87,28 +87,28 @@ Materialized views compute and maintain the results of a query incrementally. Us
 Reuse your `psql` session and build the analytics:
 
 1. The sum of purchases:
-    ```sql
+    ```mzsql
     CREATE MATERIALIZED VIEW shop.total_purchases AS
     SELECT SUM(purchase_price * quantity) AS total_purchases
     FROM shop.purchases;
     ```
 
  1. The count of purchases:
-    ```sql
+    ```mzsql
     CREATE MATERIALIZED VIEW shop.count_purchases AS
     SELECT COUNT(1) AS count_purchases
     FROM shop.purchases;
     ```
 
 1. The count of users:
-    ```sql
+    ```mzsql
     CREATE MATERIALIZED VIEW shop.total_users AS
     SELECT COUNT(1) as total_users
     FROM shop.users;
     ```
 
 1. The best sellers items:
-    ```sql
+    ```mzsql
     CREATE MATERIALIZED VIEW shop.best_sellers AS
     SELECT I.name, I.category, COUNT(1) as purchases
     FROM shop.purchases P
@@ -123,14 +123,14 @@ Reuse your `psql` session and build the analytics:
 `SUBSCRIBE` can stream updates from materialized views as they occur. Use it to verify how the analytics change over time.
 
 1. Subscribe to the best sellers items:
-    ```sql
+    ```mzsql
     COPY (SUBSCRIBE (SELECT * FROM shop.best_sellers)) TO STDOUT;
     ```
 
 1. Press `CTRL + C` to interrupt the subscription after a few changes.
 
 1. Subscribe to the best sellers items filtering by the `gadgets` category:
-    ```sql
+    ```mzsql
     COPY (SUBSCRIBE ( SELECT * FROM shop.best_sellers WHERE category = 'gadgets' )) TO STDOUT;
     ```
 

--- a/doc/user/content/quickstarts/streaming-analytics.md
+++ b/doc/user/content/quickstarts/streaming-analytics.md
@@ -32,20 +32,20 @@ Materialize provides public Kafka topics and a Confluent Schema Registry for its
 
 1. In your `psql` terminal, create a new [cluster](https://materialize.com/docs/sql/create-cluster/) and [schema](https://materialize.com/docs/sql/create-schema/):
 
-    ```sql
+    ```mzsql
     CREATE CLUSTER demo (SIZE = '100cc');
     CREATE SCHEMA shop;
     ```
 
 1. Within the same `psql` terminal, we will switch to the cluster and schema we just created. This way everything done for this demo will be safely isolated from any other workflows we may have running:
 
-    ```sql
+    ```mzsql
     SET cluster = demo;
     SET SCHEMA shop;
     ```
 
 1. Create [a connection](/sql/create-connection/#confluent-schema-registry) to the Confluent Schema Registry:
-    ```sql
+    ```mzsql
     CREATE SECRET IF NOT EXISTS csr_username AS '<TBD>';
     CREATE SECRET IF NOT EXISTS csr_password AS '<TBD>';
 
@@ -58,7 +58,7 @@ Materialize provides public Kafka topics and a Confluent Schema Registry for its
 
 1. Create [a connection](/sql/create-connection/#kafka) to the Kafka broker:
 
-    ```sql
+    ```mzsql
     CREATE SECRET kafka_password AS '<TBD>';
 
     CREATE CONNECTION kafka_connection TO KAFKA (
@@ -71,7 +71,7 @@ Materialize provides public Kafka topics and a Confluent Schema Registry for its
 
 1. Create the sources, one per Kafka topic:
 
-    ```sql
+    ```mzsql
     CREATE SOURCE IF NOT EXISTS purchases
     FROM KAFKA CONNECTION kafka_connection (TOPIC 'mysql.shop.purchases')
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_basic_http
@@ -98,7 +98,7 @@ Reuse your `psql` session and build the analytics:
 
     A `MATERIALIZED VIEW` is persisted in durable storage and is incrementally updated as new data arrives.
 
-    ```sql
+    ```mzsql
     CREATE MATERIALIZED VIEW vip_purchases AS
         SELECT
             user_id,
@@ -115,7 +115,7 @@ Reuse your `psql` session and build the analytics:
 
     1. Create a view that takes the on-time bids and finds the highest bid for each auction:
 
-    ```sql
+    ```mzsql
     CREATE VIEW highest_bid_per_auction AS
         SELECT grp.auction_id,
                bid_id,
@@ -150,7 +150,7 @@ Reuse your `psql` session and build the analytics:
 `SUBSCRIBE` can stream updates from materialized views as they occur. Use it to verify how the analytics change over time.
 
 1. Subscribe to the vip purchases:
-    ```sql
+    ```mzsql
     COPY (SUBSCRIBE (SELECT * FROM vip_purchases)) TO STDOUT;
     ```
 

--- a/doc/user/content/quickstarts/user-workflows.md
+++ b/doc/user/content/quickstarts/user-workflows.md
@@ -43,7 +43,7 @@ Sources are the first step in most Materialize projects.
 
 1. In your `psql` terminal, create [a connection](/sql/create-connection/#confluent-schema-registry) to the Confluent Schema Registry:
 
-    ```sql
+    ```mzsql
     CREATE SECRET IF NOT EXISTS csr_username AS '<TBD>';
     CREATE SECRET IF NOT EXISTS csr_password AS '<TBD>';
 
@@ -56,7 +56,7 @@ Sources are the first step in most Materialize projects.
 
 1. Create [a connection](/sql/create-connection/#kafka) to the Kafka broker:
 
-    ```sql
+    ```mzsql
     CREATE SECRET kafka_password AS '<TBD>';
 
     CREATE CONNECTION ecommerce_kafka_connection TO KAFKA (
@@ -69,7 +69,7 @@ Sources are the first step in most Materialize projects.
 
 1. Create the sources:
 
-    ```sql
+    ```mzsql
     CREATE SOURCE purchases
         FROM KAFKA CONNECTION ecommerce_kafka_connection (TOPIC 'mysql.shop.purchases')
         FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION schema_registry
@@ -92,7 +92,7 @@ Sources are the first step in most Materialize projects.
 
     Now if you run `SHOW SOURCES;`, you should see the four sources we created:
 
-    ```sql
+    ```mzsql
     materialize=> SHOW SOURCES;
         name
     ----------------
@@ -109,7 +109,7 @@ With JSON-formatted messages, we don't know the schema so the [JSON is pulled in
 
 1. Create a [view](/sql/create-view/) that casts the raw bytes into a JSON object:
 
-    ```sql
+    ```mzsql
     CREATE VIEW v_pageviews AS
         SELECT
             (data->'user_id')::int AS user_id,
@@ -123,7 +123,7 @@ With JSON-formatted messages, we don't know the schema so the [JSON is pulled in
 
 1. Define a view containing the incomplete orders:
 
-    ```sql
+    ```mzsql
     CREATE VIEW incomplete_purchases AS
         SELECT
             users.id AS user_id,
@@ -143,7 +143,7 @@ With JSON-formatted messages, we don't know the schema so the [JSON is pulled in
 
     A materialized view is persisted in durable storage and is incrementally updated as new data arrives.
 
-    ```sql
+    ```mzsql
     CREATE MATERIALIZED VIEW last_user_visit AS
         SELECT DISTINCT ON(user_id) user_id, received_at
         FROM v_pageviews
@@ -152,7 +152,7 @@ With JSON-formatted messages, we don't know the schema so the [JSON is pulled in
 
 1. Create materialized view to get all the users that have been inactive for the last 3 minutes:
 
-    ```sql
+    ```mzsql
     CREATE MATERIALIZED VIEW inactive_users_last_3_mins AS
         SELECT
             user_id,
@@ -166,7 +166,7 @@ With JSON-formatted messages, we don't know the schema so the [JSON is pulled in
 
 1. Create a materialized view to join the incomplete purchases with the inactive users to get the abandoned carts:
 
-    ```sql
+    ```mzsql
     CREATE MATERIALIZED VIEW abandoned_cart AS
         SELECT
             incomplete_purchases.user_id,
@@ -182,13 +182,13 @@ With JSON-formatted messages, we don't know the schema so the [JSON is pulled in
 
 1. To see the changes in the `abandoned_cart` materialized view as new data arrives, you can use [`SUBSCRIBE`](/sql/subscribe):
 
-    ```sql
+    ```mzsql
     SELECT * FROM abandoned_cart LIMIT 10;
     ```
 
 1. To see the changes in the `abandoned_cart` materialized view as new data arrives, you can use [`SUBSCRIBE`](/sql/subscribe):
 
-    ```sql
+    ```mzsql
     COPY ( SUBSCRIBE ( SELECT * FROM abandoned_cart ) ) TO STDOUT;
     ```
 

--- a/doc/user/content/releases/v0.100.md
+++ b/doc/user/content/releases/v0.100.md
@@ -12,7 +12,7 @@ patch: 1
 * Add a [`MAP` expression](/sql/types/map/#construction) that allows constructing a `map`
   from a list of key–value pairs or a subquery.
 
-  ```sql
+  ```mzsql
   SELECT MAP['a' => 1, 'b' => 2];
 
        map

--- a/doc/user/content/releases/v0.27.md
+++ b/doc/user/content/releases/v0.27.md
@@ -73,7 +73,7 @@ substantial breaking changes from [v0.26 LTS].
   To emulate the old behavior, explicitly create a default index after creating
   a view:
 
-  ```sql
+  ```mzsql
   CREATE VIEW <name> ...;
   CREATE DEFAULT INDEX ON <name>;
   ```
@@ -84,7 +84,7 @@ substantial breaking changes from [v0.26 LTS].
   a default index. Instead, you must explicitly create a default index after
   creating a source:
 
-  ```sql
+  ```mzsql
   CREATE SOURCE <name> ...;
   CREATE DEFAULT INDEX ON <name>;
   ```
@@ -141,7 +141,7 @@ from Materialize v0.26 LTS for Materialize v0.27:
 
 Change from:
 
-```sql
+```mzsql
 CREATE SOURCE kafka_sasl
   FROM KAFKA BROKER 'broker.tld:9092' TOPIC 'top-secret' WITH (
       security_protocol = 'SASL_SSL',
@@ -157,7 +157,7 @@ CREATE SOURCE kafka_sasl
 
 to:
 
-```sql
+```mzsql
 CREATE SECRET kafka_password AS '<BROKER_PASSWORD>';
 CREATE SECRET csr_password AS '<SCHEMA_REGISTRY_PASSWORD>';
 
@@ -182,13 +182,13 @@ CREATE SOURCE kafka_top_secret
 
 Change from:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW v AS SELECT ...
 ```
 
 to:
 
-```sql
+```mzsql
 CREATE VIEW v AS SELECT ...
 CREATE DEFAULT INDEX ON v
 ```
@@ -197,13 +197,13 @@ CREATE DEFAULT INDEX ON v
 
 Change from:
 
-```sql
+```mzsql
 CREATE MATERIALIZED SOURCE src ...
 ```
 
 to:
 
-```sql
+```mzsql
 CREATE SOURCE src ...
 ```
 
@@ -218,13 +218,13 @@ CREATE INDEX on src (lookup_col1, lookup_col2)
 
 Change from:
 
-```sql
+```mzsql
 COPY (TAIL t) TO STDOUT
 ```
 
 to:
 
-```sql
+```mzsql
 COPY (SUBSCRIBE t) TO STDOUT
 ```
 

--- a/doc/user/content/releases/v0.28.md
+++ b/doc/user/content/releases/v0.28.md
@@ -18,7 +18,7 @@ aliases: v0.28.0
 
   **New syntax**
 
-  ```sql
+  ```mzsql
   CREATE CONNECTION kafka_connection TO KAFKA (
     BROKER 'unique-jellyfish-0000-kafka.upstash.io:9092',
     SASL MECHANISMS = 'SCRAM-SHA-256',
@@ -29,7 +29,7 @@ aliases: v0.28.0
 
   **Old syntax**
 
-  ```sql
+  ```mzsql
   CREATE CONNECTION kafka_connection FOR KAFKA
     BROKER 'unique-jellyfish-0000-kafka.upstash.io:9092',
     SASL MECHANISMS = 'SCRAM-SHA-256',
@@ -56,7 +56,7 @@ aliases: v0.28.0
   cluster. For the best performance when executing `SHOW` commands, switch to
   the `mz_introspection` cluster using:
 
-  ```sql
+  ```mzsql
   SET CLUSTER = mz_introspection;
   ```
 

--- a/doc/user/content/releases/v0.29.md
+++ b/doc/user/content/releases/v0.29.md
@@ -15,7 +15,7 @@ patch: 3
   to literal values, particularly in cases where e.g. `col_a` was of type
   `VARCHAR`:
 
-  ```sql
+  ```mzsql
   SELECT * FROM table_foo WHERE col_a = 'hello';
   ```
 

--- a/doc/user/content/releases/v0.30.md
+++ b/doc/user/content/releases/v0.30.md
@@ -19,7 +19,7 @@ patch: 2
   [PostgreSQL source](/sql/create-source/postgres/), specifying the table and
   column containing an unsupported type:
 
-  ```sql
+  ```mzsql
   CREATE SOURCE pg_source
 	FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
 	FOR ALL TABLES

--- a/doc/user/content/releases/v0.32.md
+++ b/doc/user/content/releases/v0.32.md
@@ -11,7 +11,7 @@ patch: 4
   [PostgreSQL source](/sql/create-source/postgres/), using the new `TEXT
   COLUMNS` option:
 
-  ```sql
+  ```mzsql
   CREATE SOURCE mz_source
 	FROM POSTGRES CONNECTION pg_connection (
 	  PUBLICATION 'mz_source',
@@ -28,7 +28,7 @@ patch: 4
 * Improve error message for unexpected or mismatched type catalog errors,
   specifying the catalog item type:
 
-  ```sql
+  ```mzsql
   DROP VIEW mz_table;
 
   ERROR:  "materialize.public.mz_table" is a table not a view

--- a/doc/user/content/releases/v0.33.md
+++ b/doc/user/content/releases/v0.33.md
@@ -11,7 +11,7 @@ patch: 3
 to an SSH bastion server.
 
 
-  ```sql
+  ```mzsql
   CREATE CONNECTION kafka_connection TO KAFKA (
     BROKERS (
       'broker1:9092' USING SSH TUNNEL ssh_connection,

--- a/doc/user/content/releases/v0.36.md
+++ b/doc/user/content/releases/v0.36.md
@@ -19,7 +19,7 @@ patch: 2
   all extant cluster replicas as a % of the total allocation, you can now
   use:
 
-  ```sql
+  ```mzsql
   SELECT
     r.id AS replica_id,
     m.process_id,

--- a/doc/user/content/releases/v0.37.md
+++ b/doc/user/content/releases/v0.37.md
@@ -15,7 +15,7 @@ patch: 3
   to the system catalog. This view allows you to monitor the resource utilization for
   all extant cluster replicas as a % of the total resource allocation:
 
-  ```sql
+  ```mzsql
   SELECT * FROM mz_internal.mz_cluster_replica_utilization;
   ```
 

--- a/doc/user/content/releases/v0.39.md
+++ b/doc/user/content/releases/v0.39.md
@@ -16,7 +16,7 @@ patch: 3
   example, you can now get an overview of the relationship between user-defined
   objects using:
 
-  ```sql
+  ```mzsql
   SELECT
     object_id,
 	o.name,
@@ -41,7 +41,7 @@ patch: 3
   the value returned by the existing `mz_version()` function, but the parameter
   form can be more convenient for downstream applications.
 
-  ```sql
+  ```mzsql
   SHOW mz_version;
   ```
 

--- a/doc/user/content/releases/v0.40.md
+++ b/doc/user/content/releases/v0.40.md
@@ -9,7 +9,7 @@ released: true
 * Allow configuring an `AVAILABILITY ZONE` option for each broker when creating
   a Kafka connection using [AWS PrivateLink](/sql/create-connection/#kafka-network-security):
 
-  ```sql
+  ```mzsql
   CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
       SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
       AVAILABILITY ZONES ('use1-az1', 'use1-az4')

--- a/doc/user/content/releases/v0.41.md
+++ b/doc/user/content/releases/v0.41.md
@@ -17,7 +17,7 @@ patch: 1
   name of the replication slot created in the upstream PostgreSQL
   database that Materialize will create for each source.
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_internal.mz_postgres_sources;
 
        id   |             replication_slot
@@ -32,7 +32,7 @@ patch: 1
 
   **New syntax**
 
-  ```sql
+  ```mzsql
   CREATE SOURCE kafka_connection
     IN CLUSTER quickstart
     FROM KAFKA CONNECTION qck_kafka_connection (TOPIC 'test_topic')

--- a/doc/user/content/releases/v0.43.md
+++ b/doc/user/content/releases/v0.43.md
@@ -17,7 +17,7 @@ released: true
   PHYSICAL PLAN FOR [MATERIALIZED] VIEW $view_name` to print the name of the
   view. The output will now look similar to:
 
-  ```sql
+  ```mzsql
   EXPLAIN VIEW v;
 
       Optimized Plan

--- a/doc/user/content/releases/v0.45.md
+++ b/doc/user/content/releases/v0.45.md
@@ -15,7 +15,7 @@ released: true
 
   **Example**
 
-  ```sql
+  ```mzsql
   -- Given a "purchases" Kafka source, a "purchases_progress"
   -- subsource is automatically created
   SELECT partition, "offset"
@@ -48,7 +48,7 @@ released: true
 * Support `options` settings on connection startup. As an example, you can
 now specify the cluster to connect to in the `psql` connection string:
 
-  ```sql
+  ```mzsql
   psql "postgres://user%40domain.com@host:6875/materialize?options=--cluster%3Dfoo"
   ```
 
@@ -74,7 +74,7 @@ now specify the cluster to connect to in the `psql` connection string:
 
   **Example**
 
-  ```sql
+  ```mzsql
   CREATE VIEW foo AS SELECT 'bar';
 
   ERROR:  view "materialize.public.foo" already exists

--- a/doc/user/content/releases/v0.48.md
+++ b/doc/user/content/releases/v0.48.md
@@ -25,7 +25,7 @@ patch: 4
 * Support specifying multiple roles in the [`GRANT ROLE`](/sql/grant-role) and
   [`REVOKE ROLE`](/sql/revoke-role) commands.
 
-  ```sql
+  ```mzsql
   -- Grant role
   GRANT data_scientist TO joe, mike;
 

--- a/doc/user/content/releases/v0.51.md
+++ b/doc/user/content/releases/v0.51.md
@@ -13,7 +13,7 @@ patch: 1
   [PostgreSQL source](/sql/create-source/postgres/), using the new `FOR SCHEMAS(...)`
   option:
 
-  ```sql
+  ```mzsql
   CREATE SOURCE mz_source
     FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
     FOR SCHEMAS (public, finance)
@@ -33,7 +33,7 @@ patch: 1
   replaces a set of characters in a string with another set of characters
   (one by one, regardless of the order of those characters):
 
-  ```sql
+  ```mzsql
   SELECT translate('12345', '134', 'ax');
 
 	 translate

--- a/doc/user/content/releases/v0.52.md
+++ b/doc/user/content/releases/v0.52.md
@@ -38,7 +38,7 @@ mentioning it here."
   To see your current credit consumption rate, measured in credits per hour, run
   the following query:
 
-  ```sql
+  ```mzsql
   SELECT sum(s.credits_per_hour) AS credit_consumption_rate
     FROM mz_cluster_replicas r
     JOIN mz_internal.mz_cluster_replica_sizes s ON r.size = s.size;

--- a/doc/user/content/releases/v0.53.md
+++ b/doc/user/content/releases/v0.53.md
@@ -13,7 +13,7 @@ released: true
   join condition in the statement below will be referenceable as `lhs.c`,
   `rhs.c`, and `joint.c`.
 
-  ```sql
+  ```mzsql
   SELECT *
   FROM lhs
   JOIN rhs USING (c) AS joint;

--- a/doc/user/content/releases/v0.54.md
+++ b/doc/user/content/releases/v0.54.md
@@ -31,7 +31,7 @@ released: true
     roles, as well as the `ALL` keyword to indicate that all privileges should
     be granted or revoked.
 
-    ```sql
+    ```mzsql
     GRANT SELECT ON mv TO joe, mike;
 
     GRANT ALL ON CLUSTER dev TO joe;

--- a/doc/user/content/releases/v0.55.md
+++ b/doc/user/content/releases/v0.55.md
@@ -13,7 +13,7 @@ patch: 6
   current_schema`, respectively. From this release, the following sequence of
   commands provide the same functionality:
 
-  ```sql
+  ```mzsql
   materialize=> SET schema = finance;
   SET
   materialize=> SHOW schema;
@@ -23,7 +23,7 @@ patch: 6
   (1 row)
   ```
 
-  ```sql
+  ```mzsql
    materialize=> SET search_path = finance, public;
    SET
    materialize=> SELECT current_schema;

--- a/doc/user/content/releases/v0.56.md
+++ b/doc/user/content/releases/v0.56.md
@@ -20,7 +20,7 @@ patch: 4
   * Add the `has_table_privilege` access control function, which allows a role
     to query if it has privileges on a specific relation:
 
-    ```sql
+    ```mzsql
     SELECT has_table_privilege('marta','auction_house','select');
 
 	 has_table_privilege

--- a/doc/user/content/releases/v0.57.md
+++ b/doc/user/content/releases/v0.57.md
@@ -23,7 +23,7 @@ patch: 10
 * Add `RESET schema` as an alias to `RESET search_path`. From this release, the
   following sequence of commands provide the same functionality:
 
-  ```sql
+  ```mzsql
   materialize=> SET schema = finance;
   SET
   materialize=> SHOW schema;
@@ -41,7 +41,7 @@ patch: 10
   (1 row)
   ```
 
-  ```sql
+  ```mzsql
    materialize=> SET search_path = finance, public;
    SET
    materialize=> SELECT current_schema;

--- a/doc/user/content/releases/v0.59.md
+++ b/doc/user/content/releases/v0.59.md
@@ -17,7 +17,7 @@ supported in the next release.
 
 * Support parsing multi-dimensional arrays, including multi-dimensional empty arrays.
 
-  ```sql
+  ```mzsql
   materialize=> SELECT '{{1}, {2}}'::int[];
      arr
   -----------

--- a/doc/user/content/releases/v0.60.md
+++ b/doc/user/content/releases/v0.60.md
@@ -22,7 +22,7 @@ flag. The flag was raised in v0.60 -— so mentioning it here."
 
   **New syntax**
 
-  ```sql
+  ```mzsql
   CREATE SOURCE json_source
   FROM KAFKA CONNECTION kafka_connection (TOPIC 'ch_anges')
   FORMAT JSON
@@ -39,7 +39,7 @@ flag. The flag was raised in v0.60 -— so mentioning it here."
 
   **Old syntax**
 
-  ```sql
+  ```mzsql
   CREATE SOURCE json_source
   FROM KAFKA CONNECTION kafka_connection (TOPIC 'ch_anges')
   FORMAT BYTES

--- a/doc/user/content/releases/v0.62.md
+++ b/doc/user/content/releases/v0.62.md
@@ -21,7 +21,7 @@ patch: 4
   For a given JSON-formatted source, the following query cannot
   benefit from filter pushdown:
 
-  ```sql
+  ```mzsql
   SELECT *
   FROM foo
   WHERE (data ->> 'timestamp')::timestamp > mz_now();
@@ -29,7 +29,7 @@ patch: 4
 
   But can be optimized as:
 
-  ```sql
+  ```mzsql
   SELECT *
   FROM foo
   WHERE try_parse_monotonic_iso8601_timestamp(data ->> 'timestamp') > mz_now();

--- a/doc/user/content/releases/v0.67.md
+++ b/doc/user/content/releases/v0.67.md
@@ -18,7 +18,7 @@ here."
   rows as a series of inserts, updates and deletes within each distinct
   timestamp. The output rows will have the following structure:
 
-  ```sql
+  ```mzsql
    SUBSCRIBE mview ENVELOPE UPSERT (KEY (key));
 
    mz_timestamp | mz_state | key  | value

--- a/doc/user/content/releases/v0.69.md
+++ b/doc/user/content/releases/v0.69.md
@@ -21,7 +21,7 @@ flag. The flag was raised in v0.69 — so mentioning it here."
   using the new [`VALIDATE CONNECTION`](https://materialize.com/docs/sql/validate-connection/)
   syntax:
 
-   ```sql
+   ```mzsql
    VALIDATE CONNECTION ssh_connection;
    ```
 
@@ -41,7 +41,7 @@ flag. The flag was raised in v0.69 — so mentioning it here."
 * Add the `IN CLUSTER` option to the `SHOW { SOURCES | SINKS }` commands to
   restrict the objects listed to a specific cluster.
 
-  ```sql
+  ```mzsql
   SHOW SOURCES;
   ```
   ```nofmt
@@ -51,7 +51,7 @@ flag. The flag was raised in v0.69 — so mentioning it here."
    my_postgres_source | postgres |       | c2
   ```
 
-  ```sql
+  ```mzsql
   SHOW SOURCES IN CLUSTER c2;
   ```
   ```nofmt

--- a/doc/user/content/releases/v0.73.md
+++ b/doc/user/content/releases/v0.73.md
@@ -19,7 +19,7 @@ behind a feature flag."
 
     **Example:**
 
-	```sql
+	```mzsql
 	CREATE TABLE t (c1 int, c2 text);
 	COMMENT ON TABLE t IS 'materialize comment on t';
 	COMMENT ON COLUMN t.c2 IS 'materialize comment on t.c2';

--- a/doc/user/content/releases/v0.74.md
+++ b/doc/user/content/releases/v0.74.md
@@ -16,7 +16,7 @@ deployments."
 * Bring back support for [window aggregations](/sql/functions/#window-func), or
   aggregate functions (e.g., `sum`, `avg`) that use an `OVER` clause.
 
-  ```sql
+  ```mzsql
   CREATE TABLE sales(time int, amount int);
 
   INSERT INTO sales VALUES (1,3), (2,6), (3,1), (4,5), (5,5), (6,6);
@@ -50,7 +50,7 @@ deployments."
 * Improve error message for possibly mistyped column names, suggesting similarly
   named columns if the one specified cannot be found.
 
-  ```sql
+  ```mzsql
   CREATE SOURCE case_sensitive_names
   FROM POSTGRES CONNECTION pg (
     PUBLICATION 'mz_source',

--- a/doc/user/content/releases/v0.76.md
+++ b/doc/user/content/releases/v0.76.md
@@ -12,7 +12,7 @@ released: true
   using the `SSH TUNNEL` top-level option. The default connection will be used
   to connect to any new or unlisted brokers.
 
-  ```sql
+  ```mzsql
   CREATE CONNECTION kafka_connection TO KAFKA (
       BROKER 'broker1:9092',
       SSH TUNNEL ssh_connection

--- a/doc/user/content/releases/v0.77.md
+++ b/doc/user/content/releases/v0.77.md
@@ -16,7 +16,7 @@ patch: 1
 
   **Example**
 
-  ```sql
+  ```mzsql
   CREATE SOURCE webhook_with_time_based_rejection
   IN CLUSTER webhook_cluster
   FROM WEBHOOK
@@ -33,7 +33,7 @@ patch: 1
 
   **Example**
 
-  ```sql
+  ```mzsql
   SELECT timezone_offset('America/New_York', '2023-11-05T06:00:00+00')
   ----
   (EST,-05:00:00,00:00:00)

--- a/doc/user/content/releases/v0.78.md
+++ b/doc/user/content/releases/v0.78.md
@@ -23,7 +23,7 @@ patch: 15
 sources, which allows extracting individual headers from Kafka messages and
 expose them as columns of the source.
 
-  ```sql
+  ```mzsql
   CREATE SOURCE kafka_metadata
     FROM KAFKA CONNECTION kafka_connection (TOPIC 'data')
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
@@ -31,7 +31,7 @@ expose them as columns of the source.
     ENVELOPE NONE
   ```
 
-  ```sql
+  ```mzsql
   SELECT
       id,
       seller,

--- a/doc/user/content/releases/v0.83.md
+++ b/doc/user/content/releases/v0.83.md
@@ -18,7 +18,7 @@ patch: 4
   these objects in a context that requires indexing, we recommend creating a
   view over the catalog objects, and indexing that view instead.
 
-  ```sql
+  ```mzsql
   CREATE VIEW mz_objects_indexed AS
   SELECT  o.id AS object_id,
           s.name AS schema_name

--- a/doc/user/content/releases/v0.84.md
+++ b/doc/user/content/releases/v0.84.md
@@ -17,7 +17,7 @@ patch: 4
 
   **New syntax**
 
-  ```sql
+  ```mzsql
   --Create the object in a specific cluster
   CREATE SOURCE json_source
   IN CLUSTER some_cluster
@@ -32,7 +32,7 @@ patch: 4
 
   **Deprecated syntax**
 
-  ```sql
+  ```mzsql
   --Create the object in a dedicated (linked) cluster
   CREATE SOURCE json_source
   FROM KAFKA CONNECTION kafka_connection (TOPIC 'ch_anges')

--- a/doc/user/content/releases/v0.86.md
+++ b/doc/user/content/releases/v0.86.md
@@ -12,7 +12,7 @@ patch: 1
 * Add support for [handling batched events](https://materialize.com/docs/sql/create-source/webhook/#handling-batch-events)
   in the webhook source via the new `JSON ARRAY` format.
 
-  ```sql
+  ```mzsql
   CREATE SOURCE webhook_source_json_batch IN CLUSTER my_cluster FROM WEBHOOK
   BODY FORMAT JSON ARRAY
   INCLUDE HEADERS;
@@ -27,7 +27,7 @@ patch: 1
   ]
   ```
 
-  ```sql
+  ```mzsql
   SELECT COUNT(body) FROM webhook_source_json_batch;
   ----
   3
@@ -37,7 +37,7 @@ patch: 1
   Use the new `map_build` function to turn all headers exposed via `INCLUDE
   HEADERS` into a `map`, which makes it easier to extract header values.
 
-   ```sql
+   ```mzsql
    SELECT
        id,
        seller,

--- a/doc/user/content/releases/v0.87.md
+++ b/doc/user/content/releases/v0.87.md
@@ -12,7 +12,7 @@ patch: 2
 * Add support for handling batched events formatted as `NDJSON` in the
   [webhook source](https://materialize.com/docs/sql/create-source/webhook/).
 
-  ```sql
+  ```mzsql
   CREATE SOURCE webhook_json IN CLUSTER quickstart FROM WEBHOOK
   BODY FORMAT JSON;
 
@@ -30,7 +30,7 @@ patch: 2
   used to connect to all brokers, and is exclusive with the `BROKER` and
   `BROKERS` options.
 
-  ```sql
+  ```mzsql
   CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
       SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
       AVAILABILITY ZONES ('use1-az1')

--- a/doc/user/content/releases/v0.88.md
+++ b/doc/user/content/releases/v0.88.md
@@ -11,7 +11,7 @@ patch: 1
 
 * Allow `LIMIT` expressions to contain parameters.
 
-	```sql
+	```mzsql
 	  PREPARE foo AS SELECT generate_series(1, 10) LIMIT $1;
 	  EXECUTE foo (7::bigint);
 

--- a/doc/user/content/releases/v0.91.md
+++ b/doc/user/content/releases/v0.91.md
@@ -17,7 +17,7 @@ behind a feature flag."
 
   **Syntax**
 
-  ```sql
+  ```mzsql
   CREATE SECRET mysqlpass AS '<MYSQL_PASSWORD>';
 
   CREATE CONNECTION mysql_connection TO MYSQL (

--- a/doc/user/content/releases/v0.97.md
+++ b/doc/user/content/releases/v0.97.md
@@ -18,7 +18,7 @@ patch: 3
   string with the first character of every word in upper case and all other
   characters in lower case.
 
-  ```sql
+  ```mzsql
   SELECT initcap('bye DrivEr');
 
     initcap

--- a/doc/user/content/releases/v0.99.md
+++ b/doc/user/content/releases/v0.99.md
@@ -15,7 +15,7 @@ patch: 2
 
   **Syntax**
 
-  ```sql
+  ```mzsql
   CREATE CONNECTION s3_conn
    TO AWS (ASSUME ROLE ARN = 'arn:aws:iam::000000000000:role/Materializes3Exporter');
 
@@ -45,11 +45,11 @@ patch: 2
 
   **Syntax**
 
-  ```sql
+  ```mzsql
   ALTER MATERIALIZED VIEW winning_bids SET (RETAIN HISTORY FOR '2hr');
   ```
 
-  ```sql
+  ```mzsql
   ALTER MATERIALIZED VIEW winning_bids RESET (RETAIN HISTORY);
   ```
 

--- a/doc/user/content/serve-results/deepnote.md
+++ b/doc/user/content/serve-results/deepnote.md
@@ -40,7 +40,7 @@ This guide walks you through the steps required to use the collaborative data no
 1. Create a new SQL block.
 
 2. Inside the block, select the new **Materialize** integration and paste the following query:
-    ```sql
+    ```mzsql
     SELECT
         number,
         row_num

--- a/doc/user/content/serve-results/hex.md
+++ b/doc/user/content/serve-results/hex.md
@@ -41,7 +41,7 @@ This guide walks you through the steps required to use the collaborative data no
 1. Create a new SQL cell.
 
 2. Inside the cell, select the new **Materialize** connection and paste the following query:
-    ```sql
+    ```mzsql
     SELECT
         number,
         row_num

--- a/doc/user/content/serve-results/power-bi.md
+++ b/doc/user/content/serve-results/power-bi.md
@@ -64,7 +64,7 @@ To work around this Power BI limitation, you can use one of the following option
 
     For example, if you have a materialized view called `my_view`, you can create a view called `my_view_bi` with the following SQL:
 
-    ```sql
+    ```mzsql
     CREATE VIEW my_view_bi AS SELECT * FROM my_view;
     ```
 

--- a/doc/user/content/serve-results/s3.md
+++ b/doc/user/content/serve-results/s3.md
@@ -152,14 +152,14 @@ Next, you must attach the policy you just created to a Materialize-specific
    AWS account, and  `<role>` with the name of the role you created in the
    previous step:
 
-   ```sql
+   ```mzsql
    CREATE CONNECTION aws_connection
       TO AWS (ASSUME ROLE ARN = 'arn:aws:iam::<account-id>:role/<role>');
    ```
 
 1. Retrieve the external ID for the connection:
 
-   ```sql
+   ```mzsql
    SELECT awsc.id, external_id
     FROM mz_internal.mz_aws_connections awsc
     JOIN mz_connections c ON awsc.id = c.id
@@ -186,7 +186,7 @@ Next, you must attach the policy you just created to a Materialize-specific
 1. Back in Materialize, validate the AWS connection you created using the
    [`VALIDATE CONNECTION`](/sql/validate-connection) command.
 
-   ```sql
+   ```mzsql
    VALIDATE CONNECTION aws_connection;
    ```
 
@@ -201,7 +201,7 @@ command, and the AWS connection you created in the previous step.
 {{< tabs >}}
 {{< tab "Parquet">}}
 
-```sql
+```mzsql
 COPY some_object TO 's3://<bucket>/<path>'
 WITH (
     AWS CONNECTION = aws_connection,
@@ -216,7 +216,7 @@ type support and conversion, check the [reference documentation](/sql/copy-to/#c
 
 {{< tab "CSV">}}
 
-```sql
+```mzsql
 COPY some_object TO 's3://<bucket>/<path>'
 WITH (
     AWS CONNECTION = aws_connection,

--- a/doc/user/content/serve-results/sink-troubleshooting.md
+++ b/doc/user/content/serve-results/sink-troubleshooting.md
@@ -14,7 +14,7 @@ menu:
 ## Why isn't my sink exporting data?
 First, look for errors in [`mz_sink_statuses`](/sql/system-catalog/mz_internal/#mz_sink_statuses):
 
-```sql
+```mzsql
 SELECT * FROM mz_internal.mz_sink_statuses
 WHERE name = <SINK_NAME>;
 ```
@@ -31,7 +31,7 @@ Repeatedly query the
 [`mz_sink_statistics`](/sql/system-catalog/mz_internal/#mz_sink_statistics)
 table and look for ingestion statistics that advance over time:
 
-```sql
+```mzsql
 SELECT
     messages_staged,
     messages_committed,

--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -23,7 +23,7 @@ cluster, use [`ALTER ... RENAME`](/sql/alter-rename/).
 
 Alter cluster to two replicas:
 
-```sql
+```mzsql
 ALTER CLUSTER c1 SET (REPLICATION FACTOR 2);
 ```
 
@@ -31,7 +31,7 @@ ALTER CLUSTER c1 SET (REPLICATION FACTOR 2);
 
 Alter cluster to size `100cc`:
 
-```sql
+```mzsql
 ALTER CLUSTER c1 SET (SIZE '100cc');
 ```
 
@@ -47,7 +47,7 @@ by following the instructions below.
 
 Alter the `managed` status of a cluster to managed:
 
-```sql
+```mzsql
 ALTER CLUSTER c1 SET (MANAGED);
 ```
 

--- a/doc/user/content/sql/alter-default-privileges.md
+++ b/doc/user/content/sql/alter-default-privileges.md
@@ -67,19 +67,19 @@ type for sources, views, and materialized views.
 
 ## Examples
 
-```sql
+```mzsql
 ALTER DEFAULT PRIVILEGES FOR ROLE mike GRANT SELECT ON TABLES TO joe;
 ```
 
-```sql
+```mzsql
 ALTER DEFAULT PRIVILEGES FOR ROLE interns IN DATABASE dev GRANT ALL PRIVILEGES ON TABLES TO intern_managers;
 ```
 
-```sql
+```mzsql
 ALTER DEFAULT PRIVILEGES FOR ROLE developers REVOKE USAGE ON SECRETS FROM project_managers;
 ```
 
-```sql
+```mzsql
 ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO managers;
 ```
 

--- a/doc/user/content/sql/alter-owner.md
+++ b/doc/user/content/sql/alter-owner.md
@@ -26,11 +26,11 @@ index owner is always kept in-sync with the owner of the underlying relation.
 
 ## Examples
 
-```sql
+```mzsql
 ALTER TABLE t OWNER TO joe;
 ```
 
-```sql
+```mzsql
 ALTER CLUSTER REPLICA production.r1 OWNER TO admin;
 ```
 

--- a/doc/user/content/sql/alter-rename.md
+++ b/doc/user/content/sql/alter-rename.md
@@ -40,7 +40,7 @@ You cannot rename items if:
     You can only rename either view named `v1` if every dependent view's query
     that contains references to both views fully qualifies all references, e.g.
 
-    ```sql
+    ```mzsql
     CREATE VIEW v2 AS
     SELECT *
     FROM db1.s1.v1
@@ -56,7 +56,7 @@ You cannot rename items if:
 
     In the following examples, `v1` could _not_ be renamed:
 
-    ```sql
+    ```mzsql
     CREATE VIEW v3 AS
     SELECT *
     FROM v1
@@ -64,7 +64,7 @@ You cannot rename items if:
     ON v1.a = v2.v1
     ```
 
-    ```sql
+    ```mzsql
     CREATE VIEW v4 AS
     SELECT *
     FROM v1
@@ -81,7 +81,7 @@ whether that identifier is used implicitly or explicitly.
 
 Consider this example:
 
-```sql
+```mzsql
 CREATE VIEW v5 AS
 SELECT *
 FROM d1.s1.v2
@@ -102,7 +102,7 @@ However, you could rename `v1` to any other [legal identifier](/sql/identifiers)
 
 ## Examples
 
-```sql
+```mzsql
 SHOW VIEWS;
 ```
 ```nofmt
@@ -110,7 +110,7 @@ SHOW VIEWS;
 -------
  v1
 ```
-```sql
+```mzsql
 ALTER VIEW v1 RENAME TO v2;
 SHOW VIEWS;
 ```

--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -61,10 +61,10 @@ current configuration parameter defaults for a role, see [`mz_role_parameters`](
 
 #### Altering the attributes of a role
 
-```sql
+```mzsql
 ALTER ROLE rj INHERIT;
 ```
-```sql
+```mzsql
 SELECT name, inherit FROM mz_roles WHERE name = 'rj';
 ```
 ```nofmt
@@ -73,7 +73,7 @@ rj  true
 
 #### Setting configuration parameters for a role
 
-```sql
+```mzsql
 SHOW cluster;
 quickstart
 
@@ -93,7 +93,7 @@ quickstart
 ```
 
 ##### Non-inheritance
-```sql
+```mzsql
 CREATE ROLE team;
 CREATE ROLE member;
 

--- a/doc/user/content/sql/alter-secret.md
+++ b/doc/user/content/sql/alter-secret.md
@@ -47,7 +47,7 @@ After an `ALTER SECRET` command is executed:
 
 ## Examples
 
-```sql
+```mzsql
 ALTER SECRET upstash_kafka_ca_cert AS decode('c2VjcmV0Cg==', 'base64');
 ```
 

--- a/doc/user/content/sql/alter-sink.md
+++ b/doc/user/content/sql/alter-sink.md
@@ -94,7 +94,7 @@ keyspaces.
 To alter a sink originally created to use `matview_1` as the upstream relation,
 and start sinking the contents to `matview_2` instead:
 
-```sql
+```mzsql
 CREATE SINK avro_sink
   FROM matview_1
   INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_avro_topic')
@@ -103,7 +103,7 @@ CREATE SINK avro_sink
   ENVELOPE UPSERT;
 ```
 
-```sql
+```mzsql
 ALTER SINK foo SET FROM matview_2;
 ```
 

--- a/doc/user/content/sql/alter-source.md
+++ b/doc/user/content/sql/alter-source.md
@@ -63,7 +63,7 @@ You cannot drop the "progress subsource".
 
 ### Adding subsources
 
-```sql
+```mzsql
 ALTER SOURCE pg_src ADD SUBSOURCE tbl_a, tbl_b AS b WITH (TEXT COLUMNS [tbl_a.col]);
 ```
 
@@ -71,7 +71,7 @@ ALTER SOURCE pg_src ADD SUBSOURCE tbl_a, tbl_b AS b WITH (TEXT COLUMNS [tbl_a.co
 
 To drop a subsource, use the [`DROP SOURCE`](/sql/drop-source/) command:
 
-```sql
+```mzsql
 DROP SOURCE tbl_a, b CASCADE;
 ```
 

--- a/doc/user/content/sql/alter-swap.md
+++ b/doc/user/content/sql/alter-swap.md
@@ -21,7 +21,7 @@ _target&lowbar;name_ | The target [identifier](/sql/identifiers) of the item you
 
 Swapping two items is useful for a blue/green deployment
 
-```sql
+```mzsql
 CREATE SCHEMA blue;
 CREATE TABLE blue.numbers (n int);
 

--- a/doc/user/content/sql/alter-system-reset.md
+++ b/doc/user/content/sql/alter-system-reset.md
@@ -31,7 +31,7 @@ this statement.
 
 ### Reset enable RBAC
 
-```sql
+```mzsql
 SHOW enable_rbac_checks;
 
  enable_rbac_checks

--- a/doc/user/content/sql/alter-system-set.md
+++ b/doc/user/content/sql/alter-system-set.md
@@ -32,7 +32,7 @@ this statement.
 
 ### Enable RBAC
 
-```sql
+```mzsql
 SHOW enable_rbac_checks;
 
  enable_rbac_checks

--- a/doc/user/content/sql/comment-on.md
+++ b/doc/user/content/sql/comment-on.md
@@ -31,7 +31,7 @@ information on ownership and privileges, see [Role-based access control](/manage
 
 ## Examples
 
-```sql
+```mzsql
 --- Add comments.
 COMMENT ON TABLE foo IS 'this table is important';
 COMMENT ON COLUMN foo.x IS 'holds all of the important data';

--- a/doc/user/content/sql/copy-from.md
+++ b/doc/user/content/sql/copy-from.md
@@ -67,15 +67,15 @@ except that:
 
 ## Example
 
-```sql
+```mzsql
 COPY t FROM STDIN WITH (DELIMITER '|');
 ```
 
-```sql
+```mzsql
 COPY t FROM STDIN (FORMAT CSV);
 ```
 
-```sql
+```mzsql
 COPY t FROM STDIN (DELIMITER '|');
 ```
 

--- a/doc/user/content/sql/copy-to.md
+++ b/doc/user/content/sql/copy-to.md
@@ -35,7 +35,7 @@ Name     | Values                 | Default value | Description
 
 #### Subscribing to a view with binary output
 
-```sql
+```mzsql
 COPY (SUBSCRIBE some_view) TO STDOUT WITH (FORMAT binary);
 ```
 
@@ -156,7 +156,7 @@ Materialize type | Arrow extension name | [Arrow type](https://github.com/apache
 {{< tabs >}}
 {{< tab "Parquet">}}
 
-```sql
+```mzsql
 COPY some_view TO 's3://mz-to-snow/parquet/'
 WITH (
     AWS CONNECTION = aws_role_assumption,
@@ -168,7 +168,7 @@ WITH (
 
 {{< tab "CSV">}}
 
-```sql
+```mzsql
 COPY some_view TO 's3://mz-to-snow/csv/'
 WITH (
     AWS CONNECTION = aws_role_assumption,

--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -92,7 +92,7 @@ machines had computed.
 
 ## Example
 
-```sql
+```mzsql
 CREATE CLUSTER REPLICA c1.r1 (SIZE = '400cc');
 ```
 

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -45,13 +45,13 @@ active cluster.
 
 To show your session's active cluster, use the [`SHOW`](/sql/show) command:
 
-```sql
+```mzsql
 SHOW cluster;
 ```
 
 To switch your session's active cluster, use the [`SET`](/sql/set) command:
 
-```sql
+```mzsql
 SET cluster = other_cluster;
 ```
 
@@ -252,7 +252,7 @@ We plan to remove these restrictions in future versions of Materialize.
 
 Create a cluster with two `400cc` replicas:
 
-```sql
+```mzsql
 CREATE CLUSTER c1 (SIZE = '400cc', REPLICATION FACTOR = 2);
 ```
 
@@ -260,7 +260,7 @@ CREATE CLUSTER c1 (SIZE = '400cc', REPLICATION FACTOR = 2);
 
 Create a cluster with a single replica and introspection disabled:
 
-```sql
+```mzsql
 CREATE CLUSTER c (SIZE = '100cc', INTROSPECTION INTERVAL = 0);
 ```
 
@@ -272,7 +272,7 @@ that cluster replica.
 
 Create a cluster with no replicas:
 
-```sql
+```mzsql
 CREATE CLUSTER c1 (SIZE '100cc', REPLICATION FACTOR = 0);
 ```
 

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -97,7 +97,7 @@ policy, by querying the
 [`mz_internal.mz_aws_connections`](/sql/system-catalog/mz_internal/#mz_aws_connections)
 table:
 
-```sql
+```mzsql
 SELECT id, external_id, example_trust_policy FROM mz_internal.mz_aws_connections;
 ```
 
@@ -145,7 +145,7 @@ assume:
 
 To create an AWS connection that will assume the `WarehouseExport` role:
 
-```sql
+```mzsql
 CREATE CONNECTION aws_role_assumption TO AWS (
     ASSUME ROLE ARN = 'arn:aws:iam::400121260767:role/WarehouseExport',
 );
@@ -160,7 +160,7 @@ the use of role assumption-based authentication instead.
 
 To create an AWS connection that uses static access key credentials:
 
-```sql
+```mzsql
 CREATE SECRET aws_secret_access_key = '...';
 CREATE CONNECTION aws_credentials TO AWS (
     ACCESS KEY ID = 'ASIAV2KIV5LPTG6HGXG6',
@@ -206,7 +206,7 @@ Field         | Value     | Description
 To connect to a Kafka cluster with multiple bootstrap servers, use the `BROKERS`
 option:
 
-```sql
+```mzsql
 CREATE CONNECTION kafka_connection TO KAFKA (
     BROKERS ('broker1:9092', 'broker2:9092')
 );
@@ -221,7 +221,7 @@ It is insecure to use the `PLAINTEXT` security protocol unless
 you are using a [network security connection](#network-security-connections)
 to tunnel into a private network, as shown below.
 {{< /warning >}}
-```sql
+```mzsql
 CREATE CONNECTION kafka_connection TO KAFKA (
     BROKER 'unique-jellyfish-0000-kafka.upstash.io:9092',
     SECURITY PROTOCOL = 'PLAINTEXT',
@@ -232,7 +232,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 
 {{< tab "SSL">}}
 With both TLS encryption and TLS client authentication:
-```sql
+```mzsql
 CREATE SECRET kafka_ssl_cert AS '-----BEGIN CERTIFICATE----- ...';
 CREATE SECRET kafka_ssl_key AS '-----BEGIN PRIVATE KEY----- ...';
 CREATE SECRET ca_cert AS '-----BEGIN CERTIFICATE----- ...';
@@ -254,7 +254,7 @@ It is insecure to use TLS encryption with no authentication unless
 you are using a [network security connection](#network-security-connections)
 to tunnel into a private network as shown below.
 {{< /warning >}}
-```sql
+```mzsql
 CREATE SECRET ca_cert AS '-----BEGIN CERTIFICATE----- ...';
 
 CREATE CONNECTION kafka_connection TO KAFKA (
@@ -275,7 +275,7 @@ you are using a [network security connection](#network-security-connections)
 to tunnel into a private network, as shown below.
 {{< /warning >}}
 
-```sql
+```mzsql
 CREATE SECRET kafka_password AS '...';
 
 CREATE CONNECTION kafka_connection TO KAFKA (
@@ -290,7 +290,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 {{< /tab >}}
 
 {{< tab "SASL_SSL">}}
-```sql
+```mzsql
 CREATE SECRET kafka_password AS '...';
 CREATE SECRET ca_cert AS '-----BEGIN CERTIFICATE----- ...';
 
@@ -365,7 +365,7 @@ Suppose you have the following infrastructure:
 
 You can create a connection to this Kafka broker in Materialize like so:
 
-```sql
+```mzsql
 CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
     SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
     AVAILABILITY ZONES ('use1-az1', 'use1-az4')
@@ -398,7 +398,7 @@ Field                                   | Value            | Required | Descript
 
 ##### Example {#kafka-privatelink-default-example}
 
-```sql
+```mzsql
 CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
     SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
     AVAILABILITY ZONES ('use1-az1')
@@ -450,7 +450,7 @@ Field           | Value            | Required | Description
 
 Using a default SSH tunnel:
 
-```sql
+```mzsql
 CREATE CONNECTION ssh_connection TO SSH TUNNEL (
     HOST '<SSH_BASTION_HOST>',
     USER '<SSH_BASTION_USER>',
@@ -466,7 +466,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 Using different SSH tunnels for each broker, with a default for brokers that are
 not listed:
 
-```sql
+```mzsql
 CREATE CONNECTION ssh1 TO SSH TUNNEL (HOST 'ssh1', ...);
 CREATE CONNECTION ssh2 TO SSH TUNNEL (HOST 'ssh2', ...);
 
@@ -516,7 +516,7 @@ Field         | Value     | Description
 
 Using username and password authentication with TLS encryption:
 
-```sql
+```mzsql
 CREATE SECRET csr_password AS '...';
 CREATE SECRET ca_cert AS '-----BEGIN CERTIFICATE----- ...';
 
@@ -532,7 +532,7 @@ CREATE CONNECTION csr_basic TO CONFLUENT SCHEMA REGISTRY (
 
 Using TLS for encryption and authentication:
 
-```sql
+```mzsql
 CREATE SECRET csr_ssl_cert AS '-----BEGIN CERTIFICATE----- ...';
 CREATE SECRET csr_ssl_key AS '-----BEGIN PRIVATE KEY----- ...';
 CREATE SECRET ca_cert AS '-----BEGIN CERTIFICATE----- ...';
@@ -564,7 +564,7 @@ Field                       | Value            | Required | Description
 
 ##### Example {#csr-privatelink-example}
 
-```sql
+```mzsql
 CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
     SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
     AVAILABILITY ZONES ('use1-az1', 'use1-az4')
@@ -587,7 +587,7 @@ Field                       | Value            | Required | Description
 
 ##### Example {#csr-ssh-example}
 
-```sql
+```mzsql
 CREATE CONNECTION ssh_connection TO SSH TUNNEL (
     HOST '<SSH_BASTION_HOST>',
     USER '<SSH_BASTION_USER>',
@@ -635,7 +635,7 @@ Field         | Value     | Description
 
 #### Example {#mysql-example}
 
-```sql
+```mzsql
 CREATE SECRET mysqlpass AS '<POSTGRES_PASSWORD>';
 
 CREATE CONNECTION mysql_connection TO MYSQL (
@@ -662,7 +662,7 @@ Field                       | Value            | Required | Description
 
 ##### Example {#mysql-ssh-example}
 
-```sql
+```mzsql
 CREATE CONNECTION tunnel TO SSH TUNNEL (
     HOST 'bastion-host',
     PORT 22,
@@ -712,7 +712,7 @@ Field         | Value     | Description
 
 #### Example {#postgres-example}
 
-```sql
+```mzsql
 CREATE SECRET pgpass AS '<POSTGRES_PASSWORD>';
 
 CREATE CONNECTION pg_connection TO POSTGRES (
@@ -741,7 +741,7 @@ Field                       | Value            | Required | Description
 
 ##### Example {#postgres-privatelink-example}
 
-```sql
+```mzsql
 CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
    SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
    AVAILABILITY ZONES ('use1-az1', 'use1-az4')
@@ -772,7 +772,7 @@ Field                       | Value            | Required | Description
 
 ##### Example {#postgres-ssh-example}
 
-```sql
+```mzsql
 CREATE CONNECTION tunnel TO SSH TUNNEL (
     HOST 'bastion-host',
     PORT 22,
@@ -828,7 +828,7 @@ principals for AWS PrivateLink connections in your region are stored in
 the [`mz_aws_privatelink_connections`](/sql/system-catalog/mz_catalog/#mz_aws_privatelink_connections)
 system table.
 
-```sql
+```mzsql
 SELECT * FROM mz_aws_privatelink_connections;
 ```
 ```
@@ -856,7 +856,7 @@ accepting connection requests, see the [AWS PrivateLink documentation](https://d
 
 #### Example {#aws-privatelink-example}
 
-```sql
+```mzsql
 CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
     SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
     AVAILABILITY ZONES ('use1-az1', 'use1-az4')
@@ -908,7 +908,7 @@ generation algorithm as security best practices evolve.
 
 Create an SSH tunnel connection:
 
-```sql
+```mzsql
 CREATE CONNECTION ssh_connection TO SSH TUNNEL (
     HOST 'bastion-host',
     PORT 22,
@@ -918,7 +918,7 @@ CREATE CONNECTION ssh_connection TO SSH TUNNEL (
 
 Retrieve the public keys for the SSH tunnel connection you just created:
 
-```sql
+```mzsql
 SELECT
     mz_connections.name,
     mz_ssh_tunnel_connections.*

--- a/doc/user/content/sql/create-database.md
+++ b/doc/user/content/sql/create-database.md
@@ -38,10 +38,10 @@ details](../namespaces/#database-details).
 
 ## Examples
 
-```sql
+```mzsql
 CREATE DATABASE IF NOT EXISTS my_db;
 ```
-```sql
+```mzsql
 SHOW DATABASES;
 ```
 ```nofmt

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -107,7 +107,7 @@ of the index.
 You can optimize the performance of `JOIN` on two relations by ensuring their
 join keys are the key columns in an index.
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW active_customers AS
     SELECT guid, geo_id, last_active_on
     FROM customer_source
@@ -138,7 +138,7 @@ In the above example, the index `active_customers_geo_idx`...
 
 If you commonly filter by a certain column being equal to a literal value, you can set up an index over that column to speed up your queries:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW active_customers AS
     SELECT guid, geo_id, last_active_on
     FROM customer_source

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -96,7 +96,7 @@ in #27521."
 
 ### Creating a materialized view
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW winning_bids AS
 SELECT auction_id,
        bid_id,
@@ -108,7 +108,7 @@ WHERE end_time < mz_now();
 
 ### Using non-null assertions
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW users_and_orders WITH (
   -- The semantics of a FULL OUTER JOIN guarantee that user_id is not null,
   -- because one of `users.id` or `orders.user_id` must be not null, but

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -41,10 +41,10 @@ When RBAC is enabled a role must have the `CREATEROLE` system privilege to creat
 
 ## Examples
 
-```sql
+```mzsql
 CREATE ROLE db_reader;
 ```
-```sql
+```mzsql
 SELECT name FROM mz_roles;
 ```
 ```nofmt

--- a/doc/user/content/sql/create-schema.md
+++ b/doc/user/content/sql/create-schema.md
@@ -33,10 +33,10 @@ _schema&lowbar;name_ | A name for the schema. <br/><br/>You can specify the data
 
 ## Examples
 
-```sql
+```mzsql
 CREATE SCHEMA my_db.my_schema;
 ```
-```sql
+```mzsql
 SHOW SCHEMAS FROM my_db;
 ```
 ```nofmt

--- a/doc/user/content/sql/create-secret.md
+++ b/doc/user/content/sql/create-secret.md
@@ -20,7 +20,7 @@ _value_ | The value for the secret. The _value_ expression may not reference any
 
 ## Examples
 
-```sql
+```mzsql
 CREATE SECRET upstash_kafka_ca_cert AS decode('c2VjcmV0Cg==', 'base64');
 ```
 

--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -482,7 +482,7 @@ There are three ways to resolve this error:
 * Create a materialized view that deduplicates the input relation by the
   desired upsert key:
 
-  ```sql
+  ```mzsql
   -- For each row with the same key `k`, the `ORDER BY` clause ensures we
   -- keep the row with the largest value of `v`.
   CREATE MATERIALIZED VIEW deduped AS
@@ -507,7 +507,7 @@ There are three ways to resolve this error:
 * Use the `NOT ENFORCED` clause to disable Materialize's validation of the key's
   uniqueness:
 
-  ```sql
+  ```mzsql
   CREATE SINK s
   FROM original_input
   INTO KAFKA CONNECTION kafka_connection (TOPIC 't')
@@ -545,7 +545,7 @@ statements. For more details on creating connections, check the
 {{< tabs tabID="1" >}}
 {{< tab "SSL">}}
 
-```sql
+```mzsql
 CREATE SECRET kafka_ssl_key AS '<BROKER_SSL_KEY>';
 CREATE SECRET kafka_ssl_crt AS '<BROKER_SSL_CRT>';
 
@@ -559,7 +559,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 {{< /tab >}}
 {{< tab "SASL">}}
 
-```sql
+```mzsql
 CREATE SECRET kafka_password AS '<BROKER_PASSWORD>';
 
 CREATE CONNECTION kafka_connection TO KAFKA (
@@ -578,7 +578,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 {{< tabs tabID="1" >}}
 {{< tab "SSL">}}
 
-```sql
+```mzsql
 CREATE SECRET csr_ssl_crt AS '<CSR_SSL_CRT>';
 CREATE SECRET csr_ssl_key AS '<CSR_SSL_KEY>';
 CREATE SECRET csr_password AS '<CSR_PASSWORD>';
@@ -595,7 +595,7 @@ CREATE CONNECTION csr_ssl TO CONFLUENT SCHEMA REGISTRY (
 {{< /tab >}}
 {{< tab "Basic HTTP Authentication">}}
 
-```sql
+```mzsql
 CREATE SECRET IF NOT EXISTS csr_username AS '<CSR_USERNAME>';
 CREATE SECRET IF NOT EXISTS csr_password AS '<CSR_PASSWORD>';
 
@@ -616,7 +616,7 @@ CREATE CONNECTION csr_basic_http
 {{< tabs >}}
 {{< tab "Avro">}}
 
-```sql
+```mzsql
 CREATE SINK avro_sink
   FROM <source, table or mview>
   INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_avro_topic')
@@ -628,7 +628,7 @@ CREATE SINK avro_sink
 {{< /tab >}}
 {{< tab "JSON">}}
 
-```sql
+```mzsql
 CREATE SINK json_sink
   FROM <source, table or mview>
   INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_json_topic')
@@ -645,7 +645,7 @@ CREATE SINK json_sink
 {{< tabs >}}
 {{< tab "Avro">}}
 
-```sql
+```mzsql
 CREATE SINK avro_sink
   FROM <source, table or mview>
   INTO KAFKA CONNECTION kafka_connection (TOPIC 'test_avro_topic')
@@ -658,7 +658,7 @@ CREATE SINK avro_sink
 
 #### Topic configuration
 
-```sql
+```mzsql
 CREATE SINK custom_topic_sink
   IN CLUSTER my_io_cluster
   FROM <source, table or mview>
@@ -675,7 +675,7 @@ CREATE SINK custom_topic_sink
 
 #### Schema compatibility levels
 
-```sql
+```mzsql
 CREATE SINK compatibility_level_sink
   IN CLUSTER my_io_cluster
   FROM <source, table or mview>
@@ -694,7 +694,7 @@ CREATE SINK compatibility_level_sink
 Consider the following sink, `docs_sink`, built on top of a relation `t` with
 several [SQL comments](/sql/comment-on) attached.
 
-```sql
+```mzsql
 CREATE TABLE t (key int NOT NULL, value text NOT NULL);
 COMMENT ON TABLE t IS 'SQL comment on t';
 COMMENT ON COLUMN t.value IS 'SQL comment on t.value';

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -84,7 +84,7 @@ If your JSON messages have a consistent shape, we recommend creating a parsing
 [view](/get-started/key-concepts/#views) that maps the individual fields to
 columns with the required data types:
 
-```sql
+```mzsql
 -- extract jsonb into typed columns
 CREATE VIEW my_typed_source AS
   SELECT

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -228,7 +228,7 @@ Field          | Type        | Meaning
 
 And can be queried using:
 
-```sql
+```mzsql
 SELECT "offset"
 FROM <src_name>_progress;
 ```
@@ -244,7 +244,7 @@ issues, see [Troubleshooting](/ops/troubleshooting/).
 To create a load generator source that emits the next number in the sequence every
 500 milliseconds:
 
-```sql
+```mzsql
 CREATE SOURCE counter
   FROM LOAD GENERATOR COUNTER
   (TICK INTERVAL '500ms');
@@ -252,7 +252,7 @@ CREATE SOURCE counter
 
 To examine the counter:
 
-```sql
+```mzsql
 SELECT * FROM counter;
 ```
 ```nofmt
@@ -267,7 +267,7 @@ SELECT * FROM counter;
 
 To create a load generator source that simulates an auction house and emits new data every second:
 
-```sql
+```mzsql
 CREATE SOURCE auction_house
   FROM LOAD GENERATOR AUCTION
   (TICK INTERVAL '1s')
@@ -276,7 +276,7 @@ CREATE SOURCE auction_house
 
 To display the created subsources:
 
-```sql
+```mzsql
 SHOW SOURCES;
 ```
 ```nofmt
@@ -293,7 +293,7 @@ SHOW SOURCES;
 
 To examine the simulated bids:
 
-```sql
+```mzsql
 SELECT * from bids;
 ```
 ```nofmt
@@ -308,7 +308,7 @@ SELECT * from bids;
 
 To create a load generator source that simulates an online marketing campaign:
 
-```sql
+```mzsql
 CREATE SOURCE marketing
   FROM LOAD GENERATOR MARKETING
   FOR ALL TABLES;
@@ -316,7 +316,7 @@ CREATE SOURCE marketing
 
 To display the created subsources:
 
-```sql
+```mzsql
 SHOW SOURCES;
 ```
 
@@ -335,7 +335,7 @@ SHOW SOURCES;
 
 To find all impressions and clicks associated with a campaign over the last 30 days:
 
-```sql
+```mzsql
 WITH
     click_rollup AS
     (
@@ -384,7 +384,7 @@ GROUP BY campaign_id;
 
 To create the load generator source and its associated subsources:
 
-```sql
+```mzsql
 CREATE SOURCE tpch
   FROM LOAD GENERATOR TPCH (SCALE FACTOR 1)
   FOR ALL TABLES;
@@ -392,7 +392,7 @@ CREATE SOURCE tpch
 
 To display the created subsources:
 
-```sql
+```mzsql
 SHOW SOURCES;
 ```
 ```nofmt
@@ -413,7 +413,7 @@ SHOW SOURCES;
 To run the Pricing Summary Report Query (Q1), which reports the amount of
 billed, shipped, and returned items:
 
-```sql
+```mzsql
 SELECT
     l_returnflag,
     l_linestatus,

--- a/doc/user/content/sql/create-source/materialize-cdc.md
+++ b/doc/user/content/sql/create-source/materialize-cdc.md
@@ -138,7 +138,7 @@ Field | Description
 
 You specify the use of the Materialize CDC format in the [Avro schema](/sql/create-source/kafka/#format_spec) when a source is created.
 
-```sql
+```mzsql
   CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'kafka_url:9092');
 
   CREATE SOURCE name_of_source

--- a/doc/user/content/sql/create-source/mysql.md
+++ b/doc/user/content/sql/create-source/mysql.md
@@ -125,7 +125,7 @@ that overrides `binlog_expire_logs_seconds` and is set to `NULL` by default.
 Materialize ingests the raw replication stream data for all (or a specific set
 of) tables in your upstream MySQL database.
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_connection
   FOR ALL TABLES;
@@ -137,7 +137,7 @@ When you define a source, Materialize will automatically:
    initial, snapshot-based sync of the tables before it starts ingesting change
    events.
 
-    ```sql
+    ```mzsql
     SHOW SOURCES;
     ```
 
@@ -167,7 +167,7 @@ replicating `schema1.table_1` and `schema2.table_1`. Use the `FOR TABLES`
 clause to provide aliases for each upstream table, in such cases, or to specify
 an alternative destination schema in Materialize.
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_connection
   FOR TABLES (schema1.table_1 AS s1_table_1, schema2.table_1 AS s2_table_1);
@@ -194,7 +194,7 @@ Field              | Type                                                    | D
 
 And can be queried using:
 
-```sql
+```mzsql
 SELECT transaction_id
 FROM <src_name>_progress;
 ```
@@ -267,7 +267,7 @@ truncated while replicated, the whole source becomes inaccessible and will not
 produce any data until it is recreated. Instead, remove all rows from a table
 using an unqualified `DELETE`.
 
-```sql
+```mzsql
 DELETE FROM t;
 ```
 
@@ -292,7 +292,7 @@ Once created, a connection is **reusable** across multiple `CREATE SOURCE`
 statements. For more details on creating connections, check the
 [`CREATE CONNECTION`](/sql/create-connection/#mysql) documentation page.
 
-```sql
+```mzsql
 CREATE SECRET mysqlpass AS '<MYSQL_PASSWORD>';
 
 CREATE CONNECTION mysql_connection TO MYSQL (
@@ -309,7 +309,7 @@ through an SSH bastion host.
 
 {{< tabs tabID="1" >}}
 {{< tab "SSH tunnel">}}
-```sql
+```mzsql
 CREATE CONNECTION ssh_connection TO SSH TUNNEL (
     HOST 'bastion-host',
     PORT 22,
@@ -317,7 +317,7 @@ CREATE CONNECTION ssh_connection TO SSH TUNNEL (
 );
 ```
 
-```sql
+```mzsql
 CREATE CONNECTION mysql_connection TO MYSQL (
     HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
     SSH TUNNEL ssh_connection
@@ -335,7 +335,7 @@ an SSH bastion server to accept connections from Materialize, check
 
 _Create subsources for all tables in MySQL_
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
     FROM MYSQL CONNECTION mysql_connection
     FOR ALL TABLES;
@@ -343,7 +343,7 @@ CREATE SOURCE mz_source
 
 _Create subsources for all tables from specific schemas in MySQL_
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_connection
   FOR SCHEMAS (mydb, project);
@@ -351,7 +351,7 @@ CREATE SOURCE mz_source
 
 _Create subsources for specific tables in MySQL_
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_connection
   FOR TABLES (mydb.table_1, mydb.table_2 AS alias_table_2);
@@ -364,7 +364,7 @@ by Materialize, use the `TEXT COLUMNS` option to decode data as `text` for the
 affected columns. This option expects the upstream fully-qualified names of the
 replicated table and column (i.e. as defined in your MySQL database).
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_connection (
     TEXT COLUMNS (mydb.table_1.column_of_unsupported_type)
@@ -378,7 +378,7 @@ MySQL doesn't provide a way to filter out columns from the replication stream.
 To exclude specific upstream columns from being ingested, use the `IGNORE
 COLUMNS` option.
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM MYSQL CONNECTION mysql_connection (
     IGNORE COLUMNS (mydb.table_1.column_to_ignore)
@@ -393,7 +393,7 @@ the [`DROP SOURCE`](/sql/alter-source/#context) syntax to drop the affected
 subsource, and then [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/) to add
 the subsource back to the source.
 
-```sql
+```mzsql
 -- List all subsources in mz_source
 SHOW SUBSOURCES ON mz_source;
 

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -82,7 +82,7 @@ To avoid creating multiple replication slots in the upstream PostgreSQL database
 and minimize the required bandwidth, Materialize ingests the raw replication
 stream data for some specific set of tables in your publication.
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
   FOR ALL TABLES;
@@ -97,7 +97,7 @@ When you define a source, Materialize will automatically:
     `materialize_` for easy identification, and can be looked up in
     `mz_internal.mz_postgres_sources`.
 
-    ```sql
+    ```mzsql
     SELECT id, replication_slot FROM mz_internal.mz_postgres_sources;
     ```
 
@@ -108,7 +108,7 @@ When you define a source, Materialize will automatically:
     ```
 1. Create a **subsource** for each original table in the publication.
 
-    ```sql
+    ```mzsql
     SHOW SOURCES;
     ```
 
@@ -164,7 +164,7 @@ replicating `schema1.table_1` and `schema2.table_1`. Use the `FOR TABLES`
 clause to provide aliases for each upstream table, in such cases, or to specify
 an alternative destination schema in Materialize.
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
   FOR TABLES (schema1.table_1 AS s1_table_1, schema2_table_1 AS s2_table_1);
@@ -185,7 +185,7 @@ Field          | Type                                     | Meaning
 
 And can be queried using:
 
-```sql
+```mzsql
 SELECT lsn
 FROM <src_name>_progress;
 ```
@@ -271,7 +271,7 @@ truncated while replicated, the whole source becomes inaccessible and will not
 produce any data until it is recreated. Instead, remove all rows from a table
 using an unqualified `DELETE`.
 
-```sql
+```mzsql
 DELETE FROM t;
 ```
 
@@ -317,7 +317,7 @@ Once created, a connection is **reusable** across multiple `CREATE SOURCE`
 statements. For more details on creating connections, check the
 [`CREATE CONNECTION`](/sql/create-connection/#postgresql) documentation page.
 
-```sql
+```mzsql
 CREATE SECRET pgpass AS '<POSTGRES_PASSWORD>';
 
 CREATE CONNECTION pg_connection TO POSTGRES (
@@ -337,14 +337,14 @@ through an AWS PrivateLink service or an SSH bastion host.
 {{< tabs tabID="1" >}}
 {{< tab "AWS PrivateLink">}}
 
-```sql
+```mzsql
 CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
     SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
     AVAILABILITY ZONES ('use1-az1', 'use1-az4')
 );
 ```
 
-```sql
+```mzsql
 CREATE SECRET pgpass AS '<POSTGRES_PASSWORD>';
 
 CREATE CONNECTION pg_connection TO POSTGRES (
@@ -363,7 +363,7 @@ check [this guide](/ops/network-security/privatelink/).
 
 {{< /tab >}}
 {{< tab "SSH tunnel">}}
-```sql
+```mzsql
 CREATE CONNECTION ssh_connection TO SSH TUNNEL (
     HOST 'bastion-host',
     PORT 22,
@@ -371,7 +371,7 @@ CREATE CONNECTION ssh_connection TO SSH TUNNEL (
 );
 ```
 
-```sql
+```mzsql
 CREATE CONNECTION pg_connection TO POSTGRES (
     HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
     PORT 5432,
@@ -391,7 +391,7 @@ an SSH bastion server to accept connections from Materialize, check
 
 _Create subsources for all tables included in the PostgreSQL publication_
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
     FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
     FOR ALL TABLES;
@@ -400,7 +400,7 @@ CREATE SOURCE mz_source
 _Create subsources for all tables from specific schemas included in the
  PostgreSQL publication_
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
   FOR SCHEMAS (public, project);
@@ -408,7 +408,7 @@ CREATE SOURCE mz_source
 
 _Create subsources for specific tables included in the PostgreSQL publication_
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
   FOR TABLES (table_1, table_2 AS alias_table_2);
@@ -421,7 +421,7 @@ unsupported by Materialize, use the `TEXT COLUMNS` option to decode data as
 `text` for the affected columns. This option expects the upstream names of the
 replicated table and column (i.e. as defined in your PostgreSQL database).
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg_connection (
     PUBLICATION 'mz_source',
@@ -436,7 +436,7 @@ the [`DROP SOURCE`](/sql/alter-source/#context) syntax to drop the affected
 subsource, and then [`ALTER SOURCE...ADD SUBSOURCE`](/sql/alter-source/) to add
 the subsource back to the source.
 
-```sql
+```mzsql
 -- List all subsources in mz_source
 SHOW SUBSOURCES ON mz_source;
 

--- a/doc/user/content/sql/create-table.md
+++ b/doc/user/content/sql/create-table.md
@@ -74,13 +74,13 @@ tables may not depend on temporary objects.
 
 You can create a table `t` with the following statement:
 
-```sql
+```mzsql
 CREATE TABLE t (a int, b text NOT NULL);
 ```
 
 Once a table is created, you can inspect the table with various `SHOW` commands.
 
-```sql
+```mzsql
 SHOW TABLES;
 TABLES
 ------

--- a/doc/user/content/sql/create-type.md
+++ b/doc/user/content/sql/create-type.md
@@ -70,7 +70,7 @@ custom type's properties.
 
 ### Custom `list`
 
-```sql
+```mzsql
 CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 
 SELECT '{1,2}'::int4_list::text AS custom_list;
@@ -83,7 +83,7 @@ SELECT '{1,2}'::int4_list::text AS custom_list;
 
 ### Nested custom `list`
 
-```sql
+```mzsql
 CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list);
 
 SELECT '{{1,2}}'::int4_list_list::text AS custom_nested_list;
@@ -96,7 +96,7 @@ SELECT '{{1,2}}'::int4_list_list::text AS custom_nested_list;
 
 ### Custom `map`
 
-```sql
+```mzsql
 CREATE TYPE int4_map AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 
 SELECT '{a=>1}'::int4_map::text AS custom_map;
@@ -109,7 +109,7 @@ SELECT '{a=>1}'::int4_map::text AS custom_map;
 
 ### Nested custom `map`
 
-```sql
+```mzsql
 CREATE TYPE int4_map_map AS MAP (KEY TYPE = text, VALUE TYPE = int4_map);
 
 SELECT '{a=>{a=>1}}'::int4_map_map::text AS custom_nested_map;
@@ -121,7 +121,7 @@ SELECT '{a=>{a=>1}}'::int4_map_map::text AS custom_nested_map;
 ```
 
 ### Custom `row` type
-```sql
+```mzsql
 CREATE TYPE row_type AS (a int, b text);
 SELECT ROW(1, 'a')::row_type as custom_row_type;
 ```
@@ -132,7 +132,7 @@ custom_row_type
 ```
 
 ### Nested `row` type
-```sql
+```mzsql
 CREATE TYPE nested_row_type AS (a row_type, b float8);
 SELECT ROW(ROW(1, 'a'), 2.3)::nested_row_type AS custom_nested_row_type;
 ```

--- a/doc/user/content/sql/create-view.md
+++ b/doc/user/content/sql/create-view.md
@@ -47,7 +47,7 @@ views may not depend on temporary objects.
 
 ### Creating a view
 
-```sql
+```mzsql
 CREATE VIEW purchase_sum_by_region
 AS
     SELECT sum(purchase.amount) AS region_sum,

--- a/doc/user/content/sql/deallocate.md
+++ b/doc/user/content/sql/deallocate.md
@@ -20,7 +20,7 @@ Field | Use
 
 ## Example
 
-```sql
+```mzsql
 DEALLOCATE a;
 ```
 

--- a/doc/user/content/sql/delete.md
+++ b/doc/user/content/sql/delete.md
@@ -30,7 +30,7 @@ _alias_ | Only permit references to _table_name_ as _alias_.
 
 ## Examples
 
-```sql
+```mzsql
 CREATE TABLE delete_me (a int, b text);
 INSERT INTO delete_me
     VALUES
@@ -46,7 +46,7 @@ SELECT * FROM delete_me ORDER BY a;
  2 | goodbye
  3 | ok
 ```
-```sql
+```mzsql
 CREATE TABLE delete_using (b text);
 INSERT INTO delete_using VALUES ('goodbye'), ('ciao');
 DELETE FROM delete_me
@@ -59,7 +59,7 @@ SELECT * FROM delete_me;
 ---+----
  3 | ok
 ```
-```sql
+```mzsql
 DELETE FROM delete_me;
 SELECT * FROM delete_me;
 ```

--- a/doc/user/content/sql/drop-cluster-replica.md
+++ b/doc/user/content/sql/drop-cluster-replica.md
@@ -30,7 +30,7 @@ _replica&lowbar;name_ | The cluster replica you want to drop. For available clus
 
 ## Examples
 
-```sql
+```mzsql
 SHOW CLUSTER REPLICAS WHERE cluster = 'auction_house';
 ```
 
@@ -40,7 +40,7 @@ SHOW CLUSTER REPLICAS WHERE cluster = 'auction_house';
  auction_house | bigger
 ```
 
-```sql
+```mzsql
 DROP CLUSTER REPLICA auction_house.bigger;
 ```
 

--- a/doc/user/content/sql/drop-cluster.md
+++ b/doc/user/content/sql/drop-cluster.md
@@ -26,13 +26,13 @@ _cluster&lowbar;name_ | The cluster you want to drop. For available clusters, se
 
 To drop an existing cluster, run:
 
-```sql
+```mzsql
 DROP CLUSTER auction_house;
 ```
 
 To avoid issuing an error if the specified cluster does not exist, use the `IF EXISTS` option:
 
-```sql
+```mzsql
 DROP CLUSTER IF EXISTS auction_house;
 ```
 
@@ -40,7 +40,7 @@ DROP CLUSTER IF EXISTS auction_house;
 
 If the cluster has dependencies, Materialize will throw an error similar to:
 
-```sql
+```mzsql
 DROP CLUSTER auction_house;
 ```
 
@@ -50,7 +50,7 @@ ERROR:  cannot drop cluster with active indexes or materialized views
 
 , and you'll have to explicitly ask to also remove any dependent objects using the `CASCADE` option:
 
-```sql
+```mzsql
 DROP CLUSTER auction_house CASCADE;
 ```
 

--- a/doc/user/content/sql/drop-connection.md
+++ b/doc/user/content/sql/drop-connection.md
@@ -28,13 +28,13 @@ _connection&lowbar;name_ | The connection you want to drop. For available connec
 
 To drop an existing connection, run:
 
-```sql
+```mzsql
 DROP CONNECTION kafka_connection;
 ```
 
 To avoid issuing an error if the specified connection does not exist, use the `IF EXISTS` option:
 
-```sql
+```mzsql
 DROP CONNECTION IF EXISTS kafka_connection;
 ```
 
@@ -42,7 +42,7 @@ DROP CONNECTION IF EXISTS kafka_connection;
 
 If the connection has dependencies, Materialize will throw an error similar to:
 
-```sql
+```mzsql
 DROP CONNECTION kafka_connection;
 ```
 
@@ -53,7 +53,7 @@ ERROR:  cannot drop materialize.public.kafka_connection: still depended upon by 
 
 , and you'll have to explicitly ask to also remove any dependent objects using the `CASCADE` option:
 
-```sql
+```mzsql
 DROP CONNECTION kafka_connection CASCADE;
 ```
 

--- a/doc/user/content/sql/drop-database.md
+++ b/doc/user/content/sql/drop-database.md
@@ -27,20 +27,20 @@ _database&lowbar;name_ | The database you want to drop. For available databases,
 ### Remove a database containing schemas
 You can use either of the following commands:
 
-- ```sql
+- ```mzsql
   DROP DATABASE my_db;
   ```
-- ```sql
+- ```mzsql
   DROP DATABASE my_db CASCADE;
   ```
 
 ### Remove a database only if it contains no schemas
-```sql
+```mzsql
 DROP DATABASE my_db RESTRICT;
 ```
 
 ### Do not issue an error if attempting to remove a nonexistent database
-```sql
+```mzsql
 DROP DATABASE IF EXISTS my_db;
 ```
 

--- a/doc/user/content/sql/drop-index.md
+++ b/doc/user/content/sql/drop-index.md
@@ -25,7 +25,7 @@ _index&lowbar;name_ | The name of the index you want to remove.
 
 ### Remove an index
 
-```sql
+```mzsql
 SHOW VIEWS;
 ```
 ```nofmt
@@ -36,7 +36,7 @@ SHOW VIEWS;
 | q01                               |
 +-----------------------------------+
 ```
-```sql
+```mzsql
 SHOW INDEXES ON q01;
 ```
 ```nofmt
@@ -51,19 +51,19 @@ You can use the unqualified index name (`q01_geo_idx`) rather the fully qualifie
 
 You can remove an index with any of the following commands:
 
-- ```sql
+- ```mzsql
   DROP INDEX q01_geo_idx;
   ```
-- ```sql
+- ```mzsql
   DROP INDEX q01_geo_idx RESTRICT;
   ```
-- ```sql
+- ```mzsql
   DROP INDEX q01_geo_idx CASCADE;
   ```
 
 ### Do not issue an error if attempting to remove a nonexistent index
 
-```sql
+```mzsql
 DROP INDEX IF EXISTS q01_geo_idx;
 ```
 

--- a/doc/user/content/sql/drop-materialized-view.md
+++ b/doc/user/content/sql/drop-materialized-view.md
@@ -25,7 +25,7 @@ _view&lowbar;name_ | The materialized view you want to drop. For available mater
 
 ### Dropping a materialized view with no dependencies
 
-```sql
+```mzsql
 DROP MATERIALIZED VIEW winning_bids;
 ```
 ```nofmt
@@ -34,7 +34,7 @@ DROP MATERIALIZED VIEW
 
 ### Dropping a materialized view with dependencies
 
-```sql
+```mzsql
 DROP MATERIALIZED VIEW winning_bids;
 ```
 

--- a/doc/user/content/sql/drop-owned.md
+++ b/doc/user/content/sql/drop-owned.md
@@ -26,11 +26,11 @@ _role_name_   | The role name whose owned objects will be dropped.
 
 ## Examples
 
-```sql
+```mzsql
 DROP OWNED BY joe;
 ```
 
-```sql
+```mzsql
 DROP OWNED BY joe, george CASCADE;
 ```
 

--- a/doc/user/content/sql/drop-schema.md
+++ b/doc/user/content/sql/drop-schema.md
@@ -27,24 +27,24 @@ Before you can drop a schema, you must [drop all sources](../drop-source) and
 ## Example
 
 ### Remove a schema with no dependent objects
-```sql
+```mzsql
 SHOW SOURCES FROM my_schema;
 ```
 ```nofmt
 my_file_source
 ```
-```sql
+```mzsql
 DROP SCHEMA my_schema;
 ```
 
 ### Remove a schema with dependent objects
-```sql
+```mzsql
 SHOW SOURCES FROM my_schema;
 ```
 ```nofmt
 my_file_source
 ```
-```sql
+```mzsql
 DROP SCHEMA my_schema CASCADE;
 ```
 
@@ -52,16 +52,16 @@ DROP SCHEMA my_schema CASCADE;
 
 You can use either of the following commands:
 
-- ```sql
+- ```mzsql
   DROP SCHEMA my_schema;
   ```
-- ```sql
+- ```mzsql
   DROP SCHEMA my_schema RESTRICT;
   ```
 
 ### Do not issue an error if attempting to remove a nonexistent schema
 
-```sql
+```mzsql
 DROP SCHEMA IF EXISTS my_schema;
 ```
 

--- a/doc/user/content/sql/drop-secret.md
+++ b/doc/user/content/sql/drop-secret.md
@@ -26,13 +26,13 @@ _secret&lowbar;name_ | The secret you want to drop. For available secrets, see [
 
 To drop an existing secret, run:
 
-```sql
+```mzsql
 DROP SECRET upstash_sasl_password;
 ```
 
 To avoid issuing an error if the specified secret does not exist, use the `IF EXISTS` option:
 
-```sql
+```mzsql
 DROP SECRET IF EXISTS upstash_sasl_password;
 ```
 
@@ -40,7 +40,7 @@ DROP SECRET IF EXISTS upstash_sasl_password;
 
 If the secret has dependencies, Materialize will throw an error similar to:
 
-```sql
+```mzsql
 DROP SECRET upstash_sasl_password;
 ```
 
@@ -51,7 +51,7 @@ ERROR:  cannot drop materialize.public.upstash_sasl_password: still depended upo
 
 , and you'll have to explicitly ask to also remove any dependent objects using the `CASCADE` option:
 
-```sql
+```mzsql
 DROP SECRET upstash_sasl_password CASCADE;
 ```
 

--- a/doc/user/content/sql/drop-sink.md
+++ b/doc/user/content/sql/drop-sink.md
@@ -20,13 +20,13 @@ _sink&lowbar;name_ | The sink you want to drop. You can find available sink name
 
 ## Examples
 
-```sql
+```mzsql
 SHOW SINKS;
 ```
 ```nofmt
 my_sink
 ```
-```sql
+```mzsql
 DROP SINK my_sink;
 ```
 ```nofmt

--- a/doc/user/content/sql/drop-source.md
+++ b/doc/user/content/sql/drop-source.md
@@ -25,27 +25,27 @@ _source&lowbar;name_ | The name of the source you want to remove.
 
 ### Remove a source with no dependent objects
 
-```sql
+```mzsql
 SHOW SOURCES;
 ```
 ```nofmt
 ...
 my_source
 ```
-```sql
+```mzsql
 DROP SOURCE my_source;
 ```
 
 ### Remove a source with dependent objects
 
-```sql
+```mzsql
 SHOW SOURCES;
 ```
 ```nofmt
 ...
 my_source
 ```
-```sql
+```mzsql
 DROP SOURCE my_source CASCADE;
 ```
 
@@ -53,16 +53,16 @@ DROP SOURCE my_source CASCADE;
 
 You can use either of the following commands:
 
-- ```sql
+- ```mzsql
   DROP SOURCE my_source;
   ```
-- ```sql
+- ```mzsql
   DROP SOURCE my_source RESTRICT;
   ```
 
 ### Do not issue an error if attempting to remove a nonexistent source
 
-```sql
+```mzsql
 DROP SOURCE IF EXISTS my_source;
 ```
 

--- a/doc/user/content/sql/drop-table.md
+++ b/doc/user/content/sql/drop-table.md
@@ -29,7 +29,7 @@ _table_name_ | The name of the table to remove.
 ### Remove a table with no dependent objects
 Create a table *t* and verify that it was created:
 
-```sql
+```mzsql
 CREATE TABLE t (a int, b text NOT NULL);
 SHOW TABLES;
 ```
@@ -41,14 +41,14 @@ t
 
 Remove the table:
 
-```sql
+```mzsql
 DROP TABLE t;
 ```
 ### Remove a table with dependent objects
 
 Create a table *t*:
 
-```sql
+```mzsql
 CREATE TABLE t (a int, b text NOT NULL);
 INSERT INTO t VALUES (1, 'yes'), (2, 'no'), (3, 'maybe');
 SELECT * FROM t;
@@ -64,7 +64,7 @@ a |   b
 
 Create a materialized view from *t*:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW t_view AS SELECT sum(a) AS sum FROM t;
 SHOW MATERIALIZED VIEWS;
 ```
@@ -77,7 +77,7 @@ t_view  | default
 
 Remove table *t*:
 
-```sql
+```mzsql
 DROP TABLE t CASCADE;
 ```
 
@@ -85,16 +85,16 @@ DROP TABLE t CASCADE;
 
 You can use either of the following commands:
 
-- ```sql
+- ```mzsql
   DROP TABLE t;
   ```
-- ```sql
+- ```mzsql
   DROP TABLE t RESTRICT;
   ```
 
 ### Do not issue an error if attempting to remove a nonexistent table
 
-```sql
+```mzsql
 DROP TABLE IF EXISTS t;
 ```
 

--- a/doc/user/content/sql/drop-type.md
+++ b/doc/user/content/sql/drop-type.md
@@ -22,7 +22,7 @@ _data_type_name_ | The name of the type to remove.
 ## Examples
 
 ### Remove a type with no dependent objects
-```sql
+```mzsql
 CREATE TYPE int4_map AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 
 SHOW TYPES;
@@ -34,7 +34,7 @@ SHOW TYPES;
 (1 row)
 ```
 
-```sql
+```mzsql
 DROP TYPE int4_map;
 
 SHOW TYPES;
@@ -51,7 +51,7 @@ By default, `DROP TYPE` will not remove a type with dependent objects. The **CAS
 
 In the example below, the **CASCADE** switch removes `int4_list`, `int4_list_list` (which depends on `int4_list`), and the table *t*, which has a column of data type `int4_list`.
 
-```sql
+```mzsql
 CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 
 CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list);
@@ -68,7 +68,7 @@ SHOW TYPES;
 (2 rows)
 ```
 
-```sql
+```mzsql
 DROP TYPE int4_list CASCADE;
 
 SHOW TYPES;
@@ -86,16 +86,16 @@ ERROR:  unknown catalog item 't'
 
 You can use either of the following commands:
 
-- ```sql
+- ```mzsql
   DROP TYPE int4_list;
   ```
-- ```sql
+- ```mzsql
   DROP TYPE int4_list RESTRICT;
   ```
 
 ### Do not issue an error if attempting to remove a nonexistent type
 
-```sql
+```mzsql
 DROP TYPE IF EXISTS int4_list;
 ```
 

--- a/doc/user/content/sql/drop-view.md
+++ b/doc/user/content/sql/drop-view.md
@@ -29,7 +29,7 @@ _view&lowbar;name_ | The view you want to drop. You can find available view name
 
 ## Examples
 
-```sql
+```mzsql
 SHOW VIEWS;
 ```
 ```nofmt
@@ -37,7 +37,7 @@ SHOW VIEWS;
 ---------
  my_view
 ```
-```sql
+```mzsql
 DROP VIEW my_view;
 ```
 ```nofmt

--- a/doc/user/content/sql/execute.md
+++ b/doc/user/content/sql/execute.md
@@ -22,7 +22,7 @@ Field | Use
 
 ## Example
 
-```sql
+```mzsql
 EXECUTE a ('a', 'b', 1 + 2)
 ```
 

--- a/doc/user/content/sql/explain-filter-pushdown.md
+++ b/doc/user/content/sql/explain-filter-pushdown.md
@@ -54,7 +54,7 @@ in your environment.
 
 Suppose you're interested in checking the number of recent bids.
 
-```sql
+```mzsql
 SELECT count(*) FROM bids WHERE bid_time + '5 minutes' > mz_now();
 ```
 
@@ -67,7 +67,7 @@ performance.
 Explaining this query includes a `pushdown=` field under `Source materialize.public.bids`,
 which indicates that this filter can be pushed down.
 
-```sql
+```mzsql
 EXPLAIN
 SELECT count(*) FROM bids WHERE bid_time + '5 minutes' > mz_now();
 ```
@@ -89,7 +89,7 @@ Suppose it's been \~1 hour since you set up the auction house load generator
 source, and you'd like to get a sense of how much data your query would need to
 fetch.
 
-```sql
+```mzsql
 EXPLAIN FILTER PUSHDOWN FOR
 SELECT count(*) FROM bids WHERE bid_time + '5 minutes' > mz_now();
 ```
@@ -110,7 +110,7 @@ If you instead query for the last hour of data, you can see that since you only
 created the auction house source \~1 hour ago, Materialize needs to fetch
 almost everything.
 
-```sql
+```mzsql
 EXPLAIN FILTER PUSHDOWN FOR
 SELECT count(*) FROM bids WHERE bid_time + '1 hour' > mz_now();
 ```

--- a/doc/user/content/sql/explain-plan.md
+++ b/doc/user/content/sql/explain-plan.md
@@ -22,7 +22,7 @@ change arbitrarily in future versions of Materialize.
 
 Note that the `FOR` keyword is required if the `PLAN` keyword is present. In other words, the following three statements are equivalent:
 
-```sql
+```mzsql
 EXPLAIN <explainee>;
 EXPLAIN PLAN FOR <explainee>;
 EXPLAIN OPTIMIZED PLAN FOR <explainee>;
@@ -283,35 +283,35 @@ Let's start with a simple join query that lists the total amounts bid per buyer.
 
 Explain the optimized plan as text:
 
-```sql
+```mzsql
 EXPLAIN
 SELECT a.id, sum(b.amount) FROM accounts a JOIN bids b ON(a.id = b.buyer) GROUP BY a.id;
 ```
 
 Same as above, but a bit more verbose:
 
-```sql
+```mzsql
 EXPLAIN PLAN
 SELECT a.id, sum(b.amount) FROM accounts a JOIN bids b ON(a.id = b.buyer) GROUP BY a.id;
 ```
 
 Same as above, but even more verbose:
 
-```sql
+```mzsql
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 SELECT a.id, sum(b.amount) FROM accounts a JOIN bids b ON(a.id = b.buyer) GROUP BY a.id;
 ```
 
 Same as above, but every sub-plan is annotated with its schema types:
 
-```sql
+```mzsql
 EXPLAIN WITH(types) FOR
 SELECT a.id, sum(b.amount) FROM accounts a JOIN bids b ON(a.id = b.buyer) GROUP BY a.id;
 ```
 
 Explain the physical plan as text:
 
-```sql
+```mzsql
 EXPLAIN PHYSICAL PLAN FOR
 SELECT a.id, sum(b.amount) FROM accounts a JOIN bids b ON(a.id = b.buyer) GROUP BY a.id;
 ```
@@ -320,7 +320,7 @@ SELECT a.id, sum(b.amount) FROM accounts a JOIN bids b ON(a.id = b.buyer) GROUP 
 
 Let's create a view with an index for the above query.
 
-```sql
+```mzsql
 -- create the view
 CREATE VIEW my_view AS
 SELECT a.id, sum(b.amount) FROM accounts a JOIN bids b ON(a.id = b.buyer) GROUP BY a.id;
@@ -332,35 +332,35 @@ You can inspect the plan of the dataflow that will maintain your index with the 
 
 Explain the optimized plan as text:
 
-```sql
+```mzsql
 EXPLAIN
 INDEX my_view_idx;
 ```
 
 Same as above, but a bit more verbose:
 
-```sql
+```mzsql
 EXPLAIN PLAN FOR
 INDEX my_view_idx;
 ```
 
 Same as above, but even more verbose:
 
-```sql
+```mzsql
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 INDEX my_view_idx;
 ```
 
 Same as above, but every sub-plan is annotated with its schema types:
 
-```sql
+```mzsql
 EXPLAIN WITH(types) FOR
 INDEX my_view_idx;
 ```
 
 Explain the physical plan as text:
 
-```sql
+```mzsql
 EXPLAIN PHYSICAL PLAN FOR
 INDEX my_view_idx;
 ```
@@ -369,7 +369,7 @@ INDEX my_view_idx;
 
 Let's create a materialized view for the above `SELECT` query.
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW my_mat_view AS
 SELECT a.id, sum(b.amount) FROM accounts a JOIN bids b ON(a.id = b.buyer) GROUP BY a.id;
 ```
@@ -378,35 +378,35 @@ You can inspect the plan of the dataflow that will maintain your view with the f
 
 Explain the optimized plan as text:
 
-```sql
+```mzsql
 EXPLAIN
 MATERIALIZED VIEW my_mat_view;
 ```
 
 Same as above, but a bit more verbose:
 
-```sql
+```mzsql
 EXPLAIN PLAN FOR
 MATERIALIZED VIEW my_mat_view;
 ```
 
 Same as above, but even more verbose:
 
-```sql
+```mzsql
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 MATERIALIZED VIEW my_mat_view;
 ```
 
 Same as above, but every sub-plan is annotated with its schema types:
 
-```sql
+```mzsql
 EXPLAIN WITH(types)
 MATERIALIZED VIEW my_mat_view;
 ```
 
 Explain the physical plan as text:
 
-```sql
+```mzsql
 EXPLAIN PHYSICAL PLAN FOR
 MATERIALIZED VIEW my_mat_view;
 ```

--- a/doc/user/content/sql/explain-schema.md
+++ b/doc/user/content/sql/explain-schema.md
@@ -36,7 +36,7 @@ This command shows what the generated schemas would look like, without creating 
 
 ## Examples
 
-```sql
+```mzsql
 CREATE TABLE t (c1 int, c2 text);
 COMMENT ON TABLE t IS 'materialize comment on t';
 COMMENT ON COLUMN t.c2 IS 'materialize comment on t.c2';

--- a/doc/user/content/sql/explain-timestamp.md
+++ b/doc/user/content/sql/explain-timestamp.md
@@ -77,7 +77,7 @@ Field | Meaning | Example
 
 ## Examples
 
-```sql
+```mzsql
 EXPLAIN TIMESTAMP FOR MATERIALIZED VIEW users;
 ```
 ```

--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -34,7 +34,7 @@ canceling a query running on another connection.
 Materialize offers only limited support for these functions. They may be called
 only at the top level of a `SELECT` statement, like so:
 
-```sql
+```mzsql
 SELECT side_effecting_function(arg, ...);
 ```
 

--- a/doc/user/content/sql/functions/array_agg.md
+++ b/doc/user/content/sql/functions/array_agg.md
@@ -39,14 +39,14 @@ Instead, we recommend that you materialize all components required for the
 `array_agg` function call and create a non-materialized view using `array_agg`
 on top of that. That pattern is illustrated in the following statements:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW foo_view AS SELECT * FROM foo;
 CREATE VIEW bar AS SELECT array_agg(foo_view.bar) FROM foo_view;
 ```
 
 ## Examples
 
-```sql
+```mzsql
 SELECT
     title,
     ARRAY_AGG (

--- a/doc/user/content/sql/functions/cast.md
+++ b/doc/user/content/sql/functions/cast.md
@@ -177,7 +177,7 @@ Source type                                | Return type                        
 
 ## Examples
 
-```sql
+```mzsql
 SELECT INT '4';
 ```
 ```nofmt
@@ -188,7 +188,7 @@ SELECT INT '4';
 
 <hr>
 
-```sql
+```mzsql
 SELECT CAST (CAST (100.21 AS numeric(10, 2)) AS float) AS dec_to_float;
 ```
 ```nofmt
@@ -199,7 +199,7 @@ SELECT CAST (CAST (100.21 AS numeric(10, 2)) AS float) AS dec_to_float;
 
 <hr/>
 
-```sql
+```mzsql
 SELECT 100.21::numeric(10, 2)::float AS dec_to_float;
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/coalesce.md
+++ b/doc/user/content/sql/functions/coalesce.md
@@ -20,7 +20,7 @@ All elements of the parameters for `coalesce` must be of the same type; `coalesc
 
 ## Examples
 
-```sql
+```mzsql
 SELECT coalesce(NULL, 3, 2, 1) AS coalesce_res;
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/csv_extract.md
+++ b/doc/user/content/sql/functions/csv_extract.md
@@ -25,7 +25,7 @@ _col_name_  | [`string`](../../types/text/)  | The name of the column containing
 
 Create a table where one column is in CSV format and insert some rows:
 
-```sql
+```mzsql
 CREATE TABLE t (id int, data string);
 INSERT INTO t
   VALUES (1, 'some,data'), (2, 'more,data'), (3, 'also,data');
@@ -33,7 +33,7 @@ INSERT INTO t
 
 Extract the component columns from the table column which is a CSV string, sorted by column `id`:
 
-```sql
+```mzsql
 SELECT csv.* FROM t, csv_extract(2, data) csv
   ORDER BY t.id;
 ```

--- a/doc/user/content/sql/functions/date-bin-hopping.md
+++ b/doc/user/content/sql/functions/date-bin-hopping.md
@@ -39,7 +39,7 @@ _origin_ | Must be the same as _source_ | Align bins to this value. If not provi
 
 ## Examples
 
-```sql
+```mzsql
 SELECT * FROM date_bin_hopping('45s', '1m', TIMESTAMP '2001-01-01 00:01:20');
 ```
 ```nofmt
@@ -49,7 +49,7 @@ SELECT * FROM date_bin_hopping('45s', '1m', TIMESTAMP '2001-01-01 00:01:20');
  2001-01-01 00:01:15
 ```
 
-```sql
+```mzsql
 SELECT date_bin_hopping AS timeframe_start, sum(v)
   FROM ( VALUES
     (TIMESTAMP '2021-01-01 01:05', 41),

--- a/doc/user/content/sql/functions/date-bin.md
+++ b/doc/user/content/sql/functions/date-bin.md
@@ -53,7 +53,7 @@ _origin_ | Must be the same as _source_ | Align bins to this value.
 
 ## Examples
 
-```sql
+```mzsql
 SELECT
   date_bin(
     '15 minutes',
@@ -67,7 +67,7 @@ SELECT
  2001-02-16 20:35:00
 ```
 
-```sql
+```mzsql
 SELECT
   str,
   "interval",

--- a/doc/user/content/sql/functions/date-part.md
+++ b/doc/user/content/sql/functions/date-part.md
@@ -51,7 +51,7 @@ day of year | `DOY`
 
 ### Extract second from timestamptz
 
-```sql
+```mzsql
 SELECT date_part('S', TIMESTAMP '2006-01-02 15:04:05.06');
 ```
 ```nofmt
@@ -62,7 +62,7 @@ SELECT date_part('S', TIMESTAMP '2006-01-02 15:04:05.06');
 
 ### Extract century from date
 
-```sql
+```mzsql
 SELECT date_part('CENTURIES', DATE '2006-01-02');
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/date-trunc.md
+++ b/doc/user/content/sql/functions/date-trunc.md
@@ -25,7 +25,7 @@ _val_ | [`timestamp`], [`timestamp with time zone`], [`interval`] | The value yo
 
 ## Examples
 
-```sql
+```mzsql
 SELECT date_trunc('hour', TIMESTAMP '2019-11-26 15:56:46.241150') AS hour_trunc;
 ```
 ```nofmt
@@ -34,7 +34,7 @@ SELECT date_trunc('hour', TIMESTAMP '2019-11-26 15:56:46.241150') AS hour_trunc;
  2019-11-26 15:00:00.000000000
 ```
 
-```sql
+```mzsql
 SELECT date_trunc('year', TIMESTAMP '2019-11-26 15:56:46.241150') AS year_trunc;
 ```
 ```nofmt
@@ -43,7 +43,7 @@ SELECT date_trunc('year', TIMESTAMP '2019-11-26 15:56:46.241150') AS year_trunc;
  2019-01-01 00:00:00.000000000
 ```
 
-```sql
+```mzsql
 SELECT date_trunc('millennium', INTERVAL '1234 years 11 months 23 days 23:59:12.123456789') AS millennium_trunc;
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/encode.md
+++ b/doc/user/content/sql/functions/encode.md
@@ -48,7 +48,7 @@ each encoded byte, though not within a byte.
 
 Encoding and decoding in the `base64` format:
 
-```sql
+```mzsql
 SELECT encode('\x00404142ff', 'base64');
 ```
 ```nofmt
@@ -57,7 +57,7 @@ SELECT encode('\x00404142ff', 'base64');
  AEBBQv8=
 ```
 
-```sql
+```mzsql
 SELECT decode('A   EB BQv8 =', 'base64');
 ```
 ```nofmt
@@ -66,7 +66,7 @@ SELECT decode('A   EB BQv8 =', 'base64');
  \x00404142ff
 ```
 
-```sql
+```mzsql
 SELECT encode('This message is long enough that the output will run to multiple lines.', 'base64');
 ```
 ```nofmt
@@ -80,7 +80,7 @@ SELECT encode('This message is long enough that the output will run to multiple 
 
 Encoding and decoding in the `escape` format:
 
-```sql
+```mzsql
 SELECT encode('\x00404142ff', 'escape');
 ```
 ```nofmt
@@ -89,7 +89,7 @@ SELECT encode('\x00404142ff', 'escape');
  \000@AB\377
 ```
 
-```sql
+```mzsql
 SELECT decode('\000@AB\377', 'escape');
 ```
 ```nofmt
@@ -102,7 +102,7 @@ SELECT decode('\000@AB\377', 'escape');
 
 Encoding and decoding in the `hex` format:
 
-```sql
+```mzsql
 SELECT encode('\x00404142ff', 'hex');
 ```
 ```nofmt
@@ -111,7 +111,7 @@ SELECT encode('\x00404142ff', 'hex');
  00404142ff
 ```
 
-```sql
+```mzsql
 SELECT decode('00  40  41  42  ff', 'hex');
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/extract.md
+++ b/doc/user/content/sql/functions/extract.md
@@ -48,7 +48,7 @@ decade  |  `DEC`, `DECS`, `DECADE`, `DECADES`
 
 ### Extract second from timestamptz
 
-```sql
+```mzsql
 SELECT EXTRACT(S FROM TIMESTAMP '2006-01-02 15:04:05.06');
 ```
 ```nofmt
@@ -59,7 +59,7 @@ SELECT EXTRACT(S FROM TIMESTAMP '2006-01-02 15:04:05.06');
 
 ### Extract century from date
 
-```sql
+```mzsql
 SELECT EXTRACT(CENTURIES FROM DATE '2006-01-02');
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/filters.md
+++ b/doc/user/content/sql/functions/filters.md
@@ -16,7 +16,7 @@ Temporal filters cannot be used in aggregate function filters.
 
 ## Examples
 
-```sql
+```mzsql
 SELECT
     COUNT(*) AS unfiltered,
     -- The FILTER guards the evaluation which might otherwise error.

--- a/doc/user/content/sql/functions/jsonb_agg.md
+++ b/doc/user/content/sql/functions/jsonb_agg.md
@@ -40,14 +40,14 @@ Instead, we recommend that you materialize all components required for the
 `jsonb_agg` function call and create a non-materialized view using `jsonb_agg`
 on top of that. That pattern is illustrated in the following statements:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW foo_view AS SELECT * FROM foo;
 CREATE VIEW bar AS SELECT jsonb_agg(foo_view.bar) FROM foo_view;
 ```
 
 ## Examples
 
-```sql
+```mzsql
 SELECT
   jsonb_agg(t) FILTER (WHERE t.content LIKE 'h%')
     AS my_agg

--- a/doc/user/content/sql/functions/jsonb_object_agg.md
+++ b/doc/user/content/sql/functions/jsonb_object_agg.md
@@ -47,7 +47,7 @@ Instead, we recommend that you materialize all components required for the
 `jsonb_object_agg` on top of that. That pattern is illustrated in the following
 statements:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW foo_view AS SELECT key_col, val_col FROM foo;
 CREATE VIEW bar AS SELECT jsonb_object_agg(key_col, val_col) FROM foo_view;
 ```
@@ -55,7 +55,7 @@ CREATE VIEW bar AS SELECT jsonb_object_agg(key_col, val_col) FROM foo_view;
 ## Examples
 
 Consider this query:
-```sql
+```mzsql
 SELECT
   jsonb_object_agg(
     t.col1,

--- a/doc/user/content/sql/functions/justify-days.md
+++ b/doc/user/content/sql/functions/justify-days.md
@@ -24,7 +24,7 @@ _interval_ | [`interval`](../../types/interval) | The interval value to justify.
 
 ## Example
 
-```sql
+```mzsql
 SELECT justify_days(interval '35 days');
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/justify-hours.md
+++ b/doc/user/content/sql/functions/justify-hours.md
@@ -24,7 +24,7 @@ _interval_ | [`interval`](../../types/interval) | The interval value to justify.
 
 ## Example
 
-```sql
+```mzsql
 SELECT justify_hours(interval '27 hours');
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/justify-interval.md
+++ b/doc/user/content/sql/functions/justify-interval.md
@@ -26,7 +26,7 @@ _interval_ | [`interval`](../../types/interval) | The interval value to justify.
 
 ## Example
 
-```sql
+```mzsql
 SELECT justify_interval(interval '1 mon -1 hour');
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/length.md
+++ b/doc/user/content/sql/functions/length.md
@@ -69,7 +69,7 @@ issue](https://github.com/MaterializeInc/materialize/issues/589).
 
 ## Examples
 
-```sql
+```mzsql
 SELECT length('你好') AS len;
 ```
 ```nofmt
@@ -80,7 +80,7 @@ SELECT length('你好') AS len;
 
 <hr/>
 
-```sql
+```mzsql
 SELECT length('你好', 'big5') AS len;
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/list_agg.md
+++ b/doc/user/content/sql/functions/list_agg.md
@@ -40,14 +40,14 @@ Instead, we recommend that you materialize all components required for the
 `list_agg` function call and create a non-materialized view using `list_agg`
 on top of that. That pattern is illustrated in the following statements:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW foo_view AS SELECT * FROM foo;
 CREATE VIEW bar AS SELECT list_agg(foo_view.bar) FROM foo_view;
 ```
 
 ## Examples
 
-```sql
+```mzsql
 SELECT
     title,
     LIST_AGG (

--- a/doc/user/content/sql/functions/map_agg.md
+++ b/doc/user/content/sql/functions/map_agg.md
@@ -47,7 +47,7 @@ Instead, we recommend that you materialize all components required for the
 `map_agg` on top of that. That pattern is illustrated in the following
 statements:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW foo_view AS SELECT key_col, val_col FROM foo;
 CREATE VIEW bar AS SELECT map_agg(key_col, val_col) FROM foo_view;
 ```
@@ -56,7 +56,7 @@ CREATE VIEW bar AS SELECT map_agg(key_col, val_col) FROM foo_view;
 
 Consider this query:
 
-```sql
+```mzsql
 SELECT
   map_agg(
     t.k,

--- a/doc/user/content/sql/functions/now_and_mz_now.md
+++ b/doc/user/content/sql/functions/now_and_mz_now.md
@@ -69,7 +69,7 @@ materialized would be resource prohibitive.
 It is common for real-time applications to be concerned with only a recent period of time.
 In this case, we will filter a table to only include records from the last 30 seconds.
 
-```sql
+```mzsql
 -- Create a table of timestamped events.
 CREATE TABLE events (
     content TEXT,
@@ -85,13 +85,13 @@ WHERE mz_now() <= event_ts + INTERVAL '30s';
 
 Next, subscribe to the results of the view.
 
-```sql
+```mzsql
 COPY (SUBSCRIBE (SELECT event_ts, content FROM last_30_sec)) TO STDOUT;
 ```
 
 In a separate session, insert a record.
 
-```sql
+```mzsql
 INSERT INTO events VALUES (
     'hello',
     now()
@@ -111,7 +111,7 @@ You can materialize the `last_30_sec` view by creating an index on it (results s
 
 If you haven't already done so in the previous example, create a table called `events` and add a few records.
 
-```sql
+```mzsql
 -- Create a table of timestamped events.
 CREATE TABLE events (
     content TEXT,
@@ -134,7 +134,7 @@ INSERT INTO events VALUES (
 
 Execute this ad hoc query that adds the current system timestamp and current logical timestamp to the events in the `events` table.
 
-```sql
+```mzsql
 SELECT now(), mz_now(), * FROM events
 ```
 
@@ -149,7 +149,7 @@ SELECT now(), mz_now(), * FROM events
 
 Notice when you try to materialize this query, you get errors:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW cant_materialize
     AS SELECT now(), mz_now(), * FROM events;
 ```

--- a/doc/user/content/sql/functions/pushdown.md
+++ b/doc/user/content/sql/functions/pushdown.md
@@ -41,7 +41,7 @@ optimization for your query.
 
 ## Examples
 
-```sql
+```mzsql
 SELECT try_parse_monotonic_iso8601_timestamp('2015-09-18T23:56:04.123Z') AS ts;
 ```
 ```nofmt
@@ -52,7 +52,7 @@ SELECT try_parse_monotonic_iso8601_timestamp('2015-09-18T23:56:04.123Z') AS ts;
 
  <hr/>
 
-```sql
+```mzsql
 SELECT try_parse_monotonic_iso8601_timestamp('nope') AS ts;
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/string_agg.md
+++ b/doc/user/content/sql/functions/string_agg.md
@@ -42,14 +42,14 @@ Instead, we recommend that you materialize all components required for the
 `string_agg` on top of that. That pattern is illustrated in the following
 statements:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW foo_view AS SELECT * FROM foo;
 CREATE VIEW bar AS SELECT string_agg(foo_view.bar, ',');
 ```
 
 ## Examples
 
-```sql
+```mzsql
 SELECT string_agg(column1, column2)
 FROM (
     VALUES ('z', ' !'), ('a', ' @'), ('m', ' #')
@@ -63,7 +63,7 @@ FROM (
 
 Note that in the following example, the `ORDER BY` of the subquery feeding into `string_agg` gets ignored.
 
-```sql
+```mzsql
 SELECT column1, column2
 FROM (
     VALUES ('z', ' !'), ('a', ' @'), ('m', ' #')
@@ -77,7 +77,7 @@ FROM (
  a       |  @
 ```
 
-```sql
+```mzsql
 SELECT string_agg(column1, column2)
 FROM (
     SELECT column1, column2
@@ -92,6 +92,6 @@ FROM (
  a #m !z
 ```
 
-```sql
+```mzsql
 SELECT string_agg(b, ',' ORDER BY a DESC) FROM table;
 ```

--- a/doc/user/content/sql/functions/substring.md
+++ b/doc/user/content/sql/functions/substring.md
@@ -24,7 +24,7 @@ _len_ | [`int`](../../types/int) | The length of the substring you want to retur
 
 ## Examples
 
-```sql
+```mzsql
 SELECT substring('abcdefg', 3) AS substr;
 ```
 ```nofmt
@@ -35,7 +35,7 @@ SELECT substring('abcdefg', 3) AS substr;
 
  <hr/>
 
-```sql
+```mzsql
 SELECT substring('abcdefg', 3, 3) AS substr;
 ```
 ```nofmt

--- a/doc/user/content/sql/functions/timezone-and-at-time-zone.md
+++ b/doc/user/content/sql/functions/timezone-and-at-time-zone.md
@@ -33,7 +33,7 @@ _timestamptz_ | [`timestamptz`](../../types/timestamp/#timestamp-with-time-zone-
 
 ### Convert timestamp to another time zone, returned as UTC with offset
 
-```sql
+```mzsql
 SELECT TIMESTAMP '2020-12-21 18:53:49' AT TIME ZONE 'America/New_York'::text;
 ```
 ```
@@ -43,7 +43,7 @@ SELECT TIMESTAMP '2020-12-21 18:53:49' AT TIME ZONE 'America/New_York'::text;
 (1 row)
 ```
 
-```sql
+```mzsql
 SELECT TIMEZONE('America/New_York'::text,'2020-12-21 18:53:49');
 ```
 ```
@@ -55,7 +55,7 @@ SELECT TIMEZONE('America/New_York'::text,'2020-12-21 18:53:49');
 
 ### Convert timestamp to another time zone, returned as specified local time
 
-```sql
+```mzsql
 SELECT TIMESTAMPTZ '2020-12-21 18:53:49+08' AT TIME ZONE 'America/New_York'::text;
 ```
 ```
@@ -65,7 +65,7 @@ SELECT TIMESTAMPTZ '2020-12-21 18:53:49+08' AT TIME ZONE 'America/New_York'::tex
 (1 row)
 ```
 
-```sql
+```mzsql
 SELECT TIMEZONE ('America/New_York'::text,'2020-12-21 18:53:49+08');
 ```
 ```

--- a/doc/user/content/sql/functions/to_char.md
+++ b/doc/user/content/sql/functions/to_char.md
@@ -16,7 +16,7 @@ specifier token inside of double-quotes to emit it literally.
 
 #### RFC 2822 format
 
-```sql
+```mzsql
 SELECT to_char(TIMESTAMPTZ '2019-11-26 15:56:46 +00:00', 'Dy, Mon DD YYYY HH24:MI:SS +0000') AS formatted
 ```
 ```nofmt
@@ -30,7 +30,7 @@ SELECT to_char(TIMESTAMPTZ '2019-11-26 15:56:46 +00:00', 'Dy, Mon DD YYYY HH24:M
 Normally the `W` in "Welcome" would be converted to the week number, so we must quote it.
 The "to" doesn't match any format specifiers, so quotes are optional.
 
-```sql
+```mzsql
 SELECT to_char(TIMESTAMPTZ '2019-11-26 15:56:46 +00:00', '"Welcome" to Mon, YYYY') AS formatted
 ```
 ```nofmt
@@ -41,7 +41,7 @@ SELECT to_char(TIMESTAMPTZ '2019-11-26 15:56:46 +00:00', '"Welcome" to Mon, YYYY
 
 #### Ordinal modifiers
 
-```sql
+```mzsql
 SELECT to_char(TIMESTAMPTZ '2019-11-1 15:56:46 +00:00', 'Dth of Mon') AS formatted
 ```
 ```nofmt

--- a/doc/user/content/sql/grant-privilege.md
+++ b/doc/user/content/sql/grant-privilege.md
@@ -71,19 +71,19 @@ type for sources, views, and materialized views, or omit the object type.
 
 ## Examples
 
-```sql
+```mzsql
 GRANT SELECT ON mv TO joe, mike;
 ```
 
-```sql
+```mzsql
 GRANT USAGE, CREATE ON DATABASE materialize TO joe;
 ```
 
-```sql
+```mzsql
 GRANT ALL ON CLUSTER dev TO joe;
 ```
 
-```sql
+```mzsql
 GRANT CREATEDB ON SYSTEM TO joe;
 ```
 

--- a/doc/user/content/sql/grant-role.md
+++ b/doc/user/content/sql/grant-role.md
@@ -20,11 +20,11 @@ _member_name_ | The role name to add to _role_name_ as a member.
 
 ## Examples
 
-```sql
+```mzsql
 GRANT data_scientist TO joe;
 ```
 
-```sql
+```mzsql
 GRANT data_scientist TO joe, mike;
 ```
 

--- a/doc/user/content/sql/insert.md
+++ b/doc/user/content/sql/insert.md
@@ -43,7 +43,7 @@ To insert data into a table, execute an `INSERT` statement where the `VALUES` cl
 is followed by a list of tuples. Each tuple in the `VALUES` clause must have a value
 for each column in the table. If a column is nullable, a `NULL` value may be provided.
 
-```sql
+```mzsql
 CREATE TABLE t (a int, b text NOT NULL);
 
 INSERT INTO t VALUES (1, 'a'), (NULL, 'b');
@@ -60,7 +60,7 @@ is nullable. `NULL` values may not be inserted into column `b`, which is not nul
 
 You may also insert data using a column specification.
 
-```sql
+```mzsql
 CREATE TABLE t (a int, b text NOT NULL);
 
 INSERT INTO t (b, a) VALUES ('a', 1), ('b', NULL);
@@ -76,7 +76,7 @@ SELECT * FROM t;
 
 You can also insert the values returned from `SELECT` statements:
 
-```sql
+```mzsql
 CREATE TABLE s (a text);
 
 INSERT INTO s VALUES ('c');

--- a/doc/user/content/sql/namespaces.md
+++ b/doc/user/content/sql/namespaces.md
@@ -53,7 +53,7 @@ These objects are not referenced by the standard SQL namespace.
 For example, to create a materialized view in a specific cluster, your SQL
 statement would be:
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW mv IN CLUSTER cluster1 AS ...
 ```
 
@@ -62,13 +62,13 @@ Replicas are referenced as `<cluster-name>.<replica-name>`.
 For example, to delete replica `r1` in cluster `cluster1`, your SQL statement
 would be:
 
-```sql
+```mzsql
 DROP CLUSTER REPLICA cluster1.r1
 ```
 
 Roles are referenced by their name. For example, to alter the `manager` role, your SQL statement would be:
 
-```sql
+```mzsql
 ALTER ROLE manager ...
 ```
 

--- a/doc/user/content/sql/prepare.md
+++ b/doc/user/content/sql/prepare.md
@@ -27,19 +27,19 @@ Prepared statements only last for the duration of the current database session. 
 
 ### Create a prepared statement
 
-```sql
+```mzsql
 PREPARE a AS SELECT 1 + $1;
 ```
 
 ### Execute a prepared statement
 
-```sql
+```mzsql
 EXECUTE a ('a', 'b', 1 + 2)
 ```
 
 ### Deallocate a prepared statement
 
-```sql
+```mzsql
 DEALLOCATE a;
 ```
 

--- a/doc/user/content/sql/reassign-owned.md
+++ b/doc/user/content/sql/reassign-owned.md
@@ -24,11 +24,11 @@ _new_role_ | The role name of the new owner of all the objects.
 
 ## Examples
 
-```sql
+```mzsql
 REASSIGN OWNED BY joe TO mike;
 ```
 
-```sql
+```mzsql
 REASSIGN OWNED BY joe, george TO mike;
 ```
 

--- a/doc/user/content/sql/reset.md
+++ b/doc/user/content/sql/reset.md
@@ -25,7 +25,7 @@ _name_ | The configuration parameter's name.
 
 ### Reset search path
 
-```sql
+```mzsql
 SHOW search_path;
 
  search_path

--- a/doc/user/content/sql/revoke-privilege.md
+++ b/doc/user/content/sql/revoke-privilege.md
@@ -71,19 +71,19 @@ type for sources, views, and materialized views, or omit the object type.
 
 ## Examples
 
-```sql
+```mzsql
 REVOKE SELECT ON mv FROM joe, mike;
 ```
 
-```sql
+```mzsql
 REVOKE USAGE, CREATE ON DATABASE materialize FROM joe;
 ```
 
-```sql
+```mzsql
 REVOKE ALL ON CLUSTER dev FROM joe;
 ```
 
-```sql
+```mzsql
 REVOKE CREATEDB ON SYSTEM FROM joe;
 ```
 

--- a/doc/user/content/sql/revoke-role.md
+++ b/doc/user/content/sql/revoke-role.md
@@ -25,11 +25,11 @@ You may not set up circular membership loops.
 
 ## Examples
 
-```sql
+```mzsql
 REVOKE data_scientist FROM joe;
 ```
 
-```sql
+```mzsql
 REVOKE data_scientist FROM joe, mike;
 ```
 

--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -79,7 +79,7 @@ Queries that can't simply read out from an index will create an ephemeral datafl
 the results. These dataflows are bound to the active [cluster](/get-started/key-concepts#clusters),
  which you can change using:
 
-```sql
+```mzsql
 SET cluster = <cluster name>;
 ```
 
@@ -157,7 +157,7 @@ This assumes you've already [created a source](../create-source).
 The following query creates a view representing the total of all
 purchases made by users per region, and then creates an index on this view.
 
-```sql
+```mzsql
 CREATE VIEW purchases_by_region AS
     SELECT region.id, sum(purchase.total)
     FROM mysql_simple_purchase AS purchase
@@ -176,7 +176,7 @@ dropped.
 
 Assuming you've created the indexed view listed above, named `purchases_by_region`, you can simply read from the index with an ad hoc `SELECT` query:
 
-```sql
+```mzsql
 SELECT * FROM purchases_by_region;
 ```
 
@@ -184,7 +184,7 @@ In this case, Materialize simply returns the results that the index is maintaini
 
 ### Ad hoc querying
 
-```sql
+```mzsql
 SELECT region.id, sum(purchase.total)
 FROM mysql_simple_purchase AS purchase
 JOIN mysql_simple_user AS user ON purchase.user_id = user.id
@@ -199,7 +199,7 @@ you may want to create an [index](/sql/create-index) (in memory) and/or a [mater
 
 ### Using regular CTEs
 
-```sql
+```mzsql
 WITH
   regional_sales (region, total_sales) AS (
     SELECT region, sum(amount)

--- a/doc/user/content/sql/set.md
+++ b/doc/user/content/sql/set.md
@@ -39,7 +39,7 @@ configuration parameters.
 
 ### Set active cluster
 
-```sql
+```mzsql
 SHOW cluster;
 
  cluster
@@ -57,17 +57,17 @@ SHOW cluster;
 
 ### Set transaction isolation level
 
-```sql
+```mzsql
 SET transaction_isolation = 'serializable';
 ```
 
 ### Set search path
 
-```sql
+```mzsql
 SET search_path = public, qck;
 ```
 
-```sql
+```mzsql
 SET schema = qck;
 ```
 

--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -16,7 +16,7 @@ cluster configured in Materialize.
 
 ## Examples
 
-```sql
+```mzsql
 SHOW CLUSTER REPLICAS;
 ```
 
@@ -27,7 +27,7 @@ SHOW CLUSTER REPLICAS;
  quickstart    | r1      | 25cc   | t     |
 ```
 
-```sql
+```mzsql
 SHOW CLUSTER REPLICAS WHERE cluster = 'quickstart';
 ```
 

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -93,7 +93,7 @@ The following characteristics apply to the `mz_support` cluster:
 
 ## Examples
 
-```sql
+```mzsql
 SET CLUSTER = mz_catalog_server;
 
 SHOW CLUSTERS;
@@ -110,7 +110,7 @@ SHOW CLUSTERS;
  mz_support           |
 ```
 
-```sql
+```mzsql
 SHOW CLUSTERS LIKE 'auction_%';
 ```
 

--- a/doc/user/content/sql/show-columns.md
+++ b/doc/user/content/sql/show-columns.md
@@ -44,7 +44,7 @@ object.
 
 ## Examples
 
-```sql
+```mzsql
 SHOW SOURCES;
 ```
 ```nofmt
@@ -52,7 +52,7 @@ SHOW SOURCES;
 ----------
 my_sources
 ```
-```sql
+```mzsql
 SHOW COLUMNS FROM my_source;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -20,7 +20,7 @@ _schema&lowbar;name_ | The schema to show connections from. If omitted, connecti
 
 ## Examples
 
-```sql
+```mzsql
 SHOW CONNECTIONS;
 ```
 
@@ -31,7 +31,7 @@ SHOW CONNECTIONS;
  postgres_connection | postgres
 ```
 
-```sql
+```mzsql
 SHOW CONNECTIONS LIKE 'kafka%';
 ```
 

--- a/doc/user/content/sql/show-create-connection.md
+++ b/doc/user/content/sql/show-create-connection.md
@@ -18,7 +18,7 @@ _connection&lowbar;name_ | The connection you want to get the `CREATE` statement
 
 ## Examples
 
-```sql
+```mzsql
 SHOW CREATE CONNECTION kafka_connection;
 ```
 

--- a/doc/user/content/sql/show-create-index.md
+++ b/doc/user/content/sql/show-create-index.md
@@ -18,7 +18,7 @@ _index&lowbar;name_ | The index you want use. You can find available index names
 
 ## Examples
 
-```sql
+```mzsql
 SHOW INDEXES FROM my_view;
 ```
 
@@ -28,7 +28,7 @@ SHOW INDEXES FROM my_view;
  my_view_idx | t   | quickstart | {a, b}
 ```
 
-```sql
+```mzsql
 SHOW CREATE INDEX my_view_idx;
 ```
 

--- a/doc/user/content/sql/show-create-materialized-view.md
+++ b/doc/user/content/sql/show-create-materialized-view.md
@@ -18,7 +18,7 @@ _view&lowbar;name_ | The materialized view you want to use. You can find availab
 
 ## Examples
 
-```sql
+```mzsql
 SHOW CREATE MATERIALIZED VIEW winning_bids;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-create-sink.md
+++ b/doc/user/content/sql/show-create-sink.md
@@ -18,7 +18,7 @@ _sink&lowbar;name_ | The sink you want use. You can find available sink names th
 
 ## Examples
 
-```sql
+```mzsql
 SHOW SINKS
 ```
 
@@ -28,7 +28,7 @@ SHOW SINKS
  my_view_sink
 ```
 
-```sql
+```mzsql
 SHOW CREATE SINK my_view_sink;
 ```
 

--- a/doc/user/content/sql/show-create-source.md
+++ b/doc/user/content/sql/show-create-source.md
@@ -18,7 +18,7 @@ _source&lowbar;name_ | The source you want use. You can find available source na
 
 ## Examples
 
-```sql
+```mzsql
 SHOW CREATE SOURCE market_orders_raw;
 ```
 

--- a/doc/user/content/sql/show-create-table.md
+++ b/doc/user/content/sql/show-create-table.md
@@ -18,11 +18,11 @@ _table&lowbar;name_ | The table you want use. You can find available table names
 
 ## Examples
 
-```sql
+```mzsql
 CREATE TABLE t (a int, b text NOT NULL);
 ```
 
-```sql
+```mzsql
 SHOW CREATE TABLE t;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-create-view.md
+++ b/doc/user/content/sql/show-create-view.md
@@ -18,7 +18,7 @@ _view&lowbar;name_ | The view you want to use. You can find available view names
 
 ## Examples
 
-```sql
+```mzsql
 SHOW CREATE VIEW my_view;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-databases.md
+++ b/doc/user/content/sql/show-databases.md
@@ -20,10 +20,10 @@ menu:
 
 ## Examples
 
-```sql
+```mzsql
 CREATE DATABASE my_db;
 ```
-```sql
+```mzsql
 SHOW DATABASES;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-default-privileges.md
+++ b/doc/user/content/sql/show-default-privileges.md
@@ -22,7 +22,7 @@ _role_name_                                         | Only shows default privile
 
 ## Examples
 
-```sql
+```mzsql
 SHOW DEFAULT PRIVILEGES;
 ```
 
@@ -35,7 +35,7 @@ SHOW DEFAULT PRIVILEGES;
  mike         |          |        | table       | joe     | SELECT
 ```
 
-```sql
+```mzsql
 SHOW DEFAULT PRIVILEGES ON SCHEMAS;
 ```
 
@@ -45,7 +45,7 @@ SHOW DEFAULT PRIVILEGES ON SCHEMAS;
  PUBLIC       |          |        | schema      | mike    | CREATE
 ```
 
-```sql
+```mzsql
 SHOW DEFAULT PRIVILEGES FOR joe;
 ```
 

--- a/doc/user/content/sql/show-indexes.md
+++ b/doc/user/content/sql/show-indexes.md
@@ -39,7 +39,7 @@ Field | Meaning
 
 ## Examples
 
-```sql
+```mzsql
 SHOW VIEWS;
 ```
 ```nofmt
@@ -49,7 +49,7 @@ SHOW VIEWS;
  my_materialized_view
 ```
 
-```sql
+```mzsql
 SHOW INDEXES ON my_materialized_view;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-materialized-views.md
+++ b/doc/user/content/sql/show-materialized-views.md
@@ -20,7 +20,7 @@ _cluster&lowbar;name_ | The cluster to show materialized views from. If omitted,
 
 ## Examples
 
-```sql
+```mzsql
 SHOW MATERIALIZED VIEWS;
 ```
 
@@ -30,7 +30,7 @@ SHOW MATERIALIZED VIEWS;
  winning_bids | quickstart
 ```
 
-```sql
+```mzsql
 SHOW MATERIALIZED VIEWS LIKE '%bid%';
 ```
 

--- a/doc/user/content/sql/show-objects.md
+++ b/doc/user/content/sql/show-objects.md
@@ -28,7 +28,7 @@ _schema&lowbar;name_ | The schema to show objects from. Defaults to first resolv
 
 ## Examples
 
-```sql
+```mzsql
 SHOW SCHEMAS;
 ```
 ```nofmt
@@ -36,7 +36,7 @@ SHOW SCHEMAS;
 --------
  public
 ```
-```sql
+```mzsql
 SHOW OBJECTS FROM public;
 ```
 ```nofmt
@@ -47,7 +47,7 @@ my_source       | source
 my_view         | view
 my_other_source | source
 ```
-```sql
+```mzsql
 SHOW OBJECTS;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-privileges.md
+++ b/doc/user/content/sql/show-privileges.md
@@ -23,7 +23,7 @@ _role_name_                                         | Only shows privileges gran
 
 ## Examples
 
-```sql
+```mzsql
 SHOW PRIVILEGES;
 ```
 
@@ -44,7 +44,7 @@ SHOW PRIVILEGES;
  mz_system | materialize |             |        |             | system      | CREATEROLE
 ```
 
-```sql
+```mzsql
 SHOW PRIVILEGES ON SCHEMAS;
 ```
 
@@ -56,7 +56,7 @@ SHOW PRIVILEGES ON SCHEMAS;
  mz_system | materialize | materialize |        | public | schema      | USAGE
 ```
 
-```sql
+```mzsql
 SHOW PRIVILEGES FOR materialize;
 ```
 

--- a/doc/user/content/sql/show-role-membership.md
+++ b/doc/user/content/sql/show-role-membership.md
@@ -22,7 +22,7 @@ _role_name_                                         | Only shows role membership
 
 ## Examples
 
-```sql
+```mzsql
 SHOW ROLE MEMBERSHIP;
 ```
 
@@ -35,7 +35,7 @@ SHOW ROLE MEMBERSHIP;
  r6   | r5     | mz_system
 ```
 
-```sql
+```mzsql
 SHOW ROLE MEMBERSHIP FOR r2;
 ```
 

--- a/doc/user/content/sql/show-roles.md
+++ b/doc/user/content/sql/show-roles.md
@@ -15,7 +15,7 @@ menu:
 
 ## Examples
 
-```sql
+```mzsql
 SHOW ROLES;
 ```
 ```nofmt
@@ -25,7 +25,7 @@ SHOW ROLES;
  mike@ko.sh
 ```
 
-```sql
+```mzsql
 SHOW ROLES LIKE 'jo%';
 ```
 ```nofmt
@@ -34,7 +34,7 @@ SHOW ROLES LIKE 'jo%';
  joe@ko.sh
 ```
 
-```sql
+```mzsql
 SHOW ROLES WHERE name = 'mike@ko.sh';
 ```
 ```nofmt

--- a/doc/user/content/sql/show-schemas.md
+++ b/doc/user/content/sql/show-schemas.md
@@ -24,7 +24,7 @@ _database&lowbar;name_ | The database to show schemas from. Defaults to the curr
 
 ## Examples
 
-```sql
+```mzsql
 SHOW DATABASES;
 ```
 ```nofmt
@@ -33,7 +33,7 @@ SHOW DATABASES;
 materialize
 my_db
 ```
-```sql
+```mzsql
 SHOW SCHEMAS FROM my_db
 ```
 ```nofmt

--- a/doc/user/content/sql/show-secrets.md
+++ b/doc/user/content/sql/show-secrets.md
@@ -18,7 +18,7 @@ _schema&lowbar;name_ | The schema to show secrets from. If omitted, secrets from
 
 ## Examples
 
-```sql
+```mzsql
 SHOW SECRETS;
 ```
 
@@ -30,7 +30,7 @@ SHOW SECRETS;
  upstash_sasl_username
 ```
 
-```sql
+```mzsql
 SHOW SECRETS FROM public LIKE '%cert%';
 ```
 

--- a/doc/user/content/sql/show-sinks.md
+++ b/doc/user/content/sql/show-sinks.md
@@ -40,7 +40,7 @@ Field       | Meaning
 
 ## Examples
 
-```sql
+```mzsql
 SHOW SINKS;
 ```
 ```nofmt
@@ -50,7 +50,7 @@ my_sink       | kafka |         | c1
 my_other_sink | kafka |         | c2
 ```
 
-```sql
+```mzsql
 SHOW SINKS IN CLUSTER c1;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -38,7 +38,7 @@ Field | Meaning
 
 ## Examples
 
-```sql
+```mzsql
 SHOW SOURCES;
 ```
 ```nofmt
@@ -48,7 +48,7 @@ SHOW SOURCES;
  my_postgres_source | postgres |       | c2
 ```
 
-```sql
+```mzsql
 SHOW SOURCES IN CLUSTER c2;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-subsources.md
+++ b/doc/user/content/sql/show-subsources.md
@@ -48,7 +48,7 @@ Field    | Meaning
 
 ## Examples
 
-```sql
+```mzsql
 SHOW SOURCES;
 ```
 ```nofmt
@@ -57,7 +57,7 @@ SHOW SOURCES;
  postgres
  kafka
 ```
-```sql
+```mzsql
 SHOW SUBSOURCES ON pg;
 ```
 ```nofmt
@@ -67,7 +67,7 @@ SHOW SUBSOURCES ON pg;
  table1_in_postgres | subsource
  table2_in_postgres | subsource
 ```
-```sql
+```mzsql
 SHOW SUBSOURCES ON kafka;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-tables.md
+++ b/doc/user/content/sql/show-tables.md
@@ -25,7 +25,7 @@ _schema&lowbar;name_ | The schema to show tables from. Defaults to first resolva
 ## Examples
 
 ### Show user-created tables
-```sql
+```mzsql
 SHOW TABLES;
 ```
 ```nofmt
@@ -36,7 +36,7 @@ SHOW TABLES;
 ```
 
 ### Show tables from specified schema
-```sql
+```mzsql
 SHOW SCHEMAS;
 ```
 ```nofmt
@@ -44,7 +44,7 @@ SHOW SCHEMAS;
 --------
  public
 ```
-```sql
+```mzsql
 SHOW TABLES FROM public;
 ```
 ```nofmt

--- a/doc/user/content/sql/show-types.md
+++ b/doc/user/content/sql/show-types.md
@@ -21,7 +21,7 @@ _schema&lowbar;name_ | The schema to show types from. Defaults to first resolvab
 
 ### Show custom data types
 
-```sql
+```mzsql
 SHOW TYPES;
 ```
 ```

--- a/doc/user/content/sql/show-views.md
+++ b/doc/user/content/sql/show-views.md
@@ -34,7 +34,7 @@ Field | Meaning
 
 ## Examples
 
-```sql
+```mzsql
 SHOW VIEWS;
 ```
 ```nofmt

--- a/doc/user/content/sql/show.md
+++ b/doc/user/content/sql/show.md
@@ -33,7 +33,7 @@ configuration parameters.
 
 ### Show active cluster
 
-```sql
+```mzsql
 SHOW cluster;
 ```
 ```
@@ -44,7 +44,7 @@ SHOW cluster;
 
 ### Show transaction isolation level
 
-```sql
+```mzsql
 SHOW transaction_isolation;
 ```
 ```

--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -222,7 +222,7 @@ Below are the recommended ways to work around this.
 
 As an example, we'll create a [counter load generator](https://materialize.com/docs/sql/create-source/load-generator/#creating-a-counter-load-generator) that emits a row every second:
 
-```sql
+```mzsql
 CREATE SOURCE counter FROM LOAD GENERATOR COUNTER;
 ```
 
@@ -235,14 +235,14 @@ Next, let's subscribe to the `counter` load generator source that we've created 
 
 First, declare a `SUBSCRIBE` cursor:
 
-```sql
+```mzsql
 BEGIN;
 DECLARE c CURSOR FOR SUBSCRIBE (SELECT * FROM counter);
 ```
 
 Then, use [`FETCH`](/sql/fetch) in a loop to retrieve each batch of results as soon as it's ready:
 
-```sql
+```mzsql
 FETCH ALL c;
 ```
 
@@ -250,19 +250,19 @@ That will retrieve all of the rows that are currently available.
 If there are no rows available, it will wait until there are some ready and return those.
 A `timeout` can be used to specify a window in which to wait for rows. This will return up to the specified count (or `ALL`) of rows that are ready within the timeout. To retrieve up to 100 rows that are available in at most the next `1s`:
 
-```sql
+```mzsql
 FETCH 100 c WITH (timeout='1s');
 ```
 
 To retrieve all available rows available over the next `1s`:
 
-```sql
+```mzsql
 FETCH ALL c WITH (timeout='1s');
 ```
 
 A `0s` timeout can be used to return rows that are available now without waiting:
 
-```sql
+```mzsql
 FETCH ALL c WITH (timeout='0s');
 ```
 
@@ -270,7 +270,7 @@ FETCH ALL c WITH (timeout='0s');
 
 If you want to use `SUBSCRIBE` from an interactive SQL session (e.g.`psql`), wrap the query in `COPY`:
 
-```sql
+```mzsql
 COPY (SUBSCRIBE (SELECT * FROM counter)) TO STDOUT;
 ```
 
@@ -319,11 +319,11 @@ value columns.
 * Using this modifier, the output rows will have the following
 structure:
 
-   ```sql
+   ```mzsql
    SUBSCRIBE mview ENVELOPE UPSERT (KEY (key));
    ```
 
-   ```sql
+   ```mzsql
    mz_timestamp | mz_state | key  | value
    -------------|----------|------|--------
    100          | upsert   | 1    | 2
@@ -336,7 +336,7 @@ structure:
 
   _Insert_
 
-  ```sql
+  ```mzsql
    -- at time 200, add a new row with key=3, value=6
    mz_timestamp | mz_state | key  | value
    -------------|----------|------|--------
@@ -347,7 +347,7 @@ structure:
 
   _Update_
 
-  ```sql
+  ```mzsql
    -- at time 300, update key=1's value to 10
    mz_timestamp | mz_state | key  | value
    -------------|----------|------|--------
@@ -361,7 +361,7 @@ structure:
 
   _Delete_
 
-  ```sql
+  ```mzsql
    -- at time 400, delete all rows
    mz_timestamp | mz_state | key  | value
    -------------|----------|------|--------
@@ -380,7 +380,7 @@ structure:
 
   _Key violation_
 
-  ```sql
+  ```mzsql
    -- at time 500, introduce a key_violation
    mz_timestamp | mz_state        | key  | value
    -------------|-----------------|------|--------
@@ -412,11 +412,11 @@ value of the columns.
 * Using this modifier, the output rows will have the following
 structure:
 
-   ```sql
+   ```mzsql
    SUBSCRIBE mview ENVELOPE DEBEZIUM (KEY (key));
    ```
 
-   ```sql
+   ```mzsql
    mz_timestamp | mz_state | key  | before_value | after_value
    -------------|----------|------|--------------|-------
    100          | upsert   | 1    | NULL         | 2
@@ -428,7 +428,7 @@ structure:
 
   _Insert_
 
-  ```sql
+  ```mzsql
    -- at time 200, add a new row with key=3, value=6
    mz_timestamp | mz_state | key  | before_value | after_value
    -------------|----------|------|--------------|-------
@@ -442,7 +442,7 @@ structure:
 
   _Update_
 
-  ```sql
+  ```mzsql
    -- at time 300, update key=1's value to 10
    mz_timestamp | mz_state | key  | before_value | after_value
    -------------|----------|------|--------------|-------
@@ -456,7 +456,7 @@ structure:
 
   _Delete_
 
-  ```sql
+  ```mzsql
    -- at time 400, delete all rows
    mz_timestamp | mz_state | key  | before_value | after_value
    -------------|----------|------|--------------|-------
@@ -475,7 +475,7 @@ structure:
 
   _Key violation_
 
-  ```sql
+  ```mzsql
    -- at time 500, introduce a key_violation
    mz_timestamp | mz_state        | key  | before_value | after_value
    -------------|-----------------|------|--------------|-------
@@ -499,7 +499,7 @@ to sort the rows within each distinct timestamp.
 * The `ORDER BY` expression can take any column in the underlying object or
   query, including `mz_diff`.
 
-   ```sql
+   ```mzsql
    SUBSCRIBE mview WITHIN TIMESTAMP ORDER BY c1, c2 DESC NULLS LAST, mz_diff;
 
    mz_timestamp | mz_diff | c1            | c2   | c3
@@ -518,7 +518,7 @@ to sort the rows within each distinct timestamp.
 
 When you're done, you can drop the `counter` load generator source:
 
-```sql
+```mzsql
 DROP SOURCE counter;
 ```
 

--- a/doc/user/content/sql/table.md
+++ b/doc/user/content/sql/table.md
@@ -23,7 +23,7 @@ _table\_name_ | The name of the tablefrom which to retrieve rows.
 The expression `TABLE t` is exactly equivalent to the following [`SELECT`]
 expression:
 
-```sql
+```mzsql
 SELECT * FROM t;
 ```
 
@@ -31,7 +31,7 @@ SELECT * FROM t;
 
 Using a `TABLE` expression as a standalone statement:
 
-```sql
+```mzsql
 TABLE t;
 ```
 ```nofmt
@@ -43,7 +43,7 @@ TABLE t;
 
 Using a `TABLE` expression in place of a [`SELECT`] expression:
 
-```sql
+```mzsql
 TABLE t ORDER BY a DESC LIMIT 1;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/_index.md
+++ b/doc/user/content/sql/types/_index.md
@@ -130,7 +130,7 @@ If we concatenate a custom `list` (in this example, `custom_list`) and a
 structurally equivalent built-in `list` (`int4 list`), the result is of the same
 type as the custom `list` (`custom_list`).
 
-```sql
+```mzsql
 CREATE TYPE custom_list AS LIST (ELEMENT TYPE int4);
 
 SELECT pg_typeof(
@@ -151,7 +151,7 @@ If we append a structurally appropriate element (`int4`) to a custom `list`
 (`custom_list`), the result is of the same type as the custom `list`
 (`custom_list`).
 
-```sql
+```mzsql
 SELECT pg_typeof(
   list_append('{1}'::custom_list, 2)
 ) AS custom_list_built_in_element_cat;
@@ -166,7 +166,7 @@ SELECT pg_typeof(
 If we append a structurally appropriate custom element (`custom_list`) to a
 built-in `list` (`int4 list list`), the result is a `list` of custom elements.
 
-```sql
+```mzsql
 SELECT pg_typeof(
   list_append('{{1}}'::int4 list list, '{2}'::custom_list)
 ) AS built_in_list_custom_element_append;
@@ -190,7 +190,7 @@ types' polymorphic constraints.
 For example, values of type `custom_list list` and `custom_nested_list` cannot
 both be used as `listany` values for the same function:
 
-```sql
+```mzsql
 CREATE TYPE custom_nested_list AS LIST (element_type=custom_list);
 
 SELECT list_cat(
@@ -208,7 +208,7 @@ As another example, when using `custom_list list` values for `listany`
 parameters, you can only use `custom_list` or `int4 list` values for
 `listelementany` parameters––using any other custom type will fail:
 
-```sql
+```mzsql
 CREATE TYPE second_custom_list AS LIST (element_type=int4);
 
 SELECT list_append(
@@ -227,7 +227,7 @@ To make custom types interoperable, you must cast them to the same type. For
 example, casting `custom_nested_list` to `custom_list list` (or vice versa)
 makes the values passed to `listany` parameters of the same custom type:
 
-```sql
+```mzsql
 SELECT pg_typeof(
   list_cat(
     -- result is "custom_list list"

--- a/doc/user/content/sql/types/array.md
+++ b/doc/user/content/sql/types/array.md
@@ -39,7 +39,7 @@ whenever possible.
 
 You can construct arrays using the special `ARRAY` expression:
 
-```sql
+```mzsql
 SELECT ARRAY[1, 2, 3]
 ```
 ```nofmt
@@ -50,7 +50,7 @@ SELECT ARRAY[1, 2, 3]
 
 You can nest `ARRAY` constructors to create multidimensional arrays:
 
-```sql
+```mzsql
 SELECT ARRAY[ARRAY['a', 'b'], ARRAY['c', 'd']]
 ```
 ```nofmt
@@ -62,7 +62,7 @@ SELECT ARRAY[ARRAY['a', 'b'], ARRAY['c', 'd']]
 Alternatively, you can construct an array from the results subquery.  These subqueries must return a single column. Note
 that, in this form of the `ARRAY` expression, parentheses are used rather than square brackets.
 
-```sql
+```mzsql
 SELECT ARRAY(SELECT x FROM test0 WHERE x > 0 ORDER BY x DESC LIMIT 3);
 ```
 ```nofmt
@@ -75,7 +75,7 @@ Arrays cannot be "ragged." The length of each array expression must equal the
 length of all other array constructors in the same dimension. For example, the
 following ragged array is rejected:
 
-```sql
+```mzsql
 SELECT ARRAY[ARRAY[1, 2], ARRAY[3]]
 ```
 ```nofmt
@@ -102,7 +102,7 @@ quotes, backslashes and double quotes are backslash-escaped.
 The following example demonstrates the output format and includes many of the
 aforementioned special cases.
 
-```sql
+```mzsql
 SELECT ARRAY[ARRAY['a', 'white space'], ARRAY[NULL, ''], ARRAY['escape"m\e', 'nUlL']]
 ```
 ```nofmt
@@ -152,7 +152,7 @@ You can cast any type of array to a list of the same element type, as long as
 the array has only 0 or 1 dimensions, i.e. you can cast `integer[]` to `integer
 list`, as long as the array is empty or does not contain any arrays itself.
 
-```sql
+```mzsql
 SELECT pg_typeof('{1,2,3}`::integer[]::integer list);
 ```
 ```
@@ -161,7 +161,7 @@ integer list
 
 ## Examples
 
-```sql
+```mzsql
 SELECT '{1,2,3}'::int[]
 ```
 ```nofmt
@@ -170,7 +170,7 @@ SELECT '{1,2,3}'::int[]
  {1,2,3}
 ```
 
-```sql
+```mzsql
 SELECT ARRAY[ARRAY[1, 2], ARRAY[NULL, 4]]::text
 ```
 ```nofmt

--- a/doc/user/content/sql/types/boolean.md
+++ b/doc/user/content/sql/types/boolean.md
@@ -43,7 +43,7 @@ You can [cast](../../functions/cast) the following types to `boolean`:
 
 ## Examples
 
-```sql
+```mzsql
 SELECT TRUE AS t_val;
 ```
 ```nofmt
@@ -52,7 +52,7 @@ SELECT TRUE AS t_val;
  t
 ```
 
-```sql
+```mzsql
 SELECT FALSE AS f_val;
  f_val
 -------

--- a/doc/user/content/sql/types/bytea.md
+++ b/doc/user/content/sql/types/bytea.md
@@ -67,7 +67,7 @@ You can explicitly [cast](../../functions/cast) [`text`](../text) to `bytea`.
 Unless a `text` value is a [hex-formatted](#hex-format) string, casting to
 `bytea` will encode characters using UTF-8:
 
-```sql
+```mzsql
 SELECT 'hello 👋'::bytea;
 ```
 ```text
@@ -80,7 +80,7 @@ The reverse, however, is not true. Casting a `bytea` value to `text` will not
 decode UTF-8 bytes into characters. Instead, the cast unconditionally produces a
 [hex-formatted](#hex-format) string:
 
-```sql
+```mzsql
 SELECT '\x68656c6c6f20f09f918b'::bytea::text
 ```
 ```text
@@ -92,10 +92,10 @@ SELECT '\x68656c6c6f20f09f918b'::bytea::text
 To decode UTF-8 bytes into characters, use the
 [`convert_from`](../../functions#convert_from) function instead of casting:
 
-```sql
+```mzsql
 SELECT convert_from('\x68656c6c6f20f09f918b', 'utf8') AS text;
 ```
-```sql
+```mzsql
   text
 ---------
  hello 👋
@@ -104,7 +104,7 @@ SELECT convert_from('\x68656c6c6f20f09f918b', 'utf8') AS text;
 ## Examples
 
 
-```sql
+```mzsql
 SELECT '\xDEADBEEF'::bytea AS bytea_val;
 ```
 ```nofmt
@@ -115,7 +115,7 @@ SELECT '\xDEADBEEF'::bytea AS bytea_val;
 
 <hr>
 
-```sql
+```mzsql
 SELECT '\000'::bytea AS bytea_val;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/date.md
+++ b/doc/user/content/sql/types/date.md
@@ -61,7 +61,7 @@ Operation | Computes
 
 ## Examples
 
-```sql
+```mzsql
 SELECT DATE '2007-02-01' AS date_v;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/float.md
+++ b/doc/user/content/sql/types/float.md
@@ -57,7 +57,7 @@ Value       | Aliases                    | Represents
 To input these special values, write them as a string and cast that string to
 the desired floating-point type. For example:
 
-```sql
+```mzsql
 SELECT 'NaN'::real AS nan
 ```
 ```nofmt
@@ -91,7 +91,7 @@ You can [cast](../../functions/cast) to `real` or `double precision` from the fo
 
 ## Examples
 
-```sql
+```mzsql
 SELECT 1.23::real AS real_v;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/integer.md
+++ b/doc/user/content/sql/types/integer.md
@@ -90,7 +90,7 @@ From | Required context
 
 ## Examples
 
-```sql
+```mzsql
 SELECT 123::integer AS int_v;
 ```
 ```nofmt
@@ -101,7 +101,7 @@ SELECT 123::integer AS int_v;
 
 <hr/>
 
-```sql
+```mzsql
 SELECT 1.23::integer AS int_v;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/interval.md
+++ b/doc/user/content/sql/types/interval.md
@@ -115,7 +115,7 @@ Operation | Computes | Notes
 
 ## Examples
 
-```sql
+```mzsql
 SELECT INTERVAL '1' MINUTE AS interval_m;
 ```
 
@@ -127,7 +127,7 @@ SELECT INTERVAL '1' MINUTE AS interval_m;
 
 ### SQL Standard syntax
 
-```sql
+```mzsql
 SELECT INTERVAL '1-2 3 4:5:6.7' AS interval_p;
 ```
 
@@ -139,7 +139,7 @@ SELECT INTERVAL '1-2 3 4:5:6.7' AS interval_p;
 
 ### PostgreSQL syntax
 
-```sql
+```mzsql
 SELECT INTERVAL '1 year 2.3 days 4.5 seconds' AS interval_p;
 ```
 
@@ -153,7 +153,7 @@ SELECT INTERVAL '1 year 2.3 days 4.5 seconds' AS interval_p;
 
 `interval_n` demonstrates using negative and positive components in an interval.
 
-```sql
+```mzsql
 SELECT INTERVAL '-1 day 2:3:4.5' AS interval_n;
 ```
 
@@ -168,7 +168,7 @@ SELECT INTERVAL '-1 day 2:3:4.5' AS interval_n;
 `interval_r` demonstrates how `head_time_unit` and `tail_time_unit` truncate the
 interval.
 
-```sql
+```mzsql
 SELECT INTERVAL '1-2 3 4:5:6.7' DAY TO MINUTE AS interval_r;
 ```
 
@@ -184,7 +184,7 @@ SELECT INTERVAL '1-2 3 4:5:6.7' DAY TO MINUTE AS interval_r;
 as well as using `tail_time_unit` to control the `time_unit` of the last value
 of the `interval` string.
 
-```sql
+```mzsql
 SELECT INTERVAL '1 day 2-3 4' MINUTE AS interval_w;
 ```
 
@@ -196,7 +196,7 @@ SELECT INTERVAL '1 day 2-3 4' MINUTE AS interval_w;
 
 ### Interaction with timestamps
 
-```sql
+```mzsql
 SELECT TIMESTAMP '2020-01-01 8:00:00' + INTERVAL '1' DAY AS ts_interaction;
 ```
 

--- a/doc/user/content/sql/types/jsonb.md
+++ b/doc/user/content/sql/types/jsonb.md
@@ -47,7 +47,7 @@ Functions that return `Col`s are considered table functions and can only be used
 as tables, i.e. you cannot use them as scalar values. For example, you can only
 use `jsonb_object_keys` in the following way:
 
-```sql
+```mzsql
 SELECT * FROM jsonb_object_keys('{"1":2,"3":4}'::jsonb);
 ```
 
@@ -86,7 +86,7 @@ You can explicitly [cast](../../functions/cast) from [`text`](../text) to `jsonb
 
 - `jsonb::text` always produces the printed version of the JSON.
 
-    ```sql
+    ```mzsql
     SELECT ('"a"'::jsonb)::text AS jsonb_elem;
     ```
     ```nofmt
@@ -99,7 +99,7 @@ You can explicitly [cast](../../functions/cast) from [`text`](../text) to `jsonb
   element, unless the output is a single JSON string in which case they print it
   without quotes, i.e. as a SQL `text` value.
 
-    ```sql
+    ```mzsql
     SELECT ('"a"'::jsonb)->>0 AS string_elem;
     ```
     ```nofmt
@@ -111,7 +111,7 @@ You can explicitly [cast](../../functions/cast) from [`text`](../text) to `jsonb
 - `text` values passed to `to_jsonb` with quotes (`"`) produced `jsonb` strings
   with the quotes escaped.
 
-    ```sql
+    ```mzsql
     SELECT to_jsonb('"foo"') AS escaped_quotes;
     ```
     ```nofmt
@@ -134,7 +134,7 @@ object key does not exist, or if either the input value or subscript value is
 To extract an element from an array, supply the 0-indexed position as the
 subscript:
 
-```sql
+```mzsql
 SELECT ('[1, 2, 3]'::jsonb)[1]
 ```
 ```nofmt
@@ -151,7 +151,7 @@ and [`array`] types, whose subscripting operation uses 1-indexed positions.
 
 To extract a value from an object, supply the key as the subscript:
 
-```sql
+```mzsql
 SELECT ('{"a": 1, "b": 2, "c": 3}'::jsonb)['b'];
 ```
 ```nofmt
@@ -162,7 +162,7 @@ SELECT ('{"a": 1, "b": 2, "c": 3}'::jsonb)['b'];
 
 You can chain subscript operations to retrieve deeply nested elements:
 
-```sql
+```mzsql
 SELECT ('{"1": 2, "a": ["b", "c"]}'::jsonb)['a'][1];
 ```
 ```nofmt
@@ -177,7 +177,7 @@ Because the output type of the subscript operation is always `jsonb`, when
 comparing the output of a subscript to a string, you must supply a JSON string
 to compare against:
 
-```sql
+```mzsql
 SELECT ('["a", "b"]::jsonb)[1] = '"b"'
 ```
 
@@ -197,7 +197,7 @@ The type of JSON element you're accessing dictates the RHS's type.
 
 - Use a `string` to return the value for a specific key:
 
-  ```sql
+  ```mzsql
   SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb->'1' AS field_jsonb;
   ```
   ```nofmt
@@ -208,7 +208,7 @@ The type of JSON element you're accessing dictates the RHS's type.
 
 - Use an `int` to return the value in an array at a specific index:
 
-  ```sql
+  ```mzsql
   SELECT '["1", "a", 2]'::jsonb->1 AS field_jsonb;
   ```
   ```nofmt
@@ -218,7 +218,7 @@ The type of JSON element you're accessing dictates the RHS's type.
   ```
 Field accessors can also be chained together.
 
-```sql
+```mzsql
 SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb->'a'->1 AS field_jsonb;
 ```
 ```nofmt
@@ -237,7 +237,7 @@ The type of JSON element you're accessing dictates the RHS's type.
 
 - Use a `string` to return the value for a specific key:
 
-  ```sql
+  ```mzsql
   SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb->>'1' AS field_text;
   ```
   ```nofmt
@@ -248,7 +248,7 @@ The type of JSON element you're accessing dictates the RHS's type.
 
 - Use an `int` to return the value in an array at a specific index:
 
-  ```sql
+  ```mzsql
   SELECT '["1", "a", 2]'::jsonb->>1 AS field_text;
   ```
   ```nofmt
@@ -260,7 +260,7 @@ The type of JSON element you're accessing dictates the RHS's type.
 Field accessors can also be chained together, as long as the LHS remains
 `jsonb`.
 
-```sql
+```mzsql
 SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb->'a'->>1 AS field_text;
 ```
 ```nofmt
@@ -277,7 +277,7 @@ You can access specific elements in a `jsonb` value using a "path", which is a
 [text array](/sql/types/array) where each element is either a field key or an
 array element:
 
-```sql
+```mzsql
 SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb #> '{a,1}' AS field_jsonb;
 ```
 ```nofmt
@@ -294,7 +294,7 @@ The operator returns a value of type `jsonb`. If the path is invalid, it returns
 The `#>>` operator is equivalent to the [`#>`](#path-access-as-jsonb-) operator,
 except that the operator returns a value of type `text`.
 
-```sql
+```mzsql
 SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb #>> '{a,1}' AS field_text;
 ```
 ```nofmt
@@ -307,7 +307,7 @@ SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb #>> '{a,1}' AS field_text;
 
 #### `jsonb` concat (`||`)
 
-```sql
+```mzsql
 SELECT '{"1": 2}'::jsonb ||
        '{"a": ["b", "c"]}'::jsonb AS concat;
 ```
@@ -321,7 +321,7 @@ SELECT '{"1": 2}'::jsonb ||
 
 #### Remove key (`-`)
 
-```sql
+```mzsql
  SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb - 'a' AS rm_key;
 ```
 ```nofmt
@@ -336,7 +336,7 @@ SELECT '{"1": 2}'::jsonb ||
 
 Here, the left hand side does contain the right hand side, so the result is `t` for true.
 
-```sql
+```mzsql
 SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb @>
        '{"1": 2}'::jsonb AS lhs_contains_rhs;
 ```
@@ -352,7 +352,7 @@ SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb @>
 
 Here, the right hand side does contain the left hand side, so the result is `t` for true.
 
-```sql
+```mzsql
 SELECT '{"1": 2}'::jsonb <@
        '{"1": 2, "a": ["b", "c"]}'::jsonb AS lhs_contains_rhs;
 ```
@@ -366,7 +366,7 @@ SELECT '{"1": 2}'::jsonb <@
 
 #### Search top-level keys (`?`)
 
-```sql
+```mzsql
 SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb ? 'a' AS search_for_key;
 ```
 ```nofmt
@@ -375,7 +375,7 @@ SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb ? 'a' AS search_for_key;
  t
 ```
 
-```sql
+```mzsql
 SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb ? 'b' AS search_for_key;
 ```
 ```nofmt
@@ -390,7 +390,7 @@ SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb ? 'b' AS search_for_key;
 
 ##### Expanding a JSON array
 
-```sql
+```mzsql
 SELECT * FROM jsonb_array_elements('[true, 1, "a", {"b": 2}, null]'::jsonb);
 ```
 ```nofmt
@@ -405,7 +405,7 @@ SELECT * FROM jsonb_array_elements('[true, 1, "a", {"b": 2}, null]'::jsonb);
 
 ##### Flattening a JSON array
 
-```sql
+```mzsql
 SELECT t.id,
        obj->>'a' AS a,
        obj->>'b' AS b
@@ -431,7 +431,7 @@ CROSS JOIN jsonb_array_elements(t.json_col) AS obj;
 
 #### `jsonb_array_elements_text`
 
-```sql
+```mzsql
 SELECT * FROM jsonb_array_elements_text('[true, 1, "a", {"b": 2}, null]'::jsonb);
 ```
 ```nofmt
@@ -448,7 +448,7 @@ SELECT * FROM jsonb_array_elements_text('[true, 1, "a", {"b": 2}, null]'::jsonb)
 
 #### `jsonb_array_length`
 
-```sql
+```mzsql
 SELECT jsonb_array_length('[true, 1, "a", {"b": 2}, null]'::jsonb);
 ```
 ```nofmt
@@ -461,7 +461,7 @@ SELECT jsonb_array_length('[true, 1, "a", {"b": 2}, null]'::jsonb);
 
 #### `jsonb_build_array`
 
-```sql
+```mzsql
 SELECT jsonb_build_array('a', 1::float, 2.0::float, true);
 ```
 ```nofmt
@@ -474,7 +474,7 @@ SELECT jsonb_build_array('a', 1::float, 2.0::float, true);
 
 #### `jsonb_build_object`
 
-```sql
+```mzsql
 SELECT jsonb_build_object(2.0::float, 'b', 'a', 1.1::float);
 ```
 ```nofmt
@@ -487,7 +487,7 @@ SELECT jsonb_build_object(2.0::float, 'b', 'a', 1.1::float);
 
 #### `jsonb_each`
 
-```sql
+```mzsql
 SELECT * FROM jsonb_each('{"1": 2.1, "a": ["b", "c"]}'::jsonb);
 ```
 ```nofmt
@@ -503,7 +503,7 @@ Note that the `value` column is `jsonb`.
 
 #### `jsonb_each_text`
 
-```sql
+```mzsql
 SELECT * FROM jsonb_each_text('{"1": 2.1, "a": ["b", "c"]}'::jsonb);
 ```
 ```nofmt
@@ -519,7 +519,7 @@ Note that the `value` column is `string`.
 
 #### `jsonb_object_keys`
 
-```sql
+```mzsql
 SELECT * FROM jsonb_object_keys('{"1": 2, "a": ["b", "c"]}'::jsonb);
 ```
 ```nofmt
@@ -533,7 +533,7 @@ SELECT * FROM jsonb_object_keys('{"1": 2, "a": ["b", "c"]}'::jsonb);
 
 #### `jsonb_pretty`
 
-```sql
+```mzsql
 SELECT jsonb_pretty('{"1": 2, "a": ["b", "c"]}'::jsonb);
 ```
 ```nofmt
@@ -552,7 +552,7 @@ SELECT jsonb_pretty('{"1": 2, "a": ["b", "c"]}'::jsonb);
 
 #### `jsonb_typeof`
 
-```sql
+```mzsql
 SELECT jsonb_typeof('[true, 1, "a", {"b": 2}, null]'::jsonb);
 ```
 ```nofmt
@@ -561,7 +561,7 @@ SELECT jsonb_typeof('[true, 1, "a", {"b": 2}, null]'::jsonb);
  array
 ```
 
-```sql
+```mzsql
 SELECT * FROM jsonb_typeof('{"1": 2, "a": ["b", "c"]}'::jsonb);
 ```
 ```nofmt
@@ -574,7 +574,7 @@ SELECT * FROM jsonb_typeof('{"1": 2, "a": ["b", "c"]}'::jsonb);
 
 #### `jsonb_strip_nulls`
 
-```sql
+```mzsql
 SELECT jsonb_strip_nulls('[{"1":"a","2":null},"b",null,"c"]'::jsonb);
 ```
 ```nofmt
@@ -587,7 +587,7 @@ SELECT jsonb_strip_nulls('[{"1":"a","2":null},"b",null,"c"]'::jsonb);
 
 #### `to_jsonb`
 
-```sql
+```mzsql
 SELECT to_jsonb(t) AS jsonified_row
 FROM (
   VALUES

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -61,7 +61,7 @@ The name of a list type is the name of its element type followed by `list`, e.g.
 
 You can construct lists using the `LIST` expression:
 
-```sql
+```mzsql
 SELECT LIST[1, 2, 3];
 ```
 ```nofmt
@@ -72,7 +72,7 @@ SELECT LIST[1, 2, 3];
 
 You can nest `LIST` constructors to create layered lists:
 
-```sql
+```mzsql
 SELECT LIST[LIST['a', 'b'], LIST['c']];
 ```
 ```nofmt
@@ -83,7 +83,7 @@ SELECT LIST[LIST['a', 'b'], LIST['c']];
 
 You can also elide the `LIST` keyword from the interior list expressions:
 
-```sql
+```mzsql
 SELECT LIST[['a', 'b'], ['c']];
 ```
 ```nofmt
@@ -96,7 +96,7 @@ Alternatively, you can construct a list from the results of a subquery. The
 subquery must return a single column. Note that, in this form of the `LIST`
 expression, parentheses are used rather than square brackets.
 
-```sql
+```mzsql
 SELECT LIST(SELECT x FROM test0 WHERE x > 0 ORDER BY x DESC LIMIT 3);
 ```
 ```nofmt
@@ -124,7 +124,7 @@ You can access elements of lists through:
 To access an individual element of list, you can “index” into it using brackets
 (`[]`) and 1-index element positions:
 
-```sql
+```mzsql
 SELECT LIST[['a', 'b'], ['c']][1];
 ```
 ```nofmt
@@ -135,7 +135,7 @@ SELECT LIST[['a', 'b'], ['c']][1];
 
 Indexing operations can be chained together to descend the list’s layers:
 
-```sql
+```mzsql
 SELECT LIST[['a', 'b'], ['c']][1][2];
 ```
 ```nofmt
@@ -147,7 +147,7 @@ SELECT LIST[['a', 'b'], ['c']][1][2];
 If the index is invalid (either less than 1 or greater than the maximum index),
 lists return _NULL_.
 
-```sql
+```mzsql
 SELECT LIST[['a', 'b'], ['c']][1][5] AS exceed_index;
 ```
 ```nofmt
@@ -160,7 +160,7 @@ Lists have types based on their layers (unlike arrays' dimension), and error if
 you attempt to index a non-list element (i.e. indexing past the list’s last
 layer):
 
-```sql
+```mzsql
 SELECT LIST[['a', 'b'], ['c']][1][2][3];
 ```
 ```nofmt
@@ -172,7 +172,7 @@ ERROR:  cannot subscript type string
 To access contiguous ranges of a list, you can slice it using `[first index :
 last index]`, using 1-indexed positions:
 
-```sql
+```mzsql
 SELECT LIST[1,2,3,4,5][2:4] AS two_to_four;
 ```
 ```nofmt
@@ -184,7 +184,7 @@ SELECT LIST[1,2,3,4,5][2:4] AS two_to_four;
 You can omit the first index to use the first value in the list, and omit the
 last index to use all elements remaining in the list.
 
-```sql
+```mzsql
 SELECT LIST[1,2,3,4,5][:3] AS one_to_three;
 ```
 ```nofmt
@@ -193,7 +193,7 @@ SELECT LIST[1,2,3,4,5][:3] AS one_to_three;
  {1,2,3}
 ```
 
-```sql
+```mzsql
 SELECT LIST[1,2,3,4,5][3:] AS three_to_five;
 ```
 ```nofmt
@@ -205,7 +205,7 @@ SELECT LIST[1,2,3,4,5][3:] AS three_to_five;
 If the first index exceeds the list's maximum index, the operation returns an
 empty list:
 
-```sql
+```mzsql
 SELECT LIST[1,2,3,4,5][10:] AS exceed_index;
 ```
 ```nofmt
@@ -217,7 +217,7 @@ SELECT LIST[1,2,3,4,5][10:] AS exceed_index;
 If the last index exceeds the list’s maximum index, the operation returns all
 remaining elements up to its final element.
 
-```sql
+```mzsql
 SELECT LIST[1,2,3,4,5][2:10] AS two_to_end;
 ```
 ```nofmt
@@ -230,7 +230,7 @@ Performing successive slices behaves more like a traditional programming
 language taking slices of an array, rather than PostgreSQL's slicing, which
 descends into each layer.
 
-```sql
+```mzsql
 SELECT LIST[1,2,3,4,5][2:][2:3] AS successive;
 ```
 ```nofmt
@@ -258,7 +258,7 @@ backslashes and double quotes are backslash-escaped.
 The following example demonstrates the output format and includes many of the
 aforementioned special cases.
 
-```sql
+```mzsql
 SELECT LIST[['a', 'white space'], [NULL, ''], ['escape"m\e', 'nUlL']];
 ```
 ```nofmt
@@ -283,7 +283,7 @@ The text you cast must:
     For example, to cast `text` to a `date list`, you use `date`'s `text`
     representation:
 
-    ```sql
+    ```mzsql
     SELECT '{2001-02-03, 2004-05-06}'::date list as date_list;
     ```
 
@@ -305,7 +305,7 @@ The text you cast must:
 
     For example:
 
-    ```sql
+    ```mzsql
     SELECT '{
         "{brackets}",
         "\"quotes\"",
@@ -365,7 +365,7 @@ their dimension. For example, arrays of `text` are all of type `text[]` and 1D,
 example, in a two-layer list, each of the first layer’s lists can be of a
 different length:
 
-```sql
+```mzsql
 SELECT LIST[[1,2], [3]] AS ragged_list;
 ```
 ```
@@ -380,7 +380,7 @@ This is known as a "ragged list."
 example, if the first element in a 2D list has a length of 2, all subsequent
 members must also have a length of 2.
 
-```sql
+```mzsql
 SELECT ARRAY[[1,2], [3]] AS ragged_array;
 ```
 ```
@@ -392,7 +392,7 @@ ERROR:  number of array elements (3) does not match declared cardinality (4)
 When indexed, lists return a value with one less layer than the indexed list.
 For example, indexing a two-layer list returns a one-layer list.
 
-```sql
+```mzsql
 SELECT LIST[['foo'],['bar']][1] AS indexing;
 ```
 ```
@@ -404,7 +404,7 @@ SELECT LIST[['foo'],['bar']][1] AS indexing;
 Attempting to index twice into a `text list` (i.e. a one-layer list), fails
 because you cannot index `text`.
 
-```sql
+```mzsql
 SELECT LIST['foo'][1][2];
 ```
 ```
@@ -467,7 +467,7 @@ You can [cast](../../functions/cast) the following types to `list`:
 
 ### Literals
 
-```sql
+```mzsql
 SELECT LIST[[1.5, NULL],[2.25]];
 ```
 ```nofmt
@@ -478,7 +478,7 @@ SELECT LIST[[1.5, NULL],[2.25]];
 
 ### Casting between lists
 
-```sql
+```mzsql
 SELECT LIST[[1.5, NULL],[2.25]]::int list list;
 ```
 ```nofmt
@@ -489,7 +489,7 @@ SELECT LIST[[1.5, NULL],[2.25]]::int list list;
 
 ### Casting to text
 
-```sql
+```mzsql
 SELECT LIST[[1.5, NULL],[2.25]]::text;
 ```
 ```nofmt
@@ -501,7 +501,7 @@ SELECT LIST[[1.5, NULL],[2.25]]::text;
 Despite the fact that the output looks the same as the above examples, it is, in
 fact, `text`.
 
-```sql
+```mzsql
 SELECT length(LIST[[1.5, NULL],[2.25]]::text);
 ```
 ```nofmt
@@ -512,7 +512,7 @@ SELECT length(LIST[[1.5, NULL],[2.25]]::text);
 
 ### Casting from text
 
-```sql
+```mzsql
 SELECT '{{1.5,NULL},{2.25}}'::numeric(38,2) list list AS text_to_list;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/map.md
+++ b/doc/user/content/sql/types/map.md
@@ -42,7 +42,7 @@ _value&lowbar;type_ | The [type](../../types) of the map's values.
 
 You can construct maps using the `MAP` expression:
 
-```sql
+```mzsql
 SELECT MAP['a' => 1, 'b' => 2];
 ```
 ```nofmt
@@ -53,7 +53,7 @@ SELECT MAP['a' => 1, 'b' => 2];
 
 You can nest `MAP` constructors:
 
-```sql
+```mzsql
 SELECT MAP['a' => MAP['b' => 'c']];
 ```
 ```nofmt
@@ -64,7 +64,7 @@ SELECT MAP['a' => MAP['b' => 'c']];
 
 You can also elide the `MAP` keyword from the interior map expressions:
 
-```sql
+```mzsql
 SELECT MAP['a' => ['b' => 'c']];
 ```
 ```nofmt
@@ -75,7 +75,7 @@ SELECT MAP['a' => ['b' => 'c']];
 
 `MAP` expressions evalute expressions for both keys and values:
 
-```sql
+```mzsql
 SELECT MAP['a' || 'b' => 1 + 2];
 ```
 ```nofmt
@@ -89,7 +89,7 @@ subquery must return two columns: a key column of type `text` and a value column
 of any type, in that order. Note that, in this form of the `MAP` expression,
 parentheses are used rather than square brackets.
 
-```sql
+```mzsql
 SELECT MAP(SELECT key, value FROM test0 ORDER BY x DESC LIMIT 3);
 ```
 ```nofmt
@@ -128,7 +128,7 @@ encoding and decoding][binary] for these types, as well.
 The textual format for a `map` is a sequence of `key => value` mappings
 separated by commas and surrounded by curly braces (`{}`). For example:
 
-```sql
+```mzsql
 SELECT '{a=>123.4, b=>111.1}'::map[text=>double] as m;
 ```
 ```nofmt
@@ -138,7 +138,7 @@ SELECT '{a=>123.4, b=>111.1}'::map[text=>double] as m;
 ```
 
 You can create nested maps the same way:
-```sql
+```mzsql
 SELECT '{a=>{b=>{c=>d}}}'::map[text=>map[text=>map[text=>text]]] as nested_map;
 ```
 ```nofmt
@@ -177,7 +177,7 @@ You can [cast](../../functions/cast) `map` to and from the following types:
 
 Retrieves and returns the target value or `NULL`.
 
-```sql
+```mzsql
 SELECT MAP['a' => 1, 'b' => 2] -> 'a' as field_map;
 ```
 ```nofmt
@@ -186,7 +186,7 @@ SELECT MAP['a' => 1, 'b' => 2] -> 'a' as field_map;
  1
 ```
 
-```sql
+```mzsql
 SELECT MAP['a' => 1, 'b' => 2] -> 'c' as field_map;
 ```
 ```nofmt
@@ -197,7 +197,7 @@ SELECT MAP['a' => 1, 'b' => 2] -> 'c' as field_map;
 
 Field accessors can also be chained together.
 
-```sql
+```mzsql
 SELECT MAP['a' => ['b' => 1], 'c' => ['d' => 2]] -> 'a' -> 'b' as field_map;
 ```
 ```nofmt
@@ -212,7 +212,7 @@ Note that all returned values are of the map's value type.
 
 #### LHS contains RHS (`@>`)
 
-```sql
+```mzsql
 SELECT MAP['a' => 1, 'b' => 2] @> MAP['a' => 1] AS lhs_contains_rhs;
 ```
 ```nofmt
@@ -225,7 +225,7 @@ SELECT MAP['a' => 1, 'b' => 2] @> MAP['a' => 1] AS lhs_contains_rhs;
 
 #### RHS contains LHS (`<@`)
 
-```sql
+```mzsql
 SELECT MAP['a' => 1, 'b' => 2] <@ MAP['a' => 1] as rhs_contains_lhs;
 ```
 ```nofmt
@@ -238,7 +238,7 @@ SELECT MAP['a' => 1, 'b' => 2] <@ MAP['a' => 1] as rhs_contains_lhs;
 
 #### Search top-level keys (`?`)
 
-```sql
+```mzsql
 SELECT MAP['a' => 1.9, 'b' => 2.0] ? 'a' AS search_for_key;
 ```
 ```nofmt
@@ -247,7 +247,7 @@ SELECT MAP['a' => 1.9, 'b' => 2.0] ? 'a' AS search_for_key;
  t
 ```
 
-```sql
+```mzsql
 SELECT MAP['a' => ['aa' => 1.9], 'b' => ['bb' => 2.0]] ? 'aa' AS search_for_key;
 ```
 ```nofmt
@@ -261,7 +261,7 @@ SELECT MAP['a' => ['aa' => 1.9], 'b' => ['bb' => 2.0]] ? 'aa' AS search_for_key;
 Returns `true` if all keys provided on the RHS are present in the top-level of
 the map, `false` otherwise.
 
-```sql
+```mzsql
 SELECT MAP['a' => 1, 'b' => 2] ?& ARRAY['b', 'a'] as search_for_all_keys;
 ```
 ```nofmt
@@ -270,7 +270,7 @@ SELECT MAP['a' => 1, 'b' => 2] ?& ARRAY['b', 'a'] as search_for_all_keys;
  t
 ```
 
-```sql
+```mzsql
 SELECT MAP['a' => 1, 'b' => 2] ?& ARRAY['c', 'b'] as search_for_all_keys;
 ```
 ```nofmt
@@ -284,7 +284,7 @@ SELECT MAP['a' => 1, 'b' => 2] ?& ARRAY['c', 'b'] as search_for_all_keys;
 Returns `true` if any keys provided on the RHS are present in the top-level of
 the map, `false` otherwise.
 
-```sql
+```mzsql
 SELECT MAP['a' => 1, 'b' => 2] ?| ARRAY['c', 'b'] as search_for_any_keys;
 ```
 ```nofmt
@@ -293,7 +293,7 @@ SELECT MAP['a' => 1, 'b' => 2] ?| ARRAY['c', 'b'] as search_for_any_keys;
  t
 ```
 
-```sql
+```mzsql
 SELECT MAP['a' => 1, 'b' => 2] ?| ARRAY['c', 'd', '1'] as search_for_any_keys;
 ```
 ```nofmt
@@ -306,7 +306,7 @@ SELECT MAP['a' => 1, 'b' => 2] ?| ARRAY['c', 'd', '1'] as search_for_any_keys;
 
 Returns the number of entries in the map.
 
-```sql
+```mzsql
 SELECT map_length(MAP['a' => 1, 'b' => 2]);
 ```
 ```nofmt

--- a/doc/user/content/sql/types/numeric.md
+++ b/doc/user/content/sql/types/numeric.md
@@ -72,7 +72,7 @@ For details on exceeding the `numeric` type's maximum precision, see
 By default, `numeric` values do not have a specified scale, so values can have
 anywhere between 0 and 39 digits after the decimal point. For example:
 
-```sql
+```mzsql
 CREATE TABLE unscaled (c NUMERIC);
 INSERT INTO unscaled VALUES
   (987654321098765432109876543210987654321),
@@ -92,7 +92,7 @@ However, if you specify a scale on a `numeric` value, values will be rescaled
 appropriately. If the resulting value exceeds the maximum precision for
 `numeric` types, you'll receive an error.
 
-```sql
+```mzsql
 CREATE TABLE scaled (c NUMERIC(39, 20));
 
 INSERT INTO scaled VALUES
@@ -101,7 +101,7 @@ INSERT INTO scaled VALUES
 ```
 ERROR:  numeric field overflow
 ```
-```sql
+```mzsql
 INSERT INTO scaled VALUES
   (9876543210987654321.09876543210987654321),
   (.987654321098765432109876543210987654321);
@@ -119,7 +119,7 @@ SELECT c FROM scaled;
 `numeric` operations will always round off fractional values to limit their
 values to 39 digits of precision.
 
-```sql
+```mzsql
 SELECT 2 * 9876543210987654321.09876543210987654321 AS rounded;
 
                  rounded
@@ -189,7 +189,7 @@ You can [cast](../../functions/cast) from the following types to `numeric`:
 
 ## Examples
 
-```sql
+```mzsql
 SELECT 1.23::numeric AS num_v;
 ```
 ```nofmt
@@ -199,7 +199,7 @@ SELECT 1.23::numeric AS num_v;
 ```
 <hr/>
 
-```sql
+```mzsql
 SELECT 1.23::numeric(38,3) AS num_38_3_v;
 ```
 ```nofmt
@@ -210,7 +210,7 @@ SELECT 1.23::numeric(38,3) AS num_38_3_v;
 
 <hr/>
 
-```sql
+```mzsql
 SELECT 1.23e4 AS num_w_exp;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/record.md
+++ b/doc/user/content/sql/types/record.md
@@ -41,7 +41,7 @@ You cannot cast from any other types to `record`.
 
 ## Examples
 
-```sql
+```mzsql
 SELECT ROW(1, 2) AS record;
 ```
 ```nofmt
@@ -52,7 +52,7 @@ SELECT ROW(1, 2) AS record;
 
 <hr>
 
-```sql
+```mzsql
 SELECT record, (record).f2 FROM (SELECT ROW(1, 2) AS record);
 ```
 ```nofmt
@@ -66,7 +66,7 @@ record | f2
 Forgetting to parenthesize the record expression in a field selection operation
 will result in errors like the following
 
-```sql
+```mzsql
 SELECT record.f2 FROM (SELECT ROW(1, 2) AS record);
 ```
 ```nofmt

--- a/doc/user/content/sql/types/text.md
+++ b/doc/user/content/sql/types/text.md
@@ -29,7 +29,7 @@ Detail | Info
 To escape a single quote character (`'`) in a standard string literal, write two
 adjacent single quotes:
 
-```sql
+```mzsql
 SELECT 'single''quote' AS output
 ```
 ```nofmt
@@ -82,7 +82,7 @@ You can [cast](../../functions/cast) [all types](../) to `text`. All casts are b
 
 ## Examples
 
-```sql
+```mzsql
 SELECT 'hello' AS text_val;
 ```
 ```nofmt
@@ -93,7 +93,7 @@ SELECT 'hello' AS text_val;
 
 <hr>
 
-```sql
+```mzsql
 SELECT E'behold\nescape strings\U0001F632' AS escape_val;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/time.md
+++ b/doc/user/content/sql/types/time.md
@@ -58,7 +58,7 @@ Operation | Computes
 
 ## Examples
 
-```sql
+```mzsql
 SELECT TIME '01:23:45' AS t_v;
 ```
 ```nofmt
@@ -69,7 +69,7 @@ SELECT TIME '01:23:45' AS t_v;
 
 <hr/>
 
-```sql
+```mzsql
 SELECT DATE '2001-02-03' + TIME '12:34:56' AS d_t;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/timestamp.md
+++ b/doc/user/content/sql/types/timestamp.md
@@ -98,7 +98,7 @@ Operation | Computes
 
 ### Return timestamp
 
-```sql
+```mzsql
 SELECT TIMESTAMP '2007-02-01 15:04:05' AS ts_v;
 ```
 ```nofmt
@@ -109,7 +109,7 @@ SELECT TIMESTAMP '2007-02-01 15:04:05' AS ts_v;
 
 ### Return timestamp with time zone
 
-```sql
+```mzsql
 SELECT TIMESTAMPTZ '2007-02-01 15:04:05+06' AS tstz_v;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/uint.md
+++ b/doc/user/content/sql/types/uint.md
@@ -82,7 +82,7 @@ From | Required context
 
 ## Examples
 
-```sql
+```mzsql
 SELECT 123::uint4 AS int_v;
 ```
 ```nofmt
@@ -93,7 +93,7 @@ SELECT 123::uint4 AS int_v;
 
 <hr/>
 
-```sql
+```mzsql
 SELECT 1.23::uint4 AS int_v;
 ```
 ```nofmt

--- a/doc/user/content/sql/types/uuid.md
+++ b/doc/user/content/sql/types/uuid.md
@@ -51,7 +51,7 @@ You can [cast](../../functions/cast) `uuid` to [`text`](../text) by assignment a
 
 ## Examples
 
-```sql
+```mzsql
 SELECT UUID 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' AS uuid
 ```
 ```nofmt

--- a/doc/user/content/sql/update.md
+++ b/doc/user/content/sql/update.md
@@ -30,7 +30,7 @@ _alias_ | Only permit references to _table_name_ as _alias_.
 
 ## Examples
 
-```sql
+```mzsql
 CREATE TABLE update_me (a int, b text);
 INSERT INTO update_me VALUES (1, 'hello'), (2, 'goodbye');
 UPDATE update_me SET a = a + 2 WHERE b = 'hello';
@@ -42,7 +42,7 @@ SELECT * FROM update_me;
  3 | hello
  2 | goodbye
 ```
-```sql
+```mzsql
 UPDATE update_me SET b = 'aloha';
 SELECT * FROM update_me;
 ```

--- a/doc/user/content/sql/values.md
+++ b/doc/user/content/sql/values.md
@@ -26,7 +26,7 @@ alone.
 
 Using a `VALUES` expression as a standalone statement:
 
-```sql
+```mzsql
 VALUES (1, 2, 3), (4, 5, 6);
 ```
 ```nofmt
@@ -38,7 +38,7 @@ VALUES (1, 2, 3), (4, 5, 6);
 
 Using a `VALUES` expression in place of a `SELECT` expression:
 
-```sql
+```mzsql
 VALUES (1), (2), (3) ORDER BY column1 DESC LIMIT 2;
 ```
 ```nofmt
@@ -50,7 +50,7 @@ VALUES (1), (2), (3) ORDER BY column1 DESC LIMIT 2;
 
 Using a `VALUES` expression in an [`INSERT`] statement:
 
-```sql
+```mzsql
 INSERT INTO t VALUES (1, 2), (3, 4);
 ```
 

--- a/doc/user/content/transform-data/dataflow-troubleshooting.md
+++ b/doc/user/content/transform-data/dataflow-troubleshooting.md
@@ -30,7 +30,7 @@ joining relations.
 To make these concepts a bit more tangible, let's look at the example from the
 [getting started guide](https://materialize.com/docs/get-started/quickstart/).
 
-```sql
+```mzsql
 CREATE SOURCE auction_house
   FROM LOAD GENERATOR AUCTION
   (TICK INTERVAL '100ms')
@@ -52,7 +52,7 @@ understand how this SQL query is translated to a dataflow, we can use
 [`EXPLAIN PLAN`](https://materialize.com/docs/sql/explain-plan/) to display the
 plan used to evaluate the join.
 
-```sql
+```mzsql
 EXPLAIN MATERIALIZED VIEW num_bids;
 ```
 ```
@@ -135,7 +135,7 @@ To understand which dataflow is taking the most time we can query the
 time the dataflows was busy since the system started and the dataflow was
 created.
 
-```sql
+```mzsql
 -- Extract raw elapsed time information for dataflows
 SELECT
     mdo.id,
@@ -177,7 +177,7 @@ interpret. The following query therefore only returns operators from the
 `mz_scheduling_elapsed` relation. You can further drill down by adding a filter
 condition that matches the name of a specific dataflow.
 
-```sql
+```mzsql
 SELECT
     mdod.id,
     mdod.name,
@@ -231,7 +231,7 @@ operators, it will become visible in the histogram. The offending operator will
 be scheduled in much longer intervals compared to other operators, which
 reflects in the histogram as larger time buckets.
 
-```sql
+```mzsql
 -- Extract raw scheduling histogram information for operators
 WITH histograms AS (
     SELECT
@@ -280,7 +280,7 @@ The reported duration is still reporting aggregated values since the operator
 has been created. To get a feeling for which operators are currently doing
 work, you can subscribe to the changes of the relation.
 
-```sql
+```mzsql
 -- Observe changes to the raw scheduling histogram information
 COPY(SUBSCRIBE(
     WITH histograms AS (
@@ -331,7 +331,7 @@ numbers of records and the size of the arrangements. The reported records may
 exceed the number of logical records; the report reflects the uncompacted
 state.
 
-```sql
+```mzsql
 -- Extract dataflow records and sizes
 SELECT
     id,
@@ -351,7 +351,7 @@ ORDER BY size DESC
 If you need to drill down into individual operators, you can query
 `mz_arrangement_sizes` instead.
 
-```sql
+```mzsql
 -- Extract operator records and sizes
 SELECT
     mdod.id,
@@ -401,7 +401,7 @@ they (currently) have a granularity determined by the source itself. For
 example, Kafka topic ingestion work can become skewed if most of the data is in
 only one out of multiple partitions.
 
-```sql
+```mzsql
 -- Get operators where one worker has spent more than 2 times the average
 -- amount of time spent. The number 2 can be changed according to the threshold
 -- for the amount of skew deemed problematic.
@@ -438,7 +438,7 @@ position `n`, then it is part of the `x` subregion of the region defined by
 positions `0..n-1`. The example SQL query and result below shows an operator
 whose `id` is 515 that belongs to "subregion 5 of region 1 of dataflow 21".
 
-```sql
+```mzsql
 SELECT * FROM mz_internal.mz_dataflow_addresses WHERE id=515;
 ```
 ```
@@ -456,7 +456,7 @@ said operator has only a single entry. For the example operator 515 above, you
 can find the name of the dataflow if you can find the name of the operator
 whose address is just "dataflow 21."
 
-```sql
+```mzsql
 -- get id and name of the operator representing the entirety of the dataflow
 -- that a problematic operator comes from
 SELECT

--- a/doc/user/content/transform-data/join.md
+++ b/doc/user/content/transform-data/join.md
@@ -90,7 +90,7 @@ involving `LATERAL` joins, Materialize can optimize away the join entirely.
 As a simple example, the following query uses `LATERAL` to count from 1 to `x`
 for all the values of `x` in `xs`.
 
-```sql
+```mzsql
 SELECT * FROM
   (VALUES (1), (3)) xs (x)
   CROSS JOIN LATERAL generate_series(1, x) y;
@@ -145,7 +145,7 @@ valid.
 
 ![inner join diagram](/images/join-inner.png)
 
-```sql
+```mzsql
 SELECT
   employees."name" AS employee,
   managers."name" AS manager
@@ -169,7 +169,7 @@ is referenced.
 
 ![left outer join diagram](/images/join-left-outer.png)
 
-```sql
+```mzsql
 SELECT
   employees."name" AS employee,
   managers."name" AS manager
@@ -197,7 +197,7 @@ table contain `NULL` wherever the left-hand table is referenced.
 
 ![right outer join diagram](/images/join-right-outer.png)
 
-```sql
+```mzsql
 SELECT
   employees."name" AS employee,
   managers."name" AS manager
@@ -223,7 +223,7 @@ other table is referenced.
 
 ![full outer join diagram](/images/join-full-outer.png)
 
-```sql
+```mzsql
 SELECT
   employees."name" AS employee,
   managers."name" AS manager

--- a/doc/user/content/transform-data/patterns/rules-engine.md
+++ b/doc/user/content/transform-data/patterns/rules-engine.md
@@ -27,7 +27,7 @@ In our example, for each rule in a `bird_rules` dataset, we filter the `birds` d
 ### Create Resources
 
 1. Create the `birds` table and insert some birds.
-    ```sql
+    ```mzsql
     CREATE TABLE birds (
     id INT,
     name VARCHAR(50),
@@ -48,7 +48,7 @@ In our example, for each rule in a `bird_rules` dataset, we filter the `birds` d
     (10, 'Pelican', 180.4, '["White"]');
     ```
 1. Create the `bird_rules` table and insert a few rules.
-    ```sql
+    ```mzsql
     CREATE TABLE bird_rules (
     id INT,
     starts_with CHAR(1),
@@ -69,7 +69,7 @@ In our example, for each rule in a `bird_rules` dataset, we filter the `birds` d
 
 Here is the view that will execute our bird rules:
 
-```sql
+```mzsql
 CREATE VIEW birds_filtered AS
 SELECT r.id AS rule_id, b.name, b.colors, b.wingspan_cm
 FROM
@@ -92,7 +92,7 @@ LATERAL (
 ### Subscribe to Changes
 
 1. Subscribe to the changes of `birds_filtered`.
-    ```sql
+    ```mzsql
     COPY(SUBSCRIBE birds_filtered) TO STDOUT;
     ```
     ```nofmt
@@ -102,7 +102,7 @@ LATERAL (
     ```
     Notice that the majestic penguin satisfies rule 2. None of the other birds satisfy any of the rules.
 1. In a separate session, insert a new bird that satisfies rule 3. Rule 3 requires a bird whose first letter is 'R', with a wingspan greater than or equal to 20 centimeters, and whose colors contain "Red". We will insert a "Really big robin" that satisfies this rule.
-    ```sql
+    ```mzsql
     INSERT INTO birds VALUES (11, 'Really big robin', 25.0, '["Red"]');
     ```
     Back in the `SUBSCRIBE` terminal, notice the output was immediately updated.
@@ -112,7 +112,7 @@ LATERAL (
     1688674195279      1         3       Really big robin     ["Red"]        25
     ```
 1. For fun, let's delete rule 3 and see what happens.
-    ```sql
+    ```mzsql
     DELETE FROM bird_rules WHERE id = 3;
     ```
     ```nofmt
@@ -122,7 +122,7 @@ LATERAL (
     ```
     Notice the bird was removed because the rule no longer exists.
 1. Now let's update an existing bird so that it satisfies a new rule. It turns out our penguin also has some blue coloration we didn't notice before.
-    ```sql
+    ```mzsql
     UPDATE birds SET colors = '["Black","White","Blue"]' WHERE name = 'Penguin';
     ```
     ```nofmt
@@ -138,7 +138,7 @@ LATERAL (
 
 Press `Ctrl+C` to stop your `SUBSCRIBE` query and then drop the tables to clean up.
 
-```sql
+```mzsql
 DROP TABLE birds CASCADE;
 DROP TABLE bird_rules CASCADE;
 ```

--- a/doc/user/content/transform-data/patterns/time-travel-queries.md
+++ b/doc/user/content/transform-data/patterns/time-travel-queries.md
@@ -129,7 +129,7 @@ state). This will allow you to resume using the retained history upstream.
 1. The first time you start the subscription, run the following
 continuous query against Materialize in your application code:
 
-   ```sql
+   ```mzsql
    SUBSCRIBE (<your query>) WITH (PROGRESS, SNAPSHOT true);
    ```
 
@@ -146,7 +146,7 @@ is complete, so you can:
 1. To resume the subscription in subsequent restarts,
 use the following continuous query against Materialize in your application code:
 
-   ```sql
+   ```mzsql
    SUBSCRIBE (<your query>) WITH (PROGRESS, SNAPSHOT false) AS OF <last_progress_mz_timestamp>;
    ```
 
@@ -185,7 +185,7 @@ To set a history retention period for an object, use the `RETAIN HISTORY`
 option, which accepts positive [interval](/sql/types/interval/) values
 (e.g. `'1hr'`):
 
-```sql
+```mzsql
 CREATE MATERIALIZED VIEW winning_bids
 WITH (RETAIN HISTORY FOR '1hr') AS
 SELECT auction_id,
@@ -200,7 +200,7 @@ WHERE end_time < mz_now();
 
 To adjust the history retention period for an object, use `ALTER`:
 
-```sql
+```mzsql
 ALTER MATERIALIZED VIEW winning_bids SET (RETAIN HISTORY FOR '2hr');
 ```
 
@@ -209,7 +209,7 @@ ALTER MATERIALIZED VIEW winning_bids SET (RETAIN HISTORY FOR '2hr');
 To see what history retention period has been configured for an object,
 look up the object in the [`mz_internal.mz_history_retention_strategies`](/sql/system-catalog/mz_internal/#mz_history_retention_strategies) catalog table.
 
-```sql
+```mzsql
 SELECT
     d.name AS database_name,
     s.name AS schema_name,
@@ -234,6 +234,6 @@ WHERE mv.name = 'winning_bids';
 
 To disable history retention, reset the `RETAIN HISTORY` option:
 
-```sql
+```mzsql
 ALTER MATERIALIZED VIEW winning_bids RESET (RETAIN HISTORY);
 ```

--- a/doc/user/content/transform-data/patterns/top-k.md
+++ b/doc/user/content/transform-data/patterns/top-k.md
@@ -20,7 +20,7 @@ databases, you might use window functions. In Materialize, we recommend using a
 [`LATERAL` subquery](/transform-data/join/#lateral-subqueries). The general form of the
 query looks like this:
 
-```sql
+```mzsql
 SELECT * FROM
     (SELECT DISTINCT key_col FROM tbl) grp,
     LATERAL (
@@ -33,7 +33,7 @@ SELECT * FROM
 For example, suppose you have a relation containing the population of various
 U.S. cities.
 
-```sql
+```mzsql
 CREATE TABLE cities (
     name text NOT NULL,
     state text NOT NULL,
@@ -56,7 +56,7 @@ INSERT INTO cities VALUES
 
 To fetch the three most populous cities in each state:
 
-```sql
+```mzsql
 SELECT state, name FROM
     (SELECT DISTINCT state FROM cities) grp,
     LATERAL (
@@ -80,7 +80,7 @@ TX  Dallas
 Despite the verbosity of the above query, Materialize produces a straightforward
 plan:
 
-```sql
+```mzsql
 EXPLAIN SELECT state, name FROM ...
 ```
 ```nofmt
@@ -94,7 +94,7 @@ Explained Query:
 
 If _K_ = 1, i.e., you would like to see only the most populous city in each state, another approach is to use `DISTINCT ON`:
 
-```sql
+```mzsql
 SELECT DISTINCT ON(state) state, name
 FROM cities
 ORDER BY state, pop DESC;
@@ -106,7 +106,7 @@ Note that the `ORDER BY` clause should start with the expressions that are in th
 When using either the above `LATERAL` subquery pattern or `DISTINCT ON`, we recommend
 specifying [query hints](/sql/select/#query-hints) to improve memory usage. For example:
 
-```sql
+```mzsql
 SELECT state, name FROM
     (SELECT DISTINCT state FROM cities) grp,
     LATERAL (
@@ -119,7 +119,7 @@ SELECT state, name FROM
 
 or
 
-```sql
+```mzsql
 SELECT DISTINCT ON(state) state, name
 FROM cities
 OPTIONS (DISTINCT ON INPUT GROUP SIZE = 1000)

--- a/doc/user/content/transform-data/troubleshooting.md
+++ b/doc/user/content/transform-data/troubleshooting.md
@@ -110,7 +110,7 @@ It's important to note that this only applies to basic queries against **a
 single** source, materialized view or table, with no ordering, filters or
 offsets.
 
-```sql
+```mzsql
 SELECT <column list or *>
 FROM <source, materialized view or table>
 LIMIT <25 or less>;
@@ -125,7 +125,7 @@ to get the execution plan for the query, and validate that it starts with
 Use temporal flters to filter results on a timestamp column that correlates with
 the insertion or update time of each row. For example:
 
-```sql
+```mzsql
 WHERE mz_now() <= event_ts + INTERVAL '1hr'
 ```
 
@@ -187,7 +187,7 @@ The measure of cluster busyness is CPU. You can monitor CPU usage in the
 the **"Clusters"** tab in the navigation bar, and clicking into the cluster.
 You can also grab CPU usage from the system catalog using SQL:
 
-```sql
+```mzsql
 SELECT cru.cpu_percent
 FROM mz_internal.mz_cluster_replica_utilization cru
 LEFT JOIN mz_catalog.mz_cluster_replicas cr ON cru.replica_id = cr.id

--- a/doc/user/layouts/shortcodes/mysql-direct/check-the-ingestion-status.html
+++ b/doc/user/layouts/shortcodes/mysql-direct/check-the-ingestion-status.html
@@ -9,7 +9,7 @@ status of the snapshotting process.
    [`mz_source_statuses`](/sql/system-catalog/mz_internal/#mz_source_statuses)
    table to check the overall status of your source:
 
-    ```sql
+    ```mzsql
     WITH
       source_ids AS
       (SELECT id FROM mz_sources WHERE name = 'mz_source')
@@ -37,7 +37,7 @@ status of the snapshotting process.
 2. Once the source is running, use the [`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics)
    table to check the status of the initial snapshot:
 
-    ```sql
+    ```mzsql
     WITH
       source_ids AS
       (SELECT id FROM mz_sources WHERE name = 'mz_source')

--- a/doc/user/layouts/shortcodes/mysql-direct/create-a-cluster.html
+++ b/doc/user/layouts/shortcodes/mysql-direct/create-a-cluster.html
@@ -12,7 +12,7 @@ your MySQL database.
    client connected to Materialize, use the [`CREATE CLUSTER`](/sql/create-cluster/)
    command to create the new cluster:
 
-    ```sql
+    ```mzsql
     CREATE CLUSTER ingest_mysql (SIZE = '200cc');
 
     SET CLUSTER = ingest_mysql;

--- a/doc/user/layouts/shortcodes/mysql-direct/create-a-user-for-replication.html
+++ b/doc/user/layouts/shortcodes/mysql-direct/create-a-user-for-replication.html
@@ -6,7 +6,7 @@ user for Materialize with sufficient privileges to manage replication.
 
 1. Create a dedicated user for Materialize, if you don't already have one:
 
-   ```sql
+   ```mysql
    CREATE USER 'materialize'@'%' IDENTIFIED BY '<password>';
 
    ALTER USER 'materialize'@'%' REQUIRE SSL;
@@ -14,7 +14,7 @@ user for Materialize with sufficient privileges to manage replication.
 
 1. Grant the user permission to manage replication:
 
-   ```sql
+   ```mysql
    GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, LOCK TABLES ON *.* TO 'materialize'@'%';
    ```
 
@@ -24,6 +24,6 @@ user for Materialize with sufficient privileges to manage replication.
 
 1. Apply the changes:
 
-   ```sql
+   ```mysql
    FLUSH PRIVILEGES;
    ```

--- a/doc/user/layouts/shortcodes/mysql-direct/ingesting-data/allow-materialize-ips.html
+++ b/doc/user/layouts/shortcodes/mysql-direct/ingesting-data/allow-materialize-ips.html
@@ -4,7 +4,7 @@
    command to securely store the password for the `materialize` MySQL user
    you created [earlier](#step-2-create-a-user-for-replication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET mysqlpass AS '<PASSWORD>';
     ```
 
@@ -12,7 +12,7 @@
    connection object with access and authentication details for Materialize to
    use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION mysql_connection TO MYSQL (
         HOST <host>,
         PORT 3306,
@@ -27,7 +27,7 @@
 1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize
    to your Azure instance and start ingesting data:
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       FROM mysql CONNECTION mysql_connection
       FOR ALL TABLES;

--- a/doc/user/layouts/shortcodes/mysql-direct/ingesting-data/use-ssh-tunnel.html
+++ b/doc/user/layouts/shortcodes/mysql-direct/ingesting-data/use-ssh-tunnel.html
@@ -2,7 +2,7 @@
    client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel)
    command to create an SSH tunnel connection:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (
         HOST '<SSH_BASTION_HOST>',
         PORT <SSH_BASTION_PORT>,
@@ -16,7 +16,7 @@
 
 1. Get Materialize's public keys for the SSH tunnel connection:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_ssh_tunnel_connections;
     ```
 
@@ -30,7 +30,7 @@
 
 1. Back in the SQL client connected to Materialize, validate the SSH tunnel connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
-    ```sql
+    ```mzsql
     VALIDATE CONNECTION ssh_connection;
     ```
 
@@ -38,13 +38,13 @@
 
 1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` MySQL user you created [earlier](#step-2-create-a-user-for-replication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET mysqlpass AS '<PASSWORD>';
     ```
 
 1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create another connection object, this time with database access and authentication details for Materialize to use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION mysql_connection TO MYSQL (
     HOST '<host>',
     SSH TUNNEL ssh_connection
@@ -55,7 +55,7 @@
 
 1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your Azure instance and start ingesting data:
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       FROM mysql CONNECTION mysql_connection
       FOR ALL TABLES;

--- a/doc/user/layouts/shortcodes/mysql-direct/right-size-the-cluster.html
+++ b/doc/user/layouts/shortcodes/mysql-direct/right-size-the-cluster.html
@@ -6,7 +6,7 @@ accordingly.
 1. Still in a SQL client connected to Materialize, use the [`ALTER CLUSTER`](/sql/alter-cluster/)
    command to downsize the cluster to `100cc`:
 
-    ```sql
+    ```mzsql
     ALTER CLUSTER ingest_mysql SET (SIZE '100cc');
     ```
 
@@ -16,7 +16,7 @@ accordingly.
 1. Use the [`SHOW CLUSTER REPLICAS`](/sql/show-cluster-replicas/) command to
    check the status of the new replica:
 
-    ```sql
+    ```mzsql
     SHOW CLUSTER REPLICAS WHERE cluster = 'ingest_mysql';
     ```
     <p></p>

--- a/doc/user/layouts/shortcodes/network-security/privatelink-kafka.md
+++ b/doc/user/layouts/shortcodes/network-security/privatelink-kafka.md
@@ -52,7 +52,7 @@ and retrieve the AWS principal needed to configure the AWS PrivateLink service.
 1. #### Create an AWS PrivateLink connection
      In Materialize, create an [AWS PrivateLink connection](/sql/create-connection/#aws-privatelink) that references the endpoint service that you created in the previous step.
 
-     ```sql
+     ```mzsql
     CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
         SERVICE NAME 'com.amazonaws.vpce.<region_id>.vpce-svc-<endpoint_service_id>',
         AVAILABILITY ZONES ('use1-az1', 'use1-az2', 'use1-az3')
@@ -65,7 +65,7 @@ and retrieve the AWS principal needed to configure the AWS PrivateLink service.
 
 1. Retrieve the AWS principal for the AWS PrivateLink connection you just created:
 
-    ```sql
+    ```mzsql
     SELECT principal
     FROM mz_aws_privatelink_connections plc
     JOIN mz_connections c ON plc.id = c.id
@@ -90,7 +90,7 @@ and retrieve the AWS principal needed to configure the AWS PrivateLink service.
 
 Validate the AWS PrivateLink connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
-```sql
+```mzsql
 VALIDATE CONNECTION privatelink_svc;
 ```
 
@@ -100,7 +100,7 @@ If no validation error is returned, move to the next step.
 
 In Materialize, create a source connection that uses the AWS PrivateLink connection you just configured:
 
-```sql
+```mzsql
 CREATE CONNECTION kafka_connection TO KAFKA (
     BROKERS (
         'b-1.hostname-1:9096' USING AWS PRIVATELINK privatelink_svc (PORT 9001, AVAILABILITY ZONE 'use1-az2'),

--- a/doc/user/layouts/shortcodes/network-security/privatelink-postgres.md
+++ b/doc/user/layouts/shortcodes/network-security/privatelink-postgres.md
@@ -39,7 +39,7 @@
 1. #### Create an AWS PrivateLink Connection
      In Materialize, create an [AWS PrivateLink connection](/sql/create-connection/#aws-privatelink) that references the endpoint service that you created in the previous step.
 
-     ```sql
+     ```mzsql
     CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
         SERVICE NAME 'com.amazonaws.vpce.<region_id>.vpce-svc-<endpoint_service_id>',
         AVAILABILITY ZONES ('use1-az1', 'use1-az2', 'use1-az3')
@@ -52,7 +52,7 @@
 
 1. Retrieve the AWS principal for the AWS PrivateLink connection you just created:
 
-    ```sql
+    ```mzsql
     SELECT principal
     FROM mz_aws_privatelink_connections plc
     JOIN mz_connections c ON plc.id = c.id
@@ -77,7 +77,7 @@
 
 Validate the AWS PrivateLink connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
-```sql
+```mzsql
 VALIDATE CONNECTION privatelink_svc;
 ```
 
@@ -87,7 +87,7 @@ If no validation error is returned, move to the next step.
 
 In Materialize, create a source connection that uses the AWS PrivateLink connection you just configured:
 
-```sql
+```mzsql
 CREATE CONNECTION pg_connection TO POSTGRES (
     HOST 'instance.foo000.us-west-1.rds.amazonaws.com',
     PORT 5432,
@@ -100,7 +100,7 @@ CREATE CONNECTION pg_connection TO POSTGRES (
 
 This PostgreSQL connection can then be reused across multiple [CREATE SOURCE](https://materialize.com/docs/sql/create-source/postgres/) statements:
 
-```sql
+```mzsql
 CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
   FOR ALL TABLES;

--- a/doc/user/layouts/shortcodes/network-security/ssh-tunnel.md
+++ b/doc/user/layouts/shortcodes/network-security/ssh-tunnel.md
@@ -14,7 +14,7 @@ Before you begin, make sure you have access to a bastion host. You will need:
 
 In Materialize, create an [SSH tunnel connection](/sql/create-connection/#ssh-tunnel) to the bastion host:
 
-```sql
+```mzsql
 CREATE CONNECTION ssh_connection TO SSH TUNNEL (
     HOST '<SSH_BASTION_HOST>',
     USER '<SSH_BASTION_USER>',
@@ -29,7 +29,7 @@ created in the previous step.
 
 1. Materialize stores public keys for SSH tunnels in the system catalog. Query [`mz_ssh_tunnel_connections`](/sql/system-catalog/mz_catalog/#mz_ssh_tunnel_connections) to retrieve the public keys for the SSH tunnel connection you just created:
 
-    ```sql
+    ```mzsql
     SELECT
         mz_connections.name,
         mz_ssh_tunnel_connections.*
@@ -112,7 +112,7 @@ created in the previous step.
 
 5. Retrieve the static egress IPs from Materialize and configure the firewall rules (e.g. AWS Security Groups) for your bastion host to allow SSH traffic for those IP addresses only.
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_catalog.mz_egress_ips;
     ```
 
@@ -126,7 +126,7 @@ created in the previous step.
 
 To confirm that the SSH tunnel connection is correctly configured, use the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
-```sql
+```mzsql
 VALIDATE CONNECTION ssh_connection;
 ```
 

--- a/doc/user/layouts/shortcodes/postgres-direct/check-the-ingestion-status.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/check-the-ingestion-status.html
@@ -9,7 +9,7 @@ status of the snapshotting process.
    [`mz_source_statuses`](/sql/system-catalog/mz_internal/#mz_source_statuses)
    table to check the overall status of your source:
 
-    ```sql
+    ```mzsql
     WITH
       source_ids AS
       (SELECT id FROM mz_sources WHERE name = 'mz_source')
@@ -37,7 +37,7 @@ status of the snapshotting process.
 2. Once the source is running, use the [`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics)
    table to check the status of the initial snapshot:
 
-    ```sql
+    ```mzsql
     WITH
       source_ids AS
       (SELECT id FROM mz_sources WHERE name = 'mz_source')

--- a/doc/user/layouts/shortcodes/postgres-direct/create-a-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/create-a-cluster.html
@@ -12,7 +12,7 @@ your PostgreSQL database.
    client connected to Materialize, use the [`CREATE CLUSTER`](/sql/create-cluster/)
    command to create the new cluster:
 
-    ```sql
+    ```mzsql
     CREATE CLUSTER ingest_postgres (SIZE = '200cc');
 
     SET CLUSTER = ingest_postgres;

--- a/doc/user/layouts/shortcodes/postgres-direct/create-a-publication-aws.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/create-a-publication-aws.html
@@ -9,11 +9,11 @@ with sufficient privileges to manage replication.
    [replica identity](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY)
    to `FULL`:
 
-    ```sql
+    ```postgres
     ALTER TABLE <table1> REPLICA IDENTITY FULL;
     ```
 
-    ```sql
+    ```postgres
     ALTER TABLE <table2> REPLICA IDENTITY FULL;
     ```
 
@@ -28,13 +28,13 @@ with sufficient privileges to manage replication.
 
     _For specific tables:_
 
-    ```sql
+    ```postgres
     CREATE PUBLICATION mz_source FOR TABLE <table1>, <table2>;
     ```
 
     _For all tables in the database:_
 
-    ```sql
+    ```postgres
     CREATE PUBLICATION mz_source FOR ALL TABLES;
     ```
 
@@ -48,31 +48,31 @@ with sufficient privileges to manage replication.
 
 1. Create a user for Materialize, if you don't already have one:
 
-    ``` sql
+    ```postgres
     CREATE USER materialize PASSWORD '<password>';
     ```
 
 1. Grant the user permission to manage replication:
 
-    ``` sql
+    ```postgres
     GRANT rds_replication TO materialize;
     ```
 
 1. Grant the user the required permissions on the tables you want to replicate:
 
-    ```sql
+    ```postgres
     GRANT CONNECT ON DATABASE <dbname> TO materialize;
     ```
 
-    ```sql
+    ```postgres
     GRANT USAGE ON SCHEMA <schema> TO materialize;
     ```
 
-    ```sql
+    ```postgres
     GRANT SELECT ON <table1> TO materialize;
     ```
 
-    ```sql
+    ```postgres
     GRANT SELECT ON <table2> TO materialize;
     ```
 
@@ -83,6 +83,6 @@ with sufficient privileges to manage replication.
     If you expect to add tables to your publication, you can grant `SELECT` on
     all tables in the schema instead of naming the specific tables:
 
-    ```sql
+    ```postgres
     GRANT SELECT ON ALL TABLES IN SCHEMA <schema> TO materialize;
     ```

--- a/doc/user/layouts/shortcodes/postgres-direct/create-a-publication-other.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/create-a-publication-other.html
@@ -6,11 +6,11 @@ user for Materialize with sufficient privileges to manage replication.
    [replica identity](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY)
    to `FULL`:
 
-    ```sql
+    ```postgres
     ALTER TABLE <table1> REPLICA IDENTITY FULL;
     ```
 
-    ```sql
+    ```postgres
     ALTER TABLE <table2> REPLICA IDENTITY FULL;
     ```
 
@@ -25,13 +25,13 @@ user for Materialize with sufficient privileges to manage replication.
 
     _For specific tables:_
 
-    ```sql
+    ```postgres
     CREATE PUBLICATION mz_source FOR TABLE <table1>, <table2>;
     ```
 
     _For all tables in the database:_
 
-    ```sql
+    ```postgres
     CREATE PUBLICATION mz_source FOR ALL TABLES;
     ```
 
@@ -45,31 +45,31 @@ user for Materialize with sufficient privileges to manage replication.
 
 1. Create a user for Materialize, if you don't already have one:
 
-    ``` sql
+    ```postgres
     CREATE USER materialize PASSWORD '<password>';
     ```
 
 1. Grant the user permission to manage replication:
 
-    ``` sql
+    ```postgres
     ALTER ROLE materialize WITH REPLICATION;
     ```
 
 1. Grant the user the required permissions on the tables you want to replicate:
 
-    ```sql
+    ```postgres
     GRANT CONNECT ON DATABASE <dbname> TO materialize;
     ```
 
-    ```sql
+    ```postgres
     GRANT USAGE ON SCHEMA <schema> TO materialize;
     ```
 
-    ```sql
+    ```postgres
     GRANT SELECT ON <table1> TO materialize;
     ```
 
-    ```sql
+    ```postgres
     GRANT SELECT ON <table2> TO materialize;
     ```
 
@@ -80,6 +80,6 @@ user for Materialize with sufficient privileges to manage replication.
     If you expect to add tables to your publication, you can grant `SELECT` on
     all tables in the schema instead of naming the specific tables:
 
-    ```sql
+    ```postgres
     GRANT SELECT ON ALL TABLES IN SCHEMA <schema> TO materialize;
     ```

--- a/doc/user/layouts/shortcodes/postgres-direct/ingesting-data/allow-materialize-ips.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/ingesting-data/allow-materialize-ips.html
@@ -3,7 +3,7 @@
    command to securely store the password for the `materialize` PostgreSQL user you
    created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
@@ -11,7 +11,7 @@
    connection object with access and authentication details for Materialize to
    use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -31,7 +31,7 @@
 to your PostgreSQL instance and start ingesting data from the publication you
 created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')

--- a/doc/user/layouts/shortcodes/postgres-direct/ingesting-data/use-ssh-tunnel.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/ingesting-data/use-ssh-tunnel.html
@@ -1,6 +1,6 @@
 1. In the SQL client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/#ssh-tunnel) command to create an SSH tunnel connection:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (
         HOST '<SSH_BASTION_HOST>',
         PORT <SSH_BASTION_PORT>,
@@ -13,7 +13,7 @@
 
 1. Get Materialize's public keys for the SSH tunnel connection:
 
-    ```sql
+    ```mzsql
     SELECT * FROM mz_ssh_tunnel_connections;
     ```
 
@@ -27,7 +27,7 @@
 
 1. Back in the SQL client connected to Materialize, validate the SSH tunnel connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
 
-    ```sql
+    ```mzsql
     VALIDATE CONNECTION ssh_connection;
     ```
 
@@ -35,13 +35,13 @@
 
 1. Use the [`CREATE SECRET`](/sql/create-secret/) command to securely store the password for the `materialize` PostgreSQL user you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SECRET pgpass AS '<PASSWORD>';
     ```
 
 1. Use the [`CREATE CONNECTION`](/sql/create-connection/) command to create another connection object, this time with database access and authentication details for Materialize to use:
 
-    ```sql
+    ```mzsql
     CREATE CONNECTION pg_connection TO POSTGRES (
       HOST '<host>',
       PORT 5432,
@@ -58,7 +58,7 @@
 
 1. Use the [`CREATE SOURCE`](/sql/create-source/) command to connect Materialize to your Azure instance and start ingesting data from the publication you created [earlier](#step-2-create-a-publication):
 
-    ```sql
+    ```mzsql
     CREATE SOURCE mz_source
       IN CLUSTER ingest_postgres
       FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')

--- a/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/right-size-the-cluster.html
@@ -6,7 +6,7 @@ accordingly.
 1. Still in a SQL client connected to Materialize, use the [`ALTER CLUSTER`](/sql/alter-cluster/)
    command to downsize the cluster to `100cc`:
 
-    ```sql
+    ```mzsql
     ALTER CLUSTER ingest_postgres SET (SIZE '100cc');
     ```
 
@@ -16,7 +16,7 @@ accordingly.
 1. Use the [`SHOW CLUSTER REPLICAS`](/sql/show-cluster-replicas/) command to
    check the status of the new replica:
 
-    ```sql
+    ```mzsql
     SHOW CLUSTER REPLICAS WHERE cluster = 'ingest_postgres';
     ```
     <p></p>
@@ -35,7 +35,7 @@ follows:
     PostgreSQL source from the [`mz_internal.mz_postgres_sources`](/sql/system-catalog/mz_internal/#mz_postgres_sources)
     table:
 
-        ```sql
+        ```mzsql
         SELECT
             d.name AS database_name,
             n.name AS schema_name,
@@ -51,7 +51,7 @@ follows:
     1. In PostgreSQL, check the replication slot lag, using the replication slot
        name from the previous step:
 
-        ```sql
+        ```postgres
         SELECT
             pg_size_pretty(pg_current_wal_lsn() - confirmed_flush_lsn)
             AS replication_lag_bytes


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

Syntax highlighting in our docs uses a general SQL highlighter. This is fine, but we don't have highlighting on Mz-specific keywords, which is suboptimal. [I have upstreamed Materialize SQL dialect highlighting to Chroma](https://github.com/alecthomas/chroma/pull/896), the highlighting library used by Hugo. We upgraded to a compatible version of Hugo in #27679 , so now we just need to apply the new syntax highlighting to all examples of Materialize SQL dialect in the docs. I took care to _not_ update SQL Server, MySQL, and Postgres examples.

**Before**

![Without Mz syntax highlighting](https://github.com/MaterializeInc/materialize/assets/139487/f22e3113-29e8-4e86-b9e3-62f89f581b2d)

**After**

![With Mz syntax highlighting](https://github.com/MaterializeInc/materialize/assets/139487/27b31048-4ec8-4d61-bfb2-59ab77ab5eb0)

If we're happy with this, and once it's merged, I'll work on formalizing the Chroma dialect update motion as a script so we can upstream new keywords as they land.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

Sorry for the large diff! I grouped sections of the docs by commit, so that may ease review. Please let me know if you'd prefer I submit this another way.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
