### PR TITLE
mzbuild: Print output on failure

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -415,10 +415,14 @@ class CargoBuild(CargoPreImage):
                 self.rd, self.bins, self.examples
             )
 
-            output = spawn.capture(
-                cargo_build + ["--message-format=json"],
-                cwd=self.rd.root,
-            )
+            try:
+                output = spawn.capture(
+                    cargo_build + ["--message-format=json"],
+                    cwd=self.rd.root,
+                )
+            except subprocess.CalledProcessError as e:
+                print(e.stdout)
+                raise
             target_dir = self.rd.cargo_target_dir()
             for line in output.split("\n"):
                 if line.strip() == "" or not line.startswith("{"):


### PR DESCRIPTION
Reported in https://materializeinc.slack.com/archives/C01LKF361MZ/p1720469094875789

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
