### PR TITLE
output consistency: provide reproduction code in collapsible part of annotation

### DIFF
--- a/misc/python/materialize/output_consistency/execution/query_execution_manager.py
+++ b/misc/python/materialize/output_consistency/execution/query_execution_manager.py
@@ -100,7 +100,9 @@ class QueryExecutionManager:
         for test_outcome in test_outcomes:
             if test_outcome.verdict() == ValidationVerdict.FAILURE:
                 all_comparisons_passed = False
-            summary_to_update.accept_execution_result(query, test_outcome)
+            summary_to_update.accept_execution_result(
+                query, test_outcome, self.output_printer.reproduction_code_printer
+            )
 
         return all_comparisons_passed
 

--- a/misc/python/materialize/output_consistency/output/base_output_printer.py
+++ b/misc/python/materialize/output_consistency/output/base_output_printer.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import re
+from enum import Enum
 
 from materialize.output_consistency.output.format_constants import (
     COMMENT_PREFIX,
@@ -17,9 +18,19 @@ from materialize.output_consistency.output.format_constants import (
 )
 
 
+class OutputPrinterMode(Enum):
+    PRINT = 1
+    COLLECT = 2
+
+
 class BaseOutputPrinter:
+
+    def __init__(self, mode: OutputPrinterMode = OutputPrinterMode.PRINT):
+        self.mode = mode
+        self.collected_output = []
+
     def print_empty_line(self) -> None:
-        print()
+        self._print_raw("")
 
     def start_section(self, header: str, collapsed: bool = True) -> None:
         prefix = SECTION_COLLAPSED_PREFIX if collapsed else SECTION_EXPANDED_PREFIX
@@ -38,4 +49,9 @@ class BaseOutputPrinter:
         self._print_raw(adjusted_text)
 
     def _print_raw(self, sql: str) -> None:
-        print(sql)
+        if self.mode == OutputPrinterMode.PRINT:
+            print(sql)
+        elif self.mode == OutputPrinterMode.COLLECT:
+            self.collected_output.append(sql)
+        else:
+            raise RuntimeError(f"Unsupported mode: {self.mode}")

--- a/misc/python/materialize/output_consistency/output/output_printer.py
+++ b/misc/python/materialize/output_consistency/output/output_printer.py
@@ -14,7 +14,10 @@ from materialize.output_consistency.common.configuration import (
 from materialize.output_consistency.input_data.test_input_data import (
     ConsistencyTestInputData,
 )
-from materialize.output_consistency.output.base_output_printer import BaseOutputPrinter
+from materialize.output_consistency.output.base_output_printer import (
+    BaseOutputPrinter,
+    OutputPrinterMode,
+)
 from materialize.output_consistency.output.reproduction_code_printer import (
     ReproductionCodePrinter,
 )
@@ -23,7 +26,12 @@ from materialize.output_consistency.validation.validation_message import Validat
 
 
 class OutputPrinter(BaseOutputPrinter):
-    def __init__(self, input_data: ConsistencyTestInputData):
+    def __init__(
+        self,
+        input_data: ConsistencyTestInputData,
+        mode: OutputPrinterMode = OutputPrinterMode.PRINT,
+    ):
+        super().__init__(mode=mode)
         self.reproduction_code_printer = ReproductionCodePrinter(input_data)
 
     def print_sql(self, sql: str) -> None:

--- a/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
+++ b/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
@@ -17,7 +17,10 @@ from materialize.output_consistency.expression.expression_characteristics import
 from materialize.output_consistency.input_data.test_input_data import (
     ConsistencyTestInputData,
 )
-from materialize.output_consistency.output.base_output_printer import BaseOutputPrinter
+from materialize.output_consistency.output.base_output_printer import (
+    BaseOutputPrinter,
+    OutputPrinterMode,
+)
 from materialize.output_consistency.query.query_format import QueryOutputFormat
 from materialize.output_consistency.query.query_template import QueryTemplate
 from materialize.output_consistency.selection.selection import (
@@ -32,7 +35,12 @@ MAX_ERRORS_WITH_REPRODUCTION_CODE = 5
 
 
 class ReproductionCodePrinter(BaseOutputPrinter):
-    def __init__(self, input_data: ConsistencyTestInputData):
+    def __init__(
+        self,
+        input_data: ConsistencyTestInputData,
+        mode: OutputPrinterMode = OutputPrinterMode.PRINT,
+    ):
+        super().__init__(mode=mode)
         self.input_data = input_data
 
     def print_reproduction_code(self, errors: list[ValidationError]) -> None:

--- a/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
+++ b/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
@@ -111,8 +111,9 @@ class ReproductionCodePrinter(BaseOutputPrinter):
         characteristics = self.__get_involved_characteristics(
             query_template, query_column_selection
         )
+        characteristic_names = ", ".join([char.name for char in characteristics])
         self._print_text(
-            f"All assumed directly or indirectly involved characteristics: {characteristics}"
+            f"All assumed directly or indirectly involved characteristics: {characteristic_names}"
         )
 
     def __print_setup_code_for_error(

--- a/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
+++ b/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
@@ -43,14 +43,22 @@ class ReproductionCodePrinter(BaseOutputPrinter):
         super().__init__(mode=mode)
         self.input_data = input_data
 
+    def clone(self, mode: OutputPrinterMode):
+        return ReproductionCodePrinter(self.input_data, mode)
+
+    def get_reproduction_code_of_error(self, error: ValidationError) -> str:
+        reproduction_code_generator = self.clone(OutputPrinterMode.COLLECT)
+        reproduction_code_generator.print_reproduction_code_of_error(error)
+        return "\n".join(reproduction_code_generator.collected_output)
+
     def print_reproduction_code(self, errors: list[ValidationError]) -> None:
         for i, error in enumerate(errors):
             if i == MAX_ERRORS_WITH_REPRODUCTION_CODE:
                 break
 
-            self.__print_reproduction_code_of_error(error)
+            self.print_reproduction_code_of_error(error)
 
-    def __print_reproduction_code_of_error(self, error: ValidationError) -> None:
+    def print_reproduction_code_of_error(self, error: ValidationError) -> None:
         query_template = error.query_execution.query_template
 
         if error.col_index is None:

--- a/misc/python/materialize/output_consistency/status/test_summary.py
+++ b/misc/python/materialize/output_consistency/status/test_summary.py
@@ -14,6 +14,9 @@ from materialize.output_consistency.expression.expression_with_args import (
     ExpressionWithArgs,
 )
 from materialize.output_consistency.operation.operation import DbOperationOrFunction
+from materialize.output_consistency.output.reproduction_code_printer import (
+    ReproductionCodePrinter,
+)
 from materialize.output_consistency.query.query_template import QueryTemplate
 from materialize.output_consistency.status.consistency_test_logger import (
     ConsistencyTestLogger,
@@ -188,7 +191,10 @@ class ConsistencyTestSummary(ConsistencyTestLogger):
                 )
 
     def accept_execution_result(
-        self, query: QueryTemplate, test_outcome: ValidationOutcome
+        self,
+        query: QueryTemplate,
+        test_outcome: ValidationOutcome,
+        reproduction_code_printer: ReproductionCodePrinter,
     ) -> None:
         self.count_executed_query_templates += 1
         verdict = test_outcome.verdict()
@@ -201,7 +207,9 @@ class ConsistencyTestSummary(ConsistencyTestLogger):
         elif verdict == ValidationVerdict.IGNORED_FAILURE:
             self.count_ignored_error_query_templates += 1
         elif verdict == ValidationVerdict.FAILURE:
-            self.add_failures(test_outcome.to_failure_details())
+            self.add_failures(
+                test_outcome.to_failure_details(reproduction_code_printer)
+            )
         else:
             raise RuntimeError(f"Unexpected verdict: {verdict}")
 

--- a/misc/python/materialize/output_consistency/validation/validation_outcome.py
+++ b/misc/python/materialize/output_consistency/validation/validation_outcome.py
@@ -17,6 +17,9 @@ from materialize.output_consistency.ignore_filter.internal_output_inconsistency_
     YesIgnore,
 )
 from materialize.output_consistency.output.format_constants import LI_PREFIX
+from materialize.output_consistency.output.reproduction_code_printer import (
+    ReproductionCodePrinter,
+)
 from materialize.output_consistency.validation.validation_message import (
     ValidationError,
     ValidationMessage,
@@ -115,7 +118,9 @@ class ValidationOutcome:
 
         return "\n".join(f"{LI_PREFIX}{str(entry)}" for entry in entries)
 
-    def to_failure_details(self) -> list[TestFailureDetails]:
+    def to_failure_details(
+        self, reproduction_code_printer: ReproductionCodePrinter
+    ) -> list[TestFailureDetails]:
         failures = []
 
         for error in self.errors:
@@ -128,6 +133,10 @@ class ValidationOutcome:
                     test_case_name_override=test_case_name,
                     message=error.message,
                     details=str(error),
+                    additional_details_header="Code to reproduce",
+                    additional_details=reproduction_code_printer.get_reproduction_code_of_error(
+                        error
+                    ),
                 )
             )
 


### PR DESCRIPTION
### Commits
e54c0dcabc output consistency: output printer: allow redirecting output to collection
369d124d3b output consistency: output printer: provide reproduction code as string
b6d1db5982 output consistency: junit.xml: provide reproduction code
dab909d8e3 output consistency: improve output

### Nightly
https://buildkite.com/materialize/nightly/builds/8447
