### PR TITLE
testdrive: Fix auto-rewriting with spaces in strings

### DIFF
--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -139,7 +139,15 @@ fn rewrite_result(
     writeln!(buf, "{}", columns.join(" "))?;
     writeln!(buf, "----")?;
     for row in content {
-        writeln!(buf, "{}", row.join(" "))?;
+        let mut formatted_row = Vec::<String>::new();
+        for value in row {
+            if value.is_empty() || value.contains(|x: char| char::is_ascii_whitespace(&x)) {
+                formatted_row.push("\"".to_owned() + &value + "\"");
+            } else {
+                formatted_row.push(value);
+            }
+        }
+        writeln!(buf, "{}", formatted_row.join(" "))?;
     }
     state.rewrites.push(Rewrite {
         content: buf,

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -72,6 +72,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     parser.add_argument(
+        "--rewrite-results",
+        action="store_true",
+        help="Rewrite results, disables junit reports",
+    )
+
+    parser.add_argument(
         "files",
         nargs="*",
         default=["*.td"],
@@ -180,7 +186,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             # without mzcompose
             for file in args.files:
                 c.run_testdrive_files(
-                    f"--junit-report={junit_report}",
+                    (
+                        "--rewrite-results"
+                        if args.rewrite_results
+                        else f"--junit-report={junit_report}"
+                    ),
                     *non_default_testdrive_vars,
                     *passthrough_args,
                     file,


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
