### PR TITLE
bazel: Build `decnumber-sys`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -256,6 +256,16 @@ crates_repository(
     lockfile = "//misc/bazel:Cargo.crates_io.lock",
     rust_version = RUST_VERSION,
     annotations = {
+        "decnumber-sys": [crate.annotation(
+            gen_build_script = False,
+            additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.decimal.bazel",
+            # Note: This is a target we add from the additive build file above.
+            compile_data = [":decimal_static_lib"],
+            rustc_flags = [
+                "-Lnative=$(execpath :decimal_static_lib)",
+                "-lstatic=decnumber",
+            ]
+        )],
         "librocksdb-sys": [crate.annotation(
             additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.rocksdb.bazel",
             # Note: The below targets are from the additive build file.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -258,11 +258,11 @@ crates_repository(
     annotations = {
         "decnumber-sys": [crate.annotation(
             gen_build_script = False,
-            additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.decimal.bazel",
+            additive_build_file = "@//misc/bazel/c_deps:rust-sys/BUILD.decnumber.bazel",
             # Note: This is a target we add from the additive build file above.
-            compile_data = [":decimal_static_lib"],
+            compile_data = [":decnumber_static_lib"],
             rustc_flags = [
-                "-Lnative=$(execpath :decimal_static_lib)",
+                "-Lnative=$(execpath :decnumber_static_lib)",
                 "-lstatic=decnumber",
             ]
         )],

--- a/misc/bazel/c_deps/rust-sys/BUILD.decimal.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.decimal.bazel
@@ -1,0 +1,71 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
+
+"""Additive BUILD file for the decimal-sys Rust crate."""
+
+cc_library(
+    name = "decnumber",
+    srcs = [
+        "decnumber/decimal128.c",
+        "decnumber/decimal64.c",
+        "decnumber/decimal32.c",
+        "decnumber/decContext.c",
+        "decnumber/decNumber.c",
+        "decnumber/decSingle.c",
+        "decnumber/decDouble.c",
+        "decnumber/decQuad.c",
+        "decnumber/decPacked.c",
+    ],
+    hdrs = [
+        "decnumber/decimal128.h",
+        "decnumber/decimal64.h",
+        "decnumber/decimal32.h",
+        "decnumber/decContext.h",
+        "decnumber/decNumber.h",
+        "decnumber/decSingle.h",
+        "decnumber/decDouble.h",
+        "decnumber/decQuad.h",
+        "decnumber/decPacked.h",
+        "decnumber/decDPD.h",
+        "decnumber/decNumberLocal.h",
+    ],
+    textual_hdrs = [
+        # The ordering of these is important.
+        "decnumber/decCommon.c",
+        "decnumber/decBasic.c",
+    ],
+    # libdecimal strongly recommends always enabling optimizations.
+    #
+    # See: <https://github.com/MaterializeInc/rust-dec/blob/8f2670e74773e97f2f62f1f0d06b52442047883e/decnumber-sys/decnumber/readme.txt#L57-L58>
+    copts = ["-O3"] + select({
+        "//conditions:default": ["-Wno-unused-but-set-variable"],
+    }),
+    defines = ["DECLITEND=1"],
+    target_compatible_with = select({
+        "@//misc/bazel/platforms:linux_arm": [],
+        "@//misc/bazel/platforms:linux_x86_64": [],
+        "@//misc/bazel/platforms:macos_arm": [],
+        "@//misc/bazel/platforms:macos_x86_64": [],
+        # We can support more platforms but we'll need to take care to
+        # correctly define `DECLITEND`.
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+# Place the compiled static library in the right place so rustc can find it.
+copy_to_directory(
+    name = "decimal_static_lib",
+    srcs = [":decnumber"],
+    visibility = ["//visibility:public"],
+)

--- a/misc/bazel/c_deps/rust-sys/BUILD.decnumber.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.decnumber.bazel
@@ -65,7 +65,7 @@ cc_library(
 
 # Place the compiled static library in the right place so rustc can find it.
 copy_to_directory(
-    name = "decimal_static_lib",
+    name = "decnumber_static_lib",
     srcs = [":decnumber"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This PR adds a `BUILD.decnumber.bazel` file to build the libdecimal C dependency with Bazel.

### Motivation

Building libdecimal with Bazel means we'll get better caching and optimizations like specifying the CPU type or cross language inlining, "for free".

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
