### PR TITLE
tests: fix miri compilation

### DIFF
--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -444,7 +444,6 @@ impl Listeners {
                     batch_scheduled_delay: Duration::from_millis(5000),
                     max_export_timeout: Duration::from_secs(30),
                 }),
-                #[cfg(feature = "tokio-console")]
                 tokio_console: None,
                 sentry: None,
                 build_version: crate::BUILD_INFO.version,


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/8396#0190921c-c663-401b-ba11-3b4682ef7c3a.

Nightly: https://buildkite.com/materialize/nightly/builds?branch=nrainer-materialize%3Atests%2Ffix-miri