### PR TITLE
adapter: don't use max_query_result_size in RTW plans

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -420,6 +420,7 @@ pub struct CopyToContext {
 pub struct PeekStageLinearizeTimestamp {
     validity: PlanValidity,
     plan: mz_sql::plan::SelectPlan,
+    max_query_result_size: Option<u64>,
     source_ids: BTreeSet<GlobalId>,
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
@@ -433,6 +434,7 @@ pub struct PeekStageLinearizeTimestamp {
 pub struct PeekStageRealTimeRecency {
     validity: PlanValidity,
     plan: mz_sql::plan::SelectPlan,
+    max_query_result_size: Option<u64>,
     source_ids: BTreeSet<GlobalId>,
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
@@ -447,6 +449,7 @@ pub struct PeekStageRealTimeRecency {
 pub struct PeekStageTimestampReadHold {
     validity: PlanValidity,
     plan: mz_sql::plan::SelectPlan,
+    max_query_result_size: Option<u64>,
     source_ids: BTreeSet<GlobalId>,
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
@@ -462,6 +465,7 @@ pub struct PeekStageTimestampReadHold {
 pub struct PeekStageOptimize {
     validity: PlanValidity,
     plan: mz_sql::plan::SelectPlan,
+    max_query_result_size: Option<u64>,
     source_ids: BTreeSet<GlobalId>,
     id_bundle: CollectionIdBundle,
     target_replica: Option<ReplicaId>,
@@ -476,6 +480,7 @@ pub struct PeekStageOptimize {
 pub struct PeekStageFinish {
     validity: PlanValidity,
     plan: mz_sql::plan::SelectPlan,
+    max_query_result_size: Option<u64>,
     id_bundle: CollectionIdBundle,
     target_replica: Option<ReplicaId>,
     source_ids: BTreeSet<GlobalId>,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -296,7 +296,8 @@ impl Coordinator {
                     self.sequence_end_transaction(ctx, action).await;
                 }
                 Plan::Select(plan) => {
-                    self.sequence_peek(ctx, plan, target_cluster).await;
+                    let max = Some(ctx.session().vars().max_query_result_size());
+                    self.sequence_peek(ctx, plan, target_cluster, max).await;
                 }
                 Plan::Subscribe(plan) => {
                     self.sequence_subscribe(ctx, plan, target_cluster).await;
@@ -308,7 +309,8 @@ impl Coordinator {
                     ctx.retire(Ok(Self::send_immediate_rows(plan.row)));
                 }
                 Plan::ShowColumns(show_columns_plan) => {
-                    self.sequence_peek(ctx, show_columns_plan.select_plan, target_cluster)
+                    let max = Some(ctx.session().vars().max_query_result_size());
+                    self.sequence_peek(ctx, show_columns_plan.select_plan, target_cluster, max)
                         .await;
                 }
                 Plan::CopyFrom(plan) => {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2213,6 +2213,7 @@ impl Coordinator {
                         target_cluster,
                         None,
                         ExplainContext::Pushdown,
+                        Some(ctx.session().vars().max_query_result_size()),
                     ),
                     ctx
                 );
@@ -2577,6 +2578,7 @@ impl Coordinator {
                 copy_to: None,
             },
             TargetCluster::Active,
+            None,
         )
         .await;
 

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -856,7 +856,7 @@ mod tests {
     fn smoketest_packed_numeric_roundtrips() {
         let og = PackedNumeric::from_value(Numeric::from(-42));
         let bytes = og.as_bytes();
-        let rnd = PackedNumeric::from_bytes(&bytes).expect("valid");
+        let rnd = PackedNumeric::from_bytes(bytes).expect("valid");
         assert_eq!(og, rnd);
 
         // Returns an error if the size of the slice is invalid.

--- a/test/sqllogictest/updates.slt
+++ b/test/sqllogictest/updates.slt
@@ -173,3 +173,26 @@ INSERT INTO t1 VALUES((SELECT 1 ORDER BY (SELECT x FROM t1 LIMIT 1)));
 COMMIT;
 ----
 db error: ERROR: INSERT INTO t1 VALUES ((SELECT 1 ORDER BY (SELECT x FROM t1 LIMIT 1))) cannot be run inside a transaction block
+
+statement ok
+ROLLBACK
+
+# Verify that max_query_result_size doesn't affect read part of RTW queries.
+# See #27428
+statement ok
+SET max_query_result_size = '8B';
+
+query error db error: ERROR: result exceeds max size of 8 B
+SELECT generate_series(1, 100)
+
+statement ok
+INSERT INTO t SELECT * FROM t
+
+# But the internal var does limit.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET max_result_size = 1
+----
+COMPLETE 0
+
+statement error db error: ERROR: result exceeds max size of 1 B
+INSERT INTO t SELECT * FROM t


### PR DESCRIPTION
Avoid max_query_result_size in the read portion of read-then-write plans. Previously that session var would limit the size of the updates to its setting. This would cause, for example, a `DELETE` issued from the console to fail if there were more than 1MB of rows in a table.

Fixes #27428

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a