### PR TITLE
Doc: Add integration docs for Estuary Flow

### DIFF
--- a/doc/user/content/ingest-data/estuary-flow.md
+++ b/doc/user/content/ingest-data/estuary-flow.md
@@ -1,0 +1,76 @@
+---
+title: "Estuary Flow"
+description: "How to ingest real-time data from Estuary Flow into Materialize"
+aliases:
+  - /integrations/estuary/
+---
+
+[Estuary Flow](https://estuary.dev/) is a real-time data platform specializing in Change Data Capture (CDC). This guide walks through the steps to ingest data from Estuary Flow into Materialize using the Kafka source.
+A Collection in Estuary Flow is exposed as a Kafka Topic for consumption.
+
+
+## Before you begin, ensure that you have:
+
+- An Estuary Flow account.
+
+## Step 1. Create a New Secret & Create Connection
+
+Generate your refresh token from the [Estuary Flow Dashboard](https://dashboard.estuary.dev/admin/api).
+   Replace the placeholder token in the commands below with your actual token.
+
+In the [SQL Shell](https://console.materialize.com/), or your preferred SQL
+   client connected to Materialize, use the [`CREATE CONNECTION`](/sql/create-connection/)
+   command to create connection objects with access and authentication details
+   to Estuary Flow, including a schema registry:
+
+### Create Secret for Estuary Refresh Token
+
+```sql
+CREATE SECRET estuary_refresh_token AS 'your_generated_token_here';
+```
+
+### Create Kafka Connection
+
+```sql
+CREATE CONNECTION estuary_connection TO KAFKA (
+    BROKER 'dekaf.estuary.dev',
+    SECURITY PROTOCOL = 'SASL_SSL',
+    SASL MECHANISMS = 'PLAIN',
+    SASL USERNAME = '{}',
+    SASL PASSWORD = SECRET estuary_refresh_token
+);
+```
+
+### Create Schema Registry Connection
+
+```sql
+CREATE CONNECTION csr_estuary_connection TO CONFLUENT SCHEMA REGISTRY (
+    URL 'https://dekaf.estuary.dev',
+    USERNAME = '{}',
+    PASSWORD = SECRET estuary_refresh_token
+);
+```
+
+Once created, a connection is reusable across multiple CREATE SOURCE statements.
+
+## Step 2. Create a Source for an Estuary Flow Collection
+
+Define a source that reads from an Estuary Flow collection (surfaced as a Kafka topic), using the previously created connections and specifying the data format.
+
+### Create Source
+
+```sql
+CREATE SOURCE estuary_flow_source
+  FROM KAFKA CONNECTION estuary_connection (TOPIC '<name-of-your-flow-collection>')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_estuary_connection
+    ENVELOPE UPSERT;
+```
+
+Make sure to replace <name-of-your-flow-collection> with the full name of your collection from Estuary Flow; you can grab this value from the Flow dashboard.
+
+Related Pages
+
+- [`CREATE SECRET`](/sql/create-secret)
+- [`CREATE CONNECTION`](/sql/create-connection/)
+- [`CREATE SOURCE`: Kafka](/sql/create-source/kafka/)
+

--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -221,6 +221,7 @@ The level of support for these tools will improve as we extend the coverage of `
 | Meltano       | {{< supportLevel researching >}} | Not supported yet. Subscribe via "Notify Me" to register interest.                 | [](#notify) |
 | Airbyte       | {{< supportLevel researching >}} | Not supported yet. Subscribe via "Notify Me" to register interest.                 | [](#notify) |
 | Striim Cloud  | {{< supportLevel beta >}}        | See the [Striim Cloud guide](/integrations/striim/) for a step-by-step breakdown of the integration         |             |
+| Estuary Flow  | {{< supportLevel beta >}}        | See the [Estaury Flow guide](/integrations/estuary-flow/) for a step-by-step breakdown of the integration |
 
 ### Business Intelligence (BI)
 


### PR DESCRIPTION
### Motivation

This PR adds the integration guide to the docs page for Estuary Flow as discussed with @morsapaes.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
