### PR TITLE
ci: Bump cargo-test timeout and reduce flakiness (hopefully)

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -270,8 +270,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                         "--profile=ci",
                         "--cargo-profile=ci",
                         f"--partition=count:{partition}/{total}",
-                        # Most tests don't use 100% of a CPU core, so run two tests per CPU.
-                        f"--test-threads={cpu_count * 2}",
                         *args.args,
                     ],
                     env=env,

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -215,7 +215,7 @@ steps:
 
   - id: cargo-test
     label: Cargo test
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     inputs:
       - Cargo.lock
       - ".config/nextest.toml"


### PR DESCRIPTION
Timeout seen in https://buildkite.com/materialize/test/builds/84858#01905f7a-52f7-468e-b540-ac238ef7a64a

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
