### PR TITLE
persist: Stats for the new Columnar encoders

### DIFF
--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -135,6 +135,7 @@ impl ColumnDecoder<()> for UnitColumnar {
 
 impl ColumnEncoder<()> for UnitColumnar {
     type FinishedColumn = NullArray;
+    type FinishedStats = NoneStats;
 
     fn append(&mut self, _val: &()) {
         self.len += 1;
@@ -144,13 +145,14 @@ impl ColumnEncoder<()> for UnitColumnar {
         self.len += 1;
     }
 
-    fn finish(self) -> Self::FinishedColumn {
-        NullArray::new(self.len)
+    fn finish(self) -> (Self::FinishedColumn, Self::FinishedStats) {
+        (NullArray::new(self.len), NoneStats)
     }
 }
 
 impl Schema2<()> for UnitSchema {
     type ArrowColumn = NullArray;
+    type Statistics = NoneStats;
 
     type Decoder = UnitColumnar;
     type Encoder = UnitColumnar;

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -31,6 +31,7 @@ pub mod dyn_struct;
 pub mod parquet;
 pub mod part;
 pub mod stats;
+pub mod stats2;
 pub mod timestamp;
 pub mod txn;
 

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -175,6 +175,12 @@ impl<T: Into<PrimitiveStatsVariants>> From<T> for ColumnStatKinds {
     }
 }
 
+impl From<PrimitiveStats<Vec<u8>>> for ColumnStatKinds {
+    fn from(value: PrimitiveStats<Vec<u8>>) -> Self {
+        ColumnStatKinds::Bytes(BytesStats::Primitive(value))
+    }
+}
+
 impl From<StructStats> for ColumnStatKinds {
     fn from(value: StructStats) -> Self {
         ColumnStatKinds::Struct(value)

--- a/src/persist-types/src/stats/bytes.rs
+++ b/src/persist-types/src/stats/bytes.rs
@@ -65,11 +65,11 @@ impl RustType<ProtoAtomicBytesStats> for AtomicBytesStats {
 #[derive(Debug, Clone)]
 pub struct FixedSizeBytesStats {
     /// See [PrimitiveStats::lower]
-    lower: Vec<u8>,
+    pub lower: Vec<u8>,
     /// See [PrimitiveStats::upper]
-    upper: Vec<u8>,
+    pub upper: Vec<u8>,
     /// The kind of data these stats represent.
-    kind: FixedSizeBytesStatsKind,
+    pub kind: FixedSizeBytesStatsKind,
 }
 
 impl FixedSizeBytesStats {

--- a/src/persist-types/src/stats2.rs
+++ b/src/persist-types/src/stats2.rs
@@ -1,0 +1,263 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Aggregate statistics about data stored in persist.
+
+use std::fmt::Debug;
+
+use arrow::array::{
+    BinaryArray, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array,
+    Int64Array, Int8Array, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+
+use crate::stats::primitive::{
+    truncate_bytes, truncate_string, PrimitiveStats, TruncateBound, TRUNCATE_LEN,
+};
+use crate::stats::{DynStats, NoneStats};
+
+/// A type that can incrementally collect stats from a sequence of values.
+pub trait ColumnarStatsBuilder<T>: Debug {
+    /// Type of [`arrow`] column these statistics can be derived from.
+    type ArrowColumn: arrow::array::Array + 'static;
+    /// The type of statistics the collector finalizes into.
+    type FinishedStats: DynStats;
+
+    /// Create a new instance of `Self` that can be used to collect statistics.
+    fn new() -> Self
+    where
+        Self: Sized;
+
+    /// Derive statistics from a column of data.
+    fn from_column(col: &Self::ArrowColumn) -> Self
+    where
+        Self: Sized;
+    /// Derive statistics from an opaque column of data.
+    ///
+    /// Returns `None` if the opaque column is not the same type as
+    /// [`Self::ArrowColumn`].
+    fn from_column_dyn(col: &dyn arrow::array::Array) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        let col = col.as_any().downcast_ref::<Self::ArrowColumn>()?;
+        Some(Self::from_column(col))
+    }
+
+    /// Include the provided value in the current statistics.
+    fn include(&mut self, val: T);
+
+    /// Finish this collector returning the final aggregated statistics.
+    fn finish(self) -> Self::FinishedStats
+    where
+        Self::FinishedStats: Sized;
+}
+
+/// We collect stats for all primitive types in exactly the same way. This
+/// macro de-duplicates some of that logic.
+///
+/// Note: If at any point someone finds this macro too complext, they should
+/// feel free to refactor it away!
+macro_rules! primitive_stats {
+    ($native:ty, $arrow_col:ty, $min_fn:path, $max_fn:path) => {
+        impl ColumnarStatsBuilder<$native> for PrimitiveStats<$native> {
+            type FinishedStats = Self;
+            type ArrowColumn = $arrow_col;
+
+            fn new() -> Self
+            where
+                Self: Sized,
+            {
+                PrimitiveStats {
+                    lower: <$native>::default(),
+                    upper: <$native>::default(),
+                }
+            }
+
+            fn from_column(col: &Self::ArrowColumn) -> Self
+            where
+                Self: Sized,
+            {
+                let lower = $min_fn(col).unwrap_or_default();
+                let upper = $max_fn(col).unwrap_or_default();
+
+                PrimitiveStats { lower, upper }
+            }
+
+            fn include(&mut self, val: $native) {
+                self.lower = val.min(self.lower);
+                self.upper = val.max(self.upper);
+            }
+
+            fn finish(self) -> Self::FinishedStats {
+                self
+            }
+        }
+    };
+}
+
+primitive_stats!(
+    bool,
+    BooleanArray,
+    arrow::compute::min_boolean,
+    arrow::compute::max_boolean
+);
+primitive_stats!(u8, UInt8Array, arrow::compute::min, arrow::compute::max);
+primitive_stats!(u16, UInt16Array, arrow::compute::min, arrow::compute::max);
+primitive_stats!(u32, UInt32Array, arrow::compute::min, arrow::compute::max);
+primitive_stats!(u64, UInt64Array, arrow::compute::min, arrow::compute::max);
+primitive_stats!(i8, Int8Array, arrow::compute::min, arrow::compute::max);
+primitive_stats!(i16, Int16Array, arrow::compute::min, arrow::compute::max);
+primitive_stats!(i32, Int32Array, arrow::compute::min, arrow::compute::max);
+primitive_stats!(i64, Int64Array, arrow::compute::min, arrow::compute::max);
+primitive_stats!(f32, Float32Array, arrow::compute::min, arrow::compute::max);
+primitive_stats!(f64, Float64Array, arrow::compute::min, arrow::compute::max);
+
+impl ColumnarStatsBuilder<&str> for PrimitiveStats<String> {
+    type ArrowColumn = StringArray;
+    type FinishedStats = Self;
+
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        PrimitiveStats {
+            lower: String::default(),
+            upper: String::default(),
+        }
+    }
+
+    fn from_column(col: &Self::ArrowColumn) -> Self
+    where
+        Self: Sized,
+    {
+        let lower = arrow::compute::min_string(col).unwrap_or_default();
+        let lower = truncate_string(lower, TRUNCATE_LEN, TruncateBound::Lower)
+            .expect("lower bound should always truncate");
+        let upper = arrow::compute::max_string(col).unwrap_or_default();
+        let upper = truncate_string(upper, TRUNCATE_LEN, TruncateBound::Upper)
+            // NB: The cost+trim stuff will remove the column entirely if
+            // it's still too big (also this should be extremely rare in
+            // practice).
+            .unwrap_or_else(|| upper.to_owned());
+
+        PrimitiveStats { lower, upper }
+    }
+
+    fn include(&mut self, val: &str) {
+        let lower_candidate = truncate_string(val, TRUNCATE_LEN, TruncateBound::Lower)
+            .expect("lower bound should always truncate");
+        if lower_candidate < self.lower {
+            self.lower = lower_candidate
+        }
+
+        let upper_candidate = truncate_string(val, TRUNCATE_LEN, TruncateBound::Upper)
+            // NB: The cost+trim stuff will remove the column entirely if
+            // it's still too big (also this should be extremely rare in
+            // practice).
+            .unwrap_or_else(|| val.to_owned());
+        if upper_candidate < self.upper {
+            self.upper = upper_candidate
+        }
+    }
+
+    fn finish(self) -> Self::FinishedStats
+    where
+        Self::FinishedStats: Sized,
+    {
+        self
+    }
+}
+
+impl ColumnarStatsBuilder<&[u8]> for PrimitiveStats<Vec<u8>> {
+    type ArrowColumn = BinaryArray;
+    type FinishedStats = Self;
+
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        PrimitiveStats {
+            lower: Vec::default(),
+            upper: Vec::default(),
+        }
+    }
+
+    fn from_column(col: &Self::ArrowColumn) -> Self
+    where
+        Self: Sized,
+    {
+        let lower = arrow::compute::min_binary(col).unwrap_or_default();
+        let lower = truncate_bytes(lower, TRUNCATE_LEN, TruncateBound::Lower)
+            .expect("lower bound should always truncate");
+        let upper = arrow::compute::max_binary(col).unwrap_or_default();
+        let upper = truncate_bytes(upper, TRUNCATE_LEN, TruncateBound::Upper)
+            // NB: The cost+trim stuff will remove the column entirely if
+            // it's still too big (also this should be extremely rare in
+            // practice).
+            .unwrap_or_else(|| upper.to_owned());
+
+        PrimitiveStats { lower, upper }
+    }
+
+    fn include(&mut self, val: &[u8]) {
+        let lower_candidate = truncate_bytes(val, TRUNCATE_LEN, TruncateBound::Lower)
+            .expect("lower bound should always truncate");
+        if lower_candidate < self.lower {
+            self.lower = lower_candidate
+        }
+
+        let upper_candidate = truncate_bytes(val, TRUNCATE_LEN, TruncateBound::Upper)
+            // NB: The cost+trim stuff will remove the column entirely if
+            // it's still too big (also this should be extremely rare in
+            // practice).
+            .unwrap_or_else(|| val.to_owned());
+        if upper_candidate < self.upper {
+            self.upper = upper_candidate
+        }
+    }
+
+    fn finish(self) -> Self::FinishedStats
+    where
+        Self::FinishedStats: Sized,
+    {
+        self
+    }
+}
+
+/// Empty statistics for a column of data.
+#[derive(Debug)]
+pub struct NoneStatsBuilder<A>(std::marker::PhantomData<A>);
+
+impl<T, A: arrow::array::Array + 'static> ColumnarStatsBuilder<T> for NoneStatsBuilder<A> {
+    type ArrowColumn = A;
+    type FinishedStats = NoneStats;
+
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        NoneStatsBuilder(std::marker::PhantomData)
+    }
+
+    fn from_column(_col: &Self::ArrowColumn) -> Self
+    where
+        Self: Sized,
+    {
+        NoneStatsBuilder(std::marker::PhantomData)
+    }
+
+    fn include(&mut self, _val: T) {}
+
+    fn finish(self) -> Self::FinishedStats
+    where
+        Self::FinishedStats: Sized,
+    {
+        NoneStats
+    }
+}

--- a/src/persist-types/src/stats2.rs
+++ b/src/persist-types/src/stats2.rs
@@ -63,7 +63,7 @@ pub trait ColumnarStatsBuilder<T>: Debug {
 /// We collect stats for all primitive types in exactly the same way. This
 /// macro de-duplicates some of that logic.
 ///
-/// Note: If at any point someone finds this macro too complext, they should
+/// Note: If at any point someone finds this macro too complex, they should
 /// feel free to refactor it away!
 macro_rules! primitive_stats {
     ($native:ty, $arrow_col:ty, $min_fn:path, $max_fn:path) => {

--- a/src/persist-types/src/stats2.rs
+++ b/src/persist-types/src/stats2.rs
@@ -12,8 +12,8 @@
 use std::fmt::Debug;
 
 use arrow::array::{
-    BinaryArray, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array,
-    Int64Array, Int8Array, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    BinaryArray, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
+    Int8Array, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
 };
 
 use crate::stats::primitive::{

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -79,9 +79,9 @@ uuid = { version = "1.7.0", features = ["serde"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 thiserror = "1.0.37"
+tracing = { version = "0.1.37" }
 
 # for the tracing_ feature
-tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", default-features = false, optional = true }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
@@ -103,7 +103,7 @@ default = [
     "mz-proto/default",
     "workspace-hack",
 ]
-tracing_ = ["tracing", "tracing-subscriber"]
+tracing_ = ["tracing-subscriber"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -160,7 +160,7 @@ impl fmt::Display for Jsonb {
 /// A borrowed JSON value.
 ///
 /// `JsonbRef` is to [`Jsonb`] as [`&str`](prim@str) is to [`String`].
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct JsonbRef<'a> {
     datum: Datum<'a>,
 }

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -40,6 +40,7 @@ pub mod optimize;
 pub mod refresh_schedule;
 pub mod role_id;
 pub mod stats;
+pub mod stats2;
 pub mod strconv;
 pub mod timestamp;
 pub mod url;

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
 use std::{fmt, iter, vec};
 
 use anyhow::bail;
@@ -601,9 +600,8 @@ pub fn arb_relation_desc(num_cols: std::ops::Range<usize>) -> impl Strategy<Valu
         .prop_flat_map(|length| proptest::collection::vec(any::<char>(), length))
         .prop_map(|chars| chars.into_iter().collect::<String>())
         .no_shrink();
-    let name_strat = Arc::new(name_strat);
 
-    proptest::collection::vec((Arc::clone(&name_strat), any::<ColumnType>()), num_cols)
+    proptest::collection::btree_map(name_strat, any::<ColumnType>(), num_cols)
         .prop_map(RelationDesc::from_names_and_types)
 }
 

--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -91,16 +91,12 @@ impl DatumEncoder {
     }
 
     fn push_invalid(&mut self) {
-        self.encoder.push_invalid()
+        self.encoder.push_invalid();
+        self.none_stats += 1;
     }
 
     fn finish(self) -> (Arc<dyn Array>, ColumnarStats) {
         let (array, stats) = self.encoder.finish();
-        assert!(
-            self.none_stats == 0 || self.nullable,
-            "pushed nulls into a non-nullable column"
-        );
-
         let nulls = self.nullable.then_some(ColumnNullStats {
             count: self.none_stats,
         });

--- a/src/repr/src/stats2.rs
+++ b/src/repr/src/stats2.rs
@@ -1,0 +1,437 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Persist Stats for non-primitive types.
+//!
+//! For primitive types please see [`mz_persist_types::stats2`].
+
+use std::collections::BTreeMap;
+
+use arrow::array::{BinaryArray, FixedSizeBinaryArray, StringArray};
+use chrono::{DateTime, NaiveTime};
+use dec::OrderedDecimal;
+use mz_persist_types::columnar::FixedSizeCodec;
+use mz_persist_types::stats::bytes::{AtomicBytesStats, AtomicBytesStatsKind, BytesStats};
+use mz_persist_types::stats::json::{JsonMapElementStats, JsonStats};
+use mz_persist_types::stats::primitive::PrimitiveStats;
+use mz_persist_types::stats::{ColumnStatKinds, ColumnStats, PrimitiveStatsVariants};
+use mz_persist_types::stats2::ColumnarStatsBuilder;
+use ordered_float::OrderedFloat;
+use prost::Message;
+use uuid::Uuid;
+
+use crate::adt::date::Date;
+use crate::adt::datetime::PackedNaiveTime;
+use crate::adt::interval::{Interval, PackedInterval};
+use crate::adt::jsonb::{JsonbPacker, JsonbRef};
+use crate::adt::numeric::{Numeric, PackedNumeric};
+use crate::adt::timestamp::CheckedTimestamp;
+use crate::row::ProtoDatum;
+use crate::{Datum, Row, RowArena, ScalarType};
+
+/// Incrementally collects statistics for a column of `decimal`.
+#[derive(Default, Debug)]
+pub struct NumericStatsBuilder {
+    lower: OrderedDecimal<Numeric>,
+    upper: OrderedDecimal<Numeric>,
+}
+
+impl ColumnarStatsBuilder<OrderedDecimal<Numeric>> for NumericStatsBuilder {
+    type ArrowColumn = BinaryArray;
+    type FinishedStats = BytesStats;
+
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        NumericStatsBuilder {
+            lower: OrderedDecimal(Numeric::default()),
+            upper: OrderedDecimal(Numeric::default()),
+        }
+    }
+
+    fn from_column(col: &Self::ArrowColumn) -> Self
+    where
+        Self: Sized,
+    {
+        // Note: PackedNumeric __does not__ sort the same as Numeric do we
+        // can't take the binary min and max like the other 'Packed' types.
+
+        let mut builder = Self::new();
+        for val in col.iter() {
+            let Some(val) = val else {
+                continue;
+            };
+            let val = PackedNumeric::from_bytes(val)
+                .expect("failed to roundtrip Numeric")
+                .into_value();
+            builder.include(OrderedDecimal(val));
+        }
+        builder
+    }
+
+    fn include(&mut self, val: OrderedDecimal<Numeric>) {
+        self.lower = val.min(self.lower);
+        self.upper = val.max(self.upper);
+    }
+
+    fn finish(self) -> Self::FinishedStats
+    where
+        Self::FinishedStats: Sized,
+    {
+        BytesStats::Atomic(AtomicBytesStats {
+            lower: PackedNumeric::from_value(self.lower.0).as_bytes().to_vec(),
+            upper: PackedNumeric::from_value(self.upper.0).as_bytes().to_vec(),
+            kind: Some(AtomicBytesStatsKind::PackedNumeric),
+        })
+    }
+}
+
+/// Incrementally collects statistics for a column of `time`.
+#[derive(Default, Debug)]
+pub struct NaiveTimeStatsBuilder {
+    lower: NaiveTime,
+    upper: NaiveTime,
+}
+
+impl ColumnarStatsBuilder<NaiveTime> for NaiveTimeStatsBuilder {
+    type ArrowColumn = FixedSizeBinaryArray;
+    type FinishedStats = BytesStats;
+
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        NaiveTimeStatsBuilder {
+            lower: NaiveTime::default(),
+            upper: NaiveTime::default(),
+        }
+    }
+
+    fn from_column(col: &Self::ArrowColumn) -> Self
+    where
+        Self: Sized,
+    {
+        // Note: Ideally here we'd use the arrow compute kernels for getting
+        // the min and max of a column, but aren't yet implemented for a
+        // `FixedSizedBinaryArray`.
+        //
+        // See: <https://github.com/apache/arrow-rs/issues/5934>
+
+        let lower = col.into_iter().filter_map(|x| x).min();
+        let upper = col.into_iter().filter_map(|x| x).max();
+
+        let lower = lower
+            .map(|b| {
+                PackedNaiveTime::from_bytes(b)
+                    .expect("failed to roundtrip PackedNaiveTime")
+                    .into_value()
+            })
+            .unwrap_or_default();
+        let upper = upper
+            .map(|b| {
+                PackedNaiveTime::from_bytes(b)
+                    .expect("failed to roundtrip PackedNaiveTime")
+                    .into_value()
+            })
+            .unwrap_or_default();
+
+        NaiveTimeStatsBuilder { lower, upper }
+    }
+
+    fn include(&mut self, val: NaiveTime) {
+        self.lower = val.min(self.lower);
+        self.upper = val.max(self.upper);
+    }
+
+    fn finish(self) -> Self::FinishedStats
+    where
+        Self::FinishedStats: Sized,
+    {
+        BytesStats::Atomic(AtomicBytesStats {
+            lower: PackedNaiveTime::from_value(self.lower).as_bytes().to_vec(),
+            upper: PackedNaiveTime::from_value(self.upper).as_bytes().to_vec(),
+            kind: Some(AtomicBytesStatsKind::PackedTime),
+        })
+    }
+}
+
+/// Incrementally collects statistics for a column of `time`.
+#[derive(Default, Debug)]
+pub struct IntervalStatsBuilder {
+    lower: Interval,
+    upper: Interval,
+}
+
+impl ColumnarStatsBuilder<Interval> for IntervalStatsBuilder {
+    type ArrowColumn = FixedSizeBinaryArray;
+    type FinishedStats = BytesStats;
+
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        IntervalStatsBuilder {
+            lower: Interval::default(),
+            upper: Interval::default(),
+        }
+    }
+
+    fn from_column(col: &Self::ArrowColumn) -> Self
+    where
+        Self: Sized,
+    {
+        // Note: Ideally here we'd use the arrow compute kernels for getting
+        // the min and max of a column, but aren't yet implemented for a
+        // `FixedSizedBinaryArray`.
+        //
+        // See: <https://github.com/apache/arrow-rs/issues/5934>
+
+        let lower = col.into_iter().filter_map(|x| x).min();
+        let upper = col.into_iter().filter_map(|x| x).max();
+
+        let lower = lower
+            .map(|b| {
+                PackedInterval::from_bytes(b)
+                    .expect("failed to roundtrip PackedInterval")
+                    .into_value()
+            })
+            .unwrap_or_default();
+        let upper = upper
+            .map(|b| {
+                PackedInterval::from_bytes(b)
+                    .expect("failed to roundtrip PackedInterval")
+                    .into_value()
+            })
+            .unwrap_or_default();
+
+        IntervalStatsBuilder { lower, upper }
+    }
+
+    fn include(&mut self, val: Interval) {
+        self.lower = val.min(self.lower);
+        self.upper = val.max(self.upper);
+    }
+
+    fn finish(self) -> Self::FinishedStats
+    where
+        Self::FinishedStats: Sized,
+    {
+        BytesStats::Atomic(AtomicBytesStats {
+            lower: PackedInterval::from_value(self.lower).as_bytes().to_vec(),
+            upper: PackedInterval::from_value(self.upper).as_bytes().to_vec(),
+            kind: Some(AtomicBytesStatsKind::PackedInterval),
+        })
+    }
+}
+
+/// Statistics builder for a column of [`Uuid`]s.
+#[derive(Debug)]
+pub struct UuidStatsBuilder {
+    lower: Uuid,
+    upper: Uuid,
+}
+
+impl ColumnarStatsBuilder<Uuid> for UuidStatsBuilder {
+    type ArrowColumn = FixedSizeBinaryArray;
+    type FinishedStats = BytesStats;
+
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        UuidStatsBuilder {
+            lower: Uuid::default(),
+            upper: Uuid::default(),
+        }
+    }
+
+    fn from_column(col: &Self::ArrowColumn) -> Self
+    where
+        Self: Sized,
+    {
+        // Note: Ideally here we'd use the arrow compute kernels for getting
+        // the min and max of a column, but aren't yet implemented for a
+        // `FixedSizedBinaryArray`.
+        //
+        // See: <https://github.com/apache/arrow-rs/issues/5934>
+
+        let lower = col.into_iter().filter_map(|x| x).min();
+        let upper = col.into_iter().filter_map(|x| x).max();
+
+        let lower = lower
+            .map(|b| Uuid::from_slice(b).expect("failed to roundtrip UUID"))
+            .unwrap_or_default();
+        let upper = upper
+            .map(|b| Uuid::from_slice(b).expect("failed to roundtrip UUID"))
+            .unwrap_or_default();
+
+        UuidStatsBuilder { lower, upper }
+    }
+
+    fn include(&mut self, val: Uuid) {
+        self.lower = val.min(self.lower);
+        self.upper = val.max(self.upper);
+    }
+
+    fn finish(self) -> Self::FinishedStats
+    where
+        Self::FinishedStats: Sized,
+    {
+        BytesStats::Atomic(AtomicBytesStats {
+            lower: self.lower.as_bytes().to_vec(),
+            upper: self.upper.as_bytes().to_vec(),
+            kind: Some(AtomicBytesStatsKind::Uuid),
+        })
+    }
+}
+
+/// Incrementally collects statistics for a column of `jsonb`.
+#[derive(Default, Debug)]
+pub struct JsonStatsBuilder {
+    count: usize,
+    min_max: Option<(Row, Row)>,
+    nested: BTreeMap<String, JsonStatsBuilder>,
+}
+
+impl JsonStatsBuilder {
+    fn to_stats(self) -> JsonStats {
+        let Some((min, max)) = self.min_max else {
+            return JsonStats::None;
+        };
+        let (min, max) = (min.unpack_first(), max.unpack_first());
+
+        match (min, max) {
+            (Datum::JsonNull, Datum::JsonNull) => JsonStats::JsonNulls,
+            (min @ (Datum::True | Datum::False), max @ (Datum::True | Datum::False)) => {
+                JsonStats::Bools(PrimitiveStats {
+                    lower: min.unwrap_bool(),
+                    upper: max.unwrap_bool(),
+                })
+            }
+            (Datum::String(min), Datum::String(max)) => JsonStats::Strings(PrimitiveStats {
+                lower: min.to_owned(),
+                upper: max.to_owned(),
+            }),
+            (min @ Datum::Numeric(_), max @ Datum::Numeric(_)) => {
+                JsonStats::Numerics(PrimitiveStats {
+                    lower: ProtoDatum::from(min).encode_to_vec(),
+                    upper: ProtoDatum::from(max).encode_to_vec(),
+                })
+            }
+            (Datum::List(_), Datum::List(_)) => JsonStats::Lists,
+            (Datum::Map(_), Datum::Map(_)) => JsonStats::Maps(
+                self.nested
+                    .into_iter()
+                    .map(|(key, value)| {
+                        (
+                            key,
+                            JsonMapElementStats {
+                                len: value.count,
+                                stats: value.to_stats(),
+                            },
+                        )
+                    })
+                    .collect(),
+            ),
+            _ => JsonStats::Mixed,
+        }
+    }
+}
+
+impl<'a> ColumnarStatsBuilder<JsonbRef<'a>> for JsonStatsBuilder {
+    type ArrowColumn = StringArray;
+    type FinishedStats = BytesStats;
+
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        JsonStatsBuilder::default()
+    }
+
+    fn from_column(col: &Self::ArrowColumn) -> Self
+    where
+        Self: Sized,
+    {
+        let mut row = Row::default();
+        let mut builder = JsonStatsBuilder::new();
+        for val in col.into_iter() {
+            let Some(val) = val else {
+                continue;
+            };
+
+            let mut packer = row.packer();
+            JsonbPacker::new(&mut packer)
+                .pack_str(val)
+                .expect("failed to roundtrip JSON");
+            builder.include(JsonbRef::from_datum(row.unpack_first()));
+        }
+
+        builder
+    }
+
+    fn include(&mut self, val: JsonbRef<'a>) {
+        let datum = val.into_datum();
+
+        self.count += 1;
+        self.min_max = match self.min_max.take() {
+            None => Some((Row::pack_slice(&[datum]), Row::pack_slice(&[datum]))),
+            Some((mut min_row, mut max_row)) => {
+                let (min, max) = (min_row.unpack_first(), max_row.unpack_first());
+                if datum < min {
+                    min_row.packer().push(datum);
+                }
+                if datum > max {
+                    max_row.packer().push(datum);
+                }
+                Some((min_row, max_row))
+            }
+        };
+
+        if let Datum::Map(map) = datum {
+            for (key, val) in map.iter() {
+                let val_datums = self.nested.entry(key.to_owned()).or_default();
+                val_datums.include(JsonbRef::from_datum(val));
+            }
+        }
+    }
+
+    fn finish(self) -> Self::FinishedStats
+    where
+        Self::FinishedStats: Sized,
+    {
+        BytesStats::Json(self.to_stats())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use uuid::Uuid;
+
+    #[mz_ore::test]
+    fn proptest_uuid_sort_order() {
+        fn test(mut og: Vec<Uuid>) {
+            let mut as_bytes: Vec<_> = og.iter().map(|u| u.as_bytes().clone()).collect();
+
+            og.sort();
+            as_bytes.sort();
+
+            let rnd: Vec<_> = as_bytes.into_iter().map(|b| Uuid::from_bytes(b)).collect();
+
+            assert_eq!(og, rnd);
+        }
+
+        let arb_uuid = any::<[u8; 16]>().prop_map(Uuid::from_bytes);
+        proptest!(|(uuids in proptest::collection::vec(arb_uuid, 0..128))| {
+            test(uuids);
+        });
+    }
+}

--- a/src/repr/src/stats2.rs
+++ b/src/repr/src/stats2.rs
@@ -232,8 +232,8 @@ impl ColumnarStatsBuilder<OrderedDecimal<Numeric>> for NumericStatsBuilder {
         Self: Sized,
     {
         NumericStatsBuilder {
-            lower: OrderedDecimal(Numeric::default()),
-            upper: OrderedDecimal(Numeric::default()),
+            lower: OrderedDecimal(Numeric::nan()),
+            upper: OrderedDecimal(-Numeric::infinity()),
         }
     }
 

--- a/src/repr/src/stats2.rs
+++ b/src/repr/src/stats2.rs
@@ -17,7 +17,7 @@ use arrow::array::{BinaryArray, FixedSizeBinaryArray, StringArray};
 use chrono::{DateTime, NaiveTime};
 use dec::OrderedDecimal;
 use mz_persist_types::columnar::FixedSizeCodec;
-use mz_persist_types::stats::bytes::{AtomicBytesStats, AtomicBytesStatsKind, BytesStats};
+use mz_persist_types::stats::bytes::{BytesStats, FixedSizeBytesStats, FixedSizeBytesStatsKind};
 use mz_persist_types::stats::json::{JsonMapElementStats, JsonStats};
 use mz_persist_types::stats::primitive::PrimitiveStats;
 use mz_persist_types::stats::{ColumnStatKinds, ColumnStats, PrimitiveStatsVariants};
@@ -35,7 +35,7 @@ use crate::adt::timestamp::CheckedTimestamp;
 use crate::row::ProtoDatum;
 use crate::{Datum, Row, ScalarType};
 
-/// Returns a `(lower, upper)` bound from the provided [`ColumnStatsKinds`], if applicable.
+/// Returns a `(lower, upper)` bound from the provided [`ColumnStatKinds`], if applicable.
 pub fn col_values<'a>(
     typ: &ScalarType,
     stats: &'a ColumnStatKinds,
@@ -92,10 +92,10 @@ pub fn col_values<'a>(
         ),
         (
             ScalarType::Numeric { .. },
-            ColumnStatKinds::Bytes(BytesStats::Atomic(AtomicBytesStats {
+            ColumnStatKinds::Bytes(BytesStats::FixedSize(FixedSizeBytesStats {
                 lower,
                 upper,
-                kind: Some(AtomicBytesStatsKind::PackedNumeric),
+                kind: FixedSizeBytesStatsKind::PackedNumeric,
             })),
         ) => {
             let lower = PackedNumeric::from_bytes(lower)
@@ -131,7 +131,7 @@ pub fn col_values<'a>(
                 .upper()
                 .map(|x| Datum::Date(Date::from_pg_epoch(x).expect("failed to roundtrip Date"))),
         ),
-        (ScalarType::Time, ColumnStatKinds::Bytes(BytesStats::Atomic(stats))) => {
+        (ScalarType::Time, ColumnStatKinds::Bytes(BytesStats::FixedSize(stats))) => {
             let lower = PackedNaiveTime::from_bytes(&stats.lower)
                 .expect("failed to roundtrip NaiveTime")
                 .into_value();
@@ -181,7 +181,7 @@ pub fn col_values<'a>(
                 .upper()
                 .map(|x| Datum::MzTimestamp(crate::Timestamp::from(x))),
         ),
-        (ScalarType::Interval, ColumnStatKinds::Bytes(BytesStats::Atomic(stats))) => {
+        (ScalarType::Interval, ColumnStatKinds::Bytes(BytesStats::FixedSize(stats))) => {
             let lower = PackedInterval::from_bytes(&stats.lower)
                 .map(|x| x.into_value())
                 .expect("failed to roundtrip Interval");
@@ -190,7 +190,7 @@ pub fn col_values<'a>(
                 .expect("failed to roundtrip Interval");
             (Some(Datum::Interval(lower)), Some(Datum::Interval(upper)))
         }
-        (ScalarType::Uuid, ColumnStatKinds::Bytes(BytesStats::Atomic(stats))) => {
+        (ScalarType::Uuid, ColumnStatKinds::Bytes(BytesStats::FixedSize(stats))) => {
             let lower = Uuid::from_slice(&stats.lower).expect("failed to roundtrip Uuid");
             let upper = Uuid::from_slice(&stats.upper).expect("failed to roundtrip Uuid");
             (Some(Datum::Uuid(lower)), Some(Datum::Uuid(upper)))
@@ -266,10 +266,10 @@ impl ColumnarStatsBuilder<OrderedDecimal<Numeric>> for NumericStatsBuilder {
     where
         Self::FinishedStats: Sized,
     {
-        BytesStats::Atomic(AtomicBytesStats {
+        BytesStats::FixedSize(FixedSizeBytesStats {
             lower: PackedNumeric::from_value(self.lower.0).as_bytes().to_vec(),
             upper: PackedNumeric::from_value(self.upper.0).as_bytes().to_vec(),
-            kind: Some(AtomicBytesStatsKind::PackedNumeric),
+            kind: FixedSizeBytesStatsKind::PackedNumeric,
         })
     }
 }
@@ -335,10 +335,10 @@ impl ColumnarStatsBuilder<NaiveTime> for NaiveTimeStatsBuilder {
     where
         Self::FinishedStats: Sized,
     {
-        BytesStats::Atomic(AtomicBytesStats {
+        BytesStats::FixedSize(FixedSizeBytesStats {
             lower: PackedNaiveTime::from_value(self.lower).as_bytes().to_vec(),
             upper: PackedNaiveTime::from_value(self.upper).as_bytes().to_vec(),
-            kind: Some(AtomicBytesStatsKind::PackedTime),
+            kind: FixedSizeBytesStatsKind::PackedTime,
         })
     }
 }
@@ -404,10 +404,10 @@ impl ColumnarStatsBuilder<Interval> for IntervalStatsBuilder {
     where
         Self::FinishedStats: Sized,
     {
-        BytesStats::Atomic(AtomicBytesStats {
+        BytesStats::FixedSize(FixedSizeBytesStats {
             lower: PackedInterval::from_value(self.lower).as_bytes().to_vec(),
             upper: PackedInterval::from_value(self.upper).as_bytes().to_vec(),
-            kind: Some(AtomicBytesStatsKind::PackedInterval),
+            kind: FixedSizeBytesStatsKind::PackedInterval,
         })
     }
 }
@@ -465,10 +465,10 @@ impl ColumnarStatsBuilder<Uuid> for UuidStatsBuilder {
     where
         Self::FinishedStats: Sized,
     {
-        BytesStats::Atomic(AtomicBytesStats {
+        BytesStats::FixedSize(FixedSizeBytesStats {
             lower: self.lower.as_bytes().to_vec(),
             upper: self.upper.as_bytes().to_vec(),
-            kind: Some(AtomicBytesStatsKind::Uuid),
+            kind: FixedSizeBytesStatsKind::Uuid,
         })
     }
 }


### PR DESCRIPTION
This PR adds statistics to the `DatumColumnarEncoder` in `repr/src/row/encoding2.rs`, and maintains parity with the existing statistics.

There is two functional changes in this PR.

First is we add a new trait `ColumnarStatisticsBuilder` which allows us to _incrementally_ collect statistics on a column, the only type we do this for at the moment is `jsonb`. Currently to collect stats on a `jsonb` column we decode all of the data through protobuf then collect stats. Incrementally collecting stats while we encode prevents the need to do this.

Second, it makes stats collection eager. This isn't that big of a change because we do always compute stats, this just changes the functional flow a bit.

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/24830

### Tips for reviewer

This PR is split into separate commits which could be reviewed separately:

1. Introduce the new `ColumnarStatsBuilder` trait, and a few new structs
2. Adds `Statistics` as an associated type on the `Schema2` trait
3. Compute and return stats with `RowColumnarEncoder::finish`
4. Return (lower, upper) bounds for supported stat types, add test
5. Benchmarks for `jsonb`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
