### PR TITLE
De-flake a REFRESH introspection test

### DIFF
--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1562,43 +1562,6 @@ quickstart  manual  NULL
 statement ok
 SELECT mz_unsafe.mz_sleep(4);
 
-# If this fails with a recently created MV not yet being present, then bump the above sleep.
-# (Skip `mv_rte`, because it was created recently, and might not have been refreshed yet.)
-query TBB
-SELECT
-  name,
-  now() - INTERVAL '30 minutes' < last_completed_refresh,
-  next_refresh > now() - INTERVAL '5 seconds'
-FROM mz_internal.mz_materialized_view_refreshes mvr, mz_catalog.mz_materialized_views mv
-WHERE
-  mv.id = mvr.materialized_view_id AND
-  name != 'mv_rte'
-ORDER BY name;
-----
-const_mv  true  NULL
-const_mv2  true  NULL
-mv10  true  NULL
-mv11  true  NULL
-mv12  true  false
-mv3  true  NULL
-mv4  true  NULL
-mv5  NULL  true
-mv6  true  NULL
-mv7  true  NULL
-mv8  true  NULL
-mv9  true  true
-mv_aligned_to_future  true  true
-mv_aligned_to_past  true  true
-mv_assertion_plus_refresh_every  true  true
-mv_desugar1  true  NULL
-mv_desugar2  true  true
-mv_greatest  true  NULL
-mv_multiple_refresh_options  true  true
-mv_no_creation_refresh  true  true
-mvi1  true  true
-mvi2  true  true
-mvi3  true  NULL
-
 query TTTTBT
 SELECT DISTINCT
   event_type,

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -662,6 +662,37 @@ false
 
 > DROP MATERIALIZED VIEW mv_long_hydration;
 
+> SELECT
+    name,
+    now() - INTERVAL '30 minutes' < last_completed_refresh,
+    next_refresh > now() - INTERVAL '6 seconds'
+  FROM mz_internal.mz_materialized_view_refreshes mvr, mz_catalog.mz_materialized_views mv
+  WHERE
+    mv.id = mvr.materialized_view_id
+  ORDER BY name;
+mv1 true true
+mv10 <null> true
+mv11 true true
+mv12 <null> true
+mv13 <null> true
+mv14 <null> true
+mv14_at_const true <null>
+mv15_ats_const true <null>
+mv16_every_const true <null>
+mv17_before_first <null> true
+mv18_no_replica <null> false
+mv19 true true
+mv2 true true
+mv3 true true
+mv4 true <null>
+mv5 true true
+mv6 true true
+mv7 true <null>
+mv8 true true
+mv9 <null> true
+mv_at_creation true <null>
+mv_no_rep true true
+
 # ----------------------------------------
 # Cleanup
 # ----------------------------------------


### PR DESCRIPTION
Moves a flaky slt test to td, where it will be retried.

### Motivation

  * This PR fixes a test flake, discussed here: https://materializeinc.slack.com/archives/C0761MZ3QD9/p1720098448900609?thread_ts=1720097407.946299&cid=C0761MZ3QD9

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
