### PR TITLE
adapter: wire up cluster hydration check to 0dt deployment preflight

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -25,6 +25,19 @@ pub const ENABLE_0DT_DEPLOYMENT: Config<bool> = Config::new(
     "Whether to enable zero-downtime deployments (experimental).",
 );
 
+// Slightly awkward with the WITH prefix, but we can't start with a 0.
+pub const WITH_0DT_DEPLOYMENT_MAX_WAIT: Config<Duration> = Config::new(
+    "with_0dt_deployment_max_wait",
+    Duration::from_secs(5 * 60),
+    "How long to wait at most for clusters to be hydrated, when doing a zero-downtime deployment.",
+);
+
+pub const WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL: Config<Duration> = Config::new(
+    "0dt_deployment_hydration_check_interval",
+    Duration::from_secs(10),
+    "Interval at which to check cluster hydration status, when doing zero-downtime deployment.",
+);
+
 /// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.
 pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
     "enable_statement_lifecycle_logging",
@@ -56,6 +69,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&ALLOW_USER_SESSIONS)
         .add(&ENABLE_0DT_DEPLOYMENT)
+        .add(&WITH_0DT_DEPLOYMENT_MAX_WAIT)
+        .add(&WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL)
         .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
         .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -159,6 +159,13 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// LaunchDarkly is available.
     async fn get_enable_0dt_deployment(&mut self) -> Result<Option<bool>, CatalogError>;
 
+    /// Get the `with_0dt_deployment_max_wait` config value of this instance.
+    ///
+    /// This mirrors the `with_0dt_deployment_max_wait` "system var" so that we can
+    /// toggle the flag with LaunchDarkly, but use it in boot before
+    /// LaunchDarkly is available.
+    async fn get_0dt_deployment_max_wait(&mut self) -> Result<Option<Duration>, CatalogError>;
+
     /// Reports if the remote configuration was synchronized at least once.
     async fn has_system_config_synced_once(&mut self) -> Result<bool, CatalogError>;
 

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -56,6 +56,14 @@ pub(crate) const SYSTEM_CONFIG_SYNCED_KEY: &str = "system_config_synced";
 /// available.
 pub(crate) const ENABLE_0DT_DEPLOYMENT: &str = "enable_0dt_deployment";
 
+/// The key used within the "config" collection where we store a mirror of the
+/// `with_0dt_deployment_max_wait` "system var" value. This is mirrored so that
+/// we can toggle the flag with LaunchDarkly, but use it in boot before
+/// LaunchDarkly is available.
+///
+/// NOTE: Weird prefix because we can't start with a `0`.
+pub(crate) const WITH_0DT_DEPLOYMENT_MAX_WAIT: &str = "with_0dt_deployment_max_wait";
+
 const USER_ID_ALLOC_KEY: &str = "user";
 const SYSTEM_ID_ALLOC_KEY: &str = "system";
 

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -47,6 +47,7 @@ use uuid::Uuid;
 use crate::durable::debug::{Collection, DebugCatalogState, Trace};
 use crate::durable::initialize::{
     DEPLOY_GENERATION, ENABLE_0DT_DEPLOYMENT, SYSTEM_CONFIG_SYNCED_KEY, USER_VERSION_KEY,
+    WITH_0DT_DEPLOYMENT_MAX_WAIT,
 };
 use crate::durable::metrics::Metrics;
 use crate::durable::objects::serialization::proto;
@@ -1110,6 +1111,17 @@ impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
                 )))
                 .into(),
             ),
+        }
+    }
+
+    #[mz_ore::instrument(level = "debug")]
+    async fn get_0dt_deployment_max_wait(&mut self) -> Result<Option<Duration>, CatalogError> {
+        let value = self
+            .get_current_config(WITH_0DT_DEPLOYMENT_MAX_WAIT)
+            .await?;
+        match value {
+            None => Ok(None),
+            Some(millis) => Ok(Some(Duration::from_millis(millis))),
         }
     }
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -26,7 +26,7 @@ use derivative::Derivative;
 use mz_adapter::config::{system_parameter_sync, SystemParameterSyncConfig};
 use mz_adapter::load_remote_system_parameters;
 use mz_adapter::webhook::WebhookConcurrencyLimiter;
-use mz_adapter_types::dyncfgs::ENABLE_0DT_DEPLOYMENT;
+use mz_adapter_types::dyncfgs::{ENABLE_0DT_DEPLOYMENT, WITH_0DT_DEPLOYMENT_MAX_WAIT};
 use mz_build_info::{build_info, BuildInfo};
 use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_catalog::durable::BootstrapArgs;
@@ -44,12 +44,12 @@ use mz_repr::strconv;
 use mz_secrets::SecretsController;
 use mz_server_core::{ConnectionStream, ListenerHandle, ReloadTrigger, TlsCertConfig};
 use mz_sql::catalog::EnvironmentId;
-use mz_sql::session::vars::ConnectionCounter;
+use mz_sql::session::vars::{ConnectionCounter, Value, VarInput};
 use tokio::sync::oneshot;
 use tower_http::cors::AllowOrigin;
 use tracing::{info, info_span, Instrument};
 
-use crate::deployment::preflight::PreflightInput;
+use crate::deployment::preflight::{PreflightInput, PreflightOutput};
 use crate::deployment::state::DeploymentState;
 use crate::http::{HttpConfig, HttpServer, InternalHttpConfig, InternalHttpServer};
 
@@ -381,11 +381,61 @@ impl Listeners {
             );
             computed
         };
+        // Determine the maximum wait time when doing a 0dt deployment.
+        let with_0dt_deployment_max_wait = {
+            let default = config
+                .system_parameter_defaults
+                .get(WITH_0DT_DEPLOYMENT_MAX_WAIT.name())
+                .map(|x| {
+                    Duration::parse(VarInput::Flat(x)).map_err(|err| {
+                        anyhow!(
+                            "failed to parse default for {}: {:?}",
+                            WITH_0DT_DEPLOYMENT_MAX_WAIT.name(),
+                            err
+                        )
+                    })
+                })
+                .transpose()?;
+            let ld = get_ld_value(
+                WITH_0DT_DEPLOYMENT_MAX_WAIT.name(),
+                &remote_system_parameters,
+                |x| {
+                    Duration::parse(VarInput::Flat(x)).map_err(|err| {
+                        format!(
+                            "failed to parse LD value {} for {}: {:?}",
+                            x,
+                            WITH_0DT_DEPLOYMENT_MAX_WAIT.name(),
+                            err
+                        )
+                    })
+                },
+            )?;
+            let catalog = openable_adapter_storage
+                .get_0dt_deployment_max_wait()
+                .await?;
+            let computed = catalog
+                .or(ld)
+                .or(default)
+                .unwrap_or(WITH_0DT_DEPLOYMENT_MAX_WAIT.default().clone());
+            info!(
+                ?computed,
+                ?default,
+                ?ld,
+                ?catalog,
+                "determined value for {} system parameter",
+                WITH_0DT_DEPLOYMENT_MAX_WAIT.name()
+            );
+            computed
+        };
+
+        // TODO(aljoscha): We have to do the same dance for
+        // `0dt_deployment_max_wait`, and pass it to the preflight check.
 
         // Perform preflight checks.
         //
         // Preflight checks determine whether to boot in read-only mode or not.
         let mut read_only = false;
+        let mut clusters_hydrated_trigger = None;
         let preflight_config = PreflightInput {
             boot_ts,
             environment_id: config.environment_id.clone(),
@@ -398,10 +448,14 @@ impl Listeners {
             deployment_state,
             openable_adapter_storage,
             catalog_metrics: Arc::clone(&config.catalog_config.metrics),
+            hydration_max_wait: with_0dt_deployment_max_wait,
         };
         if enable_0dt_deployment {
-            (openable_adapter_storage, read_only) =
-                deployment::preflight::preflight_0dt(preflight_config).await?;
+            PreflightOutput {
+                openable_adapter_storage,
+                read_only,
+                clusters_hydrated_trigger,
+            } = deployment::preflight::preflight_0dt(preflight_config).await?;
         } else {
             openable_adapter_storage =
                 deployment::preflight::preflight_legacy(preflight_config).await?;
@@ -495,6 +549,7 @@ impl Listeners {
             tracing_handle: config.tracing_handle,
             read_only_controllers: read_only,
             enable_0dt_deployment,
+            clusters_hydrated_trigger,
         })
         .instrument(info_span!("adapter::serve"))
         .await?;

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -371,12 +371,12 @@ impl Listeners {
                 strconv::parse_bool(x).map_err(|x| x.to_string())
             })?;
             let catalog = openable_adapter_storage.get_enable_0dt_deployment().await?;
-            let computed = catalog.or(ld).or(default).unwrap_or(false);
+            let computed = ld.or(catalog).or(default).unwrap_or(false);
             info!(
                 %computed,
-                ?default,
                 ?ld,
                 ?catalog,
+                ?default,
                 "determined value for enable_0dt_deployment system parameter",
             );
             computed
@@ -413,15 +413,15 @@ impl Listeners {
             let catalog = openable_adapter_storage
                 .get_0dt_deployment_max_wait()
                 .await?;
-            let computed = catalog
-                .or(ld)
+            let computed = ld
+                .or(catalog)
                 .or(default)
                 .unwrap_or(WITH_0DT_DEPLOYMENT_MAX_WAIT.default().clone());
             info!(
                 ?computed,
-                ?default,
                 ?ld,
                 ?catalog,
+                ?default,
                 "determined value for {} system parameter",
                 WITH_0DT_DEPLOYMENT_MAX_WAIT.name()
             );

--- a/src/ore/src/channel/trigger.rs
+++ b/src/ore/src/channel/trigger.rs
@@ -69,6 +69,16 @@ pub struct Trigger {
     _tx: oneshot::Sender<()>,
 }
 
+impl Trigger {
+    /// Fire this [Trigger].
+    ///
+    /// NOTE: Dropping the trigger also fires it, but this method allows
+    /// call-sites to be more explicit.
+    pub fn fire(self) {
+        // Dropping the Trigger is what fires the oneshot.
+    }
+}
+
 /// The receiving half of a trigger channel.
 ///
 /// Awaiting the receiver will block until the trigger is dropped.


### PR DESCRIPTION
Work towards zero-downtime upgrades: https://github.com/MaterializeInc/materialize/issues/27406

I'm not sure I like this approach, especially with always having a check interval and adding another branch to the coordinator main loop. But opening now to get early feedback. This should be the last piece before we can think about rolling 0dt deployment out to staging. :fire: 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
