### PR TITLE
Introduce Chroma syntax-generation script

### DIFF
--- a/bin/gen-chroma-syntax
+++ b/bin/gen-chroma-syntax
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# gen-chroma-syntax -- regenerates a Materialize-dialect Chroma syntax file
+#                      using the currently-checked out Materialize keywords
+
+exec "$(dirname "$0")"/pyactivate -m materialize.cli.gen-chroma-syntax "$@"

--- a/doc/developer/chroma-syntax-generation.md
+++ b/doc/developer/chroma-syntax-generation.md
@@ -1,0 +1,12 @@
+# Generating new Chroma syntax highlights
+
+Chroma is the syntax highlighter used by Hugo, the static site generator that powers Materialize's docs. We have upstreamed a Materialize lexer (which is a slightly-modified version of their Postgres lexer). When new keywords are added we should upstream an update.
+
+## Generating a new lexer definition
+
+1. Fork the Chroma repo and clone it locally as a sibling of the `materialize` repo.
+2. From the root directory of the `materialize` repo, run the generate script:
+   ```shell
+   ./bin/gen-chroma-syntax
+   ```
+3. In the Chroma repo, commit the changes to the Materialize dialect file and submit them as a PR.

--- a/misc/python/materialize/cli/gen-chroma-syntax.py
+++ b/misc/python/materialize/cli/gen-chroma-syntax.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Regenerates a Materialize-dialect Chroma syntax file using the local Materialize keywords"""
+
+import argparse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from materialize import MZ_ROOT
+
+CONFIG_FIELDS = {
+    "name": "Materialize SQL dialect",
+    "alias": ["materialize", "mzsql"],
+    "mime_type": "text/x-materializesql",
+}
+
+
+def keyword_pattern():
+    keywords_file = MZ_ROOT / "src/sql-lexer/src/keywords.txt"
+    keywords = [
+        line.upper()
+        for line in keywords_file.read_text().splitlines()
+        if not (line.startswith("#") or not line.strip())
+    ]
+    return f"({'|'.join(keywords)})\\b"
+
+
+def set_keywords(root: ET.Element):
+    rule = root.find(".//rule/token[@type='Keyword']/..")
+    if not rule:
+        raise RuntimeError("No keyword rule found")
+    rule.set("pattern", keyword_pattern())
+
+
+def set_config(root: ET.Element):
+    config = root.find("config")
+    if not config:
+        raise RuntimeError("No config found")
+    for field_name, field_value in CONFIG_FIELDS.items():
+        if isinstance(field_value, list):
+            for element in config.findall(field_name):
+                config.remove(element)
+            for item in field_value:
+                field = ET.SubElement(config, field_name)
+                field.text = item
+        else:
+            field = config.find(field_name)
+            if field is None:
+                raise RuntimeError(f"No such config field: '{field_name}'")
+            field.text = field_value
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--chroma-dir",
+        default="../chroma",
+    )
+    args = parser.parse_args()
+    lexer_dir = Path(f"{args.chroma_dir}/lexers/embedded/")
+    tree = ET.parse(lexer_dir / "postgresql_sql_dialect.xml")
+    root = tree.getroot()
+    if not root:
+        raise RuntimeError("Could not find root element")
+    set_keywords(root)
+    set_config(root)
+    ET.indent(root, "  ")
+    tree.write(lexer_dir / "materialize_sql_dialect.xml", encoding="unicode")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.
Hugo uses Chroma for syntax highlighting. We upstreamed a Materialize-specific syntax to ensure our dialect's keywords are recognized as such. Now that the end-to-end change is in prod, let's automate the process of generating updates for the dialect lexer.

[I have a PR filed against the Chroma repo](https://github.com/alecthomas/chroma/pull/978) that uses a version of the lexer generated by this script.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
no user facing behavior changes