### PR TITLE
catalog: Fix formatting in initialize_state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,6 +4377,7 @@ version = "0.107.0-dev"
 dependencies = [
  "anyhow",
  "clap",
+ "futures",
  "mz-adapter",
  "mz-build-info",
  "mz-catalog",

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.66"
 clap = { version = "3.2.24", features = ["derive", "env"] }
+futures = "0.3.25"
 mz-adapter = { path = "../adapter" }
 mz-build-info = { path = "../build-info" }
 mz-catalog = { path = "../catalog" }


### PR DESCRIPTION
Previously, the function body of `initialize_state` was wrapped in an async block. For some reason this block broke `rustfmt` and prevented automatic formatting. The async block was used to box the returned future since it was very large, and we didn't want it on the stack.

This commit removes the async block and instead updates callers of `initialize_state` to box the returned future which fixes formatting. In release mode, the optimizer *should* create the future in the heap instead of creating it on the stack and moving it to the heap.

The non-whitespace characters of `initialize_state` are completely unchanged, however the indentation has been changed which makes the diff large.

### Motivation
 This PR refactors existing code.

### Tips for reviewer
The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
