### PR TITLE
[persist] Roll out compaction-y flags more widely in CI

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -89,6 +89,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_inline_writes_total_max_bytes": "1048576",
     "persist_pubsub_client_enabled": "true",
     "persist_pubsub_push_diff_enabled": "true",
+    "persist_record_compactions": "true",
     "persist_roundtrip_spine": "true",
     "persist_sink_minimum_batch_updates": "128",
     "persist_stats_audit_percent": "100",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -920,6 +920,9 @@ class FlipFlagsAction(Action):
             self.flags_with_values[f"persist_use_critical_since_{flag}"] = (
                 BOOLEAN_FLAG_VALUES
             )
+        self.flags_with_values["persist_claim_unclaimed_compactions"] = (
+            BOOLEAN_FLAG_VALUES
+        )
         self.flags_with_values["persist_roundtrip_spine"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_optimize_ignored_data_fetch"] = (
             BOOLEAN_FLAG_VALUES

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -927,7 +927,10 @@ where
 
         // NB: we don't claim unclaimed compactions when the recording flag is off, even if we'd
         // otherwise be allowed to, to avoid triggering the same compactions in every writer.
-        if record_compactions && claim_unclaimed_compactions && merge_reqs.is_empty() {
+        let all_empty_reqs = merge_reqs
+            .iter()
+            .all(|req| req.inputs.iter().all(|b| b.batch.is_empty()));
+        if record_compactions && claim_unclaimed_compactions && all_empty_reqs {
             let threshold_ms = heartbeat_timestamp_ms.saturating_sub(lease_duration_ms);
             merge_reqs.extend(self.trace.fueled_merge_reqs_before_ms(threshold_ms).take(1))
         }


### PR DESCRIPTION
### Motivation

Progress on #16607! In particular, since we're now running only versions with the proper Proto definitions, we can start rolling out the flag by default.

### Tips for reviewer

Nightlies: https://buildkite.com/materialize/nightly/builds/8258

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
