### PR TITLE
output consistency: contains operation

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/operations/array_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/array_operations_provider.py
@@ -110,6 +110,8 @@ ARRAY_OPERATION_TYPES.append(
         ],
         BooleanReturnTypeSpec(),
         comment="contains",
+        # TODO: re-enable when #28044 is fixed
+        is_enabled=False,
     )
 )
 

--- a/misc/python/materialize/output_consistency/input_data/operations/array_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/array_operations_provider.py
@@ -103,6 +103,18 @@ ARRAY_OPERATION_TYPES.append(
 
 ARRAY_OPERATION_TYPES.append(
     DbOperation(
+        "$ @> $",
+        [
+            ArrayOperationParam(),
+            ElementOfOtherCollectionOperationParam(index_of_previous_param=0),
+        ],
+        BooleanReturnTypeSpec(),
+        comment="contains",
+    )
+)
+
+ARRAY_OPERATION_TYPES.append(
+    DbOperation(
         "$ = ANY ($)",
         [
             AnyOperationParam(),

--- a/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
@@ -23,6 +23,9 @@ from materialize.output_consistency.input_data.params.list_operation_param impor
     ListOfOtherElementOperationParam,
     ListOperationParam,
 )
+from materialize.output_consistency.input_data.return_specs.boolean_return_spec import (
+    BooleanReturnTypeSpec,
+)
 from materialize.output_consistency.input_data.return_specs.collection_entry_return_spec import (
     CollectionEntryReturnTypeSpec,
 )
@@ -74,6 +77,18 @@ LIST_OPERATION_TYPES.append(
         ],
         ListReturnTypeSpec(),
         comment="prepend element to list (equal to list_prepend)",
+    )
+)
+
+LIST_OPERATION_TYPES.append(
+    DbOperation(
+        "$ @> $",
+        [
+            ListOperationParam(),
+            ElementOfOtherCollectionOperationParam(index_of_previous_param=0),
+        ],
+        BooleanReturnTypeSpec(),
+        comment="contains",
     )
 )
 

--- a/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
@@ -89,6 +89,8 @@ LIST_OPERATION_TYPES.append(
         ],
         BooleanReturnTypeSpec(),
         comment="contains",
+        # TODO: re-enable when #28044 is fixed
+        is_enabled=False,
     )
 )
 

--- a/misc/python/materialize/output_consistency/input_data/operations/range_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/range_operations_provider.py
@@ -14,7 +14,7 @@ from materialize.output_consistency.input_data.params.list_operation_param impor
     ListOperationParam,
 )
 from materialize.output_consistency.input_data.params.range_operation_param import (
-    RangeLikeOtherListOperationParam,
+    RangeLikeOtherRangeOperationParam,
     RangeOperationParam,
 )
 from materialize.output_consistency.input_data.return_specs.boolean_return_spec import (
@@ -50,7 +50,7 @@ RANGE_OPERATION_TYPES.append(
         "$ * $",
         [
             RangeOperationParam(),
-            RangeLikeOtherListOperationParam(index_of_previous_param=0),
+            RangeLikeOtherRangeOperationParam(index_of_previous_param=0),
         ],
         RangeReturnTypeSpec(),
         comment="Intersection of two ranges",
@@ -62,7 +62,7 @@ RANGE_OPERATION_TYPES.append(
         "$ && $",
         [
             RangeOperationParam(),
-            RangeLikeOtherListOperationParam(index_of_previous_param=0),
+            RangeLikeOtherRangeOperationParam(index_of_previous_param=0),
         ],
         RangeReturnTypeSpec(),
         comment="Overlap of two ranges",

--- a/misc/python/materialize/output_consistency/input_data/operations/range_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/range_operations_provider.py
@@ -9,10 +9,6 @@
 from materialize.output_consistency.input_data.params.collection_operation_param import (
     ElementOfOtherCollectionOperationParam,
 )
-from materialize.output_consistency.input_data.params.list_operation_param import (
-    ListLikeOtherListOperationParam,
-    ListOperationParam,
-)
 from materialize.output_consistency.input_data.params.range_operation_param import (
     RangeLikeOtherRangeOperationParam,
     RangeOperationParam,
@@ -38,8 +34,8 @@ RANGE_OPERATION_TYPES.append(
     DbOperation(
         "$ || $",
         [
-            ListOperationParam(),
-            ListLikeOtherListOperationParam(index_of_previous_param=0),
+            RangeOperationParam(),
+            RangeLikeOtherRangeOperationParam(index_of_previous_param=0),
         ],
         RangeReturnTypeSpec(),
     )
@@ -76,7 +72,7 @@ RANGE_OPERATION_TYPES.append(
             RangeOperationParam(),
             ElementOfOtherCollectionOperationParam(index_of_previous_param=0),
         ],
-        RangeReturnTypeSpec(),
+        BooleanReturnTypeSpec(),
         comment="contains",
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/params/range_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/range_operation_param.py
@@ -34,7 +34,7 @@ class RangeOperationParam(CollectionOperationParam):
         )
 
 
-class RangeLikeOtherListOperationParam(CollectionLikeOtherCollectionOperationParam):
+class RangeLikeOtherRangeOperationParam(CollectionLikeOtherCollectionOperationParam):
     def get_collection_type_category(self) -> DataTypeCategory:
         return DataTypeCategory.RANGE
 


### PR DESCRIPTION
This PR ...
* adds the contains operation for the array and list type
* disables the contains operation for the array and list type to address [failure in nightly/8360](https://buildkite.com/materialize/nightly/builds/8360#01907d83-4877-4dd5-8c8a-c162117df7c0) until https://github.com/MaterializeInc/materialize/pull/28044 is merged
* fixes the specification of the contains and concat operations for the range type (https://github.com/MaterializeInc/materialize/issues/28035 was discovered because the range's type function specification was accidentally applied with lists.)

### Commits
b035fa90ae output consistency: range: rename RangeLikeOtherRangeOperationParam
8f70874cd1 output consistency: range: fix operation definitions
447103992e output consistency: array and list: add contains operator
533aba1d37 output consistency: array and list: disable contains operator

### Nightly
https://buildkite.com/materialize/nightly/builds/8363
