### PR TITLE
adapter/storage: read-only mode for tables

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -698,7 +698,7 @@ impl SessionClient {
     /// No authorization is performed, so access to this function must be
     /// limited to internal servers or superusers.
     pub async fn controller_allow_writes(&mut self) -> Result<bool, anyhow::Error> {
-        self.send_without_session(|tx| Command::ControllerAllowWrites { tx })
+        self.send_without_session(|tx| Command::AllowWrites { tx })
             .await
     }
 
@@ -871,7 +871,7 @@ impl SessionClient {
                 | Command::RetireExecute { .. }
                 | Command::CheckConsistency { .. }
                 | Command::Dump { .. } => {}
-                Command::ControllerAllowWrites { .. } => {}
+                Command::AllowWrites { .. } => {}
             };
             cmd
         });

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -128,7 +128,7 @@ pub enum Command {
         tx: oneshot::Sender<Result<serde_json::Value, anyhow::Error>>,
     },
 
-    ControllerAllowWrites {
+    AllowWrites {
         tx: oneshot::Sender<Result<bool, anyhow::Error>>,
     },
 }
@@ -148,7 +148,7 @@ impl Command {
             | Command::RetireExecute { .. }
             | Command::CheckConsistency { .. }
             | Command::Dump { .. }
-            | Command::ControllerAllowWrites { .. } => None,
+            | Command::AllowWrites { .. } => None,
         }
     }
 
@@ -166,7 +166,7 @@ impl Command {
             | Command::RetireExecute { .. }
             | Command::CheckConsistency { .. }
             | Command::Dump { .. }
-            | Command::ControllerAllowWrites { .. } => None,
+            | Command::AllowWrites { .. } => None,
         }
     }
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -323,7 +323,7 @@ impl Message {
                 Command::RetireExecute { .. } => "command-retire_execute",
                 Command::CheckConsistency { .. } => "command-check_consistency",
                 Command::Dump { .. } => "command-dump",
-                Command::ControllerAllowWrites { .. } => "command-controller-allow-writes",
+                Command::AllowWrites { .. } => "command-allow-writes",
             },
             Message::ControllerReady => "controller_ready",
             Message::PurifiedStatementReady(_) => "purified_statement_ready",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1742,6 +1742,15 @@ pub struct Coordinator {
     /// meant for use during development of read-only clusters and 0dt upgrades
     /// and should go away once we have proper orchestration during upgrades.
     read_only_controllers: bool,
+
+    /// Updates to builtin tables that are being buffered while we are in
+    /// read-only mode. We apply these all at once when coming out of read-only
+    /// mode.
+    ///
+    /// This is a `Some` while in read-only mode and will be replaced by a
+    /// `None` when we transition out of read-only mode and write out any
+    /// buffered updates.
+    buffered_builtin_table_updates: Option<Vec<BuiltinTableUpdate>>,
 }
 
 impl Coordinator {
@@ -2129,9 +2138,18 @@ impl Coordinator {
             ),
         );
 
-        let builtin_updates_fut = self
-            .bootstrap_builtin_tables(&entries, builtin_table_updates)
-            .await;
+        let builtin_updates_fut = if self.controller.read_only() {
+            info!("coordinator init: stashing builtin table updates while in read-only mode");
+
+            self.buffered_builtin_table_updates
+                .as_mut()
+                .expect("in read-only mode")
+                .append(&mut builtin_table_updates);
+
+            futures::future::ready(()).boxed()
+        } else {
+            self.bootstrap_tables(&entries, builtin_table_updates).await
+        };
 
         // Destructure Self so we can do some concurrent work.
         let Self {
@@ -2176,11 +2194,11 @@ impl Coordinator {
         Ok(())
     }
 
-    /// Prepares builtin tables for writing by resetting them to a known state
-    /// and appending the given updates.
+    /// Prepares tables for writing by resetting them to a known state and
+    /// appending the given builtin table updates.
     #[allow(clippy::async_yields_async)]
     #[instrument]
-    async fn bootstrap_builtin_tables(
+    async fn bootstrap_tables(
         &mut self,
         entries: &[CatalogEntry],
         mut builtin_table_updates: Vec<BuiltinTableUpdate>,
@@ -2239,7 +2257,6 @@ impl Coordinator {
             .builtin_table_update()
             .execute(builtin_table_updates)
             .await;
-
         builtin_updates_fut
     }
 
@@ -2906,6 +2923,10 @@ impl Coordinator {
                     // `tick()` on `Interval` is cancel-safe:
                     // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
                     _ = self.advance_timelines_interval.tick() => {
+                        if self.controller.read_only() {
+                            tracing::info!("not advancing timelines in read-only mode");
+                            continue;
+                        }
                         let span = info_span!(parent: None, "coord::advance_timelines_interval");
                         span.follows_from(Span::current());
                         Message::GroupCommitInitiate(span, None)
@@ -3516,6 +3537,7 @@ pub fn serve(
                     connection_watch_sets: BTreeMap::new(),
                     cluster_replica_statuses: ClusterReplicaStatuses::new(),
                     read_only_controllers,
+                    buffered_builtin_table_updates: Some(Vec::new()),
                 };
                 let bootstrap = handle.block_on(async {
                     coord

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -456,6 +456,12 @@ impl Coordinator {
 
     /// Submit a write to be executed during the next group commit and trigger a group commit.
     pub(crate) fn submit_write(&mut self, pending_write_txn: PendingWriteTxn) {
+        if self.controller.read_only() {
+            panic!(
+                "attempting table write in read-only mode: {:?}",
+                pending_write_txn
+            );
+        }
         self.pending_writes.push(pending_write_txn);
         self.trigger_group_commit();
     }
@@ -532,6 +538,13 @@ impl<'a> BuiltinTableAppend<'a> {
     /// Returns a `Future` that resolves when the write has completed, does not block the
     /// Coordinator.
     pub fn defer(self, updates: Vec<BuiltinTableUpdate>) -> BuiltinTableAppendNotify {
+        if self.coord.controller.read_only() {
+            panic!(
+                "attempting deferred table write in read-only mode: {:?}",
+                updates
+            );
+        }
+
         let (tx, rx) = oneshot::channel();
         self.coord.pending_writes.push(PendingWriteTxn::System {
             updates,
@@ -547,6 +560,13 @@ impl<'a> BuiltinTableAppend<'a> {
     /// This method will block the Coordinator on acquiring a write timestamp from the timestamp
     /// oracle, and then returns a `Future` that will complete once the write has been applied.
     pub async fn execute(self, updates: Vec<BuiltinTableUpdate>) -> BuiltinTableAppendNotify {
+        if self.coord.controller.read_only() {
+            panic!(
+                "trying to append to builtin tables in read-only mode: {:?}",
+                updates
+            );
+        }
+
         let (tx, rx) = oneshot::channel();
 
         // Most DDL queries cause writes to system tables. Unlike writes to user tables, system

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -230,7 +230,8 @@ impl Coordinator {
                 }
 
                 Command::ControllerAllowWrites { tx } => {
-                    self.controller.allow_writes().await;
+                    let init_ts = self.get_local_write_ts().await.timestamp;
+                    self.controller.allow_writes(Some(init_ts)).await;
                     let _ = tx.send(Ok(true));
                 }
             }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -231,7 +231,7 @@ impl Coordinator {
                     let _ = tx.send(self.dump());
                 }
 
-                Command::ControllerAllowWrites { tx } => {
+                Command::AllowWrites { tx } => {
                     self.handle_allow_writes(tx).await;
                 }
             }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -14,6 +14,7 @@ use differential_dataflow::lattice::Lattice;
 use mz_adapter_types::dyncfgs::ALLOW_USER_SESSIONS;
 use mz_sql::session::metadata::SessionMetadata;
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
 use std::sync::Arc;
 
 use futures::future::LocalBoxFuture;
@@ -55,6 +56,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug_span, warn, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+use crate::catalog::BuiltinTableUpdate;
 use crate::command::{
     CatalogSnapshot, Command, ExecuteResponse, GetVariablesResponse, StartupResponse,
 };
@@ -230,14 +232,36 @@ impl Coordinator {
                 }
 
                 Command::ControllerAllowWrites { tx } => {
-                    let init_ts = self.get_local_write_ts().await.timestamp;
-                    self.controller.allow_writes(Some(init_ts)).await;
-                    let _ = tx.send(Ok(true));
+                    self.handle_allow_writes(tx).await;
                 }
             }
         }
         .instrument(debug_span!("handle_command"))
         .boxed_local()
+    }
+
+    #[mz_ore::instrument(level = "debug")]
+    async fn handle_allow_writes(&mut self, tx: oneshot::Sender<Result<bool, anyhow::Error>>) {
+        if !self.controller.read_only() {
+            let _ = tx.send(Ok(false));
+            return;
+        }
+
+        let init_ts = self.get_local_write_ts().await.timestamp;
+        self.controller.allow_writes(Some(init_ts)).await;
+
+        let builtin_table_updates = self
+            .buffered_builtin_table_updates
+            .take()
+            .expect("in read-only mode");
+
+        let entries: Vec<_> = self.catalog().entries().cloned().collect();
+
+        self.bootstrap_tables(&entries, builtin_table_updates)
+            .await
+            .await;
+
+        let _ = tx.send(Ok(true));
     }
 
     #[mz_ore::instrument(level = "debug")]
@@ -302,9 +326,10 @@ impl Coordinator {
                 self.begin_session_for_statement_logging(&conn);
                 self.active_conns.insert(conn_id.clone(), conn);
 
-                // Note: Do NOT await the notify here, we pass this back to whatever requested the
-                // startup to prevent blocking the Coordinator on a builtin table update.
-                let notify = self.builtin_table_update().defer(vec![update]);
+                // Note: Do NOT await the notify here, we pass this back to
+                // whatever requested the startup to prevent blocking the
+                // Coordinator on a builtin table update.
+                let notify = self.buffer_or_write_table_update(update);
 
                 let resp = Ok(StartupResponse {
                     role_id,
@@ -1060,7 +1085,33 @@ impl Coordinator {
         // closed at once, which occurs regularly in some workflows.
         let update = self.catalog().state().pack_session_update(&conn, -1);
         let update = self.catalog().state().resolve_builtin_table_update(update);
-        let _builtin_update_notify = self.builtin_table_update().defer(vec![update]);
+
+        let _builtin_update_notify = self.buffer_or_write_table_update(update);
+    }
+
+    /// Buffers the given update when in read-only mode or puts in a deferred
+    /// write when in read-write mode.
+    ///
+    /// Returns a `Future` that can be await'ed to be notified when the write is
+    /// complete.
+    fn buffer_or_write_table_update(
+        &mut self,
+        update: BuiltinTableUpdate,
+    ) -> impl Future<Output = ()> + Send {
+        let notify = if self.controller.read_only() {
+            self.buffered_builtin_table_updates
+                .as_mut()
+                .expect("in read-only mode")
+                .push(update);
+
+            futures::future::ready(()).boxed()
+        } else {
+            let notify = self.builtin_table_update().defer(vec![update]);
+
+            notify
+        };
+
+        notify
     }
 
     /// Returns the necessary metadata for appending to a webhook source, and a channel to send

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -185,6 +185,10 @@ impl Coordinator {
         conn_id: Option<&ConnectionId>,
         ops: Vec<catalog::Op>,
     ) -> Result<BuiltinTableAppendNotify, AdapterError> {
+        if self.controller.read_only() {
+            return Err(AdapterError::ReadOnly);
+        }
+
         event!(Level::TRACE, ops = format!("{:?}", ops));
 
         let mut sources_to_drop = vec![];

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -766,13 +766,20 @@ impl Coordinator {
                 new_process_status,
             );
 
-            let builtin_table_updates = vec![builtin_table_retraction, builtin_table_addition];
+            let mut builtin_table_updates = vec![builtin_table_retraction, builtin_table_addition];
 
-            self.builtin_table_update()
-                .execute(builtin_table_updates)
-                .await
-                .instrument(info_span!("coord::message_cluster_event::table_updates"))
-                .await;
+            if self.controller.read_only() {
+                self.buffered_builtin_table_updates
+                    .as_mut()
+                    .expect("in read-only mode")
+                    .append(&mut builtin_table_updates);
+            } else {
+                self.builtin_table_update()
+                    .execute(builtin_table_updates)
+                    .await
+                    .instrument(info_span!("coord::message_cluster_event::table_updates"))
+                    .await;
+            }
 
             let cluster = self.catalog().get_cluster(event.cluster_id);
             let replica = cluster.replica(event.replica_id).expect("Replica exists");

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -229,6 +229,9 @@ pub enum AdapterError {
     UnreadableSinkCollection,
     /// User sessions have been blocked.
     UserSessionsDisallowed,
+    /// Something attempted a write (to catalog, storage, tables, etc.) while in
+    /// read-only mode.
+    ReadOnly,
 }
 
 impl AdapterError {
@@ -540,6 +543,9 @@ impl AdapterError {
             AdapterError::RtrDropFailure(_) => SqlState::UNDEFINED_OBJECT,
             AdapterError::UnreadableSinkCollection => SqlState::from_code("MZ009"),
             AdapterError::UserSessionsDisallowed => SqlState::from_code("MZ010"),
+            // In read-only mode all transactions are implicitly read-only
+            // transactions.
+            AdapterError::ReadOnly => SqlState::READ_ONLY_SQL_TRANSACTION,
         }
     }
 
@@ -769,6 +775,7 @@ impl fmt::Display for AdapterError {
                 write!(f, "collection is not readable at any time")
             }
             AdapterError::UserSessionsDisallowed => write!(f, "login blocked"),
+            AdapterError::ReadOnly => write!(f, "cannot write in read-only mode"),
         }
     }
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -425,6 +425,35 @@ impl Plan {
             Plan::AlterRetainHistory(_) => "alter retain history",
         }
     }
+
+    /// Returns `true` iff this `Plan` is allowed to be executed in read-only
+    /// mode.
+    ///
+    /// We use an explicit allow-list, to avoid future additions automatically
+    /// falling into the `true` category.
+    pub fn allowed_in_read_only(&self) -> bool {
+        match self {
+            Plan::SetTransaction(_) => true,
+            Plan::StartTransaction(_) => true,
+            Plan::CommitTransaction(_) => true,
+            Plan::AbortTransaction(_) => true,
+            Plan::Select(_) => true,
+            Plan::EmptyQuery => true,
+            Plan::ShowAllVariables => true,
+            Plan::ShowCreate(_) => true,
+            Plan::ShowColumns(_) => true,
+            Plan::ShowVariable(_) => true,
+            Plan::InspectShard(_) => true,
+            Plan::Subscribe(_) => true,
+            Plan::CopyTo(_) => true,
+            Plan::ExplainPlan(_) => true,
+            Plan::ExplainPushdown(_) => true,
+            Plan::ExplainTimestamp(_) => true,
+            Plan::ExplainSinkSchema(_) => true,
+            Plan::ValidateConnection(_) => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -300,7 +300,17 @@ pub trait StorageController: Debug {
 
     /// Allow this controller and instances controlled by it to write to
     /// external systems.
-    async fn allow_writes(&mut self);
+    ///
+    /// If the controller has previously been told about tables (via
+    /// [StorageController::create_collections]), the caller must provide a
+    /// `register_ts`, the timestamp at which any tables that are known to the
+    /// controller should be registered in the txn system.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the controller knows about tables but no `register_ts` is
+    /// provided.
+    async fn allow_writes(&mut self, register_ts: Option<Self::Timestamp>);
 
     /// Update storage configuration with new parameters.
     fn update_parameters(&mut self, config_params: StorageParameters);

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -257,7 +257,7 @@ where
         }
     }
 
-    async fn allow_writes(&mut self) {
+    async fn allow_writes(&mut self, register_ts: Option<Self::Timestamp>) {
         if !self.read_only {
             // Already done!
             return;
@@ -265,10 +265,17 @@ where
 
         self.read_only = false;
 
+        let persist_client = self
+            .persist
+            .open(self.persist_location.clone())
+            .await
+            .unwrap();
+
         // While in read-only mode, we didn't run ingestions or write to
         // introspection collections. Start doing that now!
         let mut ingestions_to_run = Vec::new();
         let mut introspections_to_run = Vec::new();
+        let mut tables_to_register = Vec::new();
         for (id, collection) in self.collections.iter() {
             match collection.data_source {
                 DataSource::Ingestion(_) => {
@@ -279,6 +286,24 @@ where
                     introspections_to_run.push((*id, i));
                 }
                 DataSource::Webhook => (),
+                DataSource::Other(DataSourceOther::TableWrites) => {
+                    // We don't optimize allow_writes() for performance, so we
+                    // don't parallelize opening these write handles, for
+                    // example. For now it's meant as a tool during development
+                    // of zero-downtime upgrades. If it ever becomes
+                    // load-bearing, we can employ optimizations similar to what
+                    // we use in create_collections.
+                    let write_handle = self
+                        .open_data_handles(
+                            id,
+                            collection.collection_metadata.data_shard,
+                            collection.collection_metadata.relation_desc.clone(),
+                            &persist_client,
+                        )
+                        .await;
+
+                    tables_to_register.push((*id, write_handle));
+                }
                 DataSource::Progress | DataSource::Other(_) => {}
             };
         }
@@ -301,6 +326,16 @@ where
         // happens when we take over instead be a periodic thing, and make it
         // resilient to the upper moving concurrently.
         self.collection_manager.allow_writes();
+
+        if !tables_to_register.is_empty() {
+            let register_ts = register_ts
+                .as_ref()
+                .expect("must provide a register_ts")
+                .clone();
+
+            self.persist_table_worker
+                .register(register_ts, tables_to_register);
+        }
 
         for id in ingestions_to_run {
             self.run_ingestion(id)
@@ -807,7 +842,11 @@ where
         }
 
         // Register the tables all in one batch.
-        if !table_registers.is_empty() {
+        //
+        // We cannot register tables at the table worker when in read-only mode.
+        // When coming out of read-only mode (via `allow_writes()`), we will
+        // register all tables that are known by that point.
+        if !table_registers.is_empty() && !self.read_only {
             let register_ts = register_ts
                 .expect("caller should have provided a register_ts when creating a table");
             // This register call advances the logical upper of the table. The
@@ -1489,6 +1528,10 @@ where
         tokio::sync::oneshot::Receiver<Result<(), StorageError<Self::Timestamp>>>,
         StorageError<Self::Timestamp>,
     > {
+        if self.read_only {
+            return Err(StorageError::ReadOnly);
+        }
+
         // TODO(petrosagg): validate appends against the expected RelationDesc of the collection
         for (id, updates) in commands.iter() {
             if !updates.is_empty() {


### PR DESCRIPTION
Work towards zero-downtime upgrades: https://github.com/MaterializeInc/materialize/issues/27406

The approach, while in read-only mode, is roughly:

- don't do things that we do periodically but don't carry semantic
  meaning:
  - periodic upper advancement
- stash changes to builtin tables and defer bootstrapping them to when
  we come out of read-only mode
- report an error back to the client when attempting things that require
  writing: table writes, DDL, things that would change the catalog

The code that allows us to stash changes and come out of read-only mode
gracefully (in process) is not strictly required because we plan on
using the halt!-then-restart (aka. crash-and-burn) approach for coming
out of read-only mode. However, the code was easy enough to add and
might come in handy in the future.

As of this change, we don't yet make StorageCollections aware of
read-only mode, so we take over the critical SinceHandles, which is also
a "write". This is addressed in a separate change.

As of this change, it is possible to bring up an environment in
read-only mode without error'ing/panic'ing. Previously, this would fail
because the storage controller was aware of read-only mode and would
error but components up the stack would not respect that.


### Tips for reviewer

If you want, storage/cluster folks can only review the first commit and adapter folks can review the commits that build on that.

The first commit adds read-only mode for tables in the `StorageController`. This will make it so we fail when we attempt writes. As the commit explains, trying to start an `envd` in read-only mode will now panic because the layers up the stack don't respect that.

The later commits are about teaching the adapter to respect read-only mode, please see the commit messages for details.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
