### PR TITLE
mzcompose: Check for service existence when overriding

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -72,7 +72,9 @@ class StartMz(MzcomposeAction):
             healthcheck=self.healthcheck,
         )
 
-        with c.override(mz):
+        # Don't fail since we are careful to explicitly kill and collect logs
+        # of the services thus started
+        with c.override(mz, fail_on_new_service=False):
             c.up("materialized" if self.mz_service is None else self.mz_service)
 
             # If we start up Materialize with MZ_DEPLOY_GENERATION, then it
@@ -212,7 +214,9 @@ class KillMz(MzcomposeAction):
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
 
-        with c.override(Materialized(name=self.mz_service)):
+        # Don't fail since we are careful to explicitly kill and collect logs
+        # of the services thus started
+        with c.override(Materialized(name=self.mz_service), fail_on_new_service=False):
             c.kill(self.mz_service, wait=True)
 
             if self.capture_logs:

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -473,7 +473,9 @@ class Composition:
             loader.composition_path = None
 
     @contextmanager
-    def override(self, *services: "Service") -> Iterator[None]:
+    def override(
+        self, *services: "Service", fail_on_new_service: bool = True
+    ) -> Iterator[None]:
         """Temporarily update the composition with the specified services.
 
         The services must already exist in the composition. They restored to
@@ -493,6 +495,9 @@ class Composition:
         # Update the composition with the new service definitions.
         deps = self._munge_services([(s.name, cast(dict, s.config)) for s in services])
         for service in services:
+            assert (
+                not fail_on_new_service or service.name in self.compose["services"]
+            ), f"Service {service.name} not found in SERVICES: {list(self.compose['services'].keys())}"
             self.compose["services"][service.name] = service.config
 
         # Re-acquire dependencies, as the override may have swapped an `image`

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -26,6 +26,10 @@ SERVICES = [
     SchemaRegistry(),
     # We use mz_panic() in some test scenarios, so environmentd must stay up.
     Materialized(propagate_crashes=False),
+    Clusterd(name="clusterd_1_1"),
+    Clusterd(name="clusterd_1_2"),
+    Clusterd(name="clusterd_2_1"),
+    Clusterd(name="clusterd_2_2"),
     Testdrive(),
 ]
 
@@ -226,76 +230,69 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
     print(f"+++ Running disruption scenario {disruption.name}")
 
     c.up("testdrive", persistent=True)
-    c.up("materialized")
+    c.up("materialized", "clusterd_1_1", "clusterd_1_2", "clusterd_2_1", "clusterd_2_2")
 
-    nodes = [
-        Clusterd(name="clusterd_1_1"),
-        Clusterd(name="clusterd_1_2"),
-        Clusterd(name="clusterd_2_1"),
-        Clusterd(name="clusterd_2_2"),
+    c.sql(
+        "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
+        port=6877,
+        user="mz_system",
+    )
+
+    c.sql(
+        """
+        DROP CLUSTER IF EXISTS cluster1 CASCADE;
+        CREATE CLUSTER cluster1 REPLICAS (replica1 (
+            STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2100'],
+            STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2103'],
+            COMPUTECTL ADDRESSES ['clusterd_1_1:2101', 'clusterd_1_2:2101'],
+            COMPUTE ADDRESSES ['clusterd_1_1:2102', 'clusterd_1_2:2102']
+        ));
+        """
+    )
+
+    c.sql(
+        """
+        DROP CLUSTER IF EXISTS cluster2 CASCADE;
+        CREATE CLUSTER cluster2 REPLICAS (replica1 (
+            STORAGECTL ADDRESSES ['clusterd_2_1:2100', 'clusterd_2_2:2100'],
+            STORAGE ADDRESSES ['clusterd_2_1:2103', 'clusterd_2_2:2103'],
+            COMPUTECTL ADDRESSES ['clusterd_2_1:2101', 'clusterd_2_2:2101'],
+            COMPUTE ADDRESSES ['clusterd_2_1:2102', 'clusterd_2_2:2102']
+        ));
+        """
+    )
+
+    with c.override(
+        Testdrive(
+            no_reset=True,
+            materialize_params={"cluster": "cluster2"},
+            seed=id,
+        )
+    ):
+        populate(c)
+
+        # Disrupt cluster1 by some means
+        disruption.disruption(c)
+
+        validate(c)
+
+    cleanup_list = [
+        "materialized",
+        "testdrive",
+        "clusterd_1_1",
+        "clusterd_1_2",
+        "clusterd_2_1",
+        "clusterd_2_2",
     ]
+    try:
+        c.kill(*cleanup_list)
+    except UIError as e:
+        print(e)
+        # Killing multiple clusterds from the same cluster may fail
+        # as the second clusterd may have already exited after the first
+        # one was killed, due to the 'shared-fate' mechanism.
+        pass
 
-    with c.override(*nodes):
-        c.up(*[n.name for n in nodes])
-
-        c.sql(
-            "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
-            port=6877,
-            user="mz_system",
-        )
-
-        c.sql(
-            """
-            DROP CLUSTER IF EXISTS cluster1 CASCADE;
-            CREATE CLUSTER cluster1 REPLICAS (replica1 (
-                STORAGECTL ADDRESSES ['clusterd_1_1:2100', 'clusterd_1_2:2100'],
-                STORAGE ADDRESSES ['clusterd_1_1:2103', 'clusterd_1_2:2103'],
-                COMPUTECTL ADDRESSES ['clusterd_1_1:2101', 'clusterd_1_2:2101'],
-                COMPUTE ADDRESSES ['clusterd_1_1:2102', 'clusterd_1_2:2102']
-            ));
-            """
-        )
-
-        c.sql(
-            """
-            DROP CLUSTER IF EXISTS cluster2 CASCADE;
-            CREATE CLUSTER cluster2 REPLICAS (replica1 (
-                STORAGECTL ADDRESSES ['clusterd_2_1:2100', 'clusterd_2_2:2100'],
-                STORAGE ADDRESSES ['clusterd_2_1:2103', 'clusterd_2_2:2103'],
-                COMPUTECTL ADDRESSES ['clusterd_2_1:2101', 'clusterd_2_2:2101'],
-                COMPUTE ADDRESSES ['clusterd_2_1:2102', 'clusterd_2_2:2102']
-            ));
-            """
-        )
-
-        with c.override(
-            Testdrive(
-                no_reset=True,
-                materialize_params={"cluster": "cluster2"},
-                seed=id,
-            )
-        ):
-            populate(c)
-
-            # Disrupt cluster1 by some means
-            disruption.disruption(c)
-
-            validate(c)
-
-        cleanup_list = [
-            "materialized",
-            "testdrive",
-            *[n.name for n in nodes],
-        ]
-        try:
-            c.kill(*cleanup_list)
-        except UIError as e:
-            print(e)
-            # Killing multiple clusterds from the same cluster may fail
-            # as the second clusterd may have alredy exited after the first
-            # one was killed, due to the 'shared-fate' mechanism.
-            pass
-
-        c.rm(*cleanup_list, destroy_volumes=True)
+    c.rm(*cleanup_list, destroy_volumes=True)
 
     c.rm_volumes("mzdata")

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -55,6 +55,7 @@ SERVICES = [
         propagate_crashes=False,
         external_cockroach=True,
     ),
+    Postgres(),
     Redpanda(),
     Toxiproxy(),
     Testdrive(
@@ -635,7 +636,7 @@ def workflow_test_github_15496(c: Composition) -> None:
     c.down(destroy_volumes=True)
     with c.override(
         Clusterd(
-            name="clusterd_nopanic",
+            name="clusterd1",
             environment_extra=[
                 "MZ_SOFT_ASSERTIONS=0",
             ],
@@ -644,7 +645,7 @@ def workflow_test_github_15496(c: Composition) -> None:
     ):
         c.up("testdrive", persistent=True)
         c.up("materialized")
-        c.up("clusterd_nopanic")
+        c.up("clusterd1")
 
         c.sql(
             "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
@@ -663,10 +664,10 @@ def workflow_test_github_15496(c: Composition) -> None:
             """
             CREATE CLUSTER cluster1 REPLICAS (
                 r1 (
-                    STORAGECTL ADDRESSES ['clusterd_nopanic:2100'],
-                    STORAGE ADDRESSES ['clusterd_nopanic:2103'],
-                    COMPUTECTL ADDRESSES ['clusterd_nopanic:2101'],
-                    COMPUTE ADDRESSES ['clusterd_nopanic:2102'],
+                    STORAGECTL ADDRESSES ['clusterd1:2100'],
+                    STORAGE ADDRESSES ['clusterd1:2103'],
+                    COMPUTECTL ADDRESSES ['clusterd1:2101'],
+                    COMPUTE ADDRESSES ['clusterd1:2102'],
                     WORKERS 2
                 )
             );
@@ -698,7 +699,7 @@ def workflow_test_github_15496(c: Composition) -> None:
         )
 
         # ensure that an error was put into the logs
-        c1 = c.invoke("logs", "clusterd_nopanic", capture=True)
+        c1 = c.invoke("logs", "clusterd1", capture=True)
         assert "Non-positive accumulation in ReduceMinsMaxes" in c1.stdout
 
 
@@ -961,7 +962,7 @@ def workflow_test_github_17509(c: Composition) -> None:
     c.down(destroy_volumes=True)
     with c.override(
         Clusterd(
-            name="clusterd_nopanic",
+            name="clusterd1",
             environment_extra=[
                 "MZ_SOFT_ASSERTIONS=0",
             ],
@@ -970,7 +971,7 @@ def workflow_test_github_17509(c: Composition) -> None:
     ):
         c.up("testdrive", persistent=True)
         c.up("materialized")
-        c.up("clusterd_nopanic")
+        c.up("clusterd1")
 
         c.sql(
             "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
@@ -989,10 +990,10 @@ def workflow_test_github_17509(c: Composition) -> None:
             """
             CREATE CLUSTER cluster1 REPLICAS (
                 r1 (
-                    STORAGECTL ADDRESSES ['clusterd_nopanic:2100'],
-                    STORAGE ADDRESSES ['clusterd_nopanic:2103'],
-                    COMPUTECTL ADDRESSES ['clusterd_nopanic:2101'],
-                    COMPUTE ADDRESSES ['clusterd_nopanic:2102'],
+                    STORAGECTL ADDRESSES ['clusterd1:2100'],
+                    STORAGE ADDRESSES ['clusterd1:2103'],
+                    COMPUTECTL ADDRESSES ['clusterd1:2101'],
+                    COMPUTE ADDRESSES ['clusterd1:2102'],
                     WORKERS 2
                 )
             );
@@ -1036,7 +1037,7 @@ def workflow_test_github_17509(c: Composition) -> None:
         )
 
         # ensure that an error was put into the logs
-        c1 = c.invoke("logs", "clusterd_nopanic", capture=True)
+        c1 = c.invoke("logs", "clusterd1", capture=True)
         assert "Non-positive accumulation in MinsMaxesHierarchical" in c1.stdout
         assert "Negative accumulation in ReduceMinsMaxes" not in c1.stdout
 
@@ -1055,7 +1056,7 @@ def workflow_test_github_19610(c: Composition) -> None:
     c.down(destroy_volumes=True)
     with c.override(
         Clusterd(
-            name="clusterd_nopanic",
+            name="clusterd1",
             environment_extra=[
                 "MZ_PERSIST_COMPACTION_DISABLED=true",
             ],
@@ -1064,7 +1065,7 @@ def workflow_test_github_19610(c: Composition) -> None:
     ):
         c.up("testdrive", persistent=True)
         c.up("materialized")
-        c.up("clusterd_nopanic")
+        c.up("clusterd1")
 
         c.sql(
             "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
@@ -1083,10 +1084,10 @@ def workflow_test_github_19610(c: Composition) -> None:
             """
             CREATE CLUSTER cluster1 REPLICAS (
                 r1 (
-                    STORAGECTL ADDRESSES ['clusterd_nopanic:2100'],
-                    STORAGE ADDRESSES ['clusterd_nopanic:2103'],
-                    COMPUTECTL ADDRESSES ['clusterd_nopanic:2101'],
-                    COMPUTE ADDRESSES ['clusterd_nopanic:2102'],
+                    STORAGECTL ADDRESSES ['clusterd1:2100'],
+                    STORAGE ADDRESSES ['clusterd1:2103'],
+                    COMPUTECTL ADDRESSES ['clusterd1:2101'],
+                    COMPUTE ADDRESSES ['clusterd1:2102'],
                     WORKERS 4
                 )
             );
@@ -1163,7 +1164,7 @@ def workflow_test_single_time_monotonicity_enforcers(c: Composition) -> None:
     c.down(destroy_volumes=True)
     with c.override(
         Clusterd(
-            name="clusterd_nopanic",
+            name="clusterd1",
             environment_extra=[
                 "MZ_PERSIST_COMPACTION_DISABLED=true",
             ],
@@ -1172,7 +1173,7 @@ def workflow_test_single_time_monotonicity_enforcers(c: Composition) -> None:
     ):
         c.up("testdrive", persistent=True)
         c.up("materialized")
-        c.up("clusterd_nopanic")
+        c.up("clusterd1")
 
         c.sql(
             "ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;",
@@ -1191,10 +1192,10 @@ def workflow_test_single_time_monotonicity_enforcers(c: Composition) -> None:
             """
             CREATE CLUSTER cluster1 REPLICAS (
                 r1 (
-                    STORAGECTL ADDRESSES ['clusterd_nopanic:2100'],
-                    STORAGE ADDRESSES ['clusterd_nopanic:2103'],
-                    COMPUTECTL ADDRESSES ['clusterd_nopanic:2101'],
-                    COMPUTE ADDRESSES ['clusterd_nopanic:2102'],
+                    STORAGECTL ADDRESSES ['clusterd1:2100'],
+                    STORAGE ADDRESSES ['clusterd1:2103'],
+                    COMPUTECTL ADDRESSES ['clusterd1:2101'],
+                    COMPUTE ADDRESSES ['clusterd1:2102'],
                     WORKERS 4
                 )
             );
@@ -1374,7 +1375,6 @@ def workflow_test_resource_limits(c: Composition) -> None:
 
     with c.override(
         Testdrive(),
-        Postgres(),
         Materialized(),
     ):
         c.up("materialized", "postgres")
@@ -1389,13 +1389,13 @@ def workflow_pg_snapshot_resumption(c: Composition) -> None:
 
     with c.override(
         # Start postgres for the pg source
-        Postgres(),
         Testdrive(no_reset=True),
         Clusterd(
-            name="storage", environment_extra=["FAILPOINTS=pg_snapshot_failure=return"]
+            name="clusterd1",
+            environment_extra=["FAILPOINTS=pg_snapshot_failure=return"],
         ),
     ):
-        c.up("materialized", "postgres", "storage")
+        c.up("materialized", "postgres", "clusterd1")
 
         c.run_testdrive_files("pg-snapshot-resumption/01-configure-postgres.td")
         c.run_testdrive_files("pg-snapshot-resumption/02-create-sources.td")
@@ -1408,9 +1408,9 @@ def workflow_pg_snapshot_resumption(c: Composition) -> None:
 
         with c.override(
             # turn off the failpoint
-            Clusterd(name="storage")
+            Clusterd(name="clusterd1")
         ):
-            c.up("storage")
+            c.up("clusterd1")
             c.run_testdrive_files("pg-snapshot-resumption/05-verify-data.td")
 
 
@@ -1423,20 +1423,20 @@ def workflow_sink_failure(c: Composition) -> None:
         # Start postgres for the pg source
         Testdrive(no_reset=True),
         Clusterd(
-            name="storage",
+            name="clusterd1",
             environment_extra=["FAILPOINTS=kafka_sink_creation_error=return"],
         ),
     ):
-        c.up("materialized", "zookeeper", "kafka", "schema-registry", "storage")
+        c.up("materialized", "zookeeper", "kafka", "schema-registry", "clusterd1")
 
         c.run_testdrive_files("sink-failure/01-configure-sinks.td")
         c.run_testdrive_files("sink-failure/02-ensure-sink-down.td")
 
         with c.override(
             # turn off the failpoint
-            Clusterd(name="storage")
+            Clusterd(name="clusterd1")
         ):
-            c.up("storage")
+            c.up("clusterd1")
             c.run_testdrive_files("sink-failure/03-verify-data.td")
 
 
@@ -1702,13 +1702,13 @@ def workflow_pg_snapshot_partial_failure(c: Composition) -> None:
 
     with c.override(
         # Start postgres for the pg source
-        Postgres(),
         Testdrive(no_reset=True),
         Clusterd(
-            name="storage", environment_extra=["FAILPOINTS=pg_snapshot_pause=return(2)"]
+            name="clusterd1",
+            environment_extra=["FAILPOINTS=pg_snapshot_pause=return(2)"],
         ),
     ):
-        c.up("materialized", "postgres", "storage")
+        c.up("materialized", "postgres", "clusterd1")
 
         c.run_testdrive_files("pg-snapshot-partial-failure/01-configure-postgres.td")
         c.run_testdrive_files("pg-snapshot-partial-failure/02-create-sources.td")
@@ -1717,14 +1717,14 @@ def workflow_pg_snapshot_partial_failure(c: Composition) -> None:
             "pg-snapshot-partial-failure/03-verify-good-sub-source.td"
         )
 
-        c.kill("storage")
+        c.kill("clusterd1")
         # Restart the storage instance with the failpoint off...
         with c.override(
             # turn off the failpoint
-            Clusterd(name="storage")
+            Clusterd(name="clusterd1")
         ):
             c.run_testdrive_files("pg-snapshot-partial-failure/04-add-more-data.td")
-            c.up("storage")
+            c.up("clusterd1")
             c.run_testdrive_files("pg-snapshot-partial-failure/05-verify-data.td")
 
 
@@ -2122,7 +2122,6 @@ def workflow_test_query_without_default_cluster(c: Composition) -> None:
 
     with c.override(
         Testdrive(),
-        Postgres(),
         Materialized(),
     ):
         c.up("materialized", "postgres")

--- a/test/cluster/pg-snapshot-partial-failure/02-create-sources.td
+++ b/test/cluster/pg-snapshot-partial-failure/02-create-sources.td
@@ -16,10 +16,10 @@ ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 > CREATE CLUSTER storage REPLICAS (
     r1 (
-      STORAGECTL ADDRESSES ['storage:2100'],
-      STORAGE ADDRESSES ['storage:2103'],
-      COMPUTECTL ADDRESSES ['storage:2101'],
-      COMPUTE ADDRESSES ['storage:2102']
+      STORAGECTL ADDRESSES ['clusterd1:2100'],
+      STORAGE ADDRESSES ['clusterd1:2103'],
+      COMPUTECTL ADDRESSES ['clusterd1:2101'],
+      COMPUTE ADDRESSES ['clusterd1:2102']
     )
   )
 

--- a/test/cluster/pg-snapshot-resumption/02-create-sources.td
+++ b/test/cluster/pg-snapshot-resumption/02-create-sources.td
@@ -16,10 +16,10 @@ ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 > CREATE CLUSTER storage REPLICAS (
     r1 (
-      STORAGECTL ADDRESSES ['storage:2100'],
-      STORAGE ADDRESSES ['storage:2103'],
-      COMPUTECTL ADDRESSES ['storage:2101'],
-      COMPUTE ADDRESSES ['storage:2102'],
+      STORAGECTL ADDRESSES ['clusterd1:2100'],
+      STORAGE ADDRESSES ['clusterd1:2103'],
+      COMPUTECTL ADDRESSES ['clusterd1:2101'],
+      COMPUTE ADDRESSES ['clusterd1:2102'],
       WORKERS 4
     )
   )

--- a/test/cluster/sink-failure/01-configure-sinks.td
+++ b/test/cluster/sink-failure/01-configure-sinks.td
@@ -15,10 +15,10 @@ ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true
 
 > CREATE CLUSTER storage REPLICAS (
     r1 (
-      STORAGECTL ADDRESSES ['storage:2100'],
-      STORAGE ADDRESSES ['storage:2103'],
-      COMPUTECTL ADDRESSES ['storage:2101'],
-      COMPUTE ADDRESSES ['storage:2102'],
+      STORAGECTL ADDRESSES ['clusterd1:2100'],
+      STORAGE ADDRESSES ['clusterd1:2103'],
+      COMPUTECTL ADDRESSES ['clusterd1:2101'],
+      COMPUTE ADDRESSES ['clusterd1:2102'],
       WORKERS 4
     )
   )

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -77,6 +77,7 @@ from materialize.mzcompose.services.kafka import Kafka as KafkaService
 from materialize.mzcompose.services.kgen import Kgen as KgenService
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Minio
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
@@ -134,6 +135,7 @@ SERVICES = [
     Materialized(),
     Clusterd(),
     Testdrive(),
+    Mz(app_password=""),
 ]
 
 

--- a/test/get-cloud-hostname/mzcompose.py
+++ b/test/get-cloud-hostname/mzcompose.py
@@ -12,9 +12,11 @@ import os
 from materialize.mz_env_util import get_cloud_hostname
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
 
 SERVICES = [
     Materialized(),
+    Mz(app_password=""),
 ]
 
 

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -81,6 +81,9 @@ SERVICES = [
     TestCerts(),
     Toxiproxy(),
     create_postgres(pg_version=None),
+    PostgresRecvlogical(
+        replication_slot_name="", publication_name=""
+    ),  # Overriden below
 ]
 
 

--- a/test/rqg/mzcompose.py
+++ b/test/rqg/mzcompose.py
@@ -24,7 +24,12 @@ from materialize.version_ancestor_overrides import (
 )
 from materialize.version_list import resolve_ancestor_image_tag
 
-SERVICES = [RQG()]
+SERVICES = [
+    RQG(),
+    Materialized(name="mz_this"),
+    Materialized(name="mz_other"),
+    Postgres(),
+]
 
 
 class Dataset(Enum):

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -19,6 +19,7 @@ from materialize import buildkite, git
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.test_result import FailedTestExecutionError
 from materialize.scalability.benchmark_config import BenchmarkConfiguration
@@ -80,6 +81,7 @@ SERVICES = [
     ),
     Postgres(),
     Balancerd(),
+    Mz(app_password=""),
 ]
 
 DEFAULT_REGRESSION_THRESHOLD = 0.2

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -38,8 +38,18 @@ SERVICES = [
     Clusterd(),
     Postgres(),
     Zookeeper(),
-    Kafka(),
-    SchemaRegistry(),
+    Kafka(
+        name="badkafka",
+        environment=[
+            "KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181",
+            # Setting the following values to 3 to trigger a failure
+            # sets the transaction.state.log.min.isr config
+            "KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=3",
+            # sets the transaction.state.log.replication.factor config
+            "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3",
+        ],
+    ),
+    SchemaRegistry(kafka_servers=[("badkafka", "9092")]),
 ]
 
 
@@ -61,18 +71,6 @@ class KafkaTransactionLogGreaterThan1:
         c.up("testdrive", persistent=True)
 
         with c.override(
-            Kafka(
-                name="badkafka",
-                environment=[
-                    "KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181",
-                    # Setting the following values to 3 to trigger a failure
-                    # sets the transaction.state.log.min.isr config
-                    "KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=3",
-                    # sets the transaction.state.log.replication.factor config
-                    "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3",
-                ],
-            ),
-            SchemaRegistry(kafka_servers=[("badkafka", "9092")]),
             Testdrive(
                 no_reset=True,
                 seed=seed,

--- a/test/version-consistency/mzcompose.py
+++ b/test/version-consistency/mzcompose.py
@@ -27,6 +27,8 @@ from materialize.version_list import (
 SERVICES = [
     Cockroach(setup_materialize=True),
     Postgres(),
+    Materialized(name="mz_this"),  # Overridden below
+    Materialized(name="mz_other"),  # Overridden below
 ]
 
 
@@ -48,7 +50,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = test.parse_output_consistency_input_args(parser)
 
-    name_mz_this, name_mz_other = "mz_this", "mz_other"
     port_mz_internal, port_mz_this, port_mz_other = 6875, 6875, 16875
     tag_mz_other = resolve_ancestor_image_tag(
         ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS
@@ -58,24 +59,23 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     with c.override(
         Materialized(
-            name=name_mz_this,
+            name="mz_this",
             image=None,
             ports=[f"{port_mz_this}:{port_mz_internal}"],
             use_default_volumes=False,
         ),
         Materialized(
-            name=name_mz_other,
+            name="mz_other",
             image=f"materialize/materialized:{tag_mz_other}",
             ports=[f"{port_mz_other}:{port_mz_internal}"],
             use_default_volumes=False,
         ),
     ):
-        c.up(name_mz_this)
-        c.up(name_mz_other)
+        c.up("mz_this", "mz_other")
 
-        connection = c.sql_connection(service=name_mz_this, port=port_mz_internal)
+        connection = c.sql_connection(service="mz_this", port=port_mz_internal)
         test.mz2_connection = c.sql_connection(
-            service=name_mz_other, port=port_mz_internal
+            service="mz_other", port=port_mz_internal
         )
         test.evaluation_strategy_name = args.evaluation_strategy
 


### PR DESCRIPTION
As the documentation notes:

> Lest you are tempted to change this function to allow dynamically
> injecting new services: do not do this! These services will not be
> visible to other commands, like `mzcompose run`, `mzcompose logs`, or
> `mzcompose down`, which makes debugging or inspecting the composition
> challenging.

Following a discussion in https://materializeinc.slack.com/archives/C0761MZ3QD9/p1720102448448759

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
