### PR TITLE
dbt-materialize: add create/drop cluster macros

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Enable cross-database references ([#27686](https://github.com/MaterializeInc/materialize/pull/27686)). Although cross-database references are not supported in `dbt-postgres`, databases in Materialize are purely used for namespacing, and therefore do not present the same constraint.
 
+* Add the `create_cluster` and `drop_cluster` macros, which allow managing the
+  creation and deletion of clusters in workflows requiring transient
+  infrastructure (e.g. CI/CD).
+
 ## 1.8.2 - 2024-06-21
 
 * Add support for sink cutover to the blue/green deployment workflow [#27557](https://github.com/MaterializeInc/materialize/pull/27557).

--- a/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
@@ -113,7 +113,7 @@ This macro creates a cluster with the specified properties.
         {% set create_cluster_ddl %}
             CREATE CLUSTER {{ deploy_cluster }} (
                 SIZE = {{ dbt.string_literal(size) }}
-                {% if schedule_type == 'manual' and replication_factor is not none %}
+                {% if replication_factor is not none and ( schedule_type == 'manual' or schedule_type is none ) %}
                     , REPLICATION FACTOR = {{ replication_factor }}
                 {% elif schedule_type == 'on-refresh' and refresh_rehydration_time_estimate is not none %}
                     , SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = {{ dbt.string_literal(refresh_rehydration_time_estimate) }})

--- a/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
@@ -115,8 +115,12 @@ This macro creates a cluster with the specified properties.
                 SIZE = {{ dbt.string_literal(size) }}
                 {% if replication_factor is not none and ( schedule_type == 'manual' or schedule_type is none ) %}
                     , REPLICATION FACTOR = {{ replication_factor }}
-                {% elif schedule_type == 'on-refresh' and refresh_rehydration_time_estimate is not none %}
-                    , SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = {{ dbt.string_literal(refresh_rehydration_time_estimate) }})
+                {% elif schedule_type == 'on-refresh' %}
+                    {% if refresh_rehydration_time_estimate is not none %}
+                        , SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = {{ dbt.string_literal(refresh_rehydration_time_estimate) }})
+                    {% else %}
+                        , SCHEDULE = ON REFRESH
+                    {% endif %}
                 {% endif %}
             )
         {% endset %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
@@ -21,7 +21,7 @@ This macro creates a cluster with the specified properties.
   - size (str): The size of the cluster. This parameter is required.
   - replication_factor (int, optional): The replication factor for the cluster. Only applicable when schedule_type is 'manual'.
   - schedule_type (str, optional): The type of schedule for the cluster. Accepts 'manual' or 'on-refresh'.
-  - refresh_rehydration_time_estimate (str, optional): The estimated rehydration time for the cluster when schedule_type is 'on-refresh'.
+  - refresh_rehydration_time_estimate (str, optional): The estimated rehydration time for the cluster. Only applicable when schedule_type is 'on-refresh'.
   - ignore_existing_objects (bool, optional): Whether to ignore existing objects in the cluster. Defaults to false.
   - force_deploy_suffix (bool, optional): Whether to forcefully add a deploy suffix to the cluster name. Defaults to false.
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
@@ -1,0 +1,128 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{#
+This macro creates a cluster with the specified properties.
+
+  ## Arguments
+  - cluster_name (str): The name of the cluster. This parameter is required.
+  - size (str): The size of the cluster. This parameter is required.
+  - replication_factor (int, optional): The replication factor for the cluster. Only applicable when schedule_type is 'manual'.
+  - schedule_type (str, optional): The type of schedule for the cluster. Accepts 'manual' or 'on-refresh'.
+  - refresh_rehydration_time_estimate (str, optional): The estimated rehydration time for the cluster when schedule_type is 'on-refresh'.
+  - ignore_existing_objects (bool, optional): Whether to ignore existing objects in the cluster. Defaults to false.
+  - force_deploy_suffix (bool, optional): Whether to forcefully add a deploy suffix to the cluster name. Defaults to false.
+
+  Incompatibilities:
+  - replication_factor is only applicable when schedule_type is 'manual'.
+  - refresh_rehydration_time_estimate is only applicable when schedule_type is 'on-refresh'.
+#}
+{% macro create_cluster(
+    cluster_name,
+    size,
+    replication_factor=none,
+    schedule_type=none,
+    refresh_rehydration_time_estimate=none,
+    ignore_existing_objects=false,
+    force_deploy_suffix=false
+) %}
+
+    {# Input validation #}
+    {% if not cluster_name %}
+        {{ exceptions.raise_compiler_error("cluster_name must be provided") }}
+    {% endif %}
+
+    {% if not size %}
+        {{ exceptions.raise_compiler_error("size must be provided") }}
+    {% endif %}
+
+    {% set deploy_cluster = adapter.generate_final_cluster_name(cluster_name, force_deploy_suffix) %}
+
+    {% if cluster_exists(deploy_cluster) %}
+        {{ log("Deployment cluster " ~ deploy_cluster ~ " already exists", info=True) }}
+        {% set cluster_empty %}
+            WITH dataflows AS (
+                SELECT mz_indexes.id
+                FROM mz_indexes
+                JOIN mz_clusters ON mz_indexes.cluster_id = mz_clusters.id
+                WHERE mz_clusters.name = {{ dbt.string_literal(deploy_cluster) }}
+
+                UNION ALL
+
+                SELECT mz_materialized_views.id
+                FROM mz_materialized_views
+                JOIN mz_clusters ON mz_materialized_views.cluster_id = mz_clusters.id
+                WHERE mz_clusters.name = {{ dbt.string_literal(deploy_cluster) }}
+
+                UNION ALL
+
+                SELECT mz_sources.id
+                FROM mz_sources
+                JOIN mz_clusters ON mz_clusters.id = mz_sources.cluster_id
+                WHERE mz_clusters.name = {{ dbt.string_literal(deploy_cluster) }}
+
+                UNION ALL
+
+                SELECT mz_sinks.id
+                FROM mz_sinks
+                JOIN mz_clusters ON mz_clusters.id = mz_sinks.cluster_id
+                WHERE mz_clusters.name = {{ dbt.string_literal(deploy_cluster) }}
+            )
+
+            SELECT count(*)
+            FROM dataflows
+            WHERE id LIKE 'u%'
+        {% endset %}
+
+        {% set cluster_object_count = run_query(cluster_empty) %}
+        {% if execute %}
+            {% if cluster_object_count and cluster_object_count.columns[0] and cluster_object_count.rows[0][0] > 0 %}
+                {% if check_cluster_ci_tag(deploy_cluster) %}
+                    {{ log("Cluster " ~ deploy_cluster ~ " was already created for this pull request", info=True) }}
+                {% elif ignore_existing_objects %}
+                    {{ log("[Warning] Deployment cluster " ~ deploy_cluster ~ " is not empty", info=True) }}
+                    {{ log("[Warning] Confirm the objects it contains are expected before deployment", info=True) }}
+                {% else %}
+                    {{ exceptions.raise_compiler_error("
+                        Deployment cluster " ~ deploy_cluster ~ " already exists and is not empty.
+                        This is potentially dangerous as you may end up deploying objects to production you
+                        do not intend.
+
+                        If you are certain the objects in this cluster are supposed to exist, you can ignore this
+                        error by setting ignore_existing_objects to True.
+
+                        dbt run-operation create_deployment_environment --args '{ignore_existing_objects: True}'
+                    ") }}
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% else %}
+        {{ log("Creating deployment cluster " ~ deploy_cluster, info=True)}}
+        {% set create_cluster_ddl %}
+            CREATE CLUSTER {{ deploy_cluster }} (
+                SIZE = {{ dbt.string_literal(size) }}
+                {% if schedule_type == 'manual' and replication_factor is not none %}
+                    , REPLICATION FACTOR = {{ replication_factor }}
+                {% elif schedule_type == 'on-refresh' and refresh_rehydration_time_estimate is not none %}
+                    , SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = {{ dbt.string_literal(refresh_rehydration_time_estimate) }})
+                {% endif %}
+            )
+        {% endset %}
+        {{ run_query(create_cluster_ddl) }}
+        {{ set_cluster_ci_tag(deploy_cluster) }}
+    {% endif %}
+
+    {{ return(deploy_cluster) }}
+{% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
@@ -103,7 +103,7 @@ This macro creates a cluster with the specified properties.
                         If you are certain the objects in this cluster are supposed to exist, you can ignore this
                         error by setting ignore_existing_objects to True.
 
-                        dbt run-operation create_deployment_environment --args '{ignore_existing_objects: True}'
+                        dbt run-operation create_cluster --args '{ignore_existing_objects: True}'
                     ") }}
                 {% endif %}
             {% endif %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/ci/drop_cluster.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/ci/drop_cluster.sql
@@ -1,0 +1,39 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{#
+-- This macro drops a cluster used in CI.
+-- Parameters:
+--   cluster_name (str): The name of the cluster to drop.
+#}
+{% macro drop_cluster(cluster_name) %}
+
+{%- if cluster_name -%}
+
+  {{ log("Dropping cluster " ~ cluster_name ~ "...", info=True) }}
+
+  {% call statement('drop_cluster') -%}
+      DROP CLUSTER IF EXISTS {{ cluster_name }} CASCADE
+  {%- endcall -%}
+
+  {{ log("Cluster " ~ cluster_name ~ " dropped.", info=True) }}
+
+{%- else -%}
+
+  {{ exceptions.raise_compiler_error("Invalid arguments. Missing cluster name!") }}
+
+{%- endif -%}
+
+{% endmacro %}

--- a/misc/dbt-materialize/tests/adapter/test_ci.py
+++ b/misc/dbt-materialize/tests/adapter/test_ci.py
@@ -1,0 +1,309 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dbt.tests.util import run_dbt
+
+
+class TestClusterOps:
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self, project):
+        project.run_sql("DROP CLUSTER IF EXISTS test_cluster CASCADE")
+        project.run_sql("DROP CLUSTER IF EXISTS test_cluster_dbt_deploy CASCADE")
+        project.run_sql("DROP CLUSTER IF EXISTS test_manual_schedule CASCADE")
+        project.run_sql("DROP CLUSTER IF EXISTS test_on_refresh_schedule CASCADE")
+
+    def test_create_and_drop_cluster(self, project):
+        # Test creating a cluster
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+
+        # Verify cluster creation
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'test_cluster_dbt_deploy'",
+            fetch="one",
+        )
+        assert result is not None, "Cluster was not created successfully"
+
+        # Test dropping the cluster
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster_dbt_deploy"}',
+            ]
+        )
+
+        # Verify cluster dropping
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'test_cluster_dbt_deploy'",
+            fetch="one",
+        )
+        assert result is None, "Cluster was not dropped successfully"
+
+    def test_create_existing_cluster(self, project):
+        # Create the cluster for the first time
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+
+        # Try creating the same cluster again
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+
+        # Verify the cluster exists
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'test_cluster_dbt_deploy'",
+            fetch="one",
+        )
+        assert (
+            result is not None
+        ), "Cluster should exist after attempting to create it again"
+
+        # Cleanup
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster_dbt_deploy"}',
+            ]
+        )
+
+    def test_drop_nonexistent_cluster(self, project):
+        # Attempt to drop a nonexistent cluster
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "nonexistent_cluster"}',
+            ]
+        )
+
+        # Verify no cluster exists
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'nonexistent_cluster'",
+            fetch="one",
+        )
+        assert result is None, "Nonexistent cluster should not exist"
+
+    def test_create_cluster_with_objects(self, project):
+        # Create a cluster and add an object to it
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+        project.run_sql("CREATE MATERIALIZED VIEW test_view AS SELECT 1")
+
+        # Attempt to create the same cluster without ignoring existing objects
+        with pytest.raises(Exception):
+            run_dbt(
+                [
+                    "run-operation",
+                    "create_cluster",
+                    "--args",
+                    '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": false, "force_deploy_suffix": true}',
+                ],
+                expect_pass=False,
+            )
+
+        # Cleanup
+        project.run_sql("DROP MATERIALIZED VIEW IF EXISTS test_view")
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster_dbt_deploy"}',
+            ]
+        )
+
+    def test_create_cluster_with_manual_schedule(self, project):
+        # Test creating a cluster with manual schedule type
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_manual_schedule", "size": "1", "replication_factor": 2, "schedule_type": "manual", "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+
+        # Verify cluster creation
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'test_manual_schedule_dbt_deploy'",
+            fetch="one",
+        )
+        assert (
+            result is not None
+        ), "Cluster with manual schedule was not created successfully"
+
+        # Cleanup
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "test_manual_schedule_dbt_deploy"}',
+            ]
+        )
+
+    def test_create_cluster_with_on_refresh_schedule(self, project):
+        # Test creating a cluster with on-refresh schedule type
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_on_refresh_schedule", "size": "1", "schedule_type": "on-refresh", "refresh_rehydration_time_estimate": "10m", "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+
+        # Verify cluster creation
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'test_on_refresh_schedule_dbt_deploy'",
+            fetch="one",
+        )
+        assert (
+            result is not None
+        ), "Cluster with on-refresh schedule was not created successfully"
+
+        # Cleanup
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "test_on_refresh_schedule_dbt_deploy"}',
+            ]
+        )
+
+    def test_create_cluster_without_force_deploy_suffix(self, project):
+        # Test creating a cluster without force deploy suffix
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": false}',
+            ]
+        )
+
+        # Verify cluster creation
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'test_cluster'",
+            fetch="one",
+        )
+        assert (
+            result is not None
+        ), "Cluster without force deploy suffix was not created successfully"
+
+        # Cleanup
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster"}',
+            ]
+        )
+
+    def test_create_cluster_with_replication_and_schedule(self, project):
+        # Test creating a cluster with both replication factor and schedule type
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "1", "replication_factor": 2, "schedule_type": "manual", "refresh_rehydration_time_estimate": "10m", "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ]
+        )
+
+        # Verify cluster creation
+        result = project.run_sql(
+            "SELECT name FROM mz_clusters WHERE name = 'test_cluster_dbt_deploy'",
+            fetch="one",
+        )
+        assert (
+            result is not None
+        ), "Cluster with replication factor and schedule was not created successfully"
+
+        # Cleanup
+        run_dbt(
+            [
+                "run-operation",
+                "drop_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster_dbt_deploy"}',
+            ]
+        )
+
+    def test_create_cluster_without_size_and_name(self, project):
+        # Test creating a cluster without providing a size parameter
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ],
+            expect_pass=False,
+        )
+
+        # Test creating a cluster without providing a name parameter
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"size": "1", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ],
+            expect_pass=False,
+        )
+
+        # Test invalid cluster size
+        run_dbt(
+            [
+                "run-operation",
+                "create_cluster",
+                "--args",
+                '{"cluster_name": "test_cluster", "size": "invalid_size", "replication_factor": 1, "ignore_existing_objects": true, "force_deploy_suffix": true}',
+            ],
+            expect_pass=False,
+        )

--- a/misc/dbt-materialize/tests/adapter/test_ci.py
+++ b/misc/dbt-materialize/tests/adapter/test_ci.py
@@ -49,7 +49,7 @@ class TestClusterOps:
         assert properties[1] == "1"
         assert properties[2] == "1"
         assert properties[5] == "manual"
-        assert properties[6] == None
+        assert properties[6] is None
 
         # Test dropping the cluster
         run_dbt(
@@ -103,7 +103,7 @@ class TestClusterOps:
         assert properties[1] == "1"
         assert properties[2] == "1"
         assert properties[5] == "manual"
-        assert properties[6] == None
+        assert properties[6] is None
 
         # Cleanup
         run_dbt(
@@ -193,7 +193,7 @@ class TestClusterOps:
         assert properties[1] == "1"
         assert properties[2] == "2"
         assert properties[5] == "manual"
-        assert properties[6] == None
+        assert properties[6] is None
 
         # Cleanup
         run_dbt(
@@ -268,7 +268,7 @@ class TestClusterOps:
         assert properties[1] == "1"
         assert properties[2] == "1"
         assert properties[5] == "manual"
-        assert properties[6] == None
+        assert properties[6] is None
 
         # Cleanup
         run_dbt(


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Abstracting the cluster create logic into its own macro which can later on be used in CI/CD workflows similar to what has already been outlined in the [dbt-ci-templates](https://github.com/morsapaes/dbt-ci-templates) project.

As a follow-up, we can update the `dbt-cli-templates` project and include an example using these macros for an end-to-end CI workflow.