### PR TITLE
Fix null equality handling in ReductionPushdown

### DIFF
--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -430,7 +430,11 @@ impl ReduceBuilder {
                     predicates.push(
                         class[0]
                             .clone()
-                            .call_binary(expr.clone(), mz_expr::BinaryFunc::Eq),
+                            .call_binary(expr.clone(), mz_expr::BinaryFunc::Eq)
+                            .or(class[0]
+                                .clone()
+                                .call_is_null()
+                                .and(expr.clone().call_is_null())),
                     );
                 }
             }

--- a/src/transform/tests/test_transforms/reduction_pushdown.spec
+++ b/src/transform/tests/test_transforms/reduction_pushdown.spec
@@ -29,7 +29,7 @@ Source defined as t1
 
 # Regression test for #25015.
 #
-# The Join has a contition that is a local predicate
+# The Join has a condition that is a local predicate
 # and was lost prior to #25015.
 apply pipeline=reduction_pushdown
 Distinct project=[#1]
@@ -40,7 +40,7 @@ Distinct project=[#1]
 Project (#0)
   CrossJoin
     Distinct project=[#1]
-      Filter ((#1 + #1) = #0)
+      Filter (((#1 + #1) = #0) OR (((#1 + #1)) IS NULL AND (#0) IS NULL))
         Get x
     Distinct project=[]
       Get y

--- a/test/sqllogictest/transform/reduction_pushdown.slt
+++ b/test/sqllogictest/transform/reduction_pushdown.slt
@@ -87,3 +87,45 @@ Source materialize.public.y
 Target cluster: quickstart
 
 EOF
+
+## Regression test for https://github.com/MaterializeInc/materialize/issues/27702
+statement ok
+CREATE TABLE t1 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE TABLE t2 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE TABLE t3 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE MATERIALIZED VIEW pk1 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t1 WHERE f1 IS NOT NULL AND f2 IS NOT NULL;
+
+statement ok
+CREATE MATERIALIZED VIEW pk2 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t2 WHERE f1 IS NOT NULL AND f2 IS NOT NULL;
+
+statement ok
+CREATE MATERIALIZED VIEW pk3 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t3 WHERE f1 IS NOT NULL AND f2 IS NOT NULL;
+
+query T multiline
+EXPLAIN
+SELECT FROM(SELECT) a JOIN(t2 JOIN pk1 ON NULL) ON(NULL) UNION SELECT FROM(SELECT AVG(a.f2) f2 FROM t2 a RIGHT JOIN t2 USING(f1) WHERE a.f2 IS NULL) a WHERE NULLIF(a.f2, 1) NOT IN(SELECT c FROM(SELECT 0 c FROM pk1 JOIN(SELECT f2 FROM pk1) b ON NULLIF(b.f2, b.f2) < b.f2) d);
+----
+Explained Query:
+  Distinct project=[]
+    Union
+      Negate
+        Distinct project=[]
+          Project ()
+            Filter (case when (#1 = #1) then null else #1 end < #1)
+              ReadStorage materialize.public.pk1
+      Constant
+        - ()
+
+Source materialize.public.t2
+Source materialize.public.pk1
+  filter=((case when (#1 = #1) then null else #1 end < #1))
+
+Target cluster: quickstart
+
+EOF


### PR DESCRIPTION
Fixes #27702

The problem was that `=` has a different meaning in `Join` than in `Filter`: in `Filter` null won't be equal to anything, but in `Join` null is equal to null.

### Motivation

  * This PR fixes a recognized bug: #27702

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
