### PR TITLE
deps: upgrade to unpatched librdkafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8292,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#302aa0e66bdb695abeef3f963d464eb9148e4099"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#1e1a2ca438024de797f389aadde830eb73659209"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -8308,8 +8308,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.3.0+2.4.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#302aa0e66bdb695abeef3f963d464eb9148e4099"
+version = "4.3.0+2.5.0"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#1e1a2ca438024de797f389aadde830eb73659209"
 dependencies = [
  "cmake",
  "libc",

--- a/test/kafka-auth/test-kafka-ssl.td
+++ b/test/kafka-auth/test-kafka-ssl.td
@@ -44,7 +44,7 @@ contains:Invalid CA certificate
     BROKER 'kafka:9093',
     SSL CERTIFICATE AUTHORITY = 'this is garbage'
   )
-contains:ssl.ca.pem failed: not in PEM format?
+contains:failed to read certificate #0 from ssl.ca.pem: not in PEM format?
 
 # ==> Test without an SSH tunnel. <==
 


### PR DESCRIPTION
To work around an unexplained memory error involving OpenSSL, we had to revert a librdkafka commit that changes how Kafka clients load CA certificates (f8830a2).

However, after extensive review, neither @petrosagg nor I can spot a memory error in that commit. That suggests that there might be a preexisting memory error in either OpenSSL or librdkafka that https://github.com/benesch/librdkafka/commit/f8830a28652532009e3f16854cb9d5004d9de06b exacerbates. That's scary, because there might be a way to trigger that memory error even with https://github.com/benesch/librdkafka/commit/f8830a28652532009e3f16854cb9d5004d9de06b reverted.

This commit upgrades us to mainline librdkafka v2.4.0--i.e., a version of librdkafka with https://github.com/benesch/librdkafka/commit/f8830a28652532009e3f16854cb9d5004d9de06b unreverted--to make the memory error reproducible. That will allow us to debug and find the root cause of the memory error.

**FOR DEBUGGING PURPOSES ONLY. Do NOT merge this commit in its current state.**

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR will help us to debug a librdkafka issue.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
