### PR TITLE
catalog: Add multi-subscriber catalog

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -26,6 +26,8 @@ use mz_catalog::builtin::{
     MZ_CATALOG_SERVER_CLUSTER,
 };
 use mz_catalog::config::{ClusterReplicaSizeMap, Config, StateConfig};
+#[cfg(test)]
+use mz_catalog::durable::CatalogError;
 use mz_catalog::durable::{test_bootstrap_args, DurableCatalogState};
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{CatalogEntry, Cluster, ClusterReplica, Database, Role, Schema};
@@ -445,6 +447,27 @@ impl Catalog {
                 deploy_generation,
                 epoch_lower_bound,
             )
+            .await?;
+        let system_parameter_defaults = BTreeMap::default();
+        Self::open_debug_catalog_inner(storage, now, environment_id, system_parameter_defaults)
+            .await
+    }
+
+    /// Opens a read only debug persist backed catalog defined by `persist_client` and
+    /// `organization_id`.
+    ///
+    /// See [`Catalog::with_debug`].
+    pub async fn open_debug_read_only_catalog(
+        persist_client: PersistClient,
+        organization_id: Uuid,
+    ) -> Result<Catalog, anyhow::Error> {
+        let now = SYSTEM_TIME.clone();
+        let environment_id = None;
+        let openable_storage =
+            mz_catalog::durable::test_persist_backed_catalog_state(persist_client, organization_id)
+                .await;
+        let storage = openable_storage
+            .open_read_only(&test_bootstrap_args())
             .await?;
         let system_parameter_defaults = BTreeMap::default();
         Self::open_debug_catalog_inner(storage, now, environment_id, system_parameter_defaults)
@@ -1156,6 +1179,18 @@ impl Catalog {
         self.state
             .deserialize_plan_with_enable_for_item_parsing(create_sql, force_if_exists_skip)
     }
+
+    /// Listen for and apply all unconsumed updates to the durable catalog state.
+    // TODO(jkosh44) When this method is actually used outside of a test we can remove the
+    // `#[cfg(test)]` annotation.
+    #[cfg(test)]
+    async fn sync_to_current_updates(
+        &mut self,
+    ) -> Result<Vec<BuiltinTableUpdate<&'static BuiltinTable>>, CatalogError> {
+        let updates = self.storage().await.sync_to_current_updates().await?;
+        let builtin_table_updates = self.state.apply_updates(updates);
+        Ok(builtin_table_updates)
+    }
 }
 
 pub fn is_reserved_name(name: &str) -> bool {
@@ -1865,6 +1900,7 @@ mod tests {
         Builtin, BuiltinType, BUILTINS,
         REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_VIEW_FINGERPRINT_WHITESPACE,
     };
+    use mz_catalog::durable::{CatalogError, DurableCatalogError};
     use mz_catalog::SYSTEM_CONN_ID;
     use mz_controller_types::{ClusterId, ReplicaId};
     use mz_expr::MirScalarExpr;
@@ -3109,5 +3145,67 @@ mod tests {
 
             catalog.expire().await;
         }
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn test_multi_subscriber_catalog() {
+        let persist_client = PersistClient::new_for_tests().await;
+        let organization_id = Uuid::new_v4();
+        let db_name = "DB";
+
+        let mut writer_catalog =
+            Catalog::open_debug_catalog(persist_client.clone(), organization_id.clone())
+                .await
+                .unwrap();
+        let mut read_only_catalog =
+            Catalog::open_debug_read_only_catalog(persist_client.clone(), organization_id.clone())
+                .await
+                .unwrap();
+        assert!(writer_catalog.resolve_database(db_name).is_err());
+        assert!(read_only_catalog.resolve_database(db_name).is_err());
+
+        writer_catalog
+            .transact(
+                None,
+                SYSTEM_TIME().into(),
+                None,
+                vec![Op::CreateDatabase {
+                    name: db_name.to_string(),
+                    owner_id: MZ_SYSTEM_ROLE_ID,
+                }],
+            )
+            .await
+            .expect("failed to transact");
+
+        let write_db = writer_catalog.resolve_database(db_name).unwrap();
+        read_only_catalog.sync_to_current_updates().await.unwrap();
+        let read_db = read_only_catalog.resolve_database(db_name).unwrap();
+
+        assert_eq!(write_db, read_db);
+
+        let writer_catalog_fencer = Catalog::open_debug_catalog(persist_client, organization_id)
+            .await
+            .unwrap();
+        let fencer_db = writer_catalog_fencer.resolve_database(db_name).unwrap();
+        assert_eq!(fencer_db, read_db);
+
+        let write_fence_err = writer_catalog.sync_to_current_updates().await.unwrap_err();
+        assert!(matches!(
+            write_fence_err,
+            CatalogError::Durable(DurableCatalogError::Fence(_))
+        ));
+        let read_fence_err = read_only_catalog
+            .sync_to_current_updates()
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            read_fence_err,
+            CatalogError::Durable(DurableCatalogError::Fence(_))
+        ));
+
+        writer_catalog.expire().await;
+        read_only_catalog.expire().await;
+        writer_catalog_fencer.expire().await;
     }
 }


### PR DESCRIPTION
This commit adds the functionality for a read-only catalog to run
concurrently with a writer catalog, and have the read-only catalog
subscribe to changes made by the writer. The state of read-only catalog
is kept up to date with the durable catalog via the changes.
    
This functionality is only used in tests currently.
    
Works towards resolving #24844

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
