### PR TITLE
Revert "cloudtest: Await key schema too"

### DIFF
--- a/test/cloudtest/test_storage_shared_fate.py
+++ b/test/cloudtest/test_storage_shared_fate.py
@@ -46,7 +46,7 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
               ENVELOPE DEBEZIUM;
 
-            $ kafka-verify-topic sink=materialize.public.sink{i} await-value-schema=true await-key-schema=true
+            $ kafka-verify-topic sink=materialize.public.sink{i} await-value-schema=true
 
             > CREATE SOURCE sink{i}_check
               IN CLUSTER storage_shared_fate


### PR DESCRIPTION
Reverts MaterializeInc/materialize#28041

Apparently this didn't work, I'm still not sure why the test is failing now though.