### PR TITLE
storage/source/kafka: don't seek

### DIFF
--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -76,15 +76,6 @@ pub const KAFKA_POLL_MAX_WAIT: Config<Duration> = Config::new(
     available.",
 );
 
-/// The timeout when seeking through a consumer when fast-forwarding it. We expect this
-/// to happen quickly.
-pub const KAFKA_FAST_FORWARD_SEEK_TIMEOUT: Config<Duration> = Config::new(
-    "kafka_fast_forward_seek_timeout",
-    Duration::from_secs(1),
-    "The timeout when seeking through a consumer when fast-forwarding it. We expect this \
-    to happen quickly.",
-);
-
 // MySQL
 
 /// Replication heartbeat interval requested from the MySQL server.
@@ -184,7 +175,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION)
         .add(&KAFKA_CLIENT_ID_ENRICHMENT_RULES)
         .add(&KAFKA_POLL_MAX_WAIT)
-        .add(&KAFKA_FAST_FORWARD_SEEK_TIMEOUT)
         .add(&MYSQL_REPLICATION_HEARTBEAT_INTERVAL)
         .add(&MYSQL_OFFSET_KNOWN_INTERVAL)
         .add(&PG_FETCH_SLOT_RESUME_LSN_INTERVAL)


### PR DESCRIPTION
This commit fixes a flake observed in the source-sink-errors test
(#28016).

Here's what was happening:

  * The source would read the message with offset 1 from Kafka.
  * The source would emit the message to its data output.
  * The test would turn Redpanda off.
  * librdkafka would notice the broken connection and, incorrectly,
    redeliver the message with offset 1. (This is a known problem with
    librdkafka, and something the code already protects against.)
  * The source would seek to offset 2, thus marking its position within
    librdkafka as "invalid".
  * The source would fail to downgrade its capability to offset 2
    because librdkafka was no longer reporting a valid offset.
  * The test would turn Redpanda on.
  * librdkafka would successfully reconnect but not update the offset
    for the partition.
  * The source would not downgrade its capability to offset 2 because
    librdkafka was still not reporting a valid offset.

If a new message was written to Kafka at offset 2, then librdkafka
*would* emit the message and report a valid offset of 3, at which point
the source would downgrade its capability to offset 3, and both the
message at offset 1 and the message at offset 2 would become visible.

The flake started occurring after the upgrade to librdkafka v2.4. It's
not clear whether there was a behavior change inside of librdkafka, or
whether its simply a timing condition that always existed and somehow
became more common in the new version.

Regardless, the fix is straightforward: don't attempt to seek the
partition. librdkafka has only been observed to redeliver a single
message at a time, so there is no need to seek forward to skip messages.
We can simply receive and discard the errant messages normally.

Fix #28016.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
