### PR TITLE
storage: use fueled output handles in sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6167,6 +6167,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
+ "columnation",
  "crossbeam-channel",
  "csv-core",
  "datadriven",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6540,6 +6540,7 @@ name = "mz-timely-util"
 version = "0.0.0"
 dependencies = [
  "ahash",
+ "columnation",
  "differential-dataflow",
  "either",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6381,6 +6381,7 @@ dependencies = [
  "aws-types",
  "base64 0.13.1",
  "bytes",
+ "columnation",
  "criterion",
  "dec",
  "derivative",

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -22,6 +22,7 @@ aws-credential-types = { version = "1.1.1", features = ["hardcoded-credentials"]
 aws-sdk-sts = { version = "1.7.0", default-features = false, features = ["rt-tokio"] }
 aws-types = "1.1.1"
 bytes = "1.3.0"
+columnation = { git = "https://github.com/frankmcsherry/columnation" }
 dec = "0.4.8"
 derivative = "2.2.0"
 differential-dataflow = "0.12.0"

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use arrow::array::{Array, BinaryArray, BinaryBuilder, StructArray};
 use arrow::datatypes::{Field, Fields};
 use bytes::BufMut;
+use columnation::Columnation;
 use itertools::EitherOrBoth::Both;
 use itertools::Itertools;
 use mz_persist_types::columnar::{ColumnDecoder, ColumnEncoder, Schema2};
@@ -420,7 +421,7 @@ impl ProtoMapEntry<GlobalId, SourceExport<Option<ExportReference>, CollectionMet
     }
 }
 
-pub trait SourceTimestamp: timely::progress::Timestamp + Refines<()> + std::fmt::Display {
+pub trait SourceTimestamp: Timestamp + Columnation + Refines<()> + std::fmt::Display {
     fn encode_row(&self) -> Row;
     fn decode_row(row: &Row) -> Self;
 }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -488,6 +488,10 @@ impl mz_persist_types::Codec64 for MzOffset {
     }
 }
 
+impl columnation::Columnation for MzOffset {
+    type InnerRegion = columnation::CopyRegion<MzOffset>;
+}
+
 impl RustType<ProtoMzOffset> for MzOffset {
     fn into_proto(&self) -> ProtoMzOffset {
         ProtoMzOffset {

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -22,6 +22,7 @@ bytesize = "1.1.0"
 bincode = "1"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
+columnation = { git = "https://github.com/frankmcsherry/columnation" }
 crossbeam-channel = "0.5.8"
 csv-core = { version = "0.1.10" }
 dec = "0.4.8"

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -44,16 +44,18 @@ use std::convert::Infallible;
 use std::num::NonZeroU64;
 use std::pin::pin;
 
-use differential_dataflow::{AsCollection, Collection};
+use differential_dataflow::AsCollection;
 use futures::StreamExt;
 use itertools::Itertools;
 use mysql_async::prelude::Queryable;
 use mysql_async::{BinlogStream, BinlogStreamRequest, GnoInterval, Sid};
 use mz_ore::future::InTask;
 use mz_ssh_util::tunnel_manager::ManagedSshTunnelHandle;
+use mz_timely_util::containers::stack::AccountedStackBuilder;
 use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::operators::{Concat, Map};
+use timely::dataflow::operators::core::Map;
+use timely::dataflow::operators::Concat;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -64,8 +66,7 @@ use mz_mysql_util::{
     query_sys_var, MySqlConn, MySqlError, ER_SOURCE_FATAL_ERROR_READING_BINLOG_CODE,
 };
 use mz_ore::cast::CastFrom;
-use mz_ore::result::ResultExt;
-use mz_repr::{Diff, GlobalId, Row};
+use mz_repr::GlobalId;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::mysql::{gtid_set_frontier, GtidPartition, GtidState};
 use mz_storage_types::sources::MySqlSourceConnection;
@@ -74,6 +75,7 @@ use mz_timely_util::builder_async::{
 };
 
 use crate::metrics::source::mysql::MySqlSourceMetrics;
+use crate::source::types::{SourceMessage, StackedCollection};
 use crate::source::RawSourceCreationConfig;
 
 use super::{
@@ -105,7 +107,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
     rewind_stream: &Stream<G, RewindRequest>,
     metrics: MySqlSourceMetrics,
 ) -> (
-    Collection<G, (usize, Result<Row, DataflowError>), Diff>,
+    StackedCollection<G, (usize, Result<SourceMessage, DataflowError>)>,
     Stream<G, Infallible>,
     Stream<G, ReplicationError>,
     PressOnDropButton,
@@ -114,7 +116,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
     let mut builder = AsyncOperatorBuilder::new(op_name, scope);
 
     let repl_reader_id = u64::cast_from(config.responsible_worker(REPL_READER));
-    let (mut data_output, data_stream) = builder.new_output::<CapacityContainerBuilder<_>>();
+    let (mut data_output, data_stream) = builder.new_output::<AccountedStackBuilder<_>>();
     let (_upper_output, upper_stream) = builder.new_output::<CapacityContainerBuilder<_>>();
     // Captures DefiniteErrors that affect the entire source, including all subsources
     let (mut definite_error_handle, definite_errors) =
@@ -398,7 +400,8 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                             &mut repl_context,
                             &cur_gtid,
                             &mut row_event_buffer,
-                        )?;
+                        )
+                        .await?;
 
                         // Advance the frontier up to the point right before this GTID, since we
                         // might still see other events that are part of this same GTID, such as
@@ -463,14 +466,11 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
     });
 
     // TODO: Split row decoding into a separate operator that can be distributed across all workers
-    let replication_updates = data_stream
-        .as_collection()
-        .map(|(output_index, row)| (output_index, row.err_into()));
 
     let errors = definite_errors.concat(&transient_errors.map(ReplicationError::from));
 
     (
-        replication_updates,
+        data_stream.as_collection(),
         upper_stream,
         errors,
         button.press_on_drop(),

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -84,13 +84,12 @@ use std::convert::Infallible;
 use std::rc::Rc;
 use std::time::Duration;
 
-use differential_dataflow::Collection;
 use itertools::Itertools as _;
 use mz_expr::{EvalError, MirScalarExpr};
 use mz_ore::error::ErrorExt;
 use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::{simple_query_opt, PostgresError};
-use mz_repr::{Datum, Diff, Row};
+use mz_repr::{Datum, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_types::errors::{DataflowError, SourceError, SourceErrorDetails};
 use mz_storage_types::sources::postgres::CastType;
@@ -107,7 +106,7 @@ use tokio_postgres::types::PgLsn;
 use tokio_postgres::Client;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
-use crate::source::types::{ProgressStatisticsUpdate, SourceRender};
+use crate::source::types::{ProgressStatisticsUpdate, SourceRender, StackedCollection};
 use crate::source::{RawSourceCreationConfig, SourceMessage};
 
 mod replication;
@@ -127,7 +126,7 @@ impl SourceRender for PostgresSourceConnection {
         resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
-        Collection<G, (usize, Result<SourceMessage, DataflowError>), Diff>,
+        StackedCollection<G, (usize, Result<SourceMessage, DataflowError>)>,
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
@@ -197,14 +196,7 @@ impl SourceRender for PostgresSourceConnection {
 
         let stats_stream = stats_stream.concat(&snapshot_stats);
 
-        let updates = snapshot_updates.concat(&repl_updates).map(|(output, res)| {
-            let res = res.map(|row| SourceMessage {
-                key: Row::default(),
-                value: row,
-                metadata: Row::default(),
-            });
-            (output, res)
-        });
+        let updates = snapshot_updates.concat(&repl_updates);
 
         let init = std::iter::once(HealthStatusMessage {
             index: 0,

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -138,14 +138,13 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use anyhow::bail;
-use differential_dataflow::{AsCollection, Collection};
+use differential_dataflow::AsCollection;
 use futures::TryStreamExt;
 use mz_expr::MirScalarExpr;
 use mz_ore::future::InTask;
-use mz_ore::result::ResultExt;
 use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::{simple_query_opt, PostgresError};
-use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
+use mz_repr::{Datum, DatumVec, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::postgres::CastType;
@@ -153,9 +152,10 @@ use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
     Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
 };
-use mz_timely_util::operator::StreamExt as TimelyStreamExt;
+use mz_timely_util::operator::StreamExt;
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, ConnectLoop, Feedback, Map};
+use timely::dataflow::operators::core::Map;
+use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, ConnectLoop, Feedback};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp};
 use tokio_postgres::types::{Oid, PgLsn};
@@ -165,7 +165,7 @@ use tracing::{error, trace};
 use crate::metrics::source::postgres::PgSnapshotMetrics;
 use crate::source::postgres::replication::RewindRequest;
 use crate::source::postgres::{verify_schema, DefiniteError, ReplicationError, TransientError};
-use crate::source::types::ProgressStatisticsUpdate;
+use crate::source::types::{ProgressStatisticsUpdate, SourceMessage, StackedCollection};
 use crate::source::RawSourceCreationConfig;
 
 /// Renders the snapshot dataflow. See the module documentation for more information.
@@ -177,7 +177,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     table_info: BTreeMap<u32, (usize, PostgresTableDesc, Vec<(CastType, MirScalarExpr)>)>,
     metrics: PgSnapshotMetrics,
 ) -> (
-    Collection<G, (usize, Result<Row, DataflowError>), Diff>,
+    StackedCollection<G, (usize, Result<SourceMessage, DataflowError>)>,
     Stream<G, RewindRequest>,
     Stream<G, ProgressStatisticsUpdate>,
     Stream<G, ReplicationError>,
@@ -349,8 +349,8 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                         // We pick `u64::MAX` as the LSN which will (in
                         // practice) never conflict any previously revealed
                         // portions of the TVC.
-                        let update = ((*oid, Err(err.clone())), MzOffset::from(u64::MAX), 1);
-                        raw_handle.give(&data_cap_set[0], update);
+                        let update = ((*oid, Err(err.clone().into())), MzOffset::from(u64::MAX), 1);
+                        raw_handle.give_fueled(&data_cap_set[0], update).await;
                     }
 
                     definite_error_handle.give(
@@ -396,7 +396,11 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                     Ok(()) => expected_desc,
                     Err(err) => {
                         raw_handle
-                            .give(&data_cap_set[0], ((oid, Err(err)), MzOffset::minimum(), 1));
+                            .give_fueled(
+                                &data_cap_set[0],
+                                ((oid, Err(err.into())), MzOffset::minimum(), 1),
+                            )
+                            .await;
                         continue;
                     }
                 };
@@ -416,8 +420,12 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 );
                 let mut stream = pin!(client.copy_out_simple(&query).await?);
 
+                let mut update = ((oid, Ok(vec![])), MzOffset::minimum(), 1);
                 while let Some(bytes) = stream.try_next().await? {
-                    raw_handle.give(&data_cap_set[0], ((oid, Ok(bytes)), MzOffset::minimum(), 1));
+                    let data = update.0 .1.as_mut().unwrap();
+                    data.clear();
+                    data.extend_from_slice(&bytes);
+                    raw_handle.give_fueled(&data_cap_set[0], &update).await;
                     snapshot_staged += 1;
                     // TODO(guswynn): does this 1000 need to be configurable?
                     if snapshot_staged % 1000 == 0 {
@@ -481,25 +489,32 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
         })
     });
 
-    // Distribute the raw COPY data to all workers and turn it into a collection
-    let raw_collection = raw_data.distribute().as_collection();
-
     // We now decode the COPY protocol and apply the cast expressions
     let mut text_row = Row::default();
     let mut final_row = Row::default();
     let mut datum_vec = DatumVec::new();
-    let snapshot_updates = raw_collection.map(move |(oid, event)| {
-        let (output_index, _, casts) = &table_info[&oid];
+    let snapshot_updates = raw_data
+        .distribute()
+        .map(move |((oid, event), time, diff)| {
+            let (output_index, _, casts) = &table_info[oid];
 
-        let event = event.and_then(|bytes| {
-            decode_copy_row(&bytes, casts.len(), &mut text_row)?;
-            let datums = datum_vec.borrow_with(&text_row);
-            super::cast_row(casts, &datums, &mut final_row)?;
-            Ok(final_row.clone())
-        });
+            let event = event
+                .as_ref()
+                .map_err(|e: &DataflowError| e.clone())
+                .and_then(|bytes| {
+                    decode_copy_row(bytes, casts.len(), &mut text_row)?;
+                    let datums = datum_vec.borrow_with(&text_row);
+                    super::cast_row(casts, &datums, &mut final_row)?;
+                    Ok(SourceMessage {
+                        key: Row::default(),
+                        value: final_row.clone(),
+                        metadata: Row::default(),
+                    })
+                });
 
-        (*output_index, event.err_into())
-    });
+            ((*output_index, event), *time, *diff)
+        })
+        .as_collection();
 
     let errors = definite_errors.concat(&transient_errors.map(ReplicationError::from));
 

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 differential-dataflow = "0.12.0"
 either = "1"
 lgalloc = "0.3"
+columnation = { git = "https://github.com/frankmcsherry/columnation" }
 futures-util = "0.3.25"
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }

--- a/src/timely-util/src/capture.rs
+++ b/src/timely-util/src/capture.rs
@@ -17,13 +17,13 @@ use mz_ore::channel::{InstrumentedChannelMetric, InstrumentedUnboundedSender};
 use timely::communication::{Message, Push};
 use timely::dataflow::operators::capture::{Event, EventPusher};
 
-pub struct UnboundedTokioCapture<T, D, M>(pub InstrumentedUnboundedSender<Event<T, Vec<D>>, M>);
+pub struct UnboundedTokioCapture<T, C, M>(pub InstrumentedUnboundedSender<Event<T, C>, M>);
 
-impl<T, D, M> EventPusher<T, Vec<D>> for UnboundedTokioCapture<T, D, M>
+impl<T, C, M> EventPusher<T, C> for UnboundedTokioCapture<T, C, M>
 where
     M: InstrumentedChannelMetric,
 {
-    fn push(&mut self, event: Event<T, Vec<D>>) {
+    fn push(&mut self, event: Event<T, C>) {
         // NOTE: An Err(x) result just means "data not accepted" most likely
         //       because the receiver is gone. No need to panic.
         let _ = self.0.send(event);

--- a/src/timely-util/src/order.rs
+++ b/src/timely-util/src/order.rs
@@ -21,6 +21,7 @@ use std::hash::Hash;
 
 use serde::{Deserialize, Serialize};
 use timely::communication::Data;
+use timely::container::columnation::CopyRegion;
 use timely::order::Product;
 use timely::progress::timestamp::{PathSummary, Refines, Timestamp};
 use timely::progress::Antichain;
@@ -46,7 +47,7 @@ use mz_ore::cast::CastFrom;
 /// partitions have gaps between them, the produced antichain has twice as many elements as
 /// partitions. This is because the "dead space" between the selected partitions must have a
 /// representative timestamp in order for that space to be useable in the future.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Partitioned<P, T>(Product<Interval<P>, T>);
 
 impl<P: Clone + PartialOrd, T> Partitioned<P, T> {
@@ -141,6 +142,10 @@ impl<P: Clone, T: Timestamp> PathSummary<Partitioned<P, T>> for () {
     }
 }
 
+impl<P: Copy, T: Copy> columnation::Columnation for Partitioned<P, T> {
+    type InnerRegion = CopyRegion<Partitioned<P, T>>;
+}
+
 /// A trait defining the minimum and maximum values of a type.
 pub trait Extrema {
     /// The minimum value of this type.
@@ -200,7 +205,7 @@ impl Step for Uuid {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 /// A type representing an inclusive interval of type `P`, ordered under the subset relation.
 pub struct Interval<P> {
     pub lower: P,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR makes it so that sources produce collections backed by `StackWrapper<T>` timely containers as opposed to `Vec<T>` containers. The `StackWrapper` container stores its data into flat regions (currently backed by `Columnation`) which allow us to easily measure the heap size of the data produced so far. Currently these container survive until the reclocking boundary where they turn back to normal `Vec<T>` containers in the mz scope. We will probably want to use those region allocated containers throughout the storage dataflows but I didn't want to implement a bigger change than required for this feature.

Creating an output in an async operator with `StackWrapper` container and [the newly introduced](https://github.com/MaterializeInc/materialize/pull/27866) `AccountedStackBuilder` container builder unlocks a `.give_fueled()` API which will automatically yield back to timely once certain amount of MBs have been emitted into the dataflow. The limit is currently set to 128MB.

I have gone through the feature benchmark and confirmed that this change does not produce a performance regression for any of the ingestion workloads. You can find the results here https://buildkite.com/materialize/nightly/builds/8237

Closes #27211 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The PR is made of 5 simple commits that add `Columnation` implementations for relevant types and change the return type required by `SourceRender::render` to be a `Collection` that uses `StackWrapper` containers.

Then there are 4 separate commits, one for each source type, that have source specific changes required to produce these stack-container-based collections.

The files that each commit touches are disjoint so this can also be reviewed using the full diff.
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
