### PR TITLE
doc/user: don't use Hugo's CloudFront invalidation feature

### DIFF
--- a/ci/deploy_website/website.sh
+++ b/ci/deploy_website/website.sh
@@ -60,11 +60,8 @@ for slug in "${!shortlinks[@]}"; do
     aws s3 cp empty "s3://materialize-website/s/$slug" --website-redirect "${shortlinks[$slug]}"
 done
 
-# Work around bug in AWS CLI where cached credentials are not refreshed
-# properly.
-rm -rf ~/.aws/cli/cache
-
 # Hugo's CloudFront invalidation feature doesn't do anything smarter than
-# invalidating the entire distribution, so we do it here to make it clear that
-# we're invalidating the shortlinks too.
+# invalidating the entire distribution (and has bugs fetching AWS credentials in
+# recent versions), so we just do it here to make it clear that we're
+# invalidating the shortlinks too.
 AWS_PAGER="" aws cloudfront create-invalidation --distribution-id E1F8Q2NUUC41QE --paths "/*"

--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -280,7 +280,6 @@ unsafe = true
 [[deployment.targets]]
 name = "production"
 url = "s3://materialize-website?region=us-east-1"
-cloudFrontDistributionID = "E1F8Q2NUUC41QE"
 # Sync only the docs, to avoid deleting the marketing website.
 include = "docs/**"
 # Avoid deleting the LTS docs, which are deployed from the lts-docs branch.


### PR DESCRIPTION
We already do this ourselves in deploy_website.sh to pick up redirect URLs, and in recent versions of Hugo the CloudFront invalidation inexplicably sporadically fails to refresh AWS credentials.
