### PR TITLE
Docs: copyedits trial account statements

### DIFF
--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -23,8 +23,7 @@ data freshness**.
 
 ## Ready to get started? 🚀
 
-1. Sign up for a [free trial 
-   account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation).
+1. Sign up for a [free trial account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation).
 2. Follow the quickstart guide to learn the basics.
 3. Connect your own data sources and start building.
 

--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -23,9 +23,9 @@ data freshness**.
 
 ## Ready to get started? 🚀
 
-1. Sign up for a Materialize account.
+1. Sign up for a [free trial Materialize account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation).
 2. Follow the quickstart guide to learn the basics.
-3. Connect your own data sources and start building with a free trial.
+3. Connect your own data sources and start building.
 
 {{</ callout >}}
 

--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -38,7 +38,7 @@ data freshness**.
     {{< linkbox icon="doc" title="Guides" >}}
 -   [Materialize &amp; Postgres CDC](/integrations/cdc-postgres/)
 -   [dbt &amp; Materialize](/integrations/dbt/)
--   [Materialize &amp; Node.js](/integrations/node-js/)  
+-   [Materialize &amp; Node.js](/integrations/node-js/)
 
 -   [Time-windowed computation](/sql/patterns/temporal-filters/)
     {{</ linkbox >}}

--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -23,7 +23,8 @@ data freshness**.
 
 ## Ready to get started? 🚀
 
-1. Sign up for a [free trial Materialize account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation).
+1. Sign up for a [free trial 
+   account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation).
 2. Follow the quickstart guide to learn the basics.
 3. Connect your own data sources and start building.
 
@@ -38,7 +39,8 @@ data freshness**.
     {{< linkbox icon="doc" title="Guides" >}}
 -   [Materialize &amp; Postgres CDC](/integrations/cdc-postgres/)
 -   [dbt &amp; Materialize](/integrations/dbt/)
--   [Materialize &amp; Node.js](/integrations/node-js/)
+-   [Materialize &amp; Node.js](/integrations/node-js/)  
+
 -   [Time-windowed computation](/sql/patterns/temporal-filters/)
     {{</ linkbox >}}
     {{< linkbox icon="book" title="Reference" >}}

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -24,13 +24,13 @@ the superpowers of an operational data warehouse first-hand:
 
 * **Consistency**: results are always correct; never even transiently wrong.
 
-## Before you begin
+## Prerequisite
 
-All you need is a Materialize account. If you already have one —
-great! If not, [sign up for a playground account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation) first.
+A Materialize account to sign into the [Materialize console](https://console.materialize.com/). If you do not have an account, you can [sign up for a free trial account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation).
 
-When you're ready, head over to the [Materialize console](https://console.materialize.com/),
-and pop open the SQL Shell.
+## Step 0. Sign into the Console
+
+Open the [Materialize console](https://console.materialize.com/) and, if not already signed in, sign in. By default, the SQL Shell should display in the console.  You can also select SQL Shell in the console's left-hand menu.
 
 ## Step 1. Ingest streaming data
 
@@ -117,8 +117,8 @@ for each auction at its `end_time`.
         -- Where all auctions have completed
       AND mz_now() >= auctions.end_time
     ORDER BY auctions.id,
-      bids.bid_time DESC,
-      bids.amount,
+      bids.amount DESC,
+      bids.bid_time,
       bids.buyer;
     ```
 
@@ -303,8 +303,7 @@ DROP SOURCE auction_house CASCADE;
 DROP TABLE fraud_accounts;
 ```
 
-## What's next?
+
 
 [//]: # "TODO(morsapaes) Extend to suggest third party tools. dbt, Census and Metabase could all fit here to do interesting things as a follow-up."
 
-To get started with your own data, [upgrade your playground to a trial account](https://materialize.com/trial/?utm_campaign=General&utm_source=documentation).

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -26,7 +26,7 @@ the superpowers of an operational data warehouse first-hand:
 
 ## Prerequisite
 
-A Materialize account to sign into the [Materialize console](https://console.materialize.com/). If you do not have an account, you can [sign up for a free trial account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation).
+A Materialize account. If you do not have an account, you can [sign up for a free trial](https://materialize.com/register/?utm_campaign=General&utm_source=documentation).
 
 ## Step 0. Sign into the Console
 

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -309,7 +309,7 @@ DROP TABLE fraud_accounts;
 
 [//]: # "TODO(morsapaes) Extend to suggest third party tools. dbt, Census and Metabase could all fit here to do interesting things as a follow-up."
 
-- To get started with your own data, click the `Connect data` button in the
-  Console.
-
-- To get a guided tour, click the `Talk to us` button in the Console.
+To get started ingesting your own data from an external system like Kafka, MySQL
+or PostgreSQL, check the documentation for [sources](/sql/create-source/), and
+navigate to **Data** > **Sources** > **New source** in the [Materialize Console](https://console.materialize.com/)
+to create your first source.

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -28,7 +28,7 @@ the superpowers of an operational data warehouse first-hand:
 
 A Materialize account. If you do not have an account, you can [sign up for a free trial](https://materialize.com/register/?utm_campaign=General&utm_source=documentation).
 
-## Step 0. Sign into the Console
+## Step 0. Sign in to Materialize
 
 Navigate to the [Materialize console](https://console.materialize.com/) and sign
 in. By default, you should land in the SQL Shell. If you're already signed in,

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -305,7 +305,11 @@ DROP SOURCE auction_house CASCADE;
 DROP TABLE fraud_accounts;
 ```
 
-
+## What's next?
 
 [//]: # "TODO(morsapaes) Extend to suggest third party tools. dbt, Census and Metabase could all fit here to do interesting things as a follow-up."
 
+- To get started with your own data, click the `Connect data` button in the
+  Console.
+
+- To get a guided tour, click the `Talk to us` button in the Console.

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -30,7 +30,9 @@ A Materialize account. If you do not have an account, you can [sign up for a fre
 
 ## Step 0. Sign into the Console
 
-Open the [Materialize console](https://console.materialize.com/) and, if not already signed in, sign in. By default, the SQL Shell should display in the console.  You can also select SQL Shell in the console's left-hand menu.
+Navigate to the [Materialize console](https://console.materialize.com/) and sign
+in. By default, you should land in the SQL Shell. If you're already signed in,
+you can access the SQL Shell in the left-hand menu.
 
 ## Step 1. Ingest streaming data
 

--- a/doc/user/content/ingest-data/webhook-quickstart.md
+++ b/doc/user/content/ingest-data/webhook-quickstart.md
@@ -16,7 +16,7 @@ you to learn and prototype with no external dependencies.
 ## Before you begin
 
 All you need is a Materialize account. If you already have one —
-great! If not, [sign up for a playground account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation) first.
+great! If not, [sign up for a free trial account](https://materialize.com/register/?utm_campaign=General&utm_source=documentation) first.
 
 When you're ready, head over to the [Materialize console](https://console.materialize.com/),
 and pop open the SQL Shell.


### PR DESCRIPTION
Various copyedits to trial account references in our user docs:

- Sometimes, we don't specifically mention that it's a free trial account but just a Materialize account.
- Sometimes referred to as playground account

See https://github.com/MaterializeInc/materialize/issues/28071

Changes:

- Update playground account/account to free trial account.
- Remove reference to upgrading playground account to trial account since only trial account.
- Somewhat unrelated but ... fix small typo in quickstart SQL statement.



