### PR TITLE
environmentd: allow SUBSCRIBE UP TO in http

### DIFF
--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -229,6 +229,15 @@ http
 400 Bad Request
 unsupported via this API: SUBSCRIBE (SELECT * FROM t)
 
+# This is optimizer panicing due to #27999, but we only want to test that the HTTP layer isn't
+# rejecting the syntax. This comment should be deleted but the test kept with updated output when that
+# issue is fixed.
+http
+{"query":"subscribe (select * from v) up to 18446744073709551615"}
+----
+200 OK
+{"results":[{"error":{"message":"internal error: unexpected panic during query optimization","code":"XX000"},"notices":[{"message":"subscribe as of 18446744073709551615 (inclusive) up to the same bound 18446744073709551615 (exclusive) is guaranteed to be empty","code":"00000","severity":"notice"}]}]}
+
 http
 {"query":"copy (select 1) to stdout"}
 ----


### PR DESCRIPTION
Fixes MaterializeInc/database-issues#8211

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow `SUBSCRIBE .. UP TO` over HTTP endpoint.