### PR TITLE
slt: Fix some types in tests

### DIFF
--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -591,7 +591,11 @@ def compileSlowSltConfig() -> SltRunConfig:
         "test/sqllogictest/show_clusters.slt",
     }
     tests_no_auto_index_selects = {
+        # pg_typeof contains public schema name in views
+        "test/sqllogictest/cast.slt",
         "test/sqllogictest/map.slt",
+        # pg_typeof contains public schema name in views
+        "test/sqllogictest/typeof.slt",
     }
 
     tests = file_util.resolve_paths_with_wildcard(tests)


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/slt/builds/5961#01904a03-82ac-4484-a8df-26c97ad17fe3

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
