### PR TITLE
catalog: Fix savepoint catalog listen behavior

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -79,13 +79,19 @@ pub type Epoch = NonZeroI64;
 /// If a catalog is not opened, then resources should be release via [`Self::expire`].
 #[async_trait]
 pub trait OpenableDurableCatalogState: Debug + Send {
+    // TODO(jkosh44) Teaching savepoint mode how to listen to additional
+    // durable updates will be necessary for zero down time upgrades.
     /// Opens the catalog in a mode that accepts and buffers all writes,
     /// but never durably commits them. This is used to check and see if
     /// opening the catalog would be successful, without making any durable
     /// changes.
     ///
-    /// `epoch_lower_bound` is used as a lower bound for the epoch that is used by the returned
-    /// catalog.
+    /// Once a savepoint catalog reads an initial snapshot from durable
+    /// storage, it will never read another update from durable storage. As a
+    /// consequence, savepoint catalogs can never be fenced.
+    ///
+    /// `epoch_lower_bound` is used as a lower bound for the epoch that is
+    /// used by the returned catalog.
     ///
     /// Will return an error in the following scenarios:
     ///   - Catalog initialization fails.


### PR DESCRIPTION
Savepoint catalogs are able to accept writes without erroring, but the writes are never committed durably. The main usage of savepoint catalogs is to validate an upgrade in-memory before actually executing the upgrade.

Previously, savepoint catalogs would update their in-memory state based on the savepoint transactions committed by themselves AND by listening to durable changes made by any writer catalog. This is NOT correct because there is no attempt to check for conflicts or reconcile the writes made by the two separate catalogs.

This commit fixes the issue by ignoring all durable catalog updates in savepoint catalogs after the initial snapshot. A correct mental model for this is that creating a savepoint catalog is like creating a new branch of catalog state. This branch does not affect the main catalog state branch, nor does it see changes from the main branch.

Currently, there is no way to merge this savepoint branch back into the main catalog state branch. In order to achieve zero-downtime upgrades, we will need to figure out a way to merge these two branches.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
