### PR TITLE
adapter: insert-only TABLEs

### DIFF
--- a/doc/user/content/sql/create-table.md
+++ b/doc/user/content/sql/create-table.md
@@ -34,7 +34,7 @@ clarity around best practices."
 
 ### `with_options`
 
-{{< diagram "with-options-retain-history.svg" >}}
+{{< diagram "with-options.svg" >}}
 
 Field | Use
 ------|-----
@@ -43,8 +43,14 @@ _table&lowbar;name_ | A name for the table.
 _col&lowbar;name_ | The name of the column to be created in the table.
 _col&lowbar;type_ | The data type of the column indicated by _col&lowbar;name_.
 **NOT NULL** | Do not allow the column to contain _NULL_ values. Columns without this constraint can contain _NULL_ values.
-*default_expr* | A default value to use for the column in an [`INSERT`](/sql/insert) statement if an explicit value is not provided. If not specified, `NULL` is assumed.
-_retention_period_ | ***Private preview.** This option has known performance or stability issues and is under active development.* Duration for which Materialize retains historical data for performing [time travel queries](/transform-data/patterns/time-travel-queries). Accepts positive [interval](/sql/types/interval/) values (e.g. `'1hr'`). Default: `1s`.
+*default_expr* | A default value to use for the column in an [`INSERT`](/sql/insert) statement if an explicit value is not provided. If not specified, `NULL` is assumed.]]]
+
+### **CREATE TABLE** `with_options`
+
+Field | Value | Description
+-|-|-
+`RETAIN HISTORY` | _retention_period_ | ***Private preview.** This option has known performance or stability issues and is under active development.* Duration for which Materialize retains historical data for performing [time travel queries](/transform-data/patterns/time-travel-queries). Accepts positive [interval](/sql/types/interval/) values (e.g. `'1hr'`). Default: `1s`.
+`INSERT ONLY` | optional `bool`; `true` if ommitted | ***Private preview.** This option has known performance or stability issues and is under active development.* Whether the table is `INSERT`-only: `UPDATE` and `DELETE` are disallowed. Enables some memory and other optimizations.
 
 ## Details
 

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -510,6 +510,7 @@ Field        | Type                 | Meaning
 `privileges` | [`mz_aclitem array`] | The privileges belonging to the table.
 `create_sql` | [`text`]             | The `CREATE` SQL statement for the table.
 `redacted_create_sql` | [`text`]    | The redacted `CREATE` SQL statement for the table.
+`insert_only` | [`bool`]            | Whether this table is `INSERT`-only.
 
 ### `mz_timezone_abbreviations`
 

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -572,6 +572,7 @@ impl CatalogState {
                             },
                         ),
                         is_retained_metrics_object: table.is_retained_metrics_object,
+                        insert_only: false,
                     }),
                     MZ_SYSTEM_ROLE_ID,
                     PrivilegeMap::from_mz_acl_items(acl_items),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -718,6 +718,7 @@ impl CatalogState {
                 } else {
                     Datum::Null
                 },
+                Datum::from(table.insert_only),
             ]),
             diff,
         }]

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1348,6 +1348,7 @@ mod builtin_migration_tests {
                     resolved_ids: ResolvedIds(BTreeSet::new()),
                     custom_logical_compaction_window: None,
                     is_retained_metrics_object: false,
+                    insert_only: false,
                 }),
                 SimplifiedItem::MaterializedView { referenced_names } => {
                     let table_list = referenced_names

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -818,6 +818,7 @@ impl CatalogState {
                 custom_logical_compaction_window: custom_logical_compaction_window
                     .or(table.compaction_window),
                 is_retained_metrics_object,
+                insert_only: table.insert_only,
             }),
             Plan::CreateSource(CreateSourcePlan {
                 source,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -857,21 +857,29 @@ impl Coordinator {
             table,
             if_not_exists,
         } = plan;
-
-        let conn_id = if table.temporary {
+        let mz_sql::plan::Table {
+            create_sql,
+            desc,
+            defaults,
+            temporary,
+            compaction_window,
+            insert_only,
+        } = table;
+        let conn_id = if temporary {
             Some(ctx.session().conn_id())
         } else {
             None
         };
         let table_id = self.catalog_mut().allocate_user_id().await?;
         let table = Table {
-            create_sql: Some(table.create_sql),
-            desc: table.desc,
-            defaults: table.defaults,
+            create_sql: Some(create_sql),
+            desc,
+            defaults,
             conn_id: conn_id.cloned(),
             resolved_ids,
-            custom_logical_compaction_window: table.compaction_window,
+            custom_logical_compaction_window: compaction_window,
             is_retained_metrics_object: false,
+            insert_only,
         };
         let ops = vec![catalog::Op::CreateItem {
             id: table_id,
@@ -2458,14 +2466,25 @@ impl Coordinator {
 
         // Read then writes can be queued, so re-verify the id exists.
         let desc = match self.catalog().try_get_entry(&id) {
-            Some(table) => table
-                .desc(
-                    &self
+            Some(entry) => {
+                let table = entry.table().expect("must be a table");
+                if table.insert_only && !matches!(kind, MutationKind::Insert) {
+                    let name = entry.name();
+                    let name = self
                         .catalog()
-                        .resolve_full_name(table.name(), Some(ctx.session().conn_id())),
-                )
-                .expect("desc called on table")
-                .into_owned(),
+                        .resolve_full_name(name, Some(ctx.session().conn_id()));
+                    ctx.retire(Err(AdapterError::InsertOnly(name.to_string())));
+                    return;
+                }
+                entry
+                    .desc(
+                        &self
+                            .catalog()
+                            .resolve_full_name(entry.name(), Some(ctx.session().conn_id())),
+                    )
+                    .expect("desc called on table")
+                    .into_owned()
+            }
             None => {
                 ctx.retire(Err(AdapterError::Catalog(
                     mz_catalog::memory::error::Error {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -226,6 +226,8 @@ pub enum AdapterError {
     UnreadableSinkCollection,
     /// User sessions have been blocked.
     UserSessionsDisallowed,
+    /// Table is insert-only.
+    InsertOnly(String),
 }
 
 impl AdapterError {
@@ -532,6 +534,9 @@ impl AdapterError {
             AdapterError::RtrDropFailure(_) => SqlState::UNDEFINED_OBJECT,
             AdapterError::UnreadableSinkCollection => SqlState::from_code("MZ009"),
             AdapterError::UserSessionsDisallowed => SqlState::from_code("MZ010"),
+            // Postgres uses this code when trying to modify data from within a READ ONLY function
+            // or trigger, so may not be correct here.
+            AdapterError::InsertOnly(_) => SqlState::S_R_E_MODIFYING_SQL_DATA_NOT_PERMITTED,
         }
     }
 
@@ -761,6 +766,7 @@ impl fmt::Display for AdapterError {
                 write!(f, "collection is not readable at any time")
             }
             AdapterError::UserSessionsDisallowed => write!(f, "login blocked"),
+            AdapterError::InsertOnly(name) => write!(f, "cannot modify insert-only table {name}"),
         }
     }
 }

--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -206,7 +206,7 @@ impl<'a> DataflowBuilder<'a> {
                 let entry = self.catalog.get_entry(id);
                 match entry.item() {
                     CatalogItem::Table(table) => {
-                        dataflow.import_source(*id, table.desc.typ().clone(), false);
+                        dataflow.import_source(*id, table.desc.typ().clone(), table.insert_only);
                     }
                     CatalogItem::Source(source) => {
                         dataflow.import_source(

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -101,6 +101,7 @@ async fn datadriven() {
                                             resolved_ids: ResolvedIds(BTreeSet::new()),
                                             custom_logical_compaction_window: None,
                                             is_retained_metrics_object: false,
+                                            insert_only: false,
                                         }),
                                         owner_id: MZ_SYSTEM_ROLE_ID,
                                     }],

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2126,6 +2126,7 @@ pub static MZ_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         )
         .with_column("create_sql", ScalarType::String.nullable(true))
         .with_column("redacted_create_sql", ScalarType::String.nullable(true))
+        .with_column("insert_only", ScalarType::Bool.nullable(false))
         .with_key(vec![0])
         .with_key(vec![1]),
     is_retained_metrics_object: false,

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -489,6 +489,7 @@ pub struct Table {
     /// Whether the table's logical compaction window is controlled by
     /// METRICS_RETENTION
     pub is_retained_metrics_object: bool,
+    pub insert_only: bool,
 }
 
 impl Table {
@@ -1490,6 +1491,14 @@ impl CatalogEntry {
     pub fn index(&self) -> Option<&Index> {
         match self.item() {
             CatalogItem::Index(idx) => Some(idx),
+            _ => None,
+        }
+    }
+
+    /// Returns the inner [`Table`] if this entry is a table, else `None`.
+    pub fn table(&self) -> Option<&Table> {
+        match self.item() {
+            CatalogItem::Table(table) => Some(table),
             _ => None,
         }
     }

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -856,7 +856,7 @@ mod tests {
     fn smoketest_packed_numeric_roundtrips() {
         let og = PackedNumeric::from_value(Numeric::from(-42));
         let bytes = og.as_bytes();
-        let rnd = PackedNumeric::from_bytes(&bytes).expect("valid");
+        let rnd = PackedNumeric::from_bytes(bytes).expect("valid");
         assert_eq!(og, rnd);
 
         // Returns an error if the size of the slice is invalid.

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1447,22 +1447,21 @@ impl_display_t!(CreateTableStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TableOptionName {
-    // The `RETAIN HISTORY` option
+    // The `RETAIN HISTORY` option.
     RetainHistory,
     /// A special option to test that we do redact values.
     RedactedTest,
+    /// The `INSERT ONLY' option.
+    InsertOnly,
 }
 
 impl AstDisplay for TableOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        match self {
-            TableOptionName::RetainHistory => {
-                f.write_str("RETAIN HISTORY");
-            }
-            TableOptionName::RedactedTest => {
-                f.write_str("REDACTED");
-            }
-        }
+        f.write_str(match self {
+            TableOptionName::RetainHistory => "RETAIN HISTORY",
+            TableOptionName::RedactedTest => "REDACTED",
+            TableOptionName::InsertOnly => "INSERT ONLY",
+        })
     }
 }
 
@@ -1476,6 +1475,7 @@ impl WithOptionName for TableOptionName {
         match self {
             TableOptionName::RetainHistory => false,
             TableOptionName::RedactedTest => true,
+            TableOptionName::InsertOnly => false,
         }
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -41,7 +41,7 @@ CREATE TABLE t (a int NOT NULL GARBAGE)
 parse-statement
 CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
 ----
-error: Expected RETAIN, found identifier "foo"
+error: Expected one of RETAIN or INSERT, found identifier "foo"
 CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
                              ^
 
@@ -1160,7 +1160,7 @@ CREATE TABLE public.customer (
         active integer NOT NULL
 ) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
 ----
-error: Expected RETAIN, found identifier "fillfactor"
+error: Expected one of RETAIN or INSERT, found identifier "fillfactor"
 ) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
         ^
 
@@ -1195,6 +1195,13 @@ parse-statement roundtrip
 CREATE TABLE IF NOT EXISTS foo (bar int)
 ----
 CREATE TABLE IF NOT EXISTS foo (bar int4)
+
+parse-statement
+CREATE TABLE foo (bar int) WITH (INSERT ONLY)
+----
+CREATE TABLE foo (bar int4) WITH (INSERT ONLY)
+=>
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false, with_options: [TableOption { name: InsertOnly, value: None }] })
 
 parse-statement
 ALTER INDEX name SET (property = true)

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1260,6 +1260,7 @@ pub struct Table {
     pub defaults: Vec<Expr<Aug>>,
     pub temporary: bool,
     pub compaction_window: Option<CompactionWindow>,
+    pub insert_only: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -1557,6 +1558,8 @@ pub enum IndexOption {
 pub enum TableOption {
     /// Configures the logical compaction window for a table.
     RetainHistory(CompactionWindow),
+    /// Whether the table is insert only.
+    InsertOnly(bool),
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -379,14 +379,19 @@ pub fn plan_create_table(
     let create_sql = normalize::create_statement(scx, Statement::CreateTable(stmt.clone()))?;
 
     let options = plan_table_options(scx, with_options.clone())?;
-    let compaction_window = options.iter().find_map(|o| {
-        #[allow(irrefutable_let_patterns)]
-        if let crate::plan::TableOption::RetainHistory(lcw) = o {
-            Some(lcw.clone())
-        } else {
-            None
+    let mut compaction_window = None;
+    let mut insert_only = false;
+    for o in options {
+        match o {
+            crate::plan::TableOption::RetainHistory(lcw) => {
+                compaction_window = Some(lcw.clone());
+            }
+            crate::plan::TableOption::InsertOnly(insert) => {
+                scx.require_feature_flag(&vars::ENABLE_INSERT_ONLY_TABLES)?;
+                insert_only = insert;
+            }
         }
-    });
+    }
 
     let table = Table {
         create_sql,
@@ -394,6 +399,7 @@ pub fn plan_create_table(
         defaults,
         temporary,
         compaction_window,
+        insert_only,
     };
     Ok(Plan::CreateTable(CreateTablePlan {
         name,
@@ -4637,7 +4643,8 @@ fn plan_index_options(
 generate_extracted_config!(
     TableOption,
     (RetainHistory, OptionalDuration),
-    (RedactedTest, String)
+    (RedactedTest, String),
+    (InsertOnly, bool)
 );
 
 fn plan_table_options(
@@ -4647,16 +4654,20 @@ fn plan_table_options(
     let TableOptionExtracted {
         retain_history,
         redacted_test,
-        ..
+        insert_only,
+        seen: _,
     }: TableOptionExtracted = with_opts.try_into()?;
 
     if redacted_test.is_some() {
         scx.require_feature_flag(&vars::ENABLE_REDACTED_TEST_OPTION)?;
     }
 
-    let mut out = Vec::with_capacity(1);
+    let mut out = Vec::with_capacity(2);
     if let Some(cw) = plan_retain_history_option(scx, retain_history)? {
         out.push(crate::plan::TableOption::RetainHistory(cw));
+    }
+    if let Some(insert_only) = insert_only {
+        out.push(crate::plan::TableOption::InsertOnly(insert_only));
     }
     Ok(out)
 }

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2108,6 +2108,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: true,
     },
+    {
+        name: enable_insert_only_tables,
+        desc: "`INSERT`-only tables",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {

--- a/test/sqllogictest/autogenerated/mz_catalog.slt
+++ b/test/sqllogictest/autogenerated/mz_catalog.slt
@@ -352,6 +352,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 6  privileges  mz_aclitem[]
 7  create_sql  text
 8  redacted_create_sql  text
+9  insert_only  bool
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_timezone_abbreviations' ORDER BY position

--- a/test/sqllogictest/table.slt
+++ b/test/sqllogictest/table.slt
@@ -42,3 +42,49 @@ TABLE t UNION ALL TABLE t ORDER BY a LIMIT 5
 
 query error unknown catalog item 'noexist'
 TABLE noexist
+
+statement error db error: ERROR: `INSERT`\-only tables is not supported
+CREATE TABLE t2 (a int) WITH (INSERT ONLY)
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_insert_only_tables = true
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t2 (a int) WITH (INSERT ONLY)
+
+statement error db error: ERROR: cannot modify insert\-only table materialize\.public\.t2
+DELETE FROM t2
+
+statement error db error: ERROR: cannot modify insert\-only table materialize\.public\.t2
+UPDATE t2 SET a = 1
+
+statement ok
+INSERT INTO t2 VALUES (1)
+
+# Ensure monotonic Reduce operator.
+query T multiline
+EXPLAIN SELECT max(a) FROM t2
+----
+Explained Query:
+  Return
+    Union
+      Get l0
+      Map (null)
+        Union
+          Negate
+            Project ()
+              Get l0
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce aggregates=[max(#0)] monotonic
+        ReadStorage materialize.public.t2
+
+Source materialize.public.t2
+
+Target cluster: quickstart
+
+EOF


### PR DESCRIPTION
Allow marking tables as INSERT-only to allow the monotonic flag to be set during dataflow building. This prevents DELETE and UPDATE statements on the table.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add an `INSERT ONLY` option to `CREATE TABLE`.