### PR TITLE
catalog: Remove unused server config param

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -671,6 +671,7 @@ pub(crate) fn durable_migrate(
     catalog_fix_system_cluster_replica_ids_v_0_95_0(tx, boot_ts)?;
     catalog_rename_mz_introspection_cluster_v_0_103_0(tx, boot_ts)?;
     catalog_add_new_unstable_schemas_v_0_106_0(tx)?;
+    catalog_remove_wait_catalog_consolidation_on_startup_v_0_108_0(tx);
     Ok(())
 }
 
@@ -850,4 +851,10 @@ fn catalog_add_new_unstable_schemas_v_0_106_0(tx: &mut Transaction) -> Result<()
     }
 
     Ok(())
+}
+
+/// This migration removes the server configuration parameter
+/// "wait_catalog_consolidation_on_startup" which is no longer used.
+fn catalog_remove_wait_catalog_consolidation_on_startup_v_0_108_0(tx: &mut Transaction) {
+    tx.remove_system_config("wait_catalog_consolidation_on_startup");
 }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -535,17 +535,10 @@ impl Catalog {
                 }
             }
 
-            let wait_for_consolidation = catalog
-                .system_config()
-                .wait_catalog_consolidation_on_startup();
             {
                 let mut storage = catalog.storage().await;
                 storage
-                    .prune_storage_usage(
-                        config.storage_usage_retention_period,
-                        boot_ts,
-                        wait_for_consolidation,
-                    )
+                    .prune_storage_usage(config.storage_usage_retention_period, boot_ts)
                     .await?;
                 let updates = storage.sync_to_current_updates().await?;
                 soft_assert_no_log!(

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -260,7 +260,6 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         &mut self,
         retention_period: Option<Duration>,
         boot_ts: mz_repr::Timestamp,
-        wait_for_consolidation: bool,
     ) -> Result<(), CatalogError>;
 
     /// Allocates and returns `amount` IDs of `id_type`.

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -1441,7 +1441,6 @@ impl DurableCatalogState for PersistCatalogState {
         &mut self,
         retention_period: Option<Duration>,
         boot_ts: mz_repr::Timestamp,
-        _wait_for_consolidation: bool,
     ) -> Result<(), CatalogError> {
         self.sync_to_current_upper().await?;
         // If no usage retention period is set, set the cutoff to MIN so nothing

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -146,10 +146,7 @@ async fn test_get_and_prune_storage_usage(openable_state: Box<dyn OpenableDurabl
     let recent_event = VersionedStorageUsage::V1(recent_event);
 
     // Test with no retention period.
-    state
-        .prune_storage_usage(None, boot_ts, false)
-        .await
-        .unwrap();
+    state.prune_storage_usage(None, boot_ts).await.unwrap();
     let events = state.get_storage_usage().await.unwrap();
     assert_eq!(events.len(), 2);
     assert!(events.contains(&old_event));
@@ -157,7 +154,7 @@ async fn test_get_and_prune_storage_usage(openable_state: Box<dyn OpenableDurabl
 
     // Test with some retention period.
     state
-        .prune_storage_usage(Some(Duration::from_millis(10)), boot_ts, false)
+        .prune_storage_usage(Some(Duration::from_millis(10)), boot_ts)
         .await
         .unwrap();
     let events = state.get_storage_usage().await.unwrap();

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2053,13 +2053,6 @@ feature_flags!(
         enable_for_item_parsing: false,
     },
     {
-        name: wait_catalog_consolidation_on_startup,
-        desc: "When opening the Catalog, wait for consolidation to complete before returning",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: false,
-    },
-    {
         name: enable_copy_to_expr,
         desc: "COPY ... TO 's3://...'",
         default: false,


### PR DESCRIPTION
This commit removes the unused server configuration parameter, "wait_catalog_consolidation_on_startup". This was used for the legacy stash catalog implementation.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
