### PR TITLE
environmentd: prepare to integrate 0dt upgrades with deploy generations

### DIFF
--- a/src/environmentd/src/deployment.rs
+++ b/src/environmentd/src/deployment.rs
@@ -43,4 +43,5 @@
 //! environment are changeable at runtime via LaunchDarkly feature flags, but
 //! occasionally
 
+pub mod preflight;
 pub mod state;

--- a/src/environmentd/src/deployment.rs
+++ b/src/environmentd/src/deployment.rs
@@ -1,0 +1,46 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Environment deployments.
+//!
+//! A deployment is a graceful transition of an environment to a new version or
+//! configuration [^1]. This module provides the components that facilitate
+//! these deployments.
+//!
+//! Deployments are initiated and driven externally to `environmentd`. At a very
+//! high level, the process works like this:
+//!
+//!   1. The external orchestrator starts a new `environmentd` process with a
+//!      deploy generation that is greater than the previous deploy generation
+//!      (e.g., if the current deploy generation is 1, the new `environmentd`
+//!      process should be started with `--deploy-generation=2`).
+//!
+//!   2. The new `environmentd` process initializes to the extent possible. At
+//!      the moment the initialization process is quite weak and only validates
+//!      that the catalog is loadable. We plan to strengthen the initialization
+//!      process over time to include starting all `clusterd` processes in the
+//!      new deployment and ensuring that they rehydrate successfully.
+//!
+//!   3. The new deployment announces that it is ready to take over from the
+//!      previous generation (`ReadyToPromote`) via the internal HTTP server.
+//!
+//!   4. The external orchestrator promotes the new deployment via the HTTP
+//!      server.
+//!
+//!   5. The new deployment completes any remaining initialization tasks and
+//!      prepares to serve queries.
+//!
+//!   6. Simultaneously, the external orchestrator tears down the old
+//!      deployment.
+//!
+//! [^1] "Configuration" here means "command-line flags". Most settings in an
+//! environment are changeable at runtime via LaunchDarkly feature flags, but
+//! occasionally
+
+pub mod state;

--- a/src/environmentd/src/deployment/preflight.rs
+++ b/src/environmentd/src/deployment/preflight.rs
@@ -1,0 +1,113 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Preflight checks for deployments.
+
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use mz_catalog::durable::{BootstrapArgs, CatalogError, Metrics, OpenableDurableCatalogState};
+use mz_persist_client::PersistClient;
+use mz_sql::catalog::EnvironmentId;
+
+use crate::deployment::state::DeploymentState;
+use crate::BUILD_INFO;
+
+/// The necessary input for preflight checks.
+pub struct PreflightInput {
+    pub boot_ts: u64,
+    pub environment_id: EnvironmentId,
+    pub persist_client: PersistClient,
+    pub bootstrap_default_cluster_replica_size: String,
+    pub bootstrap_role: Option<String>,
+    pub deploy_generation: u64,
+    pub deployment_state: DeploymentState,
+    pub openable_adapter_storage: Box<dyn OpenableDurableCatalogState>,
+    pub catalog_metrics: Arc<Metrics>,
+}
+
+/// Perform a legacy (non-0dt) preflight check.
+pub async fn preflight_legacy(
+    PreflightInput {
+        boot_ts,
+        environment_id,
+        persist_client,
+        bootstrap_default_cluster_replica_size,
+        bootstrap_role,
+        deploy_generation,
+        deployment_state,
+        mut openable_adapter_storage,
+        catalog_metrics,
+    }: PreflightInput,
+) -> Result<Box<dyn OpenableDurableCatalogState>, anyhow::Error> {
+    tracing::info!("Requested deploy generation {deploy_generation}");
+
+    if !openable_adapter_storage.is_initialized().await? {
+        tracing::info!("Catalog storage doesn't exist so there's no current deploy generation. We won't wait to be leader");
+        deployment_state.set_is_leader();
+        return Ok(openable_adapter_storage);
+    }
+    let catalog_generation = openable_adapter_storage.get_deployment_generation().await?;
+    tracing::info!("Found catalog generation {catalog_generation:?}");
+    if catalog_generation < deploy_generation {
+        tracing::info!("Catalog generation {catalog_generation:?} is less than deploy generation {deploy_generation}. Performing pre-flight checks");
+        match openable_adapter_storage
+            .open_savepoint(
+                boot_ts.clone(),
+                &BootstrapArgs {
+                    default_cluster_replica_size: bootstrap_default_cluster_replica_size,
+                    bootstrap_role,
+                },
+                deploy_generation,
+                None,
+            )
+            .await
+        {
+            Ok(adapter_storage) => Box::new(adapter_storage).expire().await,
+            Err(CatalogError::Durable(e)) if e.can_recover_with_write_mode() => {
+                // This is theoretically possible if catalog implementation A is
+                // initialized, implementation B is uninitialized, and we are going to
+                // migrate from A to B. The current code avoids this by always
+                // initializing all implementations, regardless of the target
+                // implementation. Still it's easy to protect against this and worth it in
+                // case things change in the future.
+                tracing::warn!("Unable to perform upgrade test because the target implementation is uninitialized");
+                return Ok(mz_catalog::durable::persist_backed_catalog_state(
+                    persist_client,
+                    environment_id.organization_id(),
+                    BUILD_INFO.semver_version(),
+                    Arc::clone(&catalog_metrics),
+                )
+                .await?);
+            }
+            Err(e) => {
+                return Err(anyhow!(e).context("Catalog upgrade would have failed with this error"))
+            }
+        }
+
+        let promoted = deployment_state.set_ready_to_promote();
+
+        tracing::info!("Waiting for user to promote this envd to leader");
+        promoted.await;
+
+        Ok(mz_catalog::durable::persist_backed_catalog_state(
+            persist_client,
+            environment_id.organization_id(),
+            BUILD_INFO.semver_version(),
+            Arc::clone(&catalog_metrics),
+        )
+        .await?)
+    } else if catalog_generation == deploy_generation {
+        tracing::info!("Server requested generation {deploy_generation} which is equal to catalog's generation");
+        deployment_state.set_is_leader();
+        Ok(openable_adapter_storage)
+    } else {
+        mz_ore::halt!("Server started with requested generation {deploy_generation} but catalog was already at {catalog_generation:?}. Deploy generations must increase monotonically");
+    }
+}

--- a/src/environmentd/src/deployment/state.rs
+++ b/src/environmentd/src/deployment/state.rs
@@ -1,0 +1,153 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Deployment state handling.
+
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+
+use mz_ore::channel::trigger::{self, Trigger};
+use serde::{Deserialize, Serialize};
+
+enum DeploymentStateInner {
+    Initializing,
+    ReadyToPromote { _promote_trigger: Trigger },
+    IsLeader,
+}
+
+/// The state of an environment deployment.
+///
+/// This object should be held by the `environmentd` server. It provides methods
+/// to handle state transitions that should be driven by the server itself.
+///
+/// A deployment begins in the `Initializing` state.
+///
+/// If, during initialization, the server realizes that it is taking over from a
+/// failed `environmentd` process of a generation that is already the leader,
+/// the server may proceed directly to the `IsLeader` state, via
+/// [`DeploymentState::set_is_leader`].
+///
+/// Otherwise, the server should leave the deployment state in `Initializing`
+/// while performing initialization activities. Once the environment is ready to
+/// take over from the prior generation, the server should call
+/// [`DeploymentState::set_ready_to_promote`]. After this, the server should
+/// *not* call [`DeploymentState::set_is_leader`], as an external orchestrator
+/// will determine when promotion occurs. The future returned by
+/// `set_ready_to_promote` will resolve when promotion has occurred and the
+/// deployment should take over from the prior generation and begin serving
+/// queries.
+pub struct DeploymentState {
+    inner: Arc<Mutex<DeploymentStateInner>>,
+}
+
+impl DeploymentState {
+    /// Creates a new `LeaderState` for a deployment. The
+    ///
+    /// Returns the state and a handle to the state.
+    pub fn new() -> (DeploymentState, DeploymentStateHandle) {
+        let inner = Arc::new(Mutex::new(DeploymentStateInner::Initializing));
+        let state = DeploymentState {
+            inner: Arc::clone(&inner),
+        };
+        let handle = DeploymentStateHandle { inner };
+        (state, handle)
+    }
+
+    /// Marks the deployment as ready to be promoted to leader.
+    ///
+    /// Returns a future that resolves when the leadership promotion occurs.
+    /// When the function returns, the state will be `ReadyToPromote`. When the
+    /// returned future resolves, the state will be `IsLeader`.
+    ///
+    /// Panics if the leader state is not `Initializing`.
+    pub fn set_ready_to_promote(&self) -> impl Future<Output = ()> {
+        let (promote_trigger, promote_trigger_rx) = trigger::channel();
+        {
+            let mut inner = self.inner.lock().expect("lock poisoned");
+            assert!(
+                matches!(*inner, DeploymentStateInner::Initializing),
+                "LeaderState::set_ready_to_promote called on non-initializing state",
+            );
+            *inner = DeploymentStateInner::ReadyToPromote {
+                _promote_trigger: promote_trigger,
+            };
+        }
+        promote_trigger_rx
+    }
+
+    /// Marks the deployment as the leader.
+    ///
+    /// Panics if the leader state is not `Initializing`.
+    pub fn set_is_leader(&self) {
+        let mut inner = self.inner.lock().expect("lock poisoned");
+        assert!(
+            matches!(*inner, DeploymentStateInner::Initializing),
+            "LeaderState::set_is_leader called on non-initializing state",
+        );
+        *inner = DeploymentStateInner::IsLeader;
+    }
+}
+
+/// A cloneable handle to a [`DeploymentState`].
+///
+/// This should be held by modules providing external interfaces to
+/// `environmentd` (e.g., the HTTP server). It provides methods to inspect the
+/// current leadership state, and to promote the deployment to the leader if it
+/// is ready to do so.
+#[derive(Clone)]
+pub struct DeploymentStateHandle {
+    inner: Arc<Mutex<DeploymentStateInner>>,
+}
+
+impl DeploymentStateHandle {
+    /// Returns the current deployment status.
+    pub fn status(&self) -> DeploymentStatus {
+        let inner = self.inner.lock().expect("lock poisoned");
+        match *inner {
+            DeploymentStateInner::Initializing => DeploymentStatus::Initializing,
+            DeploymentStateInner::ReadyToPromote { .. } => DeploymentStatus::ReadyToPromote,
+            DeploymentStateInner::IsLeader => DeploymentStatus::IsLeader,
+        }
+    }
+
+    /// Attempts to promote this deployment to the leader.
+    ///
+    /// Deployments in the `Initializing` state cannot be promoted. Deployments
+    /// in the `ReadyToPromote` state or `IsLeader` state can be promoted (with
+    /// the latter case being a no-op).
+    ///
+    /// If the leader was successfully promoted, returns `Ok`. Otherwise,
+    /// returns `Err`.
+    pub fn try_promote(&self) -> Result<(), ()> {
+        let mut inner = self.inner.lock().expect("lock poisoned");
+        match *inner {
+            DeploymentStateInner::Initializing => Err(()),
+            DeploymentStateInner::ReadyToPromote { .. } => {
+                *inner = DeploymentStateInner::IsLeader;
+                Ok(())
+            }
+            DeploymentStateInner::IsLeader => Ok(()),
+        }
+    }
+}
+
+/// Describes the status of a deployment.
+///
+/// This is a simplified representation of [`DeploymentState`], suitable for
+/// announcement to the external orchestrator.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DeploymentStatus {
+    /// This deployment is not the leader. It is initializing and is not yet
+    /// ready to become the leader.
+    Initializing,
+    /// This deployment is not the leader, but it is ready to become the leader.
+    ReadyToPromote,
+    /// This deployment is the leader.
+    IsLeader,
+}

--- a/src/ore/src/channel.rs
+++ b/src/ore/src/channel.rs
@@ -26,6 +26,8 @@ use tokio::sync::oneshot;
 
 use crate::metrics::PromLabelsExt;
 
+pub mod trigger;
+
 /// Extensions for the receiving end of asynchronous channels.
 #[async_trait]
 pub trait ReceiverExt<T: Send> {

--- a/src/ore/src/channel/trigger.rs
+++ b/src/ore/src/channel/trigger.rs
@@ -1,0 +1,123 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Trigger channels.
+//!
+//! Trigger channels are a very simple form of channel that communicate only one
+//! bit of information: whether the sending half of the channel is open or
+//! closed.
+//!
+//! Here's an example of using a trigger channel to trigger work on a background
+//! task.
+//!
+//! ```
+//! # tokio_test::block_on(async {
+//! use mz_ore::channel::trigger;
+//!
+//! // Create a new trigger channel.
+//! let (trigger, trigger_rx) = trigger::channel();
+//!
+//! // Spawn a task to do some background work, but only once triggered.
+//! tokio::spawn(async {
+//!     // Wait for trigger to get dropped.
+//!     trigger_rx.await;
+//!
+//!     // Do background work.
+//! });
+//!
+//! // Do some prep work.
+//!
+//! // Fire `trigger` by dropping it.
+//! drop(trigger);
+//! # })
+//! ```
+//!
+//! A trigger channel never errors. It is not an error to drop the receiver
+//! before dropping the corresponding trigger.
+//!
+//! Trigger channels can be easily simulated with [`tokio::sync::oneshot`]
+//! channels (and in fact the implementation uses oneshot channels under the
+//! hood). However, using trigger channels can result in clearer code when the
+//! additional features of oneshot channels are not required, as trigger
+//! channels have a simpler API.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+
+use futures::FutureExt;
+use tokio::sync::oneshot;
+use tokio::sync::oneshot::error::TryRecvError;
+
+/// The sending half of a trigger channel.
+///
+/// Dropping the trigger will cause the receiver to resolve.
+#[derive(Debug)]
+pub struct Trigger {
+    _tx: oneshot::Sender<()>,
+}
+
+/// The receiving half of a trigger channel.
+///
+/// Awaiting the receiver will block until the trigger is dropped.
+#[derive(Debug)]
+pub struct Receiver {
+    rx: oneshot::Receiver<()>,
+}
+
+impl Receiver {
+    /// Reports whether the channel has been triggered.
+    pub fn is_triggered(&mut self) -> bool {
+        matches!(self.rx.try_recv(), Err(TryRecvError::Closed))
+    }
+}
+
+impl Future for Receiver {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let _ = ready!(self.rx.poll_unpin(cx));
+        Poll::Ready(())
+    }
+}
+
+/// Creates a new trigger channel.
+pub fn channel() -> (Trigger, Receiver) {
+    let (tx, rx) = oneshot::channel();
+    let trigger = Trigger { _tx: tx };
+    let trigger_rx = Receiver { rx };
+    (trigger, trigger_rx)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::channel::trigger;
+
+    #[mz_ore::test(tokio::test)]
+    async fn test_trigger_channel() {
+        let (trigger1, mut trigger1_rx) = trigger::channel();
+        let (trigger2, trigger2_rx) = trigger::channel();
+
+        crate::task::spawn(|| "test_trigger_channel", async move {
+            assert!(!trigger1_rx.is_triggered());
+            (&mut trigger1_rx).await;
+            assert!(trigger1_rx.is_triggered());
+            drop(trigger2);
+        });
+
+        drop(trigger1);
+        trigger2_rx.await;
+    }
+}

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -47,6 +47,7 @@ use mz_environmentd::CatalogConfig;
 use mz_orchestrator_process::{ProcessOrchestrator, ProcessOrchestratorConfig};
 use mz_orchestrator_tracing::{TracingCliArgs, TracingOrchestrator};
 use mz_ore::cast::{CastFrom, ReinterpretCast};
+use mz_ore::channel::trigger;
 use mz_ore::error::ErrorExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
@@ -411,7 +412,7 @@ pub struct RunnerInner<'a> {
     enable_table_keys: bool,
     verbosity: usize,
     stdout: &'a dyn WriteFmt,
-    _shutdown_trigger: oneshot::Sender<()>,
+    _shutdown_trigger: trigger::Trigger,
     _server_thread: JoinOnDropHandle<()>,
     _temp_dir: TempDir,
 }
@@ -1089,7 +1090,7 @@ impl<'a> RunnerInner<'a> {
         let (server_addr_tx, server_addr_rx) = oneshot::channel();
         let (internal_server_addr_tx, internal_server_addr_rx) = oneshot::channel();
         let (internal_http_server_addr_tx, internal_http_server_addr_rx) = oneshot::channel();
-        let (shutdown_trigger, shutdown_tripwire) = oneshot::channel();
+        let (shutdown_trigger, shutdown_trigger_rx) = trigger::channel();
         let server_thread = thread::spawn(|| {
             let runtime = match Runtime::new() {
                 Ok(runtime) => runtime,
@@ -1118,7 +1119,7 @@ impl<'a> RunnerInner<'a> {
             internal_http_server_addr_tx
                 .send(server.internal_http_local_addr())
                 .expect("receiver should not drop first");
-            let _ = runtime.block_on(shutdown_tripwire);
+            let _ = runtime.block_on(shutdown_trigger_rx);
         });
         let server_addr = server_addr_rx.await??;
         let internal_server_addr = internal_server_addr_rx.await?;


### PR DESCRIPTION
Various refactorings that will allow the cloud orchestration layer to perform a 0dt upgrade if a feature flag is enabled for the environment.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Go commit by commit.

If it's helpful, here's the commit that I'm working on that stacks on top of this refactoring to actually perform the 0dt preflight checks: https://github.com/MaterializeInc/materialize/pull/27819/commits/99c9367d899bc36ae6f2604a281a494a6642d288

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a