### PR TITLE
miri test: Ignore test_trigger_channel test

### DIFF
--- a/src/ore/src/channel/trigger.rs
+++ b/src/ore/src/channel/trigger.rs
@@ -105,6 +105,7 @@ pub fn channel() -> (Trigger, Receiver) {
 mod tests {
     use crate::channel::trigger;
 
+    #[cfg_attr(miri, ignore)] // error: unsupported operation: returning ready events from epoll_wait is not yet implemented
     #[mz_ore::test(tokio::test)]
     async fn test_trigger_channel() {
         let (trigger1, mut trigger1_rx) = trigger::channel();


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/8234#01905450-71cd-445f-9ae3-5e39e9d27122

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
