### PR TITLE
Adjust window func tests

### DIFF
--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -239,19 +239,18 @@ FROM t
 ----
 1 a b
 
-# Blocked on #8963
-#query II
-#SELECT row_number() OVER (), row_number() OVER ()
-#----
-#1 1
+# Regression test for #8963
+query II
+SELECT row_number() OVER (), row_number() OVER ()
+----
+1 1
 
-# Blocked on #8963
-#query II
-#WITH t (x) AS (VALUES ('a'), ('b'))
-#SELECT row_number() OVER (), row_number() OVER () from t
-#----
-#1 1
-#2 2
+query II
+WITH t (x) AS (VALUES ('a'), ('b'))
+SELECT row_number() OVER (), row_number() OVER () from t
+----
+1 1
+2 2
 
 # Regression for #9749
 query error window functions are not allowed in ON
@@ -3105,7 +3104,9 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 # Default frame with large peer group
-# Warning: there are multiple valid results of this query
+# Note: there are multiple valid results of this query (because the default frame is up through the current row's last
+# ORDER BY peer, and the ordering among ORDER BY peers is unspecified), but we make the result stable by internally
+# always adding all remaining columns into our orderings.
 query ITII
 WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f3) OVER (PARTITION BY f2 ORDER BY f1)

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -151,3 +151,4047 @@ Source materialize.public.edges
 Target cluster: quickstart
 
 EOF
+
+statement ok
+DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;
+
+###
+# These tests are mostly the same as in from window_funcs.slt, but here it's WITH VALUES. These are good to have,
+# because constant folding is a different code path from the normal execution.
+###
+
+mode cockroach
+
+statement error db error: ERROR: window function pg_catalog\.row_number requires an OVER clause
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT row_number() FROM t
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT row_number() OVER (ORDER BY x), x FROM t
+ORDER BY row_number
+----
+1  a
+2  b
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT row_number() OVER (ORDER BY x DESC), x FROM t
+ORDER BY row_number
+----
+1  c
+2  b
+3  a
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
+SELECT row_number() OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY row_number, x
+----
+1  a
+1  b
+2  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT row_number() OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY row_number, x
+----
+1  b
+1  c
+2  a
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY row_number, x
+----
+1  a
+1  b
+1  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT row_number() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC
+----
+9  c
+8  c
+7  c
+6  b
+5  b
+4  b
+3  a
+2  a
+1  a
+
+# Make sure a non-column expression following the window function is correctly
+# handled.
+query ITT
+WITH t (x) AS (VALUES ('a'))
+SELECT row_number() OVER (PARTITION BY NULL) AS q, x, 'b'
+FROM t
+----
+1 a b
+
+# Blocked on #8963
+#query II
+#SELECT row_number() OVER (), row_number() OVER ()
+#----
+#1 1
+
+# Blocked on #8963
+#query II
+#WITH t (x) AS (VALUES ('a'), ('b'))
+#SELECT row_number() OVER (), row_number() OVER () from t
+#----
+#1 1
+#2 2
+
+# Regression for #9749
+query error window functions are not allowed in ON
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT * FROM t AS v JOIN t ON row_number() over () > 1;
+
+query error window functions are not allowed in WHERE
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT * FROM t
+WHERE row_number() over () > 1;
+
+query T
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT DISTINCT ON (row_number() OVER ()) *
+FROM t
+ORDER BY row_number() OVER ()
+----
+a
+b
+c
+
+# dense_rank
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+2  b
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+2  b
+3  c
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+2  b
+3  a
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+2  b
+2  b
+3  a
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+1  c
+2  b
+2  b
+3  a
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY dense_rank, x
+----
+1  a
+1  b
+2  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY dense_rank, x
+----
+1  a
+1  a
+1  a
+2  b
+2  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY dense_rank, x
+----
+1  b
+1  c
+2  a
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT dense_rank() OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY dense_rank, x
+----
+1  a
+1  b
+1  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT dense_rank() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC, a1.x DESC
+----
+1  c
+1  c
+1  c
+1  b
+1  b
+1  b
+1  a
+1  a
+1  a
+
+# Make sure a non-column expression following the window function is correctly
+# handled.
+query ITT
+WITH t (x) AS (VALUES ('a'))
+SELECT dense_rank() OVER (PARTITION BY NULL) AS q, x, 'b'
+FROM t
+----
+1 a b
+
+
+query IITT
+WITH t (x, y, z) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x DESC, z), x, y, z
+FROM t
+ORDER BY y, x DESC, z
+----
+1  3  a    1
+2  2  a    1
+2  2  a    1
+3  1  a    1
+1  4  b    0
+2  4  b    1
+1  3  c    1
+2  2  c  NaN
+3  1  c  NaN
+
+
+# NaNs have the same rank
+query IITT
+WITH t (x, y, z) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY z DESC), x, y, z
+FROM t
+ORDER BY y, z DESC, x
+----
+1  1  a    1
+1  2  a    1
+1  2  a    1
+1  3  a    1
+1  4  b    1
+2  4  b    0
+1  1  c  NaN
+1  2  c  NaN
+2  3  c    1
+
+## lag
+
+# Simple cases
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+a     b
+b     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+a     b
+b     b
+b     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT lag(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+a     b
+b     b
+b     c
+c     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+b     a
+c     b
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+b     a
+b     b
+c     b
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+b     a
+b     b
+c     b
+c     c
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
+SELECT lag(x) OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+NULL  b
+a     c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
+SELECT lag(x) OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+a     a
+NULL  a
+NULL  a
+a     b
+a     c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lag(x) OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+c     a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lag(x) OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lag(a1.x) OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC, a1.x DESC
+----
+NULL  a
+c     c
+c     c
+b     c
+b     b
+b     b
+a     b
+a     a
+a     a
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+
+# With default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  -1
+1  c  NaN  -1
+2  c  NaN  1
+3  c  1  2
+4  b  1  -1
+4  b  0  4
+1  a  1  -1
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+# Complex expressions
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + coalesce(nullif(f3, 'NaN'), -10)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  -9
+3  c  1  -8
+4  b  1  NULL
+4  b  0  5
+1  a  1  NULL
+2  a  1  2
+2  a  1  3
+3  a  1  3
+
+# Nulls in the first argument
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(NULL::int) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(nullif(f1, 4)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+# Nulls in the first argument with a default value in the third argument
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(NULL::int, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+
+# Zero offset
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  7
+1  c  NaN  1
+2  c  NaN  2
+3  c  1  3
+4  b  1  4
+4  b  0  4
+1  a  1  1
+2  a  1  2
+2  a  1  2
+3  a  1  3
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  2
+1  c  NaN  NaN
+2  c  NaN  NaN
+3  c  1  4
+4  b  1  5
+4  b  0  4
+1  a  1  2
+2  a  1  3
+2  a  1  3
+3  a  1  4
+
+# Positive offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  1
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  NULL
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NaN
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  2
+2  a  1  NULL
+3  a  1  3
+
+# Out of range positive offsets
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  0
+1  c  NaN  0
+2  c  NaN  0
+3  c  1  0
+4  b  1  0
+4  b  0  0
+1  a  1  0
+2  a  1  0
+2  a  1  0
+3  a  1  0
+
+# Negative offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1  NULL
+4  b  1  4
+4  b  0  NULL
+1  a  1  2
+2  a  1  2
+2  a  1  3
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NaN
+2  c  NaN  4
+3  c  1  NULL
+4  b  1  4
+4  b  0  NULL
+1  a  1  3
+2  a  1  3
+2  a  1  4
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, -2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  4
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  3
+2  a  1  4
+2  a  1  NULL
+3  a  1  NULL
+
+# Out of range negative offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, -10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  0
+1  c  NaN  0
+2  c  NaN  0
+3  c  1  0
+4  b  1  0
+4  b  0  0
+1  a  1  0
+2  a  1  0
+2  a  1  0
+3  a  1  0
+
+# Variable per row offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  NULL
+3  a  1  1
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, f1 - 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  1
+2  c  NaN  1
+3  c  1  1
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  1
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+
+# Null offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, nullif(f1, 1)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  NULL
+3  a  1  1
+
+# Null offset with default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, NULL, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+# Variable per row default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1, f3) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  -5
+1  c  NaN  NaN
+2  c  NaN  1
+3  c  1  2
+4  b  1  1
+4  b  0  4
+1  a  1  1
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+# reduce_elision code path
+# Default offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  NULL
+3  NULL
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  NULL
+3  NULL
+
+# Zero offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 0) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  1
+3  3
+
+# Negative offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, -1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  NULL
+3  NULL
+
+# Default value with offset 1
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 1, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  10
+3  10
+
+# Default value with offset 0
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 0, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  1
+3  3
+
+# Complex expression
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, 0, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  12
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, 1, f1 * f2 + 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  3
+3  13
+
+# Complex offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, f1 - f1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  12
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, f1 - 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+3  NULL
+1  2
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, f2 - 2 * f1, f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  4
+
+# Complex default value
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 0, f1 * f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  1
+3  3
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 1, f1 * f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  12
+
+## lead
+
+# Simple cases
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT lead(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+b     a
+c     b
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT lead(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+b     a
+b     b
+c     b
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT lead(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+b     a
+b     b
+c     b
+c     c
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT lead(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lead
+----
+NULL  a
+a     b
+b     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT lead(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lead
+----
+NULL  a
+a     b
+b     b
+b     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT lead(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lead
+----
+NULL  a
+a     b
+b     b
+b     c
+c     c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
+SELECT lead(x) OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+c     a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
+SELECT lead(x) OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+a  a
+b  a
+c  a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lead(x) OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY x, lead
+----
+NULL  a
+NULL  b
+a     c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lead(x) OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+NULL  a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lead(a1.x) OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC, a1.x DESC
+----
+NULL  c
+c     c
+c     c
+c     b
+b     b
+b     b
+b     a
+a     a
+a     a
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1    NULL
+4  b  1    4
+4  b  0    NULL
+1  a  1    2
+2  a  1    2
+2  a  1    3
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1    NULL
+4  b  1    4
+4  b  0    NULL
+1  a  1    2
+2  a  1    2
+2  a  1    3
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1    NULL
+4  b  1    4
+4  b  0    NULL
+1  a  1    2
+2  a  1    2
+2  a  1    3
+3  a  1    NULL
+
+
+# With default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  -1
+1  c  NaN  2
+2  c  NaN  3
+3  c  1   -1
+4  b  1    4
+4  b  0   -1
+1  a  1    2
+2  a  1    2
+2  a  1    3
+3  a  1   -1
+
+# Complex expressions
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + coalesce(nullif(f3, 'NaN'), -10)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5    NULL
+1  c  NaN  -8
+2  c  NaN   4
+3  c  1     NULL
+4  b  1     4
+4  b  0     NULL
+1  a  1     3
+2  a  1     3
+2  a  1     4
+3  a  1     NULL
+
+# Nulls in the first argument
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(NULL::int) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    NULL
+2  a  1    NULL
+2  a  1    NULL
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(nullif(f1, 4)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5    NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    2
+2  a  1    2
+2  a  1    3
+3  a  1    NULL
+
+# Nulls in the first argument with a default value in the third argument
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(NULL::int, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    NULL
+2  a  1    NULL
+2  a  1    NULL
+3  a  1    NULL
+
+
+# Zero offset
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   7
+1  c  NaN  1
+2  c  NaN  2
+3  c  1    3
+4  b  1    4
+4  b  0    4
+1  a  1    1
+2  a  1    2
+2  a  1    2
+3  a  1    3
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   2
+1  c  NaN  NaN
+2  c  NaN  NaN
+3  c  1    4
+4  b  1    5
+4  b  0    4
+1  a  1    2
+2  a  1    3
+2  a  1    3
+3  a  1    4
+
+# Positive offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  3
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    2
+2  a  1    3
+2  a  1    NULL
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  4
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    3
+2  a  1    4
+2  a  1    NULL
+3  a  1    NULL
+
+# Out of range positive offsets
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    NULL
+2  a  1    NULL
+2  a  1    NULL
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    NULL
+2  a  1    NULL
+2  a  1    NULL
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, 10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   0
+1  c  NaN  0
+2  c  NaN  0
+3  c  1    0
+4  b  1    0
+4  b  0    0
+1  a  1    0
+2  a  1    0
+2  a  1    0
+3  a  1    0
+
+# Negative offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NaN
+3  c  1  NaN
+4  b  1  NULL
+4  b  0  5
+1  a  1  NULL
+2  a  1  2
+2  a  1  3
+3  a  1  3
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, -2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NaN
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  2
+2  a  1  NULL
+3  a  1  3
+
+# Out of range negative offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, -10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  0
+1  c  NaN  0
+2  c  NaN  0
+3  c  1  0
+4  b  1  0
+4  b  0  0
+1  a  1  0
+2  a  1  0
+2  a  1  0
+3  a  1  0
+
+# Variable per row offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  2
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  2
+2  a  1  3
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, f1 - 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  1
+2  c  NaN  3
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  1
+2  a  1  2
+2  a  1  3
+3  a  1  NULL
+
+
+# Null offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, nullif(f1, 1)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  3
+2  a  1  NULL
+3  a  1  NULL
+
+# Null offset with default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, NULL, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+# Variable per row default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 1, f3) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  -5
+1  c  NaN  2
+2  c  NaN  3
+3  c  1  1
+4  b  1  4
+4  b  0  0
+1  a  1  2
+2  a  1  2
+2  a  1  3
+3  a  1  1
+
+# reduce_elision code path
+# Default offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  NULL
+3  NULL
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  NULL
+3  NULL
+
+# Zero offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 0) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  1
+3  3
+
+# Negative offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, -1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  NULL
+3  NULL
+
+# Default value with offset 1
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 1, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  10
+3  10
+
+# Default value with offset 0
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 0, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  1
+3  3
+
+# Complex expression
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1 * f2, 0, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  2
+3  12
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1 * f2, 1, f1 * f2 + 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  3
+3  13
+
+# Complex offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1 * f2, f1 - f1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  2
+3  12
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1 * f2, f1 - 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  2
+3  NULL
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1 * f2, f2 - 2 * f1, f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  2
+3  4
+
+# Complex default value
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 0, f1 * f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  1
+3  3
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 1, f1 * f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  2
+3  12
+
+## window frames
+
+# Invalid frame start
+query error frame start cannot be UNBOUNDED FOLLOWING
+SELECT row_number() OVER (ROWS UNBOUNDED FOLLOWING)
+
+# Invalid frame end
+query error frame end cannot be UNBOUNDED PRECEDING
+SELECT row_number() OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED PRECEDING)
+
+# End frame can't be of a type that comes before the start bound
+query error frame starting from current row cannot have preceding rows
+SELECT row_number() OVER (ROWS BETWEEN CURRENT ROW AND 1 PRECEDING)
+
+query error frame starting from following row cannot have preceding rows
+SELECT row_number() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 PRECEDING)
+
+query error frame starting from following row cannot have preceding rows
+SELECT row_number() OVER (ROWS BETWEEN 1 FOLLOWING AND CURRENT ROW)
+
+# But end offsets can come before start offsets
+query I
+SELECT row_number() OVER (ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)
+----
+1
+
+query I
+SELECT row_number() OVER (ROWS BETWEEN 2 FOLLOWING AND 1 FOLLOWING)
+----
+1
+
+# Negative offsets are not allowed
+# Our error message is different from Postgres, so it's not checked here
+query error
+SELECT row_number() OVER (ROWS -1 PRECEDING)
+
+query error
+SELECT row_number() OVER (ROWS -1 FOLLOWING)
+
+# Current implementation restrictions
+# RANGE is not supported outside of the default frame
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND 1 PRECEDING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+
+# Default window frame works fine
+query I
+SELECT row_number() OVER ()
+----
+1
+
+query I
+SELECT row_number() OVER (RANGE UNBOUNDED PRECEDING)
+----
+1
+
+query I
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+----
+1
+
+# GROUPS is not supported at all
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+
+## first_value
+
+# Default frame (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND x PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  1
+3  a  4  1
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND x FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN 0 PRECEDING AND x PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND 0 PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND y PRECEDING, where x < y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND y PRECEDING, where x > y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  1
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND y PRECEDING, where x == y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  2
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  1
+3  a  4  2
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND CURRENT ROW
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND x FOLLOWING
+# Equivalent to ROWS BETWEEN x PRECEDING AND CURRENT ROW for first_value
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND UNBOUNDED FOLLOWING
+# Equivalent to ROWS BETWEEN x PRECEDING AND CURRENT ROW for first_value
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND x FOLLOWING
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN 0 FOLLOWING AND x FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN x FOLLOWING AND 0 FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x < y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x > y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x == y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  3
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  3
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  3
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  3
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# Test near-overflow behavior on offsets
+# u64::MAX FOLLOWING
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551614 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+
+# u64::MAX PRECEDING
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551615 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551614 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+
+## last_value
+
+# Default frame (RANGE BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW)
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# Default frame with large peer group
+# Warning: there are multiple valid results of this query
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f3) OVER (PARTITION BY f2 ORDER BY f1)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  3
+2  a  3  3
+3  a  4  4
+4  b  5  6
+4  b  6  6
+1  c  7  7
+2  c  8  8
+3  c  9  9
+7  d  10  10
+
+# ROWS BETWEEN x FOLLOWING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  1
+3  a  4  1
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x FOLLOWING AND 0 FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN 0 FOLLOWING AND x FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN y FOLLOWING AND x FOLLOWING, where x < y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN y FOLLOWING AND x FOLLOWING, where x > y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  1
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x == y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  2
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  1
+3  a  4  2
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 FOLLOWING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN CURRENT ROW AND x FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND x FOLLOWING
+# Equivalent to ROWS BETWEEN CURRENT ROW AND x FOLLOWING for last_value
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND x FOLLOWING
+# Equivalent to ROWS BETWEEN CURRENT ROW AND x FOLLOWING for last_value
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND CURRENT ROW
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND 0 PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN 0 PRECEDING AND x PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN y PRECEDING AND x PRECEDING, where x < y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN y PRECEDING AND x PRECEDING, where x > y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN y PRECEDING AND x PRECEDING, where x == y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  2
+2  a  2  3
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  3
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND x PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  2
+2  a  2  3
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  3
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# Test near-overflow behavior on offsets
+# u64::MAX FOLLOWING
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551615 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551614 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+
+# u64::MAX PRECEDING
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551615 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551614 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -12,15 +12,19 @@
 
 mode cockroach
 
+statement ok
+CREATE TABLE t(x string);
+
+statement ok
+INSERT INTO t VALUES ('a'), ('b'), ('c');
+
 statement error db error: ERROR: window function pg_catalog\.row_number requires an OVER clause
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
-SELECT row_number() FROM t
+SELECT row_number() FROM t;
 
 statement error db error: ERROR: OVER clause not allowed on pg_catalog\.int8range\. The OVER clause can only be used with window functions \(including aggregations\)\.
 SELECT int8range(1, 1, '') OVER (PARTITION BY 1 ORDER BY 1);
 
 query IT
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT row_number() OVER (ORDER BY x), x FROM t
 ORDER BY row_number
 ----
@@ -29,7 +33,6 @@ ORDER BY row_number
 3  c
 
 query IT
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT row_number() OVER (ORDER BY x DESC), x FROM t
 ORDER BY row_number
 ----
@@ -37,8 +40,16 @@ ORDER BY row_number
 2  b
 3  a
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string, y int);
+
+statement ok
+INSERT INTO t VALUES ('a', 98), ('b', 99), ('c', 98);
+
 query IT
-WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
 SELECT row_number() OVER (PARTITION BY y ORDER BY x), x FROM t
 ORDER BY row_number, x
 ----
@@ -46,8 +57,16 @@ ORDER BY row_number, x
 1  b
 2  c
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string, y int);
+
+statement ok
+INSERT INTO t VALUES ('a', 1), ('b', 2), ('c', 1);
+
 query IT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT row_number() OVER (PARTITION BY y ORDER BY x DESC), x FROM t
 ORDER BY row_number, x
 ----
@@ -56,7 +75,6 @@ ORDER BY row_number, x
 2  a
 
 query IT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
 ORDER BY row_number, x
 ----
@@ -65,7 +83,6 @@ ORDER BY row_number, x
 1  c
 
 query IT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT row_number() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
 FROM t AS a1, t AS a2
 ORDER BY q DESC
@@ -80,10 +97,18 @@ ORDER BY q DESC
 2  a
 1  a
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string);
+
+statement ok
+INSERT INTO t VALUES ('a');
+
 # Make sure a non-column expression following the window function is correctly
 # handled.
 query ITT
-WITH t (x) AS (VALUES ('a'))
 SELECT row_number() OVER (PARTITION BY NULL) AS q, x, 'b'
 FROM t
 ----
@@ -95,28 +120,34 @@ FROM t
 #----
 #1 1
 
+statement ok
+INSERT INTO t VALUES ('b');
+
 # Blocked on #8963
 #query II
-#WITH t (x) AS (VALUES ('a'), ('b'))
 #SELECT row_number() OVER (), row_number() OVER () from t
 #----
 #1 1
 #2 2
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string, y int);
+
+statement ok
+INSERT INTO t VALUES ('a', 1), ('b', 2), ('c', 1);
+
 query T multiline
 EXPLAIN RAW PLAN FOR
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
 ORDER BY row_number, x
 ----
 Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0, #1]
   Project (#2, #0)
-    Return
-      Map (row_number() over (partition by [#0] order by [#0 asc nulls_last]))
-        Get l0
-    With
-      cte l0 =
-        CallTable wrap2("a", 1, "b", 2, "c", 1)
+    Map (row_number() over (partition by [#0] order by [#0 asc nulls_last]))
+      Get materialize.public.t
 
 Target cluster: quickstart
 
@@ -124,21 +155,20 @@ EOF
 
 query T multiline
 EXPLAIN DECORRELATED PLAN WITH(arity) FOR
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
 ORDER BY row_number, x
 ----
 Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0, #1]
-  Project (#2, #0) // { arity: 2 }
-    Project (#0, #1, #3) // { arity: 3 }
-      Map (#2) // { arity: 4 }
-        Project (#3..=#5) // { arity: 3 }
-          Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[0](#2)) // { arity: 6 }
-            FlatMap unnest_list(#1) // { arity: 3 }
-              Reduce group_by=[#0] aggregates=[row_number[order_by=[#0 asc nulls_last]](row(list[row(#0, #1)], #0))] // { arity: 2 }
-                FlatMap wrap2("a", 1, "b", 2, "c", 1) // { arity: 2 }
-                  Constant // { arity: 0 }
-                    - ()
+  Project (#3, #0) // { arity: 2 }
+    Map (#2) // { arity: 4 }
+      Project (#3..=#5) // { arity: 3 }
+        Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[0](#2)) // { arity: 6 }
+          FlatMap unnest_list(#1) // { arity: 3 }
+            Reduce group_by=[#0] aggregates=[row_number[order_by=[#0 asc nulls_last]](row(list[row(#0, #1)], #0))] // { arity: 2 }
+              CrossJoin // { arity: 2 }
+                Constant // { arity: 0 }
+                  - ()
+                Get materialize.public.t // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -364,13 +394,20 @@ Target cluster: quickstart
 
 EOF
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string);
+
+statement ok
+INSERT INTO t VALUES ('a'), ('b'), ('c');
+
 # Regression for #9749
 query error window functions are not allowed in ON
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT * FROM t AS v JOIN t ON row_number() over () > 1;
 
 query error window functions are not allowed in WHERE
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT * FROM t
 WHERE row_number() over () > 1;
 
@@ -406,7 +443,6 @@ query error window functions are not allowed in HAVING
 SELECT 1 FROM not_allowed_tests GROUP BY 1 HAVING sum(1) OVER (PARTITION BY 1) > 1;
 
 query T
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT DISTINCT ON (row_number() OVER ()) *
 FROM t
 ORDER BY row_number() OVER ()
@@ -418,42 +454,67 @@ c
 # rank and dense_rank
 
 query error db error: ERROR: function rank has 0 parameters, but was called with 1
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT rank(x) OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
 ORDER BY dense_rank;
 
-query IIT
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
-SELECT rank() OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
+query IT
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
 ORDER BY dense_rank
+----
+1  a
+2  b
+3  c
+
+statement ok
+INSERT INTO t VALUES ('b');
+
+query IT
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+2  b
+3  c
+
+statement ok
+INSERT INTO t VALUES ('c');
+
+query IT
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+2  b
+3  c
+3  c
+
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string);
+
+statement ok
+INSERT INTO t VALUES ('a'), ('b'), ('c');
+
+query IT
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+2  b
+3  a
+
+query IIT
+SELECT rank() OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
 ----
 1  1  a
 2  2  b
 3  3  c
 
 query IIT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
-SELECT rank() OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
-ORDER BY dense_rank
-----
-1  1  a
-2  2  b
-2  2  b
-4  3  c
-
-query IIT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
-SELECT rank() OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
-ORDER BY dense_rank
-----
-1  1  a
-2  2  b
-2  2  b
-4  3  c
-4  3  c
-
-query IIT
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT rank() OVER (ORDER BY x DESC), dense_rank() OVER (ORDER BY x DESC), x FROM t
 ORDER BY dense_rank
 ----
@@ -461,8 +522,27 @@ ORDER BY dense_rank
 2  2  b
 3  3  a
 
+statement ok
+INSERT INTO t VALUES ('b');
+
+query IT
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+2  b
+2  b
+3  a
+
 query IIT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT rank() OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
+----
+1  1  a
+2  2  b
+2  2  b
+4  3  c
+
+query IIT
 SELECT rank() OVER (ORDER BY x DESC), dense_rank() OVER (ORDER BY x DESC), x FROM t
 ORDER BY dense_rank
 ----
@@ -471,8 +551,20 @@ ORDER BY dense_rank
 2  2  b
 4  3  a
 
+statement ok
+INSERT INTO t VALUES ('c');
+
+query IT
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+1  c
+2  b
+2  b
+3  a
+
 query IIT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
 SELECT rank() OVER (ORDER BY x DESC), dense_rank() OVER (ORDER BY x DESC), x FROM t
 ORDER BY dense_rank
 ----
@@ -482,19 +574,35 @@ ORDER BY dense_rank
 3  2  b
 5  3  a
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string, y int);
+
+statement ok
+INSERT INTO t VALUES ('a', 98), ('b', 99), ('c', 98);
+
 query IIT
-WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
-SELECT rank() OVER (PARTITION BY y ORDER BY x), dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
-ORDER BY dense_rank, x
+SELECT rank() OVER (PARTITION BY y ORDER BY x), dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t;
 ----
 1  1  a
 1  1  b
 2  2  c
 
+query IT
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY dense_rank, x;
+----
+1  a
+1  b
+2  c
+
+statement ok
+INSERT INTO t VALUES ('a', 98), ('a', 99);
+
 query IIT
-WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
-SELECT rank() OVER (PARTITION BY y ORDER BY x), dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
-ORDER BY dense_rank, x
+SELECT rank() OVER (PARTITION BY y ORDER BY x), dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t;
 ----
 1  1  a
 1  1  a
@@ -502,89 +610,190 @@ ORDER BY dense_rank, x
 2  2  b
 3  2  c
 
+query IT
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY dense_rank, x;
+----
+1  a
+1  a
+1  a
+2  b
+2  c
+
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string, y int);
+
+statement ok
+INSERT INTO t VALUES ('a', 1), ('b', 2), ('c', 1);
+
 query IIT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
-SELECT rank() OVER (PARTITION BY y ORDER BY x DESC), dense_rank() OVER (PARTITION BY y ORDER BY x DESC), x FROM t
-ORDER BY dense_rank, x
+SELECT rank() OVER (PARTITION BY y ORDER BY x DESC), dense_rank() OVER (PARTITION BY y ORDER BY x DESC), x FROM t;
 ----
 1  1  b
 1  1  c
 2  2  a
 
+query IT
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY dense_rank, x;
+----
+1  b
+1  c
+2  a
+
 query IIT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
-SELECT rank() OVER (PARTITION BY x ORDER BY x), dense_rank() OVER (PARTITION BY x ORDER BY x), x FROM t
-ORDER BY dense_rank, x
+SELECT rank() OVER (PARTITION BY x ORDER BY x), dense_rank() OVER (PARTITION BY x ORDER BY x), x FROM t;
 ----
 1  1  a
 1  1  b
 1  1  c
 
-query IIT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
-SELECT rank() OVER (PARTITION BY NULL ORDER BY 10000), dense_rank() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
-FROM t AS a1, t AS a2
-ORDER BY q DESC, a1.x DESC
+query IT
+SELECT dense_rank() OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY dense_rank, x;
 ----
-1  1  c
-1  1  c
-1  1  c
-1  1  b
-1  1  b
-1  1  b
+1  a
+1  b
+1  c
+
+query IIT
+SELECT rank() OVER (PARTITION BY NULL ORDER BY 10000), dense_rank() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2;
+----
 1  1  a
 1  1  a
 1  1  a
+1  1  b
+1  1  b
+1  1  b
+1  1  c
+1  1  c
+1  1  c
+
+query IT
+SELECT dense_rank() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC, a1.x DESC;
+----
+1  c
+1  c
+1  c
+1  b
+1  b
+1  b
+1  a
+1  a
+1  a
+
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string);
+
+statement ok
+INSERT INTO t VALUES ('a');
 
 # Make sure a non-column expression following the window function is correctly
 # handled.
 query IITT
-WITH t (x) AS (VALUES ('a'))
 SELECT rank() OVER (PARTITION BY NULL), dense_rank() OVER (PARTITION BY NULL) AS q, x, 'b'
-FROM t
+FROM t;
 ----
 1  1  a  b
 
+query ITT
+SELECT dense_rank() OVER (PARTITION BY NULL) AS q, x, 'b'
+FROM t;
+----
+1  a  b
+
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x int, y string, z numeric);
+
+statement ok
+INSERT INTO t VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0);
 
 query IIITT
-WITH t (x, y, z) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0))
 SELECT rank() OVER (PARTITION BY y ORDER BY x DESC, z), dense_rank() OVER (PARTITION BY y ORDER BY x DESC, z), x, y, z
-FROM t
-ORDER BY y, x DESC, z
+FROM t;
 ----
 1  1  3  a  1
-2  2  2  a  1
-2  2  2  a  1
-4  3  1  a  1
-1  1  4  b  0
-2  2  4  b  1
 1  1  3  c  1
+1  1  4  b  0
+2  2  2  a  1
+2  2  2  a  1
 2  2  2  c  NaN
+2  2  4  b  1
 3  3  1  c  NaN
+4  3  1  a  1
+
+query IITT
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x DESC, z), x, y, z
+FROM t
+ORDER BY y, x DESC, z;
+----
+1  3  a  1
+2  2  a  1
+2  2  a  1
+3  1  a  1
+1  4  b  0
+2  4  b  1
+1  3  c  1
+2  2  c  NaN
+3  1  c  NaN
 
 
 # NaNs have the same rank
 query IIITT
 WITH t (x, y, z) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0))
 SELECT rank() OVER (PARTITION BY y ORDER BY z DESC), dense_rank() OVER (PARTITION BY y ORDER BY z DESC), x, y, z
-FROM t
-ORDER BY y, z DESC, x
+FROM t;
 ----
 1  1  1  a  1
+1  1  1  c  NaN
 1  1  2  a  1
 1  1  2  a  1
+1  1  2  c  NaN
 1  1  3  a  1
 1  1  4  b  1
 2  2  4  b  0
-1  1  1  c  NaN
-1  1  2  c  NaN
 3  2  3  c  1
+
+query IITT
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY z DESC), x, y, z
+FROM t
+ORDER BY y, z DESC, x;
+----
+1  1  a  1
+1  2  a  1
+1  2  a  1
+1  3  a  1
+1  4  b  1
+2  4  b  0
+1  1  c  NaN
+1  2  c  NaN
+2  3  c  1
 
 ## lag
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string);
+
+statement ok
+INSERT INTO t VALUES ('a'), ('b'), ('c');
+
 # Simple cases
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT lag(x) OVER (ORDER BY x), x FROM t
 ORDER BY x, lag
 ----
@@ -592,8 +801,10 @@ NULL  a
 a     b
 b     c
 
+statement ok
+INSERT INTO t VALUES ('b');
+
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
 SELECT lag(x) OVER (ORDER BY x), x FROM t
 ORDER BY x, lag
 ----
@@ -602,8 +813,10 @@ a     b
 b     b
 b     c
 
+statement ok
+INSERT INTO t VALUES ('c');
+
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
 SELECT lag(x) OVER (ORDER BY x), x FROM t
 ORDER BY x, lag
 ----
@@ -613,8 +826,16 @@ b     b
 b     c
 c     c
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string);
+
+statement ok
+INSERT INTO t VALUES ('a'), ('b'), ('c');
+
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
 ORDER BY x, lag
 ----
@@ -622,8 +843,10 @@ b     a
 c     b
 NULL  c
 
+statement ok
+INSERT INTO t VALUES ('b');
+
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
 SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
 ORDER BY x, lag
 ----
@@ -632,8 +855,10 @@ b     b
 c     b
 NULL  c
 
+statement ok
+INSERT INTO t VALUES ('c');
+
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
 SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
 ORDER BY x, lag
 ----
@@ -643,8 +868,16 @@ c     b
 c     c
 NULL  c
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string, y int);
+
+statement ok
+INSERT INTO t VALUES ('a', 98), ('b', 99), ('c', 98);
+
 query TT
-WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
 SELECT lag(x) OVER (PARTITION BY y ORDER BY x), x FROM t
 ORDER BY x, lag
 ----
@@ -652,8 +885,10 @@ NULL  a
 NULL  b
 a     c
 
+statement ok
+INSERT INTO t VALUES ('a', 98), ('a', 99);
+
 query TT
-WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
 SELECT lag(x) OVER (PARTITION BY y ORDER BY x), x FROM t
 ORDER BY x, lag
 ----
@@ -663,8 +898,16 @@ NULL  a
 a     b
 a     c
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string, y int);
+
+statement ok
+INSERT INTO t VALUES ('a', 1), ('b', 2), ('c', 1);
+
 query TT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT lag(x) OVER (PARTITION BY y ORDER BY x DESC), x FROM t
 ORDER BY x, lag
 ----
@@ -673,7 +916,6 @@ NULL  b
 NULL  c
 
 query TT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT lag(x) OVER (PARTITION BY x ORDER BY x), x FROM t
 ORDER BY x, lag
 ----
@@ -682,7 +924,6 @@ NULL  b
 NULL  c
 
 query TT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT lag(a1.x) OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
 FROM t AS a1, t AS a2
 ORDER BY q DESC, a1.x DESC
@@ -697,8 +938,16 @@ a     b
 a     a
 a     a
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(f1 int, f2 string, f3 numeric);
+
+statement ok
+INSERT INTO t VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0);
+
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -715,7 +964,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  2
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -732,7 +980,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  2
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, 1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -751,7 +998,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # With default value
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, 1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -769,7 +1015,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Complex expressions
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1 + coalesce(nullif(f3, 'NaN'), -10)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -787,7 +1032,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Nulls in the first argument
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(NULL::int) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -804,7 +1048,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(nullif(f1, 4)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -822,7 +1065,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Nulls in the first argument with a default value in the third argument
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(NULL::int, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -841,7 +1083,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Zero offset
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -858,7 +1099,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  3
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1 + f3, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -876,7 +1116,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Positive offsets
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -893,7 +1132,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  2
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1 + f3, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -912,7 +1150,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 # Out of range positive offsets
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -929,7 +1166,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1 + f3, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -946,7 +1182,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1 + f3, 10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -964,7 +1199,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Negative offsets
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -981,7 +1215,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1 + f3, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -998,7 +1231,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1 + f3, -2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -1016,7 +1248,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Out of range negative offsets
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -1033,7 +1264,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1 + f3, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -1050,7 +1280,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, -10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -1068,7 +1297,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Variable per row offsets
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -1085,7 +1313,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  1
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, f1 - 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -1104,7 +1331,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Null offsets
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -1121,7 +1347,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, nullif(f1, 1)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -1139,7 +1364,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Null offset with default value
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, NULL, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -1157,7 +1381,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 
 # Variable per row default value
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lag(f1, 1, f3) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lag
@@ -1173,10 +1396,18 @@ ORDER BY f2 DESC, f3 DESC, f1, lag
 2  a  1  2
 3  a  1  2
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(f1 int, f2 int);
+
+statement ok
+INSERT INTO t VALUES (1, 2), (1, 2), (3, 4);
+
 # reduce_elision code path
 # Default offset
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1184,7 +1415,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 3  NULL
 
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1, 1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1193,7 +1423,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 
 # Zero offset
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1, 0) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1202,7 +1431,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 
 # Negative offset
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1, -1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1211,7 +1439,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 
 # Default value with offset 1
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1, 1, 10) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1220,7 +1447,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 
 # Default value with offset 0
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1, 0, 10) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1229,7 +1455,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 
 # Complex expression
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1 * f2, 0, 10) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1237,7 +1462,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 3  12
 
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1 * f2, 1, f1 * f2 + 1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1246,7 +1470,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 
 # Complex offset
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1 * f2, f1 - f1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1254,7 +1477,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 3  12
 
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1 * f2, f1 - 1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1262,7 +1484,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 1  2
 
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1 * f2, f2 - 2 * f1, f2) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1271,7 +1492,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 
 # Complex default value
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1, 0, f1 * f2) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1279,7 +1499,6 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 3  3
 
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lag(f1, 1, f1 * f2) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
@@ -1303,9 +1522,17 @@ NULL NULL
 
 ## lead
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string);
+
+statement ok
+INSERT INTO t VALUES ('a'), ('b'), ('c');
+
 # Simple cases
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT lead(x) OVER (ORDER BY x), x FROM t
 ORDER BY x, lead
 ----
@@ -1313,8 +1540,10 @@ b     a
 c     b
 NULL  c
 
+statement ok
+INSERT INTO t VALUES ('b');
+
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
 SELECT lead(x) OVER (ORDER BY x), x FROM t
 ORDER BY x, lead
 ----
@@ -1323,8 +1552,10 @@ b     b
 c     b
 NULL  c
 
+statement ok
+INSERT INTO t VALUES ('c');
+
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
 SELECT lead(x) OVER (ORDER BY x), x FROM t
 ORDER BY x, lead
 ----
@@ -1334,8 +1565,16 @@ c     b
 c     c
 NULL  c
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string);
+
+statement ok
+INSERT INTO t VALUES ('a'), ('b'), ('c');
+
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT lead(x) OVER (ORDER BY x DESC), x FROM t
 ORDER BY x, lead
 ----
@@ -1343,8 +1582,10 @@ NULL  a
 a     b
 b     c
 
+statement ok
+INSERT INTO t VALUES ('b');
+
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
 SELECT lead(x) OVER (ORDER BY x DESC), x FROM t
 ORDER BY x, lead
 ----
@@ -1353,8 +1594,10 @@ a     b
 b     b
 b     c
 
+statement ok
+INSERT INTO t VALUES ('c');
+
 query TT
-WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
 SELECT lead(x) OVER (ORDER BY x DESC), x FROM t
 ORDER BY x, lead
 ----
@@ -1364,8 +1607,16 @@ b     b
 b     c
 c     c
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string, y int);
+
+statement ok
+INSERT INTO t VALUES ('a', 98), ('b', 99), ('c', 98);
+
 query TT
-WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
 SELECT lead(x) OVER (PARTITION BY y ORDER BY x), x FROM t
 ORDER BY x, lead
 ----
@@ -1373,8 +1624,10 @@ c     a
 NULL  b
 NULL  c
 
+statement ok
+INSERT INTO t VALUES ('a', 98), ('a', 99);
+
 query TT
-WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
 SELECT lead(x) OVER (PARTITION BY y ORDER BY x), x FROM t
 ORDER BY x, lead
 ----
@@ -1384,8 +1637,16 @@ c  a
 NULL  b
 NULL  c
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x string, y int);
+
+statement ok
+INSERT INTO t VALUES ('a', 1), ('b', 2), ('c', 1);
+
 query TT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT lead(x) OVER (PARTITION BY y ORDER BY x DESC), x FROM t
 ORDER BY x, lead
 ----
@@ -1394,7 +1655,6 @@ NULL  b
 a     c
 
 query TT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT lead(x) OVER (PARTITION BY x ORDER BY x), x FROM t
 ORDER BY x, lead
 ----
@@ -1403,7 +1663,6 @@ NULL  b
 NULL  c
 
 query TT
-WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
 SELECT lead(a1.x) OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
 FROM t AS a1, t AS a2
 ORDER BY q DESC, a1.x DESC
@@ -1418,8 +1677,16 @@ b     a
 a     a
 a     a
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(f1 int, f2 string, f3 numeric);
+
+statement ok
+INSERT INTO t VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0);
+
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1436,7 +1703,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1    NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1453,7 +1719,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1    NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, 1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1472,7 +1737,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # With default value
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, 1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1490,7 +1754,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Complex expressions
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1 + coalesce(nullif(f3, 'NaN'), -10)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1508,7 +1771,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Nulls in the first argument
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(NULL::int) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1525,7 +1787,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1    NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(nullif(f1, 4)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1543,7 +1804,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Nulls in the first argument with a default value in the third argument
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(NULL::int, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1562,7 +1822,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Zero offset
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1579,7 +1838,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1    3
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1 + f3, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1597,7 +1855,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Positive offsets
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1614,7 +1871,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1    NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1 + f3, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1633,7 +1889,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 # Out of range positive offsets
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1650,7 +1905,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1    NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1 + f3, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1667,7 +1921,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1    NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1 + f3, 10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1685,7 +1938,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Negative offsets
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1702,7 +1954,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1  2
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1 + f3, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1719,7 +1970,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1  3
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1 + f3, -2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1737,7 +1987,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Out of range negative offsets
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1754,7 +2003,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1 + f3, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1771,7 +2019,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, -10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1789,7 +2036,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Variable per row offsets
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1806,7 +2052,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, f1 - 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1825,7 +2070,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Null offsets
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1842,7 +2086,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 3  a  1  NULL
 
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, nullif(f1, 1)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1860,7 +2103,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Null offset with default value
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, NULL, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1878,7 +2120,6 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 
 # Variable per row default value
 query ITTT
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
 SELECT f1, f2, f3, lead(f1, 1, f3) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
 FROM t
 ORDER BY f2 DESC, f3 DESC, f1, lead
@@ -1894,10 +2135,18 @@ ORDER BY f2 DESC, f3 DESC, f1, lead
 2  a  1  3
 3  a  1  1
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(f1 int, f2 int);
+
+statement ok
+INSERT INTO t VALUES (1, 2), (1, 2), (3, 4);
+
 # reduce_elision code path
 # Default offset
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -1906,7 +2155,6 @@ ORDER BY 1, 2
 3  NULL
 
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1, 1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -1916,7 +2164,6 @@ ORDER BY 1, 2
 
 # Zero offset
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1, 0) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -1926,7 +2173,6 @@ ORDER BY 1, 2
 
 # Negative offset
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1, -1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -1936,7 +2182,6 @@ ORDER BY 1, 2
 
 # Default value with offset 1
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1, 1, 10) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -1946,7 +2191,6 @@ ORDER BY 1, 2
 
 # Default value with offset 0
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1, 0, 10) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -1956,7 +2200,6 @@ ORDER BY 1, 2
 
 # Complex expression
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1 * f2, 0, 10) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -1965,7 +2208,6 @@ ORDER BY 1, 2
 3  12
 
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1 * f2, 1, f1 * f2 + 1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -1975,7 +2217,6 @@ ORDER BY 1, 2
 
 # Complex offset
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1 * f2, f1 - f1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -1984,7 +2225,6 @@ ORDER BY 1, 2
 3  12
 
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1 * f2, f1 - 1) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -1993,7 +2233,6 @@ ORDER BY 1, 2
 3  NULL
 
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1 * f2, f2 - 2 * f1, f2) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -2003,7 +2242,6 @@ ORDER BY 1, 2
 
 # Complex default value
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1, 0, f1 * f2) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -2012,7 +2250,6 @@ ORDER BY 1, 2
 3  3
 
 query II
-WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
 SELECT f1, lead(f1, 1, f1 * f2) OVER (PARTITION BY f1, f2)
 FROM (SELECT DISTINCT f1, f2 FROM t) q
 ORDER BY 1, 2
@@ -2249,9 +2486,17 @@ SELECT row_number() OVER (GROUPS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
 
 ## first_value
 
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(f1 int, f2 string, f3 int);
+
+statement ok
+INSERT INTO t VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10);
+
 # Default frame (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2269,7 +2514,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN UNBOUNDED PRECEDING AND x PRECEDING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2286,7 +2530,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2303,7 +2546,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 2 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2320,7 +2562,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 10 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2338,7 +2579,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2356,7 +2596,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN UNBOUNDED PRECEDING AND x FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2373,7 +2612,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2390,7 +2628,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2407,7 +2644,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 10 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2425,7 +2661,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2443,7 +2678,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN 0 PRECEDING AND x PRECEDING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2460,7 +2694,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 2 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2477,7 +2710,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 10 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2495,7 +2727,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN x PRECEDING AND 0 PRECEDING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2512,7 +2743,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2529,7 +2759,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2547,7 +2776,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN x PRECEDING AND y PRECEDING, where x < y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2564,7 +2792,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2582,7 +2809,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN x PRECEDING AND y PRECEDING, where x > y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2599,7 +2825,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2617,7 +2842,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN x PRECEDING AND y PRECEDING, where x == y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2634,7 +2858,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2651,7 +2874,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2668,7 +2890,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 10 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2686,7 +2907,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN x PRECEDING AND CURRENT ROW
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2703,7 +2923,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2720,7 +2939,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2737,7 +2955,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2756,7 +2973,6 @@ ORDER BY f2, f3, f1, first_value
 # ROWS BETWEEN x PRECEDING AND x FOLLOWING
 # Equivalent to ROWS BETWEEN x PRECEDING AND CURRENT ROW for first_value
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2773,7 +2989,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2790,7 +3005,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2807,7 +3021,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2826,7 +3039,6 @@ ORDER BY f2, f3, f1, first_value
 # ROWS BETWEEN x PRECEDING AND UNBOUNDED FOLLOWING
 # Equivalent to ROWS BETWEEN x PRECEDING AND CURRENT ROW for first_value
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2843,7 +3055,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2860,7 +3071,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2877,7 +3087,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2896,7 +3105,6 @@ ORDER BY f2, f3, f1, first_value
 # ROWS BETWEEN CURRENT ROW AND CURRENT ROW
 # Always returns current row
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2915,7 +3123,6 @@ ORDER BY f2, f3, f1, first_value
 # ROWS BETWEEN CURRENT ROW AND x FOLLOWING
 # Always returns current row
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2932,7 +3139,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2949,7 +3155,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2966,7 +3171,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 10 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -2985,7 +3189,6 @@ ORDER BY f2, f3, f1, first_value
 # ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
 # Always returns current row
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3003,7 +3206,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN 0 FOLLOWING AND x FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3020,7 +3222,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3037,7 +3238,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 10 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3055,7 +3255,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN x FOLLOWING AND 0 FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3072,7 +3271,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3089,7 +3287,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3107,7 +3304,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x < y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3124,7 +3320,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3142,7 +3337,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x > y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3159,7 +3353,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3177,7 +3370,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x == y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3194,7 +3386,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3211,7 +3402,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3228,7 +3418,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND 10 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3246,7 +3435,6 @@ ORDER BY f2, f3, f1, first_value
 
 # ROWS BETWEEN x FOLLOWING AND UNBOUNDED FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3263,7 +3451,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3280,7 +3467,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3297,7 +3483,6 @@ ORDER BY f2, f3, f1, first_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
@@ -3315,22 +3500,70 @@ ORDER BY f2, f3, f1, first_value
 
 # Test offset limits
 query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 100 FOLLOWING AND 1000001 FOLLOWING)
+
+# Test near-overflow behavior on offsets
+# u64::MAX FOLLOWING
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 FOLLOWING AND 18446744073709551615 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, first_value
 
 query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1000001 PRECEDING AND 100 FOLLOWING)
+
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551614 FOLLOWING AND 18446744073709551615 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
 
 query error Expected literal unsigned integer, found operator "\-"
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND -1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
+
+# u64::MAX PRECEDING
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551615 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551614 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+
+query ITII
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1000 PRECEDING AND 1000 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1000 PRECEDING AND 999 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
 
 # reduce_elision code path
 statement ok
@@ -3555,7 +3788,6 @@ GROUP BY f1
 
 # Default frame (RANGE BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW)
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3574,7 +3806,6 @@ ORDER BY f2, f3, f1, last_value
 # Default frame with large peer group
 # Warning: there are multiple valid results of this query
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f3) OVER (PARTITION BY f2 ORDER BY f1)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3592,7 +3823,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN x FOLLOWING AND UNBOUNDED FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3609,7 +3839,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3626,7 +3855,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3643,7 +3871,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 FOLLOWING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3661,7 +3888,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3679,7 +3905,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN x PRECEDING AND UNBOUNDED FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3696,7 +3921,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3713,7 +3937,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3730,7 +3953,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3748,7 +3970,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3766,7 +3987,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN x FOLLOWING AND 0 FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3783,7 +4003,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3800,7 +4019,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 FOLLOWING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3818,7 +4036,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN 0 FOLLOWING AND x FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3835,7 +4052,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3852,7 +4068,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 10 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3870,7 +4085,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN y FOLLOWING AND x FOLLOWING, where x < y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3887,7 +4101,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3905,7 +4118,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN y FOLLOWING AND x FOLLOWING, where x > y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3922,7 +4134,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3940,7 +4151,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x == y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3957,7 +4167,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3974,7 +4183,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -3991,7 +4199,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 FOLLOWING AND 10 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4009,7 +4216,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN CURRENT ROW AND x FOLLOWING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4026,7 +4232,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4043,7 +4248,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4060,7 +4264,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 10 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4079,7 +4282,6 @@ ORDER BY f2, f3, f1, last_value
 # ROWS BETWEEN x PRECEDING AND x FOLLOWING
 # Equivalent to ROWS BETWEEN CURRENT ROW AND x FOLLOWING for last_value
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4096,7 +4298,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4113,7 +4314,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4130,7 +4330,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 10 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4149,7 +4348,6 @@ ORDER BY f2, f3, f1, last_value
 # ROWS BETWEEN UNBOUNDED PRECEDING AND x FOLLOWING
 # Equivalent to ROWS BETWEEN CURRENT ROW AND x FOLLOWING for last_value
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4166,7 +4364,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4183,7 +4380,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4200,7 +4396,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 10 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4219,7 +4414,6 @@ ORDER BY f2, f3, f1, last_value
 # ROWS BETWEEN CURRENT ROW AND CURRENT ROW
 # Always returns current row
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4238,7 +4432,6 @@ ORDER BY f2, f3, f1, last_value
 # ROWS BETWEEN x PRECEDING AND CURRENT ROW
 # Always returns current row
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4255,7 +4448,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4272,7 +4464,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4289,7 +4480,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4308,7 +4498,6 @@ ORDER BY f2, f3, f1, last_value
 # ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
 # Always returns current row
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4326,7 +4515,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN x PRECEDING AND 0 PRECEDING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4343,7 +4531,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4360,7 +4547,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4378,7 +4564,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN 0 PRECEDING AND x PRECEDING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4395,7 +4580,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 2 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4412,7 +4596,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 10 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4430,7 +4613,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN y PRECEDING AND x PRECEDING, where x < y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4447,7 +4629,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4465,7 +4646,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN y PRECEDING AND x PRECEDING, where x > y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4482,7 +4662,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4500,7 +4679,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN y PRECEDING AND x PRECEDING, where x == y
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4517,7 +4695,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4534,7 +4711,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4551,7 +4727,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND 10 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4569,7 +4744,6 @@ ORDER BY f2, f3, f1, last_value
 
 # ROWS BETWEEN UNBOUNDED PRECEDING AND x PRECEDING
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4586,7 +4760,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4603,7 +4776,6 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 2 PRECEDING)
 FROM t
 ORDER BY f2, f3, f1, last_value
@@ -4620,8 +4792,53 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  NULL
 
 query ITII
-WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
 SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# Test near-overflow behavior on offsets
+# u64::MAX FOLLOWING
+
+# u64::MAX PRECEDING
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551615 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+
+query error db error: ERROR: Window frame offsets greater than 1000000 are currently not supported
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551614 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+
+query ITII
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1000 FOLLOWING AND 1000 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1000 FOLLOWING AND 1001 FOLLOWING)
 FROM t
 ORDER BY f2, f3, f1, last_value
 ----

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -114,21 +114,20 @@ FROM t
 ----
 1 a b
 
-# Blocked on #8963
-#query II
-#SELECT row_number() OVER (), row_number() OVER ()
-#----
-#1 1
+# Regression test for #8963
+query II
+SELECT row_number() OVER (), row_number() OVER ()
+----
+1 1
 
 statement ok
 INSERT INTO t VALUES ('b');
 
-# Blocked on #8963
-#query II
-#SELECT row_number() OVER (), row_number() OVER () from t
-#----
-#1 1
-#2 2
+query II
+SELECT row_number() OVER (), row_number() OVER () from t
+----
+1 1
+2 2
 
 statement ok
 DROP TABLE t;
@@ -3804,7 +3803,9 @@ ORDER BY f2, f3, f1, last_value
 7  d  10  7
 
 # Default frame with large peer group
-# Warning: there are multiple valid results of this query
+# Note: there are multiple valid results of this query (because the default frame is up through the current row's last
+# ORDER BY peer, and the ordering among ORDER BY peers is unspecified), but we make the result stable by internally
+# always adding all remaining columns into our orderings.
 query ITII
 SELECT f1, f2, f3, last_value(f3) OVER (PARTITION BY f2 ORDER BY f1)
 FROM t


### PR DESCRIPTION
This PR does 3 things (in 3 commits):
1. Adjust `window_funcs.slt` to not run window functions on constant inputs. Running them on constant inputs executes the window functions on different code paths, because constant folding kicks in early in the optimizer pipeline. These are straightforward changes: just replacing the constant cte with an actual table.
2. Copy-paste the constant-input version of the tests to `fold_constants.slt`, so that we keep testing also the constant folding code path for window functions.
3. Uncomment an old test and adjust some comments.

### Motivation

   * This PR adjusts window function testing.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
