### PR TITLE
storage: read-only mode for StorageCollections

### DIFF
--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -666,6 +666,7 @@ where
             config.now.clone(),
             Arc::clone(&txns_metrics),
             envd_epoch,
+            read_only,
             txn_wal_tables,
             config.connection_context.clone(),
             storage_txn,

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -12,6 +12,7 @@
 use std::backtrace::Backtrace;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -42,7 +43,7 @@ use crate::internal::metrics::Metrics;
 use crate::internal::state::{BatchPart, HollowBatch};
 use crate::internal::watch::StateWatch;
 use crate::iter::{Consolidator, SPLIT_OLD_RUNS};
-use crate::stats::{SnapshotPartStats, SnapshotPartsStats};
+use crate::stats::{SnapshotPartStats, SnapshotPartsStats, SnapshotStats};
 use crate::{parse_id, GarbageCollector, PersistConfig, ShardId};
 
 pub use crate::internal::encoding::LazyPartStats;
@@ -1017,6 +1018,35 @@ where
             _lease: lease,
             _schemas: self.schemas.clone(),
         })
+    }
+
+    /// Returns aggregate statistics about the contents of the shard TVC at the
+    /// given frontier.
+    ///
+    /// This command returns the contents of this shard as of `as_of` once they
+    /// are known. This may "block" (in an async-friendly way) if `as_of` is
+    /// greater or equal to the current `upper` of the shard. If `None` is given
+    /// for `as_of`, then the latest stats known by this process are used.
+    ///
+    /// The `Since` error indicates that the requested `as_of` cannot be served
+    /// (the caller has out of date information) and includes the smallest
+    /// `as_of` that would have been accepted.
+    pub fn snapshot_stats(
+        &self,
+        as_of: Option<Antichain<T>>,
+    ) -> impl Future<Output = Result<SnapshotStats, Since<T>>> + Send + 'static {
+        let mut machine = self.machine.clone();
+        async move {
+            let batches = match as_of {
+                Some(as_of) => machine.snapshot(&as_of).await?,
+                None => machine.applier.all_batches(),
+            };
+            let num_updates = batches.iter().map(|b| b.len).sum();
+            Ok(SnapshotStats {
+                shard_id: machine.shard_id(),
+                num_updates,
+            })
+        }
     }
 
     /// Returns aggregate statistics about the contents of the shard TVC at the

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -54,6 +54,7 @@ use mz_storage_types::sources::{
 use mz_txn_wal::metrics::Metrics as TxnMetrics;
 use mz_txn_wal::txn_read::{DataSnapshot, TxnsRead};
 use mz_txn_wal::txns::TxnsHandle;
+use timely::order::TotalOrder;
 use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, ChangeBatch, Timestamp as TimelyTimestamp};
 use timely::PartialOrder;
@@ -503,7 +504,7 @@ where
         }
     }
 
-    /// Opens a write and critical since handles for the given `shard`.
+    /// Opens a [WriteHandle] and a [SinceHandleWrapper], for holding back the since.
     ///
     /// `since` is an optional since that the read handle will be forwarded to
     /// if it is less than its current since.
@@ -517,10 +518,71 @@ where
         since: Option<&Antichain<T>>,
         relation_desc: RelationDesc,
         persist_client: &PersistClient,
-    ) -> (
-        WriteHandle<SourceData, (), T, Diff>,
-        SinceHandle<SourceData, (), T, Diff, PersistEpoch>,
-    ) {
+    ) -> (WriteHandle<SourceData, (), T, Diff>, SinceHandleWrapper<T>) {
+        let write_handle = self
+            .open_write_handle(id, shard, relation_desc, persist_client)
+            .await;
+        let since_handle = self
+            .open_critical_handle(id, shard, since, persist_client)
+            .await;
+
+        let since_handle = SinceHandleWrapper::Critical(since_handle);
+
+        (write_handle, since_handle)
+    }
+
+    /// Opens a write handle for the given `shard`.
+    async fn open_write_handle(
+        &self,
+        id: &GlobalId,
+        shard: ShardId,
+        relation_desc: RelationDesc,
+        persist_client: &PersistClient,
+    ) -> WriteHandle<SourceData, (), T, Diff> {
+        let diagnostics = Diagnostics {
+            shard_name: id.to_string(),
+            handle_purpose: format!("controller data for {}", id),
+        };
+
+        let mut write = persist_client
+            .open_writer(
+                shard,
+                Arc::new(relation_desc),
+                Arc::new(UnitSchema),
+                diagnostics.clone(),
+            )
+            .await
+            .expect("invalid persist usage");
+
+        // N.B.
+        // Fetch the most recent upper for the write handle. Otherwise, this may
+        // be behind the since of the since handle. Its vital this happens AFTER
+        // we create the since handle as it needs to be linearized with that
+        // operation. It may be true that creating the write handle after the
+        // since handle already ensures this, but we do this out of an abundance
+        // of caution.
+        //
+        // Note that this returns the upper, but also sets it on the handle to
+        // be fetched later.
+        write.fetch_recent_upper().await;
+
+        write
+    }
+
+    /// Opens a critical since handle for the given `shard`.
+    ///
+    /// `since` is an optional since that the read handle will be forwarded to
+    /// if it is less than its current since.
+    ///
+    /// This will `halt!` the process if we cannot successfully acquire a
+    /// critical handle with our current epoch.
+    async fn open_critical_handle(
+        &self,
+        id: &GlobalId,
+        shard: ShardId,
+        since: Option<&Antichain<T>>,
+        persist_client: &PersistClient,
+    ) -> SinceHandle<SourceData, (), T, Diff, PersistEpoch> {
         let diagnostics = Diagnostics {
             shard_name: id.to_string(),
             handle_purpose: format!("controller data for {}", id),
@@ -574,36 +636,56 @@ where
             }
         };
 
-        let mut write = persist_client
-            .open_writer(
+        since_handle
+    }
+
+    /// Opens a leased [ReadHandle], for the purpose of holding back a since,
+    /// for the given `shard`.
+    ///
+    /// `since` is an optional since that the read handle will be forwarded to
+    /// if it is less than its current since.
+    async fn open_leased_handle(
+        &self,
+        id: &GlobalId,
+        shard: ShardId,
+        relation_desc: RelationDesc,
+        since: Option<&Antichain<T>>,
+        persist_client: &PersistClient,
+    ) -> ReadHandle<SourceData, (), T, Diff> {
+        let diagnostics = Diagnostics {
+            shard_name: id.to_string(),
+            handle_purpose: format!("controller data for {}", id),
+        };
+
+        let use_critical_since = false;
+        let mut handle: ReadHandle<_, _, _, _> = persist_client
+            .open_leased_reader(
                 shard,
                 Arc::new(relation_desc),
                 Arc::new(UnitSchema),
                 diagnostics.clone(),
+                use_critical_since,
             )
             .await
             .expect("invalid persist usage");
 
-        // N.B.
-        // Fetch the most recent upper for the write handle. Otherwise, this may
-        // be behind the since of the since handle. Its vital this happens AFTER
-        // we create the since handle as it needs to be linearized with that
-        // operation. It may be true that creating the write handle after the
-        // since handle already ensures this, but we do this out of an abundance
-        // of caution.
-        //
-        // Note that this returns the upper, but also sets it on the handle to
-        // be fetched later.
-        write.fetch_recent_upper().await;
+        // Take the join of the handle's since and the provided `since`;
+        // this lets materialized views express the since at which their
+        // read handles "start."
+        let since = handle
+            .since()
+            .join(since.unwrap_or(&Antichain::from_elem(T::minimum())));
 
-        (write, since_handle)
+        handle.downgrade_since(&since).await;
+
+        handle
     }
 
     fn register_handles(
         &self,
         id: GlobalId,
         is_in_txns: bool,
-        since_handle: SinceHandle<SourceData, (), T, Diff, PersistEpoch>,
+        since_handle: SinceHandleWrapper<T>,
         write_handle: WriteHandle<SourceData, (), T, Diff>,
     ) {
         self.send(BackgroundCmd::Register {
@@ -1379,7 +1461,7 @@ where
                         let register_ts = register_ts.expect("caller should have provided a register_ts when creating a table");
                         if since_handle.since().elements() == &[T::minimum()] {
                             debug!("advancing {} to initial since of {:?}", id, register_ts);
-                            let token = since_handle.opaque().clone();
+                            let token = since_handle.opaque();
                             let _ = since_handle.compare_and_downgrade_since(&token, (&token, &Antichain::from_elem(register_ts.clone()))).await;
                         }
                     }
@@ -1801,6 +1883,137 @@ where
     }
 }
 
+/// Wraps either a "critical" [SinceHandle] or a leased [ReadHandle].
+///
+/// When a [StorageCollections] is in read-only mode, we will only ever acquire
+/// [ReadHandle], because acquiring the [SinceHandle] and driving forward it's
+/// since is considered a write. Conversely, when in read-write mode, we acquire
+/// [SinceHandle].
+#[derive(Debug)]
+enum SinceHandleWrapper<T>
+where
+    T: TimelyTimestamp + Lattice + Codec64,
+{
+    Critical(SinceHandle<SourceData, (), T, Diff, PersistEpoch>),
+    Leased(ReadHandle<SourceData, (), T, Diff>),
+}
+
+impl<T> SinceHandleWrapper<T>
+where
+    T: TimelyTimestamp + Lattice + Codec64 + TotalOrder,
+{
+    pub fn since(&self) -> &Antichain<T> {
+        match self {
+            Self::Critical(handle) => handle.since(),
+            Self::Leased(handle) => handle.since(),
+        }
+    }
+
+    pub fn opaque(&self) -> PersistEpoch {
+        match self {
+            Self::Critical(handle) => handle.opaque().clone(),
+            Self::Leased(_handle) => {
+                // The opaque is expected to be used with
+                // `compare_and_downgrade_since`, and the leased handle doesn't
+                // have a notion of an opaque. We pretend here and in
+                // `compare_and_downgrade_since`.
+                PersistEpoch(None)
+            }
+        }
+    }
+
+    pub async fn compare_and_downgrade_since(
+        &mut self,
+        expected: &PersistEpoch,
+        new: (&PersistEpoch, &Antichain<T>),
+    ) -> Result<Antichain<T>, PersistEpoch> {
+        match self {
+            Self::Critical(handle) => handle.compare_and_downgrade_since(expected, new).await,
+            Self::Leased(handle) => {
+                let (opaque, since) = new;
+                assert!(opaque.0.is_none());
+
+                handle.downgrade_since(since).await;
+
+                Ok(since.clone())
+            }
+        }
+    }
+
+    pub async fn maybe_compare_and_downgrade_since(
+        &mut self,
+        expected: &PersistEpoch,
+        new: (&PersistEpoch, &Antichain<T>),
+    ) -> Option<Result<Antichain<T>, PersistEpoch>> {
+        match self {
+            Self::Critical(handle) => {
+                handle
+                    .maybe_compare_and_downgrade_since(expected, new)
+                    .await
+            }
+            Self::Leased(handle) => {
+                let (opaque, since) = new;
+                assert!(opaque.0.is_none());
+
+                handle.maybe_downgrade_since(since).await;
+
+                Some(Ok(since.clone()))
+            }
+        }
+    }
+
+    pub fn snapshot_stats(
+        &self,
+        id: GlobalId,
+        as_of: Option<Antichain<T>>,
+    ) -> BoxFuture<'static, Result<SnapshotStats, StorageError<T>>> {
+        match self {
+            Self::Critical(handle) => {
+                let res = handle
+                    .snapshot_stats(as_of)
+                    .map(move |x| x.map_err(|_| StorageError::ReadBeforeSince(id)));
+                Box::pin(res)
+            }
+            Self::Leased(handle) => {
+                let res = handle
+                    .snapshot_stats(as_of)
+                    .map(move |x| x.map_err(|_| StorageError::ReadBeforeSince(id)));
+                Box::pin(res)
+            }
+        }
+    }
+
+    pub fn snapshot_stats_from_txn(
+        &self,
+        id: GlobalId,
+        data_snapshot: DataSnapshot<T>,
+    ) -> BoxFuture<'static, Result<SnapshotStats, StorageError<T>>> {
+        match self {
+            Self::Critical(handle) => Box::pin(
+                data_snapshot
+                    .snapshot_stats_from_critical(handle)
+                    .map(move |x| x.map_err(|_| StorageError::ReadBeforeSince(id))),
+            ),
+            Self::Leased(handle) => Box::pin(
+                data_snapshot
+                    .snapshot_stats_from_leased(handle)
+                    .map(move |x| x.map_err(|_| StorageError::ReadBeforeSince(id))),
+            ),
+        }
+    }
+
+    pub async fn expire(self) {
+        match self {
+            Self::Critical(_handle) => {
+                unreachable!("not trying to expire critical handles this way");
+            }
+            Self::Leased(handle) => {
+                handle.expire().await;
+            }
+        }
+    }
+}
+
 /// State maintained about individual collections.
 #[derive(Debug)]
 struct CollectionState<T> {
@@ -1878,7 +2091,7 @@ struct BackgroundTask<T: TimelyTimestamp + Lattice + Codec64> {
     // So we know what shard ID corresponds to what global ID, which we need
     // when re-enqueing futures for determining the next upper update.
     shard_by_id: BTreeMap<GlobalId, ShardId>,
-    since_handles: BTreeMap<GlobalId, SinceHandle<SourceData, (), T, Diff, PersistEpoch>>,
+    since_handles: BTreeMap<GlobalId, SinceHandleWrapper<T>>,
     txns_handle: Option<WriteHandle<SourceData, (), T, Diff>>,
     txns_shards: BTreeSet<GlobalId>,
 }
@@ -1889,7 +2102,7 @@ enum BackgroundCmd<T: TimelyTimestamp + Lattice + Codec64> {
         id: GlobalId,
         is_in_txns: bool,
         write_handle: WriteHandle<SourceData, (), T, Diff>,
-        since_handle: SinceHandle<SourceData, (), T, Diff, PersistEpoch>,
+        since_handle: SinceHandleWrapper<T>,
     },
     // This was also dead code in the StorageController. I think we keep around
     // these code paths for when we need to do migrations in the future.
@@ -1898,7 +2111,7 @@ enum BackgroundCmd<T: TimelyTimestamp + Lattice + Codec64> {
         id: GlobalId,
         is_in_txns: bool,
         write_handle: WriteHandle<SourceData, (), T, Diff>,
-        since_handle: SinceHandle<SourceData, (), T, Diff, PersistEpoch>,
+        since_handle: SinceHandleWrapper<T>,
     },
     DowngradeSince(Vec<(GlobalId, Antichain<T>)>),
     SnapshotStats(
@@ -2053,15 +2266,11 @@ where
                                         Result<SnapshotStats, StorageError<T>>,
                                     > = match as_of {
                                         SnapshotStatsAsOf::Direct(as_of) => {
-                                            Box::pin(x.snapshot_stats(Some(as_of)).map(move |x| {
-                                                x.map_err(|_| StorageError::ReadBeforeSince(id))
-                                            }))
+                                            x.snapshot_stats(id, Some(as_of))
                                         }
-                                        SnapshotStatsAsOf::Txns(data_snapshot) => Box::pin(
-                                            data_snapshot.snapshot_stats(x).map(move |x| {
-                                                x.map_err(|_| StorageError::ReadBeforeSince(id))
-                                            }),
-                                        ),
+                                        SnapshotStatsAsOf::Txns(data_snapshot) => {
+                                            x.snapshot_stats_from_txn(id, data_snapshot)
+                                        }
                                     };
                                     SnapshotStatsRes(fut)
                                 }
@@ -2510,7 +2719,7 @@ mod tests {
             .send(BackgroundCmd::Register {
                 id: GlobalId::User(1),
                 is_in_txns: false,
-                since_handle,
+                since_handle: SinceHandleWrapper::Critical(since_handle),
                 write_handle,
             })
             .unwrap();


### PR DESCRIPTION
Work towards zero-downtime upgrades: https://github.com/MaterializeInc/materialize/issues/27406

The thing that StorageCollections does which is considered a "write" is
acquiring `SinceHandles`, by bringing them into our own epoch and
downgrading their sinces. We can't be doing that in read-only mode but
we still need a way of holding back frontiers.

The approach is to instead use leased `ReadHandles` while in read-only
mode:

- they _can_ hold back the overall shard frontier, which allows reading
  collections, installing dataflows, etc.
- they _can_ time out, in which case things would panic

We would not get into incorrect situations when handles time out.
Clusters would panic, potentially an `environmentd` would panic, but we
can always "restart" our way out of those situations.

We also add code for gracefully coming out of read-only mode, by
upgrading the leased handles to critical `SinceHandles`. Those code
paths could fail, however, and we would have to invest more smarts there
if we want to use them. The initial approach for zero-downtime upgrades
(milestone 1) is the so-called crash-and-burn approach, where a
new-version `environmentd` never gracefully transitions out of read-only
mode. Instead it halts, which will make process orchestration (k8s)
bring up a new process that will start out in read-write mode and go
through regular bootstrap. The only purpose of the first read-only
`environmentd` is to let `clusterd` processes re-hydrate. Those
processes will then connect to the newly come up read-write
`environmentd` process.


### Tips for reviewer

The commit messages should describe what's going on, plus there's quite a bit of commentary in the code.

I tagged @bkirwi as well, for the changes in `StorageCollections`, plus there's some persist changes. @jkosh44 You might want to be aware of the persist/txn changes, but they feel minor. All the persist/txn changes are essentially around making `snapshot_stats` also work with a leased `ReadHandle`, so it's just plumbing/duplicating an existing method.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
