### PR TITLE
balancerd: enable jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4261,6 +4261,8 @@ dependencies = [
  "hyper 0.14.27",
  "hyper-openssl 0.9.2",
  "jsonwebtoken",
+ "mz-alloc",
+ "mz-alloc-default",
  "mz-build-info",
  "mz-environmentd",
  "mz-frontegg-auth",

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -21,6 +21,8 @@ futures = "0.3.25"
 hyper = { version = "0.14.23", features = ["http1", "server"] }
 hyper-openssl = "0.9.2"
 jsonwebtoken = "9.2.0"
+mz-alloc = { path = "../alloc" }
+mz-alloc-default = { path = "../alloc-default", optional = true }
 mz-build-info = { path = "../build-info" }
 mz-frontegg-auth = { path = "../frontegg-auth" }
 mz-http-util = { path = "../http-util" }
@@ -41,11 +43,15 @@ uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
-mz-environmentd = { path = "../environmentd", features = ["test"] }
+mz-environmentd = { path = "../environmentd", default-features = false, features = ["test"] }
 mz-frontegg-mock = { path = "../frontegg-mock" }
 postgres = "0.19.5"
 reqwest = "0.11.24"
 tempfile = "3.8.1"
 
+[features]
+default = ["mz-alloc-default"]
+jemalloc = ["mz-alloc/jemalloc"]
+
 [package.metadata.cargo-udeps.ignore]
-normal = ["workspace-hack"]
+normal = ["workspace-hack", "mz-alloc-default"]

--- a/src/balancerd/src/main.rs
+++ b/src/balancerd/src/main.rs
@@ -47,15 +47,18 @@ fn main() {
         .build()
         .expect("Failed building the Runtime");
 
+    let metrics_registry = MetricsRegistry::new();
     let (_, _tracing_guard) = runtime
         .block_on(args.tracing.configure_tracing(
             StaticTracingConfig {
                 service_name: "balancerd",
                 build_info: BUILD_INFO,
             },
-            MetricsRegistry::new(),
+            metrics_registry.clone(),
         ))
         .expect("failed to init tracing");
+
+    runtime.block_on(mz_alloc::register_metrics_into(&metrics_registry));
 
     let root_span = info_span!("balancer");
     let res = match args.command {


### PR DESCRIPTION
Bring balancerd into alignment with our other production binaries and use jemalloc by default on Linux.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
