### PR TITLE
parallel-workload: Fix id -> connection_id

### DIFF
--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -375,7 +375,7 @@ def run(
         stopping_time = datetime.datetime.now() + datetime.timedelta(seconds=30)
         while datetime.datetime.now() < stopping_time:
             cur.execute(
-                "SELECT * FROM mz_internal.mz_sessions WHERE id <> pg_backend_pid()"
+                "SELECT * FROM mz_internal.mz_sessions WHERE connection_id <> pg_backend_pid()"
             )
             sessions = cur.fetchall()
             if len(sessions) == 0:

--- a/test/lang/python/smoketest.py
+++ b/test/lang/python/smoketest.py
@@ -236,7 +236,7 @@ class SmokeTest(unittest.TestCase):
                     # Subscribe to the list of active subscriptions in
                     # Materialize.
                     metadata = metadata_conn.cursor().stream(
-                        "SUBSCRIBE (SELECT session_id FROM mz_internal.mz_subscriptions)"
+                        "SUBSCRIBE (SELECT s.connection_id FROM mz_internal.mz_subscriptions b JOIN mz_internal.mz_sessions s ON s.id = b.session_id)"
                     )
 
                     # Ensure we see our own subscription in `mz_subscriptions`.


### PR DESCRIPTION
Following https://github.com/MaterializeInc/materialize/pull/27967
Seen in https://buildkite.com/materialize/nightly/builds/8332
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
