### PR TITLE
storage/postgres: Clean up postgres purification

### DIFF
--- a/src/postgres-util/src/replication.rs
+++ b/src/postgres-util/src/replication.rs
@@ -53,25 +53,13 @@ fn test_wal_level_max() {
     }
 }
 
-pub async fn get_wal_level(
-    ssh_tunnel_manager: &SshTunnelManager,
-    config: &Config,
-) -> Result<WalLevel, PostgresError> {
-    let client = config
-        .connect("wal_level_check", ssh_tunnel_manager)
-        .await?;
+pub async fn get_wal_level(client: &Client) -> Result<WalLevel, PostgresError> {
     let wal_level = client.query_one("SHOW wal_level", &[]).await?;
     let wal_level: String = wal_level.get("wal_level");
     Ok(WalLevel::from_str(&wal_level)?)
 }
 
-pub async fn get_max_wal_senders(
-    ssh_tunnel_manager: &SshTunnelManager,
-    config: &Config,
-) -> Result<i64, PostgresError> {
-    let client = config
-        .connect("max_wal_senders_check", ssh_tunnel_manager)
-        .await?;
+pub async fn get_max_wal_senders(client: &Client) -> Result<i64, PostgresError> {
     let max_wal_senders = client
         .query_one(
             "SELECT CAST(current_setting('max_wal_senders') AS int8) AS max_wal_senders",
@@ -81,14 +69,7 @@ pub async fn get_max_wal_senders(
     Ok(max_wal_senders.get("max_wal_senders"))
 }
 
-pub async fn available_replication_slots(
-    ssh_tunnel_manager: &SshTunnelManager,
-    config: &Config,
-) -> Result<i64, PostgresError> {
-    let client = config
-        .connect("postgres_check_replication_slots", ssh_tunnel_manager)
-        .await?;
-
+pub async fn available_replication_slots(client: &Client) -> Result<i64, PostgresError> {
     let available_replication_slots = client
         .query_one(
             "SELECT
@@ -164,14 +145,7 @@ pub async fn get_timeline_id(replication_client: &Client) -> Result<u64, Postgre
     }
 }
 
-pub async fn get_current_wal_lsn(
-    ssh_tunnel_manager: &SshTunnelManager,
-    config: Config,
-) -> Result<PgLsn, PostgresError> {
-    let client = config
-        .connect("postgres_wal_lsn", ssh_tunnel_manager)
-        .await?;
-
+pub async fn get_current_wal_lsn(client: &Client) -> Result<PgLsn, PostgresError> {
     let row = client.query_one("SELECT pg_current_wal_lsn()", &[]).await?;
     let lsn: PgLsn = row.get(0);
 

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -14,15 +14,17 @@ use std::collections::{BTreeMap, BTreeSet};
 use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::Config;
 use mz_sql_parser::ast::display::AstDisplay;
-use mz_sql_parser::ast::UnresolvedItemName;
 use mz_sql_parser::ast::{
     ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CreateSubsourceStatement, Ident,
     WithOptionValue,
 };
+use mz_sql_parser::ast::{ReferencedSubsources, UnresolvedItemName};
+use mz_storage_types::connections::PostgresConnection;
 use mz_storage_types::sources::SubsourceResolver;
 use tokio_postgres::types::Oid;
 use tokio_postgres::Client;
 
+use crate::catalog::SessionCatalog;
 use crate::names::{Aug, PartialItemName, ResolvedItemName};
 use crate::normalize;
 use crate::plan::{PlanError, StatementContext};
@@ -53,7 +55,6 @@ pub(super) fn generate_text_columns(
     subsource_resolver: &SubsourceResolver,
     references: &[PostgresTableDesc],
     text_columns: &mut [UnresolvedItemName],
-    option_name: &str,
 ) -> Result<BTreeMap<u32, BTreeSet<String>>, PlanError> {
     let mut text_cols_dict: BTreeMap<u32, BTreeSet<String>> = BTreeMap::new();
 
@@ -61,7 +62,7 @@ pub(super) fn generate_text_columns(
         let (qual, col) = match name.0.split_last().expect("must have at least one element") {
             (col, qual) if qual.is_empty() => {
                 return Err(PlanError::InvalidOptionValue {
-                    option_name: option_name.to_string(),
+                    option_name: "TEXT COLUMNS".to_string(),
                     err: Box::new(PlanError::UnderqualifiedColumnName(
                         col.as_str().to_string(),
                     )),
@@ -75,7 +76,7 @@ pub(super) fn generate_text_columns(
         let (mut fully_qualified_name, idx) =
             subsource_resolver.resolve(&qual_name.0, 3).map_err(|e| {
                 PlanError::InvalidOptionValue {
-                    option_name: option_name.to_string(),
+                    option_name: "TEXT COLUMNS".to_string(),
                     err: Box::new(e.into()),
                 }
             })?;
@@ -93,7 +94,7 @@ pub(super) fn generate_text_columns(
                 })
                 .collect();
             return Err(PlanError::InvalidOptionValue {
-                option_name: option_name.to_string(),
+                option_name: "TEXT COLUMNS".to_string(),
                 err: Box::new(PlanError::UnknownColumn {
                     table: Some(
                         normalize::unresolved_item_name(fully_qualified_name)
@@ -117,7 +118,7 @@ pub(super) fn generate_text_columns(
 
         if !new {
             return Err(PlanError::InvalidOptionValue {
-                option_name: option_name.to_string(),
+                option_name: "TEXT COLUMNS".to_string(),
                 err: Box::new(PlanError::UnexpectedDuplicateReference { name: name.clone() }),
             });
         }
@@ -285,6 +286,154 @@ pub(crate) fn generate_targeted_subsources(
     }
 
     Ok((subsources, referenced_tables))
+}
+
+pub(super) struct PurifiedSubsources {
+    pub(super) new_subsources: Vec<CreateSubsourceStatement<Aug>>,
+    pub(super) referenced_tables: Vec<PostgresTableDesc>,
+    pub(super) normalized_text_columns: Vec<WithOptionValue<Aug>>,
+}
+
+// Purify the referenced subsources, return the list of subsource statements,
+// corresponding tables, and and additional fields necessary to update the source
+// options
+pub(super) async fn purify_subsources(
+    client: &Client,
+    config: &mz_postgres_util::Config,
+    publication: &str,
+    connection: &PostgresConnection,
+    referenced_subsources: &mut Option<ReferencedSubsources>,
+    mut text_columns: Vec<UnresolvedItemName>,
+    resolved_source_name: Option<ResolvedItemName>,
+    unresolved_source_name: &UnresolvedItemName,
+    catalog: &impl SessionCatalog,
+) -> Result<PurifiedSubsources, PlanError> {
+    let publication_tables = mz_postgres_util::publication_info(client, publication).await?;
+
+    if publication_tables.is_empty() {
+        Err(PgSourcePurificationError::EmptyPublication(
+            publication.to_string(),
+        ))?;
+    }
+
+    let subsource_resolver = SubsourceResolver::new(&connection.database, &publication_tables)?;
+
+    let mut validated_requested_subsources = vec![];
+    match referenced_subsources
+        .as_mut()
+        .ok_or(PgSourcePurificationError::RequiresReferencedSubsources)?
+    {
+        ReferencedSubsources::All => {
+            for table in &publication_tables {
+                let upstream_name = UnresolvedItemName::qualified(&[
+                    Ident::new(&connection.database)?,
+                    Ident::new(&table.namespace)?,
+                    Ident::new(&table.name)?,
+                ]);
+                let subsource_name =
+                    super::subsource_name_gen(unresolved_source_name, &table.name)?;
+                validated_requested_subsources.push(RequestedSubsource {
+                    upstream_name,
+                    subsource_name,
+                    table,
+                });
+            }
+        }
+        ReferencedSubsources::SubsetSchemas(schemas) => {
+            let available_schemas: BTreeSet<_> = mz_postgres_util::get_schemas(client)
+                .await?
+                .into_iter()
+                .map(|s| s.name)
+                .collect();
+
+            let requested_schemas: BTreeSet<_> =
+                schemas.iter().map(|s| s.as_str().to_string()).collect();
+
+            let missing_schemas: Vec<_> = requested_schemas
+                .difference(&available_schemas)
+                .map(|s| s.to_string())
+                .collect();
+
+            if !missing_schemas.is_empty() {
+                Err(PgSourcePurificationError::DatabaseMissingFilteredSchemas {
+                    database: connection.database.clone(),
+                    schemas: missing_schemas,
+                })?;
+            }
+
+            for table in &publication_tables {
+                if !requested_schemas.contains(table.namespace.as_str()) {
+                    continue;
+                }
+
+                let upstream_name = UnresolvedItemName::qualified(&[
+                    Ident::new(&connection.database)?,
+                    Ident::new(&table.namespace)?,
+                    Ident::new(&table.name)?,
+                ]);
+                let subsource_name =
+                    super::subsource_name_gen(unresolved_source_name, &table.name)?;
+                validated_requested_subsources.push(RequestedSubsource {
+                    upstream_name,
+                    subsource_name,
+                    table,
+                });
+            }
+        }
+        ReferencedSubsources::SubsetTables(subsources) => {
+            // The user manually selected a subset of upstream tables so we need to
+            // validate that the names actually exist and are not ambiguous
+            validated_requested_subsources.extend(super::subsource_gen(
+                subsources,
+                &subsource_resolver,
+                &publication_tables,
+                3,
+                unresolved_source_name,
+            )?);
+        }
+    };
+
+    if validated_requested_subsources.is_empty() {
+        sql_bail!(
+            "[internal error]: Postgres source must ingest at least one table, but {} matched none",
+            referenced_subsources.as_ref().unwrap().to_ast_string()
+        );
+    }
+
+    super::validate_subsource_names(&validated_requested_subsources)?;
+
+    let table_oids: Vec<_> = validated_requested_subsources
+        .iter()
+        .map(|r| r.table.oid)
+        .collect();
+
+    validate_requested_subsources_privileges(config, client, &table_oids).await?;
+
+    let text_cols_dict =
+        generate_text_columns(&subsource_resolver, &publication_tables, &mut text_columns)?;
+
+    // Normalize options to contain full qualified values.
+    text_columns.sort();
+    text_columns.dedup();
+    let normalized_text_columns: Vec<_> = text_columns
+        .into_iter()
+        .map(WithOptionValue::UnresolvedItemName)
+        .collect();
+
+    let scx = StatementContext::new(None, catalog);
+    let (new_subsources, referenced_tables) = generate_targeted_subsources(
+        &scx,
+        resolved_source_name,
+        validated_requested_subsources,
+        text_cols_dict,
+        &publication_tables,
+    )?;
+
+    Ok(PurifiedSubsources {
+        new_subsources,
+        referenced_tables,
+        normalized_text_columns,
+    })
 }
 
 mod privileges {

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -88,12 +88,14 @@ impl PostgresSourceConnection {
                 mz_ore::future::InTask::No,
             )
             .await?;
+        let client = config
+            .connect(
+                "postgres_wal_lsn",
+                &storage_configuration.connection_context.ssh_tunnel_manager,
+            )
+            .await?;
 
-        let lsn = mz_postgres_util::get_current_wal_lsn(
-            &storage_configuration.connection_context.ssh_tunnel_manager,
-            config,
-        )
-        .await?;
+        let lsn = mz_postgres_util::get_current_wal_lsn(&client).await?;
 
         let current_upper = Antichain::from_elem(MzOffset::from(u64::from(lsn)));
         Ok(current_upper)

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -780,12 +780,11 @@ fn extract_transaction<'a>(
                         // to check the current local schema against the current remote schema to
                         // ensure e.g. we haven't received a schema update with the same terminal
                         // column name which is actually a different column.
-                        let upstream_info = mz_postgres_util::publication_info(
-                            ssh_tunnel_manager,
-                            connection_config,
-                            publication,
-                        )
-                        .await?;
+                        let client = connection_config
+                            .connect("replication schema verification", ssh_tunnel_manager)
+                            .await?;
+                        let upstream_info =
+                            mz_postgres_util::publication_info(&client, publication).await?;
                         let upstream_info = upstream_info.into_iter().map(|t| (t.oid, t)).collect();
 
                         if let Err(err) =


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

The first commit refactors postgres source purification to share the same client connection across the various methods that verify postgres settings and permissions.

The second commit pulls all the common postgres logic used in both `purify_create_source` and `purify_alter_source` methods into a shared method in the `pure::postgres` module. This new structure matches what we did for the MySQL logic here https://github.com/MaterializeInc/materialize/pull/27416/commits/96e904f22c2d8badca33294ba6e3ea6f9d63611a and should help simplify my next task to refactor subsource planning. There should be no functional differences with this commit.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]


    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
