### PR TITLE
Replace all uses of #epd- slack channels with their new #rnd- names in our docs and github actions

### DIFF
--- a/.github/workflows/slack_notify_design_doc.yml
+++ b/.github/workflows/slack_notify_design_doc.yml
@@ -19,7 +19,7 @@
 #
 #     https://github.com/actions-ecosystem/action-slack-notifier/blob/fc778468d09c43a6f4d1b8cccaca59766656996a/README.md
 
-# Send a notification to the #epd-design-docs Slack channel when a new
+# Send a notification to the #rnd-design-docs Slack channel when a new
 # design doc is added.
 #
 # A notification is sent when all of these conditions are true:
@@ -56,7 +56,7 @@ jobs:
         uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
-          channel: epd-design-docs
+          channel: rnd-design-docs
           custom_payload: |
             {
               "blocks": [

--- a/.github/workflows/slack_notify_mz_introspection.yml
+++ b/.github/workflows/slack_notify_mz_introspection.yml
@@ -19,7 +19,7 @@
 #
 #     https://github.com/actions-ecosystem/action-slack-notifier/blob/fc778468d09c43a6f4d1b8cccaca59766656996a/README.md
 
-# Send a notification to the #epd-mz-introspection-council Slack channel when a change
+# Send a notification to the #rnd-mz-introspection-council Slack channel when a change
 # is made that adds or modifies an index on the mz_introspection cluster, or
 # adds or modifies an object on which those indices depend.
 # Also detects changes to catalog object retention.
@@ -74,7 +74,7 @@ jobs:
         uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
-          channel: epd-mz-introspection-council
+          channel: rnd-mz-introspection-council
           custom_payload: |
             {
               "blocks": [

--- a/.github/workflows/slack_notify_sql_parser.yml
+++ b/.github/workflows/slack_notify_sql_parser.yml
@@ -19,7 +19,7 @@
 #
 #     https://github.com/actions-ecosystem/action-slack-notifier/blob/fc778468d09c43a6f4d1b8cccaca59766656996a/README.md
 
-# Send a notification to the #epd-sql-council Slack channel when a change
+# Send a notification to the #rnd-sql-council Slack channel when a change
 # to the SQL parser or the system catalog schema is made.
 #
 # A notification is sent when all of these conditions are true:
@@ -61,7 +61,7 @@ jobs:
         uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
-          channel: epd-sql-council
+          channel: rnd-sql-council
           custom_payload: |
             {
               "blocks": [

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -124,7 +124,7 @@ your thinking and inform the writing process.
    remember that this process is not intended to design by committee.
    Use your judgment in engaging with feedback from outside of your group
    of stakeholders. Note that we have a bot that automatically posts
-   notifications about new design documents in #epd-design-docs.
+   notifications about new design documents in #rnd-design-docs.
 
 ### Iteration
 


### PR DESCRIPTION
Must merge this PR in coordination with applying the slack channel name changes, to avoid interruption to the Github Actions.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
