### PR TITLE
Rework `has_cluster_privilege` to error intentionally

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3552,11 +3552,9 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                 CASE
                 -- We need to validate the name and privileges to return a proper error before
                 -- anything else.
-                WHEN mz_unsafe.mz_error_if_null(
-                    (SELECT name FROM mz_clusters WHERE name = $2),
-                    'error cluster \"' || $2 || '\" does not exist'
-                ) IS NULL
-                OR NOT mz_internal.mz_validate_privileges($3)
+                WHEN NOT EXISTS (SELECT name FROM mz_clusters WHERE name = $2)
+                THEN mz_unsafe.mz_error_if_null(NULL, 'error cluster \"' || $2 || '\" does not exist')
+                WHEN NOT mz_internal.mz_validate_privileges($3)
                 OR $1 IS NULL
                 OR $2 IS NULL
                 OR $3 IS NULL

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3550,13 +3550,15 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             params!(String, String, String) => sql_impl_func("has_cluster_privilege(mz_internal.mz_role_oid($1), $2, $3)") => Bool, oid::FUNC_HAS_CLUSTER_PRIVILEGE_TEXT_TEXT_TEXT_OID;
             params!(Oid, String, String) => sql_impl_func(&format!("
                 CASE
-                -- We need to validate the name and privileges to return a proper error before
-                -- anything else.
+                -- We must first check $2 to avoid a potentially null error message (an error itself).
+                WHEN $2 IS NULL
+                THEN NULL
+                -- Validate the cluster name in order to return a proper error.
                 WHEN NOT EXISTS (SELECT name FROM mz_clusters WHERE name = $2)
-                THEN mz_unsafe.mz_error_if_null(NULL, 'error cluster \"' || $2 || '\" does not exist')
+                THEN mz_unsafe.mz_error_if_null(NULL::boolean, 'error cluster \"' || $2 || '\" does not exist')
+                -- Validate the privileges and other arguments.
                 WHEN NOT mz_internal.mz_validate_privileges($3)
                 OR $1 IS NULL
-                OR $2 IS NULL
                 OR $3 IS NULL
                 OR $1 NOT IN (SELECT oid FROM mz_catalog.mz_roles)
                 THEN NULL


### PR DESCRIPTION
The `has_cluster_privilege` function errors through `mz_unsafe.mz_error_if_null`, but it then uses the result in an `IS NULL` test, which is able to be optimized away (as `mz_unsafe.mz_error_if_null` cannot return `NULL`).

This PR changes the logic to test the condition explicitly and error if the test fails, rather than rely on the optimizer not noticing that the potentially erroring test can be pruned.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
