### PR TITLE
controller: remove transient_id_gen

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -41,7 +41,6 @@ use mz_ore::soft_panic_or_log;
 use mz_persist_client::PersistClient;
 use mz_repr::adt::mz_acl_item::{AclMode, PrivilegeMap};
 use mz_repr::explain::ExprHumanizer;
-use mz_repr::global_id::TransientIdGen;
 use mz_repr::namespaces::MZ_TEMP_SCHEMA;
 use mz_repr::role_id::RoleId;
 use mz_repr::{Diff, GlobalId, ScalarType};
@@ -200,7 +199,6 @@ impl Catalog {
         config: mz_controller::ControllerConfig,
         envd_epoch: core::num::NonZeroI64,
         read_only: bool,
-        transient_id_gen: Arc<TransientIdGen>,
         builtin_migration_metadata: BuiltinMigrationMetadata,
         // Whether to use the new txn-wal tables implementation or the
         // legacy one.
@@ -220,7 +218,6 @@ impl Catalog {
                 config,
                 envd_epoch,
                 read_only,
-                transient_id_gen,
                 txn_wal_tables,
                 &read_only_tx,
             )

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3412,14 +3412,12 @@ pub fn serve(
             .spawn(move || {
                 let span = info_span!(parent: parent_span, "coord::coordinator").entered();
 
-                let transient_id_gen = Arc::new(TransientIdGen::new());
                 let controller = handle
                     .block_on({
                         catalog.initialize_controller(
                             controller_config,
                             controller_envd_epoch,
                             read_only_controllers,
-                            Arc::clone(&transient_id_gen),
                             builtin_migration_metadata,
                             controller_txn_wal_tables,
                         )
@@ -3437,7 +3435,7 @@ pub fn serve(
                     strict_serializable_reads_tx,
                     dropped_read_holds_tx,
                     global_timelines: timestamp_oracles,
-                    transient_id_gen,
+                    transient_id_gen: Arc::new(TransientIdGen::new()),
                     active_conns: BTreeMap::new(),
                     storage_read_capabilities: Default::default(),
                     compute_read_capabilities: Default::default(),

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -46,7 +46,6 @@ use mz_expr::RowSetFinishing;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{soft_assert_or_log, soft_panic_or_log};
-use mz_repr::global_id::TransientIdGen;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{Datum, Diff, GlobalId, Row, TimestampManipulation};
 use mz_storage_client::controller::{IntrospectionType, StorageController, StorageWriteOp};
@@ -164,8 +163,6 @@ pub struct ComputeController<T> {
     stashed_replica_response: Option<(ComputeInstanceId, ReplicaId, ComputeResponse<T>)>,
     /// A number that increases on every `environmentd` restart.
     envd_epoch: NonZeroI64,
-    /// A generator for transient [`GlobalId`]s.
-    transient_id_gen: Arc<TransientIdGen>,
     /// The compute controller metrics.
     metrics: ComputeControllerMetrics,
     /// Dynamic system configuration.
@@ -197,7 +194,6 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
         storage_collections: Arc<dyn StorageCollections<Timestamp = T>>,
         envd_epoch: NonZeroI64,
         read_only: bool,
-        transient_id_gen: Arc<TransientIdGen>,
         metrics_registry: MetricsRegistry,
     ) -> Self {
         let (response_tx, response_rx) = crossbeam_channel::unbounded();
@@ -216,7 +212,6 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
             arrangement_exert_proportionality: 16,
             stashed_replica_response: None,
             envd_epoch,
-            transient_id_gen,
             metrics: ComputeControllerMetrics::new(metrics_registry),
             dyncfg: Arc::new(mz_dyncfgs::all_dyncfgs()),
             response_rx,
@@ -336,7 +331,6 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
             arrangement_exert_proportionality,
             stashed_replica_response,
             envd_epoch,
-            transient_id_gen: _,
             metrics: _,
             dyncfg: _,
             response_rx: _,
@@ -401,7 +395,6 @@ where
                 Arc::clone(&self.storage_collections),
                 arranged_logs,
                 self.envd_epoch,
-                Arc::clone(&self.transient_id_gen),
                 self.metrics.for_instance(id),
                 Arc::clone(&self.dyncfg),
                 self.response_tx.clone(),

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -30,7 +30,6 @@ use mz_expr::RowSetFinishing;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::global_id::TransientIdGen;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_storage_client::controller::IntrospectionType;
@@ -216,10 +215,6 @@ pub(super) struct Instance<T> {
     envd_epoch: NonZeroI64,
     /// Numbers that increase with each restart of a replica.
     replica_epochs: BTreeMap<ReplicaId, u64>,
-    /// A generator for transient [`GlobalId`]s.
-    // TODO(#26730): use this to generate IDs for introspection subscribes
-    #[allow(dead_code)]
-    transient_id_gen: Arc<TransientIdGen>,
     /// The registry the controller uses to report metrics.
     metrics: InstanceMetrics,
     /// Dynamic system configuration.
@@ -596,7 +591,6 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
             introspection_tx: _,
             envd_epoch,
             replica_epochs,
-            transient_id_gen: _,
             metrics: _,
             dyncfg: _,
         } = self;
@@ -656,7 +650,6 @@ where
         storage: Arc<dyn StorageCollections<Timestamp = T>>,
         arranged_logs: BTreeMap<LogVariant, GlobalId>,
         envd_epoch: NonZeroI64,
-        transient_id_gen: Arc<TransientIdGen>,
         metrics: InstanceMetrics,
         dyncfg: Arc<ConfigSet>,
         response_tx: crossbeam_channel::Sender<ComputeControllerResponse<T>>,
@@ -688,7 +681,6 @@ where
             introspection_tx,
             envd_epoch,
             replica_epochs: Default::default(),
-            transient_id_gen,
             metrics,
             dyncfg,
         };

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -48,7 +48,6 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::PersistLocation;
 use mz_persist_types::Codec64;
 use mz_proto::RustType;
-use mz_repr::global_id::TransientIdGen;
 use mz_repr::{GlobalId, TimestampManipulation};
 use mz_service::secrets::SecretsReaderCliArgs;
 use mz_storage_client::client::{
@@ -649,7 +648,6 @@ where
         config: ControllerConfig,
         envd_epoch: NonZeroI64,
         read_only: bool,
-        transient_id_gen: Arc<TransientIdGen>,
         // Whether to use the new txn-wal tables implementation or the
         // legacy one.
         txn_wal_tables: TxnWalTablesImpl,
@@ -697,7 +695,6 @@ where
             storage_collections,
             envd_epoch,
             read_only,
-            transient_id_gen,
             config.metrics_registry.clone(),
         );
         let (metrics_tx, metrics_rx) = mpsc::unbounded_channel();


### PR DESCRIPTION
This PR makes the compute controller stop holding a reference to the transient ID generator. The reference was added to support creation of introspection subscribes by the compute controller, but we reconsidered and are now creating them in the coordinator instead.

### Motivation

  * This PR resolves a leftover TODO.

Part of #26730

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A