### PR TITLE
storage/copy-to-s3: Allow 404 errors for DeleteObject permissions test returned when using GCS instead of S3

### DIFF
--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -233,25 +233,30 @@ where
                 };
 
                 // Confirm we have DeleteObject permissions before proceeding by trying to
-                // delete a known non-existent file since S3 will return an AccessDenied error
-                // whether or not the object exists, and no error if we have permissions and
-                // it doesn't.
-                client
+                // delete a known non-existent file.
+                // S3 will return an AccessDenied error whether or not the object exists,
+                // and no error if we have permissions and it doesn't.
+                // Other S3-compatible APIs (e.g. GCS) return a 404 error if the object
+                // does not exist, so we ignore that error.
+                match client
                     .delete_object()
                     .bucket(&bucket)
                     .key(s3_key_manager.data_key(0, 0, "delete_object_test"))
                     .send()
                     .await
-                    .map_err(|err| {
-                        if err
-                            .raw_response()
-                            .map_or(false, |r| r.status().as_u16() == 403)
-                        {
-                            anyhow!("AccessDenied error when using DeleteObject")
+                {
+                    Err(err) => {
+                        let err_code = err.raw_response().map(|r| r.status().as_u16());
+                        if err_code.map_or(false, |r| r == 403) {
+                            Err(anyhow!("AccessDenied error when using DeleteObject"))?
+                        } else if err_code.map_or(false, |r| r == 404) {
+                            // ignore 404s
                         } else {
-                            err.into()
+                            Err(anyhow!("Error when using DeleteObject: {}", err))?
                         }
-                    })?;
+                    }
+                    Ok(_) => {}
+                };
 
                 debug!(%sink_id, %worker_id, "uploading INCOMPLETE sentinel file");
                 client


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

When testing compatibility of copy-to-s3 against GCS's XML API which is meant to be API-compatible with the S3 API, we noticed that the GCS API will respond with a 404 if a `DeleteObject` request object does not exist, whereas S3 will respond with a success error code.

From https://cloud.google.com/storage/docs/xml-api/delete-object:
![image](https://github.com/MaterializeInc/materialize/assets/3818834/4e7c6f26-73b8-48f4-9ed5-02007ccb1962)


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
