### PR TITLE
ci:annotate errors: support additional collapsible section for further details

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -157,7 +157,7 @@ class JunitError:
 @dataclass(kw_only=True, unsafe_hash=True)
 class ObservedError(ObservedBaseError):
     # abstract class, do not instantiate
-    error_message: str | None
+    error_message: str
     error_details: str | None = None
     error_type: str
     location: str

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -496,11 +496,12 @@ def annotate_logged_errors(
                     )
                 )
             else:
+                # JUnit error
                 handle_error(
-                    error.message,
-                    error.text,
-                    error.testcase,
-                    None,
+                    error_message=error.message,
+                    error_details=error.text,
+                    location=error.testcase,
+                    location_url=None,
                 )
         else:
             raise RuntimeError(f"Unexpected error type: {type(error)}")

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -44,6 +44,8 @@ from materialize.ui import UIError
 RECOMMENDED_MIN_MEM = 7 * 1024**3  # 7GiB
 RECOMMENDED_MIN_CPUS = 2
 
+JUNIT_ERROR_DETAILS_SEPARATOR = "###---###"
+
 
 def main(argv: list[str]) -> None:
     parser = ArgumentParser(
@@ -687,7 +689,17 @@ To see the available workflows, run:
                     # do not provide the duration when multiple errors are derived from a test execution
                     elapsed_sec=None,
                 )
-                test_case.add_error_info(message=error.message, output=error.details)
+
+                error_details_data = error.details
+                if error.additional_details is not None:
+                    error_details_data = (error_details_data or "") + (
+                        f"{JUNIT_ERROR_DETAILS_SEPARATOR}{error.additional_details_header or 'Additional details'}"
+                        f"{JUNIT_ERROR_DETAILS_SEPARATOR}{error.additional_details}"
+                    )
+
+                test_case.add_error_info(
+                    message=error.message, output=error_details_data
+                )
                 junit_suite.test_cases.append(test_case)
 
     def write_junit_report_to_file(self, junit_suite: junit_xml.TestSuite) -> Path:

--- a/misc/python/materialize/mzcompose/test_result.py
+++ b/misc/python/materialize/mzcompose/test_result.py
@@ -36,6 +36,8 @@ class TestFailureDetails:
 
     message: str
     details: str | None
+    additional_details_header: str | None = None
+    additional_details: str | None = None
     test_class_name_override: str | None = None
     """The test class usually describes the framework."""
     test_case_name_override: str | None = None


### PR DESCRIPTION
This is the base for https://github.com/MaterializeInc/materialize/pull/28067.

### Commits
e5b6de2da0 ci: junit.xml: store additional details
cbb2684333 ci: annotate errors: make error message not nullable
31b87213e6 ci: annotate errors: extract functions
d035b2ebd8 ci: annotate errors: minor
6dbfce9e1c ci: annotate errors: include additional details in annotations

### Demo
<img width="1006" alt="Bildschirmfoto 2024-07-09 um 11 35 39" src="https://github.com/MaterializeInc/materialize/assets/129728240/16dccf80-b7a0-4dc4-af4a-6dad912cb086">

The section will be collapsed by default.