### PR TITLE
catalog: Fix savepoint storage usage pruning

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -537,10 +537,9 @@ impl Catalog {
 
             {
                 let mut storage = catalog.storage().await;
-                storage
+                let updates = storage
                     .prune_storage_usage(config.storage_usage_retention_period, boot_ts)
                     .await?;
-                let updates = storage.sync_to_current_updates().await?;
                 soft_assert_no_log!(
                     updates
                         .iter()

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -256,11 +256,13 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
 
     /// Permanently deletes storage usage events from the catalog
     /// that happened more than the retention period ago from boot_ts.
+    ///
+    /// Returns the catalog updates that result from the pruning.
     async fn prune_storage_usage(
         &mut self,
         retention_period: Option<Duration>,
         boot_ts: mz_repr::Timestamp,
-    ) -> Result<(), CatalogError>;
+    ) -> Result<Vec<memory::objects::StateUpdate>, CatalogError>;
 
     /// Allocates and returns `amount` IDs of `id_type`.
     #[mz_ore::instrument(level = "debug")]

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -1440,7 +1440,6 @@ impl DurableCatalogState for PersistCatalogState {
         self.sync_to_current_upper().await?;
 
         if self.is_read_only() {
-            self.confirm_leadership().await?;
             return Ok(Vec::new());
         }
 

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -2441,7 +2441,7 @@ pub enum StateUpdateKind {
 }
 
 /// Valid diffs for catalog state updates.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum StateDiff {
     Retraction,
     Addition,

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -18,6 +18,7 @@ use mz_catalog::durable::{
     test_bootstrap_args, test_persist_backed_catalog_state, CatalogError, DurableCatalogError,
     Item, OpenableDurableCatalogState, USER_ITEM_ALLOC_KEY,
 };
+use mz_catalog::memory::objects::{StateDiff, StateUpdateKind};
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::PersistClient;
@@ -146,19 +147,27 @@ async fn test_get_and_prune_storage_usage(openable_state: Box<dyn OpenableDurabl
     let recent_event = VersionedStorageUsage::V1(recent_event);
 
     // Test with no retention period.
-    state.prune_storage_usage(None, boot_ts).await.unwrap();
+    let updates = state.prune_storage_usage(None, boot_ts).await.unwrap();
     let events = state.get_storage_usage().await.unwrap();
-    assert_eq!(events.len(), 2);
+    assert!(updates.is_empty(), "updates should be empty: {updates:?}");
+    assert_eq!(events.len(), 2, "unexpected events len: {events:?}");
     assert!(events.contains(&old_event));
     assert!(events.contains(&recent_event));
 
     // Test with some retention period.
-    state
+    let updates = state
         .prune_storage_usage(Some(Duration::from_millis(10)), boot_ts)
         .await
         .unwrap();
     let events = state.get_storage_usage().await.unwrap();
-    assert_eq!(events.len(), 1);
+    assert_eq!(updates.len(), 1, "unexpected updates len: {updates:?}");
+    let update = updates.into_element();
+    assert_eq!(update.diff, StateDiff::Retraction);
+    let StateUpdateKind::StorageUsage(update_usage) = update.kind else {
+        panic!("unexpected update kind: {:?}", update.kind);
+    };
+    assert_eq!(update_usage.metric, old_event);
+    assert_eq!(events.len(), 1, "unexpected events len: {events:?}");
     assert_eq!(events.into_element(), recent_event);
     Box::new(state).expire().await;
 }


### PR DESCRIPTION
Previously, storage usage pruning worked by taking the following steps:

1. Durably write retractions for old storage usage events.
2. Listen for all changes to the durable catalog.
3. Generate builtin table updates from the changes.

This approach does not work for savepoint catalogs, because they only pretend to write things durably but don't actually commit the write. Therefore, listening for changes always returns an empty result. This commit fixes the issue by returning the updates from the durable transaction before commit. This matches the behavior of all other catalog writes.

While we're modifying storage usage pruning, the read-only case is optimized to return immediately.

This commit has the added benefit that read-only and savepoint catalogs will not see unrelated updates in step (2) from a writer catalog, which resolves #28055

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
