### PR TITLE
Explicit 0dt upgrade test

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1491,16 +1491,6 @@ steps:
     agents:
       queue: linux-aarch64
 
-  - id: 0dt
-    label: Zero downtime
-    depends_on: build-aarch64
-    timeout_in_minutes: 30
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: 0dt
-    agents:
-      queue: linux-aarch64
-
   - group: "Copy To S3"
     key: copy-to-s3
     steps:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -697,6 +697,16 @@ steps:
     agents:
       queue: linux-aarch64-small
 
+  - id: 0dt
+    label: Zero downtime
+    depends_on: build-aarch64
+    timeout_in_minutes: 30
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: 0dt
+    agents:
+      queue: linux-aarch64
+
   - id: skip-version-upgrade
     label: "Skip Version Upgrade"
     depends_on: build-aarch64

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -136,6 +136,9 @@ IGNORE_RE = re.compile(
     | internal\ error:\ no\ AWS\ external\ ID\ prefix\ configured
     # For tests we purposely trigger this error
     | skip-version-upgrade-materialized.* \| .* incompatible\ persist\ version\ \d+\.\d+\.\d+(-dev)?,\ current:\ \d+\.\d+\.\d+(-dev)?,\ make\ sure\ to\ upgrade\ the\ catalog\ one\ version\ at\ a\ time
+    # For 0dt upgrades
+    | halting\ process:\ unable\ to\ confirm\ leadership
+    | halting\ process:\ fenced\ out\ old\ deployment;\ rebooting\ as\ leader
     )
     """,
     re.VERBOSE | re.MULTILINE,

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -126,7 +126,7 @@ class Materialized(Service):
         if propagate_crashes:
             command += ["--orchestrator-process-propagate-crashes"]
 
-        if deploy_generation != None:
+        if deploy_generation is not None:
             command += [f"--deploy-generation={deploy_generation}"]
 
         self.default_storage_size = (

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -54,6 +54,7 @@ class Materialized(Service):
         sanity_restart: bool = True,
         platform: str | None = None,
         healthcheck: list[str] | None = None,
+        deploy_generation: int | None = None,
     ) -> None:
         if name is None:
             name = "materialized"
@@ -124,6 +125,9 @@ class Materialized(Service):
 
         if propagate_crashes:
             command += ["--orchestrator-process-propagate-crashes"]
+
+        if deploy_generation != None:
+            command += [f"--deploy-generation={deploy_generation}"]
 
         self.default_storage_size = (
             str(default_size)

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -27,7 +27,7 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    Materialized(sanity_restart=False),
+    Materialized(sanity_restart=False, deploy_generation=0),
     Testdrive(materialize_params={"cluster": "cluster"}, no_reset=True, seed=1),
 ]
 
@@ -141,7 +141,7 @@ def workflow_basic(c: Composition) -> None:
 
     # Restart in a new deploy generation, which will cause Materialize to
     # boot in read-only mode.
-    with c.override(Materialized(environment_extra=["MZ_DEPLOY_GENERATION=1"])):
+    with c.override(Materialized(deploy_generation=1)):
         c.up("materialized")
 
         c.testdrive(
@@ -233,7 +233,7 @@ def workflow_basic(c: Composition) -> None:
                 "CMD-SHELL",
                 """[ "$(curl -f localhost:6878/api/leader/status)" = '{"status":"IsLeader"}' ]""",
             ],
-            environment_extra=["MZ_DEPLOY_GENERATION=1"],
+            deploy_genreation=1,
         )
     ):
         c.up("materialized")

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -11,8 +11,11 @@ import json
 import time
 from textwrap import dedent
 
+from pg8000.exceptions import InterfaceError
+
 from materialize import buildkite
 from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mysql import MySql
@@ -20,6 +23,9 @@ from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
+from materialize.ui import CommandFailureCausedUIError
+
+DEFAULT_TIMEOUT = "10s"
 
 SERVICES = [
     MySql(),
@@ -27,8 +33,29 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    Materialized(sanity_restart=False, deploy_generation=0),
-    Testdrive(materialize_params={"cluster": "cluster"}, no_reset=True, seed=1),
+    Cockroach(),
+    Materialized(
+        name="mz_old",
+        sanity_restart=False,
+        deploy_generation=0,
+        external_cockroach=True,
+    ),
+    Materialized(
+        name="mz_new",
+        sanity_restart=False,
+        deploy_generation=1,
+        restart="on-failure",
+        external_cockroach=True,
+    ),
+    Testdrive(
+        materialize_url="postgres://materialize@mz_old:6875",
+        materialize_url_internal="postgres://materialize@mz_old:6877",
+        mz_service="mz_old",
+        materialize_params={"cluster": "cluster"},
+        no_reset=True,
+        seed=1,
+        default_timeout=DEFAULT_TIMEOUT,
+    ),
 ]
 
 
@@ -42,10 +69,10 @@ def workflow_default(c: Composition) -> None:
             c.workflow(name)
 
 
-def workflow_basic(c: Composition) -> None:
-    """Verify basic 0dt deployment flow."""
+def workflow_read_only(c: Composition) -> None:
+    """Verify read-only mode."""
     c.down(destroy_volumes=True)
-    c.up("zookeeper", "kafka", "schema-registry", "postgres", "mysql", "materialized")
+    c.up("zookeeper", "kafka", "schema-registry", "postgres", "mysql", "mz_old")
     c.up("testdrive", persistent=True)
 
     # Make sure cluster is owned by the system so it doesn't get dropped
@@ -58,6 +85,7 @@ def workflow_basic(c: Composition) -> None:
         ALTER SYSTEM SET cluster = cluster;
         ALTER SYSTEM SET enable_0dt_deployment = true;
     """,
+        service="mz_old",
         port=6877,
         user="mz_system",
     )
@@ -141,8 +169,8 @@ def workflow_basic(c: Composition) -> None:
 
     # Restart in a new deploy generation, which will cause Materialize to
     # boot in read-only mode.
-    with c.override(Materialized(deploy_generation=1)):
-        c.up("materialized")
+    with c.override(Materialized(name="mz_old", deploy_generation=1)):
+        c.up("mz_old")
 
         c.testdrive(
             dedent(
@@ -198,12 +226,12 @@ def workflow_basic(c: Composition) -> None:
             )
         )
 
-        c.up("materialized")
+        c.up("mz_old")
         # Wait up to 60s for the new deployment to become ready for promotion.
         for _ in range(1, 60):
             result = json.loads(
                 c.exec(
-                    "materialized",
+                    "mz_old",
                     "curl",
                     "localhost:6878/api/leader/status",
                     capture=True,
@@ -216,7 +244,7 @@ def workflow_basic(c: Composition) -> None:
             time.sleep(1)
         result = json.loads(
             c.exec(
-                "materialized",
+                "mz_old",
                 "curl",
                 "-X",
                 "POST",
@@ -229,14 +257,15 @@ def workflow_basic(c: Composition) -> None:
     # After promotion, the deployment should boot with writes allowed.
     with c.override(
         Materialized(
+            name="mz_old",
             healthcheck=[
                 "CMD-SHELL",
                 """[ "$(curl -f localhost:6878/api/leader/status)" = '{"status":"IsLeader"}' ]""",
             ],
-            deploy_genreation=1,
+            deploy_generation=1,
         )
     ):
-        c.up("materialized")
+        c.up("mz_old")
 
         c.testdrive(
             dedent(
@@ -290,6 +319,398 @@ def workflow_basic(c: Composition) -> None:
             A 0
             B 1
             C 2
+            """
+            )
+        )
+
+
+def workflow_basic(c: Composition) -> None:
+    """Verify basic 0dt deployment flow."""
+    c.down(destroy_volumes=True)
+    c.up("zookeeper", "kafka", "schema-registry", "postgres", "mysql", "mz_old")
+    c.up("testdrive", persistent=True)
+
+    # Make sure cluster is owned by the system so it doesn't get dropped
+    # between testdrive runs.
+    c.sql(
+        """
+        DROP CLUSTER IF EXISTS cluster CASCADE;
+        CREATE CLUSTER cluster SIZE '2-1';
+        GRANT ALL ON CLUSTER cluster TO materialize;
+        ALTER SYSTEM SET cluster = cluster;
+        ALTER SYSTEM SET enable_0dt_deployment = true;
+    """,
+        service="mz_old",
+        port=6877,
+        user="mz_system",
+    )
+
+    # Inserts should be reflected when writes are allowed.
+    c.testdrive(
+        dedent(
+            f"""
+        > SET CLUSTER = cluster;
+        > CREATE TABLE t (a int, b int);
+        > INSERT INTO t VALUES (1, 2);
+        > CREATE INDEX t_idx ON t (a, b);
+        > CREATE MATERIALIZED VIEW mv AS SELECT sum(a) FROM t;
+        > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+        > SELECT * FROM mv;
+        1
+        > SELECT max(b) FROM t;
+        2
+
+        $ kafka-create-topic topic=kafka
+        $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=kafka
+        key1A,key1B:value1A,value1B
+        > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}', SECURITY PROTOCOL = 'PLAINTEXT';
+        > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
+        > CREATE SOURCE kafka_source (key1, key2, value1, value2)
+          IN CLUSTER cluster
+          FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-${{testdrive.seed}}')
+          KEY FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
+          VALUE FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
+          ENVELOPE UPSERT;
+        > SELECT * FROM kafka_source
+        key1A key1B value1A value1B
+
+        $ postgres-execute connection=postgres://postgres:postgres@postgres
+        CREATE USER postgres1 WITH SUPERUSER PASSWORD 'postgres';
+        ALTER USER postgres1 WITH replication;
+        DROP PUBLICATION IF EXISTS postgres_source;
+        DROP TABLE IF EXISTS postgres_source_table;
+        CREATE TABLE postgres_source_table (f1 TEXT, f2 INTEGER);
+        ALTER TABLE postgres_source_table REPLICA IDENTITY FULL;
+        INSERT INTO postgres_source_table SELECT 'A', 0;
+        CREATE PUBLICATION postgres_source FOR ALL TABLES;
+
+        > CREATE SECRET pgpass AS 'postgres';
+        > CREATE CONNECTION pg FOR POSTGRES
+          HOST 'postgres',
+          DATABASE postgres,
+          USER postgres1,
+          PASSWORD SECRET pgpass;
+        > CREATE SOURCE postgres_source
+          FROM POSTGRES CONNECTION pg
+          (PUBLICATION 'postgres_source')
+          FOR TABLES (postgres_source_table);
+        > SELECT * FROM postgres_source_table;
+        A 0
+
+        $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+        $ mysql-execute name=mysql
+        # create the database if it does not exist yet but do not drop it
+        CREATE DATABASE IF NOT EXISTS public;
+        USE public;
+        CREATE USER mysql1 IDENTIFIED BY 'mysql';
+        GRANT REPLICATION SLAVE ON *.* TO mysql1;
+        GRANT ALL ON public.* TO mysql1;
+        CREATE TABLE mysql_source_table (f1 VARCHAR(32), f2 INTEGER);
+        INSERT INTO mysql_source_table VALUES ('A', 0);
+
+        > CREATE SECRET mysqlpass AS 'mysql';
+        > CREATE CONNECTION mysql TO MYSQL (
+          HOST 'mysql',
+          USER mysql1,
+          PASSWORD SECRET mysqlpass);
+        > CREATE SOURCE mysql_source1
+          FROM MYSQL CONNECTION mysql
+          FOR TABLES (public.mysql_source_table AS mysql_source_table);
+        > SELECT * FROM mysql_source_table;
+        A 0
+        """
+        )
+    )
+
+    # Start new Materialize in a new deploy generation, which will cause
+    # Materialize to boot in read-only mode.
+    c.up("mz_new")
+
+    # Verify against new Materialize that it is in read-only mode
+    with c.override(
+        Testdrive(
+            materialize_url="postgres://materialize@mz_new:6875",
+            materialize_url_internal="postgres://materialize@mz_new:6877",
+            mz_service="mz_new",
+            materialize_params={"cluster": "cluster"},
+            no_reset=True,
+            seed=1,
+            default_timeout=DEFAULT_TIMEOUT,
+        )
+    ):
+        c.up("testdrive", persistent=True)
+        c.testdrive(
+            dedent(
+                f"""
+            $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=kafka
+            key2A,key2B:value2A,value2B
+
+            $ postgres-execute connection=postgres://postgres:postgres@postgres
+            INSERT INTO postgres_source_table VALUES ('B', 1);
+
+            $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+            $ mysql-execute name=mysql
+            USE public;
+            INSERT INTO mysql_source_table VALUES ('B', 1);
+
+            > SET CLUSTER = cluster;
+            > SELECT 1
+            1
+            ! INSERT INTO t VALUES (3, 4);
+            contains: cannot write in read-only mode
+            > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+            > SELECT * FROM mv;
+            1
+            # TODO: Currently hangs
+            # > SELECT max(b) FROM t;
+            # 2
+            > SELECT mz_unsafe.mz_sleep(5)
+            <null>
+            ! INSERT INTO t VALUES (5, 6);
+            contains: cannot write in read-only mode
+            > SELECT * FROM mv;
+            1
+            ! DROP INDEX t_idx
+            contains: cannot write in read-only mode
+            # TODO: Doesn't error currently
+            ! CREATE INDEX t_idx2 ON t (a, b)
+            contains: cannot write in read-only mode
+            ! CREATE MATERIALIZED VIEW mv2 AS SELECT sum(a) FROM t;
+            contains: cannot write in read-only mode
+
+            $ set-regex match=(s\\d+|\\d{{13}}|[ ]{{12}}0|u\\d{{1,3}}|\\(\\d+-\\d\\d-\\d\\d\\s\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d\\)) replacement=<>
+
+            > EXPLAIN TIMESTAMP FOR SELECT * FROM mv;
+            "                query timestamp: <> <>\\nlargest not in advance of upper: <> <>\\n                          upper:[<> <>]\\n                          since:[<> <>]\\n        can respond immediately: true\\n                       timeline: Some(EpochMilliseconds)\\n              session wall time: <> <>\\n\\nsource materialize.public.mv (<>, storage):\\n                  read frontier:[<> <>]\\n                 write frontier:[<> <>]\\n"
+
+            > SELECT * FROM kafka_source
+            key1A key1B value1A value1B
+            key2A key2B value2A value2B
+            > SELECT * FROM postgres_source_table
+            A 0
+            B 1
+            > SELECT * FROM mysql_source_table;
+            A 0
+            B 1
+            """
+            )
+        )
+
+    # But the old Materialize can still run writes
+    c.up("testdrive", persistent=True)
+    c.testdrive(
+        dedent(
+            f"""
+        $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=kafka
+        key3A,key3B:value3A,value3B
+
+        $ postgres-execute connection=postgres://postgres:postgres@postgres
+        INSERT INTO postgres_source_table VALUES ('C', 2);
+
+        $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+        $ mysql-execute name=mysql
+        USE public;
+        INSERT INTO mysql_source_table VALUES ('C', 2);
+
+        > SET CLUSTER = cluster;
+        > SELECT 1
+        1
+        > INSERT INTO t VALUES (3, 4);
+        > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+        > SELECT * FROM mv;
+        4
+        > SELECT max(b) FROM t;
+        4
+        > SELECT mz_unsafe.mz_sleep(5)
+        <null>
+        > INSERT INTO t VALUES (5, 6);
+        > SELECT * FROM mv;
+        9
+        > DROP INDEX t_idx
+        > CREATE INDEX t_idx2 ON t (a, b)
+        > CREATE MATERIALIZED VIEW mv2 AS SELECT sum(a) FROM t;
+
+        $ set-regex match=(s\\d+|\\d{{13}}|[ ]{{12}}0|u\\d{{1,3}}|\\(\\d+-\\d\\d-\\d\\d\\s\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d\\)) replacement=<>
+
+        > EXPLAIN TIMESTAMP FOR SELECT * FROM mv;
+        "                query timestamp: <> <>\\nlargest not in advance of upper: <> <>\\n                          upper:[<> <>]\\n                          since:[<> <>]\\n        can respond immediately: true\\n                       timeline: Some(EpochMilliseconds)\\n              session wall time: <> <>\\n\\nsource materialize.public.mv (<>, storage):\\n                  read frontier:[<> <>]\\n                 write frontier:[<> <>]\\n"
+
+        > SELECT * FROM kafka_source
+        key1A key1B value1A value1B
+        key2A key2B value2A value2B
+        key3A key3B value3A value3B
+        > SELECT * FROM postgres_source_table
+        A 0
+        B 1
+        C 2
+        > SELECT * FROM mysql_source_table;
+        A 0
+        B 1
+        C 2
+        """
+        )
+    )
+
+    with c.override(
+        Testdrive(
+            materialize_url="postgres://materialize@mz_new:6875",
+            materialize_url_internal="postgres://materialize@mz_new:6877",
+            mz_service="mz_new",
+            materialize_params={"cluster": "cluster"},
+            no_reset=True,
+            seed=1,
+            default_timeout=DEFAULT_TIMEOUT,
+        )
+    ):
+        c.up("testdrive", persistent=True)
+        c.testdrive(
+            dedent(
+                """
+            > SET CLUSTER = cluster;
+            > SELECT 1
+            1
+            ! INSERT INTO t VALUES (3, 4);
+            contains: cannot write in read-only mode
+            > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+            > SELECT * FROM mv;
+            9
+            > SELECT max(b) FROM t;
+            6
+            > SELECT * FROM mv;
+            9
+            > SELECT * FROM kafka_source
+            key1A key1B value1A value1B
+            key2A key2B value2A value2B
+            key3A key3B value3A value3B
+            > SELECT * FROM postgres_source_table
+            A 0
+            B 1
+            C 2
+            > SELECT * FROM mysql_source_table;
+            A 0
+            B 1
+            C 2
+            """
+            )
+        )
+
+        # Wait up to 60s for the new deployment to become ready for promotion.
+        for _ in range(1, 60):
+            result = json.loads(
+                c.exec(
+                    "mz_new",
+                    "curl",
+                    "localhost:6878/api/leader/status",
+                    capture=True,
+                ).stdout
+            )
+            if result["status"] == "ReadyToPromote":
+                break
+            assert result["status"] == "Initializing", f"Unexpected status {result}"
+            print("Not ready yet, waiting 1s")
+            time.sleep(1)
+        result = json.loads(
+            c.exec(
+                "mz_new",
+                "curl",
+                "-X",
+                "POST",
+                "localhost:6878/api/leader/promote",
+                capture=True,
+            ).stdout
+        )
+        assert result["result"] == "Success", f"Unexpected result {result}"
+
+        # Give some time for Mz to restart after promotion
+        for i in range(10):
+            try:
+                c.sql("SELECT 1", service="mz_old")
+            except InterfaceError as e:
+                assert "network error" in str(
+                    e
+                ) or "Can't create a connection to host" in str(
+                    e
+                ), f"Unexpected error: {e}"
+            except CommandFailureCausedUIError as e:
+                # service "mz_old" is not running
+                assert "running docker compose failed" in str(e), f"Unexpected error: {e}"
+                break
+            time.sleep(1)
+        else:
+            assert False, "mz_old didn't stop running within 10 seconds"
+
+        for i in range(10):
+            try:
+                c.sql("SELECT 1", service="mz_new")
+                break
+            except CommandFailureCausedUIError:
+                pass
+            except InterfaceError:
+                pass
+            time.sleep(1)
+        else:
+            assert False, "mz_new didn't come up within 10 seconds"
+
+        c.testdrive(
+            dedent(
+                f"""
+            > SET CLUSTER = cluster;
+            > SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+            > CREATE MATERIALIZED VIEW mv3 AS SELECT sum(a) FROM t;
+            > SELECT * FROM mv;
+            9
+            > SELECT * FROM mv2;
+            9
+            > SELECT * FROM mv3;
+            9
+            > SELECT max(b) FROM t;
+            6
+            > INSERT INTO t VALUES (7, 8);
+            > SELECT * FROM mv;
+            16
+            > SELECT * FROM mv2;
+            16
+            > SELECT max(b) FROM t;
+            8
+            > SELECT * FROM kafka_source
+            key1A key1B value1A value1B
+            key2A key2B value2A value2B
+            key3A key3B value3A value3B
+            > SELECT * FROM postgres_source_table
+            A 0
+            B 1
+            C 2
+            > SELECT * FROM mysql_source_table;
+            A 0
+            B 1
+            C 2
+
+            $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=kafka
+            key4A,key4B:value4A,value4B
+
+            $ postgres-execute connection=postgres://postgres:postgres@postgres
+            INSERT INTO postgres_source_table VALUES ('D', 3);
+
+            $ mysql-connect name=mysql url=mysql://root@mysql password={MySql.DEFAULT_ROOT_PASSWORD}
+            $ mysql-execute name=mysql
+            USE public;
+            INSERT INTO mysql_source_table VALUES ('D', 3);
+
+            > SELECT * FROM kafka_source
+            key1A key1B value1A value1B
+            key2A key2B value2A value2B
+            key3A key3B value3A value3B
+            key4A key4B value4A value4B
+            > SELECT * FROM postgres_source_table
+            A 0
+            B 1
+            C 2
+            D 3
+            > SELECT * FROM mysql_source_table;
+            A 0
+            B 1
+            C 2
+            D 3
             """
             )
         )


### PR DESCRIPTION
This is largely following https://materializeinc.slack.com/archives/C058H9MH8P3/p1719925704433379?thread_ts=1719921187.025859&cid=C058H9MH8P3
This is still with long hydration after restart since we don't have https://github.com/MaterializeInc/materialize/pull/27997 yet. After that lands could check if hydration has already occurred.
I'll work on platform-checks and parallel-workload support next.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
