### PR TITLE
orchestrator: move orchestrator calls off the coordinator main thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5320,11 +5320,13 @@ dependencies = [
  "maplit",
  "mz-cloud-resources",
  "mz-orchestrator",
+ "mz-ore",
  "mz-repr",
  "mz-secrets",
  "serde",
  "serde_json",
  "sha2",
+ "tokio",
  "tracing",
  "workspace-hack",
 ]

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -671,7 +671,7 @@ impl Coordinator {
             if !cluster_replicas_to_drop.is_empty() {
                 fail::fail_point!("after_catalog_drop_replica");
                 for (cluster_id, replica_id) in cluster_replicas_to_drop {
-                    self.drop_replica(cluster_id, replica_id).await;
+                    self.drop_replica(cluster_id, replica_id);
                 }
             }
             if !log_indexes_to_drop.is_empty() {
@@ -776,7 +776,7 @@ impl Coordinator {
         Ok(builtin_update_notify)
     }
 
-    async fn drop_replica(&mut self, cluster_id: ClusterId, replica_id: ReplicaId) {
+    fn drop_replica(&mut self, cluster_id: ClusterId, replica_id: ReplicaId) {
         if let Some(Some(ReplicaMetadata { metrics })) =
             self.transient_replica_metadata.insert(replica_id, None)
         {
@@ -799,7 +799,6 @@ impl Coordinator {
 
         self.controller
             .drop_replica(cluster_id, replica_id)
-            .await
             .expect("dropping replica must not fail");
     }
 

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -666,6 +666,7 @@ where
         let persist_pubsub_url = self.persist_pubsub_url.clone();
         let txn_wal_tables = self.txn_wal_tables;
         let secrets_args = self.secrets_args.to_flags();
+        let is_cluster_size_v2 = is_cluster_size_v2(&location.size);
         let service = self
             .orchestrator
             .ensure_service(
@@ -673,7 +674,7 @@ where
                 ServiceConfig {
                     image: self.clusterd_image.clone(),
                     init_container_image: self.init_container_image.clone(),
-                    args: &|assigned| {
+                    args: Box::new(move |assigned| {
                         let mut args = vec![
                             format!(
                                 "--storage-controller-listen-addr={}",
@@ -711,14 +712,14 @@ where
                         if location.allocation.cpu_exclusive && enable_worker_core_affinity {
                             args.push("--worker-core-affinity".into());
                         }
-                        if is_cluster_size_v2(&location.size) {
+                        if is_cluster_size_v2 {
                             args.push("--is-cluster-size-v2".into());
                         }
 
                         args.extend(secrets_args.clone());
 
                         args
-                    },
+                    }),
                     ports: vec![
                         ServicePort {
                             name: "storagectl".into(),

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3.25"
 maplit = "1.0.2"
 mz-cloud-resources = { path = "../cloud-resources" }
 mz-orchestrator = { path = "../orchestrator" }
+mz-ore = { path = "../ore", features = ["async"]  }
 mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }
 k8s-openapi = { version = "0.22.0", features = ["v1_28"] }
@@ -26,6 +27,7 @@ kube = { version = "0.92.1", default-features = false, features = ["client", "ru
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 sha2 = "0.10.6"
+tokio = "1.32.0"
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -702,7 +702,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             disk,
             disk_limit,
             node_selector,
-        }: ServiceConfig<'_>,
+        }: ServiceConfig,
     ) -> Result<Box<dyn Service>, anyhow::Error> {
         // This is extremely cheap to clone, so just look into the lock once.
         let scheduling_config: ServiceSchedulingConfig =

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -42,8 +42,10 @@ use mz_orchestrator::{
     NamespacedOrchestrator, NotReadyReason, Orchestrator, Service, ServiceConfig, ServiceEvent,
     ServiceProcessMetrics, ServiceStatus,
 };
+use mz_ore::task::AbortOnDropHandle;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
+use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 
 pub mod cloud_resource_controller;
@@ -52,6 +54,8 @@ pub mod util;
 
 const FIELD_MANAGER: &str = "environmentd";
 const NODE_FAILURE_THRESHOLD_SECONDS: i64 = 30;
+
+const POD_TEMPLATE_HASH_ANNOTATION: &str = "environmentd.materialize.cloud/pod-template-hash";
 
 /// Configures a [`KubernetesOrchestrator`].
 #[derive(Debug, Clone)]
@@ -146,11 +150,18 @@ impl Orchestrator for KubernetesOrchestrator {
     fn namespace(&self, namespace: &str) -> Arc<dyn NamespacedOrchestrator> {
         let mut namespaces = self.namespaces.lock().expect("lock poisoned");
         Arc::clone(namespaces.entry(namespace.into()).or_insert_with(|| {
-            Arc::new(NamespacedKubernetesOrchestrator {
+            let (command_tx, command_rx) = mpsc::unbounded_channel();
+            let worker = OrchestratorWorker {
                 metrics_api: Api::default_namespaced(self.client.clone()),
                 custom_metrics_api: Api::default_namespaced(self.client.clone()),
                 service_api: Api::default_namespaced(self.client.clone()),
                 stateful_set_api: Api::default_namespaced(self.client.clone()),
+                pod_api: Api::default_namespaced(self.client.clone()),
+                command_rx,
+            }
+            .spawn(format!("kubernetes-orchestrator-worker:{namespace}"));
+
+            Arc::new(NamespacedKubernetesOrchestrator {
                 pod_api: Api::default_namespaced(self.client.clone()),
                 kubernetes_namespace: self.kubernetes_namespace.clone(),
                 namespace: namespace.into(),
@@ -158,6 +169,8 @@ impl Orchestrator for KubernetesOrchestrator {
                 // TODO(guswynn): make this configurable.
                 scheduling_config: Default::default(),
                 service_infos: std::sync::Mutex::new(BTreeMap::new()),
+                command_tx,
+                _worker: worker,
             })
         }))
     }
@@ -171,16 +184,14 @@ struct ServiceInfo {
 }
 
 struct NamespacedKubernetesOrchestrator {
-    metrics_api: Api<PodMetrics>,
-    custom_metrics_api: Api<MetricValueList>,
-    service_api: Api<K8sService>,
-    stateful_set_api: Api<StatefulSet>,
     pod_api: Api<Pod>,
     kubernetes_namespace: String,
     namespace: String,
     config: KubernetesOrchestratorConfig,
     scheduling_config: std::sync::RwLock<ServiceSchedulingConfig>,
     service_infos: std::sync::Mutex<BTreeMap<String, ServiceInfo>>,
+    command_tx: mpsc::UnboundedSender<WorkerCommand>,
+    _worker: AbortOnDropHandle<()>,
 }
 
 impl fmt::Debug for NamespacedKubernetesOrchestrator {
@@ -191,6 +202,58 @@ impl fmt::Debug for NamespacedKubernetesOrchestrator {
             .field("config", &self.config)
             .finish()
     }
+}
+
+/// Commands sent from a [`NamespacedKubernetesOrchestrator`] to its
+/// [`OrchestratorWorker`].
+///
+/// Commands for which the caller expects a result include a `result_tx` on which the
+/// [`OrchestratorWorker`] will deliver the result.
+enum WorkerCommand {
+    EnsureService {
+        desc: ServiceDescription,
+    },
+    DropService {
+        name: String,
+    },
+    ListServices {
+        namespace: String,
+        result_tx: oneshot::Sender<Result<Vec<String>, anyhow::Error>>,
+    },
+    FetchServiceMetrics {
+        name: String,
+        info: ServiceInfo,
+        result_tx: oneshot::Sender<Vec<ServiceProcessMetrics>>,
+    },
+}
+
+/// A description of a service to be created by an [`OrchestratorWorker`].
+struct ServiceDescription {
+    name: String,
+    scale: u16,
+    service: K8sService,
+    stateful_set: StatefulSet,
+    pod_template_hash: String,
+}
+
+/// A task executing blocking work for a [`NamespacedKubernetesOrchestrator`] in the background.
+///
+/// This type exists to enable making [`NamespacedKubernetesOrchestrator::ensure_service`] and
+/// [`NamespacedKubernetesOrchestrator::drop_service`] non-blocking, allowing invocation of these
+/// methods in latency-sensitive contexts.
+///
+/// Note that, apart from `ensure_service` and `drop_service`, this worker also handles blocking
+/// orchestrator calls that query service state (such as `list_services`). These need to be
+/// sequenced through the worker loop to ensure they linearize as expected. For example, we want to
+/// ensure that a `list_services` result contains exactly those services that were previously
+/// created with `ensure_service` and not yet dropped with `drop_service`.
+struct OrchestratorWorker {
+    metrics_api: Api<PodMetrics>,
+    custom_metrics_api: Api<MetricValueList>,
+    service_api: Api<K8sService>,
+    stateful_set_api: Api<StatefulSet>,
+    pod_api: Api<Pod>,
+    command_rx: mpsc::UnboundedReceiver<WorkerCommand>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -290,7 +353,11 @@ impl k8s_openapi::Metadata for MetricValueList {
 }
 
 impl NamespacedKubernetesOrchestrator {
-    /// Return a `wather::Config` instance that limits results to the namespace
+    fn service_name(&self, id: &str) -> String {
+        format!("{}-{id}", self.namespace)
+    }
+
+    /// Return a `watcher::Config` instance that limits results to the namespace
     /// assigned to this orchestrator.
     fn watch_pod_params(&self) -> watcher::Config {
         let ns_selector = format!(
@@ -299,11 +366,13 @@ impl NamespacedKubernetesOrchestrator {
         );
         watcher::Config::default().labels(&ns_selector)
     }
+
     /// Convert a higher-level label key to the actual one we
     /// will give to Kubernetes
     fn make_label_key(&self, key: &str) -> String {
         format!("{}.environmentd.materialize.cloud/{}", self.namespace, key)
     }
+
     fn label_selector_to_k8s(
         &self,
         MzLabelSelector { label_name, logic }: MzLabelSelector,
@@ -338,6 +407,10 @@ impl NamespacedKubernetesOrchestrator {
             values: Some(values),
         };
         Ok(lsr)
+    }
+
+    fn send_command(&self, cmd: WorkerCommand) {
+        self.command_tx.send(cmd).expect("worker task not dropped");
     }
 }
 
@@ -448,243 +521,19 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             tracing::error!("Failed to get info for {id}");
             anyhow::bail!("Failed to get info for {id}");
         };
-        /// Get metrics for a particular service and process, converting them into a sane (i.e., numeric) format.
-        ///
-        /// Note that we want to keep going even if a lookup fails for whatever reason,
-        /// so this function is infallible. If we fail to get cpu or memory for a particular pod,
-        /// we just log a warning and install `None` in the returned struct.
-        async fn get_metrics(
-            self_: &NamespacedKubernetesOrchestrator,
-            id: &str,
-            i: usize,
-            disk: bool,
-            disk_limit: Option<DiskLimit>,
-        ) -> ServiceProcessMetrics {
-            let name = format!("{}-{id}-{i}", self_.namespace);
 
-            let disk_usage_fut = async {
-                if disk {
-                    Some(
-                        self_
-                            .custom_metrics_api
-                            .get_subresource(
-                                "kubelet_volume_stats_used_bytes",
-                                // The CSI provider we use sets up persistentvolumeclaim's
-                                // with `{pod name}-scratch` as the name. It also provides
-                                // the metrics, and does so under the `persistentvolumeclaims`
-                                // resource type, instead of `pods`.
-                                &format!("{name}-scratch"),
-                            )
-                            .await,
-                    )
-                } else {
-                    None
-                }
-            };
-            let disk_capacity_fut = async {
-                if disk {
-                    Some(
-                        self_
-                            .custom_metrics_api
-                            .get_subresource(
-                                "kubelet_volume_stats_capacity_bytes",
-                                &format!("{name}-scratch"),
-                            )
-                            .await,
-                    )
-                } else {
-                    None
-                }
-            };
-            let (metrics, disk_usage, disk_capacity) = match futures::future::join3(
-                self_.metrics_api.get(&name),
-                disk_usage_fut,
-                disk_capacity_fut,
-            )
-            .await
-            {
-                (Ok(metrics), disk_usage, disk_capacity) => {
-                    // TODO(guswynn): don't tolerate errors here, when we are more
-                    // comfortable with `prometheus-adapter` in production
-                    // (And we run it in ci).
+        let (result_tx, result_rx) = oneshot::channel();
+        self.send_command(WorkerCommand::FetchServiceMetrics {
+            name: self.service_name(id),
+            info,
+            result_tx,
+        });
 
-                    let disk_usage = match disk_usage {
-                        Some(Ok(disk_usage)) => Some(disk_usage),
-                        Some(Err(e)) if !matches!(&e, Error::Api(e) if e.code == 404) => {
-                            warn!(
-                                "Failed to fetch `kubelet_volume_stats_used_bytes` for {name}: {e}"
-                            );
-                            None
-                        }
-                        _ => None,
-                    };
-
-                    let disk_capacity = match disk_capacity {
-                        Some(Ok(disk_capacity)) => Some(disk_capacity),
-                        Some(Err(e)) if !matches!(&e, Error::Api(e) if e.code == 404) => {
-                            warn!("Failed to fetch `kubelet_volume_stats_capacity_bytes` for {name}: {e}");
-                            None
-                        }
-                        _ => None,
-                    };
-
-                    (metrics, disk_usage, disk_capacity)
-                }
-                (Err(e), _, _) => {
-                    warn!("Failed to get metrics for {name}: {e}");
-                    return ServiceProcessMetrics::default();
-                }
-            };
-            let Some(PodMetricsContainer {
-                usage:
-                    PodMetricsContainerUsage {
-                        cpu: Quantity(cpu_str),
-                        memory: Quantity(mem_str),
-                    },
-                ..
-            }) = metrics.containers.get(0)
-            else {
-                warn!("metrics result contained no containers for {name}");
-                return ServiceProcessMetrics::default();
-            };
-
-            let cpu = match parse_k8s_quantity(cpu_str) {
-                Ok(q) => match q.try_to_integer(-9, true) {
-                    Some(i) => Some(i),
-                    None => {
-                        tracing::error!("CPU value {q:? }out of range");
-                        None
-                    }
-                },
-                Err(e) => {
-                    tracing::error!("Failed to parse CPU value {cpu_str}: {e}");
-                    None
-                }
-            };
-            let memory = match parse_k8s_quantity(mem_str) {
-                Ok(q) => match q.try_to_integer(0, false) {
-                    Some(i) => Some(i),
-                    None => {
-                        tracing::error!("Memory value {q:?} out of range");
-                        None
-                    }
-                },
-                Err(e) => {
-                    tracing::error!("Failed to parse memory value {mem_str}: {e}");
-                    None
-                }
-            };
-
-            let disk_usage = match (disk_usage, disk_capacity) {
-                (Some(disk_usage_metrics), Some(disk_capacity_metrics)) => {
-                    if !disk_usage_metrics.items.is_empty()
-                        && !disk_capacity_metrics.items.is_empty()
-                    {
-                        let disk_usage_str = &*disk_usage_metrics.items[0].value.0;
-                        let disk_usage = match parse_k8s_quantity(disk_usage_str) {
-                            Ok(q) => match q.try_to_integer(0, true) {
-                                Some(i) => Some(i),
-                                None => {
-                                    tracing::error!("Disk usage value {q:?} out of range");
-                                    None
-                                }
-                            },
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to parse disk usage value {disk_usage_str}: {e}"
-                                );
-                                None
-                            }
-                        };
-                        let disk_capacity_str = &*disk_capacity_metrics.items[0].value.0;
-                        let disk_capacity = match parse_k8s_quantity(disk_capacity_str) {
-                            Ok(q) => match q.try_to_integer(0, true) {
-                                Some(i) => Some(i),
-                                None => {
-                                    tracing::error!("Disk capacity value {q:?} out of range");
-                                    None
-                                }
-                            },
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to parse disk capacity value {disk_capacity_str}: {e}"
-                                );
-                                None
-                            }
-                        };
-
-                        // We only populate a `disk_usage` if we have all 5 of of:
-                        // - a disk limit (so it must be an actual managed cluster with a real limit)
-                        // - a reported disk capacity
-                        // - a reported disk usage
-                        //
-                        // There are 3 weird cases we have to handle here:
-                        // - Some instance types report a large disk capacity than the requested
-                        // limit. We clamp those capacities to the limit, which means we can
-                        // report 100% usage even if we have a bit of space left.
-                        // - Other instances report a smaller disk capacity than the limit, due to
-                        // overheads. In this case, we correct the usage by adding the overhead, so
-                        // we report a more accurate usage number.
-                        // - The disk limit can be more up-to-date (from `service_infos`) than the
-                        // reported metric. In that case, we report the minimum of the usage
-                        // and the limit, which means we can report 100% usage temporarily
-                        // if a replica is sized down.
-                        match (disk_usage, disk_capacity, disk_limit) {
-                            (
-                                Some(disk_usage),
-                                Some(disk_capacity),
-                                Some(DiskLimit(disk_limit)),
-                            ) => {
-                                let disk_capacity = if disk_limit.0 < disk_capacity {
-                                    // We issue a debug message instead
-                                    // of a warning or error because all the
-                                    // above cases are relatively common.
-                                    tracing::debug!(
-                                        "disk capacity {} is larger than the disk limit {}; \
-                                        disk usage will indicate 100% full before the disk is truly full; \
-                                        as long as the delta is small this is not a cause for concern",
-                                        disk_capacity,
-                                        disk_limit.0
-                                    );
-                                    // Clamp to the limit.
-                                    disk_limit.0
-                                } else {
-                                    disk_capacity
-                                };
-
-                                // If we overflow, just clamp to the disk limit
-                                let disk_usage = (disk_limit.0 - disk_capacity)
-                                    .checked_add(disk_usage)
-                                    .unwrap_or(disk_limit.0);
-
-                                // Clamp to the limit. Note that this can be clamped during
-                                // replica resizes of if the disk usage is ABOVE the
-                                // configured limit, as may occur on some instances.
-                                Some(std::cmp::min(disk_usage, disk_limit.0))
-                            }
-                            _ => None,
-                        }
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            };
-
-            ServiceProcessMetrics {
-                cpu_nano_cores: cpu,
-                memory_bytes: memory,
-                disk_usage_bytes: disk_usage,
-            }
-        }
-        let ret = futures::future::join_all(
-            (0..info.scale).map(|i| get_metrics(self, id, i.into(), info.disk, info.disk_limit)),
-        );
-
-        Ok(ret.await)
+        let metrics = result_rx.await.expect("worker task not dropped");
+        Ok(metrics)
     }
 
-    async fn ensure_service(
+    fn ensure_service(
         &self,
         id: &str,
         ServiceConfig {
@@ -709,7 +558,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             self.scheduling_config.read().expect("poisoned").clone();
         let disk = scheduling_config.always_use_disk || disk;
 
-        let name = format!("{}-{id}", self.namespace);
+        let name = self.service_name(id);
         // The match labels should be the minimal set of labels that uniquely
         // identify the pods in the stateful set. Changing these after the
         // `StatefulSet` is created is not permitted by Kubernetes, and we're
@@ -1257,7 +1106,6 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         let mut hasher = Sha256::new();
         hasher.update(pod_template_json);
         let pod_template_hash = format!("{:x}", hasher.finalize());
-        let pod_template_hash_annotation = "environmentd.materialize.cloud/pod-template-hash";
         pod_template_spec
             .metadata
             .as_mut()
@@ -1266,7 +1114,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             .as_mut()
             .unwrap()
             .insert(
-                pod_template_hash_annotation.to_owned(),
+                POD_TEMPLATE_HASH_ANNOTATION.to_owned(),
                 pod_template_hash.clone(),
             );
 
@@ -1290,45 +1138,16 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             status: None,
         };
 
-        self.service_api
-            .patch(
-                &name,
-                &PatchParams::apply(FIELD_MANAGER).force(),
-                &Patch::Apply(service),
-            )
-            .await?;
-        self.stateful_set_api
-            .patch(
-                &name,
-                &PatchParams::apply(FIELD_MANAGER).force(),
-                &Patch::Apply(stateful_set),
-            )
-            .await?;
-        // Explicitly delete any pods in the stateful set that don't match the
-        // template. In theory, Kubernetes would do this automatically, but
-        // in practice we have observed that it does not.
-        // See: https://github.com/kubernetes/kubernetes/issues/67250
-        for pod_id in 0..scale {
-            let pod_name = format!("{}-{}", &name, pod_id);
-            let pod = match self.pod_api.get(&pod_name).await {
-                Ok(pod) => pod,
-                // Pod already doesn't exist.
-                Err(kube::Error::Api(e)) if e.code == 404 => continue,
-                Err(e) => return Err(e.into()),
-            };
-            if pod.annotations().get(pod_template_hash_annotation) != Some(&pod_template_hash) {
-                match self
-                    .pod_api
-                    .delete(&pod_name, &DeleteParams::default())
-                    .await
-                {
-                    Ok(_) => (),
-                    // Pod got deleted while we were looking at it.
-                    Err(kube::Error::Api(e)) if e.code == 404 => (),
-                    Err(e) => return Err(e.into()),
-                }
-            }
-        }
+        self.send_command(WorkerCommand::EnsureService {
+            desc: ServiceDescription {
+                name,
+                scale,
+                service,
+                stateful_set,
+                pod_template_hash,
+            },
+        });
+
         self.service_infos.lock().expect("poisoned lock").insert(
             id.to_string(),
             ServiceInfo {
@@ -1337,49 +1156,31 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 disk_limit,
             },
         );
+
         Ok(Box::new(KubernetesService { hosts, ports }))
     }
 
     /// Drops the identified service, if it exists.
-    async fn drop_service(&self, id: &str) -> Result<(), anyhow::Error> {
+    fn drop_service(&self, id: &str) -> Result<(), anyhow::Error> {
         fail::fail_point!("kubernetes_drop_service", |_| Err(anyhow!("failpoint")));
         self.service_infos.lock().expect("poisoned lock").remove(id);
-        let name = format!("{}-{id}", self.namespace);
-        let res = self
-            .stateful_set_api
-            .delete(&name, &DeleteParams::default())
-            .await;
-        match res {
-            Ok(_) => (),
-            Err(Error::Api(e)) if e.code == 404 => (),
-            Err(e) => return Err(e.into()),
-        }
 
-        let res = self
-            .service_api
-            .delete(&name, &DeleteParams::default())
-            .await;
-        match res {
-            Ok(_) => Ok(()),
-            Err(Error::Api(e)) if e.code == 404 => Ok(()),
-            Err(e) => Err(e.into()),
-        }
+        self.send_command(WorkerCommand::DropService {
+            name: self.service_name(id),
+        });
+
+        Ok(())
     }
 
     /// Lists the identifiers of all known services.
     async fn list_services(&self) -> Result<Vec<String>, anyhow::Error> {
-        let stateful_sets = self.stateful_set_api.list(&Default::default()).await?;
-        let name_prefix = format!("{}-", self.namespace);
-        Ok(stateful_sets
-            .into_iter()
-            .filter_map(|ss| {
-                ss.metadata
-                    .name
-                    .unwrap()
-                    .strip_prefix(&name_prefix)
-                    .map(Into::into)
-            })
-            .collect())
+        let (result_tx, result_rx) = oneshot::channel();
+        self.send_command(WorkerCommand::ListServices {
+            namespace: self.namespace.clone(),
+            result_tx,
+        });
+
+        result_rx.await.expect("worker task not dropped")
     }
 
     fn watch_services(&self) -> BoxStream<'static, Result<ServiceEvent, anyhow::Error>> {
@@ -1459,6 +1260,367 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
 
     fn update_scheduling_config(&self, config: ServiceSchedulingConfig) {
         *self.scheduling_config.write().expect("poisoned") = config;
+    }
+}
+
+impl OrchestratorWorker {
+    fn spawn(self, name: String) -> AbortOnDropHandle<()> {
+        mz_ore::task::spawn(|| name, self.run()).abort_on_drop()
+    }
+
+    async fn run(mut self) {
+        while let Some(cmd) = self.command_rx.recv().await {
+            use WorkerCommand::*;
+            let result = match cmd {
+                EnsureService { desc } => self.ensure_service(desc).await,
+                DropService { name } => self.drop_service(&name).await,
+                ListServices {
+                    namespace,
+                    result_tx,
+                } => {
+                    let result = self.list_services(&namespace).await;
+                    let _ = result_tx.send(result);
+                    Ok(())
+                }
+                FetchServiceMetrics {
+                    name,
+                    info,
+                    result_tx,
+                } => {
+                    let result = self.fetch_service_metrics(&name, &info).await;
+                    let _ = result_tx.send(result);
+                    Ok(())
+                }
+            };
+
+            if let Err(error) = result {
+                panic!("kubernetes orchestrator worker failed: {error}");
+            }
+        }
+    }
+
+    async fn fetch_service_metrics(
+        &self,
+        name: &str,
+        info: &ServiceInfo,
+    ) -> Vec<ServiceProcessMetrics> {
+        /// Get metrics for a particular service and process, converting them into a sane (i.e., numeric) format.
+        ///
+        /// Note that we want to keep going even if a lookup fails for whatever reason,
+        /// so this function is infallible. If we fail to get cpu or memory for a particular pod,
+        /// we just log a warning and install `None` in the returned struct.
+        async fn get_metrics(
+            self_: &OrchestratorWorker,
+            service_name: &str,
+            i: usize,
+            disk: bool,
+            disk_limit: Option<DiskLimit>,
+        ) -> ServiceProcessMetrics {
+            let name = format!("{service_name}-{i}");
+
+            let disk_usage_fut = async {
+                if disk {
+                    Some(
+                        self_
+                            .custom_metrics_api
+                            .get_subresource(
+                                "kubelet_volume_stats_used_bytes",
+                                // The CSI provider we use sets up persistentvolumeclaim's
+                                // with `{pod name}-scratch` as the name. It also provides
+                                // the metrics, and does so under the `persistentvolumeclaims`
+                                // resource type, instead of `pods`.
+                                &format!("{name}-scratch"),
+                            )
+                            .await,
+                    )
+                } else {
+                    None
+                }
+            };
+            let disk_capacity_fut = async {
+                if disk {
+                    Some(
+                        self_
+                            .custom_metrics_api
+                            .get_subresource(
+                                "kubelet_volume_stats_capacity_bytes",
+                                &format!("{name}-scratch"),
+                            )
+                            .await,
+                    )
+                } else {
+                    None
+                }
+            };
+            let (metrics, disk_usage, disk_capacity) = match futures::future::join3(
+                self_.metrics_api.get(&name),
+                disk_usage_fut,
+                disk_capacity_fut,
+            )
+            .await
+            {
+                (Ok(metrics), disk_usage, disk_capacity) => {
+                    // TODO(guswynn): don't tolerate errors here, when we are more
+                    // comfortable with `prometheus-adapter` in production
+                    // (And we run it in ci).
+
+                    let disk_usage = match disk_usage {
+                        Some(Ok(disk_usage)) => Some(disk_usage),
+                        Some(Err(e)) if !matches!(&e, Error::Api(e) if e.code == 404) => {
+                            warn!(
+                                "Failed to fetch `kubelet_volume_stats_used_bytes` for {name}: {e}"
+                            );
+                            None
+                        }
+                        _ => None,
+                    };
+
+                    let disk_capacity = match disk_capacity {
+                        Some(Ok(disk_capacity)) => Some(disk_capacity),
+                        Some(Err(e)) if !matches!(&e, Error::Api(e) if e.code == 404) => {
+                            warn!("Failed to fetch `kubelet_volume_stats_capacity_bytes` for {name}: {e}");
+                            None
+                        }
+                        _ => None,
+                    };
+
+                    (metrics, disk_usage, disk_capacity)
+                }
+                (Err(e), _, _) => {
+                    warn!("Failed to get metrics for {name}: {e}");
+                    return ServiceProcessMetrics::default();
+                }
+            };
+            let Some(PodMetricsContainer {
+                usage:
+                    PodMetricsContainerUsage {
+                        cpu: Quantity(cpu_str),
+                        memory: Quantity(mem_str),
+                    },
+                ..
+            }) = metrics.containers.get(0)
+            else {
+                warn!("metrics result contained no containers for {name}");
+                return ServiceProcessMetrics::default();
+            };
+
+            let cpu = match parse_k8s_quantity(cpu_str) {
+                Ok(q) => match q.try_to_integer(-9, true) {
+                    Some(i) => Some(i),
+                    None => {
+                        tracing::error!("CPU value {q:? }out of range");
+                        None
+                    }
+                },
+                Err(e) => {
+                    tracing::error!("Failed to parse CPU value {cpu_str}: {e}");
+                    None
+                }
+            };
+            let memory = match parse_k8s_quantity(mem_str) {
+                Ok(q) => match q.try_to_integer(0, false) {
+                    Some(i) => Some(i),
+                    None => {
+                        tracing::error!("Memory value {q:?} out of range");
+                        None
+                    }
+                },
+                Err(e) => {
+                    tracing::error!("Failed to parse memory value {mem_str}: {e}");
+                    None
+                }
+            };
+
+            let disk_usage = match (disk_usage, disk_capacity) {
+                (Some(disk_usage_metrics), Some(disk_capacity_metrics)) => {
+                    if !disk_usage_metrics.items.is_empty()
+                        && !disk_capacity_metrics.items.is_empty()
+                    {
+                        let disk_usage_str = &*disk_usage_metrics.items[0].value.0;
+                        let disk_usage = match parse_k8s_quantity(disk_usage_str) {
+                            Ok(q) => match q.try_to_integer(0, true) {
+                                Some(i) => Some(i),
+                                None => {
+                                    tracing::error!("Disk usage value {q:?} out of range");
+                                    None
+                                }
+                            },
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to parse disk usage value {disk_usage_str}: {e}"
+                                );
+                                None
+                            }
+                        };
+                        let disk_capacity_str = &*disk_capacity_metrics.items[0].value.0;
+                        let disk_capacity = match parse_k8s_quantity(disk_capacity_str) {
+                            Ok(q) => match q.try_to_integer(0, true) {
+                                Some(i) => Some(i),
+                                None => {
+                                    tracing::error!("Disk capacity value {q:?} out of range");
+                                    None
+                                }
+                            },
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to parse disk capacity value {disk_capacity_str}: {e}"
+                                );
+                                None
+                            }
+                        };
+
+                        // We only populate a `disk_usage` if we have all 5 of of:
+                        // - a disk limit (so it must be an actual managed cluster with a real limit)
+                        // - a reported disk capacity
+                        // - a reported disk usage
+                        //
+                        // There are 3 weird cases we have to handle here:
+                        // - Some instance types report a large disk capacity than the requested
+                        // limit. We clamp those capacities to the limit, which means we can
+                        // report 100% usage even if we have a bit of space left.
+                        // - Other instances report a smaller disk capacity than the limit, due to
+                        // overheads. In this case, we correct the usage by adding the overhead, so
+                        // we report a more accurate usage number.
+                        // - The disk limit can be more up-to-date (from `service_infos`) than the
+                        // reported metric. In that case, we report the minimum of the usage
+                        // and the limit, which means we can report 100% usage temporarily
+                        // if a replica is sized down.
+                        match (disk_usage, disk_capacity, disk_limit) {
+                            (
+                                Some(disk_usage),
+                                Some(disk_capacity),
+                                Some(DiskLimit(disk_limit)),
+                            ) => {
+                                let disk_capacity = if disk_limit.0 < disk_capacity {
+                                    // We issue a debug message instead
+                                    // of a warning or error because all the
+                                    // above cases are relatively common.
+                                    tracing::debug!(
+                                        "disk capacity {} is larger than the disk limit {}; \
+                                        disk usage will indicate 100% full before the disk is truly full; \
+                                        as long as the delta is small this is not a cause for concern",
+                                        disk_capacity,
+                                        disk_limit.0
+                                    );
+                                    // Clamp to the limit.
+                                    disk_limit.0
+                                } else {
+                                    disk_capacity
+                                };
+
+                                // If we overflow, just clamp to the disk limit
+                                let disk_usage = (disk_limit.0 - disk_capacity)
+                                    .checked_add(disk_usage)
+                                    .unwrap_or(disk_limit.0);
+
+                                // Clamp to the limit. Note that this can be clamped during
+                                // replica resizes of if the disk usage is ABOVE the
+                                // configured limit, as may occur on some instances.
+                                Some(std::cmp::min(disk_usage, disk_limit.0))
+                            }
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+
+            ServiceProcessMetrics {
+                cpu_nano_cores: cpu,
+                memory_bytes: memory,
+                disk_usage_bytes: disk_usage,
+            }
+        }
+        let ret = futures::future::join_all(
+            (0..info.scale).map(|i| get_metrics(self, name, i.into(), info.disk, info.disk_limit)),
+        );
+
+        ret.await
+    }
+
+    async fn ensure_service(&self, desc: ServiceDescription) -> Result<(), anyhow::Error> {
+        self.service_api
+            .patch(
+                &desc.name,
+                &PatchParams::apply(FIELD_MANAGER).force(),
+                &Patch::Apply(desc.service),
+            )
+            .await?;
+        self.stateful_set_api
+            .patch(
+                &desc.name,
+                &PatchParams::apply(FIELD_MANAGER).force(),
+                &Patch::Apply(desc.stateful_set),
+            )
+            .await?;
+
+        // Explicitly delete any pods in the stateful set that don't match the
+        // template. In theory, Kubernetes would do this automatically, but
+        // in practice we have observed that it does not.
+        // See: https://github.com/kubernetes/kubernetes/issues/67250
+        for pod_id in 0..desc.scale {
+            let pod_name = format!("{}-{pod_id}", desc.name);
+            let pod = match self.pod_api.get(&pod_name).await {
+                Ok(pod) => pod,
+                // Pod already doesn't exist.
+                Err(kube::Error::Api(e)) if e.code == 404 => continue,
+                Err(e) => return Err(e.into()),
+            };
+            if pod.annotations().get(POD_TEMPLATE_HASH_ANNOTATION) != Some(&desc.pod_template_hash)
+            {
+                match self
+                    .pod_api
+                    .delete(&pod_name, &DeleteParams::default())
+                    .await
+                {
+                    Ok(_) => (),
+                    // Pod got deleted while we were looking at it.
+                    Err(kube::Error::Api(e)) if e.code == 404 => (),
+                    Err(e) => return Err(e.into()),
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn drop_service(&self, name: &str) -> Result<(), anyhow::Error> {
+        let res = self
+            .stateful_set_api
+            .delete(name, &DeleteParams::default())
+            .await;
+        match res {
+            Ok(_) => (),
+            Err(Error::Api(e)) if e.code == 404 => (),
+            Err(e) => return Err(e.into()),
+        }
+
+        let res = self
+            .service_api
+            .delete(name, &DeleteParams::default())
+            .await;
+        match res {
+            Ok(_) => Ok(()),
+            Err(Error::Api(e)) if e.code == 404 => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn list_services(&self, namespace: &str) -> Result<Vec<String>, anyhow::Error> {
+        let stateful_sets = self.stateful_set_api.list(&Default::default()).await?;
+        let name_prefix = format!("{namespace}-");
+        Ok(stateful_sets
+            .into_iter()
+            .filter_map(|ss| {
+                ss.metadata
+                    .name
+                    .unwrap()
+                    .strip_prefix(&name_prefix)
+                    .map(Into::into)
+            })
+            .collect())
     }
 }
 

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -48,7 +48,7 @@ use sysinfo::{Pid, PidExt, Process, ProcessExt, ProcessRefreshKind, System, Syst
 use tokio::fs::remove_dir_all;
 use tokio::net::{TcpListener, UnixStream};
 use tokio::process::{Child, Command};
-use tokio::sync::broadcast::{self, Sender};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::time::{self, Duration};
 use tokio::{fs, io, select};
 use tracing::{debug, error, info, warn};
@@ -254,47 +254,237 @@ impl ProcessOrchestrator {
 
 impl Orchestrator for ProcessOrchestrator {
     fn namespace(&self, namespace: &str) -> Arc<dyn NamespacedOrchestrator> {
-        let (service_event_tx, _) = broadcast::channel(16384);
         let mut namespaces = self.namespaces.lock().expect("lock poisoned");
         Arc::clone(namespaces.entry(namespace.into()).or_insert_with(|| {
-            Arc::new(NamespacedProcessOrchestrator {
+            let config = Arc::new(NamespacedProcessOrchestratorConfig {
                 namespace: namespace.into(),
                 image_dir: self.image_dir.clone(),
                 suppress_output: self.suppress_output,
                 metadata_dir: self.metadata_dir.clone(),
                 command_wrapper: self.command_wrapper.clone(),
-                services: Arc::new(Mutex::new(BTreeMap::new())),
-                service_event_tx,
-                system: Mutex::new(System::new()),
                 propagate_crashes: self.propagate_crashes,
                 tcp_proxy: self.tcp_proxy.clone(),
                 scratch_directory: self.scratch_directory.clone(),
                 launch_spec: self.launch_spec,
+            });
+
+            let services = Arc::new(Mutex::new(BTreeMap::new()));
+            let (service_event_tx, service_event_rx) = broadcast::channel(16384);
+            let (command_tx, command_rx) = mpsc::unbounded_channel();
+
+            let worker = OrchestratorWorker {
+                config: Arc::clone(&config),
+                services: Arc::clone(&services),
+                service_event_tx,
+                system: System::new(),
+                command_rx,
+            }
+            .spawn();
+
+            Arc::new(NamespacedProcessOrchestrator {
+                config,
+                services,
+                service_event_rx,
+                command_tx,
+                _worker: worker,
             })
         }))
     }
 }
 
+/// Configuration for a [`NamespacedProcessOrchestrator`].
 #[derive(Debug)]
-struct NamespacedProcessOrchestrator {
+struct NamespacedProcessOrchestratorConfig {
     namespace: String,
     image_dir: PathBuf,
     suppress_output: bool,
     metadata_dir: PathBuf,
     command_wrapper: Vec<String>,
-    services: Arc<Mutex<BTreeMap<String, Vec<ProcessState>>>>,
-    service_event_tx: Sender<ServiceEvent>,
-    system: Mutex<System>,
     propagate_crashes: bool,
     tcp_proxy: Option<ProcessOrchestratorTcpProxyConfig>,
     scratch_directory: PathBuf,
     launch_spec: LaunchSpec,
 }
 
+impl NamespacedProcessOrchestratorConfig {
+    fn full_id(&self, id: &str) -> String {
+        format!("{}-{}", self.namespace, id)
+    }
+
+    fn service_run_dir(&self, id: &str) -> PathBuf {
+        self.metadata_dir.join(&self.full_id(id))
+    }
+
+    fn service_scratch_dir(&self, id: &str) -> PathBuf {
+        self.scratch_directory.join(&self.full_id(id))
+    }
+}
+
+#[derive(Debug)]
+struct NamespacedProcessOrchestrator {
+    config: Arc<NamespacedProcessOrchestratorConfig>,
+    services: Arc<Mutex<BTreeMap<String, Vec<ProcessState>>>>,
+    service_event_rx: broadcast::Receiver<ServiceEvent>,
+    command_tx: mpsc::UnboundedSender<WorkerCommand>,
+    _worker: AbortOnDropHandle<()>,
+}
+
+impl NamespacedProcessOrchestrator {
+    fn send_command(&self, cmd: WorkerCommand) {
+        self.command_tx.send(cmd).expect("worker task not dropped");
+    }
+}
+
 #[async_trait]
 impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
+    fn ensure_service(
+        &self,
+        id: &str,
+        config: ServiceConfig,
+    ) -> Result<Box<dyn Service>, anyhow::Error> {
+        let service = ProcessService {
+            run_dir: self.config.service_run_dir(id),
+            scale: config.scale,
+        };
+
+        self.send_command(WorkerCommand::EnsureService {
+            id: id.to_string(),
+            config,
+        });
+
+        Ok(Box::new(service))
+    }
+
+    fn drop_service(&self, id: &str) -> Result<(), anyhow::Error> {
+        self.send_command(WorkerCommand::DropService { id: id.to_string() });
+        Ok(())
+    }
+
+    async fn list_services(&self) -> Result<Vec<String>, anyhow::Error> {
+        let (result_tx, result_rx) = oneshot::channel();
+        self.send_command(WorkerCommand::ListServices { result_tx });
+
+        result_rx.await.expect("worker task not dropped")
+    }
+
+    fn watch_services(&self) -> BoxStream<'static, Result<ServiceEvent, anyhow::Error>> {
+        let mut initial_events = vec![];
+        let mut service_event_rx = {
+            let services = self.services.lock().expect("lock poisoned");
+            for (service_id, process_states) in &*services {
+                for (process_id, process_state) in process_states.iter().enumerate() {
+                    initial_events.push(ServiceEvent {
+                        service_id: service_id.clone(),
+                        process_id: u64::cast_from(process_id),
+                        status: process_state.status.into(),
+                        time: process_state.status_time,
+                    });
+                }
+            }
+            self.service_event_rx.resubscribe()
+        };
+        Box::pin(stream! {
+            for event in initial_events {
+                yield Ok(event);
+            }
+            loop {
+                yield service_event_rx.recv().await.err_into();
+            }
+        })
+    }
+
     async fn fetch_service_metrics(
         &self,
+        id: &str,
+    ) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
+        let (result_tx, result_rx) = oneshot::channel();
+        self.send_command(WorkerCommand::FetchServiceMetrics {
+            id: id.to_string(),
+            result_tx,
+        });
+
+        result_rx.await.expect("worker task not dropped")
+    }
+
+    fn update_scheduling_config(
+        &self,
+        _config: mz_orchestrator::scheduling_config::ServiceSchedulingConfig,
+    ) {
+        // This orchestrator ignores scheduling constraints.
+    }
+}
+
+/// Commands sent from a [`NamespacedProcessOrchestrator`] to its
+/// [`OrchestratorWorker`].
+///
+/// Commands for which the caller expects a result include a `result_tx` on which the
+/// [`OrchestratorWorker`] will deliver the result.
+enum WorkerCommand {
+    EnsureService {
+        id: String,
+        config: ServiceConfig,
+    },
+    DropService {
+        id: String,
+    },
+    ListServices {
+        result_tx: oneshot::Sender<Result<Vec<String>, anyhow::Error>>,
+    },
+    FetchServiceMetrics {
+        id: String,
+        result_tx: oneshot::Sender<Result<Vec<ServiceProcessMetrics>, anyhow::Error>>,
+    },
+}
+
+/// A task executing blocking work for a [`NamespacedProcessOrchestrator`] in the background.
+///
+/// This type exists to enable making [`NamespacedProcessOrchestrator::ensure_service`] and
+/// [`NamespacedProcessOrchestrator::drop_service`] non-blocking, allowing invocation of these
+/// methods in latency-sensitive contexts.
+///
+/// Note that, apart from `ensure_service` and `drop_service`, this worker also handles blocking
+/// orchestrator calls that query service state (such as `list_services`). These need to be
+/// sequenced through the worker loop to ensure they linearize as expected. For example, we want to
+/// ensure that a `list_services` result contains exactly those services that were previously
+/// created with `ensure_service` and not yet dropped with `drop_service`.
+struct OrchestratorWorker {
+    config: Arc<NamespacedProcessOrchestratorConfig>,
+    services: Arc<Mutex<BTreeMap<String, Vec<ProcessState>>>>,
+    service_event_tx: broadcast::Sender<ServiceEvent>,
+    system: System,
+    command_rx: mpsc::UnboundedReceiver<WorkerCommand>,
+}
+
+impl OrchestratorWorker {
+    fn spawn(self) -> AbortOnDropHandle<()> {
+        let name = format!("process-orchestrator:{}", self.config.namespace);
+        mz_ore::task::spawn(|| name, self.run()).abort_on_drop()
+    }
+
+    async fn run(mut self) {
+        while let Some(cmd) = self.command_rx.recv().await {
+            use WorkerCommand::*;
+            let result = match cmd {
+                EnsureService { id, config } => self.ensure_service(id, config).await,
+                DropService { id } => self.drop_service(&id).await,
+                ListServices { result_tx } => {
+                    let _ = result_tx.send(self.list_services().await);
+                    Ok(())
+                }
+                FetchServiceMetrics { id, result_tx } => {
+                    let _ = result_tx.send(self.fetch_service_metrics(&id));
+                    Ok(())
+                }
+            };
+
+            if let Err(error) = result {
+                panic!("process orchestrator worker failed: {error}");
+            }
+        }
+    }
+
+    fn fetch_service_metrics(
+        &mut self,
         id: &str,
     ) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
         let pids: Vec<_> = {
@@ -305,14 +495,14 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             service.iter().map(|p| p.pid()).collect()
         };
 
-        let mut system = self.system.lock().expect("lock poisoned");
         let mut metrics = vec![];
         for pid in pids {
             let (cpu_nano_cores, memory_bytes) = match pid {
                 None => (None, None),
                 Some(pid) => {
-                    system.refresh_process_specifics(pid, ProcessRefreshKind::new().with_cpu());
-                    match system.process(pid) {
+                    self.system
+                        .refresh_process_specifics(pid, ProcessRefreshKind::new().with_cpu());
+                    match self.system.process(pid) {
                         None => (None, None),
                         Some(process) => {
                             // Justification for `unwrap`:
@@ -345,7 +535,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
 
     async fn ensure_service(
         &self,
-        id: &str,
+        id: String,
         ServiceConfig {
             image,
             init_container_image: _,
@@ -363,15 +553,15 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             disk_limit: _,
             node_selector: _,
         }: ServiceConfig,
-    ) -> Result<Box<dyn Service>, anyhow::Error> {
-        let full_id = format!("{}-{}", self.namespace, id);
+    ) -> Result<(), anyhow::Error> {
+        let full_id = self.config.full_id(&id);
 
-        let run_dir = self.metadata_dir.join(&full_id);
+        let run_dir = self.config.service_run_dir(&id);
         fs::create_dir_all(&run_dir)
             .await
             .context("creating run directory")?;
         let scratch_dir = if disk {
-            let scratch_dir = self.scratch_directory.join(&full_id);
+            let scratch_dir = self.config.service_scratch_dir(&id);
             fs::create_dir_all(&scratch_dir)
                 .await
                 .context("creating scratch directory")?;
@@ -382,7 +572,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
 
         {
             let mut services = self.services.lock().expect("lock poisoned");
-            let process_states = services.entry(id.to_string()).or_default();
+            let process_states = services.entry(id.clone()).or_default();
 
             // Create the state for new processes.
             let mut new_process_states = vec![];
@@ -391,7 +581,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                 let mut ports = vec![];
                 let mut tcp_proxy_addrs = BTreeMap::new();
                 for port in &ports_in {
-                    let tcp_proxy_listener = match &self.tcp_proxy {
+                    let tcp_proxy_listener = match &self.config.tcp_proxy {
                         None => None,
                         Some(tcp_proxy) => {
                             let listener = StdTcpListener::bind((tcp_proxy.listen_addr, 0))
@@ -426,7 +616,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                         memory_limit,
                         cpu_limit,
                         disk,
-                        launch_spec: self.launch_spec,
+                        launch_spec: self.config.launch_spec,
                     }),
                 );
 
@@ -447,13 +637,13 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
 
         self.maybe_write_prometheus_service_discovery_file().await;
 
-        Ok(Box::new(ProcessService { run_dir, scale }))
+        Ok(())
     }
 
     async fn drop_service(&self, id: &str) -> Result<(), anyhow::Error> {
-        let full_id = format!("{}-{}", self.namespace, id);
-        let run_dir = self.metadata_dir.join(&full_id);
-        let scratch_dir = self.scratch_directory.join(&full_id);
+        let full_id = self.config.full_id(id);
+        let run_dir = self.config.service_run_dir(id);
+        let scratch_dir = self.config.service_scratch_dir(id);
 
         // Drop the supervisor for the service, if it exists. If this service
         // was under supervision, this will kill all processes associated with
@@ -506,8 +696,8 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
 
     async fn list_services(&self) -> Result<Vec<String>, anyhow::Error> {
         let mut services = vec![];
-        let namespace_prefix = format!("{}-", self.namespace);
-        let mut entries = fs::read_dir(&self.metadata_dir).await?;
+        let namespace_prefix = format!("{}-", self.config.namespace);
+        let mut entries = fs::read_dir(&self.config.metadata_dir).await?;
         while let Some(entry) = entries.next_entry().await? {
             let filename = entry
                 .file_name()
@@ -520,41 +710,6 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
         Ok(services)
     }
 
-    fn watch_services(&self) -> BoxStream<'static, Result<ServiceEvent, anyhow::Error>> {
-        let mut initial_events = vec![];
-        let mut service_event_rx = {
-            let services = self.services.lock().expect("lock poisoned");
-            for (service_id, process_states) in &*services {
-                for (process_id, process_state) in process_states.iter().enumerate() {
-                    initial_events.push(ServiceEvent {
-                        service_id: service_id.clone(),
-                        process_id: u64::cast_from(process_id),
-                        status: process_state.status.into(),
-                        time: process_state.status_time,
-                    });
-                }
-            }
-            self.service_event_tx.subscribe()
-        };
-        Box::pin(stream! {
-            for event in initial_events {
-                yield Ok(event);
-            }
-            loop {
-                yield service_event_rx.recv().await.err_into();
-            }
-        })
-    }
-
-    fn update_scheduling_config(
-        &self,
-        _config: mz_orchestrator::scheduling_config::ServiceSchedulingConfig,
-    ) {
-        // This orchestrator ignores scheduling constraints.
-    }
-}
-
-impl NamespacedProcessOrchestrator {
     fn supervise_service_process(
         &self,
         ServiceProcessConfig {
@@ -571,15 +726,15 @@ impl NamespacedProcessOrchestrator {
             launch_spec,
         }: ServiceProcessConfig,
     ) -> impl Future<Output = ()> {
-        let suppress_output = self.suppress_output;
-        let propagate_crashes = self.propagate_crashes;
-        let command_wrapper = self.command_wrapper.clone();
-        let image = self.image_dir.join(image);
+        let suppress_output = self.config.suppress_output;
+        let propagate_crashes = self.config.propagate_crashes;
+        let command_wrapper = self.config.command_wrapper.clone();
+        let image = self.config.image_dir.join(image);
         let pid_file = run_dir.join(format!("{i}.pid"));
-        let full_id = format!("{}-{}", self.namespace, id);
+        let full_id = self.config.full_id(&id);
 
         let state_updater = ProcessStateUpdater {
-            namespace: self.namespace.clone(),
+            namespace: self.config.namespace.clone(),
             id,
             i,
             services: Arc::clone(&self.services),
@@ -674,7 +829,7 @@ impl NamespacedProcessOrchestrator {
             targets: Vec<String>,
         }
 
-        let Some(tcp_proxy) = &self.tcp_proxy else {
+        let Some(tcp_proxy) = &self.config.tcp_proxy else {
             return;
         };
         let Some(dir) = &tcp_proxy.prometheus_service_discovery_dir else {
@@ -688,7 +843,7 @@ impl NamespacedProcessOrchestrator {
                 for (i, state) in states.iter().enumerate() {
                     for (name, addr) in &state.tcp_proxy_addrs {
                         let mut labels = btreemap! {
-                            "mz_orchestrator_namespace".into() => self.namespace.clone(),
+                            "mz_orchestrator_namespace".into() => self.config.namespace.clone(),
                             "mz_orchestrator_service_id".into() => id.clone(),
                             "mz_orchestrator_port".into() => name.clone(),
                             "mz_orchestrator_ordinal".into() => i.to_string(),
@@ -706,12 +861,12 @@ impl NamespacedProcessOrchestrator {
             }
         }
 
-        let path = dir.join(Path::new(&self.namespace).with_extension("json"));
+        let path = dir.join(Path::new(&self.config.namespace).with_extension("json"));
         let contents = serde_json::to_vec_pretty(&static_configs).expect("valid json");
         if let Err(e) = fs::write(&path, &contents).await {
             warn!(
                 "{}: failed to write prometheus service discovery file: {}",
-                self.namespace,
+                self.config.namespace,
                 e.display_with_causes()
             );
         }
@@ -914,7 +1069,7 @@ struct ProcessStateUpdater {
     id: String,
     i: usize,
     services: Arc<Mutex<BTreeMap<String, Vec<ProcessState>>>>,
-    service_event_tx: Sender<ServiceEvent>,
+    service_event_tx: broadcast::Sender<ServiceEvent>,
 }
 
 impl ProcessStateUpdater {

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -362,7 +362,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             disk,
             disk_limit: _,
             node_selector: _,
-        }: ServiceConfig<'_>,
+        }: ServiceConfig,
     ) -> Result<Box<dyn Service>, anyhow::Error> {
         let full_id = format!("{}-{}", self.namespace, id);
 
@@ -421,7 +421,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                         scratch_dir: scratch_dir.clone(),
                         i,
                         image: image.clone(),
-                        args,
+                        args: &args,
                         ports,
                         memory_limit,
                         cpu_limit,

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -389,9 +389,11 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
     async fn ensure_service(
         &self,
         id: &str,
-        mut service_config: ServiceConfig<'_>,
+        mut service_config: ServiceConfig,
     ) -> Result<Box<dyn Service>, anyhow::Error> {
-        let args_fn = |listen_addrs: &BTreeMap<String, String>| {
+        let tracing_args = self.tracing_args.clone();
+        let log_prefix_arg = format!("{}-{}", self.namespace, id);
+        let args_fn = move |listen_addrs: &BTreeMap<String, String>| {
             #[cfg(feature = "tokio-console")]
             let tokio_console_listen_addr = listen_addrs.get("tokio-console");
             let mut args = (service_config.args)(listen_addrs);
@@ -419,11 +421,11 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
                 sentry_tag,
                 #[cfg(feature = "capture")]
                     capture: _,
-            } = &self.tracing_args;
+            } = &tracing_args;
             args.push(format!("--startup-log-filter={startup_log_filter}"));
             args.push(format!("--log-format={log_format}"));
             if log_prefix.is_some() {
-                args.push(format!("--log-prefix={}-{}", self.namespace, id));
+                args.push(format!("--log-prefix={log_prefix_arg}"));
             }
             if let Some(endpoint) = opentelemetry_endpoint {
                 args.push(format!("--opentelemetry-endpoint={endpoint}"));
@@ -487,7 +489,7 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
 
             args
         };
-        service_config.args = &args_fn;
+        service_config.args = Box::new(args_fn);
         #[cfg(feature = "tokio-console")]
         if self.tracing_args.tokio_console_listen_addr.is_some() {
             service_config.ports.push(ServicePort {

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -386,7 +386,7 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
         self.inner.fetch_service_metrics(id).await
     }
 
-    async fn ensure_service(
+    fn ensure_service(
         &self,
         id: &str,
         mut service_config: ServiceConfig,
@@ -497,11 +497,11 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
                 port_hint: 6669,
             });
         }
-        self.inner.ensure_service(id, service_config).await
+        self.inner.ensure_service(id, service_config)
     }
 
-    async fn drop_service(&self, id: &str) -> Result<(), anyhow::Error> {
-        self.inner.drop_service(id).await
+    fn drop_service(&self, id: &str) -> Result<(), anyhow::Error> {
+        self.inner.drop_service(id)
     }
 
     async fn list_services(&self) -> Result<Vec<String>, anyhow::Error> {

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -57,14 +57,14 @@ pub trait NamespacedOrchestrator: fmt::Debug + Send + Sync {
     /// If a service with the same ID already exists, its configuration is
     /// updated to match `config`. This may or may not involve restarting the
     /// service, depending on whether the existing service matches `config`.
-    async fn ensure_service(
+    fn ensure_service(
         &self,
         id: &str,
         config: ServiceConfig,
     ) -> Result<Box<dyn Service>, anyhow::Error>;
 
     /// Drops the identified service, if it exists.
-    async fn drop_service(&self, id: &str) -> Result<(), anyhow::Error>;
+    fn drop_service(&self, id: &str) -> Result<(), anyhow::Error>;
 
     /// Lists the identifiers of all known services.
     async fn list_services(&self) -> Result<Vec<String>, anyhow::Error>;

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -60,7 +60,7 @@ pub trait NamespacedOrchestrator: fmt::Debug + Send + Sync {
     async fn ensure_service(
         &self,
         id: &str,
-        config: ServiceConfig<'_>,
+        config: ServiceConfig,
     ) -> Result<Box<dyn Service>, anyhow::Error>;
 
     /// Drops the identified service, if it exists.
@@ -183,9 +183,9 @@ pub struct LabelSelector {
 }
 
 /// Describes the desired state of a service.
-#[derive(Derivative, Clone)]
+#[derive(Derivative)]
 #[derivative(Debug)]
-pub struct ServiceConfig<'a> {
+pub struct ServiceConfig {
     /// An opaque identifier for the executable or container image to run.
     ///
     /// Often names a container on Docker Hub or a path on the local machine.
@@ -196,7 +196,7 @@ pub struct ServiceConfig<'a> {
     /// A function that generates the arguments for each process of the service
     /// given the assigned listen addresses for each named port.
     #[derivative(Debug = "ignore")]
-    pub args: &'a (dyn Fn(&BTreeMap<String, String>) -> Vec<String> + Send + Sync),
+    pub args: Box<dyn Fn(&BTreeMap<String, String>) -> Vec<String> + Send + Sync>,
     /// Ports to expose.
     pub ports: Vec<ServicePort>,
     /// An optional limit on the memory that the service can use.


### PR DESCRIPTION
This PR makes the `ensure_service` and `drop_service` orchestrator calls non-async and non-blocking. It achieves that by introducing an orchestrator task that runs in the background and asynchronously handles requests for creating and removing services.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/17414
Fixes #24813

### Tips for reviewer

The diff is unfortunately pretty gnarly, particularly in the second commit. I recommend reviewing with whitespace ignored. The changes to `mz-orchestrator-kubernetes` are actually not that bad, mostly splitting the implementations of the `NamespacedOrchestrator` methods in two and moving parts down into the `OrchestratorWorker`. But somehow the Github diff gets utterly confused about the movement of `get_metrics` and produces a huge change as a result. Git on the CLI handles this better for me.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
