### PR TITLE
compute: Mark webhook sources as monotonic

### DIFF
--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -296,10 +296,10 @@ impl<'a> DataflowBuilder<'a> {
         // we can retrieve monotonicity information from the parent source.
         match &source.data_source {
             DataSourceDesc::Ingestion { ingestion_desc, .. } => ingestion_desc.desc.monotonic(),
+            DataSourceDesc::Webhook { .. } => true,
             DataSourceDesc::IngestionExport { .. }
             | DataSourceDesc::Introspection(_)
-            | DataSourceDesc::Progress
-            | DataSourceDesc::Webhook { .. } => false,
+            | DataSourceDesc::Progress => false,
         }
     }
 


### PR DESCRIPTION
Inspired by https://github.com/MaterializeInc/materialize/pull/27806.

Webhook sources can only be appended to, which AFAIU makes them monotonic. Marking them as such unlocks some downstream optimizations in compute.

### Motivation

* This PR adds a feature that has not yet been specified.

Mark webhook sources as monotonic to improve performance

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
