### PR TITLE
Fix page header URL interpolation following Hugo upgrades

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -17,7 +17,7 @@
 <meta name="msapplication-TileColor" content="#7F4EFF" />
 <meta name="theme-color" content="#ffffff" />
 <meta property="og:locale" content="en_US" />
-<meta property="og:url" content="{{ .Site.BaseURL }}{{ .Permalink }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:type" content="article" />
 <meta property="og:title" content="{{ $title }}" />
 <meta
@@ -38,22 +38,22 @@
 <link
   rel="shortcut icon"
   type="image/x-icon"
-  href="{{ .Site.BaseURL }}/images/materialize_favicon_32.png"
+  href="{{ .Site.BaseURL }}images/materialize_favicon_32.png"
 />
 <link
   rel="apple-touch-icon"
   sizes="180x180"
-  href="{{ .Site.BaseURL }}/images/materialize_logo_180.png"
+  href="{{ .Site.BaseURL }}images/materialize_logo_180.png"
 />
 <link
   rel="icon"
   type="image/png"
   sizes="32x32"
-  href="{{ .Site.BaseURL }}/images/materialize_favicon_32.png"
+  href="{{ .Site.BaseURL }}images/materialize_favicon_32.png"
 />
 <link
   rel="mask-icon"
-  href="{{ .Site.BaseURL }}/images/materialize_logo.svg"
+  href="{{ .Site.BaseURL }}images/materialize_logo.svg"
   color="#4d7cfe"
 />
 <link rel="canonical" href="{{ .Permalink }}" />


### PR DESCRIPTION

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.
This addresses two issues following the Hugo upgrade.

- The `BaseURL` parameter has a trailing slash, so concatenation for favicon paths was generating invalid URLs.
- The `og:url` property was generating duplicated `/docs/docs/` paths. Let's always rely on the permalink.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]


    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
