### PR TITLE
cargo test: Bump timeout for test_smoketest_all_builtins

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,6 +25,10 @@ slow-timeout = { period = "120s", terminate-after = 2 }
 filter = "package(mz-storage-types) and test(all_source_data_roundtrips)"
 slow-timeout = { period = "300s", terminate-after = 2 }
 
+[[profile.default.overrides]]
+filter = "package(mz-adapter) and test(test_smoketest_all_builtins)"
+slow-timeout = { period = "300s", terminate-after = 2 }
+
 [profile.ci]
 junit = { path = "junit_cargo-test.xml" }
 fail-fast = false


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/84788#01905aa0-c374-42ea-a74c-3dd9b6d880e9

@jkosh44 Any idea why this would start timing out now?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
