### PR TITLE
revert recent librdkafka changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8140,7 +8140,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -8156,8 +8156,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.3.0+2.4.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
+version = "4.3.0+1.9.2"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8140,7 +8140,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.29.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#1e27332856a433235aeba7f82d46d06e3f646b69"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -8157,7 +8157,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "4.3.0+2.4.0"
-source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#1e27332856a433235aeba7f82d46d06e3f646b69"
+source = "git+https://github.com/MaterializeInc/rust-rdkafka.git#f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
 dependencies = [
  "cmake",
  "libc",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -731,11 +731,6 @@ version = "10.7.0"
 [[audits.rdkafka]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
-version = "0.29.0@git:1e27332856a433235aeba7f82d46d06e3f646b69"
-
-[[audits.rdkafka]]
-who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
-criteria = "safe-to-deploy"
 version = "0.29.0@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
 
 [[audits.rdkafka]]
@@ -747,11 +742,6 @@ version = "0.29.0@git:f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "4.3.0+1.9.2@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
-
-[[audits.rdkafka-sys]]
-who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
-criteria = "safe-to-deploy"
-version = "4.3.0+2.4.0@git:1e27332856a433235aeba7f82d46d06e3f646b69"
 
 [[audits.rdkafka-sys]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -733,20 +733,10 @@ who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.29.0@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
 
-[[audits.rdkafka]]
-who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
-criteria = "safe-to-deploy"
-version = "0.29.0@git:f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
-
 [[audits.rdkafka-sys]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 version = "4.3.0+1.9.2@git:843ccffbd75f4dac93b2e34cf091bd7770b9a3de"
-
-[[audits.rdkafka-sys]]
-who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
-criteria = "safe-to-deploy"
-version = "4.3.0+2.4.0@git:f7d81eab5a21bdcf5c2dfb75dd7784b55a9953f9"
 
 [[audits.redox_syscall]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -20,7 +20,7 @@ use mz_ccsr::tls::{Certificate, Identity};
 use mz_cloud_resources::{vpc_endpoint_host, AwsExternalIdPrefix, CloudResourceReader};
 use mz_dyncfg::ConfigSet;
 use mz_kafka_util::client::{
-    BrokerAddr, BrokerRewrite, MzClientContext, MzKafkaError, TunnelConfig, TunnelingClientContext,
+    BrokerRewrite, MzClientContext, MzKafkaError, TunnelConfig, TunnelingClientContext,
 };
 use mz_ore::error::ErrorExt;
 use mz_ore::future::{InTask, OreFutureExt};
@@ -38,6 +38,7 @@ use mz_tls_util::Pkcs12Archive;
 use mz_tracing::CloneableEnvFilter;
 use proptest::strategy::Strategy;
 use proptest_derive::Arbitrary;
+use rdkafka::client::BrokerAddr;
 use rdkafka::config::FromClientConfigAndContext;
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::ClientContext;
@@ -752,11 +753,7 @@ impl KafkaConnection {
                     .next()
                     .context("BROKER is not address:port")?
                     .into(),
-                port: addr_parts
-                    .next()
-                    .unwrap_or("9092")
-                    .parse()
-                    .context("parsing BROKER port")?,
+                port: addr_parts.next().unwrap_or("9092").into(),
             };
             match &broker.tunnel {
                 Tunnel::Direct => {

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -33,7 +33,7 @@ def test_secrets(mz: MaterializeApplication) -> None:
                 SASL USERNAME = SECRET username,
                 SASL PASSWORD = SECRET password
               );
-            contains:Broker does not support SSL connections
+            contains:SSL handshake failed
             """
         )
     )

--- a/test/kafka-auth/test-kafka-sasl-plaintext.td
+++ b/test/kafka-auth/test-kafka-sasl-plaintext.td
@@ -26,7 +26,7 @@ banana
     -- SECURITY PROTOCOL defaults to SASL_SSL when other SASL options are
     -- specified.
   )
-contains:Broker does not support SSL connections
+contains:SSL handshake failed
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9095',
@@ -35,7 +35,7 @@ contains:Broker does not support SSL connections
     SASL PASSWORD SECRET password,
     SECURITY PROTOCOL SASL_SSL
   )
-contains:Broker does not support SSL connections
+contains:SSL handshake failed
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9095',

--- a/test/kafka-auth/test-kafka-sasl-ssl.td
+++ b/test/kafka-auth/test-kafka-sasl-ssl.td
@@ -92,7 +92,7 @@ contains:Invalid username or password
     SASL USERNAME 'materialize',
     SASL PASSWORD SECRET password
   )
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9096',
@@ -101,7 +101,7 @@ contains:Invalid CA certificate
     SASL PASSWORD SECRET password,
     SSL CERTIFICATE AUTHORITY = '${ca-selective-crt}'
   )
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 # ==> Test without an SSH tunnel. <==
 

--- a/test/kafka-auth/test-kafka-ssl.td
+++ b/test/kafka-auth/test-kafka-ssl.td
@@ -32,13 +32,13 @@ contains:Disconnected during handshake; broker might require SSL encryption
     BROKER 'kafka:9093'
     -- SECURITY PROTOCOL defaults to SSL when no SASL options are specified.
   )
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9093',
     SSL CERTIFICATE AUTHORITY = '${ca-selective-crt}'
   )
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 ! CREATE CONNECTION kafka_invalid TO KAFKA (
     BROKER 'kafka:9093',
@@ -100,10 +100,10 @@ contains:Client creation error
 > ALTER CONNECTION kafka RESET (SSL CERTIFICATE) WITH (VALIDATE = true);
 
 ! ALTER CONNECTION kafka RESET (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = true);
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 ! ALTER CONNECTION kafka RESET (SSL KEY), RESET (SSL CERTIFICATE), RESET (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = true);
-contains:Invalid CA certificate
+contains:certificate verify failed
 
 > ALTER CONNECTION kafka RESET (SSL KEY), RESET (SSL CERTIFICATE), RESET (SSL CERTIFICATE AUTHORITY) WITH (VALIDATE = false);
 

--- a/test/testdrive/connection-alter.td
+++ b/test/testdrive/connection-alter.td
@@ -84,7 +84,7 @@ name   create_sql
 materialize.public.conn   "CREATE CONNECTION \"materialize\".\"public\".\"conn\" TO KAFKA (BROKERS = ('${testdrive.kafka-addr}'), SECURITY PROTOCOL = \"plaintext\")"
 
 ! ALTER CONNECTION conn DROP (SECURITY PROTOCOL);
-contains:Broker does not support SSL connections
+contains:SSL handshake failed
 
 ! ALTER CONNECTION conn SET (BROKER '${testdrive.kafka-addr}'), RESET (BROKER);
 contains:cannot both SET and DROP/RESET options BROKER


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This is a conservative revert of the last 3 librdkafka related PRs in light of #28016

The reverted PRs are: 

https://github.com/MaterializeInc/materialize/pull/27964
https://github.com/MaterializeInc/materialize/pull/27965
https://github.com/MaterializeInc/materialize/pull/24931
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
