### PR TITLE
environmentd: add 0dt preflight checks behind feature flag

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1492,13 +1492,13 @@ steps:
     agents:
       queue: linux-aarch64
 
-  - id: read-only-cluster
-    label: Read-only cluster
+  - id: 0dt
+    label: Zero downtime
     depends_on: build-aarch64
     timeout_in_minutes: 30
     plugins:
       - ./ci/plugins/mzcompose:
-          composition: read-only-cluster
+          composition: 0dt
     agents:
       queue: linux-aarch64
 

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -54,7 +54,6 @@ class Materialized(Service):
         sanity_restart: bool = True,
         platform: str | None = None,
         healthcheck: list[str] | None = None,
-        read_only_controllers: bool = False,
     ) -> None:
         if name is None:
             name = "materialized"
@@ -110,9 +109,6 @@ class Materialized(Service):
 
         if unsafe_mode:
             command += ["--unsafe-mode"]
-
-        if read_only_controllers:
-            command += ["--read-only-controllers"]
 
         if not environment_id:
             environment_id = DEFAULT_MZ_ENVIRONMENT_ID

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -19,6 +19,12 @@ pub const ALLOW_USER_SESSIONS: Config<bool> = Config::new(
     "Whether to allow user roles to create new sessions. When false, only system roles will be permitted to create new sessions.",
 );
 
+pub const ENABLE_0DT_DEPLOYMENT: Config<bool> = Config::new(
+    "enable_0dt_deployment",
+    false,
+    "Whether to enable zero-downtime deployments (experimental).",
+);
+
 /// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.
 pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
     "enable_statement_lifecycle_logging",
@@ -42,6 +48,7 @@ pub const PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION: Config<Dura
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&ALLOW_USER_SESSIONS)
+        .add(&ENABLE_0DT_DEPLOYMENT)
         .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)
 }

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -9,8 +9,11 @@
 
 //! Logic related to executing catalog transactions.
 
+use std::collections::{BTreeMap, BTreeSet};
+
 use mz_adapter_types::compaction::CompactionWindow;
 use mz_adapter_types::connection::ConnectionId;
+use mz_adapter_types::dyncfgs::ENABLE_0DT_DEPLOYMENT;
 use mz_audit_log::{
     CreateOrDropClusterReplicaReasonV1, EventDetails, EventType, IdFullNameV1, ObjectType,
     SchedulingDecisionsWithReasonsV1, VersionedEvent,
@@ -28,7 +31,7 @@ use mz_ore::instrument;
 use mz_ore::now::EpochMillis;
 use mz_repr::adt::mz_acl_item::{merge_mz_acl_items, AclMode, MzAclItem, PrivilegeMap};
 use mz_repr::role_id::RoleId;
-use mz_repr::GlobalId;
+use mz_repr::{strconv, GlobalId};
 use mz_sql::catalog::{
     CatalogDatabase, CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem, CatalogRole,
     CatalogSchema, DefaultPrivilegeAclItem, DefaultPrivilegeObject, RoleAttributes, RoleMembership,
@@ -45,7 +48,6 @@ use mz_sql::{rbac, DEFAULT_SCHEMA};
 use mz_sql_parser::ast::{QualifiedReplica, Value};
 use mz_storage_client::controller::StorageController;
 use mz_storage_types::controller::TxnWalTablesImpl;
-use std::collections::{BTreeMap, BTreeSet};
 use tracing::{info, trace};
 
 use crate::catalog::{
@@ -1894,7 +1896,7 @@ impl Catalog {
             }
             Op::UpdateSystemConfiguration { name, value } => {
                 let parsed_value = state.parse_system_configuration(&name, value.borrow())?;
-                tx.upsert_system_config(&name, parsed_value)?;
+                tx.upsert_system_config(&name, parsed_value.clone())?;
                 // This mirrors the `txn_wal_tables` "system var" into the catalog
                 // storage "config" collection so that we can toggle the flag with
                 // Launch Darkly, but use it in boot before Launch Darkly is available.
@@ -1902,6 +1904,10 @@ impl Catalog {
                     let txn_wal_tables =
                         TxnWalTablesImpl::parse(value.borrow()).expect("parsing succeeded above");
                     tx.set_txn_wal_tables(txn_wal_tables)?;
+                } else if name == ENABLE_0DT_DEPLOYMENT.name() {
+                    let enable_0dt_deployment =
+                        strconv::parse_bool(&parsed_value).expect("parsing succeeded above");
+                    tx.set_enable_0dt_deployment(enable_0dt_deployment)?;
                 }
             }
             Op::ResetSystemConfiguration { name } => {
@@ -1911,11 +1917,14 @@ impl Catalog {
                 // Launch Darkly, but use it in boot before Launch Darkly is available.
                 if name == TXN_WAL_TABLES.name() {
                     tx.reset_txn_wal_tables()?;
+                } else if name == ENABLE_0DT_DEPLOYMENT.name() {
+                    tx.reset_enable_0dt_deployment()?;
                 }
             }
             Op::ResetAllSystemConfiguration => {
                 tx.clear_system_configs();
                 tx.reset_txn_wal_tables()?;
+                tx.reset_enable_0dt_deployment()?;
             }
             Op::WeirdBuiltinTableUpdates {
                 builtin_table_update,

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -144,6 +144,13 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// Get the deployment generation of this instance.
     async fn get_deployment_generation(&mut self) -> Result<u64, CatalogError>;
 
+    /// Get the `enable_0dt_deployment` config value of this instance.
+    ///
+    /// This mirrors the `enable_0dt_deployment` "system var" so that we can
+    /// toggle the flag with LaunchDarkly, but use it in boot before
+    /// LaunchDarkly is available.
+    async fn get_enable_0dt_deployment(&mut self) -> Result<Option<bool>, CatalogError>;
+
     /// Reports if the remote configuration was synchronized at least once.
     async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError>;
 

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -58,6 +58,12 @@ pub(crate) const SYSTEM_CONFIG_SYNCED_KEY: &str = "system_config_synced";
 /// for historical reasons.
 pub(crate) const TXN_WAL_TABLES: &str = "persist_txn_tables";
 
+/// The key used within the "config" collection where we store a mirror of the
+/// `enable_0dt_deployment` "system var" value. This is mirrored so that we can
+/// toggle the flag with LaunchDarkly, but use it in boot before LaunchDarkly is
+/// available.
+pub(crate) const ENABLE_0DT_DEPLOYMENT: &str = "enable_0dt_deployment";
+
 const USER_ID_ALLOC_KEY: &str = "user";
 const SYSTEM_ID_ALLOC_KEY: &str = "system";
 

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -35,7 +35,7 @@ use mz_storage_client::controller::StorageTxn;
 use mz_storage_types::controller::{StorageError, TxnWalTablesImpl};
 
 use crate::builtin::BuiltinLog;
-use crate::durable::initialize::{SYSTEM_CONFIG_SYNCED_KEY, TXN_WAL_TABLES};
+use crate::durable::initialize::{ENABLE_0DT_DEPLOYMENT, SYSTEM_CONFIG_SYNCED_KEY, TXN_WAL_TABLES};
 use crate::durable::objects::serialization::proto;
 use crate::durable::objects::{
     AuditLogKey, Cluster, ClusterConfig, ClusterIntrospectionSourceIndexKey,
@@ -1591,6 +1591,15 @@ impl<'a> Transaction<'a> {
         self.set_config(TXN_WAL_TABLES.into(), Some(u64::from(value)))
     }
 
+    /// Updates the catalog `enable_0dt_deployment` "config" value to
+    /// match the `enable_0dt_deployment` "system var" value.
+    ///
+    /// These are mirrored so that we can toggle the flag with Launch Darkly,
+    /// but use it in boot before Launch Darkly is available.
+    pub fn set_enable_0dt_deployment(&mut self, value: bool) -> Result<(), CatalogError> {
+        self.set_config(ENABLE_0DT_DEPLOYMENT.into(), Some(u64::from(value)))
+    }
+
     /// Removes the catalog `txn_wal_tables` "config" value to
     /// match the `txn_wal_tables` "system var" value.
     ///
@@ -1598,6 +1607,15 @@ impl<'a> Transaction<'a> {
     /// but use it in boot before Launch Darkly is available.
     pub fn reset_txn_wal_tables(&mut self) -> Result<(), CatalogError> {
         self.set_config(TXN_WAL_TABLES.into(), None)
+    }
+
+    /// Removes the catalog `enable_0dt_deployment` "config" value to
+    /// match the `enable_0dt_deployment` "system var" value.
+    ///
+    /// These are mirrored so that we can toggle the flag with LaunchDarkly,
+    /// but use it in boot before LaunchDarkly is available.
+    pub fn reset_enable_0dt_deployment(&mut self) -> Result<(), CatalogError> {
+        self.set_config(ENABLE_0DT_DEPLOYMENT.into(), None)
     }
 
     /// Updates the catalog `system_config_synced` "config" value to true.

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -556,13 +556,6 @@ pub struct Args {
     // === Tracing options. ===
     #[clap(flatten)]
     tracing: TracingCliArgs,
-
-    // === Testing options. ===
-    /// Whether or not to start controllers in read-only mode. This is only
-    /// meant for use during development of read-only clusters and 0dt upgrades
-    /// and should go away once we have proper orchestration during upgrades.
-    #[clap(long)]
-    read_only_controllers: bool,
 }
 
 #[derive(ArgEnum, Debug, Clone)]
@@ -978,7 +971,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 tracing_handle,
                 // Testing options.
                 now,
-                read_only_controllers: args.read_only_controllers,
             })
             .await
     })?;

--- a/src/environmentd/src/deployment.rs
+++ b/src/environmentd/src/deployment.rs
@@ -41,7 +41,10 @@
 //!
 //! [^1] "Configuration" here means "command-line flags". Most settings in an
 //! environment are changeable at runtime via LaunchDarkly feature flags, but
-//! occasionally
+//! occasionally we have settings that are only changeable via command-line
+//! flags to `environmentd`. Changing these flags requires a process restart,
+//! and performing that process restart without incurring unavailability
+//! requires this deployment infrastructure.
 
 pub mod preflight;
 pub mod state;

--- a/src/environmentd/src/deployment/state.rs
+++ b/src/environmentd/src/deployment/state.rs
@@ -47,7 +47,7 @@ pub struct DeploymentState {
 }
 
 impl DeploymentState {
-    /// Creates a new `LeaderState` for a deployment. The
+    /// Creates a new `LeaderState` for a deployment.
     ///
     /// Returns the state and a handle to the state.
     pub fn new() -> (DeploymentState, DeploymentStateHandle) {

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -27,6 +27,7 @@ use derivative::Derivative;
 use mz_adapter::config::{system_parameter_sync, SystemParameterSyncConfig};
 use mz_adapter::load_remote_system_parameters;
 use mz_adapter::webhook::WebhookConcurrencyLimiter;
+use mz_adapter_types::dyncfgs::ENABLE_0DT_DEPLOYMENT;
 use mz_build_info::{build_info, BuildInfo};
 use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_catalog::durable::BootstrapArgs;
@@ -40,6 +41,7 @@ use mz_ore::tracing::TracingHandle;
 use mz_ore::{instrument, task};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::usage::StorageUsageClient;
+use mz_repr::strconv;
 use mz_secrets::SecretsController;
 use mz_server_core::{ConnectionStream, ListenerHandle, ReloadTrigger, TlsCertConfig};
 use mz_sql::catalog::EnvironmentId;
@@ -177,10 +179,6 @@ pub struct Config {
     // === Testing options. ===
     /// A now generation function for mocking time.
     pub now: NowFn,
-    /// Whether or not to start controllers in read-only mode. This is only
-    /// meant for use during development of read-only clusters and 0dt upgrades
-    /// and should go away once we have proper orchestration during upgrades.
-    pub read_only_controllers: bool,
 }
 
 /// Configuration for network listeners.
@@ -362,7 +360,40 @@ impl Listeners {
         )
         .await?;
 
+        // Determine whether we should perform a 0dt deployment.
+        let enable_0dt_deployment = {
+            let default = config
+                .system_parameter_defaults
+                .get(ENABLE_0DT_DEPLOYMENT.name())
+                .map(|x| {
+                    strconv::parse_bool(x).map_err(|err| {
+                        anyhow!(
+                            "failed to parse default for {}: {}",
+                            ENABLE_0DT_DEPLOYMENT.name(),
+                            err
+                        )
+                    })
+                })
+                .transpose()?;
+            let ld = get_ld_value("enable_0dt_deployment", &remote_system_parameters, |x| {
+                strconv::parse_bool(x).map_err(|x| x.to_string())
+            })?;
+            let catalog = openable_adapter_storage.get_enable_0dt_deployment().await?;
+            let computed = catalog.or(ld).or(default).unwrap_or(false);
+            info!(
+                %computed,
+                ?default,
+                ?ld,
+                ?catalog,
+                "determined value for enable_0dt_deployment system parameter",
+            );
+            computed
+        };
+
         // Perform preflight checks.
+        //
+        // Preflight checks determine whether to boot in read-only mode or not.
+        let mut read_only = false;
         let preflight_config = PreflightInput {
             boot_ts,
             environment_id: config.environment_id.clone(),
@@ -376,24 +407,40 @@ impl Listeners {
             openable_adapter_storage,
             catalog_metrics: Arc::clone(&config.catalog_config.metrics),
         };
-        // TODO(benesch): perform 0dt preflight checks instead if a 0dt feature flag is
-        // enabled.
-        let openable_adapter_storage =
-            deployment::preflight::preflight_legacy(preflight_config).await?;
+        if enable_0dt_deployment {
+            (openable_adapter_storage, read_only) =
+                deployment::preflight::preflight_0dt(preflight_config).await?;
+        } else {
+            openable_adapter_storage =
+                deployment::preflight::preflight_legacy(preflight_config).await?;
+        };
 
         let bootstrap_args = BootstrapArgs {
             default_cluster_replica_size: config.bootstrap_default_cluster_replica_size.clone(),
             bootstrap_role: config.bootstrap_role,
         };
 
-        let mut adapter_storage = openable_adapter_storage
-            .open(
-                boot_ts,
-                &bootstrap_args,
-                config.controller.deploy_generation,
-                None,
-            )
-            .await?;
+        let mut adapter_storage = if read_only {
+            // TODO: behavior of migrations when booting in savepoint mode is
+            // not well defined.
+            openable_adapter_storage
+                .open_savepoint(
+                    boot_ts,
+                    &bootstrap_args,
+                    config.controller.deploy_generation,
+                    None,
+                )
+                .await?
+        } else {
+            openable_adapter_storage
+                .open(
+                    boot_ts,
+                    &bootstrap_args,
+                    config.controller.deploy_generation,
+                    None,
+                )
+                .await?
+        };
 
         let txn_wal_tables_current_ld =
             get_ld_value(TXN_WAL_TABLES.name(), &remote_system_parameters, |x| {
@@ -449,12 +496,12 @@ impl Listeners {
             txn_wal_tables = value;
         }
         info!(
-            "persist_txn_tables value of {} computed from default {:?} catalog {:?} LD {:?} and flag {:?}",
-            txn_wal_tables,
-            txn_wal_tables_default,
-            txn_wal_tables_stash_ld,
-            txn_wal_tables_current_ld,
-            config.txn_wal_tables_cli,
+            computed = %txn_wal_tables,
+            default = ?txn_wal_tables_default,
+            catalog = ?txn_wal_tables_stash_ld,
+            ld = ?txn_wal_tables_current_ld,
+            cli = ?config.txn_wal_tables_cli,
+            "determined value for persist_txn_tables system parameter",
         );
 
         // Initialize adapter.
@@ -497,7 +544,7 @@ impl Listeners {
             webhook_concurrency_limit: webhook_concurrency_limit.clone(),
             http_host_name: config.http_host_name,
             tracing_handle: config.tracing_handle,
-            read_only_controllers: config.read_only_controllers,
+            read_only_controllers: read_only,
         })
         .instrument(info_span!("adapter::serve"))
         .await?;

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -529,7 +529,6 @@ impl Listeners {
                 internal_console_redirect_url: config.internal_console_redirect_url,
                 txn_wal_tables_cli: Some(TxnWalTablesImpl::Lazy),
                 tls_reload_certs,
-                read_only_controllers: false,
             })
             .await?;
 

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1080,7 +1080,6 @@ impl<'a> RunnerInner<'a> {
             internal_console_redirect_url: None,
             txn_wal_tables_cli: Some(TxnWalTablesImpl::Lazy),
             tls_reload_certs: mz_server_core::cert_reload_never_reload(),
-            read_only_controllers: false,
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/test/0dt/mzcompose
+++ b/test/0dt/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"


### PR DESCRIPTION
Introduce a new `enable_0dt_deployment` feature flag. When enabled,
environments booted with a new deploy generation follow a zero-downtime
deployment flow:

  1. The new environment loads the catalog in savepoint mode and
     starts the controllers in read only mode.

  2. The new environment announces itself as `Initializing` while it
     waits to be ready. For now, we use a fixed 30s timer, but in the
     future we will use a far stricter definition of ready that checks
     cluster hydration status.

  3. When the new environment is promoted by the external orchestrator,
     it halts. When it is restarted, it will restart with writes allowed
     and begin serving traffic.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR adds a known desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a