### PR TITLE
output consistency: support range type

### DIFF
--- a/misc/python/materialize/output_consistency/data_type/data_type_category.py
+++ b/misc/python/materialize/output_consistency/data_type/data_type_category.py
@@ -31,5 +31,6 @@ class DataTypeCategory(Enum):
     ARRAY = 300
     LIST = 301
     MAP = 302
+    RANGE = 303
 
     OTHER_UNSUPPORTED = 400

--- a/misc/python/materialize/output_consistency/input_data/operations/all_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/all_operations_provider.py
@@ -45,6 +45,9 @@ from materialize.output_consistency.input_data.operations.map_operations_provide
 from materialize.output_consistency.input_data.operations.number_operations_provider import (
     NUMERIC_OPERATION_TYPES,
 )
+from materialize.output_consistency.input_data.operations.range_operations_provider import (
+    RANGE_OPERATION_TYPES,
+)
 from materialize.output_consistency.input_data.operations.set_operations_provider import (
     SET_OPERATION_TYPES,
 )
@@ -79,6 +82,7 @@ ALL_OPERATION_TYPES: list[DbOperationOrFunction] = list(
         MAP_OPERATION_TYPES,
         LIST_OPERATION_TYPES,
         ARRAY_OPERATION_TYPES,
+        RANGE_OPERATION_TYPES,
         UUID_OPERATION_TYPES,
         SPECIAL_OPERATION_TYPES,
     )

--- a/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
@@ -23,6 +23,9 @@ from materialize.output_consistency.input_data.params.list_operation_param impor
     ListOfOtherElementOperationParam,
     ListOperationParam,
 )
+from materialize.output_consistency.input_data.return_specs.collection_entry_return_spec import (
+    CollectionEntryReturnTypeSpec,
+)
 from materialize.output_consistency.input_data.return_specs.list_return_spec import (
     ListReturnTypeSpec,
 )
@@ -99,7 +102,7 @@ LIST_OPERATION_TYPES.append(
     DbOperation(
         "$[$]",
         [ListOperationParam(), COLLECTION_INDEX_PARAM],
-        ListReturnTypeSpec(),
+        CollectionEntryReturnTypeSpec(param_index_to_take_type=0),
         comment="access list element",
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
@@ -27,11 +27,11 @@ from materialize.output_consistency.input_data.params.string_operation_param imp
 from materialize.output_consistency.input_data.return_specs.boolean_return_spec import (
     BooleanReturnTypeSpec,
 )
+from materialize.output_consistency.input_data.return_specs.collection_entry_return_spec import (
+    CollectionEntryReturnTypeSpec,
+)
 from materialize.output_consistency.input_data.return_specs.map_return_spec import (
     MapReturnTypeSpec,
-)
-from materialize.output_consistency.input_data.return_specs.map_value_return_spec import (
-    DynamicMapValueReturnTypeSpec,
 )
 from materialize.output_consistency.input_data.return_specs.number_return_spec import (
     NumericReturnTypeSpec,
@@ -49,7 +49,7 @@ MAP_OPERATION_TYPES.append(
     DbOperation(
         "$ -> $",
         [MapOperationParam(), MAP_FIELD_NAME_PARAM],
-        DynamicMapValueReturnTypeSpec(),
+        CollectionEntryReturnTypeSpec(),
     )
 )
 MAP_OPERATION_TYPES.append(

--- a/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
@@ -49,7 +49,7 @@ MAP_OPERATION_TYPES.append(
     DbOperation(
         "$ -> $",
         [MapOperationParam(), MAP_FIELD_NAME_PARAM],
-        CollectionEntryReturnTypeSpec(),
+        CollectionEntryReturnTypeSpec(param_index_to_take_type=0),
     )
 )
 MAP_OPERATION_TYPES.append(

--- a/misc/python/materialize/output_consistency/input_data/operations/range_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/range_operations_provider.py
@@ -1,0 +1,112 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from materialize.output_consistency.input_data.params.collection_operation_param import (
+    ElementOfOtherCollectionOperationParam,
+)
+from materialize.output_consistency.input_data.params.list_operation_param import (
+    ListLikeOtherListOperationParam,
+    ListOperationParam,
+)
+from materialize.output_consistency.input_data.params.range_operation_param import (
+    RangeLikeOtherListOperationParam,
+    RangeOperationParam,
+)
+from materialize.output_consistency.input_data.return_specs.boolean_return_spec import (
+    BooleanReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.collection_entry_return_spec import (
+    CollectionEntryReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.range_return_spec import (
+    RangeReturnTypeSpec,
+)
+from materialize.output_consistency.operation.operation import (
+    DbFunction,
+    DbOperation,
+    DbOperationOrFunction,
+)
+
+RANGE_OPERATION_TYPES: list[DbOperationOrFunction] = []
+
+RANGE_OPERATION_TYPES.append(
+    DbOperation(
+        "$ || $",
+        [
+            ListOperationParam(),
+            ListLikeOtherListOperationParam(index_of_previous_param=0),
+        ],
+        RangeReturnTypeSpec(),
+    )
+)
+
+RANGE_OPERATION_TYPES.append(
+    DbOperation(
+        "$ * $",
+        [
+            RangeOperationParam(),
+            RangeLikeOtherListOperationParam(index_of_previous_param=0),
+        ],
+        RangeReturnTypeSpec(),
+        comment="Intersection of two ranges",
+    )
+)
+
+RANGE_OPERATION_TYPES.append(
+    DbOperation(
+        "$ && $",
+        [
+            RangeOperationParam(),
+            RangeLikeOtherListOperationParam(index_of_previous_param=0),
+        ],
+        RangeReturnTypeSpec(),
+        comment="Overlap of two ranges",
+    )
+)
+
+RANGE_OPERATION_TYPES.append(
+    DbOperation(
+        "$ @> $",
+        [
+            RangeOperationParam(),
+            ElementOfOtherCollectionOperationParam(index_of_previous_param=0),
+        ],
+        RangeReturnTypeSpec(),
+        comment="contains",
+    )
+)
+
+RANGE_OPERATION_TYPES.append(
+    DbFunction(
+        "isempty",
+        [
+            RangeOperationParam(),
+        ],
+        BooleanReturnTypeSpec(),
+    )
+)
+
+RANGE_OPERATION_TYPES.append(
+    DbFunction(
+        "lower",
+        [
+            RangeOperationParam(),
+        ],
+        CollectionEntryReturnTypeSpec(param_index_to_take_type=0),
+    )
+)
+
+RANGE_OPERATION_TYPES.append(
+    DbFunction(
+        "upper",
+        [
+            RangeOperationParam(),
+        ],
+        CollectionEntryReturnTypeSpec(param_index_to_take_type=0),
+    )
+)

--- a/misc/python/materialize/output_consistency/input_data/params/range_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/range_operation_param.py
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.params.collection_operation_param import (
+    CollectionLikeOtherCollectionOperationParam,
+    CollectionOfOtherElementOperationParam,
+    CollectionOperationParam,
+)
+
+
+class RangeOperationParam(CollectionOperationParam):
+    def __init__(
+        self,
+        optional: bool = False,
+        incompatibilities: set[ExpressionCharacteristics] | None = None,
+        value_type_category: DataTypeCategory | None = None,
+    ):
+        super().__init__(
+            DataTypeCategory.RANGE,
+            optional,
+            incompatibilities,
+            value_type_category=value_type_category,
+        )
+
+
+class RangeLikeOtherListOperationParam(CollectionLikeOtherCollectionOperationParam):
+    def get_collection_type_category(self) -> DataTypeCategory:
+        return DataTypeCategory.RANGE
+
+
+class RangeOfOtherElementOperationParam(CollectionOfOtherElementOperationParam):
+    def get_collection_type_category(self) -> DataTypeCategory:
+        return DataTypeCategory.RANGE

--- a/misc/python/materialize/output_consistency/input_data/return_specs/collection_entry_return_spec.py
+++ b/misc/python/materialize/output_consistency/input_data/return_specs/collection_entry_return_spec.py
@@ -9,16 +9,16 @@
 
 
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.input_data.return_specs.collection_return_spec import (
+    CollectionReturnTypeSpec,
+)
 from materialize.output_consistency.input_data.return_specs.dynamic_return_spec import (
     DynamicReturnTypeSpec,
-)
-from materialize.output_consistency.input_data.return_specs.map_return_spec import (
-    MapReturnTypeSpec,
 )
 from materialize.output_consistency.operation.return_type_spec import InputArgTypeHints
 
 
-class DynamicMapValueReturnTypeSpec(DynamicReturnTypeSpec):
+class CollectionEntryReturnTypeSpec(DynamicReturnTypeSpec):
     def __init__(self, param_index_to_take_type: int = 0):
         super().__init__(param_index_to_take_type)
         self.requires_return_type_spec_hints = True
@@ -37,5 +37,5 @@ class DynamicMapValueReturnTypeSpec(DynamicReturnTypeSpec):
             ]
         )
 
-        assert isinstance(input_arg_return_type_spec, MapReturnTypeSpec)
+        assert isinstance(input_arg_return_type_spec, CollectionReturnTypeSpec)
         return input_arg_return_type_spec.get_entry_value_type()

--- a/misc/python/materialize/output_consistency/input_data/return_specs/collection_entry_return_spec.py
+++ b/misc/python/materialize/output_consistency/input_data/return_specs/collection_entry_return_spec.py
@@ -19,7 +19,7 @@ from materialize.output_consistency.operation.return_type_spec import InputArgTy
 
 
 class CollectionEntryReturnTypeSpec(DynamicReturnTypeSpec):
-    def __init__(self, param_index_to_take_type: int = 0):
+    def __init__(self, param_index_to_take_type: int):
         super().__init__(param_index_to_take_type)
         self.requires_return_type_spec_hints = True
 

--- a/misc/python/materialize/output_consistency/input_data/return_specs/range_return_spec.py
+++ b/misc/python/materialize/output_consistency/input_data/return_specs/range_return_spec.py
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.input_data.return_specs.collection_return_spec import (
+    CollectionReturnTypeSpec,
+)
+
+
+class RangeReturnTypeSpec(CollectionReturnTypeSpec):
+    def __init__(
+        self,
+        param_index_of_map_value_type: int = 0,
+        range_value_type_category: DataTypeCategory = DataTypeCategory.DYNAMIC,
+    ):
+        super().__init__(
+            DataTypeCategory.RANGE,
+            param_index_of_map_value_type,
+            range_value_type_category,
+        )

--- a/misc/python/materialize/output_consistency/input_data/types/all_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/all_types_provider.py
@@ -33,6 +33,9 @@ from materialize.output_consistency.input_data.types.map_type_provider import (
 from materialize.output_consistency.input_data.types.number_types_provider import (
     NUMERIC_DATA_TYPES,
 )
+from materialize.output_consistency.input_data.types.range_type_provider import (
+    RANGE_DATA_TYPES,
+)
 from materialize.output_consistency.input_data.types.string_type_provider import (
     STRING_DATA_TYPES,
 )
@@ -51,6 +54,7 @@ DATA_TYPES: list[DataType] = list(
         MAP_DATA_TYPES,
         LIST_DATA_TYPES,
         ARRAY_DATA_TYPES,
+        RANGE_DATA_TYPES,
         [UUID_DATA_TYPE],
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/types/range_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/range_type_provider.py
@@ -1,0 +1,85 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.return_specs.collection_return_spec import (
+    CollectionReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.range_return_spec import (
+    RangeReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.types.collection_type_provider import (
+    CollectionDataType,
+)
+from materialize.output_consistency.operation.return_type_spec import ReturnTypeSpec
+
+INT4_RANGE_TYPE_IDENTIFIER = "INT4RANGE"
+TIMESTAMPTZ_RANGE_TYPE_IDENTIFIER = "TSTZRANGE"
+
+
+class RangeDataType(CollectionDataType):
+    def __init__(
+        self,
+        internal_identifier: str,
+        type_name: str,
+        lower_range_value: str | None,
+        upper_range_value: str | None,
+        value_type_category: DataTypeCategory,
+    ):
+        super().__init__(
+            internal_identifier,
+            type_name,
+            DataTypeCategory.RANGE,
+            entry_value_1=lower_range_value,
+            entry_value_2=upper_range_value,
+            value_type_category=value_type_category,
+            is_pg_compatible=True,
+        )
+
+    def _create_collection_return_type_spec(self) -> CollectionReturnTypeSpec:
+        return RangeReturnTypeSpec(range_value_type_category=self.value_type_category)
+
+    def resolve_return_type_spec(
+        self, characteristics: set[ExpressionCharacteristics]
+    ) -> ReturnTypeSpec:
+        return RangeReturnTypeSpec()
+
+
+def as_range(
+    lower_boundary: str | None,
+    upper_boundary: str | None,
+    lower_bound_inclusive: bool = True,
+    upper_bound_inclusive: bool = True,
+) -> str:
+    lower_boundary = lower_boundary or ""
+    upper_boundary = upper_boundary or ""
+
+    sql = f"{'[' if lower_bound_inclusive else '('}{lower_boundary},{upper_boundary}{']' if upper_bound_inclusive else ')'}"
+    return f"'{sql}'"
+
+
+INT4_RANGE_DATA_TYPE = RangeDataType(
+    INT4_RANGE_TYPE_IDENTIFIER, "INT4RANGE", "3", "8", DataTypeCategory.NUMERIC
+)
+TIMESTAMPTZ_RANGE_DATA_TYPE = RangeDataType(
+    TIMESTAMPTZ_RANGE_TYPE_IDENTIFIER,
+    "TSTZRANGE",
+    "2024-02-29 11:50:00 EST",
+    "2024-03-31 01:20:00 Europe/Vienna",
+    DataTypeCategory.DATE_TIME,
+)
+
+
+RANGE_DATA_TYPES: list[RangeDataType] = [
+    INT4_RANGE_DATA_TYPE,
+    TIMESTAMPTZ_RANGE_DATA_TYPE,
+]

--- a/misc/python/materialize/output_consistency/input_data/types/range_type_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/range_type_provider.py
@@ -8,9 +8,6 @@
 # by the Apache License, Version 2.0.
 
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
-from materialize.output_consistency.expression.expression_characteristics import (
-    ExpressionCharacteristics,
-)
 from materialize.output_consistency.input_data.return_specs.collection_return_spec import (
     CollectionReturnTypeSpec,
 )
@@ -20,7 +17,6 @@ from materialize.output_consistency.input_data.return_specs.range_return_spec im
 from materialize.output_consistency.input_data.types.collection_type_provider import (
     CollectionDataType,
 )
-from materialize.output_consistency.operation.return_type_spec import ReturnTypeSpec
 
 INT4_RANGE_TYPE_IDENTIFIER = "INT4RANGE"
 TIMESTAMPTZ_RANGE_TYPE_IDENTIFIER = "TSTZRANGE"
@@ -31,8 +27,8 @@ class RangeDataType(CollectionDataType):
         self,
         internal_identifier: str,
         type_name: str,
-        lower_range_value: str | None,
-        upper_range_value: str | None,
+        lower_range_value: str,
+        upper_range_value: str,
         value_type_category: DataTypeCategory,
     ):
         super().__init__(
@@ -47,11 +43,6 @@ class RangeDataType(CollectionDataType):
 
     def _create_collection_return_type_spec(self) -> CollectionReturnTypeSpec:
         return RangeReturnTypeSpec(range_value_type_category=self.value_type_category)
-
-    def resolve_return_type_spec(
-        self, characteristics: set[ExpressionCharacteristics]
-    ) -> ReturnTypeSpec:
-        return RangeReturnTypeSpec()
 
 
 def as_range(

--- a/misc/python/materialize/output_consistency/input_data/values/all_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/all_values_provider.py
@@ -35,6 +35,9 @@ from materialize.output_consistency.input_data.values.map_values_provider import
 from materialize.output_consistency.input_data.values.number_values_provider import (
     VALUES_PER_NUMERIC_DATA_TYPE,
 )
+from materialize.output_consistency.input_data.values.range_values_provider import (
+    VALUES_PER_RANGE_DATA_TYPE,
+)
 from materialize.output_consistency.input_data.values.string_values_provider import (
     VALUES_PER_STRING_DATA_TYPE,
 )
@@ -53,6 +56,7 @@ ALL_DATA_TYPES_WITH_VALUES: list[DataTypeWithValues] = list(
         list(VALUES_PER_MAP_DATA_TYPE.values()),
         list(VALUES_PER_LIST_DATA_TYPE.values()),
         list(VALUES_PER_ARRAY_DATA_TYPE.values()),
+        list(VALUES_PER_RANGE_DATA_TYPE.values()),
         [UUID_DATA_TYPE_WITH_VALUES],
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/values/range_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/range_values_provider.py
@@ -1,0 +1,50 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type_with_values import (
+    DataTypeWithValues,
+)
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.types.range_type_provider import (
+    RANGE_DATA_TYPES,
+    RangeDataType,
+    as_range,
+)
+
+VALUES_PER_RANGE_DATA_TYPE: dict[RangeDataType, DataTypeWithValues] = dict()
+
+for range_data_type in RANGE_DATA_TYPES:
+    values_of_type = DataTypeWithValues(range_data_type)
+    VALUES_PER_RANGE_DATA_TYPE[range_data_type] = values_of_type
+
+    values_of_type.add_raw_value(
+        as_range(None, None),
+        "EMPTY",
+        {ExpressionCharacteristics.COLLECTION_EMPTY},
+    )
+
+    values_of_type.add_raw_value(
+        as_range(range_data_type.entry_value_1, None),
+        "R_OPEN",
+        set(),
+    )
+
+    values_of_type.add_raw_value(
+        as_range(None, range_data_type.entry_value_2),
+        "L_OPEN",
+        set(),
+    )
+
+    values_of_type.add_raw_value(
+        as_range(range_data_type.entry_value_1, range_data_type.entry_value_2),
+        "CLOSED",
+        set(),
+    )

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -168,6 +168,17 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("#27253: bpchar and char trim newline")
 
+        if expression.matches(
+            partial(matches_fun_by_name, function_name_in_lower_case="array_agg"),
+            True,
+        ) and expression.matches(
+            partial(
+                involves_data_type_category, data_type_category=DataTypeCategory.RANGE
+            ),
+            True,
+        ):
+            return YesIgnore("#28007: different formatting of array_agg on range")
+
         return super()._matches_problematic_operation_or_function_invocation(
             expression, operation, all_involved_characteristics
         )


### PR DESCRIPTION
### Commits
9d54bc0c58 output consistency: generalize DynamicMapValueReturnTypeSpec to CollectionEntryReturnTypeSpec
bd421ed753 output consistency: CollectionEntryReturnTypeSpec: require explicit type source
774624f477 output consistency: list operations: fix return type specification
3fa00e640b output consistency: range type: add type
5fd701ce0a output consistency: range type: add type and return type spec
2019b7471a output consistency: range type: add values
5119d61293 output consistency: range type: add operations
25d8f62b56 output consistency: range type: add ignore

### Nightly
https://buildkite.com/materialize/nightly/builds?branch=nrainer-materialize%3Aoutput-consistency%2Fsupport-range-type