### PR TITLE
mz: faster feedback on invalid region names

### DIFF
--- a/src/cloud-api/src/client/cloud_provider.rs
+++ b/src/cloud-api/src/client/cloud_provider.rs
@@ -17,7 +17,7 @@
 //! Example:
 //! ```ignore
 //! // List all the available providers
-//! let cloud_providers = client.list_cloud_providers().await?;
+//! let cloud_providers = client.list_cloud_regions().await?;
 //!
 //! // Search the cloud provider
 //! let user_input = "aws/us-east-1";
@@ -125,10 +125,10 @@ impl FromStr for CloudProviderRegion {
 }
 
 impl Client {
-    /// List all the available cloud providers.
+    /// List all the available cloud regions.
     ///
     /// E.g.: [us-east-1, eu-west-1]
-    pub async fn list_cloud_providers(&self) -> Result<Vec<CloudProvider>, Error> {
+    pub async fn list_cloud_regions(&self) -> Result<Vec<CloudProvider>, Error> {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct CloudProviderResponse {

--- a/src/cloud-api/src/client/region.rs
+++ b/src/cloud-api/src/client/region.rs
@@ -97,7 +97,7 @@ impl Client {
 
     /// Get all the available customer regions for the current user.
     pub async fn get_all_regions(&self) -> Result<Vec<Region>, Error> {
-        let cloud_providers: Vec<CloudProvider> = self.list_cloud_providers().await?;
+        let cloud_providers: Vec<CloudProvider> = self.list_cloud_regions().await?;
         let mut regions: Vec<Region> = vec![];
 
         for cloud_provider in cloud_providers {

--- a/src/cloud-api/src/lib.rs
+++ b/src/cloud-api/src/lib.rs
@@ -28,7 +28,7 @@
 //!     .build(config);
 //!
 //! // List all the available providers
-//! let cloud_providers = client.list_cloud_providers().await.unwrap();
+//! let cloud_providers = client.list_cloud_regions().await.unwrap();
 //! ```
 //!
 //! ## Implementation

--- a/src/mz/src/command/region.rs
+++ b/src/mz/src/command/region.rs
@@ -153,7 +153,7 @@ pub async fn list(cx: RegionContext) -> Result<(), Error> {
         status: &'a str,
     }
 
-    let cloud_providers: Vec<CloudProvider> = cx.cloud_client().list_cloud_providers().await?;
+    let cloud_providers: Vec<CloudProvider> = cx.cloud_client().list_cloud_regions().await?;
     let mut regions: Vec<Region> = vec![];
 
     for cloud_provider in cloud_providers {

--- a/src/mz/src/command/region.rs
+++ b/src/mz/src/command/region.rs
@@ -119,6 +119,8 @@ pub async fn disable(cx: RegionContext) -> Result<(), Error> {
         .output_formatter()
         .loading_spinner("Retrieving information...");
 
+    let cloud_provider = cx.get_cloud_provider().await?;
+
     // The `delete_region` method retries disabling a region,
     // has an inner timeout, and manages a `504` response.
     // For any other type of error response, we handle it here
@@ -127,8 +129,6 @@ pub async fn disable(cx: RegionContext) -> Result<(), Error> {
         .max_duration(Duration::from_secs(720))
         .clamp_backoff(Duration::from_secs(1))
         .retry_async(|_| async {
-            let cloud_provider = cx.get_cloud_provider().await?;
-
             loading_spinner.set_message("Disabling region...");
             cx.cloud_client()
                 .delete_region(cloud_provider.clone())

--- a/src/mz/src/context.rs
+++ b/src/mz/src/context.rs
@@ -279,12 +279,12 @@ impl RegionContext {
     /// Returns the cloud provider from the profile context.
     pub async fn get_cloud_provider(&self) -> Result<CloudProvider, Error> {
         let client = &self.context.cloud_client;
-        let cloud_providers = client.list_cloud_providers().await?;
+        let cloud_providers = client.list_cloud_regions().await?;
 
         let provider = cloud_providers
             .into_iter()
             .find(|x| x.id == self.region_name)
-            .ok_or(Error::CloudProviderMissing)?;
+            .ok_or(Error::CloudRegionMissing)?;
 
         Ok(provider)
     }

--- a/src/mz/src/error.rs
+++ b/src/mz/src/error.rs
@@ -57,8 +57,8 @@ pub enum Error {
     #[error("Error: The profile '{0}' is missing in the configuration file. \n\nTo resolve this issue, you can either: \n1. Add the missing profile using the command `mz profile --profile {0} init` \n2. Set another existing profile using the command: `mz config set profile <profile_name>`.")]
     ProfileMissing(String),
     /// Error finding the region's cloud provider.
-    #[error("Error finding the region's cloud provider.")]
-    CloudProviderMissing,
+    #[error("Cloud region not found.")]
+    CloudRegionMissing,
     /// Error parsing TOML.
     #[error("Error parsing TOML file: {0}")]
     TomlParseError(#[from] toml_edit::de::Error),


### PR DESCRIPTION
I fat-fingered the region name, and mz appeared stuck saying "Retrieving information". After looking at the code I realized it was retrying the request with backoff. This behavior is important for the actual disable request, but the region fetch should fail fast. I also updated the error message and names of functions and the error enum to be more clear.

### Motivation

  * This PR fixes a previously unreported bug.


### Tips for reviewer

First mz contribution, all feedback appreciated!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No user facing changes
