### PR TITLE
storage/sink/kafka: prevent queue full by disabling buffering

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -220,8 +220,6 @@ struct TransactionalProducer {
     staged_bytes: u64,
     /// The timeout to use for network operations.
     socket_timeout: Duration,
-    /// The maximum duration of a transaction.
-    transaction_timeout: Duration,
 }
 
 impl TransactionalProducer {
@@ -255,17 +253,12 @@ impl TransactionalProducer {
             "compression.type",
             connection.compression_type.to_librdkafka_option().into(),
         );
-        // Increase limits for the Kafka producer's internal buffering of messages. Currently we
-        // don't have a great backpressure mechanism to tell indexes or views to slow down, so the
-        // only thing we can do with a message that we can't immediately send is to put it in a
-        // buffer and there's no point having buffers within the dataflow layer and Kafka. If the
-        // sink starts falling behind and the buffers start consuming too much memory the best
-        // thing to do is to drop the sink. Sets the buffer size to be 16 GB (note that this
-        // setting is in KB)
-        options.insert("queue.buffering.max.kbytes", format!("{}", 16 << 20));
-        // Set the max messages buffered by the producer at any time to 10MM which is the maximum
-        // allowed value.
-        options.insert("queue.buffering.max.messages", format!("{}", 10_000_000));
+        // Set the maximum buffer size limit. We don't want to impose anything lower than the max
+        // here as the operator has nothing better to do with the data than to buffer them.
+        options.insert("queue.buffering.max.kbytes", "2147483647".into());
+        // Disable the default buffer limit of 100k messages. We don't want to impose any limit
+        // here as the operator has nothing better to do with the data than to buffer them.
+        options.insert("queue.buffering.max.messages", "0".into());
         // Make the Kafka producer wait at least 10 ms before sending out MessageSets
         options.insert("queue.buffering.max.ms", format!("{}", 10));
         // Time out transactions after 60 seconds
@@ -307,7 +300,6 @@ impl TransactionalProducer {
             staged_messages: 0,
             staged_bytes: 0,
             socket_timeout: timeout_config.socket_timeout,
-            transaction_timeout: timeout_config.transaction_timeout,
         };
 
         let timeout = timeout_config.socket_timeout;
@@ -348,12 +340,12 @@ impl TransactionalProducer {
     /// retrying is equivalent to adjusting the maximum number of queued items in rdkafka so it is
     /// adviced that callers only handle this error in order to apply backpressure to the rest of
     /// the system.
-    async fn send(
+    fn send(
         &mut self,
         message: &KafkaMessage,
         time: Timestamp,
         diff: Diff,
-    ) -> Result<(), ContextCreationError> {
+    ) -> Result<(), KafkaError> {
         assert_eq!(diff, 1, "invalid sink update");
 
         let mut headers = OwnedHeaders::new().insert(Header {
@@ -396,20 +388,7 @@ impl TransactionalProducer {
         self.staged_messages += 1;
         self.statistics.inc_bytes_staged_by(record_size);
         self.staged_bytes += record_size;
-        match self.producer.send(record) {
-            Ok(()) => Ok(()),
-            Err((err, record)) => match err.rdkafka_error_code() {
-                Some(RDKafkaErrorCode::QueueFull) => {
-                    // If the internal rdkafka queue is full we have no other option than to flush
-                    // TODO(petrosagg): remove this logic once we fix upgrade to librdkafka 2.3 and
-                    // increase the queue limits
-                    let timeout = self.transaction_timeout;
-                    self.spawn_blocking(move |p| p.flush(timeout)).await?;
-                    self.producer.send(record).map_err(|(err, _)| err.into())
-                }
-                _ => Err(err.into()),
-            },
-        }
+        self.producer.send(record).map_err(|(e, _)| e)
     }
 
     /// Commits all the staged updates of the currently open transaction plus a progress record
@@ -426,20 +405,7 @@ impl TransactionalProducer {
         let record = BaseRecord::to(&self.progress_topic)
             .payload(&payload)
             .key(&self.progress_key);
-        match self.producer.send(record) {
-            Ok(()) => {}
-            Err((err, record)) => match err.rdkafka_error_code() {
-                Some(RDKafkaErrorCode::QueueFull) => {
-                    // If the internal rdkafka queue is full we have no other option than to flush
-                    // TODO(petrosagg): remove this logic once we fix the issue that cannot be
-                    // named
-                    let timeout = self.transaction_timeout;
-                    self.spawn_blocking(move |p| p.flush(timeout)).await?;
-                    self.producer.send(record).map_err(|(err, _)| err)?;
-                }
-                _ => return Err(err.into()),
-            },
-        }
+        self.producer.send(record).map_err(|(e, _)| e)?;
 
         let timeout = self.socket_timeout;
         match self
@@ -689,7 +655,7 @@ fn sink_collection<G: Scope<Timestamp = Timestamp>>(
                                         producer.begin_transaction().await?;
                                         transaction_begun = true;
                                     }
-                                    producer.send(&message, time, diff).await?;
+                                    producer.send(&message, time, diff)?;
                                 }
                                 Ordering::Greater => continue,
                             }
@@ -731,7 +697,7 @@ fn sink_collection<G: Scope<Timestamp = Timestamp>>(
                         );
                         extra_updates.sort_unstable_by(|a, b| a.1.cmp(&b.1));
                         for (message, time, diff) in extra_updates.drain(..) {
-                            producer.send(&message, time, diff).await?;
+                            producer.send(&message, time, diff)?;
                         }
 
                         info!("{name}: committing transaction for {}", progress.pretty());


### PR DESCRIPTION
Now that we're on librdkafka v2.4.0, we don't need to catch and retry QueueFull errors, but can instead disable the queue limit.

This commit is a combination of:

  * Reverting the QueueFull workaround from #24871
  * Reapplying Petros's original implementation in #24784

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
