### PR TITLE
storage/copy-to-s3: Support including a header on csv files if specified

### DIFF
--- a/doc/user/content/sql/copy-to.md
+++ b/doc/user/content/sql/copy-to.md
@@ -86,7 +86,7 @@ Setting     | Value
 delimiter   | `,`
 quote       | `"`
 escape      | `"`
-header      | `true`
+header      | `false`
 
 #### Parquet {#copy-to-s3-parquet}
 

--- a/src/pgcopy/src/lib.rs
+++ b/src/pgcopy/src/lib.rs
@@ -16,7 +16,7 @@
 mod copy;
 
 pub use copy::{
-    decode_copy_format, encode_copy_format, CopyCsvFormatParams, CopyFormatParams,
-    CopyTextFormatParams, CopyTextFormatParser, ProtoCopyCsvFormatParams, ProtoCopyFormatParams,
-    ProtoCopyTextFormatParams,
+    decode_copy_format, encode_copy_format, encode_copy_format_header, CopyCsvFormatParams,
+    CopyFormatParams, CopyTextFormatParams, CopyTextFormatParser, ProtoCopyCsvFormatParams,
+    ProtoCopyFormatParams, ProtoCopyTextFormatParams,
 };

--- a/test/testdrive/copy-to-s3-minio.td
+++ b/test/testdrive/copy-to-s3-minio.td
@@ -121,7 +121,8 @@ contains:MAX FILE SIZE cannot be less than 16MB
   WITH (
     AWS CONNECTION = aws_conn,
     MAX FILE SIZE = "100MB",
-    FORMAT = 'csv'
+    FORMAT = 'csv',
+    HEADER = true
   );
 
 > COPY (SELECT array[1,2]::int[], false::bool, 'Inf'::double, '{"s": "abc"}'::jsonb, 1::mz_timestamp, 32767::smallint, 2147483647::integer, 9223372036854775807::bigint, 12345678901234567890123.4567890123456789::numeric(39,16), '2010-10-10'::date, '10:10:10'::time, '2010-10-10 10:10:10+00'::timestamp, '2010-10-10 10:10:10+02'::timestamptz, '0 day'::interval, 'aaaa'::text, '\\xAAAA'::bytea, 'това е'::text, 'текст'::bytea) TO 's3://copytos3/test/3'
@@ -152,7 +153,8 @@ contains:S3 bucket path is not empty
     AWS CONNECTION = aws_conn,
     FORMAT = 'csv',
     DELIMITER = ';',
-    QUOTE = '`'
+    QUOTE = '`',
+    HEADER = true
   )
 
 $ set-from-sql var=key-1
@@ -167,12 +169,14 @@ $ s3-verify-data bucket=copytos3 key=test/2
 2
 
 $ s3-verify-data bucket=copytos3 key=test/2_5
+a
 1
 
 $ s3-verify-data bucket=copytos3 key=test/3
 "{1,2}",f,Infinity,"{""s"":""abc""}",1,32767,2147483647,9223372036854775807,12345678901234567890123.4567890123456789,2010-10-10,10:10:10,2010-10-10 10:10:10,2010-10-10 08:10:10+00,00:00:00,aaaa,\x5c7841414141,това е,\xd182d0b5d0bad181d182
 
 $ s3-verify-data bucket=copytos3 key=test/4_5
+array;int4;jsonb;timestamp
 {1,2};83647;`{"s":"ab``c"}`;2010-10-10 10:10:10
 
 # Copy a large amount of data in the background and check to see that the INCOMPLETE


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.
We were ignoring the `header` option for the CSV format option in copy-to-s3. This fixes the docs since the header is default-off and fixes the implementation to write a header row when `header = true` is provided.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]


    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
