### PR TITLE
Avoid null skew in outer join lowering

### DIFF
--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -247,6 +247,7 @@ impl From<&OptimizerConfig> for mz_sql::plan::HirToMirConfig {
         Self {
             enable_new_outer_join_lowering: config.features.enable_new_outer_join_lowering,
             enable_variadic_left_join_lowering: config.features.enable_variadic_left_join_lowering,
+            enable_outer_join_null_filter: config.features.enable_outer_join_null_filter,
         }
     }
 }

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -744,11 +744,14 @@ impl MirScalarExpr {
                     match e {
                         MirScalarExpr::CallUnary { func, expr } => {
                             if *func == UnaryFunc::IsNull(func::IsNull) {
-                                // Decompose IsNull expressions into a disjunction
-                                // of simpler IsNull subexpressions
-
-                                if let Some(expr) = expr.decompose_is_null() {
-                                    *e = expr
+                                if !expr.typ(column_types).nullable && !expr.could_error() {
+                                    *e = MirScalarExpr::literal_false();
+                                } else {
+                                    // Try to at least decompose IsNull into a disjunction
+                                    // of simpler IsNull subexpressions.
+                                    if let Some(expr) = expr.decompose_is_null() {
+                                        *e = expr
+                                    }
                                 }
                             } else if *func == UnaryFunc::Not(func::Not) {
                                 // Push down not expressions

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -41,12 +41,12 @@ reduce
 reduce
 (call_unary is_null (call_binary add_int_32 #1 #0)) [(int32 false) (int32 false)]
 ----
-((#0) IS NULL OR (#1) IS NULL)
+false
 
 reduce
 (call_unary is_null (call_variadic and [#1 #0])) [(bool false) (bool false)]
 ----
-((#0 AND #1)) IS NULL
+false
 
 reduce
 (call_unary is_null
@@ -116,7 +116,7 @@ reduce
 )
 [(int32 false) (int32 false)]
 ----
-((#0) IS NULL OR (#1) IS NULL)
+false
 
 # Non-null-propagating UnaryFunc around BinaryFunc
 reduce
@@ -194,16 +194,7 @@ reduce
 )
 [(int32 false) (int32 false)]
 ----
-((#0) IS NOT NULL AND (#1) IS NOT NULL)
-
-canonicalize
-[(call_unary not
-    (call_unary is_null (call_binary add_int_32 #1 #0))
-)]
-[(int32 false) (int32 false)]
-----
-(#0) IS NOT NULL
-(#1) IS NOT NULL
+true
 
 reduce
 (

--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -106,6 +106,8 @@ optimizer_feature_flags!({
     enable_reduce_mfp_fusion: bool,
     // Enable joint HIR ⇒ MIR lowering of stacks of left joins.
     enable_variadic_left_join_lowering: bool,
+    // Enable the extra null filter implemented in #28018.
+    enable_outer_join_null_filter: bool,
     // Enable cardinality estimation
     enable_cardinality_estimates: bool,
     // An exclusive upper bound on the number of results we may return from a

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1808,6 +1808,7 @@ pub enum ClusterFeatureName {
     EnableEagerDeltaJoins,
     EnableVariadicLeftJoinLowering,
     EnableLetrecFixpointAnalysis,
+    EnableOuterJoinNullFilter,
 }
 
 impl WithOptionName for ClusterFeatureName {
@@ -1822,7 +1823,8 @@ impl WithOptionName for ClusterFeatureName {
             | Self::EnableNewOuterJoinLowering
             | Self::EnableEagerDeltaJoins
             | Self::EnableVariadicLeftJoinLowering
-            | Self::EnableLetrecFixpointAnalysis => false,
+            | Self::EnableLetrecFixpointAnalysis
+            | Self::EnableOuterJoinNullFilter => false,
         }
     }
 }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -2051,7 +2051,10 @@ fn attempt_outer_equijoin(
                         // a semi-join between `left` and `both_keys`.
                         let left_present = MirRelationExpr::join_scalars(
                             vec![
-                                get_left.clone().filter(on_predicates.lhs()), // Push local predicates.
+                                get_left
+                                    .clone()
+                                    .filter(on_predicates.lhs()) // Push local predicates.
+                                    .filter(on_predicates.eq_lhs().map(|e| e.call_is_null().not())),
                                 get_both.clone(),
                             ],
                             itertools::zip_eq(

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3533,7 +3533,8 @@ generate_extracted_config!(
     (EnableEagerDeltaJoins, Option<bool>, Default(None)),
     (EnableNewOuterJoinLowering, Option<bool>, Default(None)),
     (EnableVariadicLeftJoinLowering, Option<bool>, Default(None)),
-    (EnableLetrecFixpointAnalysis, Option<bool>, Default(None))
+    (EnableLetrecFixpointAnalysis, Option<bool>, Default(None)),
+    (EnableOuterJoinNullFilter, Option<bool>, Default(None))
 );
 
 /// Convert a [`CreateClusterStatement`] into a [`Plan`].
@@ -3665,6 +3666,7 @@ pub fn plan_create_cluster_inner(
             enable_new_outer_join_lowering,
             enable_variadic_left_join_lowering,
             enable_letrec_fixpoint_analysis,
+            enable_outer_join_null_filter,
             seen: _,
         } = ClusterFeatureExtracted::try_from(features)?;
         let optimizer_feature_overrides = OptimizerFeatureOverrides {
@@ -3673,6 +3675,7 @@ pub fn plan_create_cluster_inner(
             enable_new_outer_join_lowering,
             enable_variadic_left_join_lowering,
             enable_letrec_fixpoint_analysis,
+            enable_outer_join_null_filter,
             ..Default::default()
         };
 
@@ -3761,6 +3764,7 @@ pub fn unplan_create_cluster(
                 enable_new_outer_join_lowering,
                 enable_variadic_left_join_lowering,
                 enable_letrec_fixpoint_analysis,
+                enable_outer_join_null_filter,
             } = optimizer_feature_overrides;
             let features_extracted = ClusterFeatureExtracted {
                 // Seen is ignored when unplanning.
@@ -3770,6 +3774,7 @@ pub fn unplan_create_cluster(
                 enable_new_outer_join_lowering,
                 enable_variadic_left_join_lowering,
                 enable_letrec_fixpoint_analysis,
+                enable_outer_join_null_filter,
             };
             let features = features_extracted.into_values(scx.catalog);
             let availability_zones = if availability_zones.is_empty() {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2115,6 +2115,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: true,
     },
+    {
+        name: enable_outer_join_null_filter,
+        desc: "Add an extra null filter to the semi-join part of outer join lowering",
+        default: true,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {
@@ -2127,6 +2134,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_variadic_left_join_lowering: vars.enable_variadic_left_join_lowering(),
             enable_letrec_fixpoint_analysis: vars.enable_letrec_fixpoint_analysis(),
             enable_cardinality_estimates: vars.enable_cardinality_estimates(),
+            enable_outer_join_null_filter: vars.enable_outer_join_null_filter(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),
             reoptimize_imported_views: false,
         }

--- a/src/transform/tests/testdata/canonicalize_mfp
+++ b/src/transform/tests/testdata/canonicalize_mfp
@@ -166,7 +166,7 @@ build apply=CanonicalizeMfp
     [0 3])
 ----
 Project (#0, #3)
-  Filter (#0) IS NOT NULL AND ((#0 = 5) OR (#0 = 1337))
+  Filter ((#0 = 5) OR (#0 = 1337))
     Join on=(#0 = #2)
       Project (#2)
         Filter (#2 > 1234)

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -69,11 +69,10 @@ Explained Query:
   With
     cte l2 =
       Project (#0..=#3) // { arity: 4 }
-        Filter (#0) IS NOT NULL // { arity: 5 }
-          Join on=(#0 = #4) type=differential // { arity: 5 }
-            Get l1 // { arity: 3 }
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              ReadIndex on=u u_d_idx=[differential join] // { arity: 2 }
+        Join on=(#0 = #4) type=differential // { arity: 5 }
+          Get l1 // { arity: 3 }
+          ArrangeBy keys=[[#1]] // { arity: 2 }
+            ReadIndex on=u u_d_idx=[differential join] // { arity: 2 }
     cte l1 =
       ArrangeBy keys=[[#0]] // { arity: 3 }
         Filter (#0) IS NOT NULL // { arity: 3 }

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -57,26 +57,27 @@ Explained Query:
                         Negate // { arity: 3 }
                           Project (#0..=#2) // { arity: 3 }
                             Join on=(#0 = #3) type=differential // { arity: 4 }
-                              ArrangeBy keys=[[#0]] // { arity: 3 }
-                                Get l0 // { arity: 3 }
+                              Get l1 // { arity: 3 }
                               ArrangeBy keys=[[#0]] // { arity: 1 }
                                 Distinct project=[#0] // { arity: 1 }
                                   Project (#0) // { arity: 1 }
-                                    Get l1 // { arity: 4 }
+                                    Get l2 // { arity: 4 }
                         Get l0 // { arity: 3 }
-                    Get l1 // { arity: 4 }
+                    Get l2 // { arity: 4 }
         Constant // { arity: 4 }
           - (1, 2, 11, 12)
   With
-    cte l1 =
+    cte l2 =
       Project (#0..=#3) // { arity: 4 }
         Filter (#0) IS NOT NULL // { arity: 5 }
           Join on=(#0 = #4) type=differential // { arity: 5 }
-            ArrangeBy keys=[[#0]] // { arity: 3 }
-              Filter (#0) IS NOT NULL // { arity: 3 }
-                Get l0 // { arity: 3 }
+            Get l1 // { arity: 3 }
             ArrangeBy keys=[[#1]] // { arity: 2 }
               ReadIndex on=u u_d_idx=[differential join] // { arity: 2 }
+    cte l1 =
+      ArrangeBy keys=[[#0]] // { arity: 3 }
+        Filter (#0) IS NOT NULL // { arity: 3 }
+          Get l0 // { arity: 3 }
     cte l0 =
       FlatMap generate_series(#0, #1, 1) // { arity: 3 }
         ReadIndex on=t t_a_idx=[*** full scan ***] // { arity: 2 }

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -152,7 +152,7 @@ Explained Query:
                             ReadStorage materialize.public.u // { types: "(integer?)" }
                       Map (error("more than one record produced in subquery")) // { types: "(double precision)" }
                         Project () // { types: "()" }
-                          Filter error("more than one record produced in subquery") AND (#0 > 1) // { types: "(bigint)" }
+                          Filter (#0 > 1) // { types: "(bigint)" }
                             Reduce aggregates=[count(*)] // { types: "(bigint)" }
                               Project () // { types: "()" }
                                 ReadStorage materialize.public.u // { types: "(integer?)" }

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -99,25 +99,26 @@ Explained Query:
           Negate // { types: "()" }
             Project () // { types: "()" }
               Join on=(#0 = #1) type=differential // { types: "(integer, integer)" }
-                ArrangeBy keys=[[#0]] // { types: "(integer?)" }
-                  ReadStorage materialize.public.u // { types: "(integer?)" }
+                Get l0 // { types: "(integer)" }
                 ArrangeBy keys=[[#0]] // { types: "(integer)" }
                   Distinct project=[#0] // { types: "(integer)" }
                     Project (#0) // { types: "(integer)" }
-                      Get l0 // { types: "(integer, text?, date?)" }
+                      Get l1 // { types: "(integer, text?, date?)" }
           Project () // { types: "()" }
             ReadStorage materialize.public.u // { types: "(integer?)" }
-      Get l0 // { types: "(integer, text?, date?)" }
+      Get l1 // { types: "(integer, text?, date?)" }
   With
-    cte l0 =
+    cte l1 =
       Project (#0, #2, #3) // { types: "(integer, text?, date?)" }
         Join on=(#0 = #1) type=differential // { types: "(integer, integer, text?, date?)" }
-          ArrangeBy keys=[[#0]] // { types: "(integer)" }
-            Filter (#0) IS NOT NULL // { types: "(integer)" }
-              ReadStorage materialize.public.u // { types: "(integer?)" }
+          Get l0 // { types: "(integer)" }
           ArrangeBy keys=[[#0]] // { types: "(integer, text?, date?)" }
             Filter (#0) IS NOT NULL // { types: "(integer, text?, date?)" }
               ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { types: "(integer)" }
+        Filter (#0) IS NOT NULL // { types: "(integer)" }
+          ReadStorage materialize.public.u // { types: "(integer?)" }
 
 Source materialize.public.t
   filter=((#0) IS NOT NULL)

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -196,7 +196,7 @@ WHERE l_quantity = 24
 ----
 Explained Query:
   Project (#0, #2) // { arity: 2 }
-    Filter (#0) IS NOT NULL AND ((#4 = 24) OR ((#3 = 6) AND (#4 <= 4) AND (#4 >= 3))) // { arity: 25 }
+    Filter ((#4 = 24) OR ((#3 = 6) AND (#4 <= 4) AND (#4 >= 3))) // { arity: 25 }
       Join on=(#0 = #16) type=differential // { arity: 25 }
         implementation
           %0:lineitem[#0]KAeif » %1:orders[#0]KAeif
@@ -243,7 +243,7 @@ WHERE c_acctbal >= o_totalprice
 ----
 Explained Query:
   Project (#0, #4, #17, #28) // { arity: 4 }
-    Filter (#0) IS NOT NULL AND (#17) IS NOT NULL AND (#11 > #20) AND (#10 >= #20) AND (#30 >= #19) // { arity: 33 }
+    Filter (#11 > #20) AND (#10 >= #20) AND (#30 >= #19) // { arity: 33 }
       Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
         implementation
           %0:lineitem » %1:orders[#0]KA » %2:customer[#0]KA
@@ -309,7 +309,7 @@ Explained Query:
   Project (#0..=#4, #3) // { arity: 6 }
     Reduce group_by=[#1, #2] aggregates=[count(*), min(#2), min(#0)] // { arity: 5 }
       Project (#0, #1, #28) // { arity: 3 }
-        Filter (#10 <= 1995-11-14) AND (#30 <= 12907776) AND (#10 >= 1995-04-19) AND (#0) IS NOT NULL AND (#17) IS NOT NULL AND (#30 >= #5) // { arity: 33 }
+        Filter (#10 <= 1995-11-14) AND (#30 <= 12907776) AND (#10 >= 1995-04-19) AND (#30 >= #5) // { arity: 33 }
           Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
             implementation
               %0:lineitem » %1:orders[#0]KA » %2:customer[#0]KAif
@@ -371,7 +371,7 @@ GROUP BY 1,
 Explained Query:
   Reduce group_by=[(#2 * #3), #4] aggregates=[max(#1), max(#0)] // { arity: 4 }
     Project (#0..=#3, #11) // { arity: 5 }
-      Filter (#5) IS NOT NULL AND (#13 < #6) AND (#13 <= #3) // { arity: 16 }
+      Filter (#13 < #6) AND (#13 <= #3) // { arity: 16 }
         Join on=(#4 = #7 AND #5 = #8) type=delta // { arity: 16 }
           implementation
             %0:lineitem » %1:orders[#2]K » %2:customer[#0]KA
@@ -493,7 +493,7 @@ WHERE l_quantity = 17
 ----
 Explained Query:
   Project (#11, #3) // { arity: 2 }
-    Filter (#0) IS NOT NULL AND (#12 <= #5) AND ((#1 = 7) OR (#1 = 33) OR ((#1 = 17) AND (#13 <= "x") AND (#13 >= "s"))) // { arity: 14 }
+    Filter (#12 <= #5) AND ((#1 = 7) OR (#1 = 33) OR ((#1 = 17) AND (#13 <= "x") AND (#13 >= "s"))) // { arity: 14 }
       Join on=(#0 = #2) type=delta // { arity: 14 }
         implementation
           %0:lineitem » %1:orders[#0]KA » %2:customer[×]
@@ -552,7 +552,7 @@ GROUP BY 1
 Explained Query:
   Reduce group_by=[#0] aggregates=[count(*), count(distinct #1)] // { arity: 3 }
     Project (#0, #17) // { arity: 2 }
-      Filter (#4 <= 30) AND (#12 <= 1998-11-27) AND (#12 <= 1992-11-22) AND (#4 >= 1) AND (#12 >= 1992-06-21) AND (#12 >= 1992-07-13) AND (#0) IS NOT NULL AND (#17) IS NOT NULL // { arity: 33 }
+      Filter (#4 <= 30) AND (#12 <= 1998-11-27) AND (#12 <= 1992-11-22) AND (#4 >= 1) AND (#12 >= 1992-06-21) AND (#12 >= 1992-07-13) // { arity: 33 }
         Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
           implementation
             %0:lineitem » %1:orders[#0]KA » %2:customer[#0]KA
@@ -611,7 +611,7 @@ Explained Query:
   Project (#0, #0..=#2) // { arity: 4 }
     Reduce group_by=[#1] aggregates=[min(#0), count(*)] // { arity: 3 }
       Project (#2, #3) // { arity: 2 }
-        Filter (#3) IS NOT NULL AND (#1 < #5) AND (#11 > #4) AND (#11 >= #0) // { arity: 14 }
+        Filter (#1 < #5) AND (#11 > #4) AND (#11 >= #0) // { arity: 14 }
           Join on=(#3 = #6) type=delta // { arity: 14 }
             implementation
               %0:lineitem » %1:orders[×] » %2:customer[#0]KA
@@ -668,7 +668,7 @@ GROUP BY 1
 Explained Query:
   Reduce group_by=[#2] aggregates=[max(#1), max(#0)] // { arity: 3 }
     Project (#0, #2, #28) // { arity: 3 }
-      Filter (#0 <= 280) AND (#0 <= 289) AND (#0 >= 62) AND (#0 >= 117) AND (#17) IS NOT NULL AND (#10 > #20) // { arity: 33 }
+      Filter (#0 <= 280) AND (#0 <= 289) AND (#0 >= 62) AND (#0 >= 117) AND (#10 > #20) // { arity: 33 }
         Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
           implementation
             %0:lineitem » %1:orders[#0]KAiiiif » %2:customer[#0]KA

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -154,9 +154,9 @@ SELECT * FROM pexists;
 ----
 Explained Query:
   Return
-    Get l4
+    Get l5
   With Mutually Recursive
-    cte l4 =
+    cte l5 =
       Distinct project=[#0, #1]
         Union
           Distinct project=[#0, #1]
@@ -164,60 +164,60 @@ Explained Query:
               Project (#1, #0)
                 CrossJoin type=differential
                   ArrangeBy keys=[[]]
-                    Get l1
+                    Get l2
                   ArrangeBy keys=[[]]
                     Union
                       Negate
-                        Get l3
+                        Get l4
                       Constant
                         - ()
               Project (#1, #0)
                 Map (true, -1)
-                  Get l3
+                  Get l4
           Constant
             - (1, true)
             - (2, false)
-    cte l3 =
+    cte l4 =
       Distinct project=[]
         Project ()
           Join on=(#0 = #1) type=differential
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter #1
-                  Get l2
+                  Get l3
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter NOT(#1)
-                  Get l2
-    cte l2 =
+                  Get l3
+    cte l3 =
       Union
         Project (#1, #0)
-          Get l1
-        Get l4
-    cte l1 =
+          Get l2
+        Get l5
+    cte l2 =
       Project (#1, #3)
         Join on=(#0 = #2) type=differential
           ArrangeBy keys=[[#0]]
-            Get l4
+            Get l5
           ArrangeBy keys=[[#0]]
             Union
               Negate
                 Project (#0, #1)
                   Join on=(#2 = least(#0, #1) AND #3 = greatest(#0, #1)) type=differential
                     ArrangeBy keys=[[greatest(#0, #1), least(#0, #1)]]
-                      Project (#1, #2)
-                        Filter (greatest(#1, #2)) IS NOT NULL AND (least(#1, #2)) IS NOT NULL
-                          ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+                      Get l0
                     ArrangeBy keys=[[#1, #0]]
                       Distinct project=[least(#0, #1), greatest(#0, #1)]
-                        Get l0
-              Project (#1, #2)
-                ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+                        Get l1
               Get l0
-    cte l0 =
+              Get l1
+    cte l1 =
       Project (#1, #2)
         Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
           ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+    cte l0 =
+      Project (#1, #2)
+        ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.person_knows_person_person1id_person2id (*** full scan ***)
@@ -270,9 +270,9 @@ SELECT * FROM pexists;
 ----
 Explained Query:
   Return
-    Get l4
+    Get l5
   With Mutually Recursive
-    cte l4 =
+    cte l5 =
       Distinct project=[#0, #1]
         Union
           Distinct project=[#0, #1]
@@ -280,60 +280,60 @@ Explained Query:
               Project (#1, #0)
                 CrossJoin type=differential
                   ArrangeBy keys=[[]]
-                    Get l1
+                    Get l2
                   ArrangeBy keys=[[]]
                     Union
                       Negate
-                        Get l3
+                        Get l4
                       Constant
                         - ()
               Project (#1, #0)
                 Map (true, -1)
-                  Get l3
+                  Get l4
           Constant
             - (1, true)
             - (2, false)
-    cte l3 =
+    cte l4 =
       Distinct project=[]
         Project ()
           Join on=(#0 = #1) type=differential
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter #1
-                  Get l2
+                  Get l3
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter NOT(#1)
-                  Get l2
-    cte l2 =
+                  Get l3
+    cte l3 =
       Union
         Project (#1, #0)
-          Get l1
-        Get l4
-    cte l1 =
+          Get l2
+        Get l5
+    cte l2 =
       Project (#1, #3)
         Join on=(#0 = #2) type=differential
           ArrangeBy keys=[[#0]]
-            Get l4
+            Get l5
           ArrangeBy keys=[[#0]]
             Union
               Negate
                 Project (#0, #1)
                   Join on=(#2 = least(#0, #1) AND #3 = greatest(#0, #1)) type=differential
                     ArrangeBy keys=[[greatest(#0, #1), least(#0, #1)]]
-                      Project (#1, #2)
-                        Filter (greatest(#1, #2)) IS NOT NULL AND (least(#1, #2)) IS NOT NULL
-                          ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+                      Get l0
                     ArrangeBy keys=[[#1, #0]]
                       Distinct project=[least(#0, #1), greatest(#0, #1)]
-                        Get l0
-              Project (#1, #2)
-                ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+                        Get l1
               Get l0
-    cte l0 =
+              Get l1
+    cte l1 =
       Project (#1, #2)
         Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
           ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
+    cte l0 =
+      Project (#1, #2)
+        ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.person_knows_person_person1id_person2id (*** full scan ***)

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -154,9 +154,9 @@ SELECT * FROM pexists;
 ----
 Explained Query:
   Return
-    Get l5
+    Get l4
   With Mutually Recursive
-    cte l5 =
+    cte l4 =
       Distinct project=[#0, #1]
         Union
           Distinct project=[#0, #1]
@@ -164,60 +164,60 @@ Explained Query:
               Project (#1, #0)
                 CrossJoin type=differential
                   ArrangeBy keys=[[]]
-                    Get l2
+                    Get l1
                   ArrangeBy keys=[[]]
                     Union
                       Negate
-                        Get l4
+                        Get l3
                       Constant
                         - ()
               Project (#1, #0)
                 Map (true, -1)
-                  Get l4
+                  Get l3
           Constant
             - (1, true)
             - (2, false)
-    cte l4 =
+    cte l3 =
       Distinct project=[]
         Project ()
           Join on=(#0 = #1) type=differential
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter #1
-                  Get l3
+                  Get l2
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter NOT(#1)
-                  Get l3
-    cte l3 =
+                  Get l2
+    cte l2 =
       Union
         Project (#1, #0)
-          Get l2
-        Get l5
-    cte l2 =
+          Get l1
+        Get l4
+    cte l1 =
       Project (#1, #3)
         Join on=(#0 = #2) type=differential
           ArrangeBy keys=[[#0]]
-            Get l5
+            Get l4
           ArrangeBy keys=[[#0]]
             Union
               Negate
                 Project (#0, #1)
                   Join on=(#2 = least(#0, #1) AND #3 = greatest(#0, #1)) type=differential
                     ArrangeBy keys=[[greatest(#0, #1), least(#0, #1)]]
-                      Get l0
+                      Project (#1, #2)
+                        Filter (greatest(#1, #2)) IS NOT NULL AND (least(#1, #2)) IS NOT NULL
+                          ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
                     ArrangeBy keys=[[#1, #0]]
                       Distinct project=[least(#0, #1), greatest(#0, #1)]
-                        Get l1
+                        Get l0
+              Project (#1, #2)
+                ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
               Get l0
-              Get l1
-    cte l1 =
+    cte l0 =
       Project (#1, #2)
         Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
           ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
-    cte l0 =
-      Project (#1, #2)
-        ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.person_knows_person_person1id_person2id (*** full scan ***)
@@ -270,9 +270,9 @@ SELECT * FROM pexists;
 ----
 Explained Query:
   Return
-    Get l5
+    Get l4
   With Mutually Recursive
-    cte l5 =
+    cte l4 =
       Distinct project=[#0, #1]
         Union
           Distinct project=[#0, #1]
@@ -280,60 +280,60 @@ Explained Query:
               Project (#1, #0)
                 CrossJoin type=differential
                   ArrangeBy keys=[[]]
-                    Get l2
+                    Get l1
                   ArrangeBy keys=[[]]
                     Union
                       Negate
-                        Get l4
+                        Get l3
                       Constant
                         - ()
               Project (#1, #0)
                 Map (true, -1)
-                  Get l4
+                  Get l3
           Constant
             - (1, true)
             - (2, false)
-    cte l4 =
+    cte l3 =
       Distinct project=[]
         Project ()
           Join on=(#0 = #1) type=differential
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter #1
-                  Get l3
+                  Get l2
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Filter NOT(#1)
-                  Get l3
-    cte l3 =
+                  Get l2
+    cte l2 =
       Union
         Project (#1, #0)
-          Get l2
-        Get l5
-    cte l2 =
+          Get l1
+        Get l4
+    cte l1 =
       Project (#1, #3)
         Join on=(#0 = #2) type=differential
           ArrangeBy keys=[[#0]]
-            Get l5
+            Get l4
           ArrangeBy keys=[[#0]]
             Union
               Negate
                 Project (#0, #1)
                   Join on=(#2 = least(#0, #1) AND #3 = greatest(#0, #1)) type=differential
                     ArrangeBy keys=[[greatest(#0, #1), least(#0, #1)]]
-                      Get l0
+                      Project (#1, #2)
+                        Filter (greatest(#1, #2)) IS NOT NULL AND (least(#1, #2)) IS NOT NULL
+                          ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
                     ArrangeBy keys=[[#1, #0]]
                       Distinct project=[least(#0, #1), greatest(#0, #1)]
-                        Get l1
+                        Get l0
+              Project (#1, #2)
+                ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
               Get l0
-              Get l1
-    cte l1 =
+    cte l0 =
       Project (#1, #2)
         Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
           ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
-    cte l0 =
-      Project (#1, #2)
-        ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.person_knows_person_person1id_person2id (*** full scan ***)

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -628,7 +628,7 @@ Explained Query:
     Return // { arity: 4 }
       Reduce group_by=[#0, substr(char_to_text(#3), 1, 1), extract_year_d(#2)] aggregates=[sum(#1)] // { arity: 4 }
         Project (#1, #13, #19, #23) // { arity: 4 }
-          Filter (#29 <= 2012-01-02 00:00:00) AND (#29 >= 2007-01-02 00:00:00) AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (((#26 = "GERMANY") AND (#28 = "CAMBODIA")) OR ((#26 = "CAMBODIA") AND (#28 = "GERMANY"))) // { arity: 30 }
+          Filter (#29 <= 2012-01-02 00:00:00) AND (#29 >= 2007-01-02 00:00:00) AND (((#26 = "GERMANY") AND (#28 = "CAMBODIA")) OR ((#26 = "CAMBODIA") AND (#28 = "GERMANY"))) // { arity: 30 }
             Map (date_to_timestamp(#11)) // { arity: 30 }
               Join on=(#0 = #4 AND #1 = #25 AND #2 = #9 AND #3 = #10 AND #5 = #15 AND #6 = #16 = #21 AND #7 = #17 = #22 AND #18 = #20 AND #24 = #27) type=delta // { arity: 29 }
                 implementation
@@ -711,7 +711,7 @@ Explained Query:
       Map ((#1 / case when (#2 = 0) then 1 else #2 end)) // { arity: 4 }
         Reduce group_by=[extract_year_d(#1)] aggregates=[sum(case when (#2 = "GERMANY") then #0 else 0 end), sum(#0)] // { arity: 3 }
           Project (#14, #20, #28) // { arity: 3 }
-            Filter (#0 < 1000) AND (#4) IS NOT NULL // { arity: 30 }
+            Filter (#0 < 1000) // { arity: 30 }
               Join on=(#0 = #3 = #10 AND #1 = #5 AND #2 = #27 AND #4 = #11 AND #6 = #16 AND #7 = #17 = #22 AND #8 = #18 = #23 AND #19 = #21 AND #24 = #25 AND #26 = #29) type=delta // { arity: 30 }
                 implementation
                   %0:item » %2:stock[#0]KAif » %1:supplier[#0]UK » %7:nation[#0]UK » %3:orderline[#5, #4]KKAif » %4:order[#0..=#2]UKKKiif » %5:customer[#0..=#2]UKKK » %6:nation[#0]UK » %8:region[#0]UKef
@@ -797,33 +797,32 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last, #1 desc nulls_first] output=[#0..=#2]
     Reduce group_by=[#2, extract_year_d(#1)] aggregates=[sum(#0)] // { arity: 3 }
       Project (#14, #19, #21) // { arity: 3 }
-        Filter (#0) IS NOT NULL AND (#2) IS NOT NULL // { arity: 22 }
-          Join on=(#0 = #1 = #10 AND #2 = #11 AND #3 = #4 AND #5 = #20 AND #6 = #16 AND #7 = #17 AND #8 = #18) type=delta // { arity: 22 }
-            implementation
-              %0:item » %1:stock[#0]KA » %2:supplier[#0]UK » %5:nation[#0]UK » %3:orderline[#5, #4]KKA » %4:order[#0..=#2]UKKK
-              %1:stock » %0:item[#0]UKlf » %2:supplier[#0]UK » %5:nation[#0]UK » %3:orderline[#5, #4]KKA » %4:order[#0..=#2]UKKK
-              %2:supplier » %5:nation[#0]UK » %1:stock[#2]KA » %0:item[#0]UKlf » %3:orderline[#5, #4]KKA » %4:order[#0..=#2]UKKK
-              %3:orderline » %4:order[#0..=#2]UKKK » %1:stock[#0, #1]UKK » %0:item[#0]UKlf » %2:supplier[#0]UK » %5:nation[#0]UK
-              %4:order » %3:orderline[#2, #1, #0]KKKA » %1:stock[#0, #1]UKK » %0:item[#0]UKlf » %2:supplier[#0]UK » %5:nation[#0]UK
-              %5:nation » %2:supplier[#1]KA » %1:stock[#2]KA » %0:item[#0]UKlf » %3:orderline[#5, #4]KKA » %4:order[#0..=#2]UKKK
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Project (#0) // { arity: 1 }
-                Filter like["%BB"](padchar(#4)) // { arity: 5 }
-                  ReadStorage materialize.public.item // { arity: 5 }
-            ArrangeBy keys=[[#0], [#0, #1], [#2]] // { arity: 3 }
-              Project (#0, #1, #17) // { arity: 3 }
-                ReadIndex on=stock fk_stock_warehouse=[*** full scan ***] // { arity: 18 }
-            ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
-              Project (#0, #3) // { arity: 2 }
-                ReadIndex on=supplier fk_supplier_nationkey=[*** full scan ***] // { arity: 7 }
-            ArrangeBy keys=[[#2, #1, #0], [#5, #4]] // { arity: 10 }
-              ReadIndex on=orderline fk_orderline_order=[delta join lookup] fk_orderline_stock=[delta join lookup] // { arity: 10 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-              Project (#0..=#2, #4) // { arity: 4 }
-                ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Project (#0, #1) // { arity: 2 }
-                ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
+        Join on=(#0 = #1 = #10 AND #2 = #11 AND #3 = #4 AND #5 = #20 AND #6 = #16 AND #7 = #17 AND #8 = #18) type=delta // { arity: 22 }
+          implementation
+            %0:item » %1:stock[#0]KA » %2:supplier[#0]UK » %5:nation[#0]UK » %3:orderline[#5, #4]KKA » %4:order[#0..=#2]UKKK
+            %1:stock » %0:item[#0]UKlf » %2:supplier[#0]UK » %5:nation[#0]UK » %3:orderline[#5, #4]KKA » %4:order[#0..=#2]UKKK
+            %2:supplier » %5:nation[#0]UK » %1:stock[#2]KA » %0:item[#0]UKlf » %3:orderline[#5, #4]KKA » %4:order[#0..=#2]UKKK
+            %3:orderline » %4:order[#0..=#2]UKKK » %1:stock[#0, #1]UKK » %0:item[#0]UKlf » %2:supplier[#0]UK » %5:nation[#0]UK
+            %4:order » %3:orderline[#2, #1, #0]KKKA » %1:stock[#0, #1]UKK » %0:item[#0]UKlf » %2:supplier[#0]UK » %5:nation[#0]UK
+            %5:nation » %2:supplier[#1]KA » %1:stock[#2]KA » %0:item[#0]UKlf » %3:orderline[#5, #4]KKA » %4:order[#0..=#2]UKKK
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter like["%BB"](padchar(#4)) // { arity: 5 }
+                ReadStorage materialize.public.item // { arity: 5 }
+          ArrangeBy keys=[[#0], [#0, #1], [#2]] // { arity: 3 }
+            Project (#0, #1, #17) // { arity: 3 }
+              ReadIndex on=stock fk_stock_warehouse=[*** full scan ***] // { arity: 18 }
+          ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
+            Project (#0, #3) // { arity: 2 }
+              ReadIndex on=supplier fk_supplier_nationkey=[*** full scan ***] // { arity: 7 }
+          ArrangeBy keys=[[#2, #1, #0], [#5, #4]] // { arity: 10 }
+            ReadIndex on=orderline fk_orderline_order=[delta join lookup] fk_orderline_stock=[delta join lookup] // { arity: 10 }
+          ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+            Project (#0..=#2, #4) // { arity: 4 }
+              ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              ReadIndex on=nation fk_nation_regionkey=[*** full scan ***] // { arity: 4 }
 
 Source materialize.public.item
   filter=(like["%BB"](padchar(#4)))
@@ -1030,7 +1029,7 @@ Explained Query:
     With
       cte l0 =
         Project (#0..=#3) // { arity: 4 }
-          Filter (#8 > 8) AND (#0) IS NOT NULL // { arity: 11 }
+          Filter (#8 > 8) // { arity: 11 }
             Join on=(#0 = #6 AND #1 = #4 AND #2 = #5) type=differential // { arity: 11 }
               implementation
                 %0:customer[#2, #1, #0]UKKK » %1:order[#2, #1, #3]KKKAif
@@ -1075,7 +1074,7 @@ Explained Query:
     cte l0 =
       Reduce aggregates=[sum(case when like["PR%"](padchar(#1)) then #0 else 0 end), sum(#0)] // { arity: 2 }
         Project (#8, #11) // { arity: 2 }
-          Filter (#12 < 2020-01-02 00:00:00) AND (#12 >= 2007-01-02 00:00:00) AND (#4) IS NOT NULL // { arity: 13 }
+          Filter (#12 < 2020-01-02 00:00:00) AND (#12 >= 2007-01-02 00:00:00) // { arity: 13 }
             Map (date_to_timestamp(#6)) // { arity: 13 }
               Join on=(#4 = #10) type=differential // { arity: 12 }
                 implementation
@@ -1151,7 +1150,7 @@ Explained Query:
       cte l0 =
         Reduce group_by=[#1] aggregates=[sum(#0)] // { arity: 2 }
           Project (#8, #12) // { arity: 2 }
-            Filter (#4) IS NOT NULL AND (#5) IS NOT NULL AND (date_to_timestamp(#6) >= 2007-01-02 00:00:00) // { arity: 13 }
+            Filter (date_to_timestamp(#6) >= 2007-01-02 00:00:00) // { arity: 13 }
               Join on=(#4 = #10 AND #5 = #11) type=differential // { arity: 13 }
                 implementation
                   %1:stock[#1, #0]UKK » %0:orderline[#5, #4]KKAif
@@ -1272,7 +1271,7 @@ Explained Query:
     cte l1 =
       Reduce aggregates=[sum(#0)] // { arity: 1 }
         Project (#8) // { arity: 1 }
-          Filter (#4) IS NOT NULL AND (integer_to_numeric(#7) < (bigint_to_numeric(#11) / bigint_to_numeric(case when (#12 = 0) then null else #12 end))) // { arity: 13 }
+          Filter (integer_to_numeric(#7) < (bigint_to_numeric(#11) / bigint_to_numeric(case when (#12 = 0) then null else #12 end))) // { arity: 13 }
             Join on=(#4 = #10) type=differential // { arity: 13 }
               implementation
                 %1[#0]UKA » %0:l0[#4]KA
@@ -1280,15 +1279,14 @@ Explained Query:
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Reduce group_by=[#0] aggregates=[sum(#1), count(#1)] // { arity: 3 }
                   Project (#0, #8) // { arity: 2 }
-                    Filter (#0) IS NOT NULL // { arity: 11 }
-                      Join on=(#0 = #5) type=differential // { arity: 11 }
-                        implementation
-                          %0:item[#0]UKlf » %1:l0[#4]KAlf
-                        ArrangeBy keys=[[#0]] // { arity: 1 }
-                          Project (#0) // { arity: 1 }
-                            Filter like["%b"](padchar(#4)) // { arity: 5 }
-                              ReadStorage materialize.public.item // { arity: 5 }
-                        Get l0 // { arity: 10 }
+                    Join on=(#0 = #5) type=differential // { arity: 11 }
+                      implementation
+                        %0:item[#0]UKlf » %1:l0[#4]KAlf
+                      ArrangeBy keys=[[#0]] // { arity: 1 }
+                        Project (#0) // { arity: 1 }
+                          Filter like["%b"](padchar(#4)) // { arity: 5 }
+                            ReadStorage materialize.public.item // { arity: 5 }
+                      Get l0 // { arity: 10 }
     cte l0 =
       ArrangeBy keys=[[#4]] // { arity: 10 }
         ReadIndex on=orderline fk_orderline_item=[differential join] // { arity: 10 }
@@ -1391,7 +1389,7 @@ Explained Query:
     cte l0 =
       Reduce aggregates=[sum(#0)] // { arity: 1 }
         Project (#8) // { arity: 1 }
-          Filter (#7 <= 10) AND (#7 >= 1) AND (#4) IS NOT NULL AND (#12 OR #13 OR #14 OR #15 OR #16) AND ((like["%a"](#17) AND (#12 OR #13 OR #14)) OR (like["%b"](#17) AND (#12 OR #13 OR #15)) OR (like["%c"](#17) AND (#12 OR #14 OR #16))) // { arity: 18 }
+          Filter (#7 <= 10) AND (#7 >= 1) AND (#12 OR #13 OR #14 OR #15 OR #16) AND ((like["%a"](#17) AND (#12 OR #13 OR #14)) OR (like["%b"](#17) AND (#12 OR #13 OR #15)) OR (like["%c"](#17) AND (#12 OR #14 OR #16))) // { arity: 18 }
             Map ((#2 = 1), (#2 = 2), (#2 = 3), (#2 = 4), (#2 = 5), padchar(#11)) // { arity: 18 }
               Join on=(#4 = #10) type=differential // { arity: 12 }
                 implementation
@@ -1453,7 +1451,7 @@ Explained Query:
                 Filter (integer_to_bigint((2 * #3)) > #4) // { arity: 5 }
                   Reduce group_by=[#0..=#3] aggregates=[sum(#4)] // { arity: 5 }
                     Project (#0..=#3, #11) // { arity: 5 }
-                      Filter (#1) IS NOT NULL AND (date_to_timestamp(#10) > 2010-05-23 12:00:00) // { arity: 15 }
+                      Filter (date_to_timestamp(#10) > 2010-05-23 12:00:00) // { arity: 15 }
                         Join on=(#0 = ((#1 * #2) % 10000) AND #1 = #8 = #14) type=delta // { arity: 15 }
                           implementation
                             %0:l0 » %1:stock[((#0 * #1) % 10000)]K » %3:item[#0]UKlf » %2:orderline[#4]KAif

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -5581,24 +5581,47 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                                   "Join": {
                                                     "inputs": [
                                                       {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 1
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
+                                                        "Filter": {
+                                                          "input": {
+                                                            "Get": {
+                                                              "id": {
+                                                                "Local": 1
                                                               },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": []
+                                                              "typ": {
+                                                                "column_types": [
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": true
+                                                                  },
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": true
+                                                                  }
+                                                                ],
+                                                                "keys": []
+                                                              },
+                                                              "access_strategy": "UnknownOrLocal"
+                                                            }
                                                           },
-                                                          "access_strategy": "UnknownOrLocal"
+                                                          "predicates": [
+                                                            {
+                                                              "CallUnary": {
+                                                                "func": {
+                                                                  "Not": null
+                                                                },
+                                                                "expr": {
+                                                                  "CallUnary": {
+                                                                    "func": {
+                                                                      "IsNull": null
+                                                                    },
+                                                                    "expr": {
+                                                                      "Column": 1
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
                                                         }
                                                       },
                                                       {

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -5980,24 +5980,47 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                                   "Join": {
                                                     "inputs": [
                                                       {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 6
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
+                                                        "Filter": {
+                                                          "input": {
+                                                            "Get": {
+                                                              "id": {
+                                                                "Local": 6
                                                               },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": []
+                                                              "typ": {
+                                                                "column_types": [
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": true
+                                                                  },
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": true
+                                                                  }
+                                                                ],
+                                                                "keys": []
+                                                              },
+                                                              "access_strategy": "UnknownOrLocal"
+                                                            }
                                                           },
-                                                          "access_strategy": "UnknownOrLocal"
+                                                          "predicates": [
+                                                            {
+                                                              "CallUnary": {
+                                                                "func": {
+                                                                  "Not": null
+                                                                },
+                                                                "expr": {
+                                                                  "CallUnary": {
+                                                                    "func": {
+                                                                      "IsNull": null
+                                                                    },
+                                                                    "expr": {
+                                                                      "Column": 1
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
                                                         }
                                                       },
                                                       {

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -513,7 +513,7 @@ Target cluster: quickstart
 
 EOF
 
-# Test InnerJoin (ON syntax).
+# Test LEFT JOIN and RIGHT JOIN.
 query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT t1.a, t2.a
@@ -547,7 +547,8 @@ With
                 Negate
                   Project (#0, #1)
                     Join on=(#1 = #2)
-                      Get l0
+                      Filter (#1) IS NOT NULL
+                        Get l0
                       Distinct project=[#0]
                         Project (#1)
                           Get l1

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -530,7 +530,8 @@ Return
             Negate
               Project (#0, #1)
                 Join on=(#1 = #2)
-                  Get l2
+                  Filter (#1) IS NOT NULL
+                    Get l2
                   Distinct project=[#0]
                     Project (#3)
                       Get l3

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -3034,552 +3034,541 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                 "Let": {
                   "id": 2,
                   "value": {
-                    "Project": {
+                    "ArrangeBy": {
                       "input": {
-                        "Join": {
-                          "inputs": [
-                            {
-                              "Get": {
-                                "id": {
-                                  "Local": 1
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    }
-                                  ],
-                                  "keys": []
-                                },
-                                "access_strategy": "UnknownOrLocal"
-                              }
-                            },
-                            {
-                              "Get": {
-                                "id": {
-                                  "Local": 1
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    }
-                                  ],
-                                  "keys": []
-                                },
-                                "access_strategy": "UnknownOrLocal"
-                              }
-                            },
-                            {
-                              "ArrangeBy": {
-                                "input": {
-                                  "Project": {
-                                    "input": {
-                                      "Get": {
-                                        "id": {
-                                          "Local": 0
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": false
-                                            }
-                                          ],
-                                          "keys": []
-                                        },
-                                        "access_strategy": "UnknownOrLocal"
-                                      }
-                                    },
-                                    "outputs": [
-                                      1
-                                    ]
+                        "Project": {
+                          "input": {
+                            "Get": {
+                              "id": {
+                                "Local": 0
+                              },
+                              "typ": {
+                                "column_types": [
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": false
                                   }
-                                },
-                                "keys": [
-                                  [
-                                    {
-                                      "Column": 0
-                                    }
-                                  ]
-                                ]
-                              }
+                                ],
+                                "keys": []
+                              },
+                              "access_strategy": "UnknownOrLocal"
                             }
-                          ],
-                          "equivalences": [
-                            [
-                              {
-                                "Column": 1
-                              },
-                              {
-                                "Column": 3
-                              },
-                              {
-                                "Column": 4
-                              }
-                            ]
-                          ],
-                          "implementation": {
-                            "DeltaQuery": [
-                              [
-                                [
-                                  1,
-                                  [
-                                    {
-                                      "Column": 1
-                                    }
-                                  ],
-                                  {
-                                    "unique_key": false,
-                                    "key_length": 1,
-                                    "arranged": false,
-                                    "cardinality": null,
-                                    "filters": {
-                                      "literal_equality": false,
-                                      "like": false,
-                                      "is_null": false,
-                                      "literal_inequality": 0,
-                                      "any_filter": false
-                                    },
-                                    "input": 1
-                                  }
-                                ],
-                                [
-                                  2,
-                                  [
-                                    {
-                                      "Column": 0
-                                    }
-                                  ],
-                                  {
-                                    "unique_key": false,
-                                    "key_length": 1,
-                                    "arranged": false,
-                                    "cardinality": null,
-                                    "filters": {
-                                      "literal_equality": false,
-                                      "like": false,
-                                      "is_null": false,
-                                      "literal_inequality": 0,
-                                      "any_filter": false
-                                    },
-                                    "input": 2
-                                  }
-                                ]
-                              ],
-                              [
-                                [
-                                  0,
-                                  [
-                                    {
-                                      "Column": 1
-                                    }
-                                  ],
-                                  {
-                                    "unique_key": false,
-                                    "key_length": 1,
-                                    "arranged": false,
-                                    "cardinality": null,
-                                    "filters": {
-                                      "literal_equality": false,
-                                      "like": false,
-                                      "is_null": false,
-                                      "literal_inequality": 0,
-                                      "any_filter": false
-                                    },
-                                    "input": 0
-                                  }
-                                ],
-                                [
-                                  2,
-                                  [
-                                    {
-                                      "Column": 0
-                                    }
-                                  ],
-                                  {
-                                    "unique_key": false,
-                                    "key_length": 1,
-                                    "arranged": false,
-                                    "cardinality": null,
-                                    "filters": {
-                                      "literal_equality": false,
-                                      "like": false,
-                                      "is_null": false,
-                                      "literal_inequality": 0,
-                                      "any_filter": false
-                                    },
-                                    "input": 2
-                                  }
-                                ]
-                              ],
-                              [
-                                [
-                                  0,
-                                  [
-                                    {
-                                      "Column": 1
-                                    }
-                                  ],
-                                  {
-                                    "unique_key": false,
-                                    "key_length": 1,
-                                    "arranged": false,
-                                    "cardinality": null,
-                                    "filters": {
-                                      "literal_equality": false,
-                                      "like": false,
-                                      "is_null": false,
-                                      "literal_inequality": 0,
-                                      "any_filter": false
-                                    },
-                                    "input": 0
-                                  }
-                                ],
-                                [
-                                  1,
-                                  [
-                                    {
-                                      "Column": 1
-                                    }
-                                  ],
-                                  {
-                                    "unique_key": false,
-                                    "key_length": 1,
-                                    "arranged": false,
-                                    "cardinality": null,
-                                    "filters": {
-                                      "literal_equality": false,
-                                      "like": false,
-                                      "is_null": false,
-                                      "literal_inequality": 0,
-                                      "any_filter": false
-                                    },
-                                    "input": 1
-                                  }
-                                ]
-                              ]
-                            ]
-                          }
+                          },
+                          "outputs": [
+                            1
+                          ]
                         }
                       },
-                      "outputs": [
-                        0,
-                        1,
-                        2
+                      "keys": [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ]
                       ]
                     }
                   },
                   "body": {
-                    "Union": {
-                      "base": {
-                        "Map": {
+                    "Let": {
+                      "id": 3,
+                      "value": {
+                        "Project": {
                           "input": {
-                            "Union": {
-                              "base": {
-                                "Negate": {
-                                  "input": {
-                                    "Project": {
+                            "Join": {
+                              "inputs": [
+                                {
+                                  "Get": {
+                                    "id": {
+                                      "Local": 1
+                                    },
+                                    "typ": {
+                                      "column_types": [
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": false
+                                        }
+                                      ],
+                                      "keys": []
+                                    },
+                                    "access_strategy": "UnknownOrLocal"
+                                  }
+                                },
+                                {
+                                  "Get": {
+                                    "id": {
+                                      "Local": 1
+                                    },
+                                    "typ": {
+                                      "column_types": [
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": false
+                                        }
+                                      ],
+                                      "keys": []
+                                    },
+                                    "access_strategy": "UnknownOrLocal"
+                                  }
+                                },
+                                {
+                                  "Get": {
+                                    "id": {
+                                      "Local": 2
+                                    },
+                                    "typ": {
+                                      "column_types": [
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": false
+                                        }
+                                      ],
+                                      "keys": []
+                                    },
+                                    "access_strategy": "UnknownOrLocal"
+                                  }
+                                }
+                              ],
+                              "equivalences": [
+                                [
+                                  {
+                                    "Column": 1
+                                  },
+                                  {
+                                    "Column": 3
+                                  },
+                                  {
+                                    "Column": 4
+                                  }
+                                ]
+                              ],
+                              "implementation": {
+                                "DeltaQuery": [
+                                  [
+                                    [
+                                      1,
+                                      [
+                                        {
+                                          "Column": 1
+                                        }
+                                      ],
+                                      {
+                                        "unique_key": false,
+                                        "key_length": 1,
+                                        "arranged": false,
+                                        "cardinality": null,
+                                        "filters": {
+                                          "literal_equality": false,
+                                          "like": false,
+                                          "is_null": false,
+                                          "literal_inequality": 0,
+                                          "any_filter": false
+                                        },
+                                        "input": 1
+                                      }
+                                    ],
+                                    [
+                                      2,
+                                      [
+                                        {
+                                          "Column": 0
+                                        }
+                                      ],
+                                      {
+                                        "unique_key": false,
+                                        "key_length": 1,
+                                        "arranged": false,
+                                        "cardinality": null,
+                                        "filters": {
+                                          "literal_equality": false,
+                                          "like": false,
+                                          "is_null": false,
+                                          "literal_inequality": 0,
+                                          "any_filter": false
+                                        },
+                                        "input": 2
+                                      }
+                                    ]
+                                  ],
+                                  [
+                                    [
+                                      0,
+                                      [
+                                        {
+                                          "Column": 1
+                                        }
+                                      ],
+                                      {
+                                        "unique_key": false,
+                                        "key_length": 1,
+                                        "arranged": false,
+                                        "cardinality": null,
+                                        "filters": {
+                                          "literal_equality": false,
+                                          "like": false,
+                                          "is_null": false,
+                                          "literal_inequality": 0,
+                                          "any_filter": false
+                                        },
+                                        "input": 0
+                                      }
+                                    ],
+                                    [
+                                      2,
+                                      [
+                                        {
+                                          "Column": 0
+                                        }
+                                      ],
+                                      {
+                                        "unique_key": false,
+                                        "key_length": 1,
+                                        "arranged": false,
+                                        "cardinality": null,
+                                        "filters": {
+                                          "literal_equality": false,
+                                          "like": false,
+                                          "is_null": false,
+                                          "literal_inequality": 0,
+                                          "any_filter": false
+                                        },
+                                        "input": 2
+                                      }
+                                    ]
+                                  ],
+                                  [
+                                    [
+                                      0,
+                                      [
+                                        {
+                                          "Column": 1
+                                        }
+                                      ],
+                                      {
+                                        "unique_key": false,
+                                        "key_length": 1,
+                                        "arranged": false,
+                                        "cardinality": null,
+                                        "filters": {
+                                          "literal_equality": false,
+                                          "like": false,
+                                          "is_null": false,
+                                          "literal_inequality": 0,
+                                          "any_filter": false
+                                        },
+                                        "input": 0
+                                      }
+                                    ],
+                                    [
+                                      1,
+                                      [
+                                        {
+                                          "Column": 1
+                                        }
+                                      ],
+                                      {
+                                        "unique_key": false,
+                                        "key_length": 1,
+                                        "arranged": false,
+                                        "cardinality": null,
+                                        "filters": {
+                                          "literal_equality": false,
+                                          "like": false,
+                                          "is_null": false,
+                                          "literal_inequality": 0,
+                                          "any_filter": false
+                                        },
+                                        "input": 1
+                                      }
+                                    ]
+                                  ]
+                                ]
+                              }
+                            }
+                          },
+                          "outputs": [
+                            0,
+                            1,
+                            2
+                          ]
+                        }
+                      },
+                      "body": {
+                        "Union": {
+                          "base": {
+                            "Map": {
+                              "input": {
+                                "Union": {
+                                  "base": {
+                                    "Negate": {
                                       "input": {
-                                        "Join": {
-                                          "inputs": [
-                                            {
-                                              "ArrangeBy": {
-                                                "input": {
-                                                  "Project": {
-                                                    "input": {
-                                                      "Get": {
-                                                        "id": {
-                                                          "Global": {
-                                                            "User": 1
-                                                          }
-                                                        },
-                                                        "typ": {
-                                                          "column_types": [
-                                                            {
-                                                              "scalar_type": "Int32",
-                                                              "nullable": true
-                                                            },
-                                                            {
-                                                              "scalar_type": "Int32",
-                                                              "nullable": true
-                                                            }
-                                                          ],
-                                                          "keys": []
-                                                        },
-                                                        "access_strategy": {
-                                                          "Index": [
-                                                            [
-                                                              {
-                                                                "User": 4
-                                                              },
-                                                              "FullScan"
-                                                            ]
-                                                          ]
-                                                        }
-                                                      }
+                                        "Project": {
+                                          "input": {
+                                            "Join": {
+                                              "inputs": [
+                                                {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 2
                                                     },
-                                                    "outputs": [
-                                                      1
-                                                    ]
+                                                    "typ": {
+                                                      "column_types": [
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": false
+                                                        }
+                                                      ],
+                                                      "keys": []
+                                                    },
+                                                    "access_strategy": "UnknownOrLocal"
                                                   }
                                                 },
-                                                "keys": [
-                                                  [
-                                                    {
-                                                      "Column": 0
-                                                    }
-                                                  ]
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "ArrangeBy": {
-                                                "input": {
-                                                  "Reduce": {
+                                                {
+                                                  "ArrangeBy": {
                                                     "input": {
-                                                      "Project": {
+                                                      "Reduce": {
                                                         "input": {
-                                                          "Get": {
-                                                            "id": {
-                                                              "Local": 2
-                                                            },
-                                                            "typ": {
-                                                              "column_types": [
-                                                                {
-                                                                  "scalar_type": "Int32",
-                                                                  "nullable": true
+                                                          "Project": {
+                                                            "input": {
+                                                              "Get": {
+                                                                "id": {
+                                                                  "Local": 3
                                                                 },
-                                                                {
-                                                                  "scalar_type": "Int32",
-                                                                  "nullable": false
+                                                                "typ": {
+                                                                  "column_types": [
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": true
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": false
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": true
+                                                                    }
+                                                                  ],
+                                                                  "keys": []
                                                                 },
-                                                                {
-                                                                  "scalar_type": "Int32",
-                                                                  "nullable": true
-                                                                }
-                                                              ],
-                                                              "keys": []
+                                                                "access_strategy": "UnknownOrLocal"
+                                                              }
                                                             },
-                                                            "access_strategy": "UnknownOrLocal"
+                                                            "outputs": [
+                                                              1
+                                                            ]
                                                           }
                                                         },
-                                                        "outputs": [
-                                                          1
-                                                        ]
+                                                        "group_key": [
+                                                          {
+                                                            "Column": 0
+                                                          }
+                                                        ],
+                                                        "aggregates": [],
+                                                        "monotonic": false,
+                                                        "expected_group_size": null
                                                       }
                                                     },
-                                                    "group_key": [
+                                                    "keys": [
+                                                      [
+                                                        {
+                                                          "Column": 0
+                                                        }
+                                                      ]
+                                                    ]
+                                                  }
+                                                }
+                                              ],
+                                              "equivalences": [
+                                                [
+                                                  {
+                                                    "Column": 0
+                                                  },
+                                                  {
+                                                    "Column": 1
+                                                  }
+                                                ]
+                                              ],
+                                              "implementation": {
+                                                "Differential": [
+                                                  [
+                                                    1,
+                                                    [
                                                       {
                                                         "Column": 0
                                                       }
                                                     ],
-                                                    "aggregates": [],
-                                                    "monotonic": false,
-                                                    "expected_group_size": null
-                                                  }
-                                                },
-                                                "keys": [
-                                                  [
                                                     {
-                                                      "Column": 0
+                                                      "unique_key": true,
+                                                      "key_length": 1,
+                                                      "arranged": true,
+                                                      "cardinality": null,
+                                                      "filters": {
+                                                        "literal_equality": false,
+                                                        "like": false,
+                                                        "is_null": false,
+                                                        "literal_inequality": 0,
+                                                        "any_filter": false
+                                                      },
+                                                      "input": 1
                                                     }
+                                                  ],
+                                                  [
+                                                    [
+                                                      0,
+                                                      [
+                                                        {
+                                                          "Column": 0
+                                                        }
+                                                      ],
+                                                      {
+                                                        "unique_key": false,
+                                                        "key_length": 1,
+                                                        "arranged": false,
+                                                        "cardinality": null,
+                                                        "filters": {
+                                                          "literal_equality": false,
+                                                          "like": false,
+                                                          "is_null": false,
+                                                          "literal_inequality": 0,
+                                                          "any_filter": false
+                                                        },
+                                                        "input": 0
+                                                      }
+                                                    ]
                                                   ]
                                                 ]
                                               }
                                             }
-                                          ],
-                                          "equivalences": [
-                                            [
-                                              {
-                                                "Column": 0
-                                              },
-                                              {
-                                                "Column": 1
-                                              }
-                                            ]
-                                          ],
-                                          "implementation": {
-                                            "Differential": [
-                                              [
-                                                1,
-                                                [
-                                                  {
-                                                    "Column": 0
-                                                  }
-                                                ],
-                                                {
-                                                  "unique_key": true,
-                                                  "key_length": 1,
-                                                  "arranged": true,
-                                                  "cardinality": null,
-                                                  "filters": {
-                                                    "literal_equality": false,
-                                                    "like": false,
-                                                    "is_null": false,
-                                                    "literal_inequality": 0,
-                                                    "any_filter": false
-                                                  },
-                                                  "input": 1
-                                                }
-                                              ],
-                                              [
-                                                [
-                                                  0,
-                                                  [
-                                                    {
-                                                      "Column": 0
-                                                    }
-                                                  ],
-                                                  {
-                                                    "unique_key": false,
-                                                    "key_length": 1,
-                                                    "arranged": false,
-                                                    "cardinality": null,
-                                                    "filters": {
-                                                      "literal_equality": false,
-                                                      "like": false,
-                                                      "is_null": false,
-                                                      "literal_inequality": 0,
-                                                      "any_filter": false
-                                                    },
-                                                    "input": 0
-                                                  }
-                                                ]
-                                              ]
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      "outputs": []
-                                    }
-                                  }
-                                }
-                              },
-                              "inputs": [
-                                {
-                                  "Project": {
-                                    "input": {
-                                      "Get": {
-                                        "id": {
-                                          "Global": {
-                                            "User": 1
-                                          }
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            }
-                                          ],
-                                          "keys": []
-                                        },
-                                        "access_strategy": {
-                                          "Index": [
-                                            [
-                                              {
-                                                "User": 4
-                                              },
-                                              "FullScan"
-                                            ]
-                                          ]
+                                          },
+                                          "outputs": []
                                         }
                                       }
+                                    }
+                                  },
+                                  "inputs": [
+                                    {
+                                      "Project": {
+                                        "input": {
+                                          "Get": {
+                                            "id": {
+                                              "Global": {
+                                                "User": 1
+                                              }
+                                            },
+                                            "typ": {
+                                              "column_types": [
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                },
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                }
+                                              ],
+                                              "keys": []
+                                            },
+                                            "access_strategy": {
+                                              "Index": [
+                                                [
+                                                  {
+                                                    "User": 4
+                                                  },
+                                                  "FullScan"
+                                                ]
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "outputs": []
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "scalars": [
+                                {
+                                  "Literal": [
+                                    {
+                                      "Ok": {
+                                        "data": [
+                                          0
+                                        ]
+                                      }
                                     },
-                                    "outputs": []
-                                  }
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Literal": [
+                                    {
+                                      "Ok": {
+                                        "data": [
+                                          0
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    }
+                                  ]
                                 }
                               ]
                             }
                           },
-                          "scalars": [
+                          "inputs": [
                             {
-                              "Literal": [
-                                {
-                                  "Ok": {
-                                    "data": [
-                                      0
-                                    ]
+                              "Project": {
+                                "input": {
+                                  "Get": {
+                                    "id": {
+                                      "Local": 3
+                                    },
+                                    "typ": {
+                                      "column_types": [
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": false
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ],
+                                      "keys": []
+                                    },
+                                    "access_strategy": "UnknownOrLocal"
                                   }
                                 },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ]
-                            },
-                            {
-                              "Literal": [
-                                {
-                                  "Ok": {
-                                    "data": [
-                                      0
-                                    ]
-                                  }
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ]
+                                "outputs": [
+                                  0,
+                                  2
+                                ]
+                              }
                             }
                           ]
                         }
-                      },
-                      "inputs": [
-                        {
-                          "Project": {
-                            "input": {
-                              "Get": {
-                                "id": {
-                                  "Local": 2
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    }
-                                  ],
-                                  "keys": []
-                                },
-                                "access_strategy": "UnknownOrLocal"
-                              }
-                            },
-                            "outputs": [
-                              0,
-                              2
-                            ]
-                          }
-                        }
-                      ]
+                      }
                     }
                   }
                 }

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -2059,7 +2059,196 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                           "input": {
                             "Project": {
                               "input": {
-                                "Filter": {
+                                "Join": {
+                                  "inputs": [
+                                    {
+                                      "Get": {
+                                        "id": {
+                                          "Local": 2
+                                        },
+                                        "typ": {
+                                          "column_types": [
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            }
+                                          ],
+                                          "keys": [
+                                            [
+                                              0
+                                            ]
+                                          ]
+                                        },
+                                        "access_strategy": "UnknownOrLocal"
+                                      }
+                                    },
+                                    {
+                                      "ArrangeBy": {
+                                        "input": {
+                                          "Filter": {
+                                            "input": {
+                                              "Get": {
+                                                "id": {
+                                                  "Global": {
+                                                    "User": 6
+                                                  }
+                                                },
+                                                "typ": {
+                                                  "column_types": [
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": false
+                                                    },
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": true
+                                                    }
+                                                  ],
+                                                  "keys": []
+                                                },
+                                                "access_strategy": {
+                                                  "Index": [
+                                                    [
+                                                      {
+                                                        "User": 7
+                                                      },
+                                                      "FullScan"
+                                                    ]
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "predicates": [
+                                              {
+                                                "CallUnary": {
+                                                  "func": {
+                                                    "Not": null
+                                                  },
+                                                  "expr": {
+                                                    "CallUnary": {
+                                                      "func": {
+                                                        "IsNull": null
+                                                      },
+                                                      "expr": {
+                                                        "Column": 1
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "keys": [
+                                          [
+                                            {
+                                              "Column": 1
+                                            }
+                                          ]
+                                        ]
+                                      }
+                                    }
+                                  ],
+                                  "equivalences": [
+                                    [
+                                      {
+                                        "Column": 0
+                                      },
+                                      {
+                                        "Column": 2
+                                      }
+                                    ]
+                                  ],
+                                  "implementation": {
+                                    "Differential": [
+                                      [
+                                        0,
+                                        [
+                                          {
+                                            "Column": 0
+                                          }
+                                        ],
+                                        {
+                                          "unique_key": true,
+                                          "key_length": 1,
+                                          "arranged": true,
+                                          "cardinality": null,
+                                          "filters": {
+                                            "literal_equality": false,
+                                            "like": false,
+                                            "is_null": false,
+                                            "literal_inequality": 0,
+                                            "any_filter": false
+                                          },
+                                          "input": 0
+                                        }
+                                      ],
+                                      [
+                                        [
+                                          1,
+                                          [
+                                            {
+                                              "Column": 1
+                                            }
+                                          ],
+                                          {
+                                            "unique_key": false,
+                                            "key_length": 1,
+                                            "arranged": false,
+                                            "cardinality": null,
+                                            "filters": {
+                                              "literal_equality": false,
+                                              "like": false,
+                                              "is_null": false,
+                                              "literal_inequality": 0,
+                                              "any_filter": false
+                                            },
+                                            "input": 1
+                                          }
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              },
+                              "outputs": [
+                                0,
+                                1
+                              ]
+                            }
+                          },
+                          "group_key": [
+                            0
+                          ],
+                          "order_key": [],
+                          "limit": {
+                            "Literal": [
+                              {
+                                "Ok": {
+                                  "data": [
+                                    47,
+                                    1
+                                  ]
+                                }
+                              },
+                              {
+                                "scalar_type": "Int64",
+                                "nullable": false
+                              }
+                            ]
+                          },
+                          "offset": 0,
+                          "monotonic": false,
+                          "expected_group_size": null
+                        }
+                      },
+                      "body": {
+                        "Let": {
+                          "id": 4,
+                          "value": {
+                            "TopK": {
+                              "input": {
+                                "Project": {
                                   "input": {
                                     "Join": {
                                       "inputs": [
@@ -2092,7 +2281,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                                   "Get": {
                                                     "id": {
                                                       "Global": {
-                                                        "User": 6
+                                                        "User": 8
                                                       }
                                                     },
                                                     "typ": {
@@ -2108,16 +2297,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                                       ],
                                                       "keys": []
                                                     },
-                                                    "access_strategy": {
-                                                      "Index": [
-                                                        [
-                                                          {
-                                                            "User": 7
-                                                          },
-                                                          "FullScan"
-                                                        ]
-                                                      ]
-                                                    }
+                                                    "access_strategy": "Persist"
                                                   }
                                                 },
                                                 "predicates": [
@@ -2211,232 +2391,6 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                           ]
                                         ]
                                       }
-                                    }
-                                  },
-                                  "predicates": [
-                                    {
-                                      "CallUnary": {
-                                        "func": {
-                                          "Not": null
-                                        },
-                                        "expr": {
-                                          "CallUnary": {
-                                            "func": {
-                                              "IsNull": null
-                                            },
-                                            "expr": {
-                                              "Column": 0
-                                            }
-                                          }
-                                        }
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "outputs": [
-                                0,
-                                1
-                              ]
-                            }
-                          },
-                          "group_key": [
-                            0
-                          ],
-                          "order_key": [],
-                          "limit": {
-                            "Literal": [
-                              {
-                                "Ok": {
-                                  "data": [
-                                    47,
-                                    1
-                                  ]
-                                }
-                              },
-                              {
-                                "scalar_type": "Int64",
-                                "nullable": false
-                              }
-                            ]
-                          },
-                          "offset": 0,
-                          "monotonic": false,
-                          "expected_group_size": null
-                        }
-                      },
-                      "body": {
-                        "Let": {
-                          "id": 4,
-                          "value": {
-                            "TopK": {
-                              "input": {
-                                "Project": {
-                                  "input": {
-                                    "Filter": {
-                                      "input": {
-                                        "Join": {
-                                          "inputs": [
-                                            {
-                                              "Get": {
-                                                "id": {
-                                                  "Local": 2
-                                                },
-                                                "typ": {
-                                                  "column_types": [
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": true
-                                                    }
-                                                  ],
-                                                  "keys": [
-                                                    [
-                                                      0
-                                                    ]
-                                                  ]
-                                                },
-                                                "access_strategy": "UnknownOrLocal"
-                                              }
-                                            },
-                                            {
-                                              "ArrangeBy": {
-                                                "input": {
-                                                  "Filter": {
-                                                    "input": {
-                                                      "Get": {
-                                                        "id": {
-                                                          "Global": {
-                                                            "User": 8
-                                                          }
-                                                        },
-                                                        "typ": {
-                                                          "column_types": [
-                                                            {
-                                                              "scalar_type": "Int32",
-                                                              "nullable": false
-                                                            },
-                                                            {
-                                                              "scalar_type": "Int32",
-                                                              "nullable": true
-                                                            }
-                                                          ],
-                                                          "keys": []
-                                                        },
-                                                        "access_strategy": "Persist"
-                                                      }
-                                                    },
-                                                    "predicates": [
-                                                      {
-                                                        "CallUnary": {
-                                                          "func": {
-                                                            "Not": null
-                                                          },
-                                                          "expr": {
-                                                            "CallUnary": {
-                                                              "func": {
-                                                                "IsNull": null
-                                                              },
-                                                              "expr": {
-                                                                "Column": 1
-                                                              }
-                                                            }
-                                                          }
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                },
-                                                "keys": [
-                                                  [
-                                                    {
-                                                      "Column": 1
-                                                    }
-                                                  ]
-                                                ]
-                                              }
-                                            }
-                                          ],
-                                          "equivalences": [
-                                            [
-                                              {
-                                                "Column": 0
-                                              },
-                                              {
-                                                "Column": 2
-                                              }
-                                            ]
-                                          ],
-                                          "implementation": {
-                                            "Differential": [
-                                              [
-                                                0,
-                                                [
-                                                  {
-                                                    "Column": 0
-                                                  }
-                                                ],
-                                                {
-                                                  "unique_key": true,
-                                                  "key_length": 1,
-                                                  "arranged": true,
-                                                  "cardinality": null,
-                                                  "filters": {
-                                                    "literal_equality": false,
-                                                    "like": false,
-                                                    "is_null": false,
-                                                    "literal_inequality": 0,
-                                                    "any_filter": false
-                                                  },
-                                                  "input": 0
-                                                }
-                                              ],
-                                              [
-                                                [
-                                                  1,
-                                                  [
-                                                    {
-                                                      "Column": 1
-                                                    }
-                                                  ],
-                                                  {
-                                                    "unique_key": false,
-                                                    "key_length": 1,
-                                                    "arranged": false,
-                                                    "cardinality": null,
-                                                    "filters": {
-                                                      "literal_equality": false,
-                                                      "like": false,
-                                                      "is_null": false,
-                                                      "literal_inequality": 0,
-                                                      "any_filter": false
-                                                    },
-                                                    "input": 1
-                                                  }
-                                                ]
-                                              ]
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      "predicates": [
-                                        {
-                                          "CallUnary": {
-                                            "func": {
-                                              "Not": null
-                                            },
-                                            "expr": {
-                                              "CallUnary": {
-                                                "func": {
-                                                  "IsNull": null
-                                                },
-                                                "expr": {
-                                                  "Column": 0
-                                                }
-                                              }
-                                            }
-                                          }
-                                        }
-                                      ]
                                     }
                                   },
                                   "outputs": [
@@ -4853,108 +4807,17 @@ WHERE a = c and d = e and b = f
       "plan": {
         "Project": {
           "input": {
-            "Filter": {
-              "input": {
-                "Join": {
-                  "inputs": [
-                    {
-                      "ArrangeBy": {
-                        "input": {
-                          "Filter": {
-                            "input": {
-                              "Get": {
-                                "id": {
-                                  "Global": {
-                                    "User": 1
-                                  }
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    }
-                                  ],
-                                  "keys": []
-                                },
-                                "access_strategy": {
-                                  "Index": [
-                                    [
-                                      {
-                                        "User": 4
-                                      },
-                                      "FullScan"
-                                    ]
-                                  ]
-                                }
-                              }
-                            },
-                            "predicates": [
-                              {
-                                "CallUnary": {
-                                  "func": {
-                                    "Not": null
-                                  },
-                                  "expr": {
-                                    "CallUnary": {
-                                      "func": {
-                                        "IsNull": null
-                                      },
-                                      "expr": {
-                                        "Column": 0
-                                      }
-                                    }
-                                  }
-                                }
-                              },
-                              {
-                                "CallUnary": {
-                                  "func": {
-                                    "Not": null
-                                  },
-                                  "expr": {
-                                    "CallUnary": {
-                                      "func": {
-                                        "IsNull": null
-                                      },
-                                      "expr": {
-                                        "Column": 1
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "keys": [
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ],
-                          [
-                            {
-                              "Column": 0
-                            },
-                            {
-                              "Column": 1
-                            }
-                          ]
-                        ]
-                      }
-                    },
-                    {
-                      "ArrangeBy": {
+            "Join": {
+              "inputs": [
+                {
+                  "ArrangeBy": {
+                    "input": {
+                      "Filter": {
                         "input": {
                           "Get": {
                             "id": {
                               "Global": {
-                                "User": 2
+                                "User": 1
                               }
                             },
                             "typ": {
@@ -4974,340 +4837,391 @@ WHERE a = c and d = e and b = f
                               "Index": [
                                 [
                                   {
-                                    "User": 9
+                                    "User": 4
                                   },
-                                  {
-                                    "DeltaJoin": "Lookup"
-                                  }
-                                ],
-                                [
-                                  {
-                                    "User": 10
-                                  },
-                                  {
-                                    "DeltaJoin": "Lookup"
-                                  }
+                                  "FullScan"
                                 ]
                               ]
                             }
                           }
                         },
-                        "keys": [
-                          [
-                            {
-                              "Column": 0
+                        "predicates": [
+                          {
+                            "CallUnary": {
+                              "func": {
+                                "Not": null
+                              },
+                              "expr": {
+                                "CallUnary": {
+                                  "func": {
+                                    "IsNull": null
+                                  },
+                                  "expr": {
+                                    "Column": 0
+                                  }
+                                }
+                              }
                             }
-                          ],
-                          [
-                            {
-                              "Column": 1
+                          },
+                          {
+                            "CallUnary": {
+                              "func": {
+                                "Not": null
+                              },
+                              "expr": {
+                                "CallUnary": {
+                                  "func": {
+                                    "IsNull": null
+                                  },
+                                  "expr": {
+                                    "Column": 1
+                                  }
+                                }
+                              }
                             }
-                          ]
+                          }
                         ]
                       }
                     },
-                    {
-                      "ArrangeBy": {
-                        "input": {
-                          "Filter": {
-                            "input": {
-                              "Get": {
-                                "id": {
-                                  "Global": {
-                                    "User": 3
-                                  }
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    }
-                                  ],
-                                  "keys": []
-                                },
-                                "access_strategy": {
-                                  "Index": [
-                                    [
-                                      {
-                                        "User": 11
-                                      },
-                                      "FullScan"
-                                    ]
-                                  ]
-                                }
-                              }
-                            },
-                            "predicates": [
-                              {
-                                "CallUnary": {
-                                  "func": {
-                                    "Not": null
-                                  },
-                                  "expr": {
-                                    "CallUnary": {
-                                      "func": {
-                                        "IsNull": null
-                                      },
-                                      "expr": {
-                                        "Column": 0
-                                      }
-                                    }
-                                  }
-                                }
-                              },
-                              {
-                                "CallUnary": {
-                                  "func": {
-                                    "Not": null
-                                  },
-                                  "expr": {
-                                    "CallUnary": {
-                                      "func": {
-                                        "IsNull": null
-                                      },
-                                      "expr": {
-                                        "Column": 1
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            ]
+                    "keys": [
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      [
+                        {
+                          "Column": 0
+                        },
+                        {
+                          "Column": 1
+                        }
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "ArrangeBy": {
+                    "input": {
+                      "Get": {
+                        "id": {
+                          "Global": {
+                            "User": 2
                           }
                         },
-                        "keys": [
-                          [
+                        "typ": {
+                          "column_types": [
                             {
-                              "Column": 0
+                              "scalar_type": "Int32",
+                              "nullable": true
                             },
                             {
-                              "Column": 1
+                              "scalar_type": "Int32",
+                              "nullable": true
                             }
+                          ],
+                          "keys": []
+                        },
+                        "access_strategy": {
+                          "Index": [
+                            [
+                              {
+                                "User": 9
+                              },
+                              {
+                                "DeltaJoin": "Lookup"
+                              }
+                            ],
+                            [
+                              {
+                                "User": 10
+                              },
+                              {
+                                "DeltaJoin": "Lookup"
+                              }
+                            ]
                           ]
-                        ]
+                        }
                       }
-                    }
-                  ],
-                  "equivalences": [
-                    [
-                      {
-                        "Column": 0
-                      },
-                      {
-                        "Column": 2
-                      }
-                    ],
-                    [
-                      {
-                        "Column": 1
-                      },
-                      {
-                        "Column": 5
-                      }
-                    ],
-                    [
-                      {
-                        "Column": 3
-                      },
-                      {
-                        "Column": 4
-                      }
+                    },
+                    "keys": [
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      [
+                        {
+                          "Column": 1
+                        }
+                      ]
                     ]
-                  ],
-                  "implementation": {
-                    "DeltaQuery": [
-                      [
-                        [
-                          1,
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ],
-                          {
-                            "unique_key": false,
-                            "key_length": 1,
-                            "arranged": true,
-                            "cardinality": null,
-                            "filters": {
-                              "literal_equality": false,
-                              "like": false,
-                              "is_null": false,
-                              "literal_inequality": 0,
-                              "any_filter": false
+                  }
+                },
+                {
+                  "ArrangeBy": {
+                    "input": {
+                      "Filter": {
+                        "input": {
+                          "Get": {
+                            "id": {
+                              "Global": {
+                                "User": 3
+                              }
                             },
-                            "input": 1
+                            "typ": {
+                              "column_types": [
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                }
+                              ],
+                              "keys": []
+                            },
+                            "access_strategy": {
+                              "Index": [
+                                [
+                                  {
+                                    "User": 11
+                                  },
+                                  "FullScan"
+                                ]
+                              ]
+                            }
                           }
-                        ],
-                        [
-                          2,
-                          [
-                            {
-                              "Column": 0
-                            },
-                            {
-                              "Column": 1
-                            }
-                          ],
+                        },
+                        "predicates": [
                           {
-                            "unique_key": false,
-                            "key_length": 2,
-                            "arranged": false,
-                            "cardinality": null,
-                            "filters": {
-                              "literal_equality": false,
-                              "like": false,
-                              "is_null": false,
-                              "literal_inequality": 0,
-                              "any_filter": false
-                            },
-                            "input": 2
-                          }
-                        ]
-                      ],
-                      [
-                        [
-                          0,
-                          [
-                            {
-                              "Column": 0
+                            "CallUnary": {
+                              "func": {
+                                "Not": null
+                              },
+                              "expr": {
+                                "CallUnary": {
+                                  "func": {
+                                    "IsNull": null
+                                  },
+                                  "expr": {
+                                    "Column": 0
+                                  }
+                                }
+                              }
                             }
-                          ],
+                          },
                           {
-                            "unique_key": false,
-                            "key_length": 1,
-                            "arranged": true,
-                            "cardinality": null,
-                            "filters": {
-                              "literal_equality": false,
-                              "like": false,
-                              "is_null": false,
-                              "literal_inequality": 0,
-                              "any_filter": false
-                            },
-                            "input": 0
-                          }
-                        ],
-                        [
-                          2,
-                          [
-                            {
-                              "Column": 0
-                            },
-                            {
-                              "Column": 1
+                            "CallUnary": {
+                              "func": {
+                                "Not": null
+                              },
+                              "expr": {
+                                "CallUnary": {
+                                  "func": {
+                                    "IsNull": null
+                                  },
+                                  "expr": {
+                                    "Column": 1
+                                  }
+                                }
+                              }
                             }
-                          ],
-                          {
-                            "unique_key": false,
-                            "key_length": 2,
-                            "arranged": false,
-                            "cardinality": null,
-                            "filters": {
-                              "literal_equality": false,
-                              "like": false,
-                              "is_null": false,
-                              "literal_inequality": 0,
-                              "any_filter": false
-                            },
-                            "input": 2
                           }
                         ]
-                      ],
+                      }
+                    },
+                    "keys": [
                       [
-                        [
-                          1,
-                          [
-                            {
-                              "Column": 1
-                            }
-                          ],
-                          {
-                            "unique_key": false,
-                            "key_length": 1,
-                            "arranged": true,
-                            "cardinality": null,
-                            "filters": {
-                              "literal_equality": false,
-                              "like": false,
-                              "is_null": false,
-                              "literal_inequality": 0,
-                              "any_filter": false
-                            },
-                            "input": 1
-                          }
-                        ],
-                        [
-                          0,
-                          [
-                            {
-                              "Column": 0
-                            },
-                            {
-                              "Column": 1
-                            }
-                          ],
-                          {
-                            "unique_key": false,
-                            "key_length": 2,
-                            "arranged": false,
-                            "cardinality": null,
-                            "filters": {
-                              "literal_equality": false,
-                              "like": false,
-                              "is_null": false,
-                              "literal_inequality": 0,
-                              "any_filter": false
-                            },
-                            "input": 0
-                          }
-                        ]
+                        {
+                          "Column": 0
+                        },
+                        {
+                          "Column": 1
+                        }
                       ]
                     ]
                   }
                 }
-              },
-              "predicates": [
-                {
-                  "CallUnary": {
-                    "func": {
-                      "Not": null
-                    },
-                    "expr": {
-                      "CallUnary": {
-                        "func": {
-                          "IsNull": null
-                        },
-                        "expr": {
+              ],
+              "equivalences": [
+                [
+                  {
+                    "Column": 0
+                  },
+                  {
+                    "Column": 2
+                  }
+                ],
+                [
+                  {
+                    "Column": 1
+                  },
+                  {
+                    "Column": 5
+                  }
+                ],
+                [
+                  {
+                    "Column": 3
+                  },
+                  {
+                    "Column": 4
+                  }
+                ]
+              ],
+              "implementation": {
+                "DeltaQuery": [
+                  [
+                    [
+                      1,
+                      [
+                        {
                           "Column": 0
                         }
-                      }
-                    }
-                  }
-                },
-                {
-                  "CallUnary": {
-                    "func": {
-                      "Not": null
-                    },
-                    "expr": {
-                      "CallUnary": {
-                        "func": {
-                          "IsNull": null
+                      ],
+                      {
+                        "unique_key": false,
+                        "key_length": 1,
+                        "arranged": true,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
                         },
-                        "expr": {
-                          "Column": 3
-                        }
+                        "input": 1
                       }
-                    }
-                  }
-                }
-              ]
+                    ],
+                    [
+                      2,
+                      [
+                        {
+                          "Column": 0
+                        },
+                        {
+                          "Column": 1
+                        }
+                      ],
+                      {
+                        "unique_key": false,
+                        "key_length": 2,
+                        "arranged": false,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 2
+                      }
+                    ]
+                  ],
+                  [
+                    [
+                      0,
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      {
+                        "unique_key": false,
+                        "key_length": 1,
+                        "arranged": true,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 0
+                      }
+                    ],
+                    [
+                      2,
+                      [
+                        {
+                          "Column": 0
+                        },
+                        {
+                          "Column": 1
+                        }
+                      ],
+                      {
+                        "unique_key": false,
+                        "key_length": 2,
+                        "arranged": false,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 2
+                      }
+                    ]
+                  ],
+                  [
+                    [
+                      1,
+                      [
+                        {
+                          "Column": 1
+                        }
+                      ],
+                      {
+                        "unique_key": false,
+                        "key_length": 1,
+                        "arranged": true,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 1
+                      }
+                    ],
+                    [
+                      0,
+                      [
+                        {
+                          "Column": 0
+                        },
+                        {
+                          "Column": 1
+                        }
+                      ],
+                      {
+                        "unique_key": false,
+                        "key_length": 2,
+                        "arranged": false,
+                        "cardinality": null,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 0
+                      }
+                    ]
+                  ]
+                ]
+              }
             }
           },
           "outputs": [

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -446,12 +446,11 @@ Explained Query:
     cte l4 =
       TopK group_by=[#0{b}] limit=1
         Project (#0{b}, #1{a})
-          Filter (#0{b}) IS NOT NULL
-            Join on=(#0{b} = #2{b}) type=differential
-              Get l2
-              ArrangeBy keys=[[#1{b}]]
-                Filter (#1{b}) IS NOT NULL
-                  ReadStorage materialize.public.mv
+          Join on=(#0{b} = #2{b}) type=differential
+            Get l2
+            ArrangeBy keys=[[#1{b}]]
+              Filter (#1{b}) IS NOT NULL
+                ReadStorage materialize.public.mv
     cte l3 =
       TopK group_by=[#0{b}] limit=1
         Project (#0{b}, #1{a})
@@ -771,16 +770,15 @@ WHERE a = c and d = e and b = f
 ----
 Explained Query:
   Project (#0{a}, #1{b}, #0{a}, #3{d}, #3{d}, #1{b})
-    Filter (#0{a}) IS NOT NULL AND (#3{d}) IS NOT NULL
-      Join on=(#0{a} = #2{c} AND #1{b} = #5{f} AND #3{d} = #4{e}) type=delta
-        ArrangeBy keys=[[#0{a}], [#0{a}, #1{b}]]
-          Filter (#0{a}) IS NOT NULL AND (#1{b}) IS NOT NULL
-            ReadIndex on=t t_a_idx=[*** full scan ***]
-        ArrangeBy keys=[[#0{c}], [#1{d}]]
-          ReadIndex on=u u_c_idx=[delta join lookup] u_d_idx=[delta join lookup]
-        ArrangeBy keys=[[#0{e}, #1{f}]]
-          Filter (#0{e}) IS NOT NULL AND (#1{f}) IS NOT NULL
-            ReadIndex on=v v_e_idx=[*** full scan ***]
+    Join on=(#0{a} = #2{c} AND #1{b} = #5{f} AND #3{d} = #4{e}) type=delta
+      ArrangeBy keys=[[#0{a}], [#0{a}, #1{b}]]
+        Filter (#0{a}) IS NOT NULL AND (#1{b}) IS NOT NULL
+          ReadIndex on=t t_a_idx=[*** full scan ***]
+      ArrangeBy keys=[[#0{c}], [#1{d}]]
+        ReadIndex on=u u_c_idx=[delta join lookup] u_d_idx=[delta join lookup]
+      ArrangeBy keys=[[#0{e}, #1{f}]]
+        Filter (#0{e}) IS NOT NULL AND (#1{f}) IS NOT NULL
+          ReadIndex on=v v_e_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -801,20 +799,19 @@ WHERE a = c and d = e and b = f
 ----
 Explained Query:
   Project (#0{a}, #1{b}, #0{a}, #3{d}, #3{d}, #1{b})
-    Filter (#0{a}) IS NOT NULL AND (#3{d}) IS NOT NULL
-      Join on=(#0{a} = #2{c} AND #1{b} = #5{f} AND #3{d} = #4{e}) type=delta
-        implementation
-          %0:t » %1:u[#0]KA » %2:v[#0, #1]KK
-          %1:u » %0:t[#0]KA » %2:v[#0, #1]KK
-          %2:v » %1:u[#1]KA » %0:t[#0, #1]KK
-        ArrangeBy keys=[[#0{a}], [#0{a}, #1{b}]]
-          Filter (#0{a}) IS NOT NULL AND (#1{b}) IS NOT NULL
-            ReadIndex on=t t_a_idx=[*** full scan ***]
-        ArrangeBy keys=[[#0{c}], [#1{d}]]
-          ReadIndex on=u u_c_idx=[delta join lookup] u_d_idx=[delta join lookup]
-        ArrangeBy keys=[[#0{e}, #1{f}]]
-          Filter (#0{e}) IS NOT NULL AND (#1{f}) IS NOT NULL
-            ReadIndex on=v v_e_idx=[*** full scan ***]
+    Join on=(#0{a} = #2{c} AND #1{b} = #5{f} AND #3{d} = #4{e}) type=delta
+      implementation
+        %0:t » %1:u[#0]KA » %2:v[#0, #1]KK
+        %1:u » %0:t[#0]KA » %2:v[#0, #1]KK
+        %2:v » %1:u[#1]KA » %0:t[#0, #1]KK
+      ArrangeBy keys=[[#0{a}], [#0{a}, #1{b}]]
+        Filter (#0{a}) IS NOT NULL AND (#1{b}) IS NOT NULL
+          ReadIndex on=t t_a_idx=[*** full scan ***]
+      ArrangeBy keys=[[#0{c}], [#1{d}]]
+        ReadIndex on=u u_c_idx=[delta join lookup] u_d_idx=[delta join lookup]
+      ArrangeBy keys=[[#0{e}, #1{f}]]
+        Filter (#0{e}) IS NOT NULL AND (#1{f}) IS NOT NULL
+          ReadIndex on=v v_e_idx=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -1155,13 +1152,12 @@ WHERE t.b = u.c;
 ----
 Explained Query:
   Project (#0{a}, #1{b}, #1{b}, #3{d})
-    Filter (#1{b}) IS NOT NULL
-      Join on=(#1{b} = #2{c}) type=differential
-        ArrangeBy keys=[[#1{b}]]
-          Filter (#1{b}) IS NOT NULL
-            ReadStorage materialize.public.t
-        ArrangeBy keys=[[#0{c}]]
-          ReadIndex on=u u_c=[differential join]
+    Join on=(#1{b} = #2{c}) type=differential
+      ArrangeBy keys=[[#1{b}]]
+        Filter (#1{b}) IS NOT NULL
+          ReadStorage materialize.public.t
+      ArrangeBy keys=[[#0{c}]]
+        ReadIndex on=u u_c=[differential join]
 
 Source materialize.public.t
   filter=((#1{b}) IS NOT NULL)
@@ -1181,13 +1177,12 @@ WHERE t.b = u.d;
 ----
 Explained Query:
   Project (#0{a}..=#2{c}, #1{b})
-    Filter (#1{b}) IS NOT NULL
-      Join on=(#1{b} = #3{d}) type=differential
-        ArrangeBy keys=[[#1{b}]]
-          Filter (#1{b}) IS NOT NULL
-            ReadStorage materialize.public.t
-        ArrangeBy keys=[[#1{d}]]
-          ReadIndex on=u u_d=[differential join]
+    Join on=(#1{b} = #3{d}) type=differential
+      ArrangeBy keys=[[#1{b}]]
+        Filter (#1{b}) IS NOT NULL
+          ReadStorage materialize.public.t
+      ArrangeBy keys=[[#1{d}]]
+        ReadIndex on=u u_d=[differential join]
 
 Source materialize.public.t
   filter=((#1{b}) IS NOT NULL)
@@ -1218,13 +1213,12 @@ WHERE t.a = u.c
 ----
 Explained Query:
   Project (#0{a}, #1{b}, #0{a}, #3{d})
-    Filter (#0{a}) IS NOT NULL
-      Join on=(#0{a} = #2{c}) type=differential
-        ArrangeBy keys=[[#0{a}]]
-          ReadIndex on=t t_a_idx_1=[differential join]
-        ArrangeBy keys=[[#0{c}]]
-          Filter (#0{c}) IS NOT NULL
-            ReadIndex on=u u_d=[*** full scan ***]
+    Join on=(#0{a} = #2{c}) type=differential
+      ArrangeBy keys=[[#0{a}]]
+        ReadIndex on=t t_a_idx_1=[differential join]
+      ArrangeBy keys=[[#0{c}]]
+        Filter (#0{c}) IS NOT NULL
+          ReadIndex on=u u_d=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.u_d (*** full scan ***)

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -496,26 +496,26 @@ Explained Query:
           Negate
             Project ()
               Join on=(#0{b} = #1{b}) type=differential
-                ArrangeBy keys=[[#0{b}]]
-                  Project (#1)
-                    ReadIndex on=t t_a_idx=[*** full scan ***]
+                Get l2
                 ArrangeBy keys=[[#0{b}]]
                   Distinct project=[#0{b}]
                     Project (#1)
-                      Get l2
+                      Get l3
           Project ()
             ReadIndex on=t t_a_idx=[*** full scan ***]
       Project (#0{a}, #2)
-        Get l2
+        Get l3
   With
-    cte l2 =
+    cte l3 =
       Project (#0{a}..=#2{a})
         Join on=(#1{b} = #3{b} = #4{b}) type=delta
           Get l1
           Get l1
-          ArrangeBy keys=[[#0{b}]]
-            Project (#1)
-              Get l0
+          Get l2
+    cte l2 =
+      ArrangeBy keys=[[#0{b}]]
+        Project (#1)
+          Get l0
     cte l1 =
       ArrangeBy keys=[[#1{b}]]
         Get l0

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -365,26 +365,26 @@ Explained Query:
           Negate
             Project ()
               Join on=(#0{b} = #1{b}) type=differential
-                ArrangeBy keys=[[#0{b}]]
-                  Project (#1)
-                    ReadIndex on=t t_a_idx=[*** full scan ***]
+                Get l2
                 ArrangeBy keys=[[#0{b}]]
                   Distinct project=[#0{b}]
                     Project (#1)
-                      Get l2
+                      Get l3
           Project ()
             ReadIndex on=t t_a_idx=[*** full scan ***]
       Project (#0{a}, #2)
-        Get l2
+        Get l3
   With
-    cte l2 =
+    cte l3 =
       Project (#0{a}..=#2{a})
         Join on=(#1{b} = #3{b} = #4{b}) type=delta
           Get l1
           Get l1
-          ArrangeBy keys=[[#0{b}]]
-            Project (#1)
-              Get l0
+          Get l2
+    cte l2 =
+      ArrangeBy keys=[[#0{b}]]
+        Project (#1)
+          Get l0
     cte l1 =
       ArrangeBy keys=[[#1{b}]]
         Get l0

--- a/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text_redacted.slt
@@ -315,12 +315,11 @@ Explained Query:
     cte l4 =
       TopK group_by=[#0{b}] limit=█
         Project (#0{b}, #1{a})
-          Filter (#0{b}) IS NOT NULL
-            Join on=(#0{b} = #2{b}) type=differential
-              Get l2
-              ArrangeBy keys=[[#1{b}]]
-                Filter (#1{b}) IS NOT NULL
-                  ReadStorage materialize.public.mv
+          Join on=(#0{b} = #2{b}) type=differential
+            Get l2
+            ArrangeBy keys=[[#1{b}]]
+              Filter (#1{b}) IS NOT NULL
+                ReadStorage materialize.public.mv
     cte l3 =
       TopK group_by=[#0{b}] limit=█
         Project (#0{b}, #1{a})
@@ -632,13 +631,12 @@ WHERE t.b = u.c;
 ----
 Explained Query:
   Project (#0{a}, #1{b}, #1{b}, #3{d})
-    Filter (#1{b}) IS NOT NULL
-      Join on=(#1{b} = #2{c}) type=differential
-        ArrangeBy keys=[[#1{b}]]
-          Filter (#1{b}) IS NOT NULL
-            ReadStorage materialize.public.t
-        ArrangeBy keys=[[#0{c}]]
-          ReadIndex on=u u_c=[differential join]
+    Join on=(#1{b} = #2{c}) type=differential
+      ArrangeBy keys=[[#1{b}]]
+        Filter (#1{b}) IS NOT NULL
+          ReadStorage materialize.public.t
+      ArrangeBy keys=[[#0{c}]]
+        ReadIndex on=u u_c=[differential join]
 
 Source materialize.public.t
   filter=((#1{b}) IS NOT NULL)
@@ -658,13 +656,12 @@ WHERE t.b = u.d;
 ----
 Explained Query:
   Project (#0{a}..=#2{c}, #1{b})
-    Filter (#1{b}) IS NOT NULL
-      Join on=(#1{b} = #3{d}) type=differential
-        ArrangeBy keys=[[#1{b}]]
-          Filter (#1{b}) IS NOT NULL
-            ReadStorage materialize.public.t
-        ArrangeBy keys=[[#1{d}]]
-          ReadIndex on=u u_d=[differential join]
+    Join on=(#1{b} = #3{d}) type=differential
+      ArrangeBy keys=[[#1{b}]]
+        Filter (#1{b}) IS NOT NULL
+          ReadStorage materialize.public.t
+      ArrangeBy keys=[[#1{d}]]
+        ReadIndex on=u u_d=[differential join]
 
 Source materialize.public.t
   filter=((#1{b}) IS NOT NULL)
@@ -695,13 +692,12 @@ WHERE t.a = u.c
 ----
 Explained Query:
   Project (#0{a}, #1{b}, #0{a}, #3{d})
-    Filter (#0{a}) IS NOT NULL
-      Join on=(#0{a} = #2{c}) type=differential
-        ArrangeBy keys=[[#0{a}]]
-          ReadIndex on=t t_a_idx_1=[differential join]
-        ArrangeBy keys=[[#0{c}]]
-          Filter (#0{c}) IS NOT NULL
-            ReadIndex on=u u_d=[*** full scan ***]
+    Join on=(#0{a} = #2{c}) type=differential
+      ArrangeBy keys=[[#0{a}]]
+        ReadIndex on=t t_a_idx_1=[differential join]
+      ArrangeBy keys=[[#0{c}]]
+        Filter (#0{c}) IS NOT NULL
+          ReadIndex on=u u_d=[*** full scan ***]
 
 Used Indexes:
   - materialize.public.u_d (*** full scan ***)

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -6740,28 +6740,7 @@ WHERE a = c AND d = e AND b + d > 42
                     "before": {
                       "mfp": {
                         "expressions": [],
-                        "predicates": [
-                          [
-                            1,
-                            {
-                              "CallUnary": {
-                                "func": {
-                                  "Not": null
-                                },
-                                "expr": {
-                                  "CallUnary": {
-                                    "func": {
-                                      "IsNull": null
-                                    },
-                                    "expr": {
-                                      "Column": 0
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          ]
-                        ],
+                        "predicates": [],
                         "projection": [
                           0,
                           1
@@ -6968,26 +6947,6 @@ WHERE a = c AND d = e AND b + d > 42
                             ],
                             "predicates": [
                               [
-                                1,
-                                {
-                                  "CallUnary": {
-                                    "func": {
-                                      "Not": null
-                                    },
-                                    "expr": {
-                                      "CallUnary": {
-                                        "func": {
-                                          "IsNull": null
-                                        },
-                                        "expr": {
-                                          "Column": 0
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              ],
-                              [
                                 4,
                                 {
                                   "CallBinary": {
@@ -7166,26 +7125,6 @@ WHERE a = c AND d = e AND b + d > 42
                               }
                             ],
                             "predicates": [
-                              [
-                                1,
-                                {
-                                  "CallUnary": {
-                                    "func": {
-                                      "Not": null
-                                    },
-                                    "expr": {
-                                      "CallUnary": {
-                                        "func": {
-                                          "IsNull": null
-                                        },
-                                        "expr": {
-                                          "Column": 0
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              ],
                               [
                                 4,
                                 {
@@ -7725,28 +7664,7 @@ WHERE a = c AND d = e AND f = a
                     "before": {
                       "mfp": {
                         "expressions": [],
-                        "predicates": [
-                          [
-                            1,
-                            {
-                              "CallUnary": {
-                                "func": {
-                                  "Not": null
-                                },
-                                "expr": {
-                                  "CallUnary": {
-                                    "func": {
-                                      "IsNull": null
-                                    },
-                                    "expr": {
-                                      "Column": 0
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          ]
-                        ],
+                        "predicates": [],
                         "projection": [
                           0,
                           1
@@ -7920,28 +7838,7 @@ WHERE a = c AND d = e AND f = a
                         "before": {
                           "mfp": {
                             "expressions": [],
-                            "predicates": [
-                              [
-                                1,
-                                {
-                                  "CallUnary": {
-                                    "func": {
-                                      "Not": null
-                                    },
-                                    "expr": {
-                                      "CallUnary": {
-                                        "func": {
-                                          "IsNull": null
-                                        },
-                                        "expr": {
-                                          "Column": 0
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
-                            ],
+                            "predicates": [],
                             "projection": [
                               0,
                               2,
@@ -8051,28 +7948,7 @@ WHERE a = c AND d = e AND f = a
                         "before": {
                           "mfp": {
                             "expressions": [],
-                            "predicates": [
-                              [
-                                1,
-                                {
-                                  "CallUnary": {
-                                    "func": {
-                                      "Not": null
-                                    },
-                                    "expr": {
-                                      "CallUnary": {
-                                        "func": {
-                                          "IsNull": null
-                                        },
-                                        "expr": {
-                                          "Column": 0
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
-                            ],
+                            "predicates": [],
                             "projection": [
                               0,
                               2,

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -1062,8 +1062,6 @@ Explained Query:
           map=((#1 + #2), (#0 + #2))
         lookup={ relation=1, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
-      initial_closure
-        filter=((#0) IS NOT NULL)
       source={ relation=0, key=[#0] }
     plan_path[1]
       final_closure
@@ -1076,7 +1074,7 @@ Explained Query:
       delta_stage[0]
         closure
           project=(#1, #3, #4)
-          filter=((#0) IS NOT NULL AND (#3 > 42))
+          filter=((#3 > 42))
           map=((#2 + #1), (#0 + #1))
         lookup={ relation=0, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
@@ -1087,7 +1085,7 @@ Explained Query:
       delta_stage[1]
         closure
           project=(#3, #4)
-          filter=((#0) IS NOT NULL AND (#3 > 42))
+          filter=((#3 > 42))
           map=((#2 + #1), (#0 + #1))
         lookup={ relation=0, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
@@ -1159,8 +1157,6 @@ Explained Query:
       delta_stage[0]
         lookup={ relation=1, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
-      initial_closure
-        filter=((#0) IS NOT NULL)
       source={ relation=0, key=[#0] }
     plan_path[1]
       final_closure
@@ -1168,7 +1164,6 @@ Explained Query:
       delta_stage[1]
         closure
           project=(#0, #2, #1)
-          filter=((#0) IS NOT NULL)
         lookup={ relation=0, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
       delta_stage[0]
@@ -1183,7 +1178,6 @@ Explained Query:
       delta_stage[1]
         closure
           project=(#0, #2, #1)
-          filter=((#0) IS NOT NULL)
         lookup={ relation=0, key=[#0] }
         stream={ key=[#1], thinning=(#0) }
       delta_stage[0]

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -1047,8 +1047,6 @@ Explained Query:
           map=((#1 + #2), (#0 + #2))
         lookup={ relation=1, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
-      initial_closure
-        filter=((#0) IS NOT NULL)
       source={ relation=0, key=[#0] }
     plan_path[1]
       final_closure
@@ -1061,7 +1059,7 @@ Explained Query:
       delta_stage[0]
         closure
           project=(#1, #3, #4)
-          filter=((#0) IS NOT NULL AND (#3 > 42))
+          filter=((#3 > 42))
           map=((#2 + #1), (#0 + #1))
         lookup={ relation=0, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
@@ -1072,7 +1070,7 @@ Explained Query:
       delta_stage[1]
         closure
           project=(#3, #4)
-          filter=((#0) IS NOT NULL AND (#3 > 42))
+          filter=((#3 > 42))
           map=((#2 + #1), (#0 + #1))
         lookup={ relation=0, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
@@ -1144,8 +1142,6 @@ Explained Query:
       delta_stage[0]
         lookup={ relation=1, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
-      initial_closure
-        filter=((#0) IS NOT NULL)
       source={ relation=0, key=[#0] }
     plan_path[1]
       final_closure
@@ -1153,7 +1149,6 @@ Explained Query:
       delta_stage[1]
         closure
           project=(#0, #2, #1)
-          filter=((#0) IS NOT NULL)
         lookup={ relation=0, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
       delta_stage[0]
@@ -1168,7 +1163,6 @@ Explained Query:
       delta_stage[1]
         closure
           project=(#0, #2, #1)
-          filter=((#0) IS NOT NULL)
         lookup={ relation=0, key=[#0] }
         stream={ key=[#1], thinning=(#0) }
       delta_stage[0]

--- a/test/sqllogictest/explain/replan_catalog_items.slt
+++ b/test/sqllogictest/explain/replan_catalog_items.slt
@@ -88,13 +88,12 @@ CREATE MATERIALIZED VIEW mv AS SELECT x, sum(z) FROM t1 JOIN t2 USING(y) GROUP B
 materialize.public.mv:
   Reduce group_by=[#0] aggregates=[sum(#1)]
     Project (#0, #3)
-      Filter (#1) IS NOT NULL
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            ReadIndex on=t1 t1_y_idx=[differential join]
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              ReadStorage materialize.public.t2
+      Join on=(#1 = #2) type=differential
+        ArrangeBy keys=[[#1]]
+          ReadIndex on=t1 t1_y_idx=[differential join]
+        ArrangeBy keys=[[#0]]
+          Filter (#0) IS NOT NULL
+            ReadStorage materialize.public.t2
 
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
@@ -121,13 +120,12 @@ materialize.public.v_idx:
 materialize.public.v:
   Reduce group_by=[#0] aggregates=[sum(#1)]
     Project (#0, #3)
-      Filter (#1) IS NOT NULL
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            ReadIndex on=t1 t1_y_idx=[differential join]
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              ReadStorage materialize.public.t2
+      Join on=(#1 = #2) type=differential
+        ArrangeBy keys=[[#1]]
+          ReadIndex on=t1 t1_y_idx=[differential join]
+        ArrangeBy keys=[[#0]]
+          Filter (#0) IS NOT NULL
+            ReadStorage materialize.public.t2
 
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)
@@ -151,13 +149,12 @@ materialize.public.v_idx:
 materialize.public.v:
   Reduce group_by=[#0] aggregates=[sum(#1)]
     Project (#0, #3)
-      Filter (#1) IS NOT NULL
-        Join on=(#1 = #2) type=differential
-          ArrangeBy keys=[[#1]]
-            ReadIndex on=t1 t1_y_idx=[differential join]
-          ArrangeBy keys=[[#0]]
-            Filter (#0) IS NOT NULL
-              ReadStorage materialize.public.t2
+      Join on=(#1 = #2) type=differential
+        ArrangeBy keys=[[#1]]
+          ReadIndex on=t1 t1_y_idx=[differential join]
+        ArrangeBy keys=[[#0]]
+          Filter (#0) IS NOT NULL
+            ReadStorage materialize.public.t2
 
 Source materialize.public.t2
   filter=((#0) IS NOT NULL)

--- a/test/sqllogictest/explain/view.slt
+++ b/test/sqllogictest/explain/view.slt
@@ -123,16 +123,15 @@ Return
           Project (#0, #1)
             Negate
               Join on=(#2 = integer_to_bigint(#0))
-                Get l1
+                Filter (#1 = 100) AND (#0) IS NOT NULL
+                  Get materialize.public.accounts
                 Distinct project=[#2]
                   Get l0
-          Get l1
+          Filter (#1 = 100)
+            Get materialize.public.accounts
       Filter (#1 = 100)
         Get l0
 With
-  cte l1 =
-    Filter (#1 = 100)
-      Get materialize.public.accounts
   cte l0 =
     Join on=(#2 = integer_to_bigint(#0))
       Filter (#0) IS NOT NULL
@@ -172,16 +171,15 @@ Return
           Project (#0, #1)
             Negate
               Join on=(#2 = integer_to_bigint(#0))
-                Get l1
+                Filter (#1 = 100) AND (#0) IS NOT NULL
+                  Get materialize.public.accounts
                 Distinct project=[#2]
                   Get l0
-          Get l1
+          Filter (#1 = 100)
+            Get materialize.public.accounts
       Filter (#1 = 100)
         Get l0
 With
-  cte l1 =
-    Filter (#1 = 100)
-      Get materialize.public.accounts
   cte l0 =
     Join on=(#2 = integer_to_bigint(#0))
       Filter (#0) IS NOT NULL

--- a/test/sqllogictest/github-16036.slt
+++ b/test/sqllogictest/github-16036.slt
@@ -49,7 +49,6 @@ Explained Query:
         stream={ key=[#1], thinning=(#0, #2) }
       initial_closure
         project=(#1, #0, #2)
-        filter=((#0) IS NOT NULL AND (#2) IS NOT NULL)
       source={ relation=0, key=[#1] }
     plan_path[1]
       delta_stage[1]
@@ -60,7 +59,6 @@ Explained Query:
       delta_stage[0]
         closure
           project=(#2, #3, #1)
-          filter=((#0) IS NOT NULL AND (#3) IS NOT NULL)
         lookup={ relation=0, key=[#1] }
         stream={ key=[#1], thinning=(#0) }
       initial_closure
@@ -75,7 +73,6 @@ Explained Query:
       delta_stage[0]
         closure
           project=(#2, #3, #1)
-          filter=((#0) IS NOT NULL AND (#3) IS NOT NULL)
         lookup={ relation=0, key=[#2] }
         stream={ key=[#1], thinning=(#0) }
       initial_closure

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -383,28 +383,29 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    %1[#0]UKA » %0:r[#0]K
-                  ArrangeBy keys=[[#0]] // { arity: 2 }
-                    ReadStorage materialize.public.r // { arity: 2 }
+                    %1[#0]UKA » %0:l0[#0]K
+                  Get l0 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct project=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
-                        Get l0 // { arity: 3 }
+                        Get l1 // { arity: 3 }
             ReadStorage materialize.public.r // { arity: 2 }
       Project (#0, #1, #0, #2) // { arity: 4 }
-        Get l0 // { arity: 3 }
+        Get l1 // { arity: 3 }
   With
-    cte l0 =
+    cte l1 =
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %0:l[#0]K » %1:r[#0]K
+            %0:l[#0]K » %1:l0[#0]K
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.l // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.r // { arity: 2 }
+          Get l0 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.r // { arity: 2 }
 
 Source materialize.public.l
   filter=((#0) IS NOT NULL)
@@ -428,10 +429,9 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    %1:l2[#0]UKA » %0:r[#0]K
-                  ArrangeBy keys=[[#0]] // { arity: 2 }
-                    ReadStorage materialize.public.r // { arity: 2 }
-                  Get l2 // { arity: 1 }
+                    %1:l3[#0]UKA » %0:l1[#0]K
+                  Get l1 // { arity: 2 }
+                  Get l3 // { arity: 1 }
             ReadStorage materialize.public.r // { arity: 2 }
       Map (null, null) // { arity: 4 }
         Union // { arity: 2 }
@@ -439,27 +439,29 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  %1:l2[#0]UKA » %0:l0[#0]K
+                  %1:l3[#0]UKA » %0:l0[#0]K
                 Get l0 // { arity: 2 }
-                Get l2 // { arity: 1 }
+                Get l3 // { arity: 1 }
           ReadStorage materialize.public.l // { arity: 2 }
       Project (#0, #1, #0, #2) // { arity: 4 }
-        Get l1 // { arity: 3 }
+        Get l2 // { arity: 3 }
   With
-    cte l2 =
+    cte l3 =
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Distinct project=[#0] // { arity: 1 }
           Project (#0) // { arity: 1 }
-            Get l1 // { arity: 3 }
-    cte l1 =
+            Get l2 // { arity: 3 }
+    cte l2 =
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %0:l0[#0]K » %1:r[#0]K
+            %0:l0[#0]K » %1:l1[#0]K
           Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.r // { arity: 2 }
+          Get l1 // { arity: 2 }
+    cte l1 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.r // { arity: 2 }
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Filter (#0) IS NOT NULL // { arity: 2 }

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -337,28 +337,29 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  %1[#0]UKA » %0:l[#0]K
-                ArrangeBy keys=[[#0]] // { arity: 2 }
-                  ReadStorage materialize.public.l // { arity: 2 }
+                  %1[#0]UKA » %0:l0[#0]K
+                Get l0 // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
-                      Get l0 // { arity: 3 }
+                      Get l1 // { arity: 3 }
           ReadStorage materialize.public.l // { arity: 2 }
       Project (#0, #1, #0, #2) // { arity: 4 }
-        Get l0 // { arity: 3 }
+        Get l1 // { arity: 3 }
   With
-    cte l0 =
+    cte l1 =
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %0:l[#0]K » %1:r[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.l // { arity: 2 }
+            %0:l0[#0]K » %1:r[#0]K
+          Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.r // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.l // { arity: 2 }
 
 Source materialize.public.l
 Source materialize.public.r
@@ -427,10 +428,10 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    %1:l1[#0]UKA » %0:r[#0]K
+                    %1:l2[#0]UKA » %0:r[#0]K
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     ReadStorage materialize.public.r // { arity: 2 }
-                  Get l1 // { arity: 1 }
+                  Get l2 // { arity: 1 }
             ReadStorage materialize.public.r // { arity: 2 }
       Map (null, null) // { arity: 4 }
         Union // { arity: 2 }
@@ -438,30 +439,31 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  %1:l1[#0]UKA » %0:l[#0]K
-                ArrangeBy keys=[[#0]] // { arity: 2 }
-                  ReadStorage materialize.public.l // { arity: 2 }
-                Get l1 // { arity: 1 }
+                  %1:l2[#0]UKA » %0:l0[#0]K
+                Get l0 // { arity: 2 }
+                Get l2 // { arity: 1 }
           ReadStorage materialize.public.l // { arity: 2 }
       Project (#0, #1, #0, #2) // { arity: 4 }
-        Get l0 // { arity: 3 }
+        Get l1 // { arity: 3 }
   With
-    cte l1 =
+    cte l2 =
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Distinct project=[#0] // { arity: 1 }
           Project (#0) // { arity: 1 }
-            Get l0 // { arity: 3 }
-    cte l0 =
+            Get l1 // { arity: 3 }
+    cte l1 =
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %0:l[#0]K » %1:r[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.l // { arity: 2 }
+            %0:l0[#0]K » %1:r[#0]K
+          Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.r // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.l // { arity: 2 }
 
 Source materialize.public.l
 Source materialize.public.r

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -559,14 +559,13 @@ Explained Query:
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#5, #6) // { arity: 2 }
-          Filter (#0{id}) IS NOT NULL // { arity: 9 }
-            Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
-              implementation
-                %0:tagclass[#0]KAe » %1:tag[#3]KAe
-              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("ChristianBishop")] // { arity: 5 }
-              ArrangeBy keys=[[#3{typetagclassid}]] // { arity: 4 }
-                ReadIndex on=tag tag_typetagclassid=[differential join] // { arity: 4 }
+          Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
+            implementation
+              %0:tagclass[#0]KAe » %1:tag[#3]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("ChristianBishop")] // { arity: 5 }
+            ArrangeBy keys=[[#3{typetagclassid}]] // { arity: 4 }
+              ReadIndex on=tag tag_typetagclassid=[differential join] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.tag_typetagclassid (differential join)
@@ -618,7 +617,7 @@ Explained Query:
   Finish order_by=[#4{count} desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
     Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
       Project (#10, #13, #15, #16) // { arity: 4 }
-        Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#25{locationcityid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
+        Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
           Join on=(#1{messageid} = #36{messageid} AND #10{containerforumid} = #14{id} AND #16{moderatorpersonid} = #18{id} AND #25{locationcityid} = #28{id} AND #31{partofcountryid} = #32{id}) type=delta // { arity: 37 }
             implementation
               %0:message » %5[#0]UKA » %1:forum[#1]KA » %2:person[#1]KA » %3:city[#0]KA » %4:country[#0]KAef
@@ -640,18 +639,17 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#10) // { arity: 1 }
-                  Filter (#0{id}) IS NOT NULL AND (#5{id}) IS NOT NULL // { arity: 12 }
-                    Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
-                      implementation
-                        %0:tagclass » %1:tag[#3]KA » %2:message_hastag_tag[#2]KA
-                        %1:tag » %0:tagclass[#0]KAe » %2:message_hastag_tag[#2]KA
-                        %2:message_hastag_tag » %1:tag[#0]KA » %0:tagclass[#0]KAe
-                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                        ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Philosopher")] // { arity: 5 }
-                      ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
-                        ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                      ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                        ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+                  Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
+                    implementation
+                      %0:tagclass » %1:tag[#3]KA » %2:message_hastag_tag[#2]KA
+                      %1:tag » %0:tagclass[#0]KAe » %2:message_hastag_tag[#2]KA
+                      %2:message_hastag_tag » %1:tag[#0]KA » %0:tagclass[#0]KAe
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Philosopher")] // { arity: 5 }
+                    ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
+                      ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
+                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -763,20 +761,14 @@ Explained Query:
     With
       cte l3 =
         Project (#0{creationdate}..=#3{lastname}, #5) // { arity: 5 }
-          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{containerforumid} = #18{id}) type=delta // { arity: 19 }
+          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
             implementation
-              %0:l2 » %1:message[#9]KA » %2[#0]UKA » %3[#0]UKA
-              %1:message » %2[#0]UKA » %3[#0]UKA » %0:l2[#1]K
-              %2 » %3[#0]UKA » %1:message[#10]KA » %0:l2[#1]K
-              %3 » %2[#0]UKA » %1:message[#10]KA » %0:l2[#1]K
+              %0:l2 » %1:message[#9]KA » %2[#0]UKA
+              %1:message » %2[#0]UKA » %0:l2[#1]K
+              %2 » %1:message[#10]KA » %0:l2[#1]K
             Get l2 // { arity: 4 }
             ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
               ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-              Distinct project=[#0{containerforumid}] // { arity: 1 }
-                Project (#10) // { arity: 1 }
-                  Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                    ReadIndex on=message message_creatorpersonid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
                 Get l0 // { arity: 1 }
@@ -785,18 +777,11 @@ Explained Query:
           Get l1 // { arity: 4 }
       cte l1 =
         Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
-          Join on=(#1{id} = #11{id} = #12{personid}) type=delta // { arity: 13 }
+          Join on=(#1{id} = #11{personid}) type=differential // { arity: 12 }
             implementation
-              %0:person » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:person[#1]KA
-              %2 » %1[#0]UKA » %0:person[#1]KA
+              %1[#0]UKA » %0:person[#1]KA
             ArrangeBy keys=[[#1{id}]] // { arity: 11 }
-              ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1{id}) IS NOT NULL // { arity: 11 }
-                    ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
+              ReadIndex on=person person_id=[differential join] // { arity: 11 }
             ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
               Distinct project=[#0{personid}] // { arity: 1 }
                 Project (#3) // { arity: 1 }
@@ -815,10 +800,10 @@ Explained Query:
                 ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.person_id (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.person_id (differential join)
   - materialize.public.forum_hasmember_person_forumid (differential join)
   - materialize.public.message_containerforumid (delta join lookup)
-  - materialize.public.message_creatorpersonid (*** full scan ***, delta join lookup)
+  - materialize.public.message_creatorpersonid (delta join lookup)
   - materialize.public.top100popularforumsq04_id (*** full scan ***)
 
 Target cluster: quickstart
@@ -910,18 +895,17 @@ Explained Query:
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
       cte l0 =
         Project (#1{messageid}, #5, #16) // { arity: 3 }
-          Filter (#0{id}) IS NOT NULL // { arity: 20 }
-            Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-              implementation
-                %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-                %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
-                %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
+            implementation
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join 1st input (full scan))
@@ -1041,18 +1025,17 @@ Explained Query:
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#6, #17) // { arity: 2 }
-          Filter (#0{id}) IS NOT NULL // { arity: 21 }
-            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-              implementation
-                %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-                %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
-                %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
+            implementation
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1148,18 +1131,17 @@ Explained Query:
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#6, #17) // { arity: 2 }
-          Filter (#0{id}) IS NOT NULL // { arity: 21 }
-            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-              implementation
-                %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-                %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
-                %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
+            implementation
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1260,18 +1242,17 @@ Explained Query:
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l0 =
         Project (#1{messageid}, #5, #16) // { arity: 3 }
-          Filter (#0{id}) IS NOT NULL // { arity: 20 }
-            Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-              implementation
-                %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-                %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
-                %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
+            implementation
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join 1st input (full scan))
@@ -1348,31 +1329,29 @@ Explained Query:
             Get l1 // { arity: 2 }
       cte l1 =
         Project (#2, #18) // { arity: 2 }
-          Filter (#0{messageid}) IS NOT NULL AND (#16{tagid}) IS NOT NULL // { arity: 21 }
-            Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
-              implementation
-                %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
-                %1:message » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
-                %2:message_hastag_tag » %1:message[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
-                %3:tag » %2:message_hastag_tag[#2]KA » %1:message[#1]KA » %0:l0[#0]K
-              ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-                Get l0 // { arity: 1 }
-              ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
+          Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
+            implementation
+              %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
+              %1:message » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
+              %2:message_hastag_tag » %1:message[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
+              %3:tag » %2:message_hastag_tag[#2]KA » %1:message[#1]KA » %0:l0[#0]K
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Get l0 // { arity: 1 }
+            ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
       cte l0 =
         Project (#1) // { arity: 1 }
-          Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
-            Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-              implementation
-                %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
-              ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
+          Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+            implementation
+              %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
+            ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -1529,7 +1508,7 @@ Explained Query:
       cte l3 =
         Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
           Project (#17) // { arity: 1 }
-            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) AND (#0{id}) IS NOT NULL AND (#17{creatorpersonid}) IS NOT NULL // { arity: 32 }
+            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) // { arity: 32 }
               Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
                 implementation
                   %0:l1 » %1:message_hastag_tag[#2]KA » %2:message[#1]KAiif » %3:l0[#1]KA
@@ -1544,17 +1523,16 @@ Explained Query:
                 Get l0 // { arity: 11 }
       cte l2 =
         Project (#1) // { arity: 1 }
-          Filter (#1{id}) IS NOT NULL AND (#12{tagid}) IS NOT NULL // { arity: 18 }
-            Join on=(#1{id} = #11{personid} AND #12{tagid} = #13{id}) type=delta // { arity: 18 }
-              implementation
-                %0:l0 » %1:person_hasinterest_tag[#0]K » %2:l1[#0]KAe
-                %1:person_hasinterest_tag » %2:l1[#0]KAe » %0:l0[#1]KA
-                %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
-              Get l0 // { arity: 11 }
-              ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                Project (#1{tagid}, #2) // { arity: 2 }
-                  ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
-              Get l1 // { arity: 5 }
+          Join on=(#1{id} = #11{personid} AND #12{tagid} = #13{id}) type=delta // { arity: 18 }
+            implementation
+              %0:l0 » %1:person_hasinterest_tag[#0]K » %2:l1[#0]KAe
+              %1:person_hasinterest_tag » %2:l1[#0]KAe » %0:l0[#1]KA
+              %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
+            Get l0 // { arity: 11 }
+            ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
+              Project (#1{tagid}, #2) // { arity: 2 }
+                ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
+            Get l1 // { arity: 5 }
       cte l1 =
         ArrangeBy keys=[[#0{id}]] // { arity: 5 }
           ReadIndex on=materialize.public.tag tag_name=[lookup value=("Abbas_I_of_Persia")] // { arity: 5 }
@@ -1605,7 +1583,7 @@ Explained Query:
   Finish order_by=[#4{sum_count} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3{count})] // { arity: 5 }
       Project (#1{firstname}..=#3{count}, #25) // { arity: 4 }
-        Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 26 }
+        Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
             implementation
               %0:person » %1:message[#9]KAniif » %2[#0]UKA
@@ -1716,71 +1694,69 @@ Explained Query:
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
         Project (#0{person2id}, #9) // { arity: 2 }
-          Filter (#7{tagid}) IS NOT NULL // { arity: 12 }
-            Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
-              implementation
-                %0 » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
-                %1 » %0[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
-                %2 » %0[#0]UKA » %1[#0]UKA » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
-                %3 » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-                %4:message_hastag_tag » %3[#0]UKA » %5:tag[#0]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-                %5:tag » %4:message_hastag_tag[#2]KA » %3[#0]UKA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-              ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-                Distinct project=[#0{person2id}] // { arity: 1 }
-                  Threshold // { arity: 1 }
-                    Union // { arity: 1 }
-                      Distinct project=[#0{person2id}] // { arity: 1 }
-                        Project (#6) // { arity: 1 }
-                          Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=delta // { arity: 7 }
-                            implementation
-                              %0:l2 » %1:person_knows_person[#1]KA » %2:l0[#1]KA
-                              %1:person_knows_person » %0:l2[#0]UKA » %2:l0[#1]KA
-                              %2:l0 » %1:person_knows_person[#2]KA » %0:l2[#0]UKA
-                            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-                              Get l2 // { arity: 1 }
-                            ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                            Get l0 // { arity: 3 }
-                      Negate // { arity: 1 }
-                        Get l2 // { arity: 1 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                Distinct project=[#0{id}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#8{locationcityid}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
-                      Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
-                        implementation
-                          %0:person » %1:city[#0]KA » %2:country[#0]KAef
-                          %1:city » %2:country[#0]KAef » %0:person[#8]KA
-                          %2:country » %1:city[#3]KA » %0:person[#8]KA
-                        ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
-                          ReadIndex on=person person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
-                        ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
-                          ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                          ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
-                Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                  Project (#1{creatorpersonid}, #9) // { arity: 2 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-              ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-                Distinct project=[#0{messageid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Filter (#2{tagid}) IS NOT NULL AND (#6{typetagclassid}) IS NOT NULL // { arity: 12 }
-                      Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
-                        implementation
-                          %0:message_hastag_tag » %1:tag[#0]KA » %2:tagclass[#0]KAe
-                          %1:tag » %2:tagclass[#0]KAe » %0:message_hastag_tag[#2]KA
-                          %2:tagclass » %1:tag[#3]KA » %0:message_hastag_tag[#2]KA
-                        ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                          ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join 1st input (full scan)] // { arity: 3 }
-                        ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
-                          ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                        ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                          ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Thing")] // { arity: 5 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
+          Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
+            implementation
+              %0 » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
+              %1 » %0[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
+              %2 » %0[#0]UKA » %1[#0]UKA » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
+              %3 » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+              %4:message_hastag_tag » %3[#0]UKA » %5:tag[#0]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+              %5:tag » %4:message_hastag_tag[#2]KA » %3[#0]UKA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+              Distinct project=[#0{person2id}] // { arity: 1 }
+                Threshold // { arity: 1 }
+                  Union // { arity: 1 }
+                    Distinct project=[#0{person2id}] // { arity: 1 }
+                      Project (#6) // { arity: 1 }
+                        Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=delta // { arity: 7 }
+                          implementation
+                            %0:l2 » %1:person_knows_person[#1]KA » %2:l0[#1]KA
+                            %1:person_knows_person » %0:l2[#0]UKA » %2:l0[#1]KA
+                            %2:l0 » %1:person_knows_person[#2]KA » %0:l2[#0]UKA
+                          ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                            Get l2 // { arity: 1 }
+                          ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                          Get l0 // { arity: 3 }
+                    Negate // { arity: 1 }
+                      Get l2 // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
+                    Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
+                      implementation
+                        %0:person » %1:city[#0]KA » %2:country[#0]KAef
+                        %1:city » %2:country[#0]KAef » %0:person[#8]KA
+                        %2:country » %1:city[#3]KA » %0:person[#8]KA
+                      ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+                        ReadIndex on=person person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
+                      ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
+                        ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                        ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
+            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
+                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                  ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
+                    implementation
+                      %0:message_hastag_tag » %1:tag[#0]KA » %2:tagclass[#0]KAe
+                      %1:tag » %2:tagclass[#0]KAe » %0:message_hastag_tag[#2]KA
+                      %2:tagclass » %1:tag[#3]KA » %0:message_hastag_tag[#2]KA
+                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join 1st input (full scan)] // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
+                      ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Thing")] // { arity: 5 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
     With
       cte l2 =
         Distinct project=[#0{person2id}] // { arity: 1 }
@@ -1885,7 +1861,7 @@ Explained Query:
         Get l0 // { arity: 2 }
     cte l0 =
       Project (#1{person2id}, #21) // { arity: 2 }
-        Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#1{id}) IS NOT NULL AND (#8{locationcityid}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
+        Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
           Join on=(#1{id} = #20{person1id} AND #8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 22 }
             implementation
               %0:person » %3:person_knows_person[#1]KAiif » %1:city[#0]KA » %2:country[#0]KAef
@@ -1960,22 +1936,21 @@ Explained Query:
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Filter (#1{id}) IS NOT NULL // { arity: 12 }
-                        Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
-                          implementation
-                            %1[#0]UKA » %0:l0[#1]KA
-                          Get l0 // { arity: 11 }
-                          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                            Distinct project=[#0{id}] // { arity: 1 }
-                              Project (#0{id}) // { arity: 1 }
-                                Get l1 // { arity: 2 }
+                      Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
+                        implementation
+                          %1[#0]UKA » %0:l0[#1]KA
+                        Get l0 // { arity: 11 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                          Distinct project=[#0{id}] // { arity: 1 }
+                            Project (#0{id}) // { arity: 1 }
+                              Get l1 // { arity: 2 }
                   Project (#1) // { arity: 1 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
               Get l1 // { arity: 2 }
     With
       cte l1 =
         Project (#1{messageid}, #12) // { arity: 2 }
-          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#1{id}) IS NOT NULL AND (#15{content}) IS NOT NULL // { arity: 25 }
+          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#15{content}) IS NOT NULL // { arity: 25 }
             Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
               implementation
                 %1:message[#9]KAeiif » %0:l0[#1]KAeiif
@@ -2171,7 +2146,7 @@ Explained Query:
             Get l5 // { arity: 2 }
       cte l5 =
         Project (#1{creatorpersonid}, #23) // { arity: 2 }
-          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 28 }
+          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) // { arity: 28 }
             Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
                 %0:person » %1:person_likes_message[#1]KA » %2:message[#1]KA » %3:l4[#0]K
@@ -2228,7 +2203,7 @@ Explained Query:
                 ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
       cte l0 =
         Project (#0{id}, #2{partofcontinentid}..=#6{creationdate}, #8{firstname}..=#15{email}, #17, #18) // { arity: 16 }
-          Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL AND (#4{id}) IS NOT NULL // { arity: 19 }
+          Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL // { arity: 19 }
             Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
               implementation
                 %0:country » %1:city[#3]KA » %2:person[#8]KAif
@@ -2408,13 +2383,12 @@ Explained Query:
             ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
                 Project (#9, #22) // { arity: 2 }
-                  Filter (#1{messageid}) IS NOT NULL // { arity: 26 }
-                    Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
-                      implementation
-                        %0:l6[#1]KA » %1:message[#12]KA
-                      Get l6 // { arity: 13 }
-                      ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
-                        ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
+                  Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
+                    implementation
+                      %0:l6[#1]KA » %1:message[#12]KA
+                    Get l6 // { arity: 13 }
+                    ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
+                      ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
       cte l6 =
         ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
           ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
@@ -2433,7 +2407,7 @@ Explained Query:
                 Get l3 // { arity: 4 }
       cte l3 =
         Project (#4, #5, #9, #21) // { arity: 4 }
-          Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#4{id}) IS NOT NULL AND (#9{id}) IS NOT NULL AND (#21{person2id}) IS NOT NULL AND (#30{locationcityid}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
+          Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
             Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid} AND #9{id} = #20{person1id} AND #21{person2id} = #23{id} AND #30{locationcityid} = #33{id} AND #36{partofcountryid} = #37{id}) type=delta // { arity: 41 }
               implementation
                 %0:l0 » %1:l1[#3]KA » %2:l2[#8]KA » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
@@ -2572,21 +2546,21 @@ Explained Query:
                                       Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
-                                            %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
+                                            %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
                                           ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                                            Project (#1{person2id}, #2) // { arity: 2 }
-                                              Filter (greatest(#1{person1id}, #2{person2id})) IS NOT NULL AND (least(#1{person1id}, #2{person2id})) IS NOT NULL // { arity: 3 }
-                                                ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+                                            Get l2 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                                             Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                                               Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                                                Get l2 // { arity: 3 }
-                                    Project (#1{person2id}, #2) // { arity: 2 }
-                                      ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-                                Get l2 // { arity: 3 }
+                                                Get l1 // { arity: 3 }
+                                    Get l2 // { arity: 2 }
+                                Get l1 // { arity: 3 }
                   Constant // { arity: 2 }
                     - (1450, 0)
       cte l2 =
+        Project (#1{person2id}, #2) // { arity: 2 }
+          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+      cte l1 =
         Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
           Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
             implementation
@@ -2596,59 +2570,32 @@ Explained Query:
                 ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
             ArrangeBy keys=[[#1, #0]] // { arity: 3 }
               Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-                Project (#0{person1id}..=#2{parentmessageid}) // { arity: 3 }
-                  Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
+                Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+                  Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                     implementation
-                      %0:l1 » %1[#0]UKA » %2[#0]UKA
-                      %1 » %2[#0]UKA » %0:l1[#3]K
-                      %2 » %1[#0]UKA » %0:l1[#3]K
-                    ArrangeBy keys=[[#3{containerforumid}]] // { arity: 4 }
-                      Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-                      Distinct project=[#0{containerforumid}] // { arity: 1 }
-                        Project (#3) // { arity: 1 }
-                          Filter (#3{containerforumid}) IS NOT NULL // { arity: 4 }
-                            Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
-                          Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                            ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-      cte l1 =
-        Project (#0{person1id}, #1{person2id}, #3{containerforumid}, #4) // { arity: 4 }
-          Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
-            implementation
-              %0:l0 » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:l0[#2]K
-              %2 » %1[#0]UKA » %0:l0[#2]K
-            ArrangeBy keys=[[#2{containerforumid}]] // { arity: 5 }
-              Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-              Distinct project=[#0{containerforumid}] // { arity: 1 }
-                Project (#2) // { arity: 1 }
-                  Filter (#2{containerforumid}) IS NOT NULL // { arity: 5 }
-                    Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                    ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+                      %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                      %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                      ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                    ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                      Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                        Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                      Project (#9, #10, #12) // { arity: 3 }
+                        Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    Get l0 // { arity: 1 }
+                    Get l0 // { arity: 1 }
       cte l0 =
-        Project (#1{person2id}, #2{containerforumid}, #5, #6, #8) // { arity: 5 }
-          Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
-            implementation
-              %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
-              %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
-              %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
-            ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-              Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
-              Project (#9, #10, #12) // { arity: 3 }
-                Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                  ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Distinct project=[#0{id}] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+                ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -2995,19 +2942,19 @@ Explained Query:
                   Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                     Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
-                        %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
+                        %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
                       ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                        Project (#1{person2id}, #2) // { arity: 2 }
-                          Filter (greatest(#1{person1id}, #2{person2id})) IS NOT NULL AND (least(#1{person1id}, #2{person2id})) IS NOT NULL // { arity: 3 }
-                            ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+                        Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                         Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                           Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                            Get l2 // { arity: 3 }
-                Project (#1{person2id}, #2) // { arity: 2 }
-                  ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-            Get l2 // { arity: 3 }
+                            Get l1 // { arity: 3 }
+                Get l2 // { arity: 2 }
+            Get l1 // { arity: 3 }
     cte l2 =
+      Project (#1{person2id}, #2) // { arity: 2 }
+        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+    cte l1 =
       Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
           implementation
@@ -3017,59 +2964,32 @@ Explained Query:
               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
             Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#0{person1id}..=#2{parentmessageid}) // { arity: 3 }
-                Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
+              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                   implementation
-                    %0:l1 » %1[#0]UKA » %2[#0]UKA
-                    %1 » %2[#0]UKA » %0:l1[#3]K
-                    %2 » %1[#0]UKA » %0:l1[#3]K
-                  ArrangeBy keys=[[#3{containerforumid}]] // { arity: 4 }
-                    Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-                    Distinct project=[#0{containerforumid}] // { arity: 1 }
-                      Project (#3) // { arity: 1 }
-                        Filter (#3{containerforumid}) IS NOT NULL // { arity: 4 }
-                          Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                    Distinct project=[#0{id}] // { arity: 1 }
-                      Project (#1) // { arity: 1 }
-                        Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                          ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-    cte l1 =
-      Project (#0{person1id}, #1{person2id}, #3{containerforumid}, #4) // { arity: 4 }
-        Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
-          implementation
-            %0:l0 » %1[#0]UKA » %2[#0]UKA
-            %1 » %2[#0]UKA » %0:l0[#2]K
-            %2 » %1[#0]UKA » %0:l0[#2]K
-          ArrangeBy keys=[[#2{containerforumid}]] // { arity: 5 }
-            Get l0 // { arity: 5 }
-          ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-            Distinct project=[#0{containerforumid}] // { arity: 1 }
-              Project (#2) // { arity: 1 }
-                Filter (#2{containerforumid}) IS NOT NULL // { arity: 5 }
-                  Get l0 // { arity: 5 }
-          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-            Distinct project=[#0{id}] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                  ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+                    %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                      Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                    Project (#9, #10, #12) // { arity: 3 }
+                      Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  Get l0 // { arity: 1 }
+                  Get l0 // { arity: 1 }
     cte l0 =
-      Project (#1{person2id}, #2{containerforumid}, #5, #6, #8) // { arity: 5 }
-        Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
-          implementation
-            %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
-            %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
-            %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
-          ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-          ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-            Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-          ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
-            Project (#9, #10, #12) // { arity: 3 }
-              Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+        Distinct project=[#0{id}] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+              ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3217,13 +3137,12 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
-                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                      implementation
-                        %1:tag[#0]KAe » %0:l1[#2]KAe
-                      Get l1 // { arity: 3 }
-                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                        ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                    implementation
+                      %1:tag[#0]KAe » %0:l1[#2]KAe
+                    Get l1 // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
       cte l5 =
         Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
@@ -3257,13 +3176,12 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
-                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                      implementation
-                        %1:tag[#0]KAe » %0:l1[#2]KAe
-                      Get l1 // { arity: 3 }
-                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                        ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                    implementation
+                      %1:tag[#0]KAe » %0:l1[#2]KAe
+                    Get l1 // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
       cte l2 =
         ArrangeBy keys=[[#1{name}]] // { arity: 4 }
           ReadIndex on=tag tag_name=[lookup] // { arity: 4 }
@@ -3491,19 +3409,18 @@ Explained Query:
       cte l0 =
         ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
           Project (#0{personid}, #9) // { arity: 2 }
-            Filter (#1{tagid}) IS NOT NULL // { arity: 10 }
-              Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
-                implementation
-                  %0:person_hasinterest_tag » %1:tag[#0]KAe » %2:person_knows_person[#1]KA
-                  %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
-                  %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
-                ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                  Project (#1{tagid}, #2) // { arity: 2 }
-                    ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
-                ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                  ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
-                ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
-                  ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
+            Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
+              implementation
+                %0:person_hasinterest_tag » %1:tag[#0]KAe » %2:person_knows_person[#1]KA
+                %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
+                %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
+              ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
+                Project (#1{tagid}, #2) // { arity: 2 }
+                  ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
+              ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
+                ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -3667,18 +3584,12 @@ Explained Query:
     With
       cte l1 =
         Project (#0{id}..=#2{min}) // { arity: 3 }
-          Join on=(#1{id} = #3{id} = #4{id}) type=delta // { arity: 5 }
+          Join on=(#1{id} = #3{id}) type=differential // { arity: 4 }
             implementation
-              %0:l0 » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:l0[#1]K
-              %2 » %1[#0]UKA » %0:l0[#1]K
+              %1[#0]UKA » %0:l0[#1]K
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                    Get l0 // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                Get l0 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
@@ -4200,7 +4111,7 @@ Explained Query:
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
@@ -4307,7 +4218,7 @@ Explained Query:
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
@@ -4417,7 +4328,7 @@ Explained Query:
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
@@ -4745,7 +4656,7 @@ Explained Query:
               - (10995116285979)
       cte l0 =
         Project (#1) // { arity: 1 }
-          Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+          Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
             Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
               implementation
                 %1:company[#0]KAef » %0:person_workat_company[#2]KAef

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -1960,14 +1960,15 @@ Explained Query:
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
-                        implementation
-                          %1[#0]UKA » %0:l0[#1]KA
-                        Get l0 // { arity: 11 }
-                        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                          Distinct project=[#0{id}] // { arity: 1 }
-                            Project (#0{id}) // { arity: 1 }
-                              Get l1 // { arity: 2 }
+                      Filter (#1{id}) IS NOT NULL // { arity: 12 }
+                        Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
+                          implementation
+                            %1[#0]UKA » %0:l0[#1]KA
+                          Get l0 // { arity: 11 }
+                          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                            Distinct project=[#0{id}] // { arity: 1 }
+                              Project (#0{id}) // { arity: 1 }
+                                Get l1 // { arity: 2 }
                   Project (#1) // { arity: 1 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
               Get l1 // { arity: 2 }
@@ -2545,9 +2546,9 @@ Explained Query:
     Return // { arity: 3 }
       Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
         Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
-          Get l4 // { arity: 3 }
+          Get l3 // { arity: 3 }
     With Mutually Recursive
-      cte l4 =
+      cte l3 =
         Project (#2{min}, #0, #1{person2id}) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
@@ -2557,10 +2558,10 @@ Explained Query:
                     Map ((#1 + #4)) // { arity: 6 }
                       Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
                         implementation
-                          %0:l4[#0]UK » %1[#0]K
+                          %0:l3[#0]UK » %1[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
-                            Get l4 // { arity: 3 }
+                            Get l3 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
                             Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
@@ -2571,20 +2572,20 @@ Explained Query:
                                       Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
-                                            %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
+                                            %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
                                           ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                                            Get l3 // { arity: 2 }
+                                            Project (#1{person2id}, #2) // { arity: 2 }
+                                              Filter (greatest(#1{person1id}, #2{person2id})) IS NOT NULL AND (least(#1{person1id}, #2{person2id})) IS NOT NULL // { arity: 3 }
+                                                ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                                             Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                                               Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                                 Get l2 // { arity: 3 }
-                                    Get l3 // { arity: 2 }
+                                    Project (#1{person2id}, #2) // { arity: 2 }
+                                      ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                                 Get l2 // { arity: 3 }
                   Constant // { arity: 2 }
                     - (1450, 0)
-      cte l3 =
-        Project (#1{person2id}, #2) // { arity: 2 }
-          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
       cte l2 =
         Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
           Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
@@ -2771,168 +2772,168 @@ Explained Query:
       Project (#1) // { arity: 1 }
         Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l18 // { arity: 1 }
+            Get l17 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l18 // { arity: 1 }
+                    Get l17 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
     With
-      cte l18 =
+      cte l17 =
         Reduce aggregates=[min(#0{min})] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
                 Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
                   implementation
-                    %0:l17[#1]Kef » %1:l17[#1]Kef
+                    %0:l16[#1]Kef » %1:l16[#1]Kef
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
-                        Get l17 // { arity: 4 }
+                        Get l16 // { arity: 4 }
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
-                        Get l17 // { arity: 4 }
-      cte l17 =
+                        Get l16 // { arity: 4 }
+      cte l16 =
         Project (#0..=#3) // { arity: 4 }
           Join on=(#4 = #5{max}) type=differential // { arity: 6 }
             implementation
-              %1[#0]UK » %0:l16[#4]K
+              %1[#0]UK » %0:l15[#4]K
             ArrangeBy keys=[[#4]] // { arity: 5 }
               Project (#0..=#3, #5) // { arity: 5 }
                 Filter (#5) IS NOT NULL // { arity: 6 }
-                  Get l16 // { arity: 6 }
+                  Get l15 // { arity: 6 }
             ArrangeBy keys=[[#0{max}]] // { arity: 1 }
               Filter (#0{max}) IS NOT NULL // { arity: 1 }
                 Reduce aggregates=[max(#0)] // { arity: 1 }
                   Project (#5) // { arity: 1 }
-                    Get l16 // { arity: 6 }
+                    Get l15 // { arity: 6 }
   With Mutually Recursive
-    cte l16 =
+    cte l15 =
       Distinct project=[#0..=#5] // { arity: 6 }
         Union // { arity: 6 }
           Project (#1, #0, #0, #2..=#4) // { arity: 6 }
             Map (0, false, 0) // { arity: 5 }
               Union // { arity: 2 }
                 Map (1450, false) // { arity: 2 }
-                  Get l15 // { arity: 0 }
+                  Get l14 // { arity: 0 }
                 Map (15393162796819, true) // { arity: 2 }
-                  Get l15 // { arity: 0 }
+                  Get l14 // { arity: 0 }
           Project (#0..=#3, #7, #8) // { arity: 6 }
             Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
               CrossJoin type=delta // { arity: 7 }
                 implementation
-                  %0:l12 » %1[×]U » %2[×]U
-                  %1 » %2[×]U » %0:l12[×]
-                  %2 » %1[×]U » %0:l12[×]
+                  %0:l11 » %1[×]U » %2[×]U
+                  %1 » %2[×]U » %0:l11[×]
+                  %2 » %1[×]U » %0:l11[×]
                 ArrangeBy keys=[[]] // { arity: 5 }
-                  Get l12 // { arity: 5 }
+                  Get l11 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   TopK limit=1 // { arity: 1 }
                     Project (#4) // { arity: 1 }
-                      Get l9 // { arity: 5 }
+                      Get l8 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   Union // { arity: 1 }
-                    Get l14 // { arity: 1 }
+                    Get l13 // { arity: 1 }
                     Map (null) // { arity: 1 }
                       Union // { arity: 0 }
                         Negate // { arity: 0 }
                           Project () // { arity: 0 }
-                            Get l14 // { arity: 1 }
+                            Get l13 // { arity: 1 }
                         Constant // { arity: 0 }
                           - ()
-    cte l15 =
+    cte l14 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
-            Get l8 // { arity: 2 }
-    cte l14 =
+            Get l7 // { arity: 2 }
+    cte l13 =
       Project (#1) // { arity: 1 }
         Map ((#0{min} / 2)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l13 // { arity: 1 }
+            Get l12 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l13 // { arity: 1 }
+                    Get l12 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-    cte l13 =
+    cte l12 =
       Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
         Project (#1, #3) // { arity: 2 }
           Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %0:l12[#0]Kef » %1:l12[#0]Kef
+              %0:l11[#0]Kef » %1:l11[#0]Kef
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = false) // { arity: 5 }
-                  Get l12 // { arity: 5 }
+                  Get l11 // { arity: 5 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = true) // { arity: 5 }
-                  Get l12 // { arity: 5 }
-    cte l12 =
+                  Get l11 // { arity: 5 }
+    cte l11 =
       TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
           Project (#3, #4, #1, #7, #8) // { arity: 5 }
             Map ((#6 + #2), false) // { arity: 9 }
               Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
                 implementation
-                  %0:l4[#0]K » %1:l9[#2]K
+                  %0:l3[#0]K » %1:l8[#2]K
                 ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                  Get l4 // { arity: 3 }
+                  Get l3 // { arity: 3 }
                 ArrangeBy keys=[[#2]] // { arity: 4 }
                   Project (#0..=#3) // { arity: 4 }
-                    Get l9 // { arity: 5 }
+                    Get l8 // { arity: 5 }
           Project (#0..=#3, #9) // { arity: 5 }
             Map ((#4 OR #8)) // { arity: 10 }
               Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
                 implementation
-                  %0:l16[#0..=#2]KKK » %1[#0..=#2]KKK
+                  %0:l15[#0..=#2]KKK » %1[#0..=#2]KKK
                 ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                   Project (#0..=#4) // { arity: 5 }
-                    Get l16 // { arity: 6 }
+                    Get l15 // { arity: 6 }
                 ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                   Union // { arity: 4 }
                     Map (true) // { arity: 4 }
-                      Get l11 // { arity: 3 }
+                      Get l10 // { arity: 3 }
                     Project (#0..=#2, #6) // { arity: 4 }
                       Map (false) // { arity: 7 }
                         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                           implementation
-                            %1:l10[#0..=#2]UKKK » %0[#0..=#2]KKK
+                            %1:l9[#0..=#2]UKKK » %0[#0..=#2]KKK
                           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                             Union // { arity: 3 }
                               Negate // { arity: 3 }
-                                Get l11 // { arity: 3 }
-                              Get l10 // { arity: 3 }
+                                Get l10 // { arity: 3 }
+                              Get l9 // { arity: 3 }
                           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                            Get l10 // { arity: 3 }
-    cte l11 =
+                            Get l9 // { arity: 3 }
+    cte l10 =
       Project (#0..=#2) // { arity: 3 }
         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
           implementation
-            %1[#0..=#2]UKKKA » %0:l10[#0..=#2]UKKK
+            %1[#0..=#2]UKKKA » %0:l9[#0..=#2]UKKK
           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Get l10 // { arity: 3 }
+            Get l9 // { arity: 3 }
           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
             Distinct project=[#0..=#2] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
-                Get l9 // { arity: 5 }
-    cte l10 =
+                Get l8 // { arity: 5 }
+    cte l9 =
       Distinct project=[#0..=#2] // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Get l16 // { arity: 6 }
-    cte l9 =
+          Get l15 // { arity: 6 }
+    cte l8 =
       TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
         Project (#0..=#3, #5) // { arity: 5 }
           Filter (#4 = false) // { arity: 6 }
-            Get l16 // { arity: 6 }
-    cte l8 =
+            Get l15 // { arity: 6 }
+    cte l7 =
       Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
           Distinct project=[#0{person2id}, #1] // { arity: 2 }
@@ -2940,51 +2941,51 @@ Explained Query:
               Project (#1, #0{person2id}) // { arity: 2 }
                 CrossJoin type=differential // { arity: 2 }
                   implementation
-                    %0:l5[×] » %1[×]
+                    %0:l4[×] » %1[×]
                   ArrangeBy keys=[[]] // { arity: 2 }
-                    Get l5 // { arity: 2 }
+                    Get l4 // { arity: 2 }
                   ArrangeBy keys=[[]] // { arity: 0 }
                     Union // { arity: 0 }
                       Negate // { arity: 0 }
-                        Get l7 // { arity: 0 }
+                        Get l6 // { arity: 0 }
                       Constant // { arity: 0 }
                         - ()
               Project (#1, #0) // { arity: 2 }
                 Map (true, -1) // { arity: 2 }
-                  Get l7 // { arity: 0 }
+                  Get l6 // { arity: 0 }
           Constant // { arity: 2 }
             - (1450, true)
             - (15393162796819, false)
-    cte l7 =
+    cte l6 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
             implementation
-              %0:l6[#0]Kf » %1:l6[#0]Kf
+              %0:l5[#0]Kf » %1:l5[#0]Kf
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0{person2id}) // { arity: 1 }
                 Filter #1 // { arity: 2 }
-                  Get l6 // { arity: 2 }
+                  Get l5 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0{person2id}) // { arity: 1 }
                 Filter NOT(#1) // { arity: 2 }
-                  Get l6 // { arity: 2 }
-    cte l6 =
+                  Get l5 // { arity: 2 }
+    cte l5 =
       Union // { arity: 2 }
         Project (#1, #0{person2id}) // { arity: 2 }
-          Get l5 // { arity: 2 }
-        Get l8 // { arity: 2 }
-    cte l5 =
+          Get l4 // { arity: 2 }
+        Get l7 // { arity: 2 }
+    cte l4 =
       Project (#1{person2id}, #3) // { arity: 2 }
         Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
-            %0:l8[#0]K » %1:l4[#0]K
+            %0:l7[#0]K » %1:l3[#0]K
           ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-            Get l8 // { arity: 2 }
+            Get l7 // { arity: 2 }
           ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
             Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-              Get l4 // { arity: 3 }
-    cte l4 =
+              Get l3 // { arity: 3 }
+    cte l3 =
       Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
         Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
           Union // { arity: 3 }
@@ -2994,18 +2995,18 @@ Explained Query:
                   Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                     Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
-                        %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
+                        %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
                       ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                        Get l3 // { arity: 2 }
+                        Project (#1{person2id}, #2) // { arity: 2 }
+                          Filter (greatest(#1{person1id}, #2{person2id})) IS NOT NULL AND (least(#1{person1id}, #2{person2id})) IS NOT NULL // { arity: 3 }
+                            ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                         Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                           Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                             Get l2 // { arity: 3 }
-                Get l3 // { arity: 2 }
+                Project (#1{person2id}, #2) // { arity: 2 }
+                  ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
             Get l2 // { arity: 3 }
-    cte l3 =
-      Project (#1{person2id}, #2) // { arity: 2 }
-        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
     cte l2 =
       Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -566,14 +566,13 @@ Explained Query:
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#5, #6) // { arity: 2 }
-          Filter (#0{id}) IS NOT NULL // { arity: 9 }
-            Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
-              implementation
-                %0:tagclass[#0]KAe » %1:tag[#3]KAe
-              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("ChristianBishop")] // { arity: 5 }
-              ArrangeBy keys=[[#3{typetagclassid}]] // { arity: 4 }
-                ReadIndex on=tag tag_typetagclassid=[differential join] // { arity: 4 }
+          Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
+            implementation
+              %0:tagclass[#0]KAe » %1:tag[#3]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("ChristianBishop")] // { arity: 5 }
+            ArrangeBy keys=[[#3{typetagclassid}]] // { arity: 4 }
+              ReadIndex on=tag tag_typetagclassid=[differential join] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.tag_typetagclassid (differential join)
@@ -625,7 +624,7 @@ Explained Query:
   Finish order_by=[#4{count} desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
     Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
       Project (#10, #13, #15, #16) // { arity: 4 }
-        Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#25{locationcityid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
+        Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
           Join on=(#1{messageid} = #36{messageid} AND #10{containerforumid} = #14{id} AND #16{moderatorpersonid} = #18{id} AND #25{locationcityid} = #28{id} AND #31{partofcountryid} = #32{id}) type=delta // { arity: 37 }
             implementation
               %0:message » %5[#0]UKA » %1:forum[#1]KA » %2:person[#1]KA » %3:city[#0]KA » %4:country[#0]KAef
@@ -647,18 +646,17 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#10) // { arity: 1 }
-                  Filter (#0{id}) IS NOT NULL AND (#5{id}) IS NOT NULL // { arity: 12 }
-                    Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
-                      implementation
-                        %0:tagclass » %1:tag[#3]KA » %2:message_hastag_tag[#2]KA
-                        %1:tag » %0:tagclass[#0]KAe » %2:message_hastag_tag[#2]KA
-                        %2:message_hastag_tag » %1:tag[#0]KA » %0:tagclass[#0]KAe
-                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                        ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Philosopher")] // { arity: 5 }
-                      ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
-                        ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                      ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                        ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+                  Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
+                    implementation
+                      %0:tagclass » %1:tag[#3]KA » %2:message_hastag_tag[#2]KA
+                      %1:tag » %0:tagclass[#0]KAe » %2:message_hastag_tag[#2]KA
+                      %2:message_hastag_tag » %1:tag[#0]KA » %0:tagclass[#0]KAe
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Philosopher")] // { arity: 5 }
+                    ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
+                      ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
+                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -770,20 +768,14 @@ Explained Query:
     With
       cte l3 =
         Project (#0{creationdate}..=#3{lastname}, #5) // { arity: 5 }
-          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{containerforumid} = #18{id}) type=delta // { arity: 19 }
+          Join on=(#1{id} = #13{creatorpersonid} AND #14{containerforumid} = #17{id}) type=delta // { arity: 18 }
             implementation
-              %0:l2 » %1:message[#9]KA » %2[#0]UKA » %3[#0]UKA
-              %1:message » %2[#0]UKA » %3[#0]UKA » %0:l2[#1]K
-              %2 » %3[#0]UKA » %1:message[#10]KA » %0:l2[#1]K
-              %3 » %2[#0]UKA » %1:message[#10]KA » %0:l2[#1]K
+              %0:l2 » %1:message[#9]KA » %2[#0]UKA
+              %1:message » %2[#0]UKA » %0:l2[#1]K
+              %2 » %1:message[#10]KA » %0:l2[#1]K
             Get l2 // { arity: 4 }
             ArrangeBy keys=[[#9{creatorpersonid}], [#10{containerforumid}]] // { arity: 13 }
               ReadIndex on=message message_containerforumid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-              Distinct project=[#0{containerforumid}] // { arity: 1 }
-                Project (#10) // { arity: 1 }
-                  Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
-                    ReadIndex on=message message_creatorpersonid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
                 Get l0 // { arity: 1 }
@@ -792,18 +784,11 @@ Explained Query:
           Get l1 // { arity: 4 }
       cte l1 =
         Project (#0{creationdate}..=#3{lastname}) // { arity: 4 }
-          Join on=(#1{id} = #11{id} = #12{personid}) type=delta // { arity: 13 }
+          Join on=(#1{id} = #11{personid}) type=differential // { arity: 12 }
             implementation
-              %0:person » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:person[#1]KA
-              %2 » %1[#0]UKA » %0:person[#1]KA
+              %1[#0]UKA » %0:person[#1]KA
             ArrangeBy keys=[[#1{id}]] // { arity: 11 }
-              ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1{id}) IS NOT NULL // { arity: 11 }
-                    ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
+              ReadIndex on=person person_id=[differential join] // { arity: 11 }
             ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
               Distinct project=[#0{personid}] // { arity: 1 }
                 Project (#3) // { arity: 1 }
@@ -822,10 +807,10 @@ Explained Query:
                 ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.person_id (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.person_id (differential join)
   - materialize.public.forum_hasmember_person_forumid (differential join)
   - materialize.public.message_containerforumid (delta join lookup)
-  - materialize.public.message_creatorpersonid (*** full scan ***, delta join lookup)
+  - materialize.public.message_creatorpersonid (delta join lookup)
   - materialize.public.top100popularforumsq04_id (*** full scan ***)
 
 Target cluster: quickstart
@@ -917,18 +902,17 @@ Explained Query:
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
       cte l0 =
         Project (#1{messageid}, #5, #16) // { arity: 3 }
-          Filter (#0{id}) IS NOT NULL // { arity: 20 }
-            Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-              implementation
-                %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-                %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
-                %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
+            implementation
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join 1st input (full scan))
@@ -1048,18 +1032,17 @@ Explained Query:
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#6, #17) // { arity: 2 }
-          Filter (#0{id}) IS NOT NULL // { arity: 21 }
-            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-              implementation
-                %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-                %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
-                %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
+            implementation
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1155,18 +1138,17 @@ Explained Query:
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#6, #17) // { arity: 2 }
-          Filter (#0{id}) IS NOT NULL // { arity: 21 }
-            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
-              implementation
-                %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-                %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
-                %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
+            implementation
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -1267,18 +1249,17 @@ Explained Query:
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l0 =
         Project (#1{messageid}, #5, #16) // { arity: 3 }
-          Filter (#0{id}) IS NOT NULL // { arity: 20 }
-            Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
-              implementation
-                %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
-                %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
-                %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
+          Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
+            implementation
+              %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
+              %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
+              %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join 1st input (full scan))
@@ -1355,31 +1336,29 @@ Explained Query:
             Get l1 // { arity: 2 }
       cte l1 =
         Project (#2, #18) // { arity: 2 }
-          Filter (#0{messageid}) IS NOT NULL AND (#16{tagid}) IS NOT NULL // { arity: 21 }
-            Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
-              implementation
-                %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
-                %1:message » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
-                %2:message_hastag_tag » %1:message[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
-                %3:tag » %2:message_hastag_tag[#2]KA » %1:message[#1]KA » %0:l0[#0]K
-              ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-                Get l0 // { arity: 1 }
-              ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
-                ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
+          Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
+            implementation
+              %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
+              %1:message » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
+              %2:message_hastag_tag » %1:message[#1]KA » %3:tag[#0]KA » %0:l0[#0]K
+              %3:tag » %2:message_hastag_tag[#2]KA » %1:message[#1]KA » %0:l0[#0]K
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Get l0 // { arity: 1 }
+            ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
+              ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
       cte l0 =
         Project (#1) // { arity: 1 }
-          Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
-            Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-              implementation
-                %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
-              ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
+          Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+            implementation
+              %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
+            ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+              ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
 
 Used Indexes:
   - materialize.public.tag_id (delta join lookup)
@@ -1536,7 +1515,7 @@ Explained Query:
       cte l3 =
         Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
           Project (#17) // { arity: 1 }
-            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) AND (#0{id}) IS NOT NULL AND (#17{creatorpersonid}) IS NOT NULL // { arity: 32 }
+            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) // { arity: 32 }
               Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
                 implementation
                   %0:l1 » %1:message_hastag_tag[#2]KA » %2:message[#1]KAiif » %3:l0[#1]KA
@@ -1551,17 +1530,16 @@ Explained Query:
                 Get l0 // { arity: 11 }
       cte l2 =
         Project (#1) // { arity: 1 }
-          Filter (#1{id}) IS NOT NULL AND (#12{tagid}) IS NOT NULL // { arity: 18 }
-            Join on=(#1{id} = #11{personid} AND #12{tagid} = #13{id}) type=delta // { arity: 18 }
-              implementation
-                %0:l0 » %1:person_hasinterest_tag[#0]K » %2:l1[#0]KAe
-                %1:person_hasinterest_tag » %2:l1[#0]KAe » %0:l0[#1]KA
-                %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
-              Get l0 // { arity: 11 }
-              ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                Project (#1{tagid}, #2) // { arity: 2 }
-                  ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
-              Get l1 // { arity: 5 }
+          Join on=(#1{id} = #11{personid} AND #12{tagid} = #13{id}) type=delta // { arity: 18 }
+            implementation
+              %0:l0 » %1:person_hasinterest_tag[#0]K » %2:l1[#0]KAe
+              %1:person_hasinterest_tag » %2:l1[#0]KAe » %0:l0[#1]KA
+              %2:l1 » %1:person_hasinterest_tag[#1]KA » %0:l0[#1]KA
+            Get l0 // { arity: 11 }
+            ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
+              Project (#1{tagid}, #2) // { arity: 2 }
+                ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
+            Get l1 // { arity: 5 }
       cte l1 =
         ArrangeBy keys=[[#0{id}]] // { arity: 5 }
           ReadIndex on=materialize.public.tag tag_name=[lookup value=("Abbas_I_of_Persia")] // { arity: 5 }
@@ -1612,7 +1590,7 @@ Explained Query:
   Finish order_by=[#4{sum_count} desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Reduce group_by=[#0{id}..=#2{lastname}] aggregates=[count(*), sum(#3{count})] // { arity: 5 }
       Project (#1{firstname}..=#3{count}, #25) // { arity: 4 }
-        Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 26 }
+        Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) // { arity: 26 }
           Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
             implementation
               %0:person » %1:message[#9]KAniif » %2[#0]UKA
@@ -1723,71 +1701,69 @@ Explained Query:
     Return // { arity: 3 }
       Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
         Project (#0{person2id}, #9) // { arity: 2 }
-          Filter (#7{tagid}) IS NOT NULL // { arity: 12 }
-            Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
-              implementation
-                %0 » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
-                %1 » %0[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
-                %2 » %0[#0]UKA » %1[#0]UKA » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
-                %3 » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-                %4:message_hastag_tag » %3[#0]UKA » %5:tag[#0]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-                %5:tag » %4:message_hastag_tag[#2]KA » %3[#0]UKA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
-              ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-                Distinct project=[#0{person2id}] // { arity: 1 }
-                  Threshold // { arity: 1 }
-                    Union // { arity: 1 }
-                      Distinct project=[#0{person2id}] // { arity: 1 }
-                        Project (#6) // { arity: 1 }
-                          Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=delta // { arity: 7 }
-                            implementation
-                              %0:l2 » %1:person_knows_person[#1]KA » %2:l0[#1]KA
-                              %1:person_knows_person » %0:l2[#0]UKA » %2:l0[#1]KA
-                              %2:l0 » %1:person_knows_person[#2]KA » %0:l2[#0]UKA
-                            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
-                              Get l2 // { arity: 1 }
-                            ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-                              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-                            Get l0 // { arity: 3 }
-                      Negate // { arity: 1 }
-                        Get l2 // { arity: 1 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                Distinct project=[#0{id}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#8{locationcityid}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
-                      Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
-                        implementation
-                          %0:person » %1:city[#0]KA » %2:country[#0]KAef
-                          %1:city » %2:country[#0]KAef » %0:person[#8]KA
-                          %2:country » %1:city[#3]KA » %0:person[#8]KA
-                        ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
-                          ReadIndex on=person person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
-                        ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
-                          ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                          ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
-                Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
-                  Project (#1{creatorpersonid}, #9) // { arity: 2 }
-                    ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-              ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
-                Distinct project=[#0{messageid}] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Filter (#2{tagid}) IS NOT NULL AND (#6{typetagclassid}) IS NOT NULL // { arity: 12 }
-                      Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
-                        implementation
-                          %0:message_hastag_tag » %1:tag[#0]KA » %2:tagclass[#0]KAe
-                          %1:tag » %2:tagclass[#0]KAe » %0:message_hastag_tag[#2]KA
-                          %2:tagclass » %1:tag[#3]KA » %0:message_hastag_tag[#2]KA
-                        ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
-                          ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join 1st input (full scan)] // { arity: 3 }
-                        ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
-                          ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                        ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                          ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Thing")] // { arity: 5 }
-              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
-                ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
-                ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
+          Join on=(#0{person2id} = #1{id} = #2{creatorpersonid} AND #3{messageid} = #4{messageid} = #6{messageid} AND #7{tagid} = #8{id}) type=delta // { arity: 12 }
+            implementation
+              %0 » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
+              %1 » %0[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
+              %2 » %0[#0]UKA » %1[#0]UKA » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
+              %3 » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+              %4:message_hastag_tag » %3[#0]UKA » %5:tag[#0]KA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+              %5:tag » %4:message_hastag_tag[#2]KA » %3[#0]UKA » %2[#1]K » %0[#0]UKA » %1[#0]UKA
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+              Distinct project=[#0{person2id}] // { arity: 1 }
+                Threshold // { arity: 1 }
+                  Union // { arity: 1 }
+                    Distinct project=[#0{person2id}] // { arity: 1 }
+                      Project (#6) // { arity: 1 }
+                        Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=delta // { arity: 7 }
+                          implementation
+                            %0:l2 » %1:person_knows_person[#1]KA » %2:l0[#1]KA
+                            %1:person_knows_person » %0:l2[#0]UKA » %2:l0[#1]KA
+                            %2:l0 » %1:person_knows_person[#2]KA » %0:l2[#0]UKA
+                          ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                            Get l2 // { arity: 1 }
+                          ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                          Get l0 // { arity: 3 }
+                    Negate // { arity: 1 }
+                      Get l2 // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
+                    Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
+                      implementation
+                        %0:person » %1:city[#0]KA » %2:country[#0]KAef
+                        %1:city » %2:country[#0]KAef » %0:person[#8]KA
+                        %2:country » %1:city[#3]KA » %0:person[#8]KA
+                      ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
+                        ReadIndex on=person person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
+                      ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
+                        ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+                        ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
+            ArrangeBy keys=[[#0{creatorpersonid}], [#1{messageid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
+                Project (#1{creatorpersonid}, #9) // { arity: 2 }
+                  ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
+                    implementation
+                      %0:message_hastag_tag » %1:tag[#0]KA » %2:tagclass[#0]KAe
+                      %1:tag » %2:tagclass[#0]KAe » %0:message_hastag_tag[#2]KA
+                      %2:tagclass » %1:tag[#3]KA » %0:message_hastag_tag[#2]KA
+                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
+                      ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join 1st input (full scan)] // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
+                      ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Thing")] // { arity: 5 }
+            ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
+              ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
+              ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
     With
       cte l2 =
         Distinct project=[#0{person2id}] // { arity: 1 }
@@ -1892,7 +1868,7 @@ Explained Query:
         Get l0 // { arity: 2 }
     cte l0 =
       Project (#1{person2id}, #21) // { arity: 2 }
-        Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#1{id}) IS NOT NULL AND (#8{locationcityid}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
+        Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
           Join on=(#1{id} = #20{person1id} AND #8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 22 }
             implementation
               %0:person » %3:person_knows_person[#1]KAiif » %1:city[#0]KA » %2:country[#0]KAef
@@ -1967,22 +1943,21 @@ Explained Query:
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Filter (#1{id}) IS NOT NULL // { arity: 12 }
-                        Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
-                          implementation
-                            %1[#0]UKA » %0:l0[#1]KA
-                          Get l0 // { arity: 11 }
-                          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                            Distinct project=[#0{id}] // { arity: 1 }
-                              Project (#0{id}) // { arity: 1 }
-                                Get l1 // { arity: 2 }
+                      Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
+                        implementation
+                          %1[#0]UKA » %0:l0[#1]KA
+                        Get l0 // { arity: 11 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                          Distinct project=[#0{id}] // { arity: 1 }
+                            Project (#0{id}) // { arity: 1 }
+                              Get l1 // { arity: 2 }
                   Project (#1) // { arity: 1 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
               Get l1 // { arity: 2 }
     With
       cte l1 =
         Project (#1{messageid}, #12) // { arity: 2 }
-          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#1{id}) IS NOT NULL AND (#15{content}) IS NOT NULL // { arity: 25 }
+          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#15{content}) IS NOT NULL // { arity: 25 }
             Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
               implementation
                 %1:message[#9]KAeiif » %0:l0[#1]KAeiif
@@ -2178,7 +2153,7 @@ Explained Query:
             Get l5 // { arity: 2 }
       cte l5 =
         Project (#1{creatorpersonid}, #23) // { arity: 2 }
-          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 28 }
+          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) // { arity: 28 }
             Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
                 %0:person » %1:person_likes_message[#1]KA » %2:message[#1]KA » %3:l4[#0]K
@@ -2235,7 +2210,7 @@ Explained Query:
                 ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
       cte l0 =
         Project (#0{id}, #2{partofcontinentid}..=#6{creationdate}, #8{firstname}..=#15{email}, #17, #18) // { arity: 16 }
-          Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL AND (#4{id}) IS NOT NULL // { arity: 19 }
+          Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL // { arity: 19 }
             Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
               implementation
                 %0:country » %1:city[#3]KA » %2:person[#8]KAif
@@ -2415,13 +2390,12 @@ Explained Query:
             ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
               Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
                 Project (#9, #22) // { arity: 2 }
-                  Filter (#1{messageid}) IS NOT NULL // { arity: 26 }
-                    Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
-                      implementation
-                        %0:l6[#1]KA » %1:message[#12]KA
-                      Get l6 // { arity: 13 }
-                      ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
-                        ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
+                  Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
+                    implementation
+                      %0:l6[#1]KA » %1:message[#12]KA
+                    Get l6 // { arity: 13 }
+                    ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
+                      ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
       cte l6 =
         ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
           ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
@@ -2440,7 +2414,7 @@ Explained Query:
                 Get l3 // { arity: 4 }
       cte l3 =
         Project (#4, #5, #9, #21) // { arity: 4 }
-          Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#4{id}) IS NOT NULL AND (#9{id}) IS NOT NULL AND (#21{person2id}) IS NOT NULL AND (#30{locationcityid}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
+          Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
             Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid} AND #9{id} = #20{person1id} AND #21{person2id} = #23{id} AND #30{locationcityid} = #33{id} AND #36{partofcountryid} = #37{id}) type=delta // { arity: 41 }
               implementation
                 %0:l0 » %1:l1[#3]KA » %2:l2[#8]KA » %3:person_knows_person[#1]KA » %4:l2[#1]KA » %5:l1[#0]KA » %6:l0[#0]KAef
@@ -2579,21 +2553,21 @@ Explained Query:
                                       Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
-                                            %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
+                                            %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
                                           ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                                            Project (#1{person2id}, #2) // { arity: 2 }
-                                              Filter (greatest(#1{person1id}, #2{person2id})) IS NOT NULL AND (least(#1{person1id}, #2{person2id})) IS NOT NULL // { arity: 3 }
-                                                ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+                                            Get l2 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                                             Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                                               Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                                                Get l2 // { arity: 3 }
-                                    Project (#1{person2id}, #2) // { arity: 2 }
-                                      ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-                                Get l2 // { arity: 3 }
+                                                Get l1 // { arity: 3 }
+                                    Get l2 // { arity: 2 }
+                                Get l1 // { arity: 3 }
                   Constant // { arity: 2 }
                     - (1450, 0)
       cte l2 =
+        Project (#1{person2id}, #2) // { arity: 2 }
+          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+      cte l1 =
         Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
           Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
             implementation
@@ -2603,59 +2577,32 @@ Explained Query:
                 ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
             ArrangeBy keys=[[#1, #0]] // { arity: 3 }
               Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-                Project (#0{person1id}..=#2{parentmessageid}) // { arity: 3 }
-                  Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
+                Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+                  Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                     implementation
-                      %0:l1 » %1[#0]UKA » %2[#0]UKA
-                      %1 » %2[#0]UKA » %0:l1[#3]K
-                      %2 » %1[#0]UKA » %0:l1[#3]K
-                    ArrangeBy keys=[[#3{containerforumid}]] // { arity: 4 }
-                      Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-                      Distinct project=[#0{containerforumid}] // { arity: 1 }
-                        Project (#3) // { arity: 1 }
-                          Filter (#3{containerforumid}) IS NOT NULL // { arity: 4 }
-                            Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                      Distinct project=[#0{id}] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
-                          Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                            ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-      cte l1 =
-        Project (#0{person1id}, #1{person2id}, #3{containerforumid}, #4) // { arity: 4 }
-          Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
-            implementation
-              %0:l0 » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:l0[#2]K
-              %2 » %1[#0]UKA » %0:l0[#2]K
-            ArrangeBy keys=[[#2{containerforumid}]] // { arity: 5 }
-              Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-              Distinct project=[#0{containerforumid}] // { arity: 1 }
-                Project (#2) // { arity: 1 }
-                  Filter (#2{containerforumid}) IS NOT NULL // { arity: 5 }
-                    Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                    ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+                      %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                      %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                      %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                      ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                    ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                      Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                        Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                      Project (#9, #10, #12) // { arity: 3 }
+                        Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                          ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                    Get l0 // { arity: 1 }
+                    Get l0 // { arity: 1 }
       cte l0 =
-        Project (#1{person2id}, #2{containerforumid}, #5, #6, #8) // { arity: 5 }
-          Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
-            implementation
-              %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
-              %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
-              %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
-            ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-              ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-            ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-              Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-                ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
-              Project (#9, #10, #12) // { arity: 3 }
-                Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                  ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Distinct project=[#0{id}] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+                ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3002,19 +2949,19 @@ Explained Query:
                   Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                     Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
-                        %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
+                        %1[#1, #0]UKK » %0:l2[greatest(#0, #1), least(#0, #1)]KK
                       ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                        Project (#1{person2id}, #2) // { arity: 2 }
-                          Filter (greatest(#1{person1id}, #2{person2id})) IS NOT NULL AND (least(#1{person1id}, #2{person2id})) IS NOT NULL // { arity: 3 }
-                            ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+                        Get l2 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                         Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                           Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-                            Get l2 // { arity: 3 }
-                Project (#1{person2id}, #2) // { arity: 2 }
-                  ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-            Get l2 // { arity: 3 }
+                            Get l1 // { arity: 3 }
+                Get l2 // { arity: 2 }
+            Get l1 // { arity: 3 }
     cte l2 =
+      Project (#1{person2id}, #2) // { arity: 2 }
+        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
+    cte l1 =
       Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
           implementation
@@ -3024,59 +2971,32 @@ Explained Query:
               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
             Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
-              Project (#0{person1id}..=#2{parentmessageid}) // { arity: 3 }
-                Join on=(#3{containerforumid} = #4{containerforumid} = #5{id}) type=delta // { arity: 6 }
+              Project (#1{person2id}, #2{parentmessageid}, #6) // { arity: 3 }
+                Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid} AND #5{containerforumid} = #10{id} AND #8{containerforumid} = #11{id}) type=delta // { arity: 12 }
                   implementation
-                    %0:l1 » %1[#0]UKA » %2[#0]UKA
-                    %1 » %2[#0]UKA » %0:l1[#3]K
-                    %2 » %1[#0]UKA » %0:l1[#3]K
-                  ArrangeBy keys=[[#3{containerforumid}]] // { arity: 4 }
-                    Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-                    Distinct project=[#0{containerforumid}] // { arity: 1 }
-                      Project (#3) // { arity: 1 }
-                        Filter (#3{containerforumid}) IS NOT NULL // { arity: 4 }
-                          Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                    Distinct project=[#0{id}] // { arity: 1 }
-                      Project (#1) // { arity: 1 }
-                        Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                          ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
-    cte l1 =
-      Project (#0{person1id}, #1{person2id}, #3{containerforumid}, #4) // { arity: 4 }
-        Join on=(#2{containerforumid} = #5{containerforumid} = #6{id}) type=delta // { arity: 7 }
-          implementation
-            %0:l0 » %1[#0]UKA » %2[#0]UKA
-            %1 » %2[#0]UKA » %0:l0[#2]K
-            %2 » %1[#0]UKA » %0:l0[#2]K
-          ArrangeBy keys=[[#2{containerforumid}]] // { arity: 5 }
-            Get l0 // { arity: 5 }
-          ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
-            Distinct project=[#0{containerforumid}] // { arity: 1 }
-              Project (#2) // { arity: 1 }
-                Filter (#2{containerforumid}) IS NOT NULL // { arity: 5 }
-                  Get l0 // { arity: 5 }
-          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-            Distinct project=[#0{id}] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
-                  ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
+                    %0:person_knows_person » %1:message[#1]KA » %3:l0[#0]UK » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %1:message » %3:l0[#0]UK » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %2:message » %4:l0[#0]UK » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                    %3:l0 » %1:message[#2]KA » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK » %4:l0[#0]UK
+                    %4:l0 » %2:message[#1]KA » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK » %3:l0[#0]UK
+                  ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
+                    ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
+                  ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}], [#2{containerforumid}]] // { arity: 4 }
+                    Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
+                      Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}], [#1{containerforumid}]] // { arity: 3 }
+                    Project (#9, #10, #12) // { arity: 3 }
+                      Filter (#10{containerforumid}) IS NOT NULL AND (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
+                        ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+                  Get l0 // { arity: 1 }
+                  Get l0 // { arity: 1 }
     cte l0 =
-      Project (#1{person2id}, #2{containerforumid}, #5, #6, #8) // { arity: 5 }
-        Join on=(#1{person1id} = #4{creatorpersonid} AND #2{person2id} = #7{creatorpersonid} AND #3{messageid} = #9{parentmessageid}) type=delta // { arity: 10 }
-          implementation
-            %0:person_knows_person » %1:message[#1]KA » %2:message[#0, #2]KK
-            %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KK
-            %2:message » %0:person_knows_person[#2]KA » %1:message[#0, #1]KK
-          ArrangeBy keys=[[#1{person1id}], [#2{person2id}]] // { arity: 3 }
-            ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person2id=[delta join lookup] // { arity: 3 }
-          ArrangeBy keys=[[#0{messageid}, #1{creatorpersonid}], [#1{creatorpersonid}]] // { arity: 4 }
-            Project (#1{creatorpersonid}, #9, #10, #12) // { arity: 4 }
-              ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-          ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
-            Project (#9, #10, #12) // { arity: 3 }
-              Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
-                ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
+      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+        Distinct project=[#0{id}] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
+              ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.forum_id (*** full scan ***)
@@ -3224,13 +3144,12 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
-                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                      implementation
-                        %1:tag[#0]KAe » %0:l1[#2]KAe
-                      Get l1 // { arity: 3 }
-                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                        ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                    implementation
+                      %1:tag[#0]KAe » %0:l1[#2]KAe
+                    Get l1 // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
       cte l5 =
         Project (#0{id}, #1{messageid}, #4) // { arity: 3 }
           Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=delta // { arity: 6 }
@@ -3264,13 +3183,12 @@ Explained Query:
             ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
-                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
-                      implementation
-                        %1:tag[#0]KAe » %0:l1[#2]KAe
-                      Get l1 // { arity: 3 }
-                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                        ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
+                    implementation
+                      %1:tag[#0]KAe » %0:l1[#2]KAe
+                    Get l1 // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                      ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
       cte l2 =
         ArrangeBy keys=[[#1{name}]] // { arity: 4 }
           ReadIndex on=tag tag_name=[lookup] // { arity: 4 }
@@ -3498,19 +3416,18 @@ Explained Query:
       cte l0 =
         ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
           Project (#0{personid}, #9) // { arity: 2 }
-            Filter (#1{tagid}) IS NOT NULL // { arity: 10 }
-              Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
-                implementation
-                  %0:person_hasinterest_tag » %1:tag[#0]KAe » %2:person_knows_person[#1]KA
-                  %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
-                  %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
-                ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
-                  Project (#1{tagid}, #2) // { arity: 2 }
-                    ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
-                ArrangeBy keys=[[#0{id}]] // { arity: 5 }
-                  ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
-                ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
-                  ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
+            Join on=(#0{personid} = #8{person1id} AND #1{tagid} = #2{id}) type=delta // { arity: 10 }
+              implementation
+                %0:person_hasinterest_tag » %1:tag[#0]KAe » %2:person_knows_person[#1]KA
+                %1:tag » %0:person_hasinterest_tag[#1]KA » %2:person_knows_person[#1]KA
+                %2:person_knows_person » %0:person_hasinterest_tag[#0]K » %1:tag[#0]KAe
+              ArrangeBy keys=[[#0{personid}], [#1{tagid}]] // { arity: 2 }
+                Project (#1{tagid}, #2) // { arity: 2 }
+                  ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[*** full scan ***] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
+                ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
+              ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
+                ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_name (lookup)
@@ -3674,18 +3591,12 @@ Explained Query:
     With
       cte l1 =
         Project (#0{id}..=#2{min}) // { arity: 3 }
-          Join on=(#1{id} = #3{id} = #4{id}) type=delta // { arity: 5 }
+          Join on=(#1{id} = #3{id}) type=differential // { arity: 4 }
             implementation
-              %0:l0 » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:l0[#1]K
-              %2 » %1[#0]UKA » %0:l0[#1]K
+              %1[#0]UKA » %0:l0[#1]K
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-              Distinct project=[#0{id}] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1{id}) IS NOT NULL // { arity: 3 }
-                    Get l0 // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                Get l0 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
@@ -4207,7 +4118,7 @@ Explained Query:
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
@@ -4314,7 +4225,7 @@ Explained Query:
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
@@ -4424,7 +4335,7 @@ Explained Query:
               ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+                    Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
                       Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
@@ -4752,7 +4663,7 @@ Explained Query:
               - (10995116285979)
       cte l0 =
         Project (#1) // { arity: 1 }
-          Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+          Filter (#5{name} = "Balkh_Airlines") // { arity: 8 }
             Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
               implementation
                 %1:company[#0]KAef » %0:person_workat_company[#2]KAef

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -1967,14 +1967,15 @@ Explained Query:
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
-                        implementation
-                          %1[#0]UKA » %0:l0[#1]KA
-                        Get l0 // { arity: 11 }
-                        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
-                          Distinct project=[#0{id}] // { arity: 1 }
-                            Project (#0{id}) // { arity: 1 }
-                              Get l1 // { arity: 2 }
+                      Filter (#1{id}) IS NOT NULL // { arity: 12 }
+                        Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
+                          implementation
+                            %1[#0]UKA » %0:l0[#1]KA
+                          Get l0 // { arity: 11 }
+                          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                            Distinct project=[#0{id}] // { arity: 1 }
+                              Project (#0{id}) // { arity: 1 }
+                                Get l1 // { arity: 2 }
                   Project (#1) // { arity: 1 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
               Get l1 // { arity: 2 }
@@ -2552,9 +2553,9 @@ Explained Query:
     Return // { arity: 3 }
       Project (#1{min}, #2{min}, #2{min}) // { arity: 3 }
         Filter (#1{person2id} = 15393162796819) AND (#2{min} = #2{min}) // { arity: 3 }
-          Get l4 // { arity: 3 }
+          Get l3 // { arity: 3 }
     With Mutually Recursive
-      cte l4 =
+      cte l3 =
         Project (#2{min}, #0, #1{person2id}) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
@@ -2564,10 +2565,10 @@ Explained Query:
                     Map ((#1 + #4)) // { arity: 6 }
                       Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
                         implementation
-                          %0:l4[#0]UK » %1[#0]K
+                          %0:l3[#0]UK » %1[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
-                            Get l4 // { arity: 3 }
+                            Get l3 // { arity: 3 }
                         ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
                             Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
@@ -2578,20 +2579,20 @@ Explained Query:
                                       Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
-                                            %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
+                                            %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
                                           ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                                            Get l3 // { arity: 2 }
+                                            Project (#1{person2id}, #2) // { arity: 2 }
+                                              Filter (greatest(#1{person1id}, #2{person2id})) IS NOT NULL AND (least(#1{person1id}, #2{person2id})) IS NOT NULL // { arity: 3 }
+                                                ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                                             Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                                               Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                                                 Get l2 // { arity: 3 }
-                                    Get l3 // { arity: 2 }
+                                    Project (#1{person2id}, #2) // { arity: 2 }
+                                      ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                                 Get l2 // { arity: 3 }
                   Constant // { arity: 2 }
                     - (1450, 0)
-      cte l3 =
-        Project (#1{person2id}, #2) // { arity: 2 }
-          ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
       cte l2 =
         Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
           Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
@@ -2778,168 +2779,168 @@ Explained Query:
       Project (#1) // { arity: 1 }
         Map (coalesce(#0{min_min}, -1)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l18 // { arity: 1 }
+            Get l17 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l18 // { arity: 1 }
+                    Get l17 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
     With
-      cte l18 =
+      cte l17 =
         Reduce aggregates=[min(#0{min})] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
                 Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
                   implementation
-                    %0:l17[#1]Kef » %1:l17[#1]Kef
+                    %0:l16[#1]Kef » %1:l16[#1]Kef
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
-                        Get l17 // { arity: 4 }
+                        Get l16 // { arity: 4 }
                   ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1{person2id}..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
-                        Get l17 // { arity: 4 }
-      cte l17 =
+                        Get l16 // { arity: 4 }
+      cte l16 =
         Project (#0..=#3) // { arity: 4 }
           Join on=(#4 = #5{max}) type=differential // { arity: 6 }
             implementation
-              %1[#0]UK » %0:l16[#4]K
+              %1[#0]UK » %0:l15[#4]K
             ArrangeBy keys=[[#4]] // { arity: 5 }
               Project (#0..=#3, #5) // { arity: 5 }
                 Filter (#5) IS NOT NULL // { arity: 6 }
-                  Get l16 // { arity: 6 }
+                  Get l15 // { arity: 6 }
             ArrangeBy keys=[[#0{max}]] // { arity: 1 }
               Filter (#0{max}) IS NOT NULL // { arity: 1 }
                 Reduce aggregates=[max(#0)] // { arity: 1 }
                   Project (#5) // { arity: 1 }
-                    Get l16 // { arity: 6 }
+                    Get l15 // { arity: 6 }
   With Mutually Recursive
-    cte l16 =
+    cte l15 =
       Distinct project=[#0..=#5] // { arity: 6 }
         Union // { arity: 6 }
           Project (#1, #0, #0, #2..=#4) // { arity: 6 }
             Map (0, false, 0) // { arity: 5 }
               Union // { arity: 2 }
                 Map (1450, false) // { arity: 2 }
-                  Get l15 // { arity: 0 }
+                  Get l14 // { arity: 0 }
                 Map (15393162796819, true) // { arity: 2 }
-                  Get l15 // { arity: 0 }
+                  Get l14 // { arity: 0 }
           Project (#0..=#3, #7, #8) // { arity: 6 }
             Map ((#4 OR coalesce((#3 > #6), false)), (#5 + 1)) // { arity: 9 }
               CrossJoin type=delta // { arity: 7 }
                 implementation
-                  %0:l12 » %1[×]U » %2[×]U
-                  %1 » %2[×]U » %0:l12[×]
-                  %2 » %1[×]U » %0:l12[×]
+                  %0:l11 » %1[×]U » %2[×]U
+                  %1 » %2[×]U » %0:l11[×]
+                  %2 » %1[×]U » %0:l11[×]
                 ArrangeBy keys=[[]] // { arity: 5 }
-                  Get l12 // { arity: 5 }
+                  Get l11 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   TopK limit=1 // { arity: 1 }
                     Project (#4) // { arity: 1 }
-                      Get l9 // { arity: 5 }
+                      Get l8 // { arity: 5 }
                 ArrangeBy keys=[[]] // { arity: 1 }
                   Union // { arity: 1 }
-                    Get l14 // { arity: 1 }
+                    Get l13 // { arity: 1 }
                     Map (null) // { arity: 1 }
                       Union // { arity: 0 }
                         Negate // { arity: 0 }
                           Project () // { arity: 0 }
-                            Get l14 // { arity: 1 }
+                            Get l13 // { arity: 1 }
                         Constant // { arity: 0 }
                           - ()
-    cte l15 =
+    cte l14 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
-            Get l8 // { arity: 2 }
-    cte l14 =
+            Get l7 // { arity: 2 }
+    cte l13 =
       Project (#1) // { arity: 1 }
         Map ((#0{min} / 2)) // { arity: 2 }
           Union // { arity: 1 }
-            Get l13 // { arity: 1 }
+            Get l12 // { arity: 1 }
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
                   Project () // { arity: 0 }
-                    Get l13 // { arity: 1 }
+                    Get l12 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-    cte l13 =
+    cte l12 =
       Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
         Project (#1, #3) // { arity: 2 }
           Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
             implementation
-              %0:l12[#0]Kef » %1:l12[#0]Kef
+              %0:l11[#0]Kef » %1:l11[#0]Kef
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = false) // { arity: 5 }
-                  Get l12 // { arity: 5 }
+                  Get l11 // { arity: 5 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = true) // { arity: 5 }
-                  Get l12 // { arity: 5 }
-    cte l12 =
+                  Get l11 // { arity: 5 }
+    cte l11 =
       TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
           Project (#3, #4, #1, #7, #8) // { arity: 5 }
             Map ((#6 + #2), false) // { arity: 9 }
               Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
                 implementation
-                  %0:l4[#0]K » %1:l9[#2]K
+                  %0:l3[#0]K » %1:l8[#2]K
                 ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
-                  Get l4 // { arity: 3 }
+                  Get l3 // { arity: 3 }
                 ArrangeBy keys=[[#2]] // { arity: 4 }
                   Project (#0..=#3) // { arity: 4 }
-                    Get l9 // { arity: 5 }
+                    Get l8 // { arity: 5 }
           Project (#0..=#3, #9) // { arity: 5 }
             Map ((#4 OR #8)) // { arity: 10 }
               Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 9 }
                 implementation
-                  %0:l16[#0..=#2]KKK » %1[#0..=#2]KKK
+                  %0:l15[#0..=#2]KKK » %1[#0..=#2]KKK
                 ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                   Project (#0..=#4) // { arity: 5 }
-                    Get l16 // { arity: 6 }
+                    Get l15 // { arity: 6 }
                 ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                   Union // { arity: 4 }
                     Map (true) // { arity: 4 }
-                      Get l11 // { arity: 3 }
+                      Get l10 // { arity: 3 }
                     Project (#0..=#2, #6) // { arity: 4 }
                       Map (false) // { arity: 7 }
                         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                           implementation
-                            %1:l10[#0..=#2]UKKK » %0[#0..=#2]KKK
+                            %1:l9[#0..=#2]UKKK » %0[#0..=#2]KKK
                           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                             Union // { arity: 3 }
                               Negate // { arity: 3 }
-                                Get l11 // { arity: 3 }
-                              Get l10 // { arity: 3 }
+                                Get l10 // { arity: 3 }
+                              Get l9 // { arity: 3 }
                           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                            Get l10 // { arity: 3 }
-    cte l11 =
+                            Get l9 // { arity: 3 }
+    cte l10 =
       Project (#0..=#2) // { arity: 3 }
         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
           implementation
-            %1[#0..=#2]UKKKA » %0:l10[#0..=#2]UKKK
+            %1[#0..=#2]UKKKA » %0:l9[#0..=#2]UKKK
           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Get l10 // { arity: 3 }
+            Get l9 // { arity: 3 }
           ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
             Distinct project=[#0..=#2] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
-                Get l9 // { arity: 5 }
-    cte l10 =
+                Get l8 // { arity: 5 }
+    cte l9 =
       Distinct project=[#0..=#2] // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Get l16 // { arity: 6 }
-    cte l9 =
+          Get l15 // { arity: 6 }
+    cte l8 =
       TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
         Project (#0..=#3, #5) // { arity: 5 }
           Filter (#4 = false) // { arity: 6 }
-            Get l16 // { arity: 6 }
-    cte l8 =
+            Get l15 // { arity: 6 }
+    cte l7 =
       Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
           Distinct project=[#0{person2id}, #1] // { arity: 2 }
@@ -2947,51 +2948,51 @@ Explained Query:
               Project (#1, #0{person2id}) // { arity: 2 }
                 CrossJoin type=differential // { arity: 2 }
                   implementation
-                    %0:l5[×] » %1[×]
+                    %0:l4[×] » %1[×]
                   ArrangeBy keys=[[]] // { arity: 2 }
-                    Get l5 // { arity: 2 }
+                    Get l4 // { arity: 2 }
                   ArrangeBy keys=[[]] // { arity: 0 }
                     Union // { arity: 0 }
                       Negate // { arity: 0 }
-                        Get l7 // { arity: 0 }
+                        Get l6 // { arity: 0 }
                       Constant // { arity: 0 }
                         - ()
               Project (#1, #0) // { arity: 2 }
                 Map (true, -1) // { arity: 2 }
-                  Get l7 // { arity: 0 }
+                  Get l6 // { arity: 0 }
           Constant // { arity: 2 }
             - (1450, true)
             - (15393162796819, false)
-    cte l7 =
+    cte l6 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
             implementation
-              %0:l6[#0]Kf » %1:l6[#0]Kf
+              %0:l5[#0]Kf » %1:l5[#0]Kf
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0{person2id}) // { arity: 1 }
                 Filter #1 // { arity: 2 }
-                  Get l6 // { arity: 2 }
+                  Get l5 // { arity: 2 }
             ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0{person2id}) // { arity: 1 }
                 Filter NOT(#1) // { arity: 2 }
-                  Get l6 // { arity: 2 }
-    cte l6 =
+                  Get l5 // { arity: 2 }
+    cte l5 =
       Union // { arity: 2 }
         Project (#1, #0{person2id}) // { arity: 2 }
-          Get l5 // { arity: 2 }
-        Get l8 // { arity: 2 }
-    cte l5 =
+          Get l4 // { arity: 2 }
+        Get l7 // { arity: 2 }
+    cte l4 =
       Project (#1{person2id}, #3) // { arity: 2 }
         Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
-            %0:l8[#0]K » %1:l4[#0]K
+            %0:l7[#0]K » %1:l3[#0]K
           ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
-            Get l8 // { arity: 2 }
+            Get l7 // { arity: 2 }
           ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
             Project (#0{person1id}, #1{person2id}) // { arity: 2 }
-              Get l4 // { arity: 3 }
-    cte l4 =
+              Get l3 // { arity: 3 }
+    cte l3 =
       Project (#0{person1id}, #1{person2id}, #3) // { arity: 3 }
         Map ((10 / bigint_to_double((coalesce(#2{sum}, 0) + 10)))) // { arity: 4 }
           Union // { arity: 3 }
@@ -3001,18 +3002,18 @@ Explained Query:
                   Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                     Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
-                        %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
+                        %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
                       ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
-                        Get l3 // { arity: 2 }
+                        Project (#1{person2id}, #2) // { arity: 2 }
+                          Filter (greatest(#1{person1id}, #2{person2id})) IS NOT NULL AND (least(#1{person1id}, #2{person2id})) IS NOT NULL // { arity: 3 }
+                            ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
                         Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                           Project (#0{person1id}, #1{person2id}) // { arity: 2 }
                             Get l2 // { arity: 3 }
-                Get l3 // { arity: 2 }
+                Project (#1{person2id}, #2) // { arity: 2 }
+                  ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
             Get l2 // { arity: 3 }
-    cte l3 =
-      Project (#1{person2id}, #2) // { arity: 2 }
-        ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
     cte l2 =
       Project (#0{person1id}, #1{person2id}, #4) // { arity: 3 }
         Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -802,29 +802,28 @@ Explained Query:
           Negate // { arity: 3 }
             Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
-                ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-                  Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-                    Filter (#4{facts_d01} > 42) AND (coalesce(#1{dim01_k01}, 5)) IS NOT NULL // { arity: 9 }
-                      ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+                Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Get l0 // { arity: 7 }
+                      Get l1 // { arity: 7 }
           Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
-        Get l0 // { arity: 7 }
+        Get l1 // { arity: 7 }
   With
-    cte l0 =
+    cte l1 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-          Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-            Filter (#4{facts_d01} > 42) // { arity: 9 }
-              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+        Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+    cte l0 =
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
@@ -864,29 +863,28 @@ Explained Query:
           Negate // { arity: 3 }
             Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
-                ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-                  Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-                    Filter (#4{facts_d01} > 42) AND (coalesce(#1{dim01_k01}, 5)) IS NOT NULL // { arity: 9 }
-                      ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+                Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Get l0 // { arity: 7 }
+                      Get l1 // { arity: 7 }
           Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
-        Get l0 // { arity: 7 }
+        Get l1 // { arity: 7 }
   With
-    cte l0 =
+    cte l1 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-          Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-            Filter (#4{facts_d01} > 42) // { arity: 9 }
-              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+        Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+    cte l0 =
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
@@ -913,29 +911,28 @@ materialize.public.v:
           Negate // { arity: 3 }
             Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
-                ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-                  Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-                    Filter (#4{facts_d01} > 42) AND (coalesce(#1{dim01_k01}, 5)) IS NOT NULL // { arity: 9 }
-                      ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+                Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Get l0 // { arity: 7 }
+                      Get l1 // { arity: 7 }
           Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
-        Get l0 // { arity: 7 }
+        Get l1 // { arity: 7 }
   With
-    cte l0 =
+    cte l1 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-          Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-            Filter (#4{facts_d01} > 42) // { arity: 9 }
-              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+        Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+    cte l0 =
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
@@ -971,29 +968,28 @@ materialize.public.mv:
           Negate // { arity: 3 }
             Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
-                ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-                  Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-                    Filter (#4{facts_d01} > 42) AND (coalesce(#1{dim01_k01}, 5)) IS NOT NULL // { arity: 9 }
-                      ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+                Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Get l0 // { arity: 7 }
+                      Get l1 // { arity: 7 }
           Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
-        Get l0 // { arity: 7 }
+        Get l1 // { arity: 7 }
   With
-    cte l0 =
+    cte l1 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-          Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-            Filter (#4{facts_d01} > 42) // { arity: 9 }
-              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+        Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+    cte l0 =
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -349,7 +349,8 @@ Return // { arity: 6 }
                   Negate // { arity: 11 }
                     Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                       Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                        Get l2 // { arity: 11 }
+                        Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
+                          Get l2 // { arity: 11 }
                         Distinct project=[#0{x}..=#2] // { arity: 3 }
                           Project (#17..=#19) // { arity: 3 }
                             Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
@@ -544,7 +545,7 @@ Return // { arity: 6 }
                   Negate // { arity: 11 }
                     Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                       Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                        Filter (#7{facts_d02} = 42) // { arity: 11 }
+                        Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
                           Get l2 // { arity: 11 }
                         Distinct project=[#0{x}..=#2] // { arity: 3 }
                           Project (#17..=#19) // { arity: 3 }
@@ -609,7 +610,7 @@ Return // { arity: 6 }
                   Negate // { arity: 8 }
                     Project (#0{x}..=#7{dim02_d05}) // { arity: 8 }
                       Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim02_k01}, #1{y}) = #10) // { arity: 11 }
-                        Filter (#5{dim02_d03} < 24) // { arity: 8 }
+                        Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND (coalesce(#2{dim02_k01}, #1{y})) IS NOT NULL AND (#5{dim02_d03} < 24) // { arity: 8 }
                           Get l3 // { arity: 8 }
                         Get l5 // { arity: 3 }
                   Get l3 // { arity: 8 }

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -172,7 +172,8 @@ Return // { arity: 4 }
           Negate // { arity: 9 }
             Project (#0{facts_k01}..=#8{facts_d05}) // { arity: 9 }
               Join on=(#1{dim01_k01} = #9{dim01_k01}) // { arity: 10 }
-                Get l0 // { arity: 9 }
+                Filter (#1{dim01_k01}) IS NOT NULL // { arity: 9 }
+                  Get l0 // { arity: 9 }
                 Distinct project=[#0{dim01_k01}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Get l1 // { arity: 15 }
@@ -286,7 +287,8 @@ Return // { arity: 6 }
                 Negate // { arity: 11 }
                   Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                     Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                      Get l2 // { arity: 11 }
+                      Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
+                        Get l2 // { arity: 11 }
                       Distinct project=[#0{x}..=#2] // { arity: 3 }
                         Project (#17..=#19) // { arity: 3 }
                           Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
@@ -476,7 +478,7 @@ Return // { arity: 6 }
                 Negate // { arity: 11 }
                   Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                     Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                      Filter (#7{facts_d02} = 42) // { arity: 11 }
+                      Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
                         Get l2 // { arity: 11 }
                       Distinct project=[#0{x}..=#2] // { arity: 3 }
                         Project (#17..=#19) // { arity: 3 }
@@ -616,7 +618,7 @@ Return // { arity: 6 }
                 Negate // { arity: 8 }
                   Project (#0{x}..=#7{dim01_d05}) // { arity: 8 }
                     Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim01_k01}, #0{x}) = #10) // { arity: 11 }
-                      Filter (#5{dim01_d03} > 42) // { arity: 8 }
+                      Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND (coalesce(#2{dim01_k01}, #0{x})) IS NOT NULL AND (#5{dim01_d03} > 42) // { arity: 8 }
                         Get l2 // { arity: 8 }
                       Get l5 // { arity: 3 }
                 Get l2 // { arity: 8 }
@@ -800,28 +802,29 @@ Explained Query:
           Negate // { arity: 3 }
             Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
-                Get l0 // { arity: 4 }
+                ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+                  Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+                    Filter (#4{facts_d01} > 42) AND (coalesce(#1{dim01_k01}, 5)) IS NOT NULL // { arity: 9 }
+                      ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Get l1 // { arity: 7 }
+                      Get l0 // { arity: 7 }
           Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
-        Get l1 // { arity: 7 }
+        Get l0 // { arity: 7 }
   With
-    cte l1 =
+    cte l0 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        Get l0 // { arity: 4 }
+        ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+          Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+            Filter (#4{facts_d01} > 42) // { arity: 9 }
+              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
-    cte l0 =
-      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-          Filter (#4{facts_d01} > 42) // { arity: 9 }
-            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
@@ -861,28 +864,29 @@ Explained Query:
           Negate // { arity: 3 }
             Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
-                Get l0 // { arity: 4 }
+                ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+                  Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+                    Filter (#4{facts_d01} > 42) AND (coalesce(#1{dim01_k01}, 5)) IS NOT NULL // { arity: 9 }
+                      ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Get l1 // { arity: 7 }
+                      Get l0 // { arity: 7 }
           Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
-        Get l1 // { arity: 7 }
+        Get l0 // { arity: 7 }
   With
-    cte l1 =
+    cte l0 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        Get l0 // { arity: 4 }
+        ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+          Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+            Filter (#4{facts_d01} > 42) // { arity: 9 }
+              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
-    cte l0 =
-      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-          Filter (#4{facts_d01} > 42) // { arity: 9 }
-            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
@@ -909,28 +913,29 @@ materialize.public.v:
           Negate // { arity: 3 }
             Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
-                Get l0 // { arity: 4 }
+                ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+                  Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+                    Filter (#4{facts_d01} > 42) AND (coalesce(#1{dim01_k01}, 5)) IS NOT NULL // { arity: 9 }
+                      ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Get l1 // { arity: 7 }
+                      Get l0 // { arity: 7 }
           Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
-        Get l1 // { arity: 7 }
+        Get l0 // { arity: 7 }
   With
-    cte l1 =
+    cte l0 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        Get l0 // { arity: 4 }
+        ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+          Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+            Filter (#4{facts_d01} > 42) // { arity: 9 }
+              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
-    cte l0 =
-      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-          Filter (#4{facts_d01} > 42) // { arity: 9 }
-            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01
@@ -966,28 +971,29 @@ materialize.public.mv:
           Negate // { arity: 3 }
             Project (#0{facts_k01}, #2{facts_d02}, #3) // { arity: 3 }
               Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
-                Get l0 // { arity: 4 }
+                ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+                  Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+                    Filter (#4{facts_d01} > 42) AND (coalesce(#1{dim01_k01}, 5)) IS NOT NULL // { arity: 9 }
+                      ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Get l1 // { arity: 7 }
+                      Get l0 // { arity: 7 }
           Project (#0{facts_k01}, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
       Project (#0{facts_k01}, #2{facts_d02}..=#6) // { arity: 6 }
-        Get l1 // { arity: 7 }
+        Get l0 // { arity: 7 }
   With
-    cte l1 =
+    cte l0 =
       Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
-        Get l0 // { arity: 4 }
+        ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
+          Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
+            Filter (#4{facts_d01} > 42) // { arity: 9 }
+              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
         ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0{dim01_k01}..=#2{dim01_d02}) // { arity: 3 }
             Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
-    cte l0 =
-      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
-        Project (#0{facts_k01}, #1{dim01_k01}, #4, #5) // { arity: 4 }
-          Filter (#4{facts_d01} > 42) // { arity: 9 }
-            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.facts
 Source materialize.left_joins_raw.dim01

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -150,63 +150,55 @@ foo left join bar on foo.a = bar.a
     left join quux on baz.c = quux.c;
 ----
 Explained Query:
-  Return
-    Project (#0..=#2, #14, #15, #17..=#19, #21, #22)
-      Map ((#5) IS NULL, case when #13 then null else #0 end, case when #13 then null else #4 end, (#9) IS NULL, case when #16 then null else #1 end, case when #16 then null else #7 end, case when #16 then null else #8 end, (#12) IS NULL, case when #20 then null else #10 end, case when #20 then null else #11 end)
-        Join on=(#0 = #3 AND #1 = #6 AND #10 = case when (#9) IS NULL then null else #7 end) type=delta
-          ArrangeBy keys=[[#0], [#1]]
-            ReadStorage materialize.public.foo
-          ArrangeBy keys=[[#0]]
-            Union
-              Filter (#0) IS NOT NULL
-                Map (true)
-                  ReadStorage materialize.public.bar
-              Map (null, null)
-                Threshold
-                  Union
-                    Negate
-                      Project (#0)
-                        Filter (#0) IS NOT NULL
-                          ReadStorage materialize.public.bar
-                    Distinct project=[#0]
-                      Project (#0)
-                        Get l0
-          ArrangeBy keys=[[#0], [case when (#3) IS NULL then null else #1 end]]
-            Union
-              Map (true)
-                ReadStorage materialize.public.baz
-              Map (null, null, null)
-                Threshold
-                  Union
-                    Negate
-                      Project (#0)
-                        ReadStorage materialize.public.baz
-                    Distinct project=[#0]
-                      Project (#1)
-                        Get l0
-          ArrangeBy keys=[[#0]]
-            Union
-              Map (true)
-                ReadStorage materialize.public.quux
-              Map (null, null)
-                Threshold
-                  Union
-                    Negate
-                      Project (#0)
-                        ReadStorage materialize.public.quux
-                    Distinct project=[#0]
-                      Union
-                        Project (#1)
-                          ReadStorage materialize.public.baz
-                        Constant
-                          - (null)
-  With
-    cte l0 =
-      Union
-        Project (#0, #1)
+  Project (#0..=#2, #14, #15, #17..=#19, #21, #22)
+    Map ((#5) IS NULL, case when #13 then null else #0 end, case when #13 then null else #4 end, (#9) IS NULL, case when #16 then null else #1 end, case when #16 then null else #7 end, case when #16 then null else #8 end, (#12) IS NULL, case when #20 then null else #10 end, case when #20 then null else #11 end)
+      Join on=(#0 = #3 AND #1 = #6 AND #10 = case when (#9) IS NULL then null else #7 end) type=delta
+        ArrangeBy keys=[[#0], [#1]]
           ReadStorage materialize.public.foo
-        Constant
-          - (null, null)
+        ArrangeBy keys=[[#0]]
+          Union
+            Filter (#0) IS NOT NULL
+              Map (true)
+                ReadStorage materialize.public.bar
+            Map (null, null)
+              Threshold
+                Union
+                  Negate
+                    Project (#0)
+                      Filter (#0) IS NOT NULL
+                        ReadStorage materialize.public.bar
+                  Distinct project=[#0]
+                    Project (#0)
+                      ReadStorage materialize.public.foo
+        ArrangeBy keys=[[#0], [case when (#3) IS NULL then null else #1 end]]
+          Union
+            Map (true)
+              ReadStorage materialize.public.baz
+            Map (null, null, null)
+              Threshold
+                Union
+                  Negate
+                    Project (#0)
+                      ReadStorage materialize.public.baz
+                  Distinct project=[#0]
+                    Project (#1)
+                      ReadStorage materialize.public.foo
+        ArrangeBy keys=[[#0]]
+          Union
+            Map (true)
+              ReadStorage materialize.public.quux
+            Map (null, null)
+              Threshold
+                Union
+                  Negate
+                    Project (#0)
+                      ReadStorage materialize.public.quux
+                  Distinct project=[#0]
+                    Union
+                      Project (#1)
+                        ReadStorage materialize.public.baz
+                      Constant
+                        - (null)
 
 Source materialize.public.foo
 Source materialize.public.bar
@@ -230,31 +222,32 @@ foo left join bar on foo.a = bar.a
 Explained Query:
   Return
     Union
-      Get l4
+      Get l2
       Map (0)
         Union
           Negate
             Project ()
-              Get l4
+              Get l2
           Constant
             - ()
   With
-    cte l4 =
+    cte l2 =
       Reduce aggregates=[count(*)]
         Project ()
           Join on=(#0 = #2 AND #1 = #3 AND #6 = case when (#5) IS NULL then null else #4 end) type=delta
             ArrangeBy keys=[[#0], [#1]]
-              Get l0
+              Project (#0, #1)
+                ReadStorage materialize.public.foo
             ArrangeBy keys=[[#0]]
               Union
-                Get l2
+                Get l0
                 Threshold
                   Union
                     Negate
-                      Get l2
+                      Get l0
                     Distinct project=[#0]
                       Project (#0)
-                        Get l1
+                        ReadStorage materialize.public.foo
             ArrangeBy keys=[[#0], [case when (#2) IS NULL then null else #1 end]]
               Union
                 Project (#0, #1, #3)
@@ -268,35 +261,27 @@ Explained Query:
                           ReadStorage materialize.public.baz
                       Distinct project=[#0]
                         Project (#1)
-                          Get l1
+                          ReadStorage materialize.public.foo
             ArrangeBy keys=[[#0]]
               Union
-                Get l3
+                Get l1
                 Threshold
                   Union
                     Negate
-                      Get l3
+                      Get l1
                     Distinct project=[#0]
                       Union
                         Project (#1)
                           ReadStorage materialize.public.baz
                         Constant
                           - (null)
-    cte l3 =
+    cte l1 =
       Project (#0)
         ReadStorage materialize.public.quux
-    cte l2 =
+    cte l0 =
       Project (#0)
         Filter (#0) IS NOT NULL
           ReadStorage materialize.public.bar
-    cte l1 =
-      Union
-        Get l0
-        Constant
-          - (null, null)
-    cte l0 =
-      Project (#0, #1)
-        ReadStorage materialize.public.foo
 
 Source materialize.public.foo
 Source materialize.public.bar

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -123,15 +123,14 @@ Explained Query:
                 Get l1 // { arity: 1 }
     cte l1 =
       Project (#0) // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          Join on=(#0 = #1) type=differential // { arity: 2 }
-            implementation
-              %0:l0[#0]UKA » %1:t1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                ReadStorage materialize.public.t1 // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1:t1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 1 }
     cte l0 =
       Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t2 // { arity: 1 }
@@ -372,15 +371,14 @@ Explained Query:
               Get l1 // { arity: 1 }
     cte l1 =
       Project (#0) // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          Join on=(#0 = #1) type=differential // { arity: 2 }
-            implementation
-              %0:l0[#0]UKA » %1:t1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                ReadStorage materialize.public.t1 // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1:t1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 1 }
     cte l0 =
       Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t2 // { arity: 1 }
@@ -458,15 +456,14 @@ Explained Query:
         Get l1 // { arity: 1 }
     cte l1 =
       Project (#0) // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          Join on=(#0 = #1) type=differential // { arity: 2 }
-            implementation
-              %0:l0[#0]UKA » %1:t1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                ReadStorage materialize.public.t1 // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1:t1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 1 }
     cte l0 =
       Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t2 // { arity: 1 }
@@ -562,15 +559,14 @@ Explained Query:
         Get l1 // { arity: 1 }
     cte l1 =
       Project (#0) // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          Join on=(#0 = #1) type=differential // { arity: 2 }
-            implementation
-              %0:l0[#0]UKA » %1:t2[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                ReadStorage materialize.public.t2 // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1:t2[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t2 // { arity: 1 }
     cte l0 =
       Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t3 // { arity: 1 }
@@ -640,13 +636,12 @@ Explained Query:
                 Get l6 // { arity: 1 }
     cte l6 =
       Project (#0) // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          Join on=(#0 = #1) type=differential // { arity: 2 }
-            implementation
-              %0:l5[#0]UKA » %1:l1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Get l5 // { arity: 1 }
-            Get l1 // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l5[#0]UKA » %1:l1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l5 // { arity: 1 }
+          Get l1 // { arity: 1 }
     cte l5 =
       Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
@@ -679,13 +674,12 @@ Explained Query:
                 Get l2 // { arity: 1 }
     cte l2 =
       Project (#0) // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          Join on=(#0 = #1) type=differential // { arity: 2 }
-            implementation
-              %0:l0[#0]UKA » %1:l1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            Get l1 // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:l0[#0]UKA » %1:l1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          Get l1 // { arity: 1 }
     cte l1 =
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Filter (#0) IS NOT NULL // { arity: 1 }
@@ -748,20 +742,19 @@ Explained Query:
                 Get l1 // { arity: 1 }
     cte l1 =
       Project (#0) // { arity: 1 }
-        Filter (#0) IS NOT NULL // { arity: 3 }
-          Join on=(#0 = #1 = #2) type=delta // { arity: 3 }
-            implementation
-              %0:l0 » %1:t1[#0]K » %2:t2[#0]K
-              %1:t1 » %0:l0[#0]UKA » %2:t2[#0]K
-              %2:t2 » %0:l0[#0]UKA » %1:t1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                ReadStorage materialize.public.t1 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                ReadStorage materialize.public.t2 // { arity: 1 }
+        Join on=(#0 = #1 = #2) type=delta // { arity: 3 }
+          implementation
+            %0:l0 » %1:t1[#0]K » %2:t2[#0]K
+            %1:t1 » %0:l0[#0]UKA » %2:t2[#0]K
+            %2:t2 » %0:l0[#0]UKA » %1:t1[#0]K
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 1 }
+              ReadStorage materialize.public.t2 // { arity: 1 }
     cte l0 =
       Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t3 // { arity: 1 }

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -1157,14 +1157,15 @@ materialize.public.q13:
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0{c_custkey}) // { arity: 1 }
-                    Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
-                      implementation
-                        %1[#0]UKA » %0:l0[#0]KA
-                      Get l0 // { arity: 8 }
-                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                        Distinct project=[#0{c_custkey}] // { arity: 1 }
-                          Project (#0{c_custkey}) // { arity: 1 }
-                            Get l1 // { arity: 2 }
+                    Filter (#0{c_custkey}) IS NOT NULL // { arity: 9 }
+                      Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
+                        implementation
+                          %1[#0]UKA » %0:l0[#0]KA
+                        Get l0 // { arity: 8 }
+                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                          Distinct project=[#0{c_custkey}] // { arity: 1 }
+                            Project (#0{c_custkey}) // { arity: 1 }
+                              Get l1 // { arity: 2 }
                 Project (#0{c_custkey}) // { arity: 1 }
                   ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
             Get l1 // { arity: 2 }

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -277,7 +277,7 @@ materialize.public.q02:
         ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
           Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
             Project (#0{p_partkey}, #4) // { arity: 2 }
-              Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
+              Filter (#18{r_name} = "EUROPE") // { arity: 20 }
                 Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                   implementation
                     %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
@@ -296,7 +296,7 @@ materialize.public.q02:
   With
     cte l4 =
       Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
+        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
           Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
             implementation
               %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
@@ -378,7 +378,7 @@ materialize.public.q03:
   Project (#0{o_orderkey}, #3{o_shippriority}, #1{sum}, #2{o_orderdate}) // { arity: 4 }
     Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
       Project (#8, #12, #15, #22, #23) // { arity: 5 }
-        Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
+        Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) // { arity: 33 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
               %0:customer » %1:orders[#1]KAif » %2:lineitem[#0]KAif
@@ -440,19 +440,12 @@ materialize.public.q04_primary_idx:
 materialize.public.q04:
   Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
     Project (#5) // { arity: 1 }
-      Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 11 }
-        Join on=(#0{o_orderkey} = #9{o_orderkey} = #10{l_orderkey}) type=delta // { arity: 11 }
+      Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 10 }
+        Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 10 }
           implementation
-            %0:orders » %1[#0]UKA » %2[#0]UKA
-            %1 » %2[#0]UKA » %0:orders[#0]KAiif
-            %2 » %1[#0]UKA » %0:orders[#0]KAiif
+            %1[#0]UKA » %0:orders[#0]KAiif
           ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-            ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
-          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
-            Distinct project=[#0{o_orderkey}] // { arity: 1 }
-              Project (#0{o_orderkey}) // { arity: 1 }
-                Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
-                  ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
             Distinct project=[#0{l_orderkey}] // { arity: 1 }
               Project (#0{l_orderkey}) // { arity: 1 }
@@ -460,7 +453,7 @@ materialize.public.q04:
                   ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_orders_orderkey (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (differential join)
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
 
 Target cluster: quickstart
@@ -509,7 +502,7 @@ materialize.public.q05_primary_idx:
 materialize.public.q05:
   Reduce group_by=[#2{n_name}] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
     Project (#19, #20, #24) // { arity: 3 }
-      Filter (#28{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (#25{n_regionkey}) IS NOT NULL // { arity: 30 }
+      Filter (#28{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) // { arity: 30 }
         Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #22{s_nationkey} = #23{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey} AND #18{l_suppkey} = #21{s_suppkey} AND #25{n_regionkey} = #27{r_regionkey}) type=delta // { arity: 30 }
           implementation
             %0:customer » %1:orders[#1]KAiif » %2:lineitem[#0]KA » %3:supplier[#0, #1]KK » %4:nation[#0]KA » %5:region[#0]KAef
@@ -656,7 +649,7 @@ materialize.public.q07:
   Return // { arity: 4 }
     Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
       Project (#12, #13, #17, #41, #45) // { arity: 5 }
-        Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#24{o_custkey}) IS NOT NULL AND (#35{c_nationkey}) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
+        Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
           Map ((#41{n_name} = "FRANCE"), (#41{n_name} = "GERMANY"), (#45{n_name} = "FRANCE"), (#45{n_name} = "GERMANY")) // { arity: 52 }
             Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #40{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey} AND #24{o_custkey} = #32{c_custkey} AND #35{c_nationkey} = #44{n_nationkey}) type=delta // { arity: 48 }
               implementation
@@ -753,7 +746,7 @@ materialize.public.q08:
     Map ((#1{sum} / #2{sum})) // { arity: 4 }
       Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
         Project (#21, #22, #36, #54) // { arity: 4 }
-          Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND (#33{o_custkey}) IS NOT NULL AND (#44{c_nationkey}) IS NOT NULL AND (#51{n_regionkey}) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
+          Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
             Join on=(#0{p_partkey} = #17{l_partkey} AND #9{s_suppkey} = #18{l_suppkey} AND #12{s_nationkey} = #53{n_nationkey} AND #16{l_orderkey} = #32{o_orderkey} AND #33{o_custkey} = #41{c_custkey} AND #44{c_nationkey} = #49{n_nationkey} AND #51{n_regionkey} = #57{r_regionkey}) type=delta // { arity: 60 }
               implementation
                 %0:part » %2:lineitem[#1]KA » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
@@ -850,7 +843,7 @@ materialize.public.q09_primary_idx:
 materialize.public.q09:
   Reduce group_by=[#5{n_name}, extract_year_d(#4{o_orderdate})] aggregates=[sum(((#1{l_extendedprice} * (1 - #2{l_discount})) - (#3{ps_supplycost} * #0{l_quantity})))] // { arity: 3 }
     Project (#20..=#22, #35, #41, #47) // { arity: 6 }
-      Filter (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
+      Filter like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
         Join on=(#0{p_partkey} = #17{l_partkey} = #32{ps_partkey} AND #9{s_suppkey} = #18{l_suppkey} = #33{ps_suppkey} AND #12{s_nationkey} = #46{n_nationkey} AND #16{l_orderkey} = #37{o_orderkey}) type=delta // { arity: 50 }
           implementation
             %0:part » %2:lineitem[#1]KA » %3:partsupp[#0, #1]KKA » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
@@ -939,7 +932,7 @@ materialize.public.q10:
   Project (#0{c_custkey}, #1{c_name}, #7{c_comment}, #2{sum}, #4{n_name}, #5{c_address}, #3{c_acctbal}, #6{c_phone}) // { arity: 8 }
     Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
       Project (#0{c_custkey}..=#2{c_address}, #4{c_acctbal}, #5{c_comment}, #7{l_discount}, #22, #23, #34) // { arity: 9 }
-        Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
+        Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
             implementation
               %0:customer » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef » %3:nation[#0]KA
@@ -1026,7 +1019,7 @@ materialize.public.q11:
   With
     cte l0 =
       Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
-        Filter (#13{n_name} = "GERMANY") AND (#1{ps_suppkey}) IS NOT NULL AND (#8{s_nationkey}) IS NOT NULL // { arity: 16 }
+        Filter (#13{n_name} = "GERMANY") // { arity: 16 }
           Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
             implementation
               %0:partsupp » %1:supplier[#0]KA » %2:nation[#0]KAef
@@ -1095,7 +1088,7 @@ materialize.public.q12_primary_idx:
 materialize.public.q12:
   Reduce group_by=[#1{l_shipmode}] aggregates=[sum(case when ((#0{o_orderpriority} = "2-HIGH") OR (#0{o_orderpriority} = "1-URGENT")) then 1 else 0 end), sum(case when ((#0{o_orderpriority} != "2-HIGH") AND (#0{o_orderpriority} != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
     Project (#5, #23) // { arity: 2 }
-      Filter (#21{l_receiptdate} >= 1994-01-01) AND (#0{o_orderkey}) IS NOT NULL AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
+      Filter (#21{l_receiptdate} >= 1994-01-01) AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
         Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 25 }
           implementation
             %1:lineitem[#0]KAeiif » %0:orders[#0]KAeiif
@@ -1157,22 +1150,21 @@ materialize.public.q13:
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0{c_custkey}) // { arity: 1 }
-                    Filter (#0{c_custkey}) IS NOT NULL // { arity: 9 }
-                      Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
-                        implementation
-                          %1[#0]UKA » %0:l0[#0]KA
-                        Get l0 // { arity: 8 }
-                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                          Distinct project=[#0{c_custkey}] // { arity: 1 }
-                            Project (#0{c_custkey}) // { arity: 1 }
-                              Get l1 // { arity: 2 }
+                    Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
+                      implementation
+                        %1[#0]UKA » %0:l0[#0]KA
+                      Get l0 // { arity: 8 }
+                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                        Distinct project=[#0{c_custkey}] // { arity: 1 }
+                          Project (#0{c_custkey}) // { arity: 1 }
+                            Get l1 // { arity: 2 }
                 Project (#0{c_custkey}) // { arity: 1 }
                   ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
             Get l1 // { arity: 2 }
   With
     cte l1 =
       Project (#0{c_custkey}, #8) // { arity: 2 }
-        Filter (#0{c_custkey}) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
+        Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
           Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
             implementation
               %1:orders[#1]KAf » %0:l0[#0]KAf
@@ -1236,7 +1228,7 @@ materialize.public.q14:
     cte l0 =
       Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
         Project (#5, #6, #20) // { arity: 3 }
-          Filter (#10{l_shipdate} >= 1995-09-01) AND (#1{l_partkey}) IS NOT NULL AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
+          Filter (#10{l_shipdate} >= 1995-09-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
             Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
               implementation
                 %0:lineitem[#1]KAiif » %1:part[#0]KAiif
@@ -1303,20 +1295,19 @@ materialize.public.q15_primary_idx:
 materialize.public.q15:
   Return // { arity: 5 }
     Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
-      Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
-        Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
-          implementation
-            %0:supplier » %1:l0[#0]UKA » %2[#0]UK
-            %1:l0 » %2[#0]UK » %0:supplier[#0]KA
-            %2 » %1:l0[#1]K » %0:supplier[#0]KA
-          ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
-            ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] // { arity: 7 }
-          ArrangeBy keys=[[#0{l_suppkey}], [#1{sum}]] // { arity: 2 }
-            Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
-            Reduce aggregates=[max(#0{sum})] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Get l0 // { arity: 2 }
+      Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
+        implementation
+          %0:supplier » %1:l0[#0]UKA » %2[#0]UK
+          %1:l0 » %2[#0]UK » %0:supplier[#0]KA
+          %2 » %1:l0[#1]K » %0:supplier[#0]KA
+        ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
+          ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] // { arity: 7 }
+        ArrangeBy keys=[[#0{l_suppkey}], [#1{sum}]] // { arity: 2 }
+          Get l0 // { arity: 2 }
+        ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
+          Reduce aggregates=[max(#0{sum})] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Get l0 // { arity: 2 }
   With
     cte l0 =
       Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
@@ -1409,7 +1400,7 @@ materialize.public.q16:
           Get l0 // { arity: 4 }
     cte l0 =
       Project (#1{p_brand}, #8..=#10) // { arity: 4 }
-        Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
+        Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
           Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
             implementation
               %1:part[#0]KAef » %0:partsupp[#0]KAef
@@ -1495,7 +1486,7 @@ materialize.public.q17:
                       Get l0 // { arity: 16 }
     cte l1 =
       Project (#1{l_quantity}, #4, #5) // { arity: 3 }
-        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
+        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
           Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
               %1:part[#0]KAef » %0:l0[#1]KAef
@@ -1585,17 +1576,16 @@ materialize.public.q18:
   With
     cte l1 =
       Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
-        Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
-          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
-            implementation
-              %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
-              %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
-              %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-            Get l0 // { arity: 16 }
+        Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
+          implementation
+            %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
+            %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
+            %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
+          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
+            ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
+          ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+          Get l0 // { arity: 16 }
     cte l0 =
       ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
@@ -1675,7 +1665,7 @@ materialize.public.q19:
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND (#1{l_partkey}) IS NOT NULL AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
+          Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
             Map ((#4{l_quantity} <= 20), (#4{l_quantity} >= 10), (#4{l_quantity} <= 30), (#4{l_quantity} >= 20), (#4{l_quantity} <= 11), (#4{l_quantity} >= 1), (#19{p_brand} = "Brand#12"), (#21{p_size} <= 5), ((#22{p_container} = "SM BOX") OR (#22{p_container} = "SM PKG") OR (#22{p_container} = "SM CASE") OR (#22{p_container} = "SM PACK")), (#19{p_brand} = "Brand#23"), (#21{p_size} <= 10), ((#22{p_container} = "MED BAG") OR (#22{p_container} = "MED BOX") OR (#22{p_container} = "MED PKG") OR (#22{p_container} = "MED PACK")), (#19{p_brand} = "Brand#34"), (#21{p_size} <= 15), ((#22{p_container} = "LG BOX") OR (#22{p_container} = "LG PKG") OR (#22{p_container} = "LG CASE") OR (#22{p_container} = "LG PACK"))) // { arity: 40 }
               Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
                 implementation
@@ -1801,7 +1791,7 @@ materialize.public.q20:
                   ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
     cte l0 =
       Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
-        Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
+        Filter (#8{n_name} = "CANADA") // { arity: 11 }
           Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
             implementation
               %1:nation[#0]KAef » %0:supplier[#3]KAef
@@ -1926,7 +1916,7 @@ materialize.public.q21:
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
     cte l0 =
       Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
-        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
+        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
           Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
             implementation
               %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
@@ -2029,16 +2019,15 @@ materialize.public.q22:
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0{c_custkey}) // { arity: 1 }
-                  Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
-                    Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
-                      implementation
-                        %0:l2[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                      ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
-                        Distinct project=[#0{o_custkey}] // { arity: 1 }
-                          Project (#1) // { arity: 1 }
-                            ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+                  Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
+                    implementation
+                      %0:l2[#0]UKA » %1[#0]UKA
+                    ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                      Get l2 // { arity: 1 }
+                    ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
+                      Distinct project=[#0{o_custkey}] // { arity: 1 }
+                        Project (#1) // { arity: 1 }
+                          ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
               Get l2 // { arity: 1 }
   With
     cte l2 =

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -1037,14 +1037,15 @@ materialize.public.q13:
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0{c_custkey}) // { arity: 1 }
-                    Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
-                      implementation
-                        %1[#0]UKA » %0:l0[#0]KA
-                      Get l0 // { arity: 8 }
-                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                        Distinct project=[#0{c_custkey}] // { arity: 1 }
-                          Project (#0{c_custkey}) // { arity: 1 }
-                            Get l1 // { arity: 2 }
+                    Filter (#0{c_custkey}) IS NOT NULL // { arity: 9 }
+                      Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
+                        implementation
+                          %1[#0]UKA » %0:l0[#0]KA
+                        Get l0 // { arity: 8 }
+                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                          Distinct project=[#0{c_custkey}] // { arity: 1 }
+                            Project (#0{c_custkey}) // { arity: 1 }
+                              Get l1 // { arity: 2 }
                 Project (#0{c_custkey}) // { arity: 1 }
                   ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
             Get l1 // { arity: 2 }

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -256,7 +256,7 @@ materialize.public.q02:
         ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
           Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
             Project (#0{p_partkey}, #4) // { arity: 2 }
-              Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
+              Filter (#18{r_name} = "EUROPE") // { arity: 20 }
                 Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                   implementation
                     %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
@@ -275,7 +275,7 @@ materialize.public.q02:
   With
     cte l4 =
       Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
+        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
           Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
             implementation
               %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
@@ -348,7 +348,7 @@ materialize.public.q03:
   Project (#0{o_orderkey}, #3{o_shippriority}, #1{sum}, #2{o_orderdate}) // { arity: 4 }
     Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
       Project (#8, #12, #15, #22, #23) // { arity: 5 }
-        Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
+        Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) // { arity: 33 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
               %0:customer » %1:orders[#1]KAif » %2:lineitem[#0]KAif
@@ -401,19 +401,12 @@ ORDER BY
 materialize.public.q04:
   Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
     Project (#5) // { arity: 1 }
-      Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 11 }
-        Join on=(#0{o_orderkey} = #9{o_orderkey} = #10{l_orderkey}) type=delta // { arity: 11 }
+      Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 10 }
+        Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 10 }
           implementation
-            %0:orders » %1[#0]UKA » %2[#0]UKA
-            %1 » %2[#0]UKA » %0:orders[#0]KAiif
-            %2 » %1[#0]UKA » %0:orders[#0]KAiif
+            %1[#0]UKA » %0:orders[#0]KAiif
           ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-            ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
-          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
-            Distinct project=[#0{o_orderkey}] // { arity: 1 }
-              Project (#0{o_orderkey}) // { arity: 1 }
-                Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
-                  ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
           ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
             Distinct project=[#0{l_orderkey}] // { arity: 1 }
               Project (#0{l_orderkey}) // { arity: 1 }
@@ -421,7 +414,7 @@ materialize.public.q04:
                   ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_orders_orderkey (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (differential join)
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
 
 Target cluster: quickstart
@@ -461,7 +454,7 @@ ORDER BY
 materialize.public.q05:
   Reduce group_by=[#2{n_name}] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
     Project (#19, #20, #24) // { arity: 3 }
-      Filter (#28{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (#25{n_regionkey}) IS NOT NULL // { arity: 30 }
+      Filter (#28{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) // { arity: 30 }
         Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #22{s_nationkey} = #23{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey} AND #18{l_suppkey} = #21{s_suppkey} AND #25{n_regionkey} = #27{r_regionkey}) type=delta // { arity: 30 }
           implementation
             %0:customer » %1:orders[#1]KAiif » %2:lineitem[#0]KA » %3:supplier[#0, #1]KK » %4:nation[#0]KA » %5:region[#0]KAef
@@ -590,7 +583,7 @@ materialize.public.q07:
   Return // { arity: 4 }
     Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
       Project (#12, #13, #17, #41, #45) // { arity: 5 }
-        Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#24{o_custkey}) IS NOT NULL AND (#35{c_nationkey}) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
+        Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
           Map ((#41{n_name} = "FRANCE"), (#41{n_name} = "GERMANY"), (#45{n_name} = "FRANCE"), (#45{n_name} = "GERMANY")) // { arity: 52 }
             Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #40{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey} AND #24{o_custkey} = #32{c_custkey} AND #35{c_nationkey} = #44{n_nationkey}) type=delta // { arity: 48 }
               implementation
@@ -678,7 +671,7 @@ materialize.public.q08:
     Map ((#1{sum} / #2{sum})) // { arity: 4 }
       Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
         Project (#21, #22, #36, #54) // { arity: 4 }
-          Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND (#33{o_custkey}) IS NOT NULL AND (#44{c_nationkey}) IS NOT NULL AND (#51{n_regionkey}) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
+          Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
             Join on=(#0{p_partkey} = #17{l_partkey} AND #9{s_suppkey} = #18{l_suppkey} AND #12{s_nationkey} = #53{n_nationkey} AND #16{l_orderkey} = #32{o_orderkey} AND #33{o_custkey} = #41{c_custkey} AND #44{c_nationkey} = #49{n_nationkey} AND #51{n_regionkey} = #57{r_regionkey}) type=delta // { arity: 60 }
               implementation
                 %0:part » %2:lineitem[#1]KA » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
@@ -766,7 +759,7 @@ ORDER BY
 materialize.public.q09:
   Reduce group_by=[#5{n_name}, extract_year_d(#4{o_orderdate})] aggregates=[sum(((#1{l_extendedprice} * (1 - #2{l_discount})) - (#3{ps_supplycost} * #0{l_quantity})))] // { arity: 3 }
     Project (#20..=#22, #35, #41, #47) // { arity: 6 }
-      Filter (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
+      Filter like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
         Join on=(#0{p_partkey} = #17{l_partkey} = #32{ps_partkey} AND #9{s_suppkey} = #18{l_suppkey} = #33{ps_suppkey} AND #12{s_nationkey} = #46{n_nationkey} AND #16{l_orderkey} = #37{o_orderkey}) type=delta // { arity: 50 }
           implementation
             %0:part » %2:lineitem[#1]KA » %3:partsupp[#0, #1]KKA » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
@@ -846,7 +839,7 @@ materialize.public.q10:
   Project (#0{c_custkey}, #1{c_name}, #7{c_comment}, #2{sum}, #4{n_name}, #5{c_address}, #3{c_acctbal}, #6{c_phone}) // { arity: 8 }
     Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
       Project (#0{c_custkey}..=#2{c_address}, #4{c_acctbal}, #5{c_comment}, #7{l_discount}, #22, #23, #34) // { arity: 9 }
-        Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
+        Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
             implementation
               %0:customer » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef » %3:nation[#0]KA
@@ -924,7 +917,7 @@ materialize.public.q11:
   With
     cte l0 =
       Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
-        Filter (#13{n_name} = "GERMANY") AND (#1{ps_suppkey}) IS NOT NULL AND (#8{s_nationkey}) IS NOT NULL // { arity: 16 }
+        Filter (#13{n_name} = "GERMANY") // { arity: 16 }
           Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
             implementation
               %0:partsupp » %1:supplier[#0]KA » %2:nation[#0]KAef
@@ -984,7 +977,7 @@ ORDER BY
 materialize.public.q12:
   Reduce group_by=[#1{l_shipmode}] aggregates=[sum(case when ((#0{o_orderpriority} = "2-HIGH") OR (#0{o_orderpriority} = "1-URGENT")) then 1 else 0 end), sum(case when ((#0{o_orderpriority} != "2-HIGH") AND (#0{o_orderpriority} != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
     Project (#5, #23) // { arity: 2 }
-      Filter (#21{l_receiptdate} >= 1994-01-01) AND (#0{o_orderkey}) IS NOT NULL AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
+      Filter (#21{l_receiptdate} >= 1994-01-01) AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
         Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 25 }
           implementation
             %1:lineitem[#0]KAeiif » %0:orders[#0]KAeiif
@@ -1037,22 +1030,21 @@ materialize.public.q13:
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0{c_custkey}) // { arity: 1 }
-                    Filter (#0{c_custkey}) IS NOT NULL // { arity: 9 }
-                      Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
-                        implementation
-                          %1[#0]UKA » %0:l0[#0]KA
-                        Get l0 // { arity: 8 }
-                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                          Distinct project=[#0{c_custkey}] // { arity: 1 }
-                            Project (#0{c_custkey}) // { arity: 1 }
-                              Get l1 // { arity: 2 }
+                    Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
+                      implementation
+                        %1[#0]UKA » %0:l0[#0]KA
+                      Get l0 // { arity: 8 }
+                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                        Distinct project=[#0{c_custkey}] // { arity: 1 }
+                          Project (#0{c_custkey}) // { arity: 1 }
+                            Get l1 // { arity: 2 }
                 Project (#0{c_custkey}) // { arity: 1 }
                   ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
             Get l1 // { arity: 2 }
   With
     cte l1 =
       Project (#0{c_custkey}, #8) // { arity: 2 }
-        Filter (#0{c_custkey}) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
+        Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
           Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
             implementation
               %1:orders[#1]KAf » %0:l0[#0]KAf
@@ -1107,7 +1099,7 @@ materialize.public.q14:
     cte l0 =
       Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
         Project (#5, #6, #20) // { arity: 3 }
-          Filter (#10{l_shipdate} >= 1995-09-01) AND (#1{l_partkey}) IS NOT NULL AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
+          Filter (#10{l_shipdate} >= 1995-09-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
             Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
               implementation
                 %0:lineitem[#1]KAiif » %1:part[#0]KAiif
@@ -1165,20 +1157,19 @@ ORDER BY
 materialize.public.q15:
   Return // { arity: 5 }
     Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
-      Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
-        Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
-          implementation
-            %0:supplier » %1:l0[#0]UKA » %2[#0]UK
-            %1:l0 » %2[#0]UK » %0:supplier[#0]KA
-            %2 » %1:l0[#1]K » %0:supplier[#0]KA
-          ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
-            ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] // { arity: 7 }
-          ArrangeBy keys=[[#0{l_suppkey}], [#1{sum}]] // { arity: 2 }
-            Get l0 // { arity: 2 }
-          ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
-            Reduce aggregates=[max(#0{sum})] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Get l0 // { arity: 2 }
+      Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
+        implementation
+          %0:supplier » %1:l0[#0]UKA » %2[#0]UK
+          %1:l0 » %2[#0]UK » %0:supplier[#0]KA
+          %2 » %1:l0[#1]K » %0:supplier[#0]KA
+        ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
+          ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] // { arity: 7 }
+        ArrangeBy keys=[[#0{l_suppkey}], [#1{sum}]] // { arity: 2 }
+          Get l0 // { arity: 2 }
+        ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
+          Reduce aggregates=[max(#0{sum})] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Get l0 // { arity: 2 }
   With
     cte l0 =
       Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
@@ -1265,7 +1256,7 @@ materialize.public.q16:
           Get l0 // { arity: 4 }
     cte l0 =
       Project (#1{p_brand}, #8..=#10) // { arity: 4 }
-        Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
+        Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
           Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
             implementation
               %1:part[#0]KAef » %0:partsupp[#0]KAef
@@ -1342,7 +1333,7 @@ materialize.public.q17:
                       Get l0 // { arity: 16 }
     cte l1 =
       Project (#1{l_quantity}, #4, #5) // { arity: 3 }
-        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
+        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
           Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
               %1:part[#0]KAef » %0:l0[#1]KAef
@@ -1423,17 +1414,16 @@ materialize.public.q18:
   With
     cte l1 =
       Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
-        Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
-          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
-            implementation
-              %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
-              %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
-              %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-            Get l0 // { arity: 16 }
+        Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
+          implementation
+            %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
+            %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
+            %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
+          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
+            ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
+          ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+          Get l0 // { arity: 16 }
     cte l0 =
       ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
@@ -1504,7 +1494,7 @@ materialize.public.q19:
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND (#1{l_partkey}) IS NOT NULL AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
+          Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
             Map ((#4{l_quantity} <= 20), (#4{l_quantity} >= 10), (#4{l_quantity} <= 30), (#4{l_quantity} >= 20), (#4{l_quantity} <= 11), (#4{l_quantity} >= 1), (#19{p_brand} = "Brand#12"), (#21{p_size} <= 5), ((#22{p_container} = "SM BOX") OR (#22{p_container} = "SM PKG") OR (#22{p_container} = "SM CASE") OR (#22{p_container} = "SM PACK")), (#19{p_brand} = "Brand#23"), (#21{p_size} <= 10), ((#22{p_container} = "MED BAG") OR (#22{p_container} = "MED BOX") OR (#22{p_container} = "MED PKG") OR (#22{p_container} = "MED PACK")), (#19{p_brand} = "Brand#34"), (#21{p_size} <= 15), ((#22{p_container} = "LG BOX") OR (#22{p_container} = "LG PKG") OR (#22{p_container} = "LG CASE") OR (#22{p_container} = "LG PACK"))) // { arity: 40 }
               Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
                 implementation
@@ -1621,7 +1611,7 @@ materialize.public.q20:
                   ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
     cte l0 =
       Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
-        Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
+        Filter (#8{n_name} = "CANADA") // { arity: 11 }
           Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
             implementation
               %1:nation[#0]KAef » %0:supplier[#3]KAef
@@ -1737,7 +1727,7 @@ materialize.public.q21:
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
     cte l0 =
       Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
-        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
+        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
           Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
             implementation
               %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
@@ -1831,16 +1821,15 @@ materialize.public.q22:
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0{c_custkey}) // { arity: 1 }
-                  Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
-                    Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
-                      implementation
-                        %0:l2[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                        Get l2 // { arity: 1 }
-                      ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
-                        Distinct project=[#0{o_custkey}] // { arity: 1 }
-                          Project (#1) // { arity: 1 }
-                            ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+                  Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
+                    implementation
+                      %0:l2[#0]UKA » %1[#0]UKA
+                    ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                      Get l2 // { arity: 1 }
+                    ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
+                      Distinct project=[#0{o_custkey}] // { arity: 1 }
+                        Project (#1) // { arity: 1 }
+                          ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
               Get l2 // { arity: 1 }
   With
     cte l2 =

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -1035,14 +1035,15 @@ Explained Query:
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#0{c_custkey}) // { arity: 1 }
-                      Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
-                        implementation
-                          %1[#0]UKA » %0:l0[#0]KA
-                        Get l0 // { arity: 8 }
-                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                          Distinct project=[#0{c_custkey}] // { arity: 1 }
-                            Project (#0{c_custkey}) // { arity: 1 }
-                              Get l1 // { arity: 2 }
+                      Filter (#0{c_custkey}) IS NOT NULL // { arity: 9 }
+                        Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
+                          implementation
+                            %1[#0]UKA » %0:l0[#0]KA
+                          Get l0 // { arity: 8 }
+                          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                            Distinct project=[#0{c_custkey}] // { arity: 1 }
+                              Project (#0{c_custkey}) // { arity: 1 }
+                                Get l1 // { arity: 2 }
                   Project (#0{c_custkey}) // { arity: 1 }
                     ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
               Get l1 // { arity: 2 }

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -255,7 +255,7 @@ Explained Query:
           ArrangeBy keys=[[#0{p_partkey}, #1{min_ps_supplycost}]] // { arity: 2 }
             Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
               Project (#0{p_partkey}, #4) // { arity: 2 }
-                Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
+                Filter (#18{r_name} = "EUROPE") // { arity: 20 }
                   Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                     implementation
                       %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
@@ -274,7 +274,7 @@ Explained Query:
     With
       cte l4 =
         Project (#0{p_partkey}, #2{s_name}, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-          Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
+          Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
             Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
               implementation
                 %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
@@ -347,7 +347,7 @@ Explained Query:
     Project (#0{o_orderkey}, #3{o_shippriority}, #1{sum}, #2{o_orderdate}) // { arity: 4 }
       Reduce group_by=[#0{o_orderkey}..=#2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
         Project (#8, #12, #15, #22, #23) // { arity: 5 }
-          Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
+          Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) // { arity: 33 }
             Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
               implementation
                 %0:customer » %1:orders[#1]KAif » %2:lineitem[#0]KAif
@@ -400,19 +400,12 @@ Explained Query:
   Finish order_by=[#0{o_orderpriority} asc nulls_last] output=[#0, #1]
     Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
       Project (#5) // { arity: 1 }
-        Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 11 }
-          Join on=(#0{o_orderkey} = #9{o_orderkey} = #10{l_orderkey}) type=delta // { arity: 11 }
+        Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 10 }
+          Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 10 }
             implementation
-              %0:orders » %1[#0]UKA » %2[#0]UKA
-              %1 » %2[#0]UKA » %0:orders[#0]KAiif
-              %2 » %1[#0]UKA » %0:orders[#0]KAiif
+              %1[#0]UKA » %0:orders[#0]KAiif
             ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
-              ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
-            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
-              Distinct project=[#0{o_orderkey}] // { arity: 1 }
-                Project (#0{o_orderkey}) // { arity: 1 }
-                  Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
-                    ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
             ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
               Distinct project=[#0{l_orderkey}] // { arity: 1 }
                 Project (#0{l_orderkey}) // { arity: 1 }
@@ -420,7 +413,7 @@ Explained Query:
                     ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_orders_orderkey (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (differential join)
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
 
 Target cluster: quickstart
@@ -460,7 +453,7 @@ Explained Query:
   Finish order_by=[#1{sum} desc nulls_first] output=[#0, #1]
     Reduce group_by=[#2{n_name}] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
       Project (#19, #20, #24) // { arity: 3 }
-        Filter (#28{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (#25{n_regionkey}) IS NOT NULL // { arity: 30 }
+        Filter (#28{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) // { arity: 30 }
           Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #22{s_nationkey} = #23{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey} AND #18{l_suppkey} = #21{s_suppkey} AND #25{n_regionkey} = #27{r_regionkey}) type=delta // { arity: 30 }
             implementation
               %0:customer » %1:orders[#1]KAiif » %2:lineitem[#0]KA » %3:supplier[#0, #1]KK » %4:nation[#0]KA » %5:region[#0]KAef
@@ -588,7 +581,7 @@ Explained Query:
     Return // { arity: 4 }
       Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
         Project (#12, #13, #17, #41, #45) // { arity: 5 }
-          Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#24{o_custkey}) IS NOT NULL AND (#35{c_nationkey}) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
+          Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
             Map ((#41{n_name} = "FRANCE"), (#41{n_name} = "GERMANY"), (#45{n_name} = "FRANCE"), (#45{n_name} = "GERMANY")) // { arity: 52 }
               Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #40{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey} AND #24{o_custkey} = #32{c_custkey} AND #35{c_nationkey} = #44{n_nationkey}) type=delta // { arity: 48 }
                 implementation
@@ -676,7 +669,7 @@ Explained Query:
       Map ((#1{sum} / #2{sum})) // { arity: 4 }
         Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
           Project (#21, #22, #36, #54) // { arity: 4 }
-            Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND (#33{o_custkey}) IS NOT NULL AND (#44{c_nationkey}) IS NOT NULL AND (#51{n_regionkey}) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
+            Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
               Join on=(#0{p_partkey} = #17{l_partkey} AND #9{s_suppkey} = #18{l_suppkey} AND #12{s_nationkey} = #53{n_nationkey} AND #16{l_orderkey} = #32{o_orderkey} AND #33{o_custkey} = #41{c_custkey} AND #44{c_nationkey} = #49{n_nationkey} AND #51{n_regionkey} = #57{r_regionkey}) type=delta // { arity: 60 }
                 implementation
                   %0:part » %2:lineitem[#1]KA » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
@@ -764,7 +757,7 @@ Explained Query:
   Finish order_by=[#0{n_name} asc nulls_last, #1 desc nulls_first] output=[#0..=#2]
     Reduce group_by=[#5{n_name}, extract_year_d(#4{o_orderdate})] aggregates=[sum(((#1{l_extendedprice} * (1 - #2{l_discount})) - (#3{ps_supplycost} * #0{l_quantity})))] // { arity: 3 }
       Project (#20..=#22, #35, #41, #47) // { arity: 6 }
-        Filter (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
+        Filter like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
           Join on=(#0{p_partkey} = #17{l_partkey} = #32{ps_partkey} AND #9{s_suppkey} = #18{l_suppkey} = #33{ps_suppkey} AND #12{s_nationkey} = #46{n_nationkey} AND #16{l_orderkey} = #37{o_orderkey}) type=delta // { arity: 50 }
             implementation
               %0:part » %2:lineitem[#1]KA » %3:partsupp[#0, #1]KKA » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
@@ -844,7 +837,7 @@ Explained Query:
     Project (#0{c_custkey}, #1{c_name}, #7{c_comment}, #2{sum}, #4{n_name}, #5{c_address}, #3{c_acctbal}, #6{c_phone}) // { arity: 8 }
       Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
         Project (#0{c_custkey}..=#2{c_address}, #4{c_acctbal}, #5{c_comment}, #7{l_discount}, #22, #23, #34) // { arity: 9 }
-          Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
+          Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
             Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
               implementation
                 %0:customer » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef » %3:nation[#0]KA
@@ -922,7 +915,7 @@ Explained Query:
     With
       cte l0 =
         Project (#0{ps_partkey}, #2{ps_supplycost}, #3) // { arity: 3 }
-          Filter (#13{n_name} = "GERMANY") AND (#1{ps_suppkey}) IS NOT NULL AND (#8{s_nationkey}) IS NOT NULL // { arity: 16 }
+          Filter (#13{n_name} = "GERMANY") // { arity: 16 }
             Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
               implementation
                 %0:partsupp » %1:supplier[#0]KA » %2:nation[#0]KAef
@@ -982,7 +975,7 @@ Explained Query:
   Finish order_by=[#0{l_shipmode} asc nulls_last] output=[#0..=#2]
     Reduce group_by=[#1{l_shipmode}] aggregates=[sum(case when ((#0{o_orderpriority} = "2-HIGH") OR (#0{o_orderpriority} = "1-URGENT")) then 1 else 0 end), sum(case when ((#0{o_orderpriority} != "2-HIGH") AND (#0{o_orderpriority} != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
       Project (#5, #23) // { arity: 2 }
-        Filter (#21{l_receiptdate} >= 1994-01-01) AND (#0{o_orderkey}) IS NOT NULL AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
+        Filter (#21{l_receiptdate} >= 1994-01-01) AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
           Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 25 }
             implementation
               %1:lineitem[#0]KAeiif » %0:orders[#0]KAeiif
@@ -1035,22 +1028,21 @@ Explained Query:
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#0{c_custkey}) // { arity: 1 }
-                      Filter (#0{c_custkey}) IS NOT NULL // { arity: 9 }
-                        Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
-                          implementation
-                            %1[#0]UKA » %0:l0[#0]KA
-                          Get l0 // { arity: 8 }
-                          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                            Distinct project=[#0{c_custkey}] // { arity: 1 }
-                              Project (#0{c_custkey}) // { arity: 1 }
-                                Get l1 // { arity: 2 }
+                      Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
+                        implementation
+                          %1[#0]UKA » %0:l0[#0]KA
+                        Get l0 // { arity: 8 }
+                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                          Distinct project=[#0{c_custkey}] // { arity: 1 }
+                            Project (#0{c_custkey}) // { arity: 1 }
+                              Get l1 // { arity: 2 }
                   Project (#0{c_custkey}) // { arity: 1 }
                     ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
               Get l1 // { arity: 2 }
     With
       cte l1 =
         Project (#0{c_custkey}, #8) // { arity: 2 }
-          Filter (#0{c_custkey}) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
+          Filter NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
             Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
               implementation
                 %1:orders[#1]KAf » %0:l0[#0]KAf
@@ -1104,7 +1096,7 @@ Explained Query:
     cte l0 =
       Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
         Project (#5, #6, #20) // { arity: 3 }
-          Filter (#10{l_shipdate} >= 1995-09-01) AND (#1{l_partkey}) IS NOT NULL AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
+          Filter (#10{l_shipdate} >= 1995-09-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
             Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
               implementation
                 %0:lineitem[#1]KAiif » %1:part[#0]KAiif
@@ -1162,20 +1154,19 @@ Explained Query:
   Finish order_by=[#0{s_suppkey} asc nulls_last] output=[#0..=#4]
     Return // { arity: 5 }
       Project (#0{s_suppkey}..=#2{s_address}, #4{sum}, #8) // { arity: 5 }
-        Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
-          Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
-            implementation
-              %0:supplier » %1:l0[#0]UKA » %2[#0]UK
-              %1:l0 » %2[#0]UK » %0:supplier[#0]KA
-              %2 » %1:l0[#1]K » %0:supplier[#0]KA
-            ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
-              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] // { arity: 7 }
-            ArrangeBy keys=[[#0{l_suppkey}], [#1{sum}]] // { arity: 2 }
-              Get l0 // { arity: 2 }
-            ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
-              Reduce aggregates=[max(#0{sum})] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 2 }
+        Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8{sum} = #9{max_sum}) type=delta // { arity: 10 }
+          implementation
+            %0:supplier » %1:l0[#0]UKA » %2[#0]UK
+            %1:l0 » %2[#0]UK » %0:supplier[#0]KA
+            %2 » %1:l0[#1]K » %0:supplier[#0]KA
+          ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
+            ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] // { arity: 7 }
+          ArrangeBy keys=[[#0{l_suppkey}], [#1{sum}]] // { arity: 2 }
+            Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0{max_sum}]] // { arity: 1 }
+            Reduce aggregates=[max(#0{sum})] // { arity: 1 }
+              Project (#1) // { arity: 1 }
+                Get l0 // { arity: 2 }
     With
       cte l0 =
         Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
@@ -1262,7 +1253,7 @@ Explained Query:
             Get l0 // { arity: 4 }
       cte l0 =
         Project (#1{p_brand}, #8..=#10) // { arity: 4 }
-          Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
+          Filter (#8{p_brand} != "Brand#45") AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
             Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
               implementation
                 %1:part[#0]KAef » %0:partsupp[#0]KAef
@@ -1338,7 +1329,7 @@ Explained Query:
                       Get l0 // { arity: 16 }
     cte l1 =
       Project (#1{l_quantity}, #4, #5) // { arity: 3 }
-        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
+        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") // { arity: 25 }
           Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
               %1:part[#0]KAef » %0:l0[#1]KAef
@@ -1419,17 +1410,16 @@ Explained Query:
     With
       cte l1 =
         Project (#0{c_custkey}, #1{c_name}, #8, #11, #12, #21) // { arity: 6 }
-          Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
-            Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
-              implementation
-                %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
-                %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
-                %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-              ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
-                ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-              ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
-                ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-              Get l0 // { arity: 16 }
+          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
+            implementation
+              %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
+              %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
+              %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
+            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
+              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
+            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+            Get l0 // { arity: 16 }
       cte l0 =
         ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
           ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
@@ -1499,7 +1489,7 @@ Explained Query:
     cte l0 =
       Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND (#1{l_partkey}) IS NOT NULL AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
+          Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
             Map ((#4{l_quantity} <= 20), (#4{l_quantity} >= 10), (#4{l_quantity} <= 30), (#4{l_quantity} >= 20), (#4{l_quantity} <= 11), (#4{l_quantity} >= 1), (#19{p_brand} = "Brand#12"), (#21{p_size} <= 5), ((#22{p_container} = "SM BOX") OR (#22{p_container} = "SM PKG") OR (#22{p_container} = "SM CASE") OR (#22{p_container} = "SM PACK")), (#19{p_brand} = "Brand#23"), (#21{p_size} <= 10), ((#22{p_container} = "MED BAG") OR (#22{p_container} = "MED BOX") OR (#22{p_container} = "MED PKG") OR (#22{p_container} = "MED PACK")), (#19{p_brand} = "Brand#34"), (#21{p_size} <= 15), ((#22{p_container} = "LG BOX") OR (#22{p_container} = "LG PKG") OR (#22{p_container} = "LG CASE") OR (#22{p_container} = "LG PACK"))) // { arity: 40 }
               Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
                 implementation
@@ -1616,7 +1606,7 @@ Explained Query:
                     ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
       cte l0 =
         Project (#0{s_suppkey}..=#2{s_address}) // { arity: 3 }
-          Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
+          Filter (#8{n_name} = "CANADA") // { arity: 11 }
             Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
               implementation
                 %1:nation[#0]KAef » %0:supplier[#3]KAef
@@ -1732,7 +1722,7 @@ Explained Query:
           ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
       cte l0 =
         Project (#0{s_suppkey}, #1{s_name}, #7) // { arity: 3 }
-          Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
+          Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
             Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
               implementation
                 %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
@@ -1826,16 +1816,15 @@ Explained Query:
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0{c_custkey}) // { arity: 1 }
-                    Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
-                      Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
-                        implementation
-                          %0:l2[#0]UKA » %1[#0]UKA
-                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
-                          Get l2 // { arity: 1 }
-                        ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
-                          Distinct project=[#0{o_custkey}] // { arity: 1 }
-                            Project (#1) // { arity: 1 }
-                              ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+                    Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
+                      implementation
+                        %0:l2[#0]UKA » %1[#0]UKA
+                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                        Get l2 // { arity: 1 }
+                      ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
+                        Distinct project=[#0{o_custkey}] // { arity: 1 }
+                          Project (#1) // { arity: 1 }
+                            ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
                 Get l2 // { arity: 1 }
     With
       cte l2 =

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -33,32 +33,31 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      %1[#0]UKA » %0:l1[#0]K
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Get l1 // { arity: 1 }
+                      %1[#0]UKA » %0:l0[#0]K
+                    Get l0 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct project=[#0] // { arity: 1 }
-                        Get l0 // { arity: 1 }
-              Get l1 // { arity: 1 }
+                        Get l1 // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                ReadStorage materialize.public.t1 // { arity: 2 }
           Project (#0, #0) // { arity: 2 }
-            Get l0 // { arity: 1 }
+            Get l1 // { arity: 1 }
   With
     cte l1 =
       Project (#0) // { arity: 1 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    cte l0 =
-      Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -121,29 +120,30 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    %1[#0]UKA » %0:t1[#0]K
-                  ArrangeBy keys=[[#0]] // { arity: 2 }
-                    ReadStorage materialize.public.t1 // { arity: 2 }
+                    %1[#0]UKA » %0:l0[#0]K
+                  Get l0 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct project=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
-                        Get l0 // { arity: 2 }
+                        Get l1 // { arity: 2 }
             ReadStorage materialize.public.t1 // { arity: 2 }
         Project (#0, #1, #0) // { arity: 3 }
-          Get l0 // { arity: 2 }
+          Get l1 // { arity: 2 }
   With
-    cte l0 =
+    cte l1 =
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -167,29 +167,30 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#0 = #2) type=differential // { arity: 3 }
                     implementation
-                      %1[#0]UKA » %0:t1[#0]K
-                    ArrangeBy keys=[[#0]] // { arity: 2 }
-                      ReadStorage materialize.public.t1 // { arity: 2 }
+                      %1[#0]UKA » %0:l0[#0]K
+                    Get l0 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct project=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
-                          Get l0 // { arity: 2 }
+                          Get l1 // { arity: 2 }
               ReadStorage materialize.public.t1 // { arity: 2 }
           Project (#0, #1, #0) // { arity: 3 }
-            Get l0 // { arity: 2 }
+            Get l1 // { arity: 2 }
   With
-    cte l0 =
+    cte l1 =
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -213,29 +214,30 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#0 = #2) type=differential // { arity: 3 }
                     implementation
-                      %1[#0]UKA » %0:t1[#0]K
-                    ArrangeBy keys=[[#0]] // { arity: 2 }
-                      ReadStorage materialize.public.t1 // { arity: 2 }
+                      %1[#0]UKA » %0:l0[#0]K
+                    Get l0 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct project=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
-                          Get l0 // { arity: 2 }
+                          Get l1 // { arity: 2 }
               ReadStorage materialize.public.t1 // { arity: 2 }
           Project (#0, #1, #0) // { arity: 3 }
-            Get l0 // { arity: 2 }
+            Get l1 // { arity: 2 }
   With
-    cte l0 =
+    cte l1 =
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -346,32 +348,31 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      %1[#0]UKA » %0:l1[#0]K
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Get l1 // { arity: 1 }
+                      %1[#0]UKA » %0:l0[#0]K
+                    Get l0 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct project=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
-                          Get l0 // { arity: 2 }
-              Get l1 // { arity: 1 }
+                          Get l1 // { arity: 2 }
+              Project (#0) // { arity: 1 }
+                ReadStorage materialize.public.t1 // { arity: 2 }
           Project (#0, #0, #1) // { arity: 3 }
-            Get l0 // { arity: 2 }
+            Get l1 // { arity: 2 }
   With
     cte l1 =
-      Project (#0) // { arity: 1 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    cte l0 =
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -453,32 +454,31 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      %1[#0]UKA » %0:l1[#0]K
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Get l1 // { arity: 1 }
+                      %1[#0]UKA » %0:l0[#0]K
+                    Get l0 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct project=[#0] // { arity: 1 }
-                        Get l0 // { arity: 1 }
-              Get l1 // { arity: 1 }
+                        Get l1 // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                ReadStorage materialize.public.t1 // { arity: 2 }
           Project (#0, #0) // { arity: 2 }
-            Get l0 // { arity: 1 }
+            Get l1 // { arity: 1 }
   With
     cte l1 =
       Project (#0) // { arity: 1 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    cte l0 =
-      Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -502,31 +502,30 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#0 = #1) type=differential // { arity: 2 }
                   implementation
-                    %1[#0]UKA » %0:l1[#0]K
-                  ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Get l1 // { arity: 1 }
+                    %1[#0]UKA » %0:l0[#0]K
+                  Get l0 // { arity: 1 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct project=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
-                        Get l0 // { arity: 2 }
-            Get l1 // { arity: 1 }
-        Get l0 // { arity: 2 }
+                        Get l1 // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        Get l1 // { arity: 2 }
   With
     cte l1 =
-      Project (#0) // { arity: 1 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    cte l0 =
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -550,31 +549,30 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#0 = #1) type=differential // { arity: 2 }
                   implementation
-                    %1[#0]UKA » %0:l1[#0]K
-                  ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Get l1 // { arity: 1 }
+                    %1[#0]UKA » %0:l0[#0]K
+                  Get l0 // { arity: 1 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct project=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
-                        Get l0 // { arity: 2 }
-            Get l1 // { arity: 1 }
-        Get l0 // { arity: 2 }
+                        Get l1 // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        Get l1 // { arity: 2 }
   With
     cte l1 =
-      Project (#0) // { arity: 1 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    cte l0 =
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -681,27 +679,28 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#1 = #2) type=differential // { arity: 3 }
                   implementation
-                    %1[#0]UKA » %0:t1[#1]K
-                  ArrangeBy keys=[[#1]] // { arity: 2 }
-                    ReadStorage materialize.public.t1 // { arity: 2 }
+                    %1[#0]UKA » %0:l0[#1]K
+                  Get l0 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct project=[#0] // { arity: 1 }
                       Project (#1) // { arity: 1 }
-                        Get l0 // { arity: 3 }
+                        Get l1 // { arity: 3 }
             ReadStorage materialize.public.t1 // { arity: 2 }
-        Get l0 // { arity: 3 }
+        Get l1 // { arity: 3 }
   With
-    cte l0 =
+    cte l1 =
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %0:t1[#1]K » %1:t2[#0]K
-          ArrangeBy keys=[[#1]] // { arity: 2 }
-            Filter (#1) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
+            %0:l0[#1]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#1]] // { arity: 2 }
+        Filter (#1) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2
@@ -725,27 +724,28 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#1 = #2) type=differential // { arity: 3 }
                     implementation
-                      %1[#0]UKA » %0:t1[#1]K
-                    ArrangeBy keys=[[#1]] // { arity: 2 }
-                      ReadStorage materialize.public.t1 // { arity: 2 }
+                      %1[#0]UKA » %0:l0[#1]K
+                    Get l0 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct project=[#0] // { arity: 1 }
                         Project (#1) // { arity: 1 }
-                          Get l0 // { arity: 3 }
+                          Get l1 // { arity: 3 }
               ReadStorage materialize.public.t1 // { arity: 2 }
-          Get l0 // { arity: 3 }
+          Get l1 // { arity: 3 }
   With
-    cte l0 =
+    cte l1 =
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %0:t1[#1]K » %1:t2[#0]K
-          ArrangeBy keys=[[#1]] // { arity: 2 }
-            Filter (#1) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
+            %0:l0[#1]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#1]] // { arity: 2 }
+        Filter (#1) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 Source materialize.public.t2

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -153,19 +153,18 @@ where foo.a = bar.a
 ----
 Explained Query:
   Project (#0, #5) // { arity: 2 }
-    Filter (#0) IS NOT NULL // { arity: 6 }
-      Join on=(#0 = #2 AND #3 = #4) type=delta // { arity: 6 }
-        implementation
-          %0:foo » %1:bar[#0]KA » %2:baz[#0]UK
-          %1:bar » %2:baz[#0]UK » %0:foo[#0]KA
-          %2:baz » %1:bar[#1]K » %0:foo[#0]KA
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          ReadIndex on=foo foo_idx=[delta join 1st input (full scan)] // { arity: 2 }
-        ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
-          Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
-            ReadIndex on=bar bar_idx=[*** full scan ***] // { arity: 2 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          ReadStorage materialize.public.baz // { arity: 2 }
+    Join on=(#0 = #2 AND #3 = #4) type=delta // { arity: 6 }
+      implementation
+        %0:foo » %1:bar[#0]KA » %2:baz[#0]UK
+        %1:bar » %2:baz[#0]UK » %0:foo[#0]KA
+        %2:baz » %1:bar[#1]K » %0:foo[#0]KA
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=foo foo_idx=[delta join 1st input (full scan)] // { arity: 2 }
+      ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
+          ReadIndex on=bar bar_idx=[*** full scan ***] // { arity: 2 }
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadStorage materialize.public.baz // { arity: 2 }
 
 Source materialize.public.baz
 
@@ -208,19 +207,18 @@ where foo.a = bar.a
 ----
 Explained Query:
   Project (#0, #5) // { arity: 2 }
-    Filter (#0) IS NOT NULL AND (#3) IS NOT NULL // { arity: 6 }
-      Join on=(#0 = #2 AND #3 = #4) type=delta // { arity: 6 }
-        implementation
-          %0:foo » %1:bar[#0]KA » %2:baz[#0]KA
-          %1:bar » %0:foo[#0]KA » %2:baz[#0]KA
-          %2:baz » %1:bar[#1]K » %0:foo[#0]KA
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          ReadIndex on=foo foo_idx=[delta join 1st input (full scan)] // { arity: 2 }
-        ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
-          Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
-            ReadIndex on=bar bar_idx=[*** full scan ***] // { arity: 2 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          ReadIndex on=baz baz_idx=[delta join lookup] // { arity: 2 }
+    Join on=(#0 = #2 AND #3 = #4) type=delta // { arity: 6 }
+      implementation
+        %0:foo » %1:bar[#0]KA » %2:baz[#0]KA
+        %1:bar » %0:foo[#0]KA » %2:baz[#0]KA
+        %2:baz » %1:bar[#1]K » %0:foo[#0]KA
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=foo foo_idx=[delta join 1st input (full scan)] // { arity: 2 }
+      ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
+        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
+          ReadIndex on=bar bar_idx=[*** full scan ***] // { arity: 2 }
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=baz baz_idx=[delta join lookup] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.foo_idx (delta join 1st input (full scan))
@@ -301,7 +299,7 @@ where foo.a = bar.a
 ----
 Explained Query:
   Project (#3, #1, #5) // { arity: 3 }
-    Filter (#0) IS NOT NULL AND (#4) IS NOT NULL // { arity: 6 }
+    Filter (#4) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #2 AND #4 = (#0 + 4)) type=delta // { arity: 6 }
         implementation
           %0:bar » %1:foo[#0]KA » %2:baz[#0]KA

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -716,14 +716,15 @@ Explained Query:
         Union // { arity: 2 }
           Negate // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
-              Join on=(#0 = #2) type=differential // { arity: 3 }
-                implementation
-                  %1[#0]UKA » %0:l0[#0]KA
-                Get l0 // { arity: 2 }
-                ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct project=[#0] // { arity: 1 }
-                    Project (#0) // { arity: 1 }
-                      Get l1 // { arity: 3 }
+              Filter (#0) IS NOT NULL // { arity: 3 }
+                Join on=(#0 = #2) type=differential // { arity: 3 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#0]KA
+                  Get l0 // { arity: 2 }
+                  ArrangeBy keys=[[#0]] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l1 // { arity: 3 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
     cte l1 =
       Project (#0, #1, #3) // { arity: 3 }

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -184,7 +184,7 @@ Explained Query:
               ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
           Map (error("more than one record produced in subquery")) // { arity: 1 }
             Project () // { arity: 0 }
-              Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+              Filter (#0 > 1) // { arity: 1 }
                 Reduce aggregates=[count(*)] // { arity: 1 }
                   Project () // { arity: 0 }
                     ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
@@ -220,7 +220,7 @@ Explained Query:
             Get l0 // { arity: 3 }
           Map (error("more than one record produced in subquery")) // { arity: 1 }
             Project () // { arity: 0 }
-              Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+              Filter (#0 > 1) // { arity: 1 }
                 Reduce aggregates=[count(*)] // { arity: 1 }
                   Project () // { arity: 0 }
                     Get l0 // { arity: 3 }
@@ -239,23 +239,22 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE f1 = (SELECT f1
 ----
 Explained Query:
   Project (#0, #1) // { arity: 2 }
-    Filter (#0) IS NOT NULL // { arity: 3 }
-      Join on=(#0 = #2) type=differential // { arity: 3 }
-        implementation
-          %0:t1[#0]KA » %1[#0]K
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          ReadIndex on=t1 i1=[differential join] // { arity: 2 }
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Union // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
-            Map (error("more than one record produced in subquery")) // { arity: 1 }
-              Project () // { arity: 0 }
-                Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-                  Reduce aggregates=[count(*)] // { arity: 1 }
-                    Project () // { arity: 0 }
-                      ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+    Join on=(#0 = #2) type=differential // { arity: 3 }
+      implementation
+        %0:t1[#0]KA » %1[#0]K
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        ReadIndex on=t1 i1=[differential join] // { arity: 2 }
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Union // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
+          Map (error("more than one record produced in subquery")) // { arity: 1 }
+            Project () // { arity: 0 }
+              Filter (#0 > 1) // { arity: 1 }
+                Reduce aggregates=[count(*)] // { arity: 1 }
+                  Project () // { arity: 0 }
+                    ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1 (*** full scan ***, differential join)
@@ -716,15 +715,14 @@ Explained Query:
         Union // { arity: 2 }
           Negate // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
-              Filter (#0) IS NOT NULL // { arity: 3 }
-                Join on=(#0 = #2) type=differential // { arity: 3 }
-                  implementation
-                    %1[#0]UKA » %0:l0[#0]KA
-                  Get l0 // { arity: 2 }
-                  ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Distinct project=[#0] // { arity: 1 }
-                      Project (#0) // { arity: 1 }
-                        Get l1 // { arity: 3 }
+              Join on=(#0 = #2) type=differential // { arity: 3 }
+                implementation
+                  %1[#0]UKA » %0:l0[#0]KA
+                Get l0 // { arity: 2 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l1 // { arity: 3 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
     cte l1 =
       Project (#0, #1, #3) // { arity: 3 }
@@ -972,21 +970,20 @@ Explained Query:
   With
     cte l2 =
       Project (#0, #1) // { arity: 2 }
-        Filter (#0) IS NOT NULL // { arity: 3 }
-          Join on=(#0 = #2) type=differential // { arity: 3 }
-            implementation
-              %0:l0[#0]KA » %1[#0]K
-            Get l0 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Union // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l1 // { arity: 3 }
-                Map (error("more than one record produced in subquery")) // { arity: 1 }
-                  Project () // { arity: 0 }
-                    Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-                      Reduce aggregates=[count(*)] // { arity: 1 }
-                        Project () // { arity: 0 }
-                          Get l1 // { arity: 3 }
+        Join on=(#0 = #2) type=differential // { arity: 3 }
+          implementation
+            %0:l0[#0]KA » %1[#0]K
+          Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Union // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l1 // { arity: 3 }
+              Map (error("more than one record produced in subquery")) // { arity: 1 }
+                Project () // { arity: 0 }
+                  Filter (#0 > 1) // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Get l1 // { arity: 3 }
     cte l1 =
       ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l0 =

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -165,28 +165,29 @@ Explained Query:
         Project (#0, #1) // { arity: 2 }
           Join on=(#0 = #2) type=differential // { arity: 3 }
             implementation
-              %1[#0]UKA » %0:t3[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              ReadStorage materialize.public.t3 // { arity: 2 }
+              %1[#0]UKA » %0:l0[#0]K
+            Get l0 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Distinct project=[#0] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 2 }
+                  Get l1 // { arity: 2 }
       ReadStorage materialize.public.t3 // { arity: 2 }
-      Get l0 // { arity: 2 }
+      Get l1 // { arity: 2 }
   With
-    cte l0 =
+    cte l1 =
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %0:t3[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t3 // { arity: 2 }
+            %0:l0[#0]K » %1:t2[#0]K
+          Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#1) // { arity: 1 }
               Filter (#1) IS NOT NULL // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Filter (#0) IS NOT NULL // { arity: 2 }
+          ReadStorage materialize.public.t3 // { arity: 2 }
 
 Source materialize.public.t2
   filter=((#1) IS NOT NULL)

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -544,7 +544,6 @@ ArrangeBy[[Column(0)]]
 ArrangeBy[[Column(0)]]
 ArrangeBy[[Column(0)]]
 ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
 "ArrangeBy[[Column(0)]]"
 ArrangeBy[[]]
 ArrangeBy[[]]
@@ -731,7 +730,7 @@ ReduceMinsMaxes
 "ArrangeBy[[Column(0), Column(2)]]"           1
 "ArrangeBy[[Column(0)]]-errors"              25
 "ArrangeBy[[Column(0)]]"                     80
-"ArrangeBy[[Column(1), Column(3)]]"           2
+"ArrangeBy[[Column(1), Column(3)]]"           1
 "ArrangeBy[[Column(1)]]-errors"               6
 ArrangeBy[[Column(13)]]                       1
 "ArrangeBy[[Column(1)]]"                     16

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -543,7 +543,6 @@ ArrangeBy[[Column(0)]]
 ArrangeBy[[Column(0)]]
 ArrangeBy[[Column(0)]]
 ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
 "ArrangeBy[[Column(0)]]"
 ArrangeBy[[]]
 ArrangeBy[[]]


### PR DESCRIPTION
This adds an `IS NOT NULL` filter in the left (right) join lowering before the left (right) input is fed into the semi-join. This doesn't change the result of the plan, because the right (left) input of this join was already filtered for nulls [here](https://github.com/MaterializeInc/materialize/blob/d7c1be4d2e86b2c1739b14eb2530882aa8711cb3/src/sql/src/plan/lowering.rs#L2033). This has two benefits:
- We avoid the possibility of many nulls in the left (right) input skewing the join's arrangement. (This is not just a theoretical concern, it's actually happening at https://github.com/MaterializeInc/accounts/issues/3 right now.)
- When the left (right) input's key doesn't have a NOT NULL constraint, this saves us one arrangement on the left (right) input, because of a new CSE opportunity. See for example the change in `joins.slt`.

The above change alone was introducing various performance regressions due to lost CSE opportunities. However, the second commit eliminates all these performance regressions. It does a minor change in `MirScalarExpr::reduce`: we eliminate `IS NULL` when the input type is known to be non-nullable and the input expression can't error. The non-erroring is important, otherwise we had a correctness regression in `privilege_grants.slt`, because an `error_if_null(...) IS NULL` was eliminated. In addition to eliminating all the performance regressions that the `IS NOT NULL` filter caused, this also eliminated lots of IS NOT NULL filters that were on top of joins. Additionally, it dramatically simplified some plans (see e.g. `ldbc_bi.slt` query 04, 15, 19), which is probably due to `RedundantJoin` having an easier time due to less filters standing in the way.

### Motivation

  * This PR optimizes performance:
    * https://github.com/MaterializeInc/materialize/issues/28026
    * Eliminates lots of IS NOT NULL filters from the top of joins.
    * Makes it easier for other optimizations (`RedundantJoin`) to operate.

### Tips for reviewer

Some of the plan changes are easier to view with whitespace changes not shown, because the disappearance of a Filters causes big de-indentations.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
