### PR TITLE
[persist] Reallocate arrow arrays via lgalloc and use them in ColumnarRecords

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -864,8 +864,7 @@ where
 
         let ((mut key_lower, _), _, _) = &updates[0];
         let start = Instant::now();
-        let mut builder = ColumnarRecordsBuilder::default();
-        builder.reserve_exact(
+        let mut builder = ColumnarRecordsBuilder::with_capacity(
             self.current_part.len(),
             self.current_part_key_bytes,
             self.current_part_value_bytes,

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -10,19 +10,18 @@
 //! A columnar representation of ((Key, Val), Time, i64) data suitable for in-memory
 //! reads and persistent storage.
 
+use std::fmt;
 use std::mem::size_of;
 use std::sync::Arc;
-use std::{cmp, fmt};
 
-use ::arrow::array::Array;
-use ::arrow::array::Int64Array;
-use ::arrow::datatypes::ArrowNativeType;
+use ::arrow::array::{Array, BinaryArray, BinaryBuilder, Int64Array};
+use ::arrow::buffer::OffsetBuffer;
+use ::arrow::datatypes::ToByteSlice;
 use bytes::Bytes;
-use mz_ore::bytes::MaybeLgBytes;
-use mz_ore::lgbytes::MetricsRegion;
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 
 use crate::gen::persist::ProtoColumnarRecords;
+use crate::indexed::columnar::arrow::realloc_array;
 use crate::metrics::ColumnarMetrics;
 
 pub mod arrow;
@@ -92,11 +91,9 @@ const BYTES_PER_KEY_VAL_OFFSET: usize = 4;
 #[derive(Clone, PartialEq)]
 pub struct ColumnarRecords {
     len: usize,
-    key_data: MaybeLgBytes,
-    key_offsets: Arc<MetricsRegion<i32>>,
-    val_data: MaybeLgBytes,
-    val_offsets: Arc<MetricsRegion<i32>>,
-    timestamps: Arc<MetricsRegion<i64>>,
+    key_data: BinaryArray,
+    val_data: BinaryArray,
+    timestamps: Int64Array,
     diffs: Int64Array,
 }
 
@@ -116,9 +113,9 @@ impl ColumnarRecords {
     /// The number of logical bytes in the represented data, excluding offsets
     /// and lengths.
     pub fn goodbytes(&self) -> usize {
-        self.key_data.as_ref().len()
-            + self.val_data.as_ref().len()
-            + 8 * (*self.timestamps).as_ref().len()
+        self.key_data.values().len()
+            + self.val_data.values().len()
+            + self.timestamps.values().inner().len()
             + self.diffs.values().inner().len()
     }
 
@@ -138,11 +135,9 @@ impl ColumnarRecords {
         // obvious.
         ColumnarRecordsRef {
             len: self.len,
-            key_data: self.key_data.as_ref(),
-            key_offsets: (*self.key_offsets).as_ref(),
-            val_data: self.val_data.as_ref(),
-            val_offsets: (*self.val_offsets).as_ref(),
-            timestamps: (*self.timestamps).as_ref(),
+            key_data: &self.key_data,
+            val_data: &self.val_data,
+            timestamps: self.timestamps.values(),
             diffs: self.diffs.values(),
         }
     }
@@ -157,10 +152,8 @@ impl ColumnarRecords {
 #[derive(Clone)]
 struct ColumnarRecordsRef<'a> {
     len: usize,
-    key_data: &'a [u8],
-    key_offsets: &'a [i32],
-    val_data: &'a [u8],
-    val_offsets: &'a [i32],
+    key_data: &'a BinaryArray,
+    val_data: &'a BinaryArray,
     timestamps: &'a [i64],
     diffs: &'a [i64],
 }
@@ -173,73 +166,35 @@ impl<'a> fmt::Debug for ColumnarRecordsRef<'a> {
 
 impl<'a> ColumnarRecordsRef<'a> {
     fn validate(&self) -> Result<(), String> {
-        let key_data_size = self.key_offsets.len() * BYTES_PER_KEY_VAL_OFFSET + self.key_data.len();
+        let key_data_size =
+            self.key_data.values().len() + self.key_data.offsets().inner().inner().len();
         if key_data_size > KEY_VAL_DATA_MAX_LEN {
             return Err(format!(
                 "expected encoded key offsets and data size to be less than or equal to {} got {}",
                 KEY_VAL_DATA_MAX_LEN, key_data_size
             ));
         }
-        if self.key_offsets.len() != self.len + 1 {
+        if self.key_data.len() != self.len {
             return Err(format!(
-                "expected {} key_offsets got {}",
-                self.len + 1,
-                self.key_offsets.len()
+                "expected {} keys got {}",
+                self.len,
+                self.key_data.len()
             ));
         }
-        if let Some(first_key_offset) = self.key_offsets.first() {
-            if *first_key_offset != 0 {
-                return Err(format!(
-                    "expected first key offset to be 0 got {}",
-                    first_key_offset
-                ));
-            }
-        }
-        if let Some(last_key_offset) = self.key_offsets.last() {
-            let last_key_offset = last_key_offset.to_usize().ok_or_else(|| {
-                format!("last_key_offset is not valid usize, {}", last_key_offset)
-            })?;
-            if last_key_offset != self.key_data.len() {
-                return Err(format!(
-                    "expected {} bytes of key data got {}",
-                    last_key_offset,
-                    self.key_data.len()
-                ));
-            }
-        }
-        let val_data_size = self.val_offsets.len() * BYTES_PER_KEY_VAL_OFFSET + self.val_data.len();
+        let val_data_size =
+            self.val_data.values().len() + self.val_data.offsets().inner().inner().len();
         if val_data_size > KEY_VAL_DATA_MAX_LEN {
             return Err(format!(
                 "expected encoded val offsets and data size to be less than or equal to {} got {}",
                 KEY_VAL_DATA_MAX_LEN, val_data_size
             ));
         }
-        if self.val_offsets.len() != self.len + 1 {
+        if self.val_data.len() != self.len {
             return Err(format!(
-                "expected {} val_offsets got {}",
-                self.len + 1,
-                self.val_offsets.len()
+                "expected {} vals got {}",
+                self.len,
+                self.val_data.len()
             ));
-        }
-        if let Some(first_val_offset) = self.val_offsets.first() {
-            if *first_val_offset != 0 {
-                return Err(format!(
-                    "expected first val offset to be 0 got {}",
-                    first_val_offset
-                ));
-            }
-        }
-        if let Some(last_val_offset) = self.val_offsets.last() {
-            let last_val_offset = last_val_offset.to_usize().ok_or_else(|| {
-                format!("last_val_offset is not valid usize, {}", last_val_offset)
-            })?;
-            if last_val_offset != self.val_data.len() {
-                return Err(format!(
-                    "expected {} bytes of val data got {}",
-                    last_val_offset,
-                    self.val_data.len()
-                ));
-            }
         }
         if self.diffs.len() != self.len {
             return Err(format!(
@@ -256,31 +211,6 @@ impl<'a> ColumnarRecordsRef<'a> {
             ));
         }
 
-        // Unlike most of our Validate methods, this one is called in a
-        // production code path: when decoding a columnar batch. Only check the
-        // more expensive assertions in debug.
-        #[cfg(debug_assertions)]
-        {
-            let (mut prev_key, mut prev_val) = (0, 0);
-            for i in 0..=self.len {
-                let (key, val) = (self.key_offsets[i], self.val_offsets[i]);
-                if key < prev_key {
-                    return Err(format!(
-                        "expected non-decreasing key offsets got {} followed by {}",
-                        prev_key, key
-                    ));
-                }
-                if val < prev_val {
-                    return Err(format!(
-                        "expected non-decreasing val offsets got {} followed by {}",
-                        prev_val, val
-                    ));
-                }
-                prev_key = key;
-                prev_val = val;
-            }
-        }
-
         Ok(())
     }
 
@@ -292,27 +222,11 @@ impl<'a> ColumnarRecordsRef<'a> {
             return None;
         }
 
-        let key_start = self.key_offsets[idx]
-            .to_usize()
-            .expect("key_start to be valid usize");
-        let key_end = self.key_offsets[idx + 1]
-            .to_usize()
-            .expect("key_end to be valid usize");
-
-        let val_start = self.val_offsets[idx]
-            .to_usize()
-            .expect("val_start to be valid usize");
-        let val_end = self.val_offsets[idx + 1]
-            .to_usize()
-            .expect("val_end to be valid usize");
-
         // There used to be `debug_assert_eq!(self.validate(), Ok(()))`, but it
         // resulted in accidentally O(n^2) behavior in debug mode. Instead, we
         // push that responsibility to the ColumnarRecordsRef constructor.
-        let key_range = key_start..key_end;
-        let val_range = val_start..val_end;
-        let key = &self.key_data[key_range];
-        let val = &self.val_data[val_range];
+        let key = self.key_data.value(idx);
+        let val = self.val_data.value(idx);
         let ts = i64::to_le_bytes(self.timestamps[idx]);
         let diff = i64::to_le_bytes(self.diffs[idx]);
         Some(((key, val), ts, diff))
@@ -352,91 +266,48 @@ impl<'a> ExactSizeIterator for ColumnarRecordsIter<'a> {}
 
 /// An abstraction to incrementally add ((Key, Value), Time, i64) records
 /// in a columnar representation, and eventually get back a [ColumnarRecords].
+#[derive(Debug)]
 pub struct ColumnarRecordsBuilder {
     len: usize,
-    key_data: Vec<u8>,
-    key_offsets: Vec<i32>,
-    val_data: Vec<u8>,
-    val_offsets: Vec<i32>,
+    key_data: BinaryBuilder,
+    val_data: BinaryBuilder,
     timestamps: Vec<i64>,
     diffs: Vec<i64>,
 }
 
-impl fmt::Debug for ColumnarRecordsBuilder {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.borrow(), fmt)
-    }
-}
-
 impl Default for ColumnarRecordsBuilder {
     fn default() -> Self {
-        let mut ret = ColumnarRecordsBuilder {
+        ColumnarRecordsBuilder {
             len: 0,
-            key_data: Vec::new(),
-            key_offsets: Vec::new(),
-            val_data: Vec::new(),
-            val_offsets: Vec::new(),
+            key_data: BinaryBuilder::new(),
+            val_data: BinaryBuilder::new(),
             timestamps: Vec::new(),
             diffs: Vec::new(),
-        };
-        // Push initial 0 offsets to maintain our invariants, even as we build.
-        ret.key_offsets.push(0);
-        ret.val_offsets.push(0);
-        debug_assert_eq!(ret.borrow().validate(), Ok(()));
-        ret
+        }
     }
 }
 
 impl ColumnarRecordsBuilder {
+    /// Reserve space for the given number of items with the given sizes in bytes.
+    /// If they end up being too small, the underlying buffers will be resized as usual.
+    pub fn with_capacity(items: usize, key_bytes: usize, val_bytes: usize) -> Self {
+        let key_data = BinaryBuilder::with_capacity(items, key_bytes);
+        let val_data = BinaryBuilder::with_capacity(items, val_bytes);
+        let timestamps = Vec::with_capacity(items);
+        let diffs = Vec::with_capacity(items);
+        Self {
+            len: 0,
+            key_data,
+            val_data,
+            timestamps,
+            diffs,
+        }
+    }
+
     /// The number of (potentially duplicated) ((Key, Val), Time, i64) records
     /// stored in Self.
     pub fn len(&self) -> usize {
         self.len
-    }
-
-    /// Borrow Self as a [ColumnarRecordsRef].
-    fn borrow<'a>(&'a self) -> ColumnarRecordsRef<'a> {
-        let ret = ColumnarRecordsRef {
-            len: self.len,
-            key_data: self.key_data.as_slice(),
-            key_offsets: self.key_offsets.as_slice(),
-            val_data: self.val_data.as_slice(),
-            val_offsets: self.val_offsets.as_slice(),
-            timestamps: self.timestamps.as_slice(),
-            diffs: self.diffs.as_slice(),
-        };
-        debug_assert_eq!(ret.validate(), Ok(()));
-        ret
-    }
-
-    /// Reserve space for `additional` more records, based on `key_size_guess` and
-    /// `val_size_guess`.
-    ///
-    /// The guesses for key and val sizes are best effort, and if they end up being
-    /// too small, the underlying buffers will be resized.
-    pub fn reserve(&mut self, additional: usize, key_size_guess: usize, val_size_guess: usize) {
-        self.key_offsets.reserve(additional);
-        self.key_data
-            .reserve(cmp::min(additional * key_size_guess, KEY_VAL_DATA_MAX_LEN));
-        self.val_offsets.reserve(additional);
-        self.val_data
-            .reserve(cmp::min(additional * val_size_guess, KEY_VAL_DATA_MAX_LEN));
-        self.timestamps.reserve(additional);
-        self.diffs.reserve(additional);
-        debug_assert_eq!(self.borrow().validate(), Ok(()));
-    }
-
-    /// Reserve space for `additional` more records, with exact sizes for the key and value data.
-    pub fn reserve_exact(&mut self, additional: usize, key_bytes: usize, val_bytes: usize) {
-        self.key_offsets.reserve(additional);
-        self.key_data
-            .reserve(cmp::min(key_bytes, KEY_VAL_DATA_MAX_LEN));
-        self.val_offsets.reserve(additional);
-        self.val_data
-            .reserve(cmp::min(val_bytes, KEY_VAL_DATA_MAX_LEN));
-        self.timestamps.reserve(additional);
-        self.diffs.reserve(additional);
-        debug_assert_eq!(self.borrow().validate(), Ok(()));
     }
 
     /// Returns if the given key_offsets+key_data or val_offsets+val_data fits
@@ -445,11 +316,11 @@ impl ColumnarRecordsBuilder {
     /// Note that limit is always [KEY_VAL_DATA_MAX_LEN] in production. It's
     /// only override-able here for testing.
     pub fn can_fit(&self, key: &[u8], val: &[u8], limit: usize) -> bool {
-        let key_data_size = (self.key_offsets.len() + 1) * BYTES_PER_KEY_VAL_OFFSET
-            + self.key_data.len()
+        let key_data_size = self.key_data.values_slice().len()
+            + self.key_data.offsets_slice().to_byte_slice().len()
             + key.len();
-        let val_data_size = (self.val_offsets.len() + 1) * BYTES_PER_KEY_VAL_OFFSET
-            + self.val_data.len()
+        let val_data_size = self.val_data.values_slice().len()
+            + self.val_data.offsets_slice().to_byte_slice().len()
             + val.len();
         key_data_size <= limit && val_data_size <= limit
     }
@@ -471,12 +342,8 @@ impl ColumnarRecordsBuilder {
 
         // NB: We should never hit the following expects because we check them
         // above.
-        self.key_data.extend_from_slice(key);
-        self.key_offsets
-            .push(i32::try_from(self.key_data.len()).expect("key_data is smaller than 2GB"));
-        self.val_data.extend_from_slice(val);
-        self.val_offsets
-            .push(i32::try_from(self.val_data.len()).expect("val_data is smaller than 2GB"));
+        self.key_data.append_value(key);
+        self.val_data.append_value(val);
         self.timestamps.push(i64::from_le_bytes(ts));
         self.diffs.push(i64::from_le_bytes(diff));
         self.len += 1;
@@ -485,17 +352,15 @@ impl ColumnarRecordsBuilder {
     }
 
     /// Finalize constructing a [ColumnarRecords].
-    pub fn finish(self, metrics: &ColumnarMetrics) -> ColumnarRecords {
+    pub fn finish(mut self, _metrics: &ColumnarMetrics) -> ColumnarRecords {
         // We're almost certainly going to immediately encode this and drop it,
-        // so don't bother actually copying the data into lgalloc, use the
-        // `heap_region` method instead. Revisit if that changes.
+        // so don't bother actually copying the data into lgalloc.
+        // Revisit if that changes.
         let ret = ColumnarRecords {
             len: self.len,
-            key_data: MaybeLgBytes::Bytes(Bytes::from(self.key_data)),
-            key_offsets: Arc::new(metrics.lgbytes_arrow.heap_region(self.key_offsets)),
-            val_data: MaybeLgBytes::Bytes(Bytes::from(self.val_data)),
-            val_offsets: Arc::new(metrics.lgbytes_arrow.heap_region(self.val_offsets)),
-            timestamps: Arc::new(metrics.lgbytes_arrow.heap_region(self.timestamps)),
+            key_data: BinaryBuilder::finish(&mut self.key_data),
+            val_data: BinaryBuilder::finish(&mut self.val_data),
+            timestamps: self.timestamps.into(),
             diffs: self.diffs.into(),
         };
         debug_assert_eq!(ret.borrow().validate(), Ok(()));
@@ -515,11 +380,11 @@ impl ColumnarRecords {
     pub fn into_proto(&self) -> ProtoColumnarRecords {
         ProtoColumnarRecords {
             len: self.len.into_proto(),
-            key_offsets: (*self.key_offsets).as_ref().to_vec(),
-            key_data: Bytes::copy_from_slice(self.key_data.as_ref()),
-            val_offsets: (*self.val_offsets).as_ref().to_vec(),
-            val_data: Bytes::copy_from_slice(self.val_data.as_ref()),
-            timestamps: (*self.timestamps).as_ref().to_vec(),
+            key_offsets: self.key_data.offsets().to_vec(),
+            key_data: Bytes::copy_from_slice(self.key_data.value_data()),
+            val_offsets: self.val_data.offsets().to_vec(),
+            val_data: Bytes::copy_from_slice(self.val_data.value_data()),
+            timestamps: self.timestamps.values().to_vec(),
             diffs: self.diffs.values().to_vec(),
         }
     }
@@ -529,14 +394,23 @@ impl ColumnarRecords {
         lgbytes: &ColumnarMetrics,
         proto: ProtoColumnarRecords,
     ) -> Result<Self, TryFromProtoError> {
+        let binary_array = |data: Bytes, offsets: Vec<i32>| match BinaryArray::try_new(
+            OffsetBuffer::new(offsets.into()),
+            data.into(),
+            None,
+        ) {
+            Ok(data) => Ok(realloc_array(&data, lgbytes)),
+            Err(e) => Err(TryFromProtoError::InvalidFieldError(format!(
+                "Unable to decode binary array from repeated proto fields: {e:?}"
+            ))),
+        };
+
         let ret = ColumnarRecords {
             len: proto.len.into_rust()?,
-            key_offsets: Arc::new(lgbytes.lgbytes_arrow.heap_region(proto.key_offsets)),
-            key_data: MaybeLgBytes::Bytes(proto.key_data),
-            val_offsets: Arc::new(lgbytes.lgbytes_arrow.heap_region(proto.val_offsets)),
-            val_data: MaybeLgBytes::Bytes(proto.val_data),
-            timestamps: Arc::new(lgbytes.lgbytes_arrow.heap_region(proto.timestamps)),
-            diffs: proto.diffs.into(),
+            key_data: binary_array(proto.key_data, proto.key_offsets)?,
+            val_data: binary_array(proto.val_data, proto.val_offsets)?,
+            timestamps: realloc_array(&proto.timestamps.into(), lgbytes),
+            diffs: realloc_array(&proto.diffs.into(), lgbytes),
         };
         let () = ret
             .borrow()

--- a/src/persist/src/indexed/columnar/arrow.rs
+++ b/src/persist/src/indexed/columnar/arrow.rs
@@ -69,11 +69,7 @@ pub fn encode_arrow_batch_kvtd(x: &ColumnarRecords) -> Vec<arrow::array::ArrayRe
         None,
     )
     .expect("valid ts array");
-    let diff = PrimitiveArray::<arrow::datatypes::Int64Type>::try_new(
-        (*x.diffs).as_ref().to_vec().into(),
-        None,
-    )
-    .expect("valid diff array");
+    let diff = x.diffs.clone();
 
     vec![Arc::new(key), Arc::new(val), Arc::new(ts), Arc::new(diff)]
 }
@@ -202,7 +198,7 @@ pub fn decode_arrow_batch_kvtd(
     let val_data = Arc::new(to_region(val.value_data(), metrics));
 
     let timestamps = Arc::new(to_region(&time.values()[..], metrics));
-    let diffs = Arc::new(to_region(&diff.values()[..], metrics));
+    let diffs = realloc_primitive(diff, metrics);
 
     let len = key.len();
     let ret = ColumnarRecords {

--- a/src/persist/src/workload.rs
+++ b/src/persist/src/workload.rs
@@ -159,10 +159,10 @@ impl DataGenerator {
         if batch_start >= batch_end {
             return None;
         }
-        let mut batch = ColumnarRecordsBuilder::default();
-        batch.reserve(
-            batch_end - batch_start,
-            self.record_size_bytes - TS_DIFF_GOODPUT_SIZE,
+        let items = batch_end - batch_start;
+        let mut batch = ColumnarRecordsBuilder::with_capacity(
+            items,
+            (self.record_size_bytes - TS_DIFF_GOODPUT_SIZE) * items,
             0,
         );
         for record_idx in batch_start..batch_end {

--- a/src/storage/examples/upsert_open_loop/workload.rs
+++ b/src/storage/examples/upsert_open_loop/workload.rs
@@ -212,10 +212,11 @@ impl DataGenerator {
         if batch_start >= batch_end {
             return None;
         }
-        let mut batch = ColumnarRecordsBuilder::default();
-        batch.reserve(
-            batch_end - batch_start,
-            self.key_record_size_bytes + self.value_record_size_bytes - TS_DIFF_GOODPUT_SIZE,
+        let items = batch_end - batch_start;
+        let mut batch = ColumnarRecordsBuilder::with_capacity(
+            items,
+            (self.key_record_size_bytes + self.value_record_size_bytes - TS_DIFF_GOODPUT_SIZE)
+                * items,
             0,
         );
         for record_idx in batch_start..batch_end {


### PR DESCRIPTION
- Allow shifting arrow arrays to lgalloc-backed storage.
- Switch to using arrow abstractions instead of lgalloc-flavoured abstractions in `ColumnarRecords` using the new helpers.

### Motivation

Known desirable: https://github.com/MaterializeInc/materialize/issues/27571

In particular, using these for `ColumnarRecords` avoids some conversion costs and some duplicate validations. (Some of the properties we manually validated are guaranteed in arrow by construction.)

The main incentive is to allow re-allocating `StructArrays` and other complex types, but I plan to leave that for a future PR.

### Tips for reviewer

Nightlies: https://buildkite.com/materialize/nightly/builds/8437#_. Any errors also seem to happen on `main`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
