### PR TITLE
adapter: use Name struct for plan insights names

### DIFF
--- a/src/adapter/src/explain/insights.rs
+++ b/src/adapter/src/explain/insights.rs
@@ -69,14 +69,18 @@ pub struct PlanInsights {
     pub persist_count: Vec<Name>,
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct FastPathCluster {
-    index: String,
-    on: String,
+    index: Name,
+    on: Name,
 }
 
 impl PlanInsights {
-    pub async fn compute_fast_path_clusters(&mut self, ctx: PlanInsightsContext) {
+    pub async fn compute_fast_path_clusters(
+        &mut self,
+        humanizer: &dyn ExprHumanizer,
+        ctx: PlanInsightsContext,
+    ) {
         let session: Arc<dyn SessionMetadata + Send> = Arc::new(ctx.session);
         let tasks = ctx
             .compute_instances
@@ -121,18 +125,12 @@ impl PlanInsights {
             if let PeekPlan::FastPath(plan) = plan {
                 let idx_name = if let FastPathPlan::PeekExisting(_, idx_id, _, _) = plan {
                     let idx_entry = ctx.catalog.get_entry(&idx_id);
-                    let idx_name = ctx
-                        .catalog
-                        .resolve_full_name(idx_entry.name(), Some(session.conn_id()));
-                    let on_entry = ctx
-                        .catalog
-                        .get_entry(&idx_entry.index().expect("must be index").on);
-                    let on_name = ctx
-                        .catalog
-                        .resolve_full_name(on_entry.name(), Some(session.conn_id()));
                     Some(FastPathCluster {
-                        index: idx_name.to_string(),
-                        on: on_name.to_string(),
+                        index: structured_name(humanizer, idx_id),
+                        on: structured_name(
+                            humanizer,
+                            idx_entry.index().expect("must be index").on,
+                        ),
                     })
                 } else {
                     // This shouldn't ever happen (changing the cluster should not affect whether a

--- a/src/adapter/src/explain/optimizer_trace.rs
+++ b/src/adapter/src/explain/optimizer_trace.rs
@@ -208,7 +208,9 @@ impl OptimizerTrace {
                     (plan_insights.as_mut(), insights_ctx, is_fast_path)
                 {
                     if insights_ctx.enable_re_optimize {
-                        plan_insights.compute_fast_path_clusters(insights_ctx).await;
+                        plan_insights
+                            .compute_fast_path_clusters(humanizer, insights_ctx)
+                            .await;
                     }
                 }
 

--- a/test/sqllogictest/explain/plan_insights.slt
+++ b/test/sqllogictest/explain/plan_insights.slt
@@ -750,8 +750,16 @@ EXPLAIN PLAN INSIGHTS AS JSON FOR SELECT * FROM t
     },
     "fast_path_clusters": {
       "quickstart": {
-        "index": "materialize.public.t_primary_idx",
-        "on": "materialize.public.t"
+        "index": {
+          "database": "materialize",
+          "schema": "public",
+          "item": "t_primary_idx"
+        },
+        "on": {
+          "database": "materialize",
+          "schema": "public",
+          "item": "t"
+        }
       }
     },
     "persist_count": []


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a