### PR TITLE
tests: Keep clusterd logs in replica-isolation test

### DIFF
--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -35,6 +35,10 @@ SERVICES = [
             "log_filter": "mz_cluster::server=debug,info",
         },
     ),
+    Clusterd(name="clusterd_1_1"),
+    Clusterd(name="clusterd_1_2"),
+    Clusterd(name="clusterd_2_1"),
+    Clusterd(name="clusterd_2_2"),
     Testdrive(),
 ]
 
@@ -414,82 +418,81 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 
 def run_test(c: Composition, disruption: Disruption, id: int) -> None:
+    # Cleanup here instead of at the end of the test to make sure we keep state
+    # and logs in case something goes wrong
+    cleanup_list = [
+        "materialized",
+        "testdrive",
+        "clusterd_1_1",
+        "clusterd_1_2",
+        "clusterd_2_1",
+        "clusterd_2_2",
+    ]
+    c.kill(*cleanup_list)
+    c.rm(*cleanup_list, destroy_volumes=True)
+    c.rm_volumes("mzdata")
     print(f"+++ Running disruption scenario {disruption.name}")
 
     c.up("testdrive", persistent=True)
+    c.up("materialized", "clusterd_1_1", "clusterd_1_2", "clusterd_2_1", "clusterd_2_2")
 
-    nodes = [
-        Clusterd(name="clusterd_1_1"),
-        Clusterd(name="clusterd_1_2"),
-        Clusterd(name="clusterd_2_1"),
-        Clusterd(name="clusterd_2_2"),
-    ]
+    c.sql(
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
+        port=6877,
+        user="mz_system",
+    )
 
-    with c.override(*nodes):
-        c.up("materialized", *[n.name for n in nodes])
-
+    if ArrangedIntro in disruption.compaction_checks:
+        # Disable introspection subscribes because they break the
+        # `ArrangedIntro` check by disabling compaction of logging indexes
+        # on all replicas if one of the replicas is failing. That's because
+        # of a defect of replica-targeted subscribes: They get installed on
+        # all replicas but only the targeted replica can drive the write
+        # frontier forward. If the targeted replica is crashing, the write
+        # frontier cannot advance and thus the read frontier cannot either.
+        #
+        # TODO(#27399): Fix this by installing targeted subscribes only on the
+        #               targeted replica.
         c.sql(
-            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
+            "ALTER SYSTEM SET enable_introspection_subscribes = false;",
             port=6877,
             user="mz_system",
         )
 
-        if ArrangedIntro in disruption.compaction_checks:
-            # Disable introspection subscribes because they break the
-            # `ArrangedIntro` check by disabling compaction of logging indexes
-            # on all replicas if one of the replicas is failing. That's because
-            # of a defect of replica-targeted subscribes: They get installed on
-            # all replicas but only the targeted replica can drive the write
-            # frontier forward. If the targeted replica is crashing, the write
-            # frontier cannot advance and thus the read frontier cannot either.
-            #
-            # TODO(#27399): Fix this by installing targeted subscribes only on the
-            #               targeted replica.
-            c.sql(
-                "ALTER SYSTEM SET enable_introspection_subscribes = false;",
-                port=6877,
-                user="mz_system",
+    c.sql(
+        """
+        CREATE CLUSTER cluster1 REPLICAS (
+            replica1 (
+                STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2100'],
+                STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2103'],
+                COMPUTECTL ADDRESSES ['clusterd_1_1:2101', 'clusterd_1_2:2101'],
+                COMPUTE ADDRESSES ['clusterd_1_1:2102', 'clusterd_1_2:2102']
+            ),
+            replica2 (
+                STORAGECTL ADDRESSES ['clusterd_2_1:2100', 'clusterd_2_2:2100'],
+                STORAGE ADDRESSES ['clusterd_2_1:2103', 'clusterd_2_2:2103'],
+                COMPUTECTL ADDRESSES ['clusterd_2_1:2101', 'clusterd_2_2:2101'],
+                COMPUTE ADDRESSES ['clusterd_2_1:2102', 'clusterd_2_2:2102']
             )
-
-        c.sql(
-            """
-            CREATE CLUSTER cluster1 REPLICAS (
-                replica1 (
-                    STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2100'],
-                    STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2103'],
-                    COMPUTECTL ADDRESSES ['clusterd_1_1:2101', 'clusterd_1_2:2101'],
-                    COMPUTE ADDRESSES ['clusterd_1_1:2102', 'clusterd_1_2:2102']
-                ),
-                replica2 (
-                    STORAGECTL ADDRESSES ['clusterd_2_1:2100', 'clusterd_2_2:2100'],
-                    STORAGE ADDRESSES ['clusterd_2_1:2103', 'clusterd_2_2:2103'],
-                    COMPUTECTL ADDRESSES ['clusterd_2_1:2101', 'clusterd_2_2:2101'],
-                    COMPUTE ADDRESSES ['clusterd_2_1:2102', 'clusterd_2_2:2102']
-                )
-            )
-            """
         )
+        """
+    )
 
-        with c.override(
-            Testdrive(
-                no_reset=True,
-                materialize_params={"cluster": "cluster1"},
-                seed=id,
-                default_timeout="300s",
-            )
-        ):
-            populate(c)
+    with c.override(
+        Testdrive(
+            no_reset=True,
+            materialize_params={"cluster": "cluster1"},
+            seed=id,
+            default_timeout="300s",
+        )
+    ):
+        populate(c)
 
-            # Disrupt replica1 by some means
-            disruption.disruption(c)
+        # Disrupt replica1 by some means
+        disruption.disruption(c)
 
-            validate(c)
-            validate_introspection_compaction(c, disruption.compaction_checks)
-
-        cleanup_list = ["materialized", "testdrive", *[n.name for n in nodes]]
-        c.kill(*cleanup_list)
-        c.rm(*cleanup_list, destroy_volumes=True)
-        c.rm_volumes("mzdata")
+        validate(c)
+        validate_introspection_compaction(c, disruption.compaction_checks)
 
 
 def get_single_value_from_cursor(cursor: Cursor) -> Any:


### PR DESCRIPTION
The c.overwrite would make us lose them, see also discussion in https://materializeinc.slack.com/archives/C0761MZ3QD9/p1720102448448759

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
