### PR TITLE
persist: Handle the special case of columnar encoding an empty `RelationDesc`

### DIFF
--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -49,8 +49,8 @@ pub use crate::datum_vec::{DatumVec, DatumVecBorrow};
 pub use crate::diff::Diff;
 pub use crate::global_id::GlobalId;
 pub use crate::relation::{
-    ColumnName, ColumnType, NotNullViolation, ProtoColumnName, ProtoColumnType, ProtoRelationDesc,
-    ProtoRelationType, RelationDesc, RelationType,
+    arb_row_for_relation, ColumnName, ColumnType, NotNullViolation, ProtoColumnName,
+    ProtoColumnType, ProtoRelationDesc, ProtoRelationType, RelationDesc, RelationType,
 };
 pub use crate::row::collection::{ProtoRowCollection, RowCollection, SortedRowCollectionIter};
 pub use crate::row::encoding::{

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -580,9 +580,7 @@ impl Arbitrary for RelationDesc {
             (1, Just(128..256)),
         ]);
 
-        num_columns
-            .prop_flat_map(|num_cols| arb_relation_desc(num_cols))
-            .boxed()
+        num_columns.prop_flat_map(arb_relation_desc).boxed()
     }
 }
 

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -7,12 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
 use std::{fmt, iter, vec};
 
 use anyhow::bail;
 use mz_lowertest::MzReflect;
 use mz_ore::str::StrExt;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use proptest::prelude::*;
+use proptest::strategy::{Strategy, Union};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -20,7 +23,7 @@ use crate::relation_and_scalar::proto_relation_type::ProtoKey;
 pub use crate::relation_and_scalar::{
     ProtoColumnName, ProtoColumnType, ProtoRelationDesc, ProtoRelationType,
 };
-use crate::{Datum, ScalarType};
+use crate::{arb_datum_for_column, Datum, Row, ScalarType};
 
 /// The type of a [`Datum`].
 ///
@@ -353,7 +356,7 @@ impl From<ColumnName> for mz_sql_parser::ast::Ident {
 /// });
 /// let desc = RelationDesc::new(relation_type, names);
 /// ```
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct RelationDesc {
     typ: RelationType,
     names: Vec<ColumnName>,
@@ -562,6 +565,50 @@ impl RelationDesc {
     }
 }
 
+impl Arbitrary for RelationDesc {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<RelationDesc>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        let num_columns = Union::new_weighted(vec![
+            (100, Just(0..4)),
+            (50, Just(4..8)),
+            (25, Just(8..16)),
+            (12, Just(16..32)),
+            (6, Just(32..64)),
+            (3, Just(64..128)),
+            (1, Just(128..256)),
+        ]);
+
+        num_columns
+            .prop_flat_map(|num_cols| arb_relation_desc(num_cols))
+            .boxed()
+    }
+}
+
+/// Returns a [`Strategy`] that generates an arbitrary [`RelationDesc`] with a number columns
+/// within the range provided.
+pub fn arb_relation_desc(num_cols: std::ops::Range<usize>) -> impl Strategy<Value = RelationDesc> {
+    // Long column names are generally uninteresting, and can greatly
+    // increase the runtime for a test case, so bound the max length.
+    let name_length = Union::new_weighted(vec![
+        (50, Just(0..8)),
+        (20, Just(8..16)),
+        (5, Just(16..128)),
+        (1, Just(128..1024)),
+        (1, Just(1024..4096)),
+    ]);
+
+    let name_strat = name_length
+        .prop_flat_map(|length| proptest::collection::vec(any::<char>(), length))
+        .prop_map(|chars| chars.into_iter().collect::<String>())
+        .no_shrink();
+    let name_strat = Arc::new(name_strat);
+
+    proptest::collection::vec((Arc::clone(&name_strat), any::<ColumnType>()), num_cols)
+        .prop_map(RelationDesc::from_names_and_types)
+}
+
 impl IntoIterator for RelationDesc {
     type Item = (ColumnName, ColumnType);
     type IntoIter = iter::Zip<vec::IntoIter<ColumnName>, vec::IntoIter<ColumnType>>;
@@ -569,6 +616,17 @@ impl IntoIterator for RelationDesc {
     fn into_iter(self) -> Self::IntoIter {
         self.names.into_iter().zip(self.typ.column_types)
     }
+}
+
+/// Returns a [`Strategy`] that yields arbitrary [`Row`]s for the provided [`RelationDesc`].
+pub fn arb_row_for_relation(desc: &RelationDesc) -> impl Strategy<Value = Row> {
+    let datums: Vec<_> = desc
+        .typ()
+        .columns()
+        .iter()
+        .map(arb_datum_for_column)
+        .collect();
+    datums.prop_map(|x| Row::pack(x.iter().map(Datum::from)))
 }
 
 /// Expression violated not-null constraint on named column

--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -1453,13 +1453,13 @@ mod tests {
 
     #[track_caller]
     fn roundtrip_rows(desc: &RelationDesc, rows: Vec<Row>) {
-        let mut encoder = <RelationDesc as Schema2<Row>>::encoder(&desc).unwrap();
+        let mut encoder = <RelationDesc as Schema2<Row>>::encoder(desc).unwrap();
         for row in &rows {
-            encoder.append(&row);
+            encoder.append(row);
         }
         let col = encoder.finish();
 
-        let decoder = <RelationDesc as Schema2<Row>>::decoder(&desc, col).unwrap();
+        let decoder = <RelationDesc as Schema2<Row>>::decoder(desc, col).unwrap();
 
         let mut rnd_row = Row::default();
         for (idx, og_row) in rows.into_iter().enumerate() {

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -3601,6 +3601,9 @@ impl Arbitrary for ScalarType {
             Just(ScalarType::RegClass).boxed(),
             Just(ScalarType::Int2Vector).boxed(),
         ])
+        // None of the leaf ScalarTypes types are really "simpler" than others
+        // so don't waste time trying to shrink.
+        .no_shrink()
         .boxed();
 
         // There are a limited set of types we support in ranges.


### PR DESCRIPTION
We encode `Row`s in Arrow with a `StructArray`, but Arrow doesn't support a `StructArray` with no fields. To handle this case [we use a `NullArray`](https://github.com/MaterializeInc/materialize/blob/main/src/persist-types/src/dyn_struct.rs#L97) on encode, but on decode we don't consider this case and [always expect a `StructArray`](https://github.com/MaterializeInc/materialize/blob/main/src/persist-types/src/dyn_struct.rs#L241).

This PR adds support for columnar encoding an empty `RelationDesc` in the new columnar encoder at the `SourceData` level. What makes this problem a little tricky is differentiating between an empty `Row` and a null entry. There are two approaches we could take to solve this problem:

1. Handle this in `RowColumnarEncoder`. We could add a special "internal" column when we create a `RowColumnarEncoder` for an empty `RelationDesc`, e.g. a `BooleanArray`. We could encode empty `Row`s as `true` and null entries as normal by setting an entry in the validity bitmap.
2. Handle this in `SourceDataColumnarEncoder`. When creating a `SourceDataColumnarEncoder` for an empty `RelationDesc`, instead of creating a `RowColumnarEncoder` we create a `NullArray`. On decode if the `err` column is null then we know to decode an empty `Row`.

This PR implements approach 2. A `NullArray` can be encoded in constant space, just an integer count for the number of nulls, and IMO is a bit cleaner than a special "internal" column.

I also only implemented this fix in the new columnar encoder since the existing one will be removed soon. I also added a proptest that generates an arbitrary `RelationDesc` and then generates arbitrary data for that `RelationDesc` and asserts it all roundtrips through Parquet. I ran this test for >48 hours.

### Motivation

Forward fixes https://github.com/MaterializeInc/materialize/issues/27840

### Tips for reviewer

This PR is split into two commits which can be reviewed separately:

1. The changes to support encoding an empty `RelationDesc`
4. Adds new proptest strategies and tests to add coverage for this case and more.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
