### PR TITLE
compute: drop `CollectionState` eagerly

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -1532,12 +1532,11 @@ impl CollectionState {
 /// State remembered about a dropped compute collection.
 ///
 /// This is the subset of the full [`CollectionState`] that survives the invocation of
-/// [`ActiveComputeState::drop_collection`], until it is finally dropped in
-/// [`ActiveComputeState::report_dropped_collections`]. It includes any information required to
-/// report the dropping of a collection to the controller.
+/// `drop_collection`, until it is finally dropped in `report_dropped_collections`. It includes any
+/// information required to report the dropping of a collection to the controller.
 ///
 /// Note that this state must _not_ store any state (such as tokens) whose dropping releases
-/// resources elsewhere in the system. A [`DroppedCollectionState`] for a collection dropped during
+/// resources elsewhere in the system. A `DroppedCollection` for a collection dropped during
 /// reconciliation might be alive at the same time as the [`CollectionState`] for the re-created
 /// collection, and if the dropped collection hasn't released all its held resources by the time
 /// the new one is created, conflicts can ensue.

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -80,7 +80,7 @@ pub struct ComputeState {
     ///  * Subscribes report their frontiers through the `subscribe_response_buffer`.
     pub collections: BTreeMap<GlobalId, CollectionState>,
     /// Collections that were recently dropped and whose removal needs to be reported.
-    pub dropped_collections: Vec<(GlobalId, CollectionState)>,
+    pub dropped_collections: Vec<(GlobalId, DroppedCollection)>,
     /// The traces available for sharing across dataflows.
     pub traces: TraceManager,
     /// Shared buffer with SUBSCRIBE operator instances by which they can respond.
@@ -514,21 +514,20 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
     ///
     /// Collection dropping occurs in three phases:
     ///
-    ///  1. This method removes the collection from the `ComputeState` and drops its dataflow
-    ///     tokens. It does _not_ yet drop the `CollectionState` but adds it to
-    ///     `dropped_collections`.
+    ///  1. This method removes the collection from the [`ComputeState`] and drops its
+    ///     [`CollectionState`], including its held dataflow tokens. It then adds the dropped
+    ///     collection to `dropped_collections`.
     ///  2. The next step of the Timely worker lets the source operators observe the token drops
     ///     and shut themselves down.
-    ///  3. `report_dropped_collections` removes the `CollectionState` from `dropped_collections`,
-    ///     emits any outstanding final responses required by the compute protocol, then drops the
-    ///     `CollectionState`.
+    ///  3. `report_dropped_collections` removes the entry from `dropped_collections` and emits any
+    ///     outstanding final responses required by the compute protocol.
     ///
     /// These steps ensure that we don't report a collection as dropped to the controller before it
     /// has stopped reading from its inputs. Doing so would allow the controller to release its
     /// read holds on the inputs, which could lead to panics from the replica trying to read
     /// already compacted times.
     fn drop_collection(&mut self, id: GlobalId) {
-        let mut collection = self
+        let collection = self
             .compute_state
             .collections
             .remove(&id)
@@ -536,16 +535,15 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
 
         // If this collection is an index, remove its trace.
         self.compute_state.traces.remove(&id);
-        // If this collection is a sink, drop its sink token.
-        collection.sink_token.take();
-
         // If the collection is unscheduled, remove it from the list of waiting collections.
         self.compute_state.suspended_collections.remove(&id);
 
         // Remember the collection as dropped, for emission of outstanding final compute responses.
-        self.compute_state
-            .dropped_collections
-            .push((id, collection));
+        let dropped = DroppedCollection {
+            reported_frontiers: collection.reported_frontiers,
+            is_subscribe_or_copy: collection.is_subscribe_or_copy,
+        };
+        self.compute_state.dropped_collections.push((id, dropped));
     }
 
     /// Initializes timely dataflow logging and publishes as a view.
@@ -692,7 +690,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                 continue;
             }
 
-            let reported = collection.reported_frontiers();
+            let reported = collection.reported_frontiers;
             let write_frontier = (!reported.write_frontier.is_empty()).then(Antichain::new);
             let input_frontier = (!reported.input_frontier.is_empty()).then(Antichain::new);
             let output_frontier = (!reported.output_frontier.is_empty()).then(Antichain::new);
@@ -1529,6 +1527,23 @@ impl CollectionState {
     fn set_reported_output_frontier(&mut self, frontier: ReportedFrontier) {
         self.reported_frontiers.output_frontier = frontier;
     }
+}
+
+/// State remembered about a dropped compute collection.
+///
+/// This is the subset of the full [`CollectionState`] that survives the invocation of
+/// [`ActiveComputeState::drop_collection`], until it is finally dropped in
+/// [`ActiveComputeState::report_dropped_collections`]. It includes any information required to
+/// report the dropping of a collection to the controller.
+///
+/// Note that this state must _not_ store any state (such as tokens) whose dropping releases
+/// resources elsewhere in the system. A [`DroppedCollectionState`] for a collection dropped during
+/// reconciliation might be alive at the same time as the [`CollectionState`] for the re-created
+/// collection, and if the dropped collection hasn't released all its held resources by the time
+/// the new one is created, conflicts can ensue.
+pub struct DroppedCollection {
+    reported_frontiers: ReportedFrontiers,
+    is_subscribe_or_copy: bool,
 }
 
 /// An event reporting the hydration status of an LIR node in a dataflow.


### PR DESCRIPTION
The dropping of collections happens in two phases, to ensure that dataflow sources can stop reading from the inputs before we announce the relinquishing of their read holds to the controller. Previously this was done by keeping the `CollectionState` alive until `report_dropped_collections`, so that method could inspect the reported frontiers. Keeping the `CollectionState` alive also meant keeping its `CollectionLogging` alive.

This made it possible for two `CollectionLogging` instances to be alive for the same collection after reconciliation. When reconciliation drops and reinstalls a collection, it makes sure that the `AllowCompaction` command is handled before the `CreateDataflow` command. Handling `AllowCompaction` results in a `drop_collection` call, but intentionally not in a `report_dropped_collections` call (that is deferred until after the next Timely step), so the old `CollectionLogging` instance stays alive. Then handling `CreateDataflow` creates a new `CollectionLogging` instance for the same collection ID. Creation and deletion of `CollectionLogging` instances causes emission of log events, and the logging dataflows assume that collection IDs are unique, so having two `CollectionLogging` instances for the same ID alive corrupts the logging dataflow state.

The fix is to make sure `drop_collection` also drops the `CollectionLogging` instance of the collection, as it already does with sink tokens. This commit does that, but to prevent issues like this from reappearing when we add more fields to `CollectionState`, it also introduces a separate `DroppedCollection` type that only holds the state required by `report_dropped_collections`. This forces us to be explicit about which fields we want to survive `drop_collection` and lets us make sure that none of them holds onto any shared resources.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/27915

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
