### PR TITLE
storage/source/kafka: correct stale comment about fast forwarding

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -1014,7 +1014,7 @@ impl KafkaSourceReader {
         // that we are ever going to see holds.
         // Offsets are guaranteed to be contiguous when compaction is disabled. If compaction
         // is enabled, there may be gaps in the sequence.
-        // If we see an "old" offset, we ast-forward the consumer and skip that message
+        // If we see an "old" offset, we skip that message.
 
         // Given the explicit consumer to partition assignment, we should never receive a message
         // for a partition for which we have no metadata


### PR DESCRIPTION
Since 3ae934db81, we no longer fast forward. We just skip messages one at a time. Correct a comment that was claiming otherwise.

h/t @rjobanp for the eagle eyes

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a stale comment.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
