### PR TITLE
bazel: `cargo-gazelle` fix `rust_binary` name collision, upgrade Rust version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -232,7 +232,7 @@ rules_rust_dependencies()
 # Fetch and register the relevant Rust toolchains. We use a custom macro that
 # depends on `rules_rust` but cuts down on bloat from their defaults.
 
-RUST_VERSION = "1.78.0"
+RUST_VERSION = "1.79.0"
 
 load("//misc/bazel/toolchains:rust.bzl", "rust_toolchains")
 rust_toolchains(


### PR DESCRIPTION
It's relatively common for Rust library targets and binary targets to have the same name, e.g. when you have a `lib.rs` and a `main.rs`. `cargo-gazelle` had some automatic detection for this, but it looks like it broke after the most recent Rust upgrade because Cargo changed from a snake_case default to kebab-case. 

This PR changes the name collision detection to explicitly use snake_case. It also updates the version of Rust that Bazel uses to be the same as the default one we build with.

### Motivation

Fixes `cargo-gazelle`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
