### PR TITLE
tests: Support running a subset of disruptions

### DIFF
--- a/misc/python/materialize/util.py
+++ b/misc/python/materialize/util.py
@@ -18,10 +18,11 @@ import os
 import pathlib
 import random
 import subprocess
+from collections.abc import Iterator
 from enum import Enum
 from pathlib import Path
 from threading import Thread
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
 import zstandard
 
@@ -116,3 +117,22 @@ def compute_sha256_of_file(path: str | Path) -> str:
 
 def compute_sha256_of_utf8_string(string: str) -> str:
     return hashlib.sha256(bytes(string, encoding="utf-8")).hexdigest()
+
+
+class HasName(Protocol):
+    name: str
+
+
+U = TypeVar("U", bound=HasName)
+
+
+def selected_by_name(selected: list[str], objs: list[U]) -> Iterator[U]:
+    for name in selected:
+        for obj in objs:
+            if obj.name == name:
+                yield obj
+                break
+        else:
+            raise ValueError(
+                f"Unknown object with name {name} in {[obj.name for obj in objs]}"
+            )

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -18,6 +18,7 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
 from materialize.ui import UIError
+from materialize.util import selected_by_name
 
 SERVICES = [
     Zookeeper(),
@@ -97,17 +98,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
-    selected_disruptions = []
-    for name in args.disruptions:
-        for disruption in disruptions:
-            if disruption.name == name:
-                selected_disruptions.append(disruption)
-                break
-        else:
-            raise ValueError(f"Unknown disruption {name}")
-
     c.up("zookeeper", "kafka", "schema-registry")
-    for id, disruption in enumerate(selected_disruptions):
+    for id, disruption in enumerate(selected_by_name(args.disruptions, disruptions)):
         run_test(c, disruption, id)
 
 

--- a/test/crdb-restarts/mzcompose.py
+++ b/test/crdb-restarts/mzcompose.py
@@ -17,6 +17,7 @@ from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.ui import UIError
+from materialize.util import selected_by_name
 
 CRDB_NODE_COUNT = 4
 TESTDRIVE_TIMEOUT = (
@@ -145,16 +146,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
-    selected_disruptions = []
-    for name in args.disruptions:
-        for disruption in DISRUPTIONS:
-            if disruption.name == name:
-                selected_disruptions.append(disruption)
-                break
-        else:
-            raise ValueError(f"Unknown disruption {name}")
-
-    for d in selected_disruptions:
+    for d in selected_by_name(args.disruptions, DISRUPTIONS):
         run_disruption(c, d)
 
 

--- a/test/pubsub-disruption/mzcompose.py
+++ b/test/pubsub-disruption/mzcompose.py
@@ -16,6 +16,7 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.toxiproxy import Toxiproxy
+from materialize.util import selected_by_name
 
 SERVICES = [
     Materialized(options=["--persist-pubsub-url=http://toxiproxy:6879"]),
@@ -73,16 +74,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
-    selected_disruptions = []
-    for name in args.disruptions:
-        for disruption in disruptions:
-            if disruption.name == name:
-                selected_disruptions.append(disruption)
-                break
-        else:
-            raise ValueError(f"Unknown disruption {name}")
-
-    for disruption in selected_disruptions:
+    for disruption in selected_by_name(args.disruptions, disruptions):
         c.down(destroy_volumes=True)
         c.up("redpanda", "materialized")
         c.up("testdrive", persistent=True)

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -23,6 +23,7 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
+from materialize.util import selected_by_name
 
 SERVICES = [
     Zookeeper(),
@@ -407,17 +408,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
-    selected_disruptions = []
-    for name in args.disruptions:
-        for disruption in disruptions:
-            if disruption.name == name:
-                selected_disruptions.append(disruption)
-                break
-        else:
-            raise ValueError(f"Unknown disruption {name}")
-
     c.up("zookeeper", "kafka", "schema-registry", "localstack")
-    for id, disruption in enumerate(selected_disruptions):
+    for id, disruption in enumerate(selected_by_name(args.disruptions, disruptions)):
         run_test(c, disruption, id)
 
 

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -549,16 +549,16 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
-    to_run = []
+    selected_disruptions = []
     for name in args.disruptions:
         for disruption in disruptions:
             if disruption.name == name:
-                to_run.append(disruption)
+                selected_disruptions.append(disruption)
                 break
         else:
             raise ValueError(f"Unknown disruption {name}")
 
-    sharded_disruptions = buildkite.shard_list(to_run, lambda s: s.name)
+    sharded_disruptions = buildkite.shard_list(selected_disruptions, lambda s: s.name)
     print(
         f"Disruptions in shard with index {buildkite.get_parallelism_index()}: {[d.name for d in sharded_disruptions]}"
     )

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -24,6 +24,7 @@ from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
+from materialize.util import selected_by_name
 
 
 def schema() -> str:
@@ -549,16 +550,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
-    selected_disruptions = []
-    for name in args.disruptions:
-        for disruption in disruptions:
-            if disruption.name == name:
-                selected_disruptions.append(disruption)
-                break
-        else:
-            raise ValueError(f"Unknown disruption {name}")
-
-    sharded_disruptions = buildkite.shard_list(selected_disruptions, lambda s: s.name)
+    sharded_disruptions = buildkite.shard_list(
+        list(selected_by_name(args.disruptions, disruptions)), lambda s: s.name
+    )
     print(
         f"Disruptions in shard with index {buildkite.get_parallelism_index()}: {[d.name for d in sharded_disruptions]}"
     )


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
