### PR TITLE
output consistency: record type: fix function definition, add ignore entry

### DIFF
--- a/misc/python/materialize/output_consistency/generators/expression_generator.py
+++ b/misc/python/materialize/output_consistency/generators/expression_generator.py
@@ -30,6 +30,9 @@ from materialize.output_consistency.expression.expression import (
 from materialize.output_consistency.expression.expression_with_args import (
     ExpressionWithArgs,
 )
+from materialize.output_consistency.input_data.params.same_operation_param import (
+    SameOperationParam,
+)
 from materialize.output_consistency.input_data.test_input_data import (
     ConsistencyTestInputData,
 )
@@ -275,6 +278,9 @@ class ExpressionGenerator:
     ) -> Expression:
         if isinstance(param, EnumConstantOperationParam):
             return self._pick_enum_constant(param)
+
+        if isinstance(param, SameOperationParam):
+            return arg_context.args[param.index_of_previous_param]
 
         create_complex_arg = (
             arg_context.requires_aggregation()

--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -129,7 +129,13 @@ def is_function_invoked_only_with_non_nested_parameters(
 def involves_data_type_category(
     expression: Expression, data_type_category: DataTypeCategory
 ) -> bool:
-    return expression.resolve_resulting_return_type_category() == data_type_category
+    return involves_data_type_categories(expression, {data_type_category})
+
+
+def involves_data_type_categories(
+    expression: Expression, data_type_categories: set[DataTypeCategory]
+) -> bool:
+    return expression.resolve_resulting_return_type_category() in data_type_categories
 
 
 def is_known_to_involve_exact_data_types(

--- a/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
@@ -79,7 +79,7 @@ AGGREGATE_OPERATION_TYPES.append(
 AGGREGATE_OPERATION_TYPES.append(
     DbFunction(
         "max",
-        [AnyOperationParam()],
+        [AnyOperationParam(include_record_type=False)],
         DynamicReturnTypeSpec(),
         is_aggregation=True,
         relevance=OperationRelevance.HIGH,
@@ -88,7 +88,7 @@ AGGREGATE_OPERATION_TYPES.append(
 AGGREGATE_OPERATION_TYPES.append(
     DbFunction(
         "min",
-        [AnyOperationParam()],
+        [AnyOperationParam(include_record_type=False)],
         DynamicReturnTypeSpec(),
         is_aggregation=True,
         relevance=OperationRelevance.HIGH,

--- a/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
@@ -16,6 +16,9 @@ from materialize.output_consistency.input_data.params.boolean_operation_param im
 from materialize.output_consistency.input_data.params.number_operation_param import (
     NumericOperationParam,
 )
+from materialize.output_consistency.input_data.params.same_operation_param import (
+    SameOperationParam,
+)
 from materialize.output_consistency.input_data.params.string_operation_param import (
     StringOperationParam,
 )
@@ -156,8 +159,12 @@ AGGREGATE_OPERATION_TYPES.append(
 AGGREGATE_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "string_agg",
-        {2: "string_agg($, $ ORDER BY row_index)"},
-        [StringOperationParam(), StringOperationParam()],
+        {3: "string_agg($, $ ORDER BY row_index, $)"},
+        [
+            StringOperationParam(),
+            StringOperationParam(),
+            SameOperationParam(index_of_previous_param=1),
+        ],
         StringReturnTypeSpec(),
         is_aggregation=True,
         relevance=OperationRelevance.LOW,

--- a/misc/python/materialize/output_consistency/input_data/operations/array_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/array_operations_provider.py
@@ -27,6 +27,9 @@ from materialize.output_consistency.input_data.params.enum_constant_operation_pa
 from materialize.output_consistency.input_data.params.number_operation_param import (
     NumericOperationParam,
 )
+from materialize.output_consistency.input_data.params.same_operation_param import (
+    SameOperationParam,
+)
 from materialize.output_consistency.input_data.return_specs.array_return_spec import (
     ArrayReturnTypeSpec,
 )
@@ -178,8 +181,8 @@ ARRAY_OPERATION_TYPES.append(
 ARRAY_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "array_agg",
-        {1: "array_agg($ ORDER BY row_index)"},
-        [AnyOperationParam()],
+        {2: "array_agg($ ORDER BY row_index, $)"},
+        [AnyOperationParam(), SameOperationParam(index_of_previous_param=0)],
         ArrayReturnTypeSpec(array_value_type_category=DataTypeCategory.DYNAMIC),
         is_aggregation=True,
         comment="with ordering",

--- a/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
@@ -72,7 +72,7 @@ LIST_OPERATION_TYPES.append(
     DbOperation(
         "$ || $",
         [
-            AnyOperationParam(),
+            AnyOperationParam(include_record_type=False),
             ListOfOtherElementOperationParam(index_of_previous_param=0),
         ],
         ListReturnTypeSpec(),
@@ -96,7 +96,7 @@ LIST_OPERATION_TYPES.append(
     DbFunction(
         "list_agg",
         [
-            AnyOperationParam(),
+            AnyOperationParam(include_record_type=False),
             AnyLikeOtherOperationParam(index_of_previous_param=0, optional=True),
             AnyLikeOtherOperationParam(index_of_previous_param=0, optional=True),
             AnyLikeOtherOperationParam(index_of_previous_param=0, optional=True),

--- a/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/map_operations_provider.py
@@ -24,6 +24,9 @@ from materialize.output_consistency.input_data.params.map_operation_param import
 from materialize.output_consistency.input_data.params.record_operation_param import (
     RecordOperationParam,
 )
+from materialize.output_consistency.input_data.params.same_operation_param import (
+    SameOperationParam,
+)
 from materialize.output_consistency.input_data.params.string_operation_param import (
     StringOperationParam,
 )
@@ -109,8 +112,12 @@ MAP_OPERATION_TYPES.append(
 MAP_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "map_agg",
-        {2: "map_agg($, $ ORDER BY row_index)"},
-        [StringOperationParam(only_type_text=True), AnyOperationParam()],
+        {3: "map_agg($, $ ORDER BY row_index, $)"},
+        [
+            StringOperationParam(only_type_text=True),
+            AnyOperationParam(),
+            SameOperationParam(index_of_previous_param=1),
+        ],
         MapReturnTypeSpec(),
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/operations/record_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/record_operations_provider.py
@@ -37,7 +37,7 @@ RECORD_OPERATION_TYPES: list[DbOperationOrFunction] = []
 
 RECORD_OPERATION_TYPES.append(
     DbFunction(
-        "record",
+        "row",
         [StringOperationParam(), AnyOperationParam()],
         RecordReturnTypeSpec(),
         comment="variant useful for map_build",
@@ -46,7 +46,7 @@ RECORD_OPERATION_TYPES.append(
 
 RECORD_OPERATION_TYPES.append(
     DbFunction(
-        "record",
+        "row",
         [
             AnyOperationParam(),
             AnyOperationParam(optional=True),

--- a/misc/python/materialize/output_consistency/input_data/operations/record_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/record_operations_provider.py
@@ -61,7 +61,8 @@ RECORD_OPERATION_TYPES.append(
 
 RECORD_OPERATION_TYPES.append(
     DbOperation(
-        "$.$",
+        # the parentheses are necessary for Postgres only
+        "($).$",
         [RecordOperationParam(), RECORD_FIELD_PARAM],
         UndeterminedReturnTypeSpec(),
     )

--- a/misc/python/materialize/output_consistency/input_data/operations/record_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/record_operations_provider.py
@@ -34,12 +34,15 @@ from materialize.output_consistency.operation.operation import (
 
 RECORD_OPERATION_TYPES: list[DbOperationOrFunction] = []
 
+TAG_RECORD_CREATION = "record_creation"
+
 
 RECORD_OPERATION_TYPES.append(
     DbFunction(
         "row",
         [StringOperationParam(), AnyOperationParam()],
         RecordReturnTypeSpec(),
+        tags={TAG_RECORD_CREATION},
         comment="variant useful for map_build",
     )
 )
@@ -54,8 +57,9 @@ RECORD_OPERATION_TYPES.append(
             AnyOperationParam(optional=True),
         ],
         RecordReturnTypeSpec(),
-        comment="generic variant",
+        tags={TAG_RECORD_CREATION},
         relevance=OperationRelevance.LOW,
+        comment="generic variant",
     )
 )
 

--- a/misc/python/materialize/output_consistency/input_data/params/any_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/any_operation_param.py
@@ -20,6 +20,7 @@ from materialize.output_consistency.operation.operation_param import OperationPa
 class AnyOperationParam(OperationParam):
     def __init__(
         self,
+        include_record_type: bool = True,
         optional: bool = False,
         incompatibilities: set[ExpressionCharacteristics] | None = None,
         incompatibility_combinations: (
@@ -33,9 +34,17 @@ class AnyOperationParam(OperationParam):
             incompatibility_combinations,
         )
 
+        self.include_record_type = include_record_type
+
     def supports_type(
         self, data_type: DataType, previous_args: list[Expression]
     ) -> bool:
+        if (
+            not self.include_record_type
+            and data_type.category == DataTypeCategory.RECORD
+        ):
+            return False
+
         return True
 
 

--- a/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
+++ b/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
@@ -124,5 +124,5 @@ ARRAY_DIMENSION_PARAM = EnumConstantOperationParam(
 )
 
 RECORD_FIELD_PARAM = EnumConstantOperationParam(
-    ["f1", "f2", "f3", "f4"], add_quotes=False, add_invalid_value=True
+    ["*", "f1", "f2", "f3", "f4"], add_quotes=False, add_invalid_value=True
 )

--- a/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
+++ b/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
@@ -124,5 +124,8 @@ ARRAY_DIMENSION_PARAM = EnumConstantOperationParam(
 )
 
 RECORD_FIELD_PARAM = EnumConstantOperationParam(
-    ["*", "f1", "f2", "f3", "f4"], add_quotes=False, add_invalid_value=True
+    # do not use "*" because it will mess up the column mapping between query and result
+    ["f1", "f2", "f3", "f4"],
+    add_quotes=False,
+    add_invalid_value=True,
 )

--- a/misc/python/materialize/output_consistency/input_data/params/same_operation_param.py
+++ b/misc/python/materialize/output_consistency/input_data/params/same_operation_param.py
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.data_type.data_type import DataType
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.expression.expression import Expression
+from materialize.output_consistency.operation.operation_param import OperationParam
+
+
+class SameOperationParam(OperationParam):
+    def __init__(
+        self,
+        index_of_previous_param: int,
+        optional: bool = False,
+    ):
+        super().__init__(
+            DataTypeCategory.ANY,
+            optional,
+        )
+        self.index_of_previous_param = index_of_previous_param
+
+    def supports_type(
+        self, data_type: DataType, previous_args: list[Expression]
+    ) -> bool:
+        return True

--- a/misc/python/materialize/output_consistency/validation/error_message_normalizer.py
+++ b/misc/python/materialize/output_consistency/validation/error_message_normalizer.py
@@ -35,4 +35,17 @@ class ErrorMessageNormalizer:
             # tracked with https://github.com/MaterializeInc/materialize/issues/23497
             normalized_message = normalized_message[0 : normalized_message.index(" (")]
 
+        if (
+            "not found in data type record" in normalized_message
+            or (
+                re.search(
+                    r"function .*?record\(.*\) does not exist", normalized_message
+                )
+            )
+            or (re.search(r"operator does not exist:.*? record", normalized_message))
+            or "CAST does not support casting from record" in normalized_message
+        ):
+            # tracked with https://github.com/MaterializeInc/materialize/issues/28129
+            normalized_message = normalized_message.replace("?", "")
+
         return normalized_message

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -294,7 +294,13 @@ class ResultComparator:
             raise RuntimeError("Result contains no columns!")
 
         if num_columns1 != num_columns2:
-            raise RuntimeError("Results count different number of columns!")
+            raise RuntimeError("Results contain a different number of columns!")
+
+        if num_columns1 != len(query_execution.query_template.select_expressions):
+            # This would happen with the disabled .* operator on a row() function
+            raise RuntimeError(
+                "Number of columns in the result does not match the number of select expressions!"
+            )
 
         for col_index in range(0, num_columns1):
             self.validate_column(

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -362,7 +362,9 @@ class ResultComparator:
 
         return type(value1) == type(value2)
 
-    def is_value_equal(self, value1: Any, value2: Any) -> bool:
+    def is_value_equal(
+        self, value1: Any, value2: Any, is_tolerant: bool = False
+    ) -> bool:
         if value1 == value2:
             return True
 
@@ -393,7 +395,8 @@ class ResultComparator:
             return False
 
         for value1, value2 in zip(collection1, collection2):
-            if not self.is_value_equal(value1, value2):
+            # use is_tolerant because tuples may contain all values as strings
+            if not self.is_value_equal(value1, value2, is_tolerant=True):
                 return False
 
         return True

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -367,7 +367,10 @@ class ResultComparator:
             return True
 
         if isinstance(value1, list) and isinstance(value2, list):
-            return self.is_list_equal(value1, value2)
+            return self.is_list_or_tuple_equal(value1, value2)
+
+        if isinstance(value1, tuple) and isinstance(value2, tuple):
+            return self.is_list_or_tuple_equal(value1, value2)
 
         if isinstance(value1, Decimal) and isinstance(value2, Decimal):
             if value1.is_nan() and value2.is_nan():
@@ -383,11 +386,13 @@ class ResultComparator:
 
         return False
 
-    def is_list_equal(self, list1: list[Any], list2: list[Any]) -> bool:
-        if len(list1) != len(list2):
+    def is_list_or_tuple_equal(
+        self, collection1: list[Any] | tuple[Any], collection2: list[Any] | tuple[Any]
+    ) -> bool:
+        if len(collection1) != len(collection2):
             return False
 
-        for value1, value2 in zip(list1, list2):
+        for value1, value2 in zip(collection1, collection2):
             if not self.is_value_equal(value1, value2):
                 return False
 


### PR DESCRIPTION
This actually enables the record type; it was not really active before because the value generation had failed.

### Commits
76a615638d output consistency: record type: fix function definitions
856f273da2 output consistency: record type: extend record field param
cb7df343dd output consistency: record type: disable .* on row(...)
3e9c4c251c output consistency: record type: normalize error messages
4e38f99791 output consistency: record type: allow disabling record in AnyOperationParam
1323c80874 output consistency: add matcher function variant
ae9211cfcf output consistency: introduce SameOperationParam
0b4fb964b4 output consistency: order string_agg, array_agg, and map_agg additionally by the value itself
b7b4b274eb output consistency: value comparison: compare tuples value by value
ed4af0ebc9 postgres consistency: value comparison: handle decimal string values in tuples
9017b66c3a postgres consistency: record type: adjust function definition
045f3764cc postgres consistency: record type: add ignore entries


### Identified issues
* https://github.com/MaterializeInc/materialize/issues/28129
* https://github.com/MaterializeInc/materialize/issues/28130
* https://github.com/MaterializeInc/materialize/issues/28131
* https://github.com/MaterializeInc/materialize/issues/17870 (already existed)
* https://github.com/MaterializeInc/materialize/issues/28159

### Nightly
https://buildkite.com/materialize/nightly/builds?branch=nrainer-materialize%3Aoutput-consistency%2Frecord-type