### PR TITLE
deps: upgrade to a rdkafka with DNS resolution callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8137,7 +8137,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#1e27332856a433235aeba7f82d46d06e3f646b69"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -8154,7 +8154,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "4.3.0+2.4.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#1e27332856a433235aeba7f82d46d06e3f646b69"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -731,6 +731,11 @@ version = "10.7.0"
 [[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
+version = "0.29.0@git:1e27332856a433235aeba7f82d46d06e3f646b69"
+
+[[audits.rdkafka]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
 version = "0.29.0@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
 
 [[audits.rdkafka]]
@@ -742,6 +747,11 @@ version = "0.29.0@git:f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "4.3.0+1.9.2@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
+
+[[audits.rdkafka-sys]]
+who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
+criteria = "safe-to-deploy"
+version = "4.3.0+2.4.0@git:1e27332856a433235aeba7f82d46d06e3f646b69"
 
 [[audits.rdkafka-sys]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -20,7 +20,7 @@ use mz_ccsr::tls::{Certificate, Identity};
 use mz_cloud_resources::{vpc_endpoint_host, AwsExternalIdPrefix, CloudResourceReader};
 use mz_dyncfg::ConfigSet;
 use mz_kafka_util::client::{
-    BrokerRewrite, MzClientContext, MzKafkaError, TunnelConfig, TunnelingClientContext,
+    BrokerAddr, BrokerRewrite, MzClientContext, MzKafkaError, TunnelConfig, TunnelingClientContext,
 };
 use mz_ore::error::ErrorExt;
 use mz_ore::future::{InTask, OreFutureExt};
@@ -38,7 +38,6 @@ use mz_tls_util::Pkcs12Archive;
 use mz_tracing::CloneableEnvFilter;
 use proptest::strategy::Strategy;
 use proptest_derive::Arbitrary;
-use rdkafka::client::BrokerAddr;
 use rdkafka::config::FromClientConfigAndContext;
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::ClientContext;
@@ -753,7 +752,11 @@ impl KafkaConnection {
                     .next()
                     .context("BROKER is not address:port")?
                     .into(),
-                port: addr_parts.next().unwrap_or("9092").into(),
+                port: addr_parts
+                    .next()
+                    .unwrap_or("9092")
+                    .parse()
+                    .context("parsing BROKER port")?,
             };
             match &broker.tunnel {
                 Tunnel::Direct => {


### PR DESCRIPTION
The last piece of the puzzle for denying connections to local IPs (MaterializeInc/console#1635) is to intercept DNS calls made by librdkafka and reject any DNS responses that contain local IPs.

This commit upgrades to a version of rdkafka that permits overriding the DNS resolution callback in full. The previous version permitted rewriting the hostname and port prior to DNS resolution, but not inspecting the resolved addresses.

Actually wiring up the DNS resolution callback to use the `ore::net::lookup_host` function that rejects local IPs is left to a future commit to ease the review of this commit. There should be no behavior changes as a result of this commit.

~Note to self: depends on merging https://github.com/MaterializeInc/rust-rdkafka/pull/17.~ ✅ 

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR makes progress towards a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
