### PR TITLE
timely-util/builder_async: offer automatically yielding give API

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -326,15 +326,13 @@ where
                     Some(event) = desired_oks_input.next() => {
                         if let Event::Data([_, cap], mut data) = event {
                             desired_oks_output
-                                .give_container(&cap, &mut data)
-                                .await;
+                                .give_container(&cap, &mut data);
                         }
                     }
                     Some(event) = desired_errs_input.next() => {
                         if let Event::Data([_, cap], mut data) = event {
                             desired_errs_output
-                                .give_container(&cap, &mut data)
-                                .await;
+                                .give_container(&cap, &mut data);
                         }
                     }
                     // All inputs are exhausted, so we can shut down.
@@ -448,7 +446,7 @@ where
                     match event {
                         Event::Data([_, cap], mut data) => {
                             // Just passthrough the data.
-                            desired_oks_output.give_container(&cap, &mut data).await;
+                            desired_oks_output.give_container(&cap, &mut data);
                             continue;
                         }
                         Event::Progress(frontier) => {
@@ -460,7 +458,7 @@ where
                     match event {
                         Event::Data([_, cap], mut data) => {
                             // Just passthrough the data.
-                            desired_errs_output.give_container(&cap, &mut data).await;
+                            desired_errs_output.give_container(&cap, &mut data);
                             continue;
                         }
                         Event::Progress(frontier) => {
@@ -548,7 +546,7 @@ where
                     batch_description
                 );
 
-                output.give(&cap, batch_description).await;
+                output.give(&cap, batch_description);
 
                 // WIP: We downgrade our capability so that downstream
                 // operators (writer and appender) can know when all the
@@ -946,7 +944,7 @@ where
                         }
                     };
 
-                    output.give(&cap, batch_or_data).await;
+                    output.give(&cap, batch_or_data);
                 }
             }
         }

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -502,7 +502,7 @@ where
                 if let Some(lease) = lease {
                     leases.borrow_mut().push_at(current_ts.clone(), lease);
                 }
-                descs_output.give(&session_cap, (worker_idx, part)).await;
+                descs_output.give(&session_cap, (worker_idx, part));
             }
 
             current_frontier.join_assign(&progress);
@@ -577,7 +577,7 @@ where
                         // outputs or sessions across await points, which
                         // would prevent messages from being flushed from
                         // the shared timely output buffer.
-                        fetched_output.give(&fetched_cap, fetched).await;
+                        fetched_output.give(&fetched_cap, fetched);
                     }
                 }
             }

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -924,7 +924,7 @@ where
 
                 // Emit the data at the given time, and update the frontier and capabilities
                 // to just beyond the part.
-                data_output.give(&cap_set.delayed(&time), part).await;
+                data_output.give(&cap_set.delayed(&time), part);
 
                 if let Some(metrics) = &metrics {
                     metrics.emitted_bytes.inc_by(u64::cast_from(byte_size))
@@ -1419,9 +1419,7 @@ mod tests {
                 let time = element.0.clone();
                 let part = element.1;
                 last = Some((time, Subtime(0)));
-                output_handle
-                    .give(&capability.as_ref().unwrap().delayed(&last.unwrap()), part)
-                    .await;
+                output_handle.give(&capability.as_ref().unwrap().delayed(&last.unwrap()), part);
             }
             if let Some(last) = last {
                 capability

--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -177,7 +177,7 @@ where
                 AsyncEvent::Data(cap, data) => {
                     for (((error, _), _), ts, _) in data {
                         if !up_to.less_equal(&ts) {
-                            start_handle.give(&cap, Err(error.to_string())).await;
+                            start_handle.give(&cap, Err(error.to_string()));
                             return;
                         }
                     }
@@ -269,7 +269,7 @@ where
         };
 
         let res = leader_work.await.map_err(|e| e.to_string_with_causes());
-        start_handle.give(&start_cap, res).await;
+        start_handle.give(&start_cap, res);
     });
 
     // Broadcast the result to all workers so that they will all see any error that occurs
@@ -401,7 +401,7 @@ where
                 AsyncEvent::Data(cap, data) => {
                     for res in data {
                         if res.is_err() {
-                            completion_handle.give(&cap, res.map(|_| 0)).await;
+                            completion_handle.give(&cap, res.map(|_| 0));
                             return;
                         }
                     }
@@ -475,9 +475,7 @@ where
         }
         .await;
 
-        completion_handle
-            .give(&completion_cap, res.map_err(|e| e.to_string_with_causes()))
-            .await;
+        completion_handle.give(&completion_cap, res.map_err(|e| e.to_string_with_causes()));
     });
 
     completion_stream

--- a/src/storage/examples/upsert_open_loop.rs
+++ b/src/storage/examples/upsert_open_loop.rs
@@ -814,7 +814,7 @@ where
                         .map(|((key, value), _ts, _diff)| (key.to_vec(), value.to_vec()))
                         .collect_vec();
 
-                    output.give_container(&cap, &mut batch).await;
+                    output.give_container(&cap, &mut batch);
                 }
             }
         }
@@ -980,10 +980,10 @@ where
                 if let Some(previous_v) = previous_v {
                     // we might be able to avoid this extra key clone here,
                     // if we really tried
-                    output.give(*cap, (k.clone(), previous_v, -1)).await;
+                    output.give(*cap, (k.clone(), previous_v, -1));
                 }
                 // we don't do deletes right now
-                output.give(*cap, (k, v, 1)).await;
+                output.give(*cap, (k, v, 1));
             }
 
             // Discard entries, capabilities for complete times.
@@ -1029,10 +1029,10 @@ where
                         if let Some(previous_v) = previous_v {
                             // we might be able to avoid this extra key clone here,
                             // if we really tried
-                            output.give(&cap, (k.clone(), previous_v, -1)).await;
+                            output.give(&cap, (k.clone(), previous_v, -1));
                         }
                         // we don't do deletes right now
-                        output.give(&cap, (k, v, 1)).await;
+                        output.give(&cap, (k, v, 1));
                     }
                 }
                 AsyncEvent::Progress(_new_frontier) => (),

--- a/src/storage/src/decode.rs
+++ b/src/storage/src/decode.rs
@@ -564,9 +564,7 @@ pub fn render_decode_delimited<G: Scope, FromTime: Timestamp>(
                             value_decoder.log_successes(n_successes);
                         }
 
-                        output_handle
-                            .give_container(&cap, &mut output_container)
-                            .await;
+                        output_handle.give_container(&cap, &mut output_container);
                     }
                     AsyncEvent::Progress(frontier) => cap_set.downgrade(frontier.iter()),
                 }

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -1185,17 +1185,15 @@ mod tests {
             }
             let mut capability = Some(caps.pop().unwrap());
             while let Some(element) = input.recv().await {
-                output_handle
-                    .give(
-                        capability.as_ref().unwrap(),
-                        (
-                            element.worker_id,
-                            element.input_index,
-                            element.namespace,
-                            element.update,
-                        ),
-                    )
-                    .await;
+                output_handle.give(
+                    capability.as_ref().unwrap(),
+                    (
+                        element.worker_id,
+                        element.input_index,
+                        element.namespace,
+                        element.update,
+                    ),
+                );
             }
 
             capability.take();

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -429,9 +429,7 @@ where
             while let Some(event) = desired_input.next().await {
                 match event {
                     Event::Data([_output_cap, data_output_cap], mut data) => {
-                        data_output
-                            .give_container(&data_output_cap, &mut data)
-                            .await;
+                        data_output.give_container(&data_output_cap, &mut data);
                     }
                     Event::Progress(_) => {}
                 }
@@ -489,9 +487,7 @@ where
                 match event {
                     Event::Data([_output_cap, data_output_cap], mut data) => {
                         // Just passthrough the data.
-                        data_output
-                            .give_container(&data_output_cap, &mut data)
-                            .await;
+                        data_output.give_container(&data_output_cap, &mut data);
                         continue;
                     }
                     Event::Progress(frontier) => {
@@ -528,7 +524,7 @@ where
                     batch_description
                 );
 
-                output.give(&cap, batch_description).await;
+                output.give(&cap, batch_description);
 
                 // We downgrade our capability to the batch
                 // description upper, as there will never be
@@ -876,7 +872,7 @@ where
                         batch_tokens.push(batch);
                     }
 
-                    output.give_container(&cap, &mut batch_tokens).await;
+                    output.give_container(&cap, &mut batch_tokens);
 
                     processed_desired_frontier.clone_from(&desired_frontier);
                     processed_descriptions_frontier.clone_from(&batch_descriptions_frontier);

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -1245,7 +1245,7 @@ fn encode_collection<G: Scope>(
                             value,
                             headers,
                         };
-                        output.give(&cap, (message, time, diff)).await;
+                        output.give(&cap, (message, time, diff));
                     }
                 }
             }

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -225,15 +225,13 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
 
         if !config.responsible_for(()) {
             // Emit 0, to mark this worker as having started up correctly.
-            stats_output
-                .give(
-                    &stats_cap,
-                    ProgressStatisticsUpdate::SteadyState {
-                        offset_known: 0,
-                        offset_committed: 0,
-                    },
-                )
-                .await;
+            stats_output.give(
+                &stats_cap,
+                ProgressStatisticsUpdate::SteadyState {
+                    offset_known: 0,
+                    offset_committed: 0,
+                },
+            );
             return;
         }
 
@@ -290,7 +288,7 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
                     // generate a significant amount of data that will overwhelm the dataflow.
                     // Since those are not required downstream we eagerly ignore them here.
                     if resume_offset <= offset {
-                        data_output.give(&cap, (message, offset, diff)).await;
+                        data_output.give(&cap, (message, offset, diff));
                     }
                 }
                 Event::Progress(Some(offset)) => {
@@ -334,19 +332,17 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
                         // we are not going to implement snapshot progress statistics for them
                         // right now, but will come back to it.
                         if let Some(offset_committed) = offset_committed {
-                            stats_output
-                                .give(
-                                    &stats_cap,
-                                    ProgressStatisticsUpdate::SteadyState {
-                                        // technically we could have _known_ a larger offset
-                                        // than the one that has been committed, but we can
-                                        // never recover that known amount on restart, so we
-                                        // just advance these in lock step.
-                                        offset_known: offset_committed,
-                                        offset_committed,
-                                    },
-                                )
-                                .await;
+                            stats_output.give(
+                                &stats_cap,
+                                ProgressStatisticsUpdate::SteadyState {
+                                    // technically we could have _known_ a larger offset
+                                    // than the one that has been committed, but we can
+                                    // never recover that known amount on restart, so we
+                                    // just advance these in lock step.
+                                    offset_known: offset_committed,
+                                    offset_committed,
+                                },
+                            );
                         }
                     }
                 }

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -308,20 +308,18 @@ impl SourceRender for KafkaSourceConnection {
                         ),
                         None,
                     );
-                    health_output
-                        .give(
-                            &health_cap,
-                            HealthStatusMessage {
-                                index: 0,
-                                namespace: if matches!(e, ContextCreationError::Ssh(_)) {
-                                    StatusNamespace::Ssh
-                                } else {
-                                    Self::STATUS_NAMESPACE.clone()
-                                },
-                                update,
+                    health_output.give(
+                        &health_cap,
+                        HealthStatusMessage {
+                            index: 0,
+                            namespace: if matches!(e, ContextCreationError::Ssh(_)) {
+                                StatusNamespace::Ssh
+                            } else {
+                                Self::STATUS_NAMESPACE.clone()
                             },
-                        )
-                        .await;
+                            update,
+                        },
+                    );
                     // IMPORTANT: wedge forever until the `SuspendAndRestart` is processed.
                     // Returning would incorrectly present to the remap operator as progress to the
                     // empty frontier which would be incorrectly recorded to the remap shard.
@@ -549,7 +547,7 @@ impl SourceRender for KafkaSourceConnection {
                             )),
                         }));
                         let time = data_cap.time().clone();
-                        data_output.give(&data_cap, ((0, Err(err)), time, 1)).await;
+                        data_output.give(&data_cap, ((0, Err(err)), time, 1));
                         return;
                     }
 
@@ -566,7 +564,7 @@ impl SourceRender for KafkaSourceConnection {
                                     )),
                                 }));
                                 let time = data_cap.time().clone();
-                                data_output.give(&data_cap, ((0, Err(err)), time, 1)).await;
+                                data_output.give(&data_cap, ((0, Err(err)), time, 1));
                                 return;
                             }
                         }
@@ -643,16 +641,14 @@ impl SourceRender for KafkaSourceConnection {
                                 reader.source_name, reader.topic_name, e
                             );
                             let status = HealthStatusUpdate::stalled(error, None);
-                            health_output
-                                .give(
-                                    &health_cap,
-                                    HealthStatusMessage {
-                                        index: 0,
-                                        namespace: Self::STATUS_NAMESPACE.clone(),
-                                        update: status,
-                                    },
-                                )
-                                .await;
+                            health_output.give(
+                                &health_cap,
+                                HealthStatusMessage {
+                                    index: 0,
+                                    namespace: Self::STATUS_NAMESPACE.clone(),
+                                    update: status,
+                                },
+                            );
                         }
                         Ok(message) => {
                             let (message, ts) =
@@ -665,7 +661,7 @@ impl SourceRender for KafkaSourceConnection {
                                         error: SourceErrorDetails::Other(format!("{}", e)),
                                     }))
                                 });
-                                data_output.give(part_cap, ((0, msg), time, diff)).await;
+                                data_output.give(part_cap, ((0, msg), time, diff));
                             }
                         }
                     }
@@ -690,7 +686,7 @@ impl SourceRender for KafkaSourceConnection {
                                         error: SourceErrorDetails::Other(format!("{}", e)),
                                     }))
                                 });
-                                data_output.give(part_cap, ((0, msg), time, diff)).await;
+                                data_output.give(part_cap, ((0, msg), time, diff));
                             }
                             Ok(None) => continue,
                             Err(err) => {
@@ -708,16 +704,14 @@ impl SourceRender for KafkaSourceConnection {
                                     ),
                                     None,
                                 );
-                                health_output
-                                    .give(
-                                        &health_cap,
-                                        HealthStatusMessage {
-                                            index: 0,
-                                            namespace: Self::STATUS_NAMESPACE.clone(),
-                                            update: status,
-                                        },
-                                    )
-                                    .await;
+                                health_output.give(
+                                    &health_cap,
+                                    HealthStatusMessage {
+                                        index: 0,
+                                        namespace: Self::STATUS_NAMESPACE.clone(),
+                                        update: status,
+                                    },
+                                );
                             }
                         }
                     }
@@ -767,28 +761,24 @@ impl SourceRender for KafkaSourceConnection {
                     (health_status.kafka.take(), health_status.ssh.take())
                 };
                 if let Some(status) = kafka_status {
-                    health_output
-                        .give(
-                            &health_cap,
-                            HealthStatusMessage {
-                                index: 0,
-                                namespace: Self::STATUS_NAMESPACE.clone(),
-                                update: status,
-                            },
-                        )
-                        .await;
+                    health_output.give(
+                        &health_cap,
+                        HealthStatusMessage {
+                            index: 0,
+                            namespace: Self::STATUS_NAMESPACE.clone(),
+                            update: status,
+                        },
+                    );
                 }
                 if let Some(status) = ssh_status {
-                    health_output
-                        .give(
-                            &health_cap,
-                            HealthStatusMessage {
-                                index: 0,
-                                namespace: StatusNamespace::Ssh,
-                                update: status,
-                            },
-                        )
-                        .await;
+                    health_output.give(
+                        &health_cap,
+                        HealthStatusMessage {
+                            index: 0,
+                            namespace: StatusNamespace::Ssh,
+                            update: status,
+                        },
+                    );
                 }
 
                 // If we have a new `offset_known` from the partition metadata thread, and
@@ -807,27 +797,23 @@ impl SourceRender for KafkaSourceConnection {
                     }
                 };
                 if let Some((offset_known, offset_committed)) = progress_statistics {
-                    stats_output
-                        .give(
-                            &stats_cap,
-                            ProgressStatisticsUpdate::SteadyState {
-                                offset_committed,
-                                offset_known,
-                            },
-                        )
-                        .await;
+                    stats_output.give(
+                        &stats_cap,
+                        ProgressStatisticsUpdate::SteadyState {
+                            offset_committed,
+                            offset_known,
+                        },
+                    );
                 }
 
                 if let (Some(snapshot_total), true) = (snapshot_total, is_snapshotting) {
-                    stats_output
-                        .give(
-                            &stats_cap,
-                            ProgressStatisticsUpdate::Snapshot {
-                                records_known: snapshot_total,
-                                records_staged: snapshot_staged,
-                            },
-                        )
-                        .await;
+                    stats_output.give(
+                        &stats_cap,
+                        ProgressStatisticsUpdate::Snapshot {
+                            records_known: snapshot_total,
+                            records_staged: snapshot_staged,
+                        },
+                    );
 
                     if snapshot_total == snapshot_staged {
                         is_snapshotting = false;

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -339,14 +339,12 @@ async fn return_definite_error(
             GtidPartition::new_range(Uuid::minimum(), Uuid::maximum(), GtidState::MAX),
             1,
         );
-        data_handle.give(&data_cap_set[0], update).await;
+        data_handle.give(&data_cap_set[0], update);
     }
-    definite_error_handle
-        .give(
-            &definite_error_cap_set[0],
-            ReplicationError::Definite(Rc::new(err)),
-        )
-        .await;
+    definite_error_handle.give(
+        &definite_error_cap_set[0],
+        ReplicationError::Definite(Rc::new(err)),
+    );
     ()
 }
 

--- a/src/storage/src/source/mysql/replication.rs
+++ b/src/storage/src/source/mysql/replication.rs
@@ -398,8 +398,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                             &mut repl_context,
                             &cur_gtid,
                             &mut row_event_buffer,
-                        )
-                        .await?;
+                        )?;
 
                         // Advance the frontier up to the point right before this GTID, since we
                         // might still see other events that are part of this same GTID, such as

--- a/src/storage/src/source/mysql/replication/events.rs
+++ b/src/storage/src/source/mysql/replication/events.rs
@@ -102,8 +102,7 @@ pub(super) async fn handle_query_event(
                            verification error for {table:?}: {err:?}");
                     let gtid_cap = ctx.data_cap_set.delayed(new_gtid);
                     ctx.data_output
-                        .give(&gtid_cap, ((*output_index, Err(err)), new_gtid.clone(), 1))
-                        .await;
+                        .give(&gtid_cap, ((*output_index, Err(err)), new_gtid.clone(), 1));
                     ctx.errored_tables.insert(table.clone());
                 }
             }
@@ -136,8 +135,7 @@ pub(super) async fn handle_query_event(
                     if let Some((output_index, _)) = ctx.table_info.get(dropped_table) {
                         let gtid_cap = ctx.data_cap_set.delayed(new_gtid);
                         ctx.data_output
-                            .give(&gtid_cap, ((*output_index, Err(err)), new_gtid.clone(), 1))
-                            .await;
+                            .give(&gtid_cap, ((*output_index, Err(err)), new_gtid.clone(), 1));
                         ctx.errored_tables.insert(dropped_table.clone());
                     }
                 }
@@ -163,19 +161,17 @@ pub(super) async fn handle_query_event(
                        for {table:?}");
                 if let Some((output_index, _)) = ctx.table_info.get(&table) {
                     let gtid_cap = ctx.data_cap_set.delayed(new_gtid);
-                    ctx.data_output
-                        .give(
-                            &gtid_cap,
+                    ctx.data_output.give(
+                        &gtid_cap,
+                        (
                             (
-                                (
-                                    *output_index,
-                                    Err(DefiniteError::TableTruncated(table.to_string())),
-                                ),
-                                new_gtid.clone(),
-                                1,
+                                *output_index,
+                                Err(DefiniteError::TableTruncated(table.to_string())),
                             ),
-                        )
-                        .await;
+                            new_gtid.clone(),
+                            1,
+                        ),
+                    );
                     ctx.errored_tables.insert(table);
                 }
             }
@@ -196,7 +192,7 @@ pub(super) async fn handle_query_event(
 ///
 /// We use these events to update the dataflow with the new rows, and return a new
 /// frontier with which to advance the dataflow's progress.
-pub(super) async fn handle_rows_event(
+pub(super) fn handle_rows_event(
     event: RowsEventData<'_>,
     ctx: &mut ReplContext<'_>,
     new_gtid: &GtidPartition,
@@ -287,8 +283,7 @@ pub(super) async fn handle_rows_event(
                 retractions += 1;
             }
             ctx.data_output
-                .give(&gtid_cap, (data, new_gtid.clone(), diff))
-                .await;
+                .give(&gtid_cap, (data, new_gtid.clone(), diff));
         }
     }
 
@@ -301,7 +296,7 @@ pub(super) async fn handle_rows_event(
     if !event_buffer.is_empty() {
         let (rewind_data_cap, _) = ctx.rewinds.get(&table).unwrap();
         for d in event_buffer.drain(..) {
-            ctx.data_output.give(rewind_data_cap, d).await;
+            ctx.data_output.give(rewind_data_cap, d);
         }
     }
 

--- a/src/storage/src/source/mysql/snapshot.rs
+++ b/src/storage/src/source/mysql/snapshot.rs
@@ -181,15 +181,13 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                         // but having done no snapshotting. Otherwise leave
                         // this not filled in (no snapshotting is occurring in this instance of
                         // the dataflow).
-                        stats_output
-                            .give(
-                                &stats_cap[0],
-                                ProgressStatisticsUpdate::Snapshot {
-                                    records_known: 0,
-                                    records_staged: 0,
-                                },
-                            )
-                            .await;
+                        stats_output.give(
+                            &stats_cap[0],
+                            ProgressStatisticsUpdate::Snapshot {
+                                records_known: 0,
+                                records_staged: 0,
+                            },
+                        );
                     }
                     return Ok(());
                 } else {
@@ -364,16 +362,14 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                 for (table, err) in errored_tables {
                     let (output_index, _) = reader_snapshot_table_info.get(table).unwrap();
                     // Publish the error for this table and stop ingesting it
-                    raw_handle
-                        .give(
-                            &data_cap_set[0],
-                            (
-                                (*output_index, Err(err.clone())),
-                                GtidPartition::minimum(),
-                                1,
-                            ),
-                        )
-                        .await;
+                    raw_handle.give(
+                        &data_cap_set[0],
+                        (
+                            (*output_index, Err(err.clone())),
+                            GtidPartition::minimum(),
+                            1,
+                        ),
+                    );
                     trace!(%id, "timely-{worker_id} stopping snapshot of table {table} \
                                     due to schema mismatch");
                     removed_tables.push(table.clone());
@@ -392,15 +388,13 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                 )
                 .await?;
 
-                stats_output
-                    .give(
-                        &stats_cap[0],
-                        ProgressStatisticsUpdate::Snapshot {
-                            records_known: snapshot_total,
-                            records_staged: 0,
-                        },
-                    )
-                    .await;
+                stats_output.give(
+                    &stats_cap[0],
+                    ProgressStatisticsUpdate::Snapshot {
+                        records_known: snapshot_total,
+                        records_staged: 0,
+                    },
+                );
 
                 // This worker has nothing else to do
                 if reader_snapshot_table_info.is_empty() {
@@ -427,25 +421,21 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                             }
                             Err(err) => Err(err)?,
                         };
-                        raw_handle
-                            .give(
-                                &data_cap_set[0],
-                                ((*output_index, event), GtidPartition::minimum(), 1),
-                            )
-                            .await;
+                        raw_handle.give(
+                            &data_cap_set[0],
+                            ((*output_index, event), GtidPartition::minimum(), 1),
+                        );
                         count += 1;
                         snapshot_staged += 1;
                         // TODO(guswynn): does this 1000 need to be configurable?
                         if snapshot_staged % 1000 == 0 {
-                            stats_output
-                                .give(
-                                    &stats_cap[0],
-                                    ProgressStatisticsUpdate::Snapshot {
-                                        records_known: snapshot_total,
-                                        records_staged: snapshot_staged,
-                                    },
-                                )
-                                .await;
+                            stats_output.give(
+                                &stats_cap[0],
+                                ProgressStatisticsUpdate::Snapshot {
+                                    records_known: snapshot_total,
+                                    records_staged: snapshot_staged,
+                                },
+                            );
                         }
                     }
                     trace!(%id, "timely-{worker_id} snapshotted {count} records from \
@@ -464,7 +454,7 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                         table: table.clone(),
                         snapshot_upper: snapshot_gtid_frontier.clone(),
                     };
-                    rewinds_handle.give(&rewind_cap_set[0], req).await;
+                    rewinds_handle.give(&rewind_cap_set[0], req);
                 }
                 *rewind_cap_set = CapabilitySet::new();
 
@@ -473,15 +463,13 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                                  bigger than records staged {snapshot_staged}");
                     snapshot_staged = snapshot_total;
                 }
-                stats_output
-                    .give(
-                        &stats_cap[0],
-                        ProgressStatisticsUpdate::Snapshot {
-                            records_known: snapshot_total,
-                            records_staged: snapshot_staged,
-                        },
-                    )
-                    .await;
+                stats_output.give(
+                    &stats_cap[0],
+                    ProgressStatisticsUpdate::Snapshot {
+                        records_known: snapshot_total,
+                        records_staged: snapshot_staged,
+                    },
+                );
                 Ok(())
             })
         });

--- a/src/storage/src/source/mysql/statistics.rs
+++ b/src/storage/src/source/mysql/statistics.rs
@@ -53,15 +53,13 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
             // Only run the replication reader on the worker responsible for it.
             if !config.responsible_for(STATISTICS) {
                 // Emit 0, to mark this worker as having started up correctly.
-                stats_output
-                    .give(
-                        &stats_cap[0],
-                        ProgressStatisticsUpdate::SteadyState {
-                            offset_known: 0,
-                            offset_committed: 0,
-                        },
-                    )
-                    .await;
+                stats_output.give(
+                    &stats_cap[0],
+                    ProgressStatisticsUpdate::SteadyState {
+                        offset_known: 0,
+                        offset_committed: 0,
+                    },
+                );
                 return Ok(());
             }
 
@@ -123,15 +121,13 @@ pub(crate) fn render<G: Scope<Timestamp = GtidPartition>>(
                 if let (Some(offset_known), Some(offset_committed)) =
                     (offset_known, offset_committed)
                 {
-                    stats_output
-                        .give(
-                            &stats_cap[0],
-                            ProgressStatisticsUpdate::SteadyState {
-                                offset_known,
-                                offset_committed,
-                            },
-                        )
-                        .await;
+                    stats_output.give(
+                        &stats_cap[0],
+                        ProgressStatisticsUpdate::SteadyState {
+                            offset_known,
+                            offset_committed,
+                        },
+                    );
                 }
             }
 

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -182,15 +182,13 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
 
             if !config.responsible_for("slot") {
                 // Emit 0, to mark this worker as having started up correctly.
-                stats_output
-                    .give(
-                        &stats_cap[0],
-                        ProgressStatisticsUpdate::SteadyState {
-                            offset_known: 0,
-                            offset_committed: 0,
-                        },
-                    )
-                    .await;
+                stats_output.give(
+                    &stats_cap[0],
+                    ProgressStatisticsUpdate::SteadyState {
+                        offset_known: 0,
+                        offset_committed: 0,
+                    },
+                );
                 return Ok(());
             }
 
@@ -308,14 +306,12 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                                 // We pick `u64::MAX` as the LSN which will (in practice) never conflict
                                 // any previously revealed portions of the TVC.
                                 let update = ((oid, Err(err.clone())), MzOffset::from(u64::MAX), 1);
-                                data_output.give(&data_cap_set[0], update).await;
+                                data_output.give(&data_cap_set[0], update);
                             }
-                            definite_error_handle
-                                .give(
-                                    &definite_error_cap_set[0],
-                                    ReplicationError::Definite(Rc::new(err)),
-                                )
-                                .await;
+                            definite_error_handle.give(
+                                &definite_error_cap_set[0],
+                                ReplicationError::Definite(Rc::new(err)),
+                            );
                             return Ok(());
                         }
                         rewinds.insert(req.oid, (cap.clone(), req));
@@ -349,15 +345,13 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                         // We pick `u64::MAX` as the LSN which will (in practice) never conflict
                         // any previously revealed portions of the TVC.
                         let update = ((oid, Err(err.clone())), MzOffset::from(u64::MAX), 1);
-                        data_output.give(&data_cap_set[0], update).await;
+                        data_output.give(&data_cap_set[0], update);
                     }
 
-                    definite_error_handle
-                        .give(
-                            &definite_error_cap_set[0],
-                            ReplicationError::Definite(Rc::new(err)),
-                        )
-                        .await;
+                    definite_error_handle.give(
+                        &definite_error_cap_set[0],
+                        ReplicationError::Definite(Rc::new(err)),
+                    );
                     return Ok(());
                 }
             };
@@ -414,12 +408,10 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                                 if let Some((data_cap, req)) = rewinds.get(&oid) {
                                     if commit_lsn <= req.snapshot_lsn {
                                         let update = (data.clone(), MzOffset::from(0), -diff);
-                                        data_output.give(data_cap, update).await;
+                                        data_output.give(data_cap, update);
                                     }
                                 }
-                                data_output
-                                    .give(&data_cap_set[0], (data, commit_lsn, diff))
-                                    .await;
+                                data_output.give(&data_cap_set[0], (data, commit_lsn, diff));
                             }
                         }
                         _ => return Err(TransientError::BareTransactionEvent),
@@ -662,17 +654,15 @@ async fn raw_stream<'a>(
                 let upstream_stat = { progress_stat_shared_value.lock().expect("poisoned").take() };
                 if let Some(upstream_stat) = upstream_stat {
                     let upstream_stat = upstream_stat?;
-                    stats_output
-                        .give(
-                            stats_cap,
-                            ProgressStatisticsUpdate::SteadyState {
-                                // Similar to the kafka source, we don't subtract 1 from the upper as we want to report the
-                                // _number of bytes_ we have processed/in upstream.
-                                offset_known: upstream_stat.offset,
-                                offset_committed: last_committed_upper.offset,
-                            },
-                        )
-                        .await;
+                    stats_output.give(
+                        stats_cap,
+                        ProgressStatisticsUpdate::SteadyState {
+                            // Similar to the kafka source, we don't subtract 1 from the upper as we want to report the
+                            // _number of bytes_ we have processed/in upstream.
+                            offset_known: upstream_stat.offset,
+                            offset_committed: last_committed_upper.offset,
+                        },
+                    );
                 }
             }
         }

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -346,14 +346,14 @@ where
                     Err(_) => {}
                 }
             }
-            data_output.give_container(&cap_data, &mut data).await;
+            data_output.give_container(&cap_data, &mut data);
 
             for statuses in statuses_by_idx.values_mut() {
                 if statuses.is_empty() {
                     continue;
                 }
 
-                health_output.give_container(&health_cap, statuses).await;
+                health_output.give_container(&health_cap, statuses);
                 statuses.clear()
             }
         }
@@ -496,7 +496,7 @@ where
         );
 
         let cap = cap_set.delayed(cap_set.first().unwrap());
-        remap_output.give_container(&cap, &mut initial_batch.updates).await;
+        remap_output.give_container(&cap, &mut initial_batch.updates);
         drop(cap);
         cap_set.downgrade(initial_batch.upper);
 
@@ -524,7 +524,7 @@ where
                     );
 
                     let cap = cap_set.delayed(cap_set.first().unwrap());
-                    remap_output.give_container(&cap, &mut remap_trace_batch.updates).await;
+                    remap_output.give_container(&cap, &mut remap_trace_batch.updates);
 
                     // If the last remap trace closed the input, we no longer
                     // need to (or can) advance the timestamper.
@@ -537,7 +537,7 @@ where
                     let mut remap_trace_batch = timestamper.advance().await;
 
                     let cap = cap_set.delayed(cap_set.first().unwrap());
-                    remap_output.give_container(&cap, &mut remap_trace_batch.updates).await;
+                    remap_output.give_container(&cap, &mut remap_trace_batch.updates);
 
                     cap_set.downgrade(remap_trace_batch.upper);
                 }
@@ -732,7 +732,7 @@ where
                         };
 
                         let ts_cap = cap_set.delayed(&into_ts);
-                        reclocked_output.give(&ts_cap, (output, into_ts, diff)).await;
+                        reclocked_output.give(&ts_cap, (output, into_ts, diff));
                         total_processed += 1;
                     }
                     // The loop above might have completely emptied batches. We can now remove them

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -847,12 +847,8 @@ where
             let retraction = Err(UpsertError::Value(error.clone()));
             error.is_legacy_dont_touch_it = false;
             let insertion = Err(UpsertError::Value(error));
-            output_handle
-                .give(&output_cap, (retraction, time.clone(), -diff))
-                .await;
-            output_handle
-                .give(&output_cap, (insertion, time, diff))
-                .await;
+            output_handle.give(&output_cap, (retraction, time.clone(), -diff));
+            output_handle.give(&output_cap, (insertion, time, diff));
         }
 
         tracing::info!(
@@ -938,9 +934,7 @@ where
                         )
                         .await;
 
-                        output_handle
-                            .give_container(&output_cap, &mut output_updates)
-                            .await;
+                        output_handle.give_container(&output_cap, &mut output_updates);
 
                         if let Some(ts) = upper.as_option() {
                             output_cap.downgrade(ts);
@@ -976,9 +970,7 @@ where
                 )
                 .await;
 
-                output_handle
-                    .give_container(&output_cap, &mut output_updates)
-                    .await;
+                output_handle.give_container(&output_cap, &mut output_updates);
             }
         }
     });
@@ -1026,7 +1018,7 @@ async fn process_upsert_state_error<G: Scope>(
     health_cap: &Capability<<G as ScopeParent>::Timestamp>,
 ) {
     let update = HealthStatusUpdate::halting(e.context(context).to_string_with_causes(), None);
-    health_output.give(health_cap, (0, update)).await;
+    health_output.give(health_cap, (0, update));
     std::future::pending::<()>().await;
     unreachable!("pending future never returns");
 }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -22,8 +22,6 @@ use futures_util::task::ArcWake;
 use timely::communication::{Message, Pull, Push};
 use timely::container::{CapacityContainerBuilder, ContainerBuilder, PushInto};
 use timely::dataflow::channels::pact::ParallelizationContract;
-use timely::dataflow::channels::pushers::buffer::Session;
-use timely::dataflow::channels::pushers::counter::Counter as PushCounter;
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::channels::Bundle;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
@@ -190,45 +188,6 @@ pub enum Event<T: Timestamp, C, D> {
     Progress(Antichain<T>),
 }
 
-// TODO: delete and use CapabilityTrait instead once TimelyDataflow/timely-dataflow#512 gets merged
-pub trait CapabilityTrait<T: Timestamp> {
-    fn session<'a, CB, P>(
-        &'a self,
-        handle: &'a mut OutputHandleCore<'_, T, CB, P>,
-    ) -> Session<'a, T, CB, PushCounter<T, CB::Container, P>>
-    where
-        CB: ContainerBuilder,
-        P: Push<Bundle<T, CB::Container>>;
-}
-
-impl<T: Timestamp> CapabilityTrait<T> for InputCapability<T> {
-    #[inline]
-    fn session<'a, CB, P>(
-        &'a self,
-        handle: &'a mut OutputHandleCore<'_, T, CB, P>,
-    ) -> Session<'a, T, CB, PushCounter<T, CB::Container, P>>
-    where
-        CB: ContainerBuilder,
-        P: Push<Bundle<T, CB::Container>>,
-    {
-        handle.session_with_builder(self)
-    }
-}
-
-impl<T: Timestamp> CapabilityTrait<T> for Capability<T> {
-    #[inline]
-    fn session<'a, CB, P>(
-        &'a self,
-        handle: &'a mut OutputHandleCore<'_, T, CB, P>,
-    ) -> Session<'a, T, CB, PushCounter<T, CB::Container, P>>
-    where
-        CB: ContainerBuilder,
-        P: Push<Bundle<T, CB::Container>>,
-    {
-        handle.session_with_builder(self)
-    }
-}
-
 pub struct AsyncOutputHandle<
     T: Timestamp,
     CB: ContainerBuilder,
@@ -248,12 +207,9 @@ where
     P: Push<Bundle<T, C>> + 'static,
 {
     #[inline]
-    pub fn give_container<Cap>(&mut self, cap: &Cap, container: &mut C)
-    where
-        Cap: CapabilityTrait<T>,
-    {
+    pub fn give_container(&mut self, cap: &Capability<T>, container: &mut C) {
         let mut handle = self.handle.borrow_mut();
-        cap.session(&mut handle).give_container(container);
+        handle.session_with_builder(cap).give_container(container);
     }
 }
 
@@ -300,13 +256,12 @@ where
     C: Container,
     P: Push<Bundle<T, C>> + 'static,
 {
-    pub fn give<CP, D>(&mut self, cap: &CP, data: D)
+    pub fn give<D>(&mut self, cap: &Capability<T>, data: D)
     where
-        CP: CapabilityTrait<T>,
         CapacityContainerBuilder<C>: PushInto<D>,
     {
         let mut handle = self.handle.borrow_mut();
-        cap.session(&mut handle).push_into(data);
+        handle.session_with_builder(cap).give(data);
     }
 }
 

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -656,7 +656,7 @@ impl<G: Scope> OperatorBuilder<G> {
                 .map(CapabilitySet::from_elem)
                 .collect::<Vec<_>>();
             if let Err(err) = constructor(&mut *caps).await {
-                error_output.give(&error_cap, Rc::new(err)).await;
+                error_output.give(&error_cap, Rc::new(err));
                 drop(error_cap);
                 // IMPORTANT: wedge this operator until the button is pressed. Returning would drop
                 // the capabilities and could produce incorrect progress statements.
@@ -777,7 +777,7 @@ mod test {
                         Event::Data(cap, data) => {
                             for item in data.iter().copied() {
                                 tokio::task::yield_now().await;
-                                output.give(&cap, item).await;
+                                output.give(&cap, item);
                             }
                         }
                         Event::Progress(_frontier) => {}

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -247,9 +247,8 @@ where
     C: Container,
     P: Push<Bundle<T, C>> + 'static,
 {
-    #[allow(clippy::unused_async)]
     #[inline]
-    pub async fn give_container<Cap>(&mut self, cap: &Cap, container: &mut C)
+    pub fn give_container<Cap>(&mut self, cap: &Cap, container: &mut C)
     where
         Cap: CapabilityTrait<T>,
     {
@@ -301,8 +300,7 @@ where
     C: Container,
     P: Push<Bundle<T, C>> + 'static,
 {
-    #[allow(clippy::unused_async)]
-    pub async fn give<CP, D>(&mut self, cap: &CP, data: D)
+    pub fn give<CP, D>(&mut self, cap: &CP, data: D)
     where
         CP: CapabilityTrait<T>,
         CapacityContainerBuilder<C>: PushInto<D>,

--- a/src/timely-util/src/containers/stack.rs
+++ b/src/timely-util/src/containers/stack.rs
@@ -214,8 +214,8 @@ impl<T: Columnation> Default for StackWrapper<T> {
 /// A Stacked container builder that keep track of container memory usage.
 #[derive(Default)]
 pub struct AccountedStackBuilder<CB> {
-    bytes: Cell<usize>,
-    builder: CB,
+    pub bytes: Cell<usize>,
+    pub builder: CB,
 }
 
 impl<T, CB> ContainerBuilder for AccountedStackBuilder<CB>

--- a/src/txn-wal/src/operator.rs
+++ b/src/txn-wal/src/operator.rs
@@ -208,7 +208,7 @@ where
         }
 
         debug!("{} emitting {:?}", name, subscribe.remap);
-        remap_output.give(&cap, subscribe.remap.clone()).await;
+        remap_output.give(&cap, subscribe.remap.clone());
 
         loop {
             let _ = txns_cache.update_ge(&subscribe.remap.logical_upper).await;
@@ -237,7 +237,7 @@ where
                         logical_upper: new_upper,
                     };
                     debug!("{} emitting {:?}", name, subscribe.remap);
-                    remap_output.give(&cap, subscribe.remap.clone()).await;
+                    remap_output.give(&cap, subscribe.remap.clone());
                 }
                 // We know there are no writes in `[logical_upper,
                 // new_progress)`, so advance our output frontier.
@@ -337,7 +337,7 @@ where
             if remap.physical_upper != physical_upper {
                 physical_upper = remap.physical_upper.clone();
                 debug!("{} emitting {:?}", name, remap);
-                remap_output.give(&cap, remap).await;
+                remap_output.give(&cap, remap);
             } else {
                 debug!("{} not emitting {:?}", name, remap);
             }
@@ -433,7 +433,7 @@ where
                     // `mfp_and_decode` (after this operator) do the necessary
                     // filtering.
                     debug!("{} emitting data {:?}", name, data);
-                    passthrough_output.give_container(&cap, &mut data).await;
+                    passthrough_output.give_container(&cap, &mut data);
                 }
                 AsyncEvent::Progress(new_progress) => {
                     // If `until.less_equal(new_progress)`, it means that all


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR offers a fueled give API that automatically yields back to timely after certain number of bytes have been emitted into the dataflow. The value is currently capped at 128MB, which is the size of a persist part. This API is only available for operators that make use of `StackWrapper` containers which can accurately track their heap size.

As part of this PR I also made the original `give` and `give_container` methods synchronous. The only reason they were async in the first place was because I had initially envisioned this auto-yield API to be the default and so the async-ness was reserved. Since I no longer think this is a good idea I removed the async keyword.



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
The diff is big due to the last commit that contains all the removed `.await` calls. Only the changes in `timely-util` need review. Everything else is mechanical. 
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
