### PR TITLE
compute: leave `Let` nodes in `FlatPlan`s

### DIFF
--- a/src/compute-types/src/plan/flat_plan.proto
+++ b/src/compute-types/src/plan/flat_plan.proto
@@ -61,6 +61,12 @@ message ProtoFlatPlanNode {
         ProtoGetPlan plan = 3;
     }
 
+    message ProtoLet {
+        mz_expr.id.ProtoLocalId id = 1;
+        uint64 value = 2;
+        uint64 body  = 3;
+    }
+
     message ProtoLetRec {
         repeated mz_expr.id.ProtoLocalId ids = 1;
         repeated uint64 values = 2;
@@ -144,5 +150,6 @@ message ProtoFlatPlanNode {
         ProtoThreshold threshold = 10;
         ProtoUnion union = 11;
         ProtoArrangeBy arrange_by = 12;
+        ProtoLet let = 13;
     }
 }


### PR DESCRIPTION
`Let` nodes introduce structure into rendered dataflow graphs, which is valueable for making sense of them, especially when they become large. Previously the `Plan`-to-`FlatPlan` translation would remove `Let` nodes because the flat representation didn't require them. This commit re-introduces them and adds the required corresponding rendering logic.

[Slack discussion.](https://materializeinc.slack.com/archives/C0761MZ3QD9/p1719218068134629)

### Motivation

  * This PR adds a known-desirable feature.

Closes #27837

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
