### PR TITLE
Use structured diff for MRE equality

### DIFF
--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -54,7 +54,7 @@ pub use scalar::{
 
 /// A [`MirRelationExpr`] that claims to have been optimized, e.g., by an
 /// `transform::Optimizer`.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct OptimizedMirRelationExpr(pub MirRelationExpr);
 
 impl OptimizedMirRelationExpr {

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -84,7 +84,7 @@ pub trait CollectionPlan {
 ///
 /// The AST is meant to reflect the capabilities of the `differential_dataflow::Collection` type,
 /// written generically enough to avoid run-time compilation work.
-#[derive(Clone, Debug, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(Clone, Debug, Ord, PartialOrd, Serialize, Deserialize, MzReflect)]
 pub enum MirRelationExpr {
     /// A constant relation containing specified rows.
     ///

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -84,7 +84,7 @@ pub trait CollectionPlan {
 ///
 /// The AST is meant to reflect the capabilities of the `differential_dataflow::Collection` type,
 /// written generically enough to avoid run-time compilation work.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(Clone, Debug, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
 pub enum MirRelationExpr {
     /// A constant relation containing specified rows.
     ///
@@ -301,6 +301,13 @@ pub enum MirRelationExpr {
         keys: Vec<Vec<MirScalarExpr>>,
     },
 }
+
+impl PartialEq for MirRelationExpr {
+    fn eq(&self, other: &Self) -> bool {
+        structured_diff::MreDiff::new(self, other).next().is_none()
+    }
+}
+impl Eq for MirRelationExpr {}
 
 impl MirRelationExpr {
     /// Reports the schema of the relation.
@@ -3543,5 +3550,300 @@ mod tests {
         };
 
         assert_eq!(act, exp);
+    }
+}
+
+/// An iterator over AST structures, which calls out nodes in difference.
+///
+/// The iterators visit two ASTs in tandem, continuing as long as the AST node data matches,
+/// and yielding an output pair as soon as the AST nodes do not match. Their intent is to call
+/// attention to the moments in the ASTs where they differ, and incidentally a stack-free way
+/// to compare two ASTs.
+mod structured_diff {
+
+    use super::MirRelationExpr;
+
+    ///  An iterator over structured differences between two `MirRelationExpr` instances.
+    pub struct MreDiff<'a> {
+        /// Pairs of expressions that must still be compared.
+        todo: Vec<(&'a MirRelationExpr, &'a MirRelationExpr)>,
+    }
+
+    impl<'a> MreDiff<'a> {
+        /// Create a new `MirRelationExpr` structured difference.
+        pub fn new(expr1: &'a MirRelationExpr, expr2: &'a MirRelationExpr) -> Self {
+            MreDiff {
+                todo: vec![(expr1, expr2)],
+            }
+        }
+    }
+
+    impl<'a> Iterator for MreDiff<'a> {
+        // Pairs of expressions that do not match.
+        type Item = (&'a MirRelationExpr, &'a MirRelationExpr);
+
+        fn next(&mut self) -> Option<Self::Item> {
+            while let Some((expr1, expr2)) = self.todo.pop() {
+                match (expr1, expr2) {
+                    (
+                        MirRelationExpr::Constant {
+                            rows: rows1,
+                            typ: typ1,
+                        },
+                        MirRelationExpr::Constant {
+                            rows: rows2,
+                            typ: typ2,
+                        },
+                    ) => {
+                        if rows1 != rows2 || typ1 != typ2 {
+                            return Some((expr1, expr2));
+                        }
+                    }
+                    (
+                        MirRelationExpr::Get {
+                            id: id1,
+                            typ: typ1,
+                            access_strategy: as1,
+                        },
+                        MirRelationExpr::Get {
+                            id: id2,
+                            typ: typ2,
+                            access_strategy: as2,
+                        },
+                    ) => {
+                        if id1 != id2 || typ1 != typ2 || as1 != as2 {
+                            return Some((expr1, expr2));
+                        }
+                    }
+                    (
+                        MirRelationExpr::Let {
+                            id: id1,
+                            body: body1,
+                            value: value1,
+                        },
+                        MirRelationExpr::Let {
+                            id: id2,
+                            body: body2,
+                            value: value2,
+                        },
+                    ) => {
+                        if id1 != id2 {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.push((body1, body2));
+                            self.todo.push((value1, value2));
+                        }
+                    }
+                    (
+                        MirRelationExpr::LetRec {
+                            ids: ids1,
+                            body: body1,
+                            values: values1,
+                            limits: limits1,
+                        },
+                        MirRelationExpr::LetRec {
+                            ids: ids2,
+                            body: body2,
+                            values: values2,
+                            limits: limits2,
+                        },
+                    ) => {
+                        if ids1 != ids2 || limits1 != limits2 {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.push((body1, body2));
+                            self.todo.extend(values1.iter().zip(values2.iter()));
+                        }
+                    }
+                    (
+                        MirRelationExpr::Project {
+                            outputs: outputs1,
+                            input: input1,
+                        },
+                        MirRelationExpr::Project {
+                            outputs: outputs2,
+                            input: input2,
+                        },
+                    ) => {
+                        if outputs1 != outputs2 {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.push((input1, input2));
+                        }
+                    }
+                    (
+                        MirRelationExpr::Map {
+                            scalars: scalars1,
+                            input: input1,
+                        },
+                        MirRelationExpr::Map {
+                            scalars: scalars2,
+                            input: input2,
+                        },
+                    ) => {
+                        if scalars1 != scalars2 {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.push((input1, input2));
+                        }
+                    }
+                    (
+                        MirRelationExpr::Filter {
+                            predicates: predicates1,
+                            input: input1,
+                        },
+                        MirRelationExpr::Filter {
+                            predicates: predicates2,
+                            input: input2,
+                        },
+                    ) => {
+                        if predicates1 != predicates2 {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.push((input1, input2));
+                        }
+                    }
+                    (
+                        MirRelationExpr::FlatMap {
+                            input: input1,
+                            func: func1,
+                            exprs: exprs1,
+                        },
+                        MirRelationExpr::FlatMap {
+                            input: input2,
+                            func: func2,
+                            exprs: exprs2,
+                        },
+                    ) => {
+                        if func1 != func2 || exprs1 != exprs2 {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.push((input1, input2));
+                        }
+                    }
+                    (
+                        MirRelationExpr::Join {
+                            inputs: inputs1,
+                            equivalences: eq1,
+                            implementation: impl1,
+                        },
+                        MirRelationExpr::Join {
+                            inputs: inputs2,
+                            equivalences: eq2,
+                            implementation: impl2,
+                        },
+                    ) => {
+                        if eq1 != eq2 || impl1 != impl2 {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.extend(inputs1.iter().zip(inputs2.iter()));
+                        }
+                    }
+                    (
+                        MirRelationExpr::Reduce {
+                            aggregates: aggregates1,
+                            input: inputs1,
+                            group_key: gk1,
+                            monotonic: m1,
+                            expected_group_size: egs1,
+                        },
+                        MirRelationExpr::Reduce {
+                            aggregates: aggregates2,
+                            input: inputs2,
+                            group_key: gk2,
+                            monotonic: m2,
+                            expected_group_size: egs2,
+                        },
+                    ) => {
+                        if aggregates1 != aggregates2 || gk1 != gk2 || m1 != m2 || egs1 != egs2 {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.push((inputs1, inputs2));
+                        }
+                    }
+                    (
+                        MirRelationExpr::TopK {
+                            group_key: gk1,
+                            order_key: order1,
+                            input: input1,
+                            limit: l1,
+                            offset: o1,
+                            monotonic: m1,
+                            expected_group_size: egs1,
+                        },
+                        MirRelationExpr::TopK {
+                            group_key: gk2,
+                            order_key: order2,
+                            input: input2,
+                            limit: l2,
+                            offset: o2,
+                            monotonic: m2,
+                            expected_group_size: egs2,
+                        },
+                    ) => {
+                        if order1 != order2
+                            || gk1 != gk2
+                            || l1 != l2
+                            || o1 != o2
+                            || m1 != m2
+                            || egs1 != egs2
+                        {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.push((input1, input2));
+                        }
+                    }
+                    (
+                        MirRelationExpr::Negate { input: input1 },
+                        MirRelationExpr::Negate { input: input2 },
+                    ) => {
+                        self.todo.push((input1, input2));
+                    }
+                    (
+                        MirRelationExpr::Threshold { input: input1 },
+                        MirRelationExpr::Threshold { input: input2 },
+                    ) => {
+                        self.todo.push((input1, input2));
+                    }
+                    (
+                        MirRelationExpr::Union {
+                            base: base1,
+                            inputs: inputs1,
+                        },
+                        MirRelationExpr::Union {
+                            base: base2,
+                            inputs: inputs2,
+                        },
+                    ) => {
+                        if inputs1.len() != inputs2.len() {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.push((base1, base2));
+                            self.todo.extend(inputs1.iter().zip(inputs2.iter()));
+                        }
+                    }
+                    (
+                        MirRelationExpr::ArrangeBy {
+                            keys: keys1,
+                            input: input1,
+                        },
+                        MirRelationExpr::ArrangeBy {
+                            keys: keys2,
+                            input: input2,
+                        },
+                    ) => {
+                        if keys1 != keys2 {
+                            return Some((expr1, expr2));
+                        } else {
+                            self.todo.push((input1, input2));
+                        }
+                    }
+                    _ => {
+                        return Some((expr1, expr2));
+                    }
+                }
+            }
+            None
+        }
     }
 }


### PR DESCRIPTION
Our `MirRelationExpr`s have historically had stack overflow challenges, and we've steered away from methods that might overflow. I *think* one example is `PartialEq::eq`, among others (pretty much everything we derive?). So, this tries out using a form of structured diffing to support a stack-free equality test, as well as providing the basis for other comparisons (`PartialOrd` and `Ord`, except they are tedious to write without a derived implementation).

One thing this calls out is that our approach to ASTs which commingles the tree structure (e.g. `input`) with the AST node structure .. is annoying. It's also annoying for flat representations which would prefer to pivot the representation. Perhaps we should revisit this and have a abstract AST generic over node metadata, which would unblock many things (including a stack-free post-order traversal, should we aspire to that). 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
