### PR TITLE
Wire up `enable_outer_join_null_filter` to `EXPLAIN`

### DIFF
--- a/src/repr/src/explain.rs
+++ b/src/repr/src/explain.rs
@@ -309,7 +309,7 @@ pub trait Explain<'a>: 'a {
     /// should return an [`ExplainError::UnsupportedFormat`].
     ///
     /// If an [`ExplainConfig`] parameter cannot be honored, the
-    /// implementation should silently ignore this paramter and
+    /// implementation should silently ignore this parameter and
     /// proceed without returning a [`Result::Err`].
     #[allow(unused_variables)]
     fn explain_text(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
@@ -325,7 +325,7 @@ pub trait Explain<'a>: 'a {
     /// should return an [`ExplainError::UnsupportedFormat`].
     ///
     /// If an [`ExplainConfig`] parameter cannot be honored, the
-    /// implementation should silently ignore this paramter and
+    /// implementation should silently ignore this parameter and
     /// proceed without returning a [`Result::Err`].
     #[allow(unused_variables)]
     fn explain_json(&'a mut self, context: &'a Self::Context) -> Result<Self::Json, ExplainError> {
@@ -341,7 +341,7 @@ pub trait Explain<'a>: 'a {
     /// should return an [`ExplainError::UnsupportedFormat`].
     ///
     /// If an [`ExplainConfig`] parameter cannot be honored, the
-    /// implementation should silently ignore this paramter and
+    /// implementation should silently ignore this parameter and
     /// proceed without returning a [`Result::Err`].
     #[allow(unused_variables)]
     fn explain_dot(&'a mut self, context: &'a Self::Context) -> Result<Self::Dot, ExplainError> {
@@ -424,7 +424,7 @@ pub trait ExprHumanizer: fmt::Debug {
     /// Same as above, but without qualifications, e.g., only `foo` for `materialize.public.foo`.
     fn humanize_id_unqualified(&self, id: GlobalId) -> Option<String>;
 
-    /// Like [`Self::humanize_id`], but returns the consituent parts of the
+    /// Like [`Self::humanize_id`], but returns the constituent parts of the
     /// name as individual elements.
     fn humanize_id_parts(&self, id: GlobalId) -> Option<Vec<String>>;
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3305,6 +3305,7 @@ pub enum ExplainPlanOptionName {
     EnableEagerDeltaJoins,
     EnableVariadicLeftJoinLowering,
     EnableLetrecFixpointAnalysis,
+    EnableOuterJoinNullFilter,
 }
 
 impl WithOptionName for ExplainPlanOptionName {
@@ -3338,7 +3339,8 @@ impl WithOptionName for ExplainPlanOptionName {
             | Self::EnableNewOuterJoinLowering
             | Self::EnableEagerDeltaJoins
             | Self::EnableVariadicLeftJoinLowering
-            | Self::EnableLetrecFixpointAnalysis => false,
+            | Self::EnableLetrecFixpointAnalysis
+            | Self::EnableOuterJoinNullFilter => false,
         }
     }
 }

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -362,7 +362,8 @@ generate_extracted_config!(
     (EnableNewOuterJoinLowering, Option<bool>, Default(None)),
     (EnableEagerDeltaJoins, Option<bool>, Default(None)),
     (EnableVariadicLeftJoinLowering, Option<bool>, Default(None)),
-    (EnableLetrecFixpointAnalysis, Option<bool>, Default(None))
+    (EnableLetrecFixpointAnalysis, Option<bool>, Default(None)),
+    (EnableOuterJoinNullFilter, Option<bool>, Default(None))
 );
 
 impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
@@ -402,13 +403,18 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
             subtree_size: v.subtree_size,
             timing: v.timing,
             types: v.types,
+            // The ones that are initialized with `Default::default()` are not wired up to EXPLAIN.
             features: OptimizerFeatureOverrides {
                 enable_eager_delta_joins: v.enable_eager_delta_joins,
                 enable_new_outer_join_lowering: v.enable_new_outer_join_lowering,
                 enable_variadic_left_join_lowering: v.enable_variadic_left_join_lowering,
                 enable_letrec_fixpoint_analysis: v.enable_letrec_fixpoint_analysis,
+                enable_consolidate_after_union_negate: Default::default(),
+                enable_reduce_mfp_fusion: Default::default(),
+                enable_outer_join_null_filter: v.enable_outer_join_null_filter,
+                enable_cardinality_estimates: Default::default(),
+                persist_fast_path_limit: Default::default(),
                 reoptimize_imported_views: v.reoptimize_imported_views,
-                ..Default::default()
             },
         })
     }


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/pull/28018 added a feature flag, but forgot to wire it up to EXPLAIN. This PR does this.

Additionally, it removes the blanket default initializer `..Default::default()`, so that this can't happen in the future with new flags.

### Motivation

  * This PR wires up an already-existing feature flag to EXPLAIN.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
