### PR TITLE
storage: in CollectionManager, _do_ gracefully handle shutdown

### DIFF
--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -568,7 +568,32 @@ where
     }
 
     fn handle_shutdown(&mut self) {
-        unreachable!("we are not currently unregistering differential storage-managed collections");
+        let mut senders = Vec::new();
+
+        // Prevent new messages from being sent.
+        self.cmd_rx.close();
+
+        // Get as many waiting senders as possible.
+        'collect: while let Ok((_batch, sender)) = self.cmd_rx.try_recv() {
+            senders.push(sender);
+
+            // Note: because we're shutting down the sending side of `rx` is no
+            // longer accessible, and thus we should no longer receive new
+            // requests. We add this check just as an extra guard.
+            if senders.len() > CHANNEL_CAPACITY {
+                // There's not a correctness issue if we receive new requests, just
+                // unexpected behavior.
+                tracing::error!("Write task channel should not be receiving new requests");
+                break 'collect;
+            }
+        }
+
+        // Notify them that this collection is closed.
+        //
+        // Note: if a task is shutting down, that indicates the source has been
+        // dropped, at which point the identifier is invalid. Returning this
+        // error provides a better user experience.
+        notify_listeners(senders, || Err(StorageError::IdentifierInvalid(self.id)));
     }
 
     async fn handle_updates(


### PR DESCRIPTION
Fixes #27853

Before, we were assuming that the shutdown code paths can never be reached in production or CI, but that turns out to be wrong: https://github.com/MaterializeInc/materialize/issues/27853

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
