### PR TITLE
storage: switch sources to columnated `DataflowError`

### DIFF
--- a/src/storage-types/src/errors.proto
+++ b/src/storage-types/src/errors.proto
@@ -10,7 +10,6 @@
 syntax = "proto3";
 
 import "expr/src/scalar.proto";
-import "repr/src/global_id.proto";
 import "repr/src/row.proto";
 import "storage-types/src/shim.proto";
 
@@ -38,7 +37,7 @@ message ProtoSourceErrorDetails {
 }
 
 message ProtoSourceError {
-    mz_repr.global_id.ProtoGlobalId source_id = 1;
+    reserved 1;
     ProtoSourceErrorDetails error = 2;
 }
 

--- a/src/storage/src/source.rs
+++ b/src/storage/src/source.rs
@@ -25,7 +25,7 @@
 // https://github.com/tokio-rs/prost/issues/237
 #![allow(missing_docs)]
 
-use crate::source::types::{SourceMessage, SourceReaderError};
+use crate::source::types::SourceMessage;
 
 pub mod generator;
 mod kafka;

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use differential_dataflow::{AsCollection, Collection};
 use futures::StreamExt;
 use mz_repr::{Diff, Row};
+use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::load_generator::{
     Event, Generator, KeyValueLoadGenerator, LoadGenerator, LoadGeneratorSourceConnection,
 };
@@ -24,7 +25,7 @@ use timely::progress::Antichain;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::source::types::{ProgressStatisticsUpdate, SourceRender};
-use crate::source::{RawSourceCreationConfig, SourceMessage, SourceReaderError};
+use crate::source::{RawSourceCreationConfig, SourceMessage};
 
 mod auction;
 mod counter;
@@ -131,7 +132,7 @@ impl GeneratorKind {
         committed_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
         start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
-        Collection<G, (usize, Result<SourceMessage, SourceReaderError>), Diff>,
+        Collection<G, (usize, Result<SourceMessage, DataflowError>), Diff>,
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
@@ -173,7 +174,7 @@ impl SourceRender for LoadGeneratorSourceConnection {
         committed_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
         start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
-        Collection<G, (usize, Result<SourceMessage, SourceReaderError>), Diff>,
+        Collection<G, (usize, Result<SourceMessage, DataflowError>), Diff>,
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
         Stream<G, ProgressStatisticsUpdate>,
@@ -199,7 +200,7 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
     committed_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
     required_exports: usize,
 ) -> (
-    Collection<G, (usize, Result<SourceMessage, SourceReaderError>), Diff>,
+    Collection<G, (usize, Result<SourceMessage, DataflowError>), Diff>,
     Option<Stream<G, Infallible>>,
     Stream<G, HealthStatusMessage>,
     Stream<G, ProgressStatisticsUpdate>,

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -66,6 +66,7 @@ use mz_mysql_util::{
 use mz_ore::cast::CastFrom;
 use mz_ore::result::ResultExt;
 use mz_repr::{Diff, GlobalId, Row};
+use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::mysql::{gtid_set_frontier, GtidPartition, GtidState};
 use mz_storage_types::sources::MySqlSourceConnection;
 use mz_timely_util::builder_async::{
@@ -73,7 +74,6 @@ use mz_timely_util::builder_async::{
 };
 
 use crate::metrics::source::mysql::MySqlSourceMetrics;
-use crate::source::types::SourceReaderError;
 use crate::source::RawSourceCreationConfig;
 
 use super::{
@@ -105,7 +105,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
     rewind_stream: &Stream<G, RewindRequest>,
     metrics: MySqlSourceMetrics,
 ) -> (
-    Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
+    Collection<G, (usize, Result<Row, DataflowError>), Diff>,
     Stream<G, Infallible>,
     Stream<G, ReplicationError>,
     PressOnDropButton,

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -102,13 +102,14 @@ use mz_ore::future::InTask;
 use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::result::ResultExt;
 use mz_repr::{Diff, Row};
+use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::mysql::{gtid_set_frontier, GtidPartition};
 use mz_storage_types::sources::MySqlSourceConnection;
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
 
 use crate::metrics::source::mysql::MySqlSnapshotMetrics;
 use crate::source::types::ProgressStatisticsUpdate;
-use crate::source::{RawSourceCreationConfig, SourceReaderError};
+use crate::source::RawSourceCreationConfig;
 
 use super::schemas::verify_schemas;
 use super::{
@@ -124,7 +125,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
     subsources: Vec<SubsourceInfo>,
     metrics: MySqlSnapshotMetrics,
 ) -> (
-    Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
+    Collection<G, (usize, Result<Row, DataflowError>), Diff>,
     Stream<G, RewindRequest>,
     Stream<G, ProgressStatisticsUpdate>,
     Stream<G, ReplicationError>,

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -90,6 +90,7 @@ use mz_postgres_util::simple_query_opt;
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_ssh_util::tunnel_manager::SshTunnelManager;
+use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::postgres::CastType;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
@@ -119,7 +120,6 @@ use crate::metrics::source::postgres::PgSourceMetrics;
 use crate::source::postgres::verify_schema;
 use crate::source::postgres::{DefiniteError, ReplicationError, TransientError};
 use crate::source::types::ProgressStatisticsUpdate;
-use crate::source::types::SourceReaderError;
 use crate::source::RawSourceCreationConfig;
 
 /// Postgres epoch is 2000-01-01T00:00:00Z
@@ -147,7 +147,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     committed_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
     metrics: PgSourceMetrics,
 ) -> (
-    Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
+    Collection<G, (usize, Result<Row, DataflowError>), Diff>,
     Stream<G, Infallible>,
     Stream<G, ProgressStatisticsUpdate>,
     Stream<G, ReplicationError>,

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -147,6 +147,7 @@ use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::{simple_query_opt, PostgresError};
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
+use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::postgres::CastType;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection};
 use mz_timely_util::builder_async::{
@@ -165,7 +166,6 @@ use crate::metrics::source::postgres::PgSnapshotMetrics;
 use crate::source::postgres::replication::RewindRequest;
 use crate::source::postgres::{verify_schema, DefiniteError, ReplicationError, TransientError};
 use crate::source::types::ProgressStatisticsUpdate;
-use crate::source::types::SourceReaderError;
 use crate::source::RawSourceCreationConfig;
 
 /// Renders the snapshot dataflow. See the module documentation for more information.
@@ -177,7 +177,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     table_info: BTreeMap<u32, (usize, PostgresTableDesc, Vec<(CastType, MirScalarExpr)>)>,
     metrics: PgSnapshotMetrics,
 ) -> (
-    Collection<G, (usize, Result<Row, SourceReaderError>), Diff>,
+    Collection<G, (usize, Result<Row, DataflowError>), Diff>,
     Stream<G, RewindRequest>,
     Stream<G, ProgressStatisticsUpdate>,
     Stream<G, ReplicationError>,

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -49,7 +49,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::controller::CollectionMetadata;
-use mz_storage_types::errors::SourceError;
+use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::{SourceConnection, SourceExport, SourceTimestamp};
 use mz_timely_util::antichain::AntichainExt;
 use mz_timely_util::builder_async::{
@@ -76,7 +76,7 @@ use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate};
 use crate::metrics::source::SourceMetrics;
 use crate::metrics::StorageMetrics;
 use crate::source::reclock::{ReclockBatch, ReclockFollower, ReclockOperator};
-use crate::source::types::{SourceMessage, SourceOutput, SourceReaderError, SourceRender};
+use crate::source::types::{SourceMessage, SourceOutput, SourceRender};
 use crate::statistics::SourceStatistics;
 
 /// Shared configuration information for all source types. This is used in the
@@ -160,7 +160,7 @@ pub fn create_raw_source<'g, G: Scope<Timestamp = ()>, C>(
 ) -> (
     Vec<(
         Collection<Child<'g, G, mz_repr::Timestamp>, SourceOutput<C::Time>, Diff>,
-        Collection<Child<'g, G, mz_repr::Timestamp>, SourceError, Diff>,
+        Collection<Child<'g, G, mz_repr::Timestamp>, DataflowError, Diff>,
     )>,
     Stream<G, HealthStatusMessage>,
     Vec<PressOnDropButton>,
@@ -262,7 +262,7 @@ fn source_render_operator<G, C>(
     resume_uppers: impl futures::Stream<Item = Antichain<C::Time>> + 'static,
     start_signal: impl std::future::Future<Output = ()> + 'static,
 ) -> (
-    Collection<G, (usize, Result<SourceMessage, SourceReaderError>), Diff>,
+    Collection<G, (usize, Result<SourceMessage, DataflowError>), Diff>,
     Stream<G, Infallible>,
     Stream<G, HealthStatusMessage>,
     Vec<PressOnDropButton>,
@@ -320,7 +320,7 @@ where
                     // Downstream consumers of this data will preserve this
                     // status.
                     Err(ref error) => HealthStatusUpdate::stalled(
-                        error.inner.to_string(),
+                        error.to_string(),
                         Some("retracting the errored value may resume the source".to_string()),
                     ),
                 };
@@ -566,21 +566,14 @@ fn reclock_operator<G, FromTime, D, M>(
     config: RawSourceCreationConfig,
     mut timestamper: ReclockFollower<FromTime, mz_repr::Timestamp>,
     mut source_rx: InstrumentedUnboundedReceiver<
-        Event<
-            FromTime,
-            Vec<(
-                (usize, Result<SourceMessage, SourceReaderError>),
-                FromTime,
-                D,
-            )>,
-        >,
+        Event<FromTime, Vec<((usize, Result<SourceMessage, DataflowError>), FromTime, D)>>,
         M,
     >,
     remap_trace_updates: Collection<G, FromTime, Diff>,
     source_metrics: Arc<SourceMetrics>,
 ) -> Vec<(
     Collection<G, SourceOutput<FromTime>, D>,
-    Collection<G, SourceError, Diff>,
+    Collection<G, DataflowError, Diff>,
 )>
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
@@ -627,7 +620,7 @@ where
         let mut source_upper = MutableAntichain::new_bottom(FromTime::minimum());
 
         // Stash of batches that have not yet been timestamped.
-        type Batch<T, D> = Vec<((usize, Result<SourceMessage, SourceReaderError>), T, D)>;
+        type Batch<T, D> = Vec<((usize, Result<SourceMessage, DataflowError>), T, D)>;
         let mut untimestamped_batches: Vec<(FromTime, Batch<FromTime, D>)> = Vec::new();
 
         // Stash of reclock updates that are still beyond the upper frontier
@@ -734,13 +727,7 @@ where
                                 };
                                 (idx, Ok(ok))
                             }
-                            Err(SourceReaderError { inner }) => {
-                                let err = SourceError {
-                                    source_id: id,
-                                    error: inner,
-                                };
-                                (idx, Err(err))
-                            }
+                            Err(err) => (idx, Err(err)),
                         };
 
                         let ts_cap = cap_set.delayed(&into_ts);


### PR DESCRIPTION
### Motivation

This change enables storage dataflows to make use of columnated/lgalloced containers when moving data between operators. We could have gone the other way and implemented a columnation region for the `SourceReaderError` type but since there aren't any actual downsides to switching to `DataflowError` we go for this simpler approach.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
