### PR TITLE
adapter: always declare MV imports non-monotonic

### DIFF
--- a/src/adapter/src/optimize/dataflows.rs
+++ b/src/adapter/src/optimize/dataflows.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use chrono::{DateTime, Utc};
 use maplit::{btreemap, btreeset};
 
-use mz_catalog::memory::objects::{CatalogItem, DataSourceDesc, Source, View};
+use mz_catalog::memory::objects::{CatalogItem, DataSourceDesc, Index, Source, View};
 use mz_compute_client::controller::error::InstanceMissing;
 use mz_compute_types::dataflows::{DataflowDesc, DataflowDescription, IndexDesc};
 
@@ -179,6 +179,8 @@ impl<'a> DataflowBuilder<'a> {
                 return Ok(());
             }
 
+            let monotonic = self.monotonic_object(*id);
+
             // A valid index is any index on `id` that is known to index oracle.
             // Here, we import all indexes that belong to all imported collections. Later,
             // `prune_and_annotate_dataflow_index_imports` runs at the end of the MIR
@@ -198,7 +200,6 @@ impl<'a> DataflowBuilder<'a> {
                                 .resolve_full_name(entry.name(), entry.conn_id()),
                         )
                         .expect("indexes can only be built on items with descs");
-                    let monotonic = self.monotonic_view(*id);
                     dataflow.import_index(index_id, index_desc, desc.typ().clone(), monotonic);
                 }
             } else {
@@ -206,24 +207,20 @@ impl<'a> DataflowBuilder<'a> {
                 let entry = self.catalog.get_entry(id);
                 match entry.item() {
                     CatalogItem::Table(table) => {
-                        dataflow.import_source(*id, table.desc.typ().clone(), false);
+                        dataflow.import_source(*id, table.desc.typ().clone(), monotonic);
                     }
                     CatalogItem::Source(source) => {
-                        dataflow.import_source(
-                            *id,
-                            source.desc.typ().clone(),
-                            self.monotonic_source(source),
-                        );
+                        dataflow.import_source(*id, source.desc.typ().clone(), monotonic);
                     }
                     CatalogItem::View(view) => {
                         let expr = view.optimized_expr.clone();
                         self.import_view_into_dataflow(id, &expr, dataflow)?;
                     }
                     CatalogItem::MaterializedView(mview) => {
-                        dataflow.import_source(*id, mview.desc.typ().clone(), false);
+                        dataflow.import_source(*id, mview.desc.typ().clone(), monotonic);
                     }
                     CatalogItem::Log(log) => {
-                        dataflow.import_source(*id, log.variant.desc().typ().clone(), false);
+                        dataflow.import_source(*id, log.variant.desc().typ().clone(), monotonic);
                     }
                     _ => unreachable!(),
                 }
@@ -302,36 +299,42 @@ impl<'a> DataflowBuilder<'a> {
         }
     }
 
-    /// Determine the given view's monotonicity.
+    /// Determine the given objects's monotonicity.
     ///
-    /// This recursively traverses the expressions of all (non-materialized) views involved in the
-    /// given view's query expression. If this becomes a performance problem, we could add the
-    /// monotonicity information of views into the catalog instead.
+    /// This recursively traverses the expressions of all views depended on by the given object.
+    /// If this becomes a performance problem, we could add the monotonicity information of views
+    /// into the catalog instead.
     ///
     /// Note that materialized views are never monotonic, no matter their definition, because the
     /// self-correcting persist_sink may insert retractions to correct the contents of its output
     /// collection.
-    fn monotonic_view(&self, id: GlobalId) -> bool {
-        self.monotonic_view_inner(id, &mut BTreeMap::new())
+    fn monotonic_object(&self, id: GlobalId) -> bool {
+        self.monotonic_object_inner(id, &mut BTreeMap::new())
             .unwrap_or_else(|e| {
-                warn!("Error inspecting view {id} for monotonicity: {e}");
+                warn!(%id, "error inspecting object for monotonicity: {e}");
                 false
             })
     }
 
-    fn monotonic_view_inner(
+    fn monotonic_object_inner(
         &self,
         id: GlobalId,
         memo: &mut BTreeMap<GlobalId, bool>,
     ) -> Result<bool, RecursionLimitError> {
-        self.checked_recur(|_| {
+        // An object might be reached multiple times. If we already computed the monotonicity of
+        // the given ID, use that. If not, then compute it and remember the result.
+        if let Some(monotonic) = memo.get(&id) {
+            return Ok(*monotonic);
+        }
+
+        let monotonic = self.checked_recur(|_| {
             match self.catalog.get_entry(&id).item() {
                 CatalogItem::Source(source) => Ok(self.monotonic_source(source)),
                 CatalogItem::View(View { optimized_expr, .. }) => {
                     let mut view_expr = optimized_expr.clone().into_inner();
 
                     // Inspect global ids that occur in the Gets in view_expr, and collect the ids
-                    // of monotonic views and sources (but not indexes or materialized views).
+                    // of monotonic dependees.
                     let mut monotonic_ids = BTreeSet::new();
                     let recursion_result: Result<(), RecursionLimitError> = view_expr
                         .try_visit_post(&mut |e| {
@@ -340,21 +343,8 @@ impl<'a> DataflowBuilder<'a> {
                                 ..
                             } = e
                             {
-                                let got_id = *got_id;
-
-                                // A view might be reached multiple times. If we already computed
-                                // the monotonicity of the gid, then use that. If not, then compute
-                                // it now.
-                                let monotonic = match memo.get(&got_id) {
-                                    Some(monotonic) => *monotonic,
-                                    None => {
-                                        let monotonic = self.monotonic_view_inner(got_id, memo)?;
-                                        memo.insert(got_id, monotonic);
-                                        monotonic
-                                    }
-                                };
-                                if monotonic {
-                                    monotonic_ids.insert(got_id);
+                                if self.monotonic_object_inner(*got_id, memo)? {
+                                    monotonic_ids.insert(*got_id);
                                 }
                             }
                             Ok(())
@@ -362,7 +352,7 @@ impl<'a> DataflowBuilder<'a> {
                     if let Err(error) = recursion_result {
                         // We still might have got some of the IDs, so just log and continue. Now
                         // the subsequent monotonicity analysis can have false negatives.
-                        warn!("Error inspecting view {id} for monotonicity: {error}");
+                        warn!(%id, "error inspecting view for monotonicity: {error}");
                     }
 
                     // Use `monotonic_ids` as a starting point for propagating monotonicity info.
@@ -372,17 +362,21 @@ impl<'a> DataflowBuilder<'a> {
                         &mut BTreeSet::new(),
                     )
                 }
+                CatalogItem::Index(Index { on, .. }) => self.monotonic_object_inner(*on, memo),
                 CatalogItem::Secret(_)
                 | CatalogItem::Type(_)
                 | CatalogItem::Connection(_)
                 | CatalogItem::Table(_)
                 | CatalogItem::Log(_)
-                | CatalogItem::Index(_)
                 | CatalogItem::MaterializedView(_)
                 | CatalogItem::Sink(_)
                 | CatalogItem::Func(_) => Ok(false),
             }
-        })
+        })?;
+
+        memo.insert(id, monotonic);
+
+        Ok(monotonic)
     }
 }
 

--- a/test/cluster/index-source-stuck/run.td
+++ b/test/cluster/index-source-stuck/run.td
@@ -77,7 +77,7 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[min(#0)] monotonic
+      Reduce aggregates=[min(#0)]
         ReadIndex on=mv mv_counter_idx=[*** full scan ***]
 
 Used Indexes:

--- a/test/sqllogictest/transform/monotonic.slt
+++ b/test/sqllogictest/transform/monotonic.slt
@@ -43,7 +43,7 @@ Target cluster: quickstart
 
 EOF
 
-# Propagating monotonicity analysis through materialized views
+# _No_ propagation of monotonicity through materialized views
 
 statement ok
 CREATE MATERIALIZED VIEW v1 AS SELECT DISTINCT counter % 3 as f1 FROM counter GROUP BY counter % 3;
@@ -55,7 +55,7 @@ query T multiline
 EXPLAIN SELECT * FROM v1 CROSS JOIN LATERAL (SELECT * FROM v2 WHERE counter < f1 ORDER BY counter DESC LIMIT 3);
 ----
 Explained Query:
-  TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=3 monotonic
+  TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=3
     Filter (#1 < #0)
       CrossJoin type=differential
         ArrangeBy keys=[[]]

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -344,19 +344,22 @@ true true true true true
 > CREATE CLUSTER counter_cluster SIZE = '1';
 > CREATE SOURCE counter IN CLUSTER counter_cluster FROM LOAD GENERATOR COUNTER (TICK INTERVAL '2ms');
 
-> CREATE MATERIALIZED VIEW input AS
+> CREATE VIEW input AS
   SELECT counter % 1000 + 1 AS f1, counter % 10 + 1 AS f2
   FROM counter;
+> CREATE DEFAULT INDEX ON input;
 
-> CREATE MATERIALIZED VIEW m_minmax AS
+> CREATE VIEW m_minmax AS
   SELECT f1, MIN(f2), MAX(f2)
   FROM input
   GROUP BY f1;
+> CREATE DEFAULT INDEX ON m_minmax;
 
-> CREATE MATERIALIZED VIEW m_top1 AS
+> CREATE VIEW m_top1 AS
   SELECT DISTINCT ON (f1) f1, f2
   FROM input
   ORDER BY f1, f2 DESC;
+> CREATE DEFAULT INDEX ON m_top1;
 
 > SELECT
     records >= 2 * 1000,

--- a/test/testdrive/monotonic.td
+++ b/test/testdrive/monotonic.td
@@ -195,9 +195,21 @@ Used Indexes:
 
 Target cluster: quickstart
 
+# _No_ propagation of monotonicity through materialized views.
+
 > CREATE MATERIALIZED VIEW m1 AS SELECT b FROM non_dbz_data;
 
 > CREATE VIEW v11 AS SELECT * FROM m1 ORDER BY b LIMIT 3;
+
+? EXPLAIN PHYSICAL PLAN FOR SELECT * FROM v11;
+Explained Query:
+  TopK::MonotonicTopK order_by=[#0 asc nulls_last] limit=3 must_consolidate
+    Get::PassArrangements materialize.public.m1
+      raw=true
+
+Source materialize.public.m1
+
+Target cluster: quickstart
 
 # Check arrangements, seeing new arrangements can mean a significant increase
 # in memory consumptions and should be understood before adapting the values.
@@ -228,15 +240,3 @@ Target cluster: quickstart
 "Dataflow: materialize.public.monotonic_min" ReduceMonotonic
 "Dataflow: materialize.public.non_dbz_data_indexed_primary_idx" "ArrangeBy[[Column(0), Column(1)]]"
 "Dataflow: materialize.public.non_dbz_data_indexed_primary_idx" "ArrangeBy[[Column(0), Column(1)]]-errors"
-
-# Propagating monotonicity analysis through materialized views
-
-? EXPLAIN PHYSICAL PLAN FOR SELECT * FROM v11;
-Explained Query:
-  TopK::MonotonicTopK order_by=[#0 asc nulls_last] limit=3
-    Get::PassArrangements materialize.public.m1
-      raw=true
-
-Source materialize.public.m1
-
-Target cluster: quickstart


### PR DESCRIPTION
Every materialized view has at its output a self-correcting persist sink that reserves the right to insert "corrections" whenever it notices that its output collection differs from the desired state. Across releases this can happen (e.g. when we fix a bug in the optimizer or rendering), so we always need to assume that a persist sink can emit retractions into the MV collection. This makes all MVs non-monotonic, and treating them as monotonic would be a mistake.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
