### PR TITLE
coord/controller: Start to move creating replicas off the main Coord thread

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -702,7 +702,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             disk,
             disk_limit,
             node_selector,
-        }: ServiceConfig<'_>,
+        }: ServiceConfig,
     ) -> Result<Box<dyn Service>, anyhow::Error> {
         // This is extremely cheap to clone, so just look into the lock once.
         let scheduling_config: ServiceSchedulingConfig =

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -362,7 +362,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             disk,
             disk_limit: _,
             node_selector: _,
-        }: ServiceConfig<'_>,
+        }: ServiceConfig,
     ) -> Result<Box<dyn Service>, anyhow::Error> {
         let full_id = format!("{}-{}", self.namespace, id);
 
@@ -421,7 +421,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                         scratch_dir: scratch_dir.clone(),
                         i,
                         image: image.clone(),
-                        args,
+                        args: Arc::clone(&args),
                         ports,
                         memory_limit,
                         cpu_limit,
@@ -718,13 +718,13 @@ impl NamespacedProcessOrchestrator {
     }
 }
 
-struct ServiceProcessConfig<'a> {
+struct ServiceProcessConfig {
     id: String,
     run_dir: PathBuf,
     scratch_dir: Option<PathBuf>,
     i: usize,
     image: String,
-    args: &'a (dyn Fn(&BTreeMap<String, String>) -> Vec<String> + Send + Sync),
+    args: Arc<dyn Fn(&BTreeMap<String, String>) -> Vec<String> + Send + Sync>,
     ports: Vec<ServiceProcessPort>,
     disk: bool,
     memory_limit: Option<MemoryLimit>,

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -60,7 +60,7 @@ pub trait NamespacedOrchestrator: fmt::Debug + Send + Sync {
     async fn ensure_service(
         &self,
         id: &str,
-        config: ServiceConfig<'_>,
+        config: ServiceConfig,
     ) -> Result<Box<dyn Service>, anyhow::Error>;
 
     /// Drops the identified service, if it exists.
@@ -185,7 +185,7 @@ pub struct LabelSelector {
 /// Describes the desired state of a service.
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]
-pub struct ServiceConfig<'a> {
+pub struct ServiceConfig {
     /// An opaque identifier for the executable or container image to run.
     ///
     /// Often names a container on Docker Hub or a path on the local machine.
@@ -196,7 +196,7 @@ pub struct ServiceConfig<'a> {
     /// A function that generates the arguments for each process of the service
     /// given the assigned listen addresses for each named port.
     #[derivative(Debug = "ignore")]
-    pub args: &'a (dyn Fn(&BTreeMap<String, String>) -> Vec<String> + Send + Sync),
+    pub args: Arc<dyn Fn(&BTreeMap<String, String>) -> Vec<String> + Send + Sync>,
     /// Ports to expose.
     pub ports: Vec<ServicePort>,
     /// An optional limit on the memory that the service can use.


### PR DESCRIPTION
This is a WIP PR that starts to move the creation of cluster replicas off the main Coord thread. It's largely just Rust related refactoring so we can `await` various Futures at different places.

So far I broke `Controller::create_replicas` into two steps, `async fn initialize_replicas(...)` and `fn register_replicas(...)`, where initializing is a `'static Future` that can be spawned onto the runtime and awaited concurrently, and once completed you can register the created replicas with the storage and compute controllers.

I'm not sure if this is a safe approach though. The overall flow would look something like:

1. Catalog transaction to record new replicas (blocks Coordinator)
2. Spawn async task with `initialize_replicas(...)`, moving off main Coord thread
3. ??? anything else can run
4. `initialize_replicas(...)` completes, we call `register_replicas(...)`

At step 3 the replicas exist in the catalog and so they are observable by other sessions, but the storage and compute controllers don't know about them yet, this seems like a problem. We could move the call to `initializing_replicas(...)` before the catalog transaction, but if we panic after initializing but before the catalog transaction, I think we'll leak the resources.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Hide whitespace

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
