### PR TITLE
docs: Handle special characters in JSON to SQL widget

### DIFF
--- a/doc/user/layouts/shortcodes/json-parser.html
+++ b/doc/user/layouts/shortcodes/json-parser.html
@@ -44,6 +44,10 @@ function escapeIdent(s) {
     return `"${s.replace(/"/g, `""`)}"`;
 }
 
+function replaceSpecialChar(s) {
+    return s.replace(/[^a-zA-Z0-9 _]/g, "_")
+}
+
 function isDate(value) {
     var dateParsed = new Date(Date.parse(value));
     if (isNaN(dateParsed.getTime())) {
@@ -153,7 +157,8 @@ function formSql(selectItems, viewName, sourceName, objectType, columnName) {
         type = "MATERIALIZED VIEW";
     }
 
-    let sqlParts = selectItems.map(([name, wrapping_function, cast, parents, isNull, value]) => {
+    // Map all of our field into a column reference and alias.
+    const rawSqlParts = selectItems.map(([name, wrapping_function, cast, parents, isNull, value]) => {
         let path = columnName || "body";
 
         // Iterate over parents to build the path, skipping the columnName/base if it's included
@@ -172,10 +177,27 @@ function formSql(selectItems, viewName, sourceName, objectType, columnName) {
 
         // Construct column alias without redundant name appending
         let columnAliasParts = parents.slice(columnName ? 1 : 0);
-        let columnAlias = columnAliasParts.join("_");
+        let columnAlias = replaceSpecialChar(columnAliasParts.join("_"));
+
+        return [sqlItem, columnAlias];
+    });
+
+    // De-dupe column aliases by optionally appending a suffix.
+    const nextSuffixes = new Map();
+    const sqlParts = rawSqlParts.map(([sqlItem, columnAlias]) => {
+        const suffix = nextSuffixes.get(columnAlias);
+
+        // If we haven't seen this column alias before, no need to add a suffix.
+        if (suffix === undefined) {
+            nextSuffixes.set(columnAlias, 1);
+        } else {
+            nextSuffixes.set(columnAlias, suffix + 1);
+            columnAlias = `${columnAlias}${suffix}`;
+        }
 
         return `${sqlItem} AS ${columnAlias}`;
-    }).join(",\n    ");
+    })
+    .join(",\n    ");
 
     return `CREATE ${type} ${viewName} AS SELECT\n    ${sqlParts}\nFROM ${sourceName};`;
 }


### PR DESCRIPTION
This PR updates the JSON to SQL widget to replace characters "special characters", i.e. anything not in the character class `[a-zA-Z _]` with an `_`. It then de-dupes column aliases by appending a number. For example:

```
{
  "%foo": 1,
  "^foo": 1
}

CREATE VIEW my_view AS SELECT
    (json_column->>'%foo')::numeric AS _foo,
    (json_column->>'^foo')::numeric AS _foo1
FROM my_source;
```

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/27995

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Updates the JSON to SQL widget to better handle special characters
