### PR TITLE
adapter: disallow using inner PlanValidity fields for SQL logic

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -68,6 +68,7 @@
 
 use chrono::{DateTime, Utc};
 use mz_sql::names::ResolvedIds;
+use mz_sql::session::user::User;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
@@ -122,8 +123,6 @@ use mz_secrets::{SecretsController, SecretsReader};
 use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::{CatalogCluster, EnvironmentId};
 use mz_sql::plan::{self, AlterSinkPlan, CreateConnectionPlan, Params, QueryWhen};
-use mz_sql::rbac::UnauthorizedError;
-use mz_sql::session::user::{RoleMetadata, User};
 use mz_sql::session::vars::{ConnectionCounter, SystemVars};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::ExplainStage;
@@ -161,6 +160,7 @@ use crate::coord::peek::PendingPeek;
 use crate::coord::read_policy::ReadHoldsInner;
 use crate::coord::timeline::{TimelineContext, TimelineState};
 use crate::coord::timestamp_selection::{TimestampContext, TimestampDetermination};
+use crate::coord::validity::PlanValidity;
 use crate::error::AdapterError;
 use crate::explain::insights::PlanInsightsContext;
 use crate::explain::optimizer_trace::{DispatchGuard, OptimizerTrace};
@@ -204,6 +204,7 @@ mod privatelink_status;
 pub mod read_policy;
 mod sequencer;
 mod sql;
+mod validity;
 
 #[derive(Debug)]
 pub enum Message<T = mz_repr::Timestamp> {
@@ -385,6 +386,7 @@ pub struct ValidationReady<T> {
     #[derivative(Debug = "ignore")]
     pub ctx: ExecuteContext,
     pub result: Result<T, AdapterError>,
+    pub dependency_ids: BTreeSet<GlobalId>,
     pub connection_gid: GlobalId,
     pub plan_validity: PlanValidity,
     pub otel_ctx: OpenTelemetryContext,
@@ -514,6 +516,7 @@ pub struct PeekStageCopyTo {
     optimizer: optimize::copy_to::Optimizer,
     global_lir_plan: optimize::copy_to::GlobalLirPlan,
     optimization_finished_at: EpochMillis,
+    source_ids: BTreeSet<GlobalId>,
 }
 
 #[derive(Debug)]
@@ -753,6 +756,9 @@ pub struct SubscribeOptimizeMir {
     validity: PlanValidity,
     plan: plan::SubscribePlan,
     timeline: TimelineContext,
+    dependency_ids: BTreeSet<GlobalId>,
+    cluster_id: ComputeInstanceId,
+    replica_id: Option<ReplicaId>,
 }
 
 #[derive(Debug)]
@@ -762,14 +768,18 @@ pub struct SubscribeTimestampOptimizeLir {
     timeline: TimelineContext,
     optimizer: optimize::subscribe::Optimizer,
     global_mir_plan: optimize::subscribe::GlobalMirPlan<optimize::subscribe::Unresolved>,
+    dependency_ids: BTreeSet<GlobalId>,
+    replica_id: Option<ReplicaId>,
 }
 
 #[derive(Debug)]
 pub struct SubscribeFinish {
     validity: PlanValidity,
     cluster_id: ComputeInstanceId,
+    replica_id: Option<ReplicaId>,
     plan: plan::SubscribePlan,
     global_lir_plan: optimize::subscribe::GlobalLirPlan,
+    dependency_ids: BTreeSet<GlobalId>,
 }
 
 #[derive(Debug)]
@@ -784,6 +794,8 @@ pub struct IntrospectionSubscribeOptimizeMir {
     validity: PlanValidity,
     plan: plan::SubscribePlan,
     subscribe_id: GlobalId,
+    cluster_id: ComputeInstanceId,
+    replica_id: ReplicaId,
 }
 
 #[derive(Debug)]
@@ -791,6 +803,8 @@ pub struct IntrospectionSubscribeTimestampOptimizeLir {
     validity: PlanValidity,
     optimizer: optimize::subscribe::Optimizer,
     global_mir_plan: optimize::subscribe::GlobalMirPlan<optimize::subscribe::Unresolved>,
+    cluster_id: ComputeInstanceId,
+    replica_id: ReplicaId,
 }
 
 #[derive(Debug)]
@@ -798,6 +812,8 @@ pub struct IntrospectionSubscribeFinish {
     validity: PlanValidity,
     global_lir_plan: optimize::subscribe::GlobalLirPlan,
     read_holds: ReadHolds<Timestamp>,
+    cluster_id: ComputeInstanceId,
+    replica_id: ReplicaId,
 }
 
 #[derive(Debug)]
@@ -852,87 +868,6 @@ pub enum TargetCluster {
     Active,
     /// The cluster selected at the start of a transaction.
     Transaction(ClusterId),
-}
-
-/// A struct to hold information about the validity of plans and if they should be abandoned after
-/// doing work off of the Coordinator thread.
-#[derive(Debug)]
-pub struct PlanValidity {
-    /// The most recent revision at which this plan was verified as valid.
-    transient_revision: u64,
-    /// Objects on which the plan depends.
-    dependency_ids: BTreeSet<GlobalId>,
-    cluster_id: Option<ComputeInstanceId>,
-    replica_id: Option<ReplicaId>,
-    role_metadata: RoleMetadata,
-}
-
-impl PlanValidity {
-    /// Returns an error if the current catalog no longer has all dependencies.
-    fn check(&mut self, catalog: &Catalog) -> Result<(), AdapterError> {
-        if self.transient_revision == catalog.transient_revision() {
-            return Ok(());
-        }
-        // If the transient revision changed, we have to recheck. If successful, bump the revision
-        // so next check uses the above fast path.
-        if let Some(cluster_id) = self.cluster_id {
-            let Some(cluster) = catalog.try_get_cluster(cluster_id) else {
-                return Err(AdapterError::ChangedPlan(format!(
-                    "cluster {} was removed",
-                    cluster_id
-                )));
-            };
-
-            if let Some(replica_id) = self.replica_id {
-                if cluster.replica(replica_id).is_none() {
-                    return Err(AdapterError::ChangedPlan(format!(
-                        "replica {} of cluster {} was removed",
-                        replica_id, cluster_id
-                    )));
-                }
-            }
-        }
-        // It is sufficient to check that all the dependency_ids still exist because we assume:
-        // - Ids do not mutate.
-        // - Ids are not reused.
-        // - If an id was dropped, this will detect it and error.
-        for id in &self.dependency_ids {
-            if catalog.try_get_entry(id).is_none() {
-                return Err(AdapterError::ChangedPlan(format!(
-                    "dependency was removed: {id}",
-                )));
-            }
-        }
-        if catalog
-            .try_get_role(&self.role_metadata.current_role)
-            .is_none()
-        {
-            return Err(AdapterError::Unauthorized(
-                UnauthorizedError::ConcurrentRoleDrop(self.role_metadata.current_role.clone()),
-            ));
-        }
-        if catalog
-            .try_get_role(&self.role_metadata.session_role)
-            .is_none()
-        {
-            return Err(AdapterError::Unauthorized(
-                UnauthorizedError::ConcurrentRoleDrop(self.role_metadata.session_role.clone()),
-            ));
-        }
-
-        if catalog
-            .try_get_role(&self.role_metadata.authenticated_role)
-            .is_none()
-        {
-            return Err(AdapterError::Unauthorized(
-                UnauthorizedError::ConcurrentRoleDrop(
-                    self.role_metadata.authenticated_role.clone(),
-                ),
-            ));
-        }
-        self.transient_revision = catalog.transient_revision();
-        Ok(())
-    }
 }
 
 /// Result types for each stage of a sequence.

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -131,13 +131,13 @@ macro_rules! guard_write_critical_section {
                 $coord.defer_write(Deferred::Plan(DeferredPlan {
                     ctx: $ctx,
                     plan: $plan_to_defer,
-                    validity: PlanValidity {
-                        transient_revision: $coord.catalog().transient_revision(),
-                        dependency_ids: $dependency_ids,
-                        cluster_id: None,
-                        replica_id: None,
+                    validity: PlanValidity::new(
+                        $coord.catalog().transient_revision(),
+                        $dependency_ids,
+                        None,
+                        None,
                         role_metadata,
-                    },
+                    ),
                 }));
                 return;
             }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -686,13 +686,13 @@ impl Coordinator {
                     )
                     .await;
                     let result = result.map_err(|e| e.into());
-                    let plan_validity = PlanValidity {
+                    let plan_validity = PlanValidity::new(
                         transient_revision,
-                        dependency_ids: resolved_ids.0,
+                        resolved_ids.0,
                         cluster_id,
-                        replica_id: None,
-                        role_metadata: ctx.session().role_metadata().clone(),
-                    };
+                        None,
+                        ctx.session().role_metadata().clone(),
+                    );
                     // It is not an error for purification to complete after `internal_cmd_rx` is dropped.
                     let result = internal_cmd_tx.send(Message::PurifiedStatementReady(
                         PurifiedStatementReady {

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -581,6 +581,7 @@ impl Coordinator {
             connection_gid,
             mut plan_validity,
             otel_ctx,
+            dependency_ids,
         }: CreateConnectionValidationReady,
     ) {
         otel_ctx.attach_as_parent();
@@ -608,7 +609,7 @@ impl Coordinator {
                 ctx.session_mut(),
                 connection_gid,
                 plan,
-                ResolvedIds(plan_validity.dependency_ids),
+                ResolvedIds(dependency_ids),
             )
             .await;
         ctx.retire(result);
@@ -623,6 +624,7 @@ impl Coordinator {
             connection_gid,
             mut plan_validity,
             otel_ctx,
+            dependency_ids: _,
         }: AlterConnectionValidationReady,
     ) {
         otel_ctx.attach_as_parent();

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -696,14 +696,15 @@ impl Coordinator {
                         ctx,
                         result,
                         connection_gid,
-                        plan_validity: PlanValidity {
+                        plan_validity: PlanValidity::new(
                             transient_revision,
-                            dependency_ids: resolved_ids.0,
-                            cluster_id: None,
-                            replica_id: None,
+                            resolved_ids.0.clone(),
+                            None,
+                            None,
                             role_metadata,
-                        },
+                        ),
                         otel_ctx,
+                        dependency_ids: resolved_ids.0,
                     },
                 ));
                 if let Err(e) = result {
@@ -3066,13 +3067,13 @@ impl Coordinator {
 
         let otel_ctx = OpenTelemetryContext::obtain();
 
-        let plan_validity = PlanValidity {
-            transient_revision: self.catalog().transient_revision(),
-            dependency_ids: BTreeSet::from_iter([plan.sink.from]),
-            cluster_id: Some(plan.in_cluster),
-            replica_id: None,
-            role_metadata: ctx.session().role_metadata().clone(),
-        };
+        let plan_validity = PlanValidity::new(
+            self.catalog().transient_revision(),
+            BTreeSet::from_iter([plan.sink.from]),
+            Some(plan.in_cluster),
+            None,
+            ctx.session().role_metadata().clone(),
+        );
 
         // Re-resolve items in the altered statement
         // Parse statement.
@@ -3346,14 +3347,15 @@ impl Coordinator {
                             ctx,
                             result,
                             connection_gid: id,
-                            plan_validity: PlanValidity {
+                            plan_validity: PlanValidity::new(
                                 transient_revision,
-                                dependency_ids,
-                                cluster_id: None,
-                                replica_id: None,
+                                dependency_ids.clone(),
+                                None,
+                                None,
                                 role_metadata,
-                            },
+                            ),
                             otel_ctx,
+                            dependency_ids,
                         },
                     ));
                     if let Err(e) = result {

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -80,13 +80,13 @@ impl Coordinator {
         session: &Session,
         plan: plan::AlterClusterPlan,
     ) -> Result<ClusterStage, AdapterError> {
-        let validity = PlanValidity {
-            transient_revision: self.catalog().transient_revision(),
-            dependency_ids: BTreeSet::new(),
-            cluster_id: Some(plan.id.clone()),
-            replica_id: None,
-            role_metadata: session.role_metadata().clone(),
-        };
+        let validity = PlanValidity::new(
+            self.catalog().transient_revision(),
+            BTreeSet::new(),
+            Some(plan.id.clone()),
+            None,
+            session.role_metadata().clone(),
+        );
         Ok(ClusterStage::Alter(AlterCluster { validity, plan }))
     }
 

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -281,13 +281,13 @@ impl Coordinator {
             ..
         } = &plan;
 
-        let validity = PlanValidity {
-            transient_revision: self.catalog().transient_revision(),
-            dependency_ids: BTreeSet::from_iter(std::iter::once(*on)),
-            cluster_id: Some(*cluster_id),
-            replica_id: None,
-            role_metadata: session.role_metadata().clone(),
-        };
+        let validity = PlanValidity::new(
+            self.catalog().transient_revision(),
+            BTreeSet::from_iter(std::iter::once(*on)),
+            Some(*cluster_id),
+            None,
+            session.role_metadata().clone(),
+        );
 
         Ok(CreateIndexStage::Optimize(CreateIndexOptimize {
             validity,

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -356,13 +356,13 @@ impl Coordinator {
             });
         }
 
-        let validity = PlanValidity {
-            transient_revision: self.catalog().transient_revision(),
-            dependency_ids: expr_depends_on.clone(),
-            cluster_id: Some(*cluster_id),
-            replica_id: None,
-            role_metadata: session.role_metadata().clone(),
-        };
+        let validity = PlanValidity::new(
+            self.catalog().transient_revision(),
+            expr_depends_on.clone(),
+            Some(*cluster_id),
+            None,
+            session.role_metadata().clone(),
+        );
 
         // Check whether we can read all inputs at all the REFRESH AT times.
         if let Some(refresh_schedule) = refresh_schedule {

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -263,13 +263,13 @@ impl Coordinator {
         self.validate_timeline_context(expr_depends_on.iter().copied())?;
         self.validate_system_column_references(*ambiguous_columns, &expr_depends_on)?;
 
-        let validity = PlanValidity {
-            transient_revision: self.catalog().transient_revision(),
-            dependency_ids: expr_depends_on.clone(),
-            cluster_id: None,
-            replica_id: None,
-            role_metadata: session.role_metadata().clone(),
-        };
+        let validity = PlanValidity::new(
+            self.catalog().transient_revision(),
+            expr_depends_on.clone(),
+            None,
+            None,
+            session.role_metadata().clone(),
+        );
 
         Ok(CreateViewStage::Optimize(CreateViewOptimize {
             validity,

--- a/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
+++ b/src/adapter/src/coord/sequencer/inner/explain_timestamp.rs
@@ -98,13 +98,13 @@ impl Coordinator {
             .catalog()
             .resolve_target_cluster(target_cluster, session)?;
         let cluster_id = cluster.id;
-        let validity = PlanValidity {
-            transient_revision: self.catalog().transient_revision(),
-            dependency_ids: plan.raw_plan.depends_on(),
-            cluster_id: Some(cluster_id),
-            replica_id: None,
-            role_metadata: session.role_metadata().clone(),
-        };
+        let validity = PlanValidity::new(
+            self.catalog().transient_revision(),
+            plan.raw_plan.depends_on(),
+            Some(cluster_id),
+            None,
+            session.role_metadata().clone(),
+        );
         Ok(ExplainTimestampStage::Optimize(ExplainTimestampOptimize {
             validity,
             plan,

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -370,13 +370,13 @@ impl Coordinator {
         )?;
         session.add_notices(notices);
 
-        let validity = PlanValidity {
-            transient_revision: catalog.transient_revision(),
-            dependency_ids: source_ids.clone(),
-            cluster_id: Some(cluster.id()),
-            replica_id: target_replica,
-            role_metadata: session.role_metadata().clone(),
-        };
+        let validity = PlanValidity::new(
+            catalog.transient_revision(),
+            source_ids.clone(),
+            Some(cluster.id()),
+            target_replica,
+            session.role_metadata().clone(),
+        );
 
         Ok(PeekStage::LinearizeTimestamp(PeekStageLinearizeTimestamp {
             validity,
@@ -478,7 +478,7 @@ impl Coordinator {
 
         // Although we have added `sources.depends_on()` to the validity already, also add the
         // sufficient collections for safety.
-        validity.dependency_ids.extend(id_bundle.iter());
+        validity.extend_dependencies(id_bundle.iter());
 
         let determination = self.sequence_peek_timestamp(
             session,
@@ -675,6 +675,7 @@ impl Coordinator {
                                 optimizer,
                                 global_lir_plan,
                                 optimization_finished_at,
+                                source_ids,
                             })
                         }
                         // Internal optimizer errors are handled differently
@@ -927,10 +928,11 @@ impl Coordinator {
         &mut self,
         ctx: &ExecuteContext,
         PeekStageCopyTo {
-            validity,
+            validity: _,
             optimizer,
             global_lir_plan,
             optimization_finished_at,
+            source_ids,
         }: PeekStageCopyTo,
     ) -> Result<StageResult<Box<PeekStage>>, AdapterError> {
         if let Some(id) = ctx.extra.contents() {
@@ -954,7 +956,7 @@ impl Coordinator {
             conn_id: ctx.session().conn_id().clone(),
             tx,
             cluster_id,
-            depends_on: validity.dependency_ids.clone(),
+            depends_on: source_ids,
         };
         // Add metadata for the new COPY TO. CopyTo returns a `ready` future, so it is safe to drop.
         drop(

--- a/src/adapter/src/coord/sequencer/inner/secret.rs
+++ b/src/adapter/src/coord/sequencer/inner/secret.rs
@@ -95,13 +95,13 @@ impl Coordinator {
         plan: plan::CreateSecretPlan,
     ) -> Result<SecretStage, AdapterError> {
         // No dependencies.
-        let validity = PlanValidity {
-            transient_revision: self.catalog().transient_revision(),
-            dependency_ids: BTreeSet::new(),
-            cluster_id: None,
-            replica_id: None,
-            role_metadata: session.role_metadata().clone(),
-        };
+        let validity = PlanValidity::new(
+            self.catalog().transient_revision(),
+            BTreeSet::new(),
+            None,
+            None,
+            session.role_metadata().clone(),
+        );
         Ok(SecretStage::CreateEnsure(CreateSecretEnsure {
             validity,
             plan,
@@ -240,13 +240,13 @@ impl Coordinator {
         // calls `ensure()` and returns a success result to the client. If there's a concurrent
         // delete of the secret, the persisted secret is in an unknown state (but will be cleaned up
         // if needed at next envd boot), but we will still return success.
-        let validity = PlanValidity {
-            transient_revision: self.catalog().transient_revision(),
-            dependency_ids: BTreeSet::new(),
-            cluster_id: None,
-            replica_id: None,
-            role_metadata: ctx.session().role_metadata().clone(),
-        };
+        let validity = PlanValidity::new(
+            self.catalog().transient_revision(),
+            BTreeSet::new(),
+            None,
+            None,
+            ctx.session().role_metadata().clone(),
+        );
         let stage = SecretStage::Alter(AlterSecret { validity, plan });
         self.sequence_staged(ctx, Span::current(), stage).await;
     }
@@ -278,13 +278,13 @@ impl Coordinator {
         // change. The state of the persisted secret is unknown, and if the rotate ensure'd
         // after the delete (i.e., the secret is persisted to the secret store but not the
         // catalog), the secret will be cleaned up during next envd boot.
-        let validity = PlanValidity {
-            transient_revision: self.catalog().transient_revision(),
-            dependency_ids: BTreeSet::from_iter(std::iter::once(id)),
-            cluster_id: None,
-            replica_id: None,
-            role_metadata: ctx.session().role_metadata().clone(),
-        };
+        let validity = PlanValidity::new(
+            self.catalog().transient_revision(),
+            BTreeSet::from_iter(std::iter::once(id)),
+            None,
+            None,
+            ctx.session().role_metadata().clone(),
+        );
         let stage = SecretStage::RotateKeysEnsure(RotateKeysSecretEnsure { validity, id });
         self.sequence_staged(ctx, Span::current(), stage).await;
     }

--- a/src/adapter/src/coord/validity.rs
+++ b/src/adapter/src/coord/validity.rs
@@ -1,0 +1,278 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeSet;
+
+use mz_cluster_client::ReplicaId;
+use mz_compute_types::ComputeInstanceId;
+use mz_repr::GlobalId;
+use mz_sql::rbac::UnauthorizedError;
+use mz_sql::session::user::RoleMetadata;
+
+use crate::catalog::Catalog;
+use crate::AdapterError;
+
+// The inner fields of PlanValidity are not pub to prevent callers from using them in SQL logic.
+// Callers are responsible for tracking their own needed IDs explicitly and not using
+// PlanValidity as a logic sidecar.
+
+/// A struct to hold information about the validity of plans and if they should be abandoned after
+/// doing work off of the Coordinator thread.
+#[derive(Debug, Clone)]
+pub struct PlanValidity {
+    /// The most recent revision at which this plan was verified as valid.
+    transient_revision: u64,
+    /// Objects on which the plan depends.
+    dependency_ids: BTreeSet<GlobalId>,
+    cluster_id: Option<ComputeInstanceId>,
+    replica_id: Option<ReplicaId>,
+    role_metadata: RoleMetadata,
+}
+
+impl PlanValidity {
+    pub fn new(
+        transient_revision: u64,
+        dependency_ids: BTreeSet<GlobalId>,
+        cluster_id: Option<ComputeInstanceId>,
+        replica_id: Option<ReplicaId>,
+        role_metadata: RoleMetadata,
+    ) -> Self {
+        PlanValidity {
+            transient_revision,
+            dependency_ids,
+            cluster_id,
+            replica_id,
+            role_metadata,
+        }
+    }
+
+    pub fn extend_dependencies(&mut self, ids: impl Iterator<Item = GlobalId>) {
+        self.dependency_ids.extend(ids);
+    }
+
+    /// Returns an error if the current catalog no longer has all dependencies.
+    pub fn check(&mut self, catalog: &Catalog) -> Result<(), AdapterError> {
+        if self.transient_revision == catalog.transient_revision() {
+            return Ok(());
+        }
+        // If the transient revision changed, we have to recheck. If successful, bump the revision
+        // so next check uses the above fast path.
+        if let Some(cluster_id) = self.cluster_id {
+            let Some(cluster) = catalog.try_get_cluster(cluster_id) else {
+                return Err(AdapterError::ChangedPlan(format!(
+                    "cluster {} was removed",
+                    cluster_id
+                )));
+            };
+
+            if let Some(replica_id) = self.replica_id {
+                if cluster.replica(replica_id).is_none() {
+                    return Err(AdapterError::ChangedPlan(format!(
+                        "replica {} of cluster {} was removed",
+                        replica_id, cluster_id
+                    )));
+                }
+            }
+        }
+        // It is sufficient to check that all the dependency_ids still exist because we assume:
+        // - Ids do not mutate.
+        // - Ids are not reused.
+        // - If an id was dropped, this will detect it and error.
+        for id in &self.dependency_ids {
+            if catalog.try_get_entry(id).is_none() {
+                return Err(AdapterError::ChangedPlan(format!(
+                    "dependency was removed: {id}",
+                )));
+            }
+        }
+        if catalog
+            .try_get_role(&self.role_metadata.current_role)
+            .is_none()
+        {
+            return Err(AdapterError::Unauthorized(
+                UnauthorizedError::ConcurrentRoleDrop(self.role_metadata.current_role.clone()),
+            ));
+        }
+        if catalog
+            .try_get_role(&self.role_metadata.session_role)
+            .is_none()
+        {
+            return Err(AdapterError::Unauthorized(
+                UnauthorizedError::ConcurrentRoleDrop(self.role_metadata.session_role.clone()),
+            ));
+        }
+
+        if catalog
+            .try_get_role(&self.role_metadata.authenticated_role)
+            .is_none()
+        {
+            return Err(AdapterError::Unauthorized(
+                UnauthorizedError::ConcurrentRoleDrop(
+                    self.role_metadata.authenticated_role.clone(),
+                ),
+            ));
+        }
+        self.transient_revision = catalog.transient_revision();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use mz_adapter_types::connection::ConnectionId;
+    use mz_cluster_client::ReplicaId;
+    use mz_controller_types::ClusterId;
+    use mz_ore::assert_contains;
+    use mz_repr::role_id::RoleId;
+    use mz_repr::{GlobalId, Timestamp};
+    use mz_sql::catalog::RoleAttributes;
+    use mz_sql::session::metadata::SessionMetadata;
+
+    use crate::catalog::{Catalog, Op};
+    use crate::coord::validity::PlanValidity;
+    use crate::session::{Session, SessionConfig};
+    use crate::AdapterError;
+
+    #[mz_ore::test(tokio::test)]
+    async fn test_plan_validity() {
+        Catalog::with_debug(|mut catalog| async move {
+            let conn_id = ConnectionId::Static(1);
+            let user = String::from("validity_user");
+            let role = "validity_role";
+            catalog
+                .transact(
+                    None,
+                    Timestamp::MIN,
+                    None,
+                    vec![Op::CreateRole {
+                        name: role.into(),
+                        attributes: RoleAttributes::new(),
+                    }],
+                )
+                .await
+                .expect("is ok");
+            let role = catalog.try_get_role_by_name(role).expect("must exist");
+            // Can't use a dummy session because we need a valid role for the validity check.
+            let mut session = Session::<Timestamp>::new(
+                &mz_build_info::DUMMY_BUILD_INFO,
+                SessionConfig {
+                    conn_id,
+                    user,
+                    external_metadata_rx: None,
+                },
+            );
+            session.initialize_role_metadata(role.id);
+            let empty = PlanValidity::new(
+                // Set the transient rev 1 down so the check logic runs.
+                catalog
+                    .transient_revision()
+                    .checked_sub(1)
+                    .expect("must subtract"),
+                BTreeSet::new(),
+                None,
+                None,
+                session.role_metadata().clone(),
+            );
+            let some_system_cluster = catalog
+                .clusters()
+                .find(|c| matches!(c.id, ClusterId::System(_)))
+                .expect("must exist");
+
+            // Plan generation and result assertion closures.
+            let tests: &[(
+                Box<dyn Fn(&mut PlanValidity)>,
+                Box<dyn Fn(Result<(), AdapterError>)>,
+            )] = &[
+                (
+                    Box::new(|_validity| {}),
+                    Box::new(|res| assert!(res.is_ok(), "{res:?}")),
+                ),
+                (
+                    Box::new(|validity| {
+                        validity.cluster_id = Some(ClusterId::User(3));
+                    }),
+                    Box::new(|res| {
+                        assert_contains!(
+                            res.expect_err("must err").to_string(),
+                            "cluster u3 was removed"
+                        )
+                    }),
+                ),
+                (
+                    Box::new(|validity| {
+                        validity.cluster_id = Some(some_system_cluster.id);
+                        validity.replica_id = Some(ReplicaId::User(4));
+                    }),
+                    Box::new(|res| {
+                        assert_contains!(
+                            res.expect_err("must err").to_string(),
+                            format!(
+                                "replica u4 of cluster {} was removed",
+                                some_system_cluster.id
+                            ),
+                        )
+                    }),
+                ),
+                (
+                    Box::new(|validity| {
+                        validity.extend_dependencies(vec![GlobalId::User(6)].into_iter());
+                    }),
+                    Box::new(|res| {
+                        assert_contains!(
+                            res.expect_err("must err").to_string(),
+                            "dependency was removed: u6"
+                        )
+                    }),
+                ),
+                (
+                    Box::new(|validity| {
+                        validity.role_metadata.current_role = RoleId::User(5);
+                    }),
+                    Box::new(|res| {
+                        assert_contains!(
+                            res.expect_err("must err").to_string(),
+                            "role u5 was concurrently dropped"
+                        )
+                    }),
+                ),
+                (
+                    Box::new(|validity| {
+                        validity.role_metadata.session_role = RoleId::User(5);
+                    }),
+                    Box::new(|res| {
+                        assert_contains!(
+                            res.expect_err("must err").to_string(),
+                            "role u5 was concurrently dropped"
+                        )
+                    }),
+                ),
+                (
+                    Box::new(|validity| {
+                        validity.role_metadata.authenticated_role = RoleId::User(5);
+                    }),
+                    Box::new(|res| {
+                        assert_contains!(
+                            res.expect_err("must err").to_string(),
+                            "role u5 was concurrently dropped"
+                        )
+                    }),
+                ),
+            ];
+            for (get_validity, check_res) in tests {
+                let mut validity = empty.clone();
+                get_validity(&mut validity);
+                let res = validity.check(&catalog);
+                check_res(res);
+            }
+        })
+        .await
+    }
+}

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -792,11 +792,7 @@ impl<T: TimestampManipulation> Session<T> {
 
     /// Initializes the session's role metadata.
     pub fn initialize_role_metadata(&mut self, role_id: RoleId) {
-        self.role_metadata = Some(RoleMetadata {
-            authenticated_role: role_id,
-            session_role: role_id,
-            current_role: role_id,
-        });
+        self.role_metadata = Some(RoleMetadata::new(role_id));
     }
 
     /// Ensures that a timestamp oracle exists for `timeline` and returns a mutable reference to

--- a/src/sql/src/session/user.rs
+++ b/src/sql/src/session/user.rs
@@ -131,3 +131,14 @@ pub struct RoleMetadata {
     /// checks.
     pub current_role: RoleId,
 }
+
+impl RoleMetadata {
+    /// Returns a RoleMetadata with all fields set to `id`.
+    pub fn new(id: RoleId) -> RoleMetadata {
+        RoleMetadata {
+            authenticated_role: id,
+            session_role: id,
+            current_role: id,
+        }
+    }
+}


### PR DESCRIPTION
PlanValidity may be changing in the near future to no longer track anything beyond the transient revision. Refactor places where parts of the plan validity were used for various SQL logic by explicitly requiring and passing that data instead.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a