### PR TITLE
testdrive: Disable entire loadgen query

### DIFF
--- a/test/testdrive/load-generator-key-value.td
+++ b/test/testdrive/load-generator-key-value.td
@@ -153,19 +153,20 @@ up_quick     6 6  0  0 48 16
 2   4
 3   4
 
+# Doesn't work reliably under high load in CI
 # Higher offsets than before, as we produce more values.
-# u.offset_known > 3, # Doesn't work reliably under high load in CI
-> SELECT
-    s.name,
-    u.offset_committed = u.offset_known,
-    u.snapshot_records_known,
-    u.snapshot_records_staged,
-    u.messages_received > 48,
-    u.records_indexed
-  FROM mz_sources s
-  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
-  WHERE s.name IN ('up_with_update')
-up_with_update true 48 48 true 16
+# > SELECT
+#     s.name,
+#     u.offset_known > 3,
+#     u.offset_committed = u.offset_known,
+#     u.snapshot_records_known,
+#     u.snapshot_records_staged,
+#     u.messages_received > 48,
+#     u.records_indexed
+#   FROM mz_sources s
+#   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+#   WHERE s.name IN ('up_with_update')
+# up_with_update true true 48 48 true 16
 
 # Also, despite the same seed, values should be different than the snapshot-only source.
 > SELECT


### PR DESCRIPTION
Still failing in https://buildkite.com/materialize/test/builds/84427#019049f0-5909-45b8-990f-4b6bf440c750

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
