### PR TITLE
build: Update crc32c version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "crc32c"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version",
 ]

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-NIGHTLY_RUST_DATE=2024-06-20
+NIGHTLY_RUST_DATE=2024-06-23
 
 cd "$(dirname "$0")/.."
 

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -303,7 +303,7 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.crc32c]]
-version = "0.6.5"
+version = "0.6.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.crc32fast]]


### PR DESCRIPTION
Causes build failures in nightly: https://buildkite.com/materialize/nightly/builds/8208#01904b4d-44c4-48bb-909a-44a04fa26077
```
error[E0635]: unknown feature `stdarch_arm_crc32`
  --> /cargo/registry/src/index.crates.io-6f17d22bba15001f/crc32c-0.6.5/src/lib.rs:23:60
   |
23 | #![cfg_attr(all(target_arch = "aarch64", nightly), feature(stdarch_arm_crc32))]
   |
```
Follow-up to https://github.com/MaterializeInc/materialize/pull/27794

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
