### PR TITLE
test analytics: materialized views: add query hint to mv_build_job_success

### DIFF
--- a/misc/python/materialize/test_analytics/setup/views/02-build-job.sql
+++ b/misc/python/materialize/test_analytics/setup/views/02-build-job.sql
@@ -86,6 +86,8 @@ WITH MUTUALLY RECURSIVE data (build_id TEXT, pipeline TEXT, build_number INT, bu
         d.build_step_key,
         d.predecessor_index,
         d.success
+    -- this applies to max(b2.build_number)
+    OPTIONS (AGGREGATE INPUT GROUP SIZE = 10)
 )
 SELECT
     d.build_id,


### PR DESCRIPTION
This addresses https://materializeinc.slack.com/archives/C01LKF361MZ/p1719911926469159.

```
materialize=> select * from mz_internal.mz_expected_group_size_advice;
 dataflow_id |                   dataflow_name                   | region_id |    region_name     | levels | to_cut |  savings   | hint
-------------+---------------------------------------------------+-----------+--------------------+--------+--------+------------+-------
 6           | Dataflow: raw.test_analytics.mv_build_job_success | 753       | ReduceHierarchical |      8 |      4 | 6400884191 | 65535
(1 row)
```

Let's see how much this brings. If the optimization is not sufficient I can also consider reducing the number of collected build predecessors (currently `d.predecessor_index < 10`).