### PR TITLE
ci/deploy: exclude rustdoc from search engines

### DIFF
--- a/ci/deploy/devsite.sh
+++ b/ci/deploy/devsite.sh
@@ -17,13 +17,12 @@ cargo about generate ci/deploy/licenses.hbs > misc/www/licenses.html
 
 aws s3 cp --recursive misc/www/ s3://materialize-dev-website/
 
-bin/doc
-aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust
-
-# Documenting private items causes broken links in many crates we don't control.
-# So exclude all the pages from search engine indexes to avoid harming our
-# SEO score with a number of broken links.
+# We exclude all of these pages from search engines for SEO purposes. We don't
+# want to spend our crawl budget on these pages, nor have these pages appear
+# ahead of our marketing content.
+RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc
 RUSTDOCFLAGS="--html-in-header $PWD/ci/deploy/noindex.html" bin/doc --document-private-items
+aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust
 aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust-private
 
 bin/pydoc


### PR DESCRIPTION
To help with SEO for our marketing content.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
