### PR TITLE
feature benchmark: add ignore entry for PR#27988

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -31,6 +31,12 @@ def get_ancestor_overrides_for_performance_regressions(
     # Commits must be ordered descending by their date.
     min_ancestor_mz_version_per_commit = dict()
 
+    if scenario_class_name == "MinMax":
+        # PR#27988 (adapter: always declare MV imports non-monotonic) increased wallclock and memory
+        min_ancestor_mz_version_per_commit[
+            "c18aa43828a7d2e9527151a0251c1f75a06d1469"
+        ] = MzVersion.parse_mz("v0.108.0")
+
     if scenario_class_name == "AccumulateReductions":
         # PR#26807 (compute: hydration status based on output frontiers) increased messages
         min_ancestor_mz_version_per_commit[


### PR DESCRIPTION
This PR adds a feature benchmark ignore entry for #27988.

### Motivation

   * This PR fixes a nightly test.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A