### PR TITLE
test: reduce test cases for `all_source_data_roundtrips`

### DIFF
--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1967,9 +1967,12 @@ mod tests {
                 .prop_map(move |datas| (desc.clone(), datas))
         });
 
-        proptest!(|((desc, source_datas) in strat)| {
-            roundtrip_source_data(desc, source_datas);
-        });
+        proptest!(
+            ProptestConfig::with_cases(100),
+            |((desc, source_datas) in strat)| {
+                roundtrip_source_data(desc, source_datas);
+            }
+        );
     }
 
     #[mz_ore::test]


### PR DESCRIPTION
Otherwise this test timesout in CI

### Motivation

Fix CI timeout

Closes: https://github.com/MaterializeInc/materialize/issues/27916

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
