### PR TITLE
storage/sink/kafka: record number of consumed progress records

### DIFF
--- a/src/storage/src/metrics/sink/kafka.rs
+++ b/src/storage/src/metrics/sink/kafka.rs
@@ -51,6 +51,8 @@ pub(crate) struct KafkaSinkMetricDefs {
     pub rdkafka_disconnects: IntGaugeVec,
     /// The number of outstanding progress records that need to be read before the sink can resume.
     pub outstanding_progress_records: UIntGaugeVec,
+    /// The number of progress records consumed while resuming the sink.
+    pub consumed_progress_records: UIntGaugeVec,
     /// The number of partitions this sink is publishing to.
     pub partition_count: UIntGaugeVec,
 }
@@ -142,6 +144,11 @@ impl KafkaSinkMetricDefs {
                 help: "The number of outstanding progress records that need to be read before the sink can resume.",
                 var_labels: ["sink_id"],
             )),
+            consumed_progress_records: registry.register(metric!(
+                name: "mz_sink_consumed_progress_records",
+                help: "The number of progress records consumed by the sink.",
+                var_labels: ["sink_id"],
+            )),
             partition_count: registry.register(metric!(
                 name: "mz_sink_partition_count",
                 help: "The number of partitions this sink is publishing to.",
@@ -187,6 +194,8 @@ pub(crate) struct KafkaSinkMetrics {
     pub rdkafka_disconnects: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
     /// The number of outstanding progress records that need to be read before the sink can resume.
     pub outstanding_progress_records: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    /// The number of progress records consumed while resuming the sink.
+    pub consumed_progress_records: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     /// The number of partitions this sink is publishing to.
     pub partition_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
 }
@@ -241,6 +250,9 @@ impl KafkaSinkMetrics {
                 .get_delete_on_drop_gauge(labels.to_vec()),
             outstanding_progress_records: defs
                 .outstanding_progress_records
+                .get_delete_on_drop_gauge(labels.to_vec()),
+            consumed_progress_records: defs
+                .consumed_progress_records
                 .get_delete_on_drop_gauge(labels.to_vec()),
             partition_count: defs
                 .partition_count

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -875,6 +875,8 @@ async fn determine_sink_progress(
         // transactions, there might even be a lot of garbage at the end of the
         // topic or in between.
 
+        metrics.consumed_progress_records.set(0);
+
         // First, determine the current high water mark for the progress topic.
         // This is the position our `progress_client` consumer *must* reach
         // before we can conclude that we've seen the latest progress record for
@@ -1011,6 +1013,8 @@ async fn determine_sink_progress(
                 // This is a progress message for a different sink.
                 continue;
             }
+
+            metrics.consumed_progress_records.inc();
 
             let Some(payload) = message.payload() else {
                 continue


### PR DESCRIPTION
We want a metric that reveals whether compaction is working on users' progress topics.

The outstanding_progress_records metric is close, but the low water mark of a topic may get stuck arbitrarily far in the past if a sink is dropped, so the delta between a progress topic's high and low water marks is not a good measure of whether a user has enabled compaction.

Instead, introduce a consumed_progress_records metric, which directly records the number of messages in a progress topic for each sink. If this number ever ticks up into the hundreds of thousands or millions, that is a clear sign that compaction is not working.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR adds a known desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
