### PR TITLE
user/docs: add documentation for @> and <@ for lists

### DIFF
--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -519,6 +519,11 @@ SELECT '{{1.5,NULL},{2.25}}'::numeric(38,2) list list AS text_to_list;
 
 ### List containment
 
+{{< note >}}
+Like [array containment operators in PostgreSQL](https://www.postgresql.org/docs/current/functions-array.html#FUNCTIONS-ARRAY),
+list containment operators in Materialize **do not** account for duplicates.
+{{< /note >}}
+
 {{< warn-if-unreleased "v0.107" >}}
 
 ```mzsql
@@ -539,7 +544,6 @@ SELECT LIST[2,7] <@ LIST[1,7,4,2,6] AS is_contained_by;
  t
 ```
 
-Note that array containment in Postgres does NOT account for duplicates. This is mirrored by the list implementation.
 
 ```mzsql
 SELECT LIST[7,3,1] @> LIST[1,3,3,3,3,7] AS contains;

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -562,4 +562,3 @@ SELECT LIST[1,3,7,NULL] @> LIST[1,3,7,NULL] AS contains;
 ----------
  f
 ```
-

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -459,10 +459,6 @@ You can [cast](../../functions/cast) the following types to `list`:
 - [`text`](../text) (explicitly). See [details](#text-to-list-casts).
 - Other `lists` as noted above.
 
-### Known limitations
-
-- `list` data can only be sent to PostgreSQL as `text` {{% gh 4628 %}}
-
 ## Examples
 
 ### Literals

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -9,19 +9,19 @@ menu:
 Lists are ordered sequences of homogenously typed elements. Lists' elements can
 be other lists, known as "layered lists."
 
-Detail | Info
--------|------
-**Quick Syntax** | `LIST[[1,2],[3]]`
-**Size** | Variable
-**Catalog name** | Anonymous, but [nameable](../../create-type)
+| Detail           | Info                                         |
+| ---------------- | -------------------------------------------- |
+| **Quick Syntax** | `LIST[[1,2],[3]]`                            |
+| **Size**         | Variable                                     |
+| **Catalog name** | Anonymous, but [nameable](../../create-type) |
 
 ## Syntax
 
 {{< diagram "type-list.svg" >}}
 
-Field | Use
-------|-----
-_element_ | An element of any [data type](../) to place in the list. Note that all elements must be of the same type.
+| Field     | Use                                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------------------- |
+| _element_ | An element of any [data type](../) to place in the list. Note that all elements must be of the same type. |
 
 ## List functions + operators
 
@@ -337,11 +337,11 @@ also be able to infer how list differs from it, as well.
 
 #### Terminology
 
-Feature | Array term | List term
---------|------------|-----------
-**Nested structure** | Multidimensional array | Layered list
-**Accessing single element** | Subscripting | Indexing<sup>1</sup>
-**Accessing range of elements** | Subscripting | Slicing<sup>1</sup>
+| Feature                         | Array term             | List term            |
+| ------------------------------- | ---------------------- | -------------------- |
+| **Nested structure**            | Multidimensional array | Layered list         |
+| **Accessing single element**    | Subscripting           | Indexing<sup>1</sup> |
+| **Accessing range of elements** | Subscripting           | Slicing<sup>1</sup>  |
 
 <sup>1</sup>In some places, such as error messages, Materialize refers to
 both list indexing and list slicing as subscripting.
@@ -519,4 +519,35 @@ SELECT '{{1.5,NULL},{2.25}}'::numeric(38,2) list list AS text_to_list;
      text_to_list
 ----------------------
  {{1.50,NULL},{2.25}}
+```
+
+### List containment
+
+```mzsql
+SELECT LIST[1,4,3] @> LIST[3,1] AS contains;
+```
+```nofmt
+ contains
+----------
+ t
+```
+
+```mzsql
+SELECT LIST[2,7] <@ LIST[1,7,4,2,6] AS is_contained_by;
+```
+```nofmt
+ is_contained_by
+-----------------
+ t
+```
+
+Note that array containment in Postgres does NOT account for duplicates. This is mirrored by the list implementation.
+
+```mzsql
+SELECT LIST[1,3,7] @> LIST[1,3,3,3,3,7] AS contains;
+```
+```nofmt
+ contains
+----------
+ t
 ```

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -553,3 +553,13 @@ SELECT LIST[7,3,1] @> LIST[1,3,3,3,3,7] AS contains;
 ----------
  t
 ```
+
+```mzsql
+SELECT LIST[1,3,7,NULL] @> LIST[1,3,7,NULL] AS contains;
+```
+```nofmt
+ contains
+----------
+ f
+```
+

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -523,6 +523,8 @@ SELECT '{{1.5,NULL},{2.25}}'::numeric(38,2) list list AS text_to_list;
 
 ### List containment
 
+{{< warn-if-unreleased "v0.107" >}}
+
 ```mzsql
 SELECT LIST[1,4,3] @> LIST[3,1] AS contains;
 ```

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -544,7 +544,7 @@ SELECT LIST[2,7] <@ LIST[1,7,4,2,6] AS is_contained_by;
 Note that array containment in Postgres does NOT account for duplicates. This is mirrored by the list implementation.
 
 ```mzsql
-SELECT LIST[1,3,7] @> LIST[1,3,3,3,3,7] AS contains;
+SELECT LIST[7,3,1] @> LIST[1,3,3,3,3,7] AS contains;
 ```
 ```nofmt
  contains

--- a/doc/user/layouts/shortcodes/list-operators.html
+++ b/doc/user/layouts/shortcodes/list-operators.html
@@ -3,5 +3,5 @@ Operator | Description
 <code>listany &vert;&vert; listany</code> | Concatenate the two lists.
 <code>listany &vert;&vert; listelementany</code> | Append the element to the list.
 <code>listelementany &vert;&vert; listany</code> | Prepend the element to the list.
-<code>listany @&gt; listany</code> | Does the left list contain all elements of the right list.
-<code>listany &lt;@ listany</code> | Are all elements of the left list contained in the right list.
+<code>listany @&gt; listany</code> | Check if the first list contains all elements of the second list.
+<code>listany &lt;@ listany</code> | Check if all elements of the first list are contained in the second list.

--- a/doc/user/layouts/shortcodes/list-operators.html
+++ b/doc/user/layouts/shortcodes/list-operators.html
@@ -3,5 +3,5 @@ Operator | Description
 <code>listany &vert;&vert; listany</code> | Concatenate the two lists.
 <code>listany &vert;&vert; listelementany</code> | Append the element to the list.
 <code>listelementany &vert;&vert; listany</code> | Prepend the element to the list.
-<code>listany @&gt; listany</code> | Does the left list contain all elements from the right list.
-<code>listany &lt;@ listany</code> | Is the left list contained in the right list.
+<code>listany @&gt; listany</code> | Does the left list contain all elements of the right list.
+<code>listany &lt;@ listany</code> | Are all elements of the left list contained in the right list.

--- a/doc/user/layouts/shortcodes/list-operators.html
+++ b/doc/user/layouts/shortcodes/list-operators.html
@@ -3,3 +3,5 @@ Operator | Description
 <code>listany &vert;&vert; listany</code> | Concatenate the two lists.
 <code>listany &vert;&vert; listelementany</code> | Append the element to the list.
 <code>listelementany &vert;&vert; listany</code> | Prepend the element to the list.
+<code>listany @&gt; listany</code> | Does the left list contain all elements from the right list.
+<code>listany &lt;@ listany</code> | Is the left list contained in the right list.

--- a/doc/user/layouts/shortcodes/list-operators.html
+++ b/doc/user/layouts/shortcodes/list-operators.html
@@ -5,3 +5,4 @@ Operator | Description
 <code>listelementany &vert;&vert; listany</code> | Prepend the element to the list.
 <code>listany @&gt; listany</code> | Does the left list contain all elements from the right list.
 <code>listany &lt;@ listany</code> | Is the left list contained in the right list.
+

--- a/doc/user/layouts/shortcodes/list-operators.html
+++ b/doc/user/layouts/shortcodes/list-operators.html
@@ -5,4 +5,3 @@ Operator | Description
 <code>listelementany &vert;&vert; listany</code> | Prepend the element to the list.
 <code>listany @&gt; listany</code> | Does the left list contain all elements from the right list.
 <code>listany &lt;@ listany</code> | Is the left list contained in the right list.
-


### PR DESCRIPTION
Add documentation for `@>` and `<@` introduced in #27959