### PR TITLE
rust: Upgrade `kube`, `k8s-openapi`, `tokio`, and `openssl`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8799,6 +8799,7 @@ version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,23 +370,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -461,7 +474,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 0.2.9",
- "hyper",
+ "hyper 0.14.27",
  "ring",
  "time",
  "tokio",
@@ -754,7 +767,7 @@ dependencies = [
  "http 0.2.9",
  "http-body 0.4.5",
  "http-body 1.0.0",
- "hyper",
+ "hyper 0.14.27",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -844,7 +857,7 @@ dependencies = [
  "headers",
  "http 0.2.9",
  "http-body 0.4.5",
- "hyper",
+ "hyper 0.14.27",
  "itoa",
  "matchit",
  "memchr",
@@ -859,7 +872,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1432,6 +1445,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "connection-string"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,13 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.7"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
-dependencies = [
- "cfg-if",
- "lazy_static",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -2274,13 +2292,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eventsource-client"
 version = "0.11.0"
 source = "git+https://github.com/MaterializeInc/rust-eventsource-client#fb749fde693a9757289238ee71d4e9b3590fb24b"
 dependencies = [
  "futures",
- "hyper",
- "hyper-timeout",
+ "hyper 0.14.27",
+ "hyper-timeout 0.4.1",
  "hyper-tls",
  "log",
  "pin-project",
@@ -2405,6 +2444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2881,12 +2929,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -2941,13 +2989,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-openssl"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
 dependencies = [
  "http 0.2.9",
- "hyper",
+ "hyper 0.14.27",
  "linked_hash_set",
  "once_cell",
  "openssl",
@@ -2959,15 +3026,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-openssl"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527d4d619ca2c2aafa31ec139a3d1d60bf557bf7578a1f20f743637eccd9ca19"
+dependencies = [
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "linked_hash_set",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "parking_lot",
+ "pin-project",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.27",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.3.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2977,10 +3076,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.27",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2 0.5.7",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3175,23 +3294,38 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f54898088ccb91df1b492cc80029a6fdf1c48ca0db7c6822a8babad69c94658"
+checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
 dependencies = [
+ "jsonptr",
  "serde",
  "serde_json",
  "thiserror",
- "treediff",
 ]
 
 [[package]]
-name = "jsonpath_lib"
-version = "0.3.0"
+name = "jsonpath-rust"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
 dependencies = [
- "log",
+ "lazy_static",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+dependencies = [
+ "fluent-uri",
  "serde",
  "serde_json",
 ]
@@ -3225,12 +3359,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3606fd16aca7989db2f84bb25684d0270c6d6fa1dbcd0025af7b4130523a6"
+checksum = "19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755"
 dependencies = [
- "base64 0.21.5",
- "bytes",
+ "base64 0.22.0",
  "chrono",
  "schemars",
  "serde",
@@ -3249,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.87.1"
+version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34392aea935145070dcd5b39a6dea689ac6534d7d117461316c3d157b1d0fc3"
+checksum = "231c5a5392d9e2a9b0d923199760d3f1dd73b95288f2871d16c7c90ba4954506"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -3262,27 +3395,28 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.87.1"
+version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7266548b9269d9fa19022620d706697e64f312fb2ba31b93e6986453fcc82c92"
+checksum = "8f4bf54135062ff60e2a0dfb3e7a9c8e931fc4a535b4d6bd561e0a1371321c61"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.22.0",
  "bytes",
  "chrono",
  "either",
  "futures",
  "home",
- "http 0.2.9",
- "http-body 0.4.5",
- "hyper",
- "hyper-openssl",
- "hyper-timeout",
- "jsonpath_lib",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-openssl 0.10.2",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "openssl",
  "pem",
- "pin-project",
  "rand",
  "secrecy",
  "serde",
@@ -3290,25 +3424,24 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.23.1",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.5.2",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
-version = "0.87.1"
+version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8321c315b96b59f59ef6b33f604b84b905ab8f9ff114a4f909d934c520227b1"
+checksum = "40fb9bd8141cbc0fe6b0d9112d371679b4cb607b45c31dd68d92e40864a12975"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http 0.2.9",
+ "http 1.1.0",
  "json-patch",
  "k8s-openapi",
- "once_cell",
  "schemars",
  "serde",
  "serde_json",
@@ -3317,9 +3450,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.87.1"
+version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54591e1f37fc329d412c0fdaced010cc1305b546a39f283fc51700f8fb49421"
+checksum = "08fc86f70076921fdf2f433bbd2a796dc08ac537dc1db1f062cfa63ed4fa15fb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3330,24 +3463,26 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.87.1"
+version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e511e2c1a368d9d4bf6e70db58197e535d818df355b5a2007a8aeb17a370a8ba"
+checksum = "b7eb2fb986f81770eb55ec7f857e197019b31b38768d2410f6c1046ffac34225"
 dependencies = [
  "ahash",
+ "async-broadcast",
+ "async-stream",
  "async-trait",
  "backoff",
  "derivative",
  "futures",
  "hashbrown 0.14.5",
  "json-patch",
+ "jsonptr",
  "k8s-openapi",
  "kube-client",
  "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
- "smallvec",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -3365,7 +3500,7 @@ dependencies = [
  "data-encoding",
  "eventsource-client",
  "futures",
- "hyper",
+ "hyper 0.14.27",
  "hyper-tls",
  "launchdarkly-server-sdk-evaluation",
  "lazy_static",
@@ -3807,7 +3942,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "socket2 0.5.3",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tokio-native-tls",
@@ -3861,7 +3996,7 @@ dependencies = [
  "clap",
  "csv",
  "dirs",
- "hyper",
+ "hyper 0.14.27",
  "indicatif",
  "maplit",
  "mz-build-info",
@@ -4123,8 +4258,8 @@ dependencies = [
  "clap",
  "domain",
  "futures",
- "hyper",
- "hyper-openssl",
+ "hyper 0.14.27",
+ "hyper-openssl 0.9.2",
  "jsonwebtoken",
  "mz-build-info",
  "mz-environmentd",
@@ -4269,7 +4404,7 @@ name = "mz-ccsr"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "hyper",
+ "hyper 0.14.27",
  "mz-build-tools",
  "mz-ore",
  "mz-tls-util",
@@ -4655,8 +4790,8 @@ dependencies = [
  "http 0.2.9",
  "http-body 0.4.5",
  "humantime",
- "hyper",
- "hyper-openssl",
+ "hyper 0.14.27",
+ "hyper-openssl 0.9.2",
  "hyper-tls",
  "include_dir",
  "insta",
@@ -4742,13 +4877,13 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "tower",
- "tower-http",
+ "tower-http 0.4.3",
  "tracing",
  "tracing-capture",
  "tracing-core",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "tungstenite",
+ "tungstenite 0.20.1",
  "url",
  "uuid",
  "workspace-hack",
@@ -4866,7 +5001,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "socket2 0.5.3",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tokio-postgres",
@@ -4932,7 +5067,7 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
- "hyper",
+ "hyper 0.14.27",
  "jsonwebtoken",
  "mz-frontegg-auth",
  "mz-ore",
@@ -4952,7 +5087,7 @@ dependencies = [
  "axum",
  "headers",
  "http 0.2.9",
- "hyper",
+ "hyper 0.14.27",
  "include_dir",
  "mz-ore",
  "prometheus",
@@ -4960,7 +5095,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.4.3",
  "tracing",
  "tracing-subscriber",
  "workspace-hack",
@@ -5268,7 +5403,7 @@ dependencies = [
  "futures",
  "hibitset",
  "http 0.2.9",
- "hyper",
+ "hyper 0.14.27",
  "hyper-tls",
  "lgalloc",
  "libc",
@@ -5903,7 +6038,7 @@ dependencies = [
  "futures",
  "mz-ore",
  "openssl",
- "socket2 0.5.3",
+ "socket2 0.5.7",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6122,7 +6257,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-stream",
- "tower-http",
+ "tower-http 0.4.3",
  "tracing",
  "uuid",
  "walkdir",
@@ -6957,11 +7092,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.55"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -6989,18 +7124,18 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.28.1+1.1.1w"
+version = "300.3.1+3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf7e82ffd6d3d6e6524216a0bfd85509f68b5b28354e8e7800057e44cefa9b4"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.90"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -7159,6 +7294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7293,6 +7434,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7343,22 +7529,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -8066,7 +8252,7 @@ dependencies = [
  "h2",
  "http 0.2.9",
  "http-body 0.4.5",
- "hyper",
+ "hyper 0.14.27",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -8117,7 +8303,7 @@ dependencies = [
  "chrono",
  "futures",
  "http 0.2.9",
- "hyper",
+ "hyper 0.14.27",
  "reqwest",
  "reqwest-middleware",
  "retry-policies",
@@ -8613,7 +8799,6 @@ version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
- "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -8876,12 +9061,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9216,18 +9401,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9428,9 +9613,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -9440,7 +9625,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.7",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -9467,9 +9652,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9478,9 +9663,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-metrics"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b2fc67d5dec41db679b9b052eb572269616926040b7831e32c8a152df77b84"
+checksum = "eace09241d62c98b7eeb1107d4c5c64ca3bd7da92e8c218c153ab3a78f9be112"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -9540,7 +9725,7 @@ dependencies = [
  "postgres-types",
  "rand",
  "serde",
- "socket2 0.5.3",
+ "socket2 0.5.7",
  "tokio",
  "tokio-util",
 ]
@@ -9572,14 +9757,26 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.20.1",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.23.0",
 ]
 
 [[package]]
@@ -9659,8 +9856,8 @@ dependencies = [
  "h2",
  "http 0.2.9",
  "http-body 0.4.5",
- "hyper",
- "hyper-timeout",
+ "hyper 0.14.27",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost",
@@ -9721,6 +9918,25 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "base64 0.21.5",
+ "bitflags 2.4.1",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9889,15 +10105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "treediff"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
-dependencies = [
- "serde_json",
-]
-
-[[package]]
 name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9935,6 +10142,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9967,6 +10192,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "uname"
@@ -10343,6 +10574,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10553,6 +10793,7 @@ dependencies = [
  "digest",
  "either",
  "flate2",
+ "futures",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -10563,7 +10804,7 @@ dependencies = [
  "getrandom",
  "globset",
  "hashbrown 0.14.5",
- "hyper",
+ "hyper 0.14.27",
  "indexmap 1.9.1",
  "insta",
  "itertools 0.10.5",
@@ -10622,7 +10863,7 @@ dependencies = [
  "sha2",
  "similar",
  "smallvec",
- "socket2 0.5.3",
+ "socket2 0.5.7",
  "subtle",
  "syn 1.0.107",
  "syn 2.0.63",
@@ -10636,11 +10877,10 @@ dependencies = [
  "toml_datetime",
  "tonic",
  "tower",
- "tower-http",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
- "tungstenite",
+ "tungstenite 0.20.1",
  "twox-hash",
  "uncased",
  "unicode-bidi",

--- a/deny.toml
+++ b/deny.toml
@@ -97,6 +97,28 @@ skip = [
     # A few crates -> `num_enum_derive` -> `proc-macro-crate` -> `toml_edit v0.19.14`.
     { name = "toml_edit", version = "0.19.14" },
     { name = "toml_edit", version = "0.20.2" },
+
+    # `tonic` has yet to upgrade to `hyper 1.*`, but it is close! Until then
+    # we'll need to duplicate some related hyper deps.
+    #
+    # See: <https://github.com/hyperium/tonic/pull/1740>
+    { name = "hyper", version = "0.14.27" },
+    { name = "hyper", version = "1.3.1" },
+
+    { name = "hyper-openssl", version = "0.9.2" },
+    { name = "hyper-openssl", version = "0.10.2" },
+
+    { name = "hyper-timeout", version = "0.4.1" },
+    { name = "hyper-timeout", version = "0.5.1" },
+
+    { name = "tokio-tungstenite", version = "0.20.1" },
+    { name = "tokio-tungstenite", version = "0.23.1" },
+
+    { name = "tungstenite", version = "0.20.1" },
+    { name = "tungstenite", version = "0.23.0" },
+
+    { name = "tower-http", version = "0.4.3" },
+    { name = "tower-http", version = "0.5.2" },
 ]
 
 # Use `tracing` instead.
@@ -131,7 +153,6 @@ wrappers = [
     "eventsource-client",
     "fail",
     "globset",
-    "jsonpath_lib",
     "launchdarkly-server-sdk",
     "launchdarkly-server-sdk-evaluation",
     "mio",
@@ -168,10 +189,10 @@ wrappers = [
   "bstr",
   "console",
   "criterion",
-  "crossbeam-utils",
   "dynfmt",
   "findshlibs",
   "insta",
+  "jsonpath-rust",
   "launchdarkly-server-sdk",
   "launchdarkly-server-sdk-evaluation",
   "mysql_async",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -96,6 +96,26 @@ who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.2.1"
 
+[[audits.async-broadcast]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+
+[[audits.async-broadcast]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+
+[[audits.async-stream]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.5"
+
+[[audits.async-stream-impl]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.5"
+
 [[audits.atoi]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
@@ -176,6 +196,11 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 version = "0.1.50"
 
+[[audits.concurrent-queue]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.5.0"
+
 [[audits.convert_case]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
@@ -185,6 +210,11 @@ version = "0.6.0"
 who = "Jan Teske <jteske@posteo.net>"
 criteria = "safe-to-deploy"
 version = "0.8.0"
+
+[[audits.crossbeam-utils]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.8.20"
 
 [[audits.csv-async]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"
@@ -228,6 +258,16 @@ who = "Sean Loiselle <sean@materialize.io>"
 criteria = "safe-to-deploy"
 version = "0.3.26"
 
+[[audits.event-listener]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "5.3.1"
+
+[[audits.event-listener-strategy]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.2"
+
 [[audits.fixedbitset]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
@@ -242,6 +282,11 @@ version = "23.5.26"
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.4.1"
+
+[[audits.fluent-uri]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.4"
 
 [[audits.funty]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
@@ -283,6 +328,31 @@ who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.6.4"
 
+[[audits.http-body-util]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+
+[[audits.hyper]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.3.1"
+
+[[audits.hyper-openssl]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.10.2"
+
+[[audits.hyper-timeout]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.1"
+
+[[audits.hyper-util]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.5"
+
 [[audits.id-arena]]
 who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
@@ -298,10 +368,60 @@ who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "3.0.4"
 
+[[audits.json-patch]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0"
+
+[[audits.jsonpath-rust]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.1"
+
+[[audits.jsonpath-rust]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.1"
+
+[[audits.jsonptr]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.4.7"
+
 [[audits.jsonwebtoken]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 delta = "8.3.0 -> 9.2.0"
+
+[[audits.k8s-openapi]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.22.0"
+
+[[audits.kube]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.92.1"
+
+[[audits.kube-client]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.92.1"
+
+[[audits.kube-core]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.92.1"
+
+[[audits.kube-derive]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.92.1"
+
+[[audits.kube-runtime]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.92.1"
 
 [[audits.launchdarkly-server-sdk]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"
@@ -418,6 +538,21 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 delta = "1.17.1 -> 1.19.0"
 
+[[audits.openssl]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.10.64"
+
+[[audits.openssl-src]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "300.3.1+3.3.1"
+
+[[audits.openssl-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.9.102"
+
 [[audits.opentelemetry]]
 who = "Gus Wynn <gus@materialize.com>"
 criteria = "maintained-and-necessary"
@@ -453,15 +588,50 @@ who = "Gus Wynn <gus@materialize.com>"
 criteria = "maintained-and-necessary"
 version = "4.2.0"
 
+[[audits.parking]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.2.0"
+
 [[audits.parquet]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "51.0.0"
 
+[[audits.pest]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.7.10"
+
+[[audits.pest_derive]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.7.10"
+
+[[audits.pest_generator]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.7.10"
+
+[[audits.pest_meta]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.7.10"
+
 [[audits.petgraph]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.6.5"
+
+[[audits.pin-project]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.1.5"
+
+[[audits.pin-project-internal]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.1.5"
 
 [[audits.postgres]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
@@ -638,6 +808,11 @@ who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "1.13.2"
 
+[[audits.socket2]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.7"
+
 [[audits.spin]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
@@ -683,6 +858,16 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
 delta = "3.8.0 -> 3.8.1"
 
+[[audits.thiserror]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.61"
+
+[[audits.thiserror-impl]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.61"
+
 [[audits.thrift]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
@@ -708,6 +893,21 @@ who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.12.0@git:0c26e5e4198085d6c90db11930f2dba52e9f32cc"
 
+[[audits.tokio]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.38.0"
+
+[[audits.tokio-macros]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.3.0"
+
+[[audits.tokio-metrics]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+
 [[audits.tokio-postgres]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
@@ -722,6 +922,21 @@ version = "0.7.8@git:02336bebb28507665184c21566e5d1dc8de1dd7d"
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.7.8@git:91522e47643ebb6d6a5e392957b2319e5bb522ad"
+
+[[audits.tokio-tungstenite]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.20.1"
+
+[[audits.tokio-tungstenite]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.23.1"
+
+[[audits.tower-http]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.2"
 
 [[audits.tracing-capture]]
 who = "Matt Jibson <matt.jibson@gmail.com>"
@@ -758,6 +973,16 @@ who = "Matt Jibson <matt.jibson@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.1.0"
 
+[[audits.tungstenite]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.23.0"
+
+[[audits.ucd-trie]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.6"
+
 [[audits.untrusted]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "maintained-and-necessary"
@@ -772,6 +997,16 @@ version = "1.7.0"
 who = "Gus Wynn <gus@materialize.com>"
 criteria = "maintained-and-necessary"
 version = "0.2.4"
+
+[[audits.windows-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.52.0"
+
+[[audits.windows-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.52.0"
 
 [[audits.windows-targets]]
 who = "Roshan Jobanputra <roshan@materialize.com>"

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -146,14 +146,6 @@ criteria = "safe-to-deploy"
 version = "0.4.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.async-stream]]
-version = "0.3.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.async-stream-impl]]
-version = "0.3.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.asynchronous-codec]]
 version = "0.6.0"
 criteria = "safe-to-deploy"
@@ -336,10 +328,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-queue]]
 version = "0.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.crossbeam-utils]]
-version = "0.8.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.crunchy]]
@@ -634,10 +622,6 @@ criteria = "safe-to-deploy"
 version = "0.4.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.http-body-util]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.http-range-header]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
@@ -682,10 +666,6 @@ criteria = "safe-to-deploy"
 version = "0.10.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.json-patch]]
-version = "1.0.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.jsonpath_lib]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
@@ -694,32 +674,8 @@ criteria = "safe-to-deploy"
 version = "0.8.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.k8s-openapi]]
-version = "0.20.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.keyed_priority_queue]]
 version = "0.4.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.kube]]
-version = "0.87.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.kube-client]]
-version = "0.87.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.kube-core]]
-version = "0.87.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.kube-derive]]
-version = "0.87.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.kube-runtime]]
-version = "0.87.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.launchdarkly-server-sdk-evaluation]]
@@ -870,16 +826,8 @@ criteria = "safe-to-deploy"
 version = "0.15.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.openssl]]
-version = "0.10.55"
-criteria = "safe-to-deploy"
-
 [[exemptions.openssl-probe]]
 version = "0.1.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.openssl-sys]]
-version = "0.9.90"
 criteria = "safe-to-deploy"
 
 [[exemptions.option-ext]]
@@ -956,14 +904,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.phf_shared]]
 version = "0.11.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.pin-project]]
-version = "1.0.12"
-criteria = "safe-to-deploy"
-
-[[exemptions.pin-project-internal]]
-version = "1.0.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.pkg-config]]
@@ -1314,10 +1254,6 @@ criteria = "safe-to-deploy"
 version = "0.4.9"
 criteria = "safe-to-deploy"
 
-[[exemptions.socket2]]
-version = "0.5.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.spin]]
 version = "0.5.2"
 criteria = "safe-to-deploy"
@@ -1430,20 +1366,12 @@ criteria = "safe-to-deploy"
 version = "1.1.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.tokio]]
-version = "1.32.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.tokio-io-timeout]]
 version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-io-utility]]
 version = "0.7.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.tokio-metrics]]
-version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-native-tls]]
@@ -1456,10 +1384,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tokio-pipe]]
 version = "0.2.12"
-criteria = "safe-to-deploy"
-
-[[exemptions.tokio-tungstenite]]
-version = "0.20.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tonic]]

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -413,6 +413,13 @@ user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
+[[publisher.hyper]]
+version = "1.3.1"
+when = "2024-04-16"
+user-id = 359
+user-login = "seanmonstar"
+user-name = "Sean McArthur"
+
 [[publisher.hyper-tls]]
 version = "0.5.0"
 when = "2020-12-29"
@@ -520,6 +527,13 @@ user-name = "Sean McArthur"
 [[publisher.openssl-src]]
 version = "111.28.1+1.1.1w"
 when = "2023-12-11"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.openssl-src]]
+version = "300.3.1+3.3.1"
+when = "2024-06-04"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -793,6 +807,13 @@ user-name = "Andrew Gallant"
 [[publisher.tokio-macros]]
 version = "1.7.0"
 when = "2021-12-15"
+user-id = 10
+user-login = "carllerche"
+user-name = "Carl Lerche"
+
+[[publisher.tokio-macros]]
+version = "2.3.0"
+when = "2024-05-30"
 user-id = 10
 user-login = "carllerche"
 user-name = "Carl Lerche"
@@ -1441,6 +1462,34 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 version = "0.4.5"
 notes = "No unsafe usage or ambient capabilities"
+
+[[audits.google.audits.async-stream]]
+who = "Tyler Mandry <tmandry@google.com>"
+criteria = "safe-to-deploy"
+version = "0.3.4"
+notes = "Reviewed on https://fxrev.dev/761470"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.async-stream]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.3.5"
+notes = "Reviewed on https://fxrev.dev/906795"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.async-stream-impl]]
+who = "Tyler Mandry <tmandry@google.com>"
+criteria = "safe-to-deploy"
+version = "0.3.4"
+notes = "Reviewed on https://fxrev.dev/761470"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.async-stream-impl]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.3.5"
+notes = "Reviewed on https://fxrev.dev/906795"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.base64]]
 who = "Adam Langley <agl@chromium.org>"

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -95,7 +95,7 @@ static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = [
     "bincode",
 ] }
-tokio = { version = "1.32.0", features = ["rt", "time"] }
+tokio = { version = "1.38.0", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.11"
 tracing = "0.1.37"

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -22,7 +22,7 @@ http = "0.2.8"
 hyper-tls = { version = "0.5.0" }
 mz-ore = { path = "../ore", default-features = false }
 thiserror = "1.0.37"
-tokio = { version = "1.32.0", default-features = false, features = ["macros"] }
+tokio = { version = "1.38.0", default-features = false, features = ["macros"] }
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -32,7 +32,7 @@ num_cpus = "1.14.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
 prometheus = { version = "0.13.3", default-features = false }
 semver = "1.0.16"
-tokio = { version = "1.24.2", default-features = false }
+tokio = { version = "1.38.0", default-features = false }
 tokio-openssl = "0.6.3"
 tokio-postgres = { version = "0.7.8" }
 tokio-util = { version = "0.7.4", features = ["codec"] }

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -26,7 +26,7 @@ mz-sql = { path = "../sql" }
 once_cell = "1.16.0"
 serde = "1.0.152"
 serde_json = "1.0.89"
-tokio = "1.32.0"
+tokio = "1.38.0"
 tokio-postgres = { version = "0.7.8", features = ["with-serde_json-1"] }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -67,7 +67,7 @@ insta = "1.32"
 mz-postgres-util = { path = "../postgres-util" }
 rand = "0.8.5"
 similar-asserts = "1.4"
-tokio = { version = "1.32.0" }
+tokio = { version = "1.38.0" }
 tokio-postgres = { version = "0.7.8" }
 
 [build-dependencies]

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -31,7 +31,7 @@ hyper = { version = "0.14.23", features = ["server"] }
 once_cell = "1.16.0"
 mz-ore = { path = "../ore", features = ["async", "test"] }
 serde_json = "1.0.89"
-tokio = { version = "1.32.0", features = ["macros"] }
+tokio = { version = "1.38.0", features = ["macros"] }
 tracing = "0.1.37"
 
 [build-dependencies]

--- a/src/cloud-api/Cargo.toml
+++ b/src/cloud-api/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = "1.16.0"
 serde = { version = "1.0.130", features = ["derive"] }
 url = "2.2.2"
 thiserror = "1.0.37"
-tokio = "1.32.0"
+tokio = "1.38.0"
 mz-frontegg-client = { path = "../frontegg-client" }
 mz-frontegg-auth = { path = "../frontegg-auth" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -12,8 +12,8 @@ workspace = true
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.68"
-k8s-openapi = { version = "0.20.0", features = ["schemars", "v1_28"] }
-kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "ws"] }
+k8s-openapi = { version = "0.22.0", features = ["schemars", "v1_28"] }
+kube = { version = "0.92.1", default-features = false, features = ["client", "derive", "openssl-tls", "ws"] }
 chrono = { version = "0.4.35", default-features = false }
 futures = "0.3.25"
 mz-ore = { path = "../ore", features = [] }

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
-tokio = "1.32.0"
+tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.9.2"
 tracing = "0.1.37"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -35,7 +35,7 @@ scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "net"] }
+tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -37,7 +37,7 @@ mz-timely-util = { path = "../timely-util" }
 mz-txn-wal = { path = "../txn-wal" }
 once_cell = { version = "1.16.0" }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "test-util"] }
+tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -48,7 +48,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = "1.32.0"
+tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.9.2"
 tracing = "0.1.37"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -45,7 +45,7 @@ scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "net"] }
+tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -35,7 +35,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = "1.32.0"
+tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tracing = "0.1.37"
 uuid = { version = "1.7.0" }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -102,7 +102,7 @@ shell-words = "1.1.0"
 sysctl = "0.5.4"
 tempfile = "3.8.1"
 thiserror = "1.0.37"
-tokio = { version = "1.32.0", features = ["sync"] }
+tokio = { version = "1.38.0", features = ["sync"] }
 tokio-openssl = "0.6.3"
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = { version = "0.1.11", features = ["net"] }

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -125,9 +125,10 @@ enum TestCase<'a> {
 
 fn assert_http_rejected() -> Assert<Box<dyn Fn(Option<StatusCode>, String)>> {
     Assert::Err(Box::new(|code, message| {
-        const ALLOWED_MESSAGES: [&str; 2] = [
+        const ALLOWED_MESSAGES: [&str; 3] = [
             "Connection reset by peer",
             "connection closed before message completed",
+            "invalid HTTP version parsed",
         ];
         assert_eq!(code, None);
         if !ALLOWED_MESSAGES
@@ -1286,7 +1287,7 @@ async fn test_auth_base_disable_tls() {
                     // a graceful error message. This could plausibly change
                     // due to OpenSSL or Hyper refactorings.
                     assert!(code.is_none());
-                    assert_contains!(message, "ssl3_get_record:wrong version number");
+                    assert_contains!(message, "packet length too long");
                 })),
             },
             // System user cannot login via external ports.

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -30,7 +30,7 @@ sha2 = "0.10.6"
 socket2 = "0.5.3"
 thiserror = "1.0.37"
 tonic = { version = "0.9.2", features = ["gzip"] }
-tokio = { version = "1.32.0", features = ["rt"] }
+tokio = { version = "1.38.0", features = ["rt"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tokio-util = { version = "0.7.4", features = ["io"] }

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -26,7 +26,7 @@ reqwest-retry = "0.2.2"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
-tokio = { version = "1.32.0", features = ["macros"] }
+tokio = { version = "1.38.0", features = ["macros"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
@@ -34,7 +34,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [dev-dependencies]
 axum = "0.6.20"
 mz-ore = { path = "../ore", features = ["network", "test"] }
-tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/frontegg-client/Cargo.toml
+++ b/src/frontegg-client/Cargo.toml
@@ -17,7 +17,7 @@ reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.152", features = ["derive"] }
 once_cell = "1.16.0"
 thiserror = "1.0.37"
-tokio = { version = "1.32.0", features = ["macros"] }
+tokio = { version = "1.38.0", features = ["macros"] }
 serde_json = "1.0.89"
 uuid = { version = "1.7.0", features = ["serde"] }
 url = "2.3.1"

--- a/src/frontegg-mock/Cargo.toml
+++ b/src/frontegg-mock/Cargo.toml
@@ -19,7 +19,7 @@ mz-frontegg-auth = { path = "../frontegg-auth" }
 mz-ore = { path = "../ore", default-features = false, features = ["cli"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
-tokio = { version = "1.24.2", default-features = false }
+tokio = { version = "1.38.0", default-features = false }
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -21,7 +21,7 @@ mz-ore = { path = "../ore", default-features = false, features = ["metrics", "tr
 prometheus = { version = "0.13.3", default-features = false }
 serde = "1.0.152"
 serde_json = { version = "1.0.89" }
-tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "retry", "timeout", "util"] }
 tower-http = { version = "0.4.2", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = "0.1.37"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -32,14 +32,14 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 prost-reflect = "0.11.4"
 serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.32.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.38.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }
-tokio = { version = "1.32.0", features = ["macros"] }
+tokio = { version = "1.38.0", features = ["macros"] }
 
 [build-dependencies]
 mz-build-tools = { path = "../build-tools", default-features = false }

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.8.5"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
-tokio = { version = "1.32.0", features = ["macros", "rt", "sync"] }
+tokio = { version = "1.38.0", features = ["macros", "rt", "sync"] }
 thiserror = "1.0.37"
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/lsp-server/Cargo.toml
+++ b/src/lsp-server/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 ropey = "1.5.0"
 once_cell = "1.16.0"
 serde_json = "1.0.89"
-tokio = { version = "1.24.2", features = ["sync"] }
+tokio = { version = "1.38.0", features = ["sync"] }
 tower-lsp = { version = "0.20.0", features = ["proposed"]}
 serde = { version = "1.0.152", features = ["derive"] }
 mz-build-info = { path = "../build-info" }

--- a/src/metrics/Cargo.toml
+++ b/src/metrics/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2.138"
 mz-ore = { path = "../ore", features = ["metrics"] }
 paste = "1.0"
 prometheus = { version = "0.13.3", default-features = false }
-tokio = { version = "1.32.0", features = ["time"]}
+tokio = { version = "1.38.0", features = ["time"]}
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -34,7 +34,7 @@ serde-aux = "4.1.2"
 serde_json = "1.0.89"
 tabled = "0.10.0"
 time = "0.3.17"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.38.0", features = ["full"] }
 toml = "0.8.2"
 toml_edit = { version = "0.20.2", features = ["serde"] }
 thiserror = "1.0.37"

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -21,8 +21,8 @@ mz-cloud-resources = { path = "../cloud-resources" }
 mz-orchestrator = { path = "../orchestrator" }
 mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }
-k8s-openapi = { version = "0.20.0", features = ["v1_28"] }
-kube = { version = "0.87.1", default-features = false, features = ["client", "runtime", "ws"] }
+k8s-openapi = { version = "0.22.0", features = ["v1_28"] }
+kube = { version = "0.92.1", default-features = false, features = ["client", "runtime", "ws"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 sha2 = "0.10.6"

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0.89"
 scopeguard = "1.1.0"
 sha1 = "0.10.5"
 sysinfo = "0.27.2"
-tokio = { version = "1.32.0", features = [ "fs", "process", "time" ] }
+tokio = { version = "1.38.0", features = [ "fs", "process", "time" ] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -50,7 +50,7 @@ smallvec = { version = "1.10.0", optional = true }
 stacker = { version = "0.1.15", optional = true }
 sentry = { version = "0.29.1", optional = true, features = ["debug-images"] }
 serde = { version = "1.0.152", features = ["derive"] }
-tokio = { version = "1.32.0", features = [
+tokio = { version = "1.38.0", features = [
   "io-util",
   "net",
   "rt-multi-thread",
@@ -100,7 +100,7 @@ mz-ore = { path = "../ore", features = ["id_gen"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 scopeguard = "1.1.0"
 serde_json = "1.0.89"
-tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 tokio-test = "0.4.2"
 tracing-subscriber = "0.3.16"
 

--- a/src/ore/src/channel.rs
+++ b/src/ore/src/channel.rs
@@ -54,12 +54,12 @@ pub trait ReceiverExt<T: Send> {
     ///
     /// TODO(parkmycar): We should refactor this to use `impl Iterator` instead of `Vec` when
     /// "impl trait in trait" is supported.
-    async fn recv_many(&mut self, max: usize) -> Option<Vec<T>>;
+    async fn mz_recv_many(&mut self, max: usize) -> Option<Vec<T>>;
 }
 
 #[async_trait]
 impl<T: Send> ReceiverExt<T> for tokio::sync::mpsc::Receiver<T> {
-    async fn recv_many(&mut self, max: usize) -> Option<Vec<T>> {
+    async fn mz_recv_many(&mut self, max: usize) -> Option<Vec<T>> {
         // Wait for a value to be ready.
         let first = self.recv().await?;
         let mut buffer = Vec::from([first]);
@@ -83,7 +83,7 @@ impl<T: Send> ReceiverExt<T> for tokio::sync::mpsc::Receiver<T> {
 
 #[async_trait]
 impl<T: Send> ReceiverExt<T> for tokio::sync::mpsc::UnboundedReceiver<T> {
-    async fn recv_many(&mut self, max: usize) -> Option<Vec<T>> {
+    async fn mz_recv_many(&mut self, max: usize) -> Option<Vec<T>> {
         // Wait for a value to be ready.
         let first = self.recv().await?;
         let mut buffer = Vec::from([first]);
@@ -274,11 +274,11 @@ mod tests {
         tx.try_send(5).expect("enough capacity");
 
         // Receive a max of three elements at once.
-        let elements = block_on(rx.recv_many(3)).expect("values");
+        let elements = block_on(rx.mz_recv_many(3)).expect("values");
         assert_eq!(elements, [1, 2, 3]);
 
         // Receive the remaining elements.
-        let elements = block_on(rx.recv_many(8)).expect("values");
+        let elements = block_on(rx.mz_recv_many(8)).expect("values");
         assert_eq!(elements, [4, 5]);
     }
 
@@ -294,11 +294,11 @@ mod tests {
         tx.send(5).expect("enough capacity");
 
         // Receive a max of three elements at once.
-        let elements = block_on(rx.recv_many(3)).expect("values");
+        let elements = block_on(rx.mz_recv_many(3)).expect("values");
         assert_eq!(elements, [1, 2, 3]);
 
         // Receive the remaining elements.
-        let elements = block_on(rx.recv_many(8)).expect("values");
+        let elements = block_on(rx.mz_recv_many(8)).expect("values");
         assert_eq!(elements, [4, 5]);
     }
 
@@ -317,7 +317,7 @@ mod tests {
         let waker = futures::task::noop_waker();
         let mut cx = std::task::Context::from_waker(&waker);
 
-        let mut recv_many = rx.recv_many(4);
+        let mut recv_many = rx.mz_recv_many(4);
 
         // The channel is closed, but there are outstanding permits, so we should return pending.
         assert!(recv_many.poll_unpin(&mut cx).is_pending());
@@ -336,7 +336,7 @@ mod tests {
         drop(recv_many);
 
         // Polling the channel one more time should return None since the channel is closed.
-        let elements = match rx.recv_many(4).poll_unpin(&mut cx) {
+        let elements = match rx.mz_recv_many(4).poll_unpin(&mut cx) {
             std::task::Poll::Ready(elements) => elements,
             std::task::Poll::Pending => panic!("future didn't immediately return"),
         };
@@ -347,7 +347,7 @@ mod tests {
     fn test_empty_channel() {
         let (tx, mut rx) = mpsc::channel::<usize>(16);
 
-        let recv_many = rx.recv_many(4);
+        let recv_many = rx.mz_recv_many(4);
         drop(tx);
 
         let elements = block_on(recv_many);
@@ -364,7 +364,7 @@ mod tests {
         tx.try_send(3).expect("enough capacity");
 
         // Even though we specify a max of one, we'll receive at least 2.
-        let elements = block_on(rx.recv_many(1)).expect("values");
+        let elements = block_on(rx.mz_recv_many(1)).expect("values");
         assert_eq!(elements, [1, 2]);
     }
 
@@ -388,7 +388,7 @@ mod tests {
             block_on(async {
                 futures::select_biased! {
                     single = &mut immediate_ready => result.push(single),
-                    many = &mut rx.recv_many(2).fuse() => {
+                    many = &mut rx.mz_recv_many(2).fuse() => {
                         let values = many.expect("stream ended!");
                         result.extend(values);
                     },
@@ -415,10 +415,10 @@ mod tests {
         drop(tx);
 
         // Make sure the buffer is larger than queued elements.
-        let elements = block_on(rx.recv_many(4)).expect("elements");
+        let elements = block_on(rx.mz_recv_many(4)).expect("elements");
         assert_eq!(elements, [1, 2, 3]);
 
         // Receiving again should return None.
-        assert!(block_on(rx.recv_many(4)).is_none());
+        assert!(block_on(rx.mz_recv_many(4)).is_none());
     }
 }

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -40,7 +40,7 @@ prometheus = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.32.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 url = "2.3.1"
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -61,7 +61,7 @@ serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 thiserror = "1.0.37"
-tokio = { version = "1.32.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-metrics = "0.3.0"
 tokio-stream = "0.1.11"
 tonic = "0.9.2"

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -55,7 +55,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.32.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
+tokio = { version = "1.38.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/pgwire-common/Cargo.toml
+++ b/src/pgwire-common/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "1.3.0"
 bytesize = "1.1.0"
 mz-ore = { path = "../ore", features = ["network"], default-features = false }
 mz-server-core = { path = "../server-core", default-features = false }
-tokio = "1.24.2"
+tokio = "1.38.0"
 tokio-openssl = "0.6.3"
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -31,7 +31,7 @@ mz-server-core = { path = "../server-core" }
 mz-sql = { path = "../sql" }
 openssl = { version = "0.10.48", features = ["vendored"] }
 postgres = { version = "0.19.5" }
-tokio = "1.32.0"
+tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tokio-openssl = "0.6.3"
 tokio-util = { version = "0.7.4", features = ["codec"] }

--- a/src/postgres-client/Cargo.toml
+++ b/src/postgres-client/Cargo.toml
@@ -15,7 +15,7 @@ deadpool-postgres = "0.10.3"
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes_"] }
 mz-tls-util = { path = "../tls-util" }
 prometheus = { version = "0.13.3", default-features = false}
-tokio = { version = "1.32.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
+tokio = { version = "1.38.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -32,7 +32,7 @@ prost = { version = "0.11.3", features = [
 ], optional = true }
 serde = { version = "1.0.152", features = ["derive"], optional = true }
 thiserror = "1.0.37"
-tokio = { version = "1.32.0", features = ["fs", "rt", "sync"] }
+tokio = { version = "1.38.0", features = ["fs", "rt", "sync"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/prof-http/Cargo.toml
+++ b/src/prof-http/Cargo.toml
@@ -24,7 +24,7 @@ mz-http-util = { path = "../http-util", default-features = false }
 mz-ore = { path = "../ore", default-features = false }
 mz-prof = { path = "../prof", default-features = false }
 serde = { version = "1.0.152", features = ["derive"] }
-tokio = { version = "1.32.0", features = ["time"] }
+tokio = { version = "1.38.0", features = ["time"] }
 tracing = { version = "0.1.37", optional = true }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -23,7 +23,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 tempfile = "3.8.1"
 tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"], optional = true }
 tracing = "0.1.37"
-tokio = { version = "1.32.0", features = ["time"] }
+tokio = { version = "1.38.0", features = ["time"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [build-dependencies]

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -67,7 +67,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 regex = "1.7.0"
 ryu = "1.0.12"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89", features = ["arbitrary_precision"] }
+serde_json = { version = "1.0.89", features = ["arbitrary_precision", "preserve_order"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 static_assertions = "1.1"
 strsim = "0.10"

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -23,7 +23,7 @@ prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
-tokio = { version = "1.32.0", features = ["macros", "sync", "rt"] }
+tokio = { version = "1.38.0", features = ["macros", "sync", "rt"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 thiserror = "1.0.37"

--- a/src/s3-datagen/Cargo.toml
+++ b/src/s3-datagen/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.25"
 indicatif = "0.17.2"
 mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-ore = { path = "../ore", features = ["cli"] }
-tokio = { version = "1.32.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.38.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -18,7 +18,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 mz-ore = { path = "../ore" }
-tokio = { version = "1.32.0", features = ["macros", "rt"] }
+tokio = { version = "1.38.0", features = ["macros", "rt"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/segment/Cargo.toml
+++ b/src/segment/Cargo.toml
@@ -15,7 +15,7 @@ mz-ore = { path = "../ore", features = ["async"], default-features = false }
 segment = { version = "0.2.1", features = ["native-tls-vendored"], default-features = false }
 serde_json = "1.0.89"
 time = "0.3.17"
-tokio = { version = "1.32.0", features = ["sync"] }
+tokio = { version = "1.38.0", features = ["sync"] }
 tracing = "0.1.37"
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/server-core/Cargo.toml
+++ b/src/server-core/Cargo.toml
@@ -18,7 +18,7 @@ tokio-stream = "0.1.11"
 tracing = "0.1.37"
 futures = "0.3.25"
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
-tokio = "1.24.2"
+tokio = "1.38.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -36,7 +36,7 @@ semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 sysinfo = "0.27.2"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = "1.32.0"
+tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tonic = "0.9.2"
 tower = "0.4.13"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -80,7 +80,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 static_assertions = "1.1"
 thiserror = "1.0.37"
-tokio = { version = "1.32.0", features = ["fs"] }
+tokio = { version = "1.38.0", features = ["fs"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -49,7 +49,7 @@ serde_json = "1.0.89"
 tempfile = "3.8.1"
 time = "0.3.17"
 tracing = "0.1.37"
-tokio = "1.32.0"
+tokio = "1.38.0"
 tokio-postgres = { version = "0.7.8", features = [
   "with-chrono-0_4",
   "with-uuid-1",

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { version = "1.0.89" }
 ssh-key = { version = "0.4.3" }
 tempfile = "3.3.0"
 thiserror = { version = "1.0.37" }
-tokio = "1.32.0"
+tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tracing = "0.1.37"
 zeroize = { version = "1.5.7", features = ["serde"] }

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -49,7 +49,7 @@ static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = [
     "bincode",
 ] }
-tokio = { version = "1.32.0", features = [
+tokio = { version = "1.38.0", features = [
     "fs",
     "rt",
     "sync",

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -38,7 +38,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util", "time"] }
+tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
 tracing = "0.1.37"

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -486,7 +486,7 @@ where
                 }
 
                 // Pull as many queued updates off the channel as possible.
-                cmd = self.cmd_rx.recv_many(CHANNEL_CAPACITY) => {
+                cmd = self.cmd_rx.mz_recv_many(CHANNEL_CAPACITY) => {
                     if let Some(batch) = cmd {
 
                         let _ = self.handle_updates(batch).await?;
@@ -890,7 +890,7 @@ where
                     }
 
                     // Pull as many queued updates off the channel as possible.
-                    cmd = rx.recv_many(CHANNEL_CAPACITY) => {
+                    cmd = rx.mz_recv_many(CHANNEL_CAPACITY) => {
                         if let Some(batch) = cmd {
                             // To rate limit appends to persist we add artifical latency, and will
                             // finish no sooner than this instant.

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -37,7 +37,7 @@ sentry = { version = "0.29.1" }
 serde = { version = "1.0.152", features = ["derive"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 thiserror = "1.0.37"
-tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util", "time"] }
+tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -62,7 +62,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = { version = "1.0.89", features = ["preserve_order"] }
 thiserror = "1.0.37"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -65,7 +65,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util", "time"] }
+tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -86,7 +86,7 @@ sha2 = "0.10.6"
 timely = { version = "0.12.0", default-features = false, features = [
     "bincode",
 ] }
-tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "test-util"] }
+tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["io"] }
@@ -112,7 +112,7 @@ mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 itertools = "0.10.5"
 num_cpus = "1.14.0"
 tempfile = "3.8.1"
-tokio = { version = "1.32.0", features = ["test-util"] }
+tokio = { version = "1.38.0", features = ["test-util"] }
 
 [features]
 default = ["mz-build-tools/default"]

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -73,7 +73,7 @@ tiberius = { version = "0.11.3", default-features = false }
 time = "0.3.17"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-tokio = { version = "1.32.0", features = ["process"] }
+tokio = { version = "1.38.0", features = ["process"] }
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["compat"] }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -20,7 +20,7 @@ timely = { version = "0.12.0", default-features = false, features = ["bincode"] 
 serde = { version = "1.0.152", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["async", "process", "tracing_", "test"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
-tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread", "time"] }
 num-traits = "0.2"
 ahash = { version = "0.8.11", default-features = false }
 uuid = { version = "1.7.0", features = ["serde", "v4"] }

--- a/src/timestamp-oracle/Cargo.toml
+++ b/src/timestamp-oracle/Cargo.toml
@@ -22,7 +22,7 @@ mz-postgres-client = { path = "../postgres-client" }
 mz-repr = { path = "../repr", features = ["tracing_"] }
 rand = "0.8.5"
 serde = "1.0.152"
-tokio = { version = "1.32.0", features = ["rt", "time"] }
+tokio = { version = "1.38.0", features = ["rt", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/tls-util/Cargo.toml
+++ b/src/tls-util/Cargo.toml
@@ -15,7 +15,7 @@ openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
 postgres-openssl = { version = "0.5.0" }
 thiserror = "1.0.37"
-tokio = { version = "1.32.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
+tokio = { version = "1.38.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/txn-wal/Cargo.toml
+++ b/src/txn-wal/Cargo.toml
@@ -24,7 +24,7 @@ prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.32.0", default-features = false, features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.38.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -104,7 +104,7 @@ schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.203", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.117", features = ["alloc", "arbitrary_precision", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.117", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth"] }
 sha2 = { version = "0.10.6" }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "serde", "union", "write"] }
@@ -229,7 +229,7 @@ schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.203", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.117", features = ["alloc", "arbitrary_precision", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.117", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth"] }
 sha2 = { version = "0.10.6" }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "serde", "union", "write"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -36,13 +36,14 @@ console = { version = "0.15.5", default-features = false, features = ["ansi-pars
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
-crossbeam-utils = { version = "0.8.7" }
+crossbeam-utils = { version = "0.8.20" }
 crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
 dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0", features = ["serde"] }
 flate2 = { version = "1.0.24", features = ["zlib"] }
+futures = { version = "0.3.25" }
 futures-channel = { version = "0.3.30", features = ["sink"] }
 futures-core = { version = "0.3.30" }
 futures-executor = { version = "0.3.25" }
@@ -58,10 +59,10 @@ indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 insta = { version = "1.33.0", features = ["json"] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12.1" }
 itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10.5" }
-k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_28"] }
-kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
-kube-client = { version = "0.87.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
-kube-core = { version = "0.87.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
+k8s-openapi = { version = "0.22.0", default-features = false, features = ["schemars", "v1_28"] }
+kube = { version = "0.92.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
+kube-client = { version = "0.92.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
+kube-core = { version = "0.92.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
 libc = { version = "0.2.153", features = ["extra_traits", "use_std"] }
 libz-sys = { version = "1.1.8", features = ["static"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
@@ -78,7 +79,7 @@ num = { version = "0.4.1" }
 num-bigint = { version = "0.4.3" }
 num-integer = { version = "0.1.46", features = ["i128"] }
 num-traits = { version = "0.2.15", features = ["i128", "libm"] }
-openssl = { version = "0.10.55", features = ["vendored"] }
+openssl = { version = "0.10.64", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
@@ -103,24 +104,23 @@ schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.203", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.117", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.117", features = ["alloc", "arbitrary_precision", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sha2 = { version = "0.10.6" }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
-smallvec = { version = "1.13.2", default-features = false, features = ["const_generics", "serde", "union", "write"] }
-socket2 = { version = "0.5.3", default-features = false, features = ["all"] }
+smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "serde", "union", "write"] }
+socket2 = { version = "0.5.7", default-features = false, features = ["all"] }
 subtle = { version = "2.4.1" }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.63", features = ["extra-traits", "full", "visit-mut"] }
 textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
-tokio = { version = "1.32.0", features = ["full", "stats", "test-util", "tracing"] }
+tokio = { version = "1.38.0", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.14", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
 toml_datetime = { version = "0.6.3", default-features = false, features = ["serde"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
 tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "load-shed", "retry", "timeout", "util"] }
-tower-http = { version = "0.4.3", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
@@ -160,13 +160,14 @@ console = { version = "0.15.5", default-features = false, features = ["ansi-pars
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
-crossbeam-utils = { version = "0.8.7" }
+crossbeam-utils = { version = "0.8.20" }
 crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
 debugid = { version = "0.8.0", default-features = false, features = ["serde"] }
 dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0", features = ["serde"] }
 flate2 = { version = "1.0.24", features = ["zlib"] }
+futures = { version = "0.3.25" }
 futures-channel = { version = "0.3.30", features = ["sink"] }
 futures-core = { version = "0.3.30" }
 futures-executor = { version = "0.3.25" }
@@ -182,10 +183,10 @@ indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 insta = { version = "1.33.0", features = ["json"] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12.1" }
 itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10.5" }
-k8s-openapi = { version = "0.20.0", default-features = false, features = ["schemars", "v1_28"] }
-kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
-kube-client = { version = "0.87.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
-kube-core = { version = "0.87.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
+k8s-openapi = { version = "0.22.0", default-features = false, features = ["schemars", "v1_28"] }
+kube = { version = "0.92.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
+kube-client = { version = "0.92.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
+kube-core = { version = "0.92.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
 libc = { version = "0.2.153", features = ["extra_traits", "use_std"] }
 libz-sys = { version = "1.1.8", features = ["static"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
@@ -202,7 +203,7 @@ num = { version = "0.4.1" }
 num-bigint = { version = "0.4.3" }
 num-integer = { version = "0.1.46", features = ["i128"] }
 num-traits = { version = "0.2.15", features = ["i128", "libm"] }
-openssl = { version = "0.10.55", features = ["vendored"] }
+openssl = { version = "0.10.64", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
@@ -228,25 +229,24 @@ schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.203", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.117", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.117", features = ["alloc", "arbitrary_precision", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sha2 = { version = "0.10.6" }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
-smallvec = { version = "1.13.2", default-features = false, features = ["const_generics", "serde", "union", "write"] }
-socket2 = { version = "0.5.3", default-features = false, features = ["all"] }
+smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "serde", "union", "write"] }
+socket2 = { version = "0.5.7", default-features = false, features = ["all"] }
 subtle = { version = "2.4.1" }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.63", features = ["extra-traits", "full", "visit-mut"] }
 textwrap = { version = "0.16.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
 time-macros = { version = "0.2.6", default-features = false, features = ["formatting", "parsing", "serde"] }
-tokio = { version = "1.32.0", features = ["full", "stats", "test-util", "tracing"] }
+tokio = { version = "1.38.0", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.14", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
 toml_datetime = { version = "0.6.3", default-features = false, features = ["serde"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
 tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "load-shed", "retry", "timeout", "util"] }
-tower-http = { version = "0.4.3", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
@@ -266,7 +266,7 @@ zstd-sys = { version = "2.0.9", features = ["std"] }
 bitflags = { version = "2.4.1", default-features = false, features = ["std"] }
 camino = { version = "1.1.7", default-features = false, features = ["serde1"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
-openssl-sys = { version = "0.9.90", default-features = false, features = ["vendored"] }
+openssl-sys = { version = "0.9.102", default-features = false, features = ["vendored"] }
 pathdiff = { version = "0.2.1", default-features = false, features = ["camino"] }
 ring = { version = "0.17.7", features = ["std"] }
 
@@ -274,7 +274,7 @@ ring = { version = "0.17.7", features = ["std"] }
 bitflags = { version = "2.4.1", default-features = false, features = ["std"] }
 camino = { version = "1.1.7", default-features = false, features = ["serde1"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
-openssl-sys = { version = "0.9.90", default-features = false, features = ["vendored"] }
+openssl-sys = { version = "0.9.102", default-features = false, features = ["vendored"] }
 pathdiff = { version = "0.2.1", default-features = false, features = ["camino"] }
 ring = { version = "0.17.7", features = ["std"] }
 

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -33,7 +33,7 @@ def test_secrets(mz: MaterializeApplication) -> None:
                 SASL USERNAME = SECRET username,
                 SASL PASSWORD = SECRET password
               );
-            contains:Broker does not support SSL connections
+            contains:SSL handshake failed
             """
         )
     )

--- a/test/kafka-auth/test-kafka-mssl.td
+++ b/test/kafka-auth/test-kafka-mssl.td
@@ -29,7 +29,7 @@ banana
     BROKER 'kafka:9094',
     SSL CERTIFICATE AUTHORITY = '${ca-crt}'
   )
-contains:sslv3 alert bad certificate
+contains:ssl/tls alert bad certificate
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9094',
@@ -37,7 +37,7 @@ contains:sslv3 alert bad certificate
     SSL KEY SECRET kafka1_key,
     SSL CERTIFICATE AUTHORITY '${ca-crt}'
   )
-contains:sslv3 alert certificate unknown
+contains:ssl/tls alert certificate unknown
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9094',
@@ -45,7 +45,7 @@ contains:sslv3 alert certificate unknown
     SSL KEY SECRET kafka1_key,
     SSL CERTIFICATE AUTHORITY '${ca-crt}'
   )
-contains:x509 certificate routines:X509_check_private_key:key values mismatch
+contains:x509 certificate routines::key values mismatch
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9094',

--- a/test/kafka-auth/test-kafka-sasl-mssl.td
+++ b/test/kafka-auth/test-kafka-sasl-mssl.td
@@ -33,7 +33,7 @@ banana
     SASL PASSWORD SECRET password,
     SSL CERTIFICATE AUTHORITY = '${ca-crt}'
   )
-contains:sslv3 alert bad certificate
+contains:ssl/tls alert bad certificate
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9097',
@@ -44,7 +44,7 @@ contains:sslv3 alert bad certificate
     SSL KEY SECRET kafka1_key,
     SSL CERTIFICATE AUTHORITY '${ca-crt}'
   )
-contains:sslv3 alert certificate unknown
+contains:ssl/tls alert certificate unknown
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9097',

--- a/test/kafka-auth/test-kafka-sasl-plaintext.td
+++ b/test/kafka-auth/test-kafka-sasl-plaintext.td
@@ -26,7 +26,7 @@ banana
     -- SECURITY PROTOCOL defaults to SASL_SSL when other SASL options are
     -- specified.
   )
-contains:Broker does not support SSL connections
+contains:SSL handshake failed
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9095',
@@ -35,7 +35,7 @@ contains:Broker does not support SSL connections
     SASL PASSWORD SECRET password,
     SECURITY PROTOCOL SASL_SSL
   )
-contains:Broker does not support SSL connections
+contains:SSL handshake failed
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9095',

--- a/test/kafka-auth/test-kafka-sasl-ssl.td
+++ b/test/kafka-auth/test-kafka-sasl-ssl.td
@@ -92,7 +92,7 @@ contains:Invalid username or password
     SASL USERNAME 'materialize',
     SASL PASSWORD SECRET password
   )
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9096',
@@ -101,7 +101,7 @@ contains:Invalid CA certificate
     SASL PASSWORD SECRET password,
     SSL CERTIFICATE AUTHORITY = '${ca-selective-crt}'
   )
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 # ==> Test without an SSH tunnel. <==
 

--- a/test/kafka-auth/test-kafka-ssl.td
+++ b/test/kafka-auth/test-kafka-ssl.td
@@ -100,10 +100,10 @@ contains:Client creation error
 > ALTER CONNECTION kafka RESET (SSL CERTIFICATE) WITH (VALIDATE = true);
 
 ! ALTER CONNECTION kafka RESET (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = true);
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 ! ALTER CONNECTION kafka RESET (SSL KEY), RESET (SSL CERTIFICATE), RESET (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = true);
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 > ALTER CONNECTION kafka RESET (SSL KEY), RESET (SSL CERTIFICATE), RESET (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = false);
 

--- a/test/kafka-auth/test-kafka-ssl.td
+++ b/test/kafka-auth/test-kafka-ssl.td
@@ -32,13 +32,13 @@ contains:Disconnected during handshake; broker might require SSL encryption
     BROKER 'kafka:9093'
     -- SECURITY PROTOCOL defaults to SSL when no SASL options are specified.
   )
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9093',
     SSL CERTIFICATE AUTHORITY = '${ca-selective-crt}'
   )
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9093',

--- a/test/kafka-auth/test-schema-registry-ssl-basic.td
+++ b/test/kafka-auth/test-schema-registry-ssl-basic.td
@@ -157,7 +157,7 @@ contains:requires both SSL KEY and SSL CERTIFICATE
 contains:requires both SSL KEY and SSL CERTIFICATE
 
 ! ALTER CONNECTION schema_registry SET (SSL KEY = SECRET invalid_secret), SET (SSL CERTIFICATE = 'x') WITH (VALIDATE = true);
-contains:ANY PRIVATE KEY
+contains:No supported data to decode
 
 ! ALTER CONNECTION schema_registry SET (SSL CERTIFICATE AUTHORITY = 'x') WITH (VALIDATE = true);
 contains:CERTIFICATE
@@ -167,10 +167,10 @@ contains:CERTIFICATE
 > ALTER CONNECTION schema_registry RESET (SSL CERTIFICATE);
 
 ! ALTER CONNECTION schema_registry RESET (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = true);
-contains:self signed certificate in certificate chain
+contains:self-signed certificate in certificate chain
 
 ! ALTER CONNECTION schema_registry RESET (SSL KEY), RESET (SSL CERTIFICATE), RESET (SSL CERTIFICATE AUTHORITY);
-contains:self signed certificate in certificate chain
+contains:self-signed certificate in certificate chain
 
 ! ALTER CONNECTION schema_registry RESET (USERNAME);
 contains:Unauthorized

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.66"
 itertools = "0.10.5"
 mz-metabase = { path = "../../../src/metabase" }
 mz-ore = { path = "../../../src/ore", features = ["network", "async", "test"] }
-tokio = { version = "1.24.2", features = ["macros"] }
+tokio = { version = "1.38.0", features = ["macros"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../../../src/workspace-hack" }

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -16,7 +16,7 @@ mz-kafka-util = { path = "../../src/kafka-util" }
 mz-ore = { path = "../../src/ore", features = ["async"] }
 rand = "0.8.5"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
-tokio = "1.24.2"
+tokio = "1.38.0"
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../../src/workspace-hack" }

--- a/test/testdrive/connection-alter.td
+++ b/test/testdrive/connection-alter.td
@@ -84,7 +84,7 @@ name   create_sql
 materialize.public.conn   "CREATE CONNECTION \"materialize\".\"public\".\"conn\" TO KAFKA (BROKERS = ('${testdrive.kafka-addr}'), SECURITY PROTOCOL = \"plaintext\")"
 
 ! ALTER CONNECTION conn DROP (SECURITY PROTOCOL);
-contains:Broker does not support SSL connections
+contains:SSL handshake failed
 
 ! ALTER CONNECTION conn SET (BROKER '${testdrive.kafka-addr}'), RESET (BROKER);
 contains:cannot both SET and DROP/RESET options BROKER


### PR DESCRIPTION
This PR updates the following Rust dependencies:

* `kube`: `0.87.1 -> 0.92.1`
* `k8s-openapi`: `0.20.0 -> 0.22.0`
* `tokio`: `1.32.0 -> 1.38.0`
* `openssl-src`: `111.28.1+1.1.1w -> 300.3.1+3.3.1`

Unfortunately this adds a decent amount of duplicate dependencies because `tonic` hasn't yet upgraded to `hyper 1.0`, but the upstream PR to do that is in flight!

Also, `tokio` added an upstream API for channels is similar to our `ChannelExt::recv_many`, for now to avoid conflict I renamed our API to `mz_recv_many`.

### Motivation

Upgrade a number of important dependencies

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
