### PR TITLE
[skunk] Use typed shard ids instead of bare strings

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -887,7 +887,7 @@ impl CatalogState {
                 let newly_inserted = self
                     .storage_metadata
                     .unfinalized_shards
-                    .insert(unfinalized_shard.shard.clone());
+                    .insert(unfinalized_shard.shard);
                 assert!(
                     newly_inserted,
                     "values must be explicitly retracted before inserting a new value: {unfinalized_shard:?}",

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -196,7 +196,7 @@ fn assign_new_user_global_ids(
 
     // !WARNING!
     //
-    // double-check that using this fn doesn't interfer with any other
+    // double-check that using this fn doesn't interfere with any other
     // migrations
 
     // Convert the IDs we need into a set with constant-time lookup.

--- a/src/catalog/src/durable/objects.rs
+++ b/src/catalog/src/durable/objects.rs
@@ -33,6 +33,7 @@ use std::collections::BTreeMap;
 use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
 use mz_controller::clusters::ReplicaLogging;
 use mz_controller_types::{ClusterId, ReplicaId};
+use mz_persist_types::ShardId;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
@@ -872,7 +873,7 @@ impl DurableType for StorageUsage {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StorageCollectionMetadata {
     pub id: GlobalId,
-    pub shard: String,
+    pub shard: ShardId,
 }
 
 impl DurableType for StorageCollectionMetadata {
@@ -900,7 +901,7 @@ impl DurableType for StorageCollectionMetadata {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnfinalizedShard {
-    pub shard: String,
+    pub shard: ShardId,
 }
 
 impl DurableType for UnfinalizedShard {
@@ -1150,21 +1151,21 @@ pub struct StorageCollectionMetadataKey {
 /// manipulated by the storage controller.
 #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Ord)]
 pub struct StorageCollectionMetadataValue {
-    pub(crate) shard: String,
+    pub(crate) shard: ShardId,
 }
 
 /// This value is stored transparently, however, it should only ever be
 /// manipulated by the storage controller.
 #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Ord)]
 pub struct UnfinalizedShardKey {
-    pub(crate) shard: String,
+    pub(crate) shard: ShardId,
 }
 
 /// This value is stored transparently, however, it should only ever be
 /// manipulated by the storage controller.
 #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Ord)]
 pub struct TxnWalShardValue {
-    pub(crate) shard: String,
+    pub(crate) shard: ShardId,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Ord, Hash)]

--- a/src/catalog/src/durable/objects/serialization.rs
+++ b/src/catalog/src/durable/objects/serialization.rs
@@ -730,7 +730,9 @@ impl RustType<proto::StorageCollectionMetadataValue> for StorageCollectionMetada
     }
 
     fn from_proto(proto: proto::StorageCollectionMetadataValue) -> Result<Self, TryFromProtoError> {
-        Ok(StorageCollectionMetadataValue { shard: proto.shard })
+        Ok(StorageCollectionMetadataValue {
+            shard: proto.shard.into_rust()?,
+        })
     }
 }
 
@@ -742,7 +744,9 @@ impl RustType<proto::UnfinalizedShardKey> for UnfinalizedShardKey {
     }
 
     fn from_proto(proto: proto::UnfinalizedShardKey) -> Result<Self, TryFromProtoError> {
-        Ok(UnfinalizedShardKey { shard: proto.shard })
+        Ok(UnfinalizedShardKey {
+            shard: proto.shard.into_rust()?,
+        })
     }
 }
 
@@ -754,7 +758,9 @@ impl RustType<proto::TxnWalShardValue> for TxnWalShardValue {
     }
 
     fn from_proto(proto: proto::TxnWalShardValue) -> Result<Self, TryFromProtoError> {
-        Ok(TxnWalShardValue { shard: proto.shard })
+        Ok(TxnWalShardValue {
+            shard: proto.shard.into_rust()?,
+        })
     }
 }
 

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -12,7 +12,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::num::NonZeroI64;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -405,7 +404,6 @@ where
         let txns_id = txn
             .get_txn_wal_shard()
             .expect("must call prepare initialization before creating StorageCollections");
-        let txns_id = ShardId::from_str(txns_id.as_str()).expect("shard ID must be valid");
 
         let txns_client = persist_clients
             .open(persist_location.clone())
@@ -965,11 +963,7 @@ where
         self.finalized_shards
             .lock()
             .expect("lock poisoned")
-            .retain(|shard| {
-                storage_metadata
-                    .unfinalized_shards
-                    .contains(shard.to_string().as_str())
-            });
+            .retain(|shard| storage_metadata.unfinalized_shards.contains(shard));
     }
 }
 
@@ -993,13 +987,6 @@ where
         drop_ids: BTreeSet<GlobalId>,
     ) -> Result<(), StorageError<T>> {
         let metadata = txn.get_collection_metadata();
-
-        let processed_metadata: Result<Vec<_>, _> = metadata
-            .into_iter()
-            .map(|(id, shard)| ShardId::from_str(&shard).map(|shard| (id, shard)))
-            .collect();
-
-        let metadata = processed_metadata.map_err(|e| StorageError::Generic(anyhow::anyhow!(e)))?;
         let existing_metadata: BTreeSet<_> = metadata.into_iter().map(|(id, _)| id).collect();
 
         // Determine which collections we do not yet have metadata for.
@@ -1025,11 +1012,7 @@ where
         // dropped from the catalog, but the dataflow is still running on a
         // worker, assuming the shard is safe to finalize on reboot may cause
         // the cluster to panic.
-        let unfinalized_shards = txn
-            .get_unfinalized_shards()
-            .into_iter()
-            .map(|shard| ShardId::from_str(&shard).expect("deserialization corrupted"))
-            .collect_vec();
+        let unfinalized_shards = txn.get_unfinalized_shards().into_iter().collect_vec();
 
         info!(?unfinalized_shards, "initializing finalizable_shards");
 
@@ -1211,7 +1194,7 @@ where
         txn.insert_collection_metadata(
             ids_to_add
                 .into_iter()
-                .map(|id| (id, ShardId::new().to_string()))
+                .map(|id| (id, ShardId::new()))
                 .collect(),
         )?;
 
@@ -1232,7 +1215,7 @@ where
             .lock()
             .expect("lock poisoned")
             .iter()
-            .map(|v| v.to_string())
+            .copied()
             .collect();
         txn.mark_shards_as_finalized(finalized_shards);
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2262,7 +2262,7 @@ where
 pub fn prepare_initialization<T>(txn: &mut dyn StorageTxn<T>) -> Result<(), StorageError<T>> {
     if txn.get_txn_wal_shard().is_none() {
         let txns_id = ShardId::new();
-        txn.write_txn_wal_shard(txns_id.to_string())?;
+        txn.write_txn_wal_shard(txns_id)?;
     }
 
     Ok(())
@@ -2305,7 +2305,6 @@ where
         let txns_id = txn
             .get_txn_wal_shard()
             .expect("must call prepare initialization before creating storage controller");
-        let txns_id = ShardId::from_str(txns_id.as_str()).expect("shard ID must be valid");
 
         let txns_client = persist_clients
             .open(persist_location.clone())

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -203,7 +203,7 @@ pub enum StorageError<T> {
     /// Collection metadata already exists for ID.
     CollectionMetadataAlreadyExists(GlobalId),
     /// Some other collection is already writing to this persist shard.
-    PersistShardAlreadyInUse(String),
+    PersistShardAlreadyInUse(ShardId),
     /// Txn WAL shard already exists.
     TxnWalShardAlreadyExists,
     /// The item that a subsource refers to is unexpectedly missing from the


### PR DESCRIPTION
### Motivation

Refactoring! More efficient and less error-prone to handle (de)serialization at the edges.

### Tips for reviewer

There are some comments that suggest that some of these values were meant to be treated as opaque. If this seems too "transparent" I could introduce a newtype wrapper...

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
