### PR TITLE
Fix "no replicas available" sql hint to be conditional based on managed or unmanaged cluster

### DIFF
--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -286,6 +286,7 @@ impl Coordinator {
         if cluster.replicas().next().is_none() && explain_ctx.needs_cluster() {
             return Err(AdapterError::NoClusterReplicasAvailable(
                 cluster.name.clone(),
+                cluster.is_managed(),
             ));
         }
 
@@ -322,6 +323,7 @@ impl Coordinator {
                     None => {
                         return Err(AdapterError::NoClusterReplicasAvailable(
                             cluster.name.clone(),
+                            cluster.is_managed(),
                         ))
                     }
                 };

--- a/src/adapter/src/coord/sequencer/inner/peek.rs
+++ b/src/adapter/src/coord/sequencer/inner/peek.rs
@@ -284,10 +284,10 @@ impl Coordinator {
             .override_from(&explain_ctx);
 
         if cluster.replicas().next().is_none() && explain_ctx.needs_cluster() {
-            return Err(AdapterError::NoClusterReplicasAvailable(
-                cluster.name.clone(),
-                cluster.is_managed(),
-            ));
+            return Err(AdapterError::NoClusterReplicasAvailable {
+                name: cluster.name.clone(),
+                is_managed: cluster.is_managed(),
+            });
         }
 
         let optimizer = match copy_to_ctx {
@@ -321,10 +321,10 @@ impl Coordinator {
                 {
                     Some(count) => u64::cast_from(count),
                     None => {
-                        return Err(AdapterError::NoClusterReplicasAvailable(
-                            cluster.name.clone(),
-                            cluster.is_managed(),
-                        ))
+                        return Err(AdapterError::NoClusterReplicasAvailable {
+                            name: cluster.name.clone(),
+                            is_managed: cluster.is_managed(),
+                        })
                     }
                 };
                 copy_to_ctx.output_batch_count = Some(max_worker_count);

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -98,7 +98,7 @@ pub enum AdapterError {
     /// Transaction cluster was dropped in the middle of a transaction.
     ConcurrentClusterDrop,
     /// Target cluster has no replicas to service query.
-    NoClusterReplicasAvailable(String),
+    NoClusterReplicasAvailable(String, bool),
     /// The named operation cannot be run in a transaction.
     OperationProhibitsTransaction(String),
     /// The named operation requires an active transaction.
@@ -367,8 +367,13 @@ impl AdapterError {
                 "Try choosing one of the smaller sizes to start. Available sizes: {}",
                 expected.join(", ")
             )),
-            AdapterError::NoClusterReplicasAvailable(_) => {
-                Some("You can create cluster replicas using CREATE CLUSTER REPLICA".into())
+            AdapterError::NoClusterReplicasAvailable(_, is_managed) => {
+                Some(if *is_managed {
+                    "You can adjust the replication factor of the cluster with ALTER CLUSTER. \
+                    For example `ALTER CLUSTER <cluster-name> SET (REPLICATION FACTOR 1)`".into()
+                } else {
+                    "You can create cluster replicas using CREATE CLUSTER REPLICA".into()
+                })
             }
             AdapterError::UntargetedLogRead { .. } => Some(
                 "Use `SET cluster_replica = <replica-name>` to target a specific replica in the \
@@ -457,7 +462,7 @@ impl AdapterError {
             AdapterError::InvalidTableMutationSelection => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::ConstraintViolation(NotNullViolation(_)) => SqlState::NOT_NULL_VIOLATION,
             AdapterError::ConcurrentClusterDrop => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::NoClusterReplicasAvailable(_) => SqlState::FEATURE_NOT_SUPPORTED,
+            AdapterError::NoClusterReplicasAvailable(..) => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::OperationProhibitsTransaction(_) => SqlState::ACTIVE_SQL_TRANSACTION,
             AdapterError::OperationRequiresTransaction(_) => SqlState::NO_ACTIVE_SQL_TRANSACTION,
             AdapterError::ParseError(_) => SqlState::SYNTAX_ERROR,
@@ -599,7 +604,7 @@ impl fmt::Display for AdapterError {
             AdapterError::ConcurrentClusterDrop => {
                 write!(f, "the transaction's active cluster has been dropped")
             }
-            AdapterError::NoClusterReplicasAvailable(cluster) => {
+            AdapterError::NoClusterReplicasAvailable(cluster, _) => {
                 write!(
                     f,
                     "CLUSTER {} has no replicas available to service request",

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -98,7 +98,10 @@ pub enum AdapterError {
     /// Transaction cluster was dropped in the middle of a transaction.
     ConcurrentClusterDrop,
     /// Target cluster has no replicas to service query.
-    NoClusterReplicasAvailable(String, bool),
+    NoClusterReplicasAvailable {
+        name: String,
+        is_managed: bool,
+    },
     /// The named operation cannot be run in a transaction.
     OperationProhibitsTransaction(String),
     /// The named operation requires an active transaction.
@@ -367,12 +370,12 @@ impl AdapterError {
                 "Try choosing one of the smaller sizes to start. Available sizes: {}",
                 expected.join(", ")
             )),
-            AdapterError::NoClusterReplicasAvailable(_, is_managed) => {
+            AdapterError::NoClusterReplicasAvailable { is_managed, .. } => {
                 Some(if *is_managed {
-                    "You can adjust the replication factor of the cluster with ALTER CLUSTER. \
-                    For example `ALTER CLUSTER <cluster-name> SET (REPLICATION FACTOR 1)`".into()
+                    "Use ALTER CLUSTER to adjust the replication factor of the cluster. \
+                    Example:`ALTER CLUSTER <cluster-name> SET (REPLICATION FACTOR 1)`".into()
                 } else {
-                    "You can create cluster replicas using CREATE CLUSTER REPLICA".into()
+                    "Use CREATE CLUSTER REPLICA to attach cluster replicas to the cluster".into()
                 })
             }
             AdapterError::UntargetedLogRead { .. } => Some(
@@ -462,7 +465,7 @@ impl AdapterError {
             AdapterError::InvalidTableMutationSelection => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::ConstraintViolation(NotNullViolation(_)) => SqlState::NOT_NULL_VIOLATION,
             AdapterError::ConcurrentClusterDrop => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::NoClusterReplicasAvailable(..) => SqlState::FEATURE_NOT_SUPPORTED,
+            AdapterError::NoClusterReplicasAvailable { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::OperationProhibitsTransaction(_) => SqlState::ACTIVE_SQL_TRANSACTION,
             AdapterError::OperationRequiresTransaction(_) => SqlState::NO_ACTIVE_SQL_TRANSACTION,
             AdapterError::ParseError(_) => SqlState::SYNTAX_ERROR,
@@ -604,11 +607,11 @@ impl fmt::Display for AdapterError {
             AdapterError::ConcurrentClusterDrop => {
                 write!(f, "the transaction's active cluster has been dropped")
             }
-            AdapterError::NoClusterReplicasAvailable(cluster, _) => {
+            AdapterError::NoClusterReplicasAvailable { name, .. } => {
                 write!(
                     f,
                     "CLUSTER {} has no replicas available to service request",
-                    cluster.quoted()
+                    name.quoted()
                 )
             }
             AdapterError::OperationProhibitsTransaction(op) => {

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -562,7 +562,7 @@ simple
 SELECT generate_series(1, 1)
 ----
 db error: ERROR: CLUSTER "empty" has no replicas available to service request
-HINT: You can create cluster replicas using CREATE CLUSTER REPLICA
+HINT: Use CREATE CLUSTER REPLICA to attach cluster replicas to the cluster
 
 statement ok
 DROP CLUSTER empty
@@ -574,7 +574,7 @@ simple
 SELECT generate_series(1, 1)
 ----
 db error: ERROR: CLUSTER "empty" has no replicas available to service request
-HINT: You can adjust the replication factor of the cluster with ALTER CLUSTER. For example `ALTER CLUSTER <cluster-name> SET (REPLICATION FACTOR 1)`
+HINT: Use ALTER CLUSTER to adjust the replication factor of the cluster. Example:`ALTER CLUSTER <cluster-name> SET (REPLICATION FACTOR 1)`
 
 
 # Phillip's tests

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -558,8 +558,23 @@ CREATE CLUSTER empty REPLICAS ()
 statement ok
 SET cluster = empty
 
-query error CLUSTER "empty" has no replicas available to service request
-SELECT generate_series(1, 1);
+simple
+SELECT generate_series(1, 1)
+----
+db error: ERROR: CLUSTER "empty" has no replicas available to service request
+HINT: You can create cluster replicas using CREATE CLUSTER REPLICA
+
+statement ok
+DROP CLUSTER empty
+
+statement ok
+CREATE CLUSTER empty (SIZE '1', REPLICATION FACTOR 0)
+
+simple
+SELECT generate_series(1, 1)
+----
+db error: ERROR: CLUSTER "empty" has no replicas available to service request
+HINT: You can adjust the replication factor of the cluster with ALTER CLUSTER. For example `ALTER CLUSTER <cluster-name> SET (REPLICATION FACTOR 1)`
 
 
 # Phillip's tests


### PR DESCRIPTION
Fix "no cluster replicas available" adapter sql hint to be conditional based on managed or unmanaged cluster, as reported in https://github.com/MaterializeInc/materialize/issues/20000#issuecomment-2197198856.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
