### PR TITLE
storage: read-only mode for (most of) storage

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -230,7 +230,7 @@ impl Coordinator {
                 }
 
                 Command::ControllerAllowWrites { tx } => {
-                    self.controller.allow_writes();
+                    self.controller.allow_writes().await;
                     let _ = tx.send(Ok(true));
                 }
             }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -212,16 +212,18 @@ impl Coordinator {
                     self.drain_statement_log().await;
                 }
                 Message::PrivateLinkVpcEndpointEvents(events) => {
-                    self.controller
-                        .storage
-                        .append_introspection_updates(
-                            mz_storage_client::controller::IntrospectionType::PrivatelinkConnectionStatusHistory,
-                            events
-                                .into_iter()
-                                .map(|e| (mz_repr::Row::from(e), 1))
-                                .collect(),
-                        )
-                        .await;
+                    if !self.controller.read_only() {
+                        self.controller
+                            .storage
+                            .append_introspection_updates(
+                                mz_storage_client::controller::IntrospectionType::PrivatelinkConnectionStatusHistory,
+                                events
+                                    .into_iter()
+                                    .map(|e| (mz_repr::Row::from(e), 1))
+                                    .collect(),
+                            )
+                            .await;
+                    }
                 }
                 Message::CheckSchedulingPolicies => {
                     self.check_scheduling_policies().await;

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -254,7 +254,7 @@ impl Coordinator {
             (StatementLifecycleHistory, statement_lifecycle_updates),
             (SqlText, sql_text_updates),
         ] {
-            if !updates.is_empty() {
+            if !updates.is_empty() && !self.controller.read_only() {
                 self.controller
                     .storage
                     .append_introspection_updates(type_, updates)

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -355,6 +355,7 @@ impl<T> ShouldHalt for StorageError<T> {
             | StorageError::IngestionInstanceMissing { .. }
             | StorageError::ExportInstanceMissing { .. }
             | StorageError::Generic(_)
+            | StorageError::ReadOnly
             | StorageError::DataflowError(_)
             | StorageError::InvalidAlter { .. }
             | StorageError::ShuttingDown(_)

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -325,9 +325,7 @@ where
         self.read_only = false;
 
         self.compute.allow_writes();
-        // TODO: Storage does not yet understand the concept of read-only
-        // instances.
-
+        self.storage.allow_writes();
         self.remove_past_generation_replicas_in_background();
     }
 
@@ -674,6 +672,7 @@ where
             config.now,
             Arc::clone(&txns_metrics),
             envd_epoch,
+            read_only,
             config.metrics_registry.clone(),
             txn_wal_tables,
             config.connection_context,

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -316,7 +316,7 @@ where
 
     /// Allow this controller and instances controlled by it to write to
     /// external systems.
-    pub fn allow_writes(&mut self) {
+    pub async fn allow_writes(&mut self) {
         if !self.read_only {
             // Already transitioned out of read-only mode!
             return;
@@ -325,7 +325,7 @@ where
         self.read_only = false;
 
         self.compute.allow_writes();
-        self.storage.allow_writes();
+        self.storage.allow_writes().await;
         self.remove_past_generation_replicas_in_background();
     }
 
@@ -725,7 +725,7 @@ where
         // `read_only = false` _and_ when later transitioning out of read-only
         // mode. This way we keep that logic in one place.
         if !read_only {
-            this.allow_writes();
+            this.allow_writes().await;
         }
 
         this

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -298,6 +298,10 @@ pub trait StorageController: Debug {
     /// This method can be invoked immediately, at the potential expense of performance.
     fn initialization_complete(&mut self);
 
+    /// Allow this controller and instances controlled by it to write to
+    /// external systems.
+    fn allow_writes(&mut self);
+
     /// Update storage configuration with new parameters.
     fn update_parameters(&mut self, config_params: StorageParameters);
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -300,7 +300,7 @@ pub trait StorageController: Debug {
 
     /// Allow this controller and instances controlled by it to write to
     /// external systems.
-    fn allow_writes(&mut self);
+    async fn allow_writes(&mut self);
 
     /// Update storage configuration with new parameters.
     fn update_parameters(&mut self, config_params: StorageParameters);

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -219,6 +219,9 @@ pub enum StorageError<T> {
     /// A generic error that happens during operations of the storage controller.
     // TODO(aljoscha): Get rid of this!
     Generic(anyhow::Error),
+    /// We are in read-only mode and were asked to do a something that requires
+    /// writing.
+    ReadOnly,
 }
 
 impl<T: Debug + Display + 'static> Error for StorageError<T> {
@@ -245,6 +248,7 @@ impl<T: Debug + Display + 'static> Error for StorageError<T> {
             Self::RtrTimeout(_) => None,
             Self::RtrDropFailure(_) => None,
             Self::Generic(err) => err.source(),
+            Self::ReadOnly => None,
         }
     }
 }
@@ -331,6 +335,7 @@ impl<T: fmt::Display + 'static> fmt::Display for StorageError<T> {
                 "real-time source dropped before ingesting the upstream system's visible frontier"
             ),
             Self::Generic(err) => std::fmt::Display::fmt(err, f),
+            Self::ReadOnly => write!(f, "cannot write in read-only mode"),
         }
     }
 }


### PR DESCRIPTION
Work towards zero-downtime upgrades: https://github.com/MaterializeInc/materialize/issues/27406

We don't yet check the read-only bit when writing to tables!

As of this change, components further up the stack are not yet aware of
read-only mode, so they will attempt to write and will then error or
panic. Follow-up commits will introduce read-only mode for those
components as well.

I have a branch that threads read-only mode through more things, and actually makes an `envd` bootable in read-only mode. For reference when reviewing this PR: https://github.com/MaterializeInc/materialize/pull/27841

@MaterializeInc/testing I'm afraid this is not yet testable, only the full thing in https://github.com/MaterializeInc/materialize/pull/27841 will be testable: there you can bring up and environment in read-only mode and see that no writes are happening/allowed.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
