### PR TITLE
parallel-workload: Fix publication reuse in PG

### DIFF
--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -459,8 +459,8 @@ class PgExecutor(Executor):
                     ALTER TABLE {identifier(self.table)} REPLICA IDENTITY FULL;
                     CREATE USER postgres{self.num} WITH SUPERUSER PASSWORD 'postgres';
                     ALTER USER postgres{self.num} WITH replication;
-                    DROP PUBLICATION IF EXISTS postgres_source;
-                    CREATE PUBLICATION postgres_source FOR ALL TABLES;""",
+                    DROP PUBLICATION IF EXISTS {self.source};
+                    CREATE PUBLICATION {self.source} FOR ALL TABLES;""",
             )
         self.pg_conn.autocommit = False
 
@@ -479,7 +479,7 @@ class PgExecutor(Executor):
                 cur,
                 f"""CREATE SOURCE {identifier(self.database)}.{identifier(self.schema)}.{identifier(self.source)}
                     {f"IN CLUSTER {identifier(self.cluster)}" if self.cluster else ""}
-                    FROM POSTGRES CONNECTION pg{self.num} (PUBLICATION 'postgres_source')
+                    FROM POSTGRES CONNECTION pg{self.num} (PUBLICATION '{self.source}')
                     FOR TABLES ({identifier(self.table)} AS {identifier(self.table)})""",
             )
         self.mz_conn.autocommit = False


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/8232#019051bf-b62f-4b07-98e7-bb5d985778cf

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
