### PR TITLE
binaries: panic in response to errors in `main`

### DIFF
--- a/src/balancerd/src/main.rs
+++ b/src/balancerd/src/main.rs
@@ -66,8 +66,7 @@ fn main() {
     };
 
     if let Err(err) = res {
-        eprintln!("balancer: fatal: {}", err.display_with_causes());
-        std::process::exit(1);
+        panic!("balancer: fatal: {}", err.display_with_causes());
     }
     drop(_tracing_guard);
 }

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0.
 
 use std::path::PathBuf;
-use std::process;
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -156,8 +155,7 @@ async fn main() {
         enable_version_flag: true,
     });
     if let Err(err) = run(args).await {
-        eprintln!("clusterd: fatal: {}", err.display_with_causes());
-        process::exit(1);
+        panic!("clusterd: fatal: {}", err.display_with_causes());
     }
 }
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::{cmp, env, iter, process, thread};
+use std::{cmp, env, iter, thread};
 
 use anyhow::{bail, Context};
 use clap::{ArgEnum, Parser};
@@ -581,8 +581,7 @@ fn main() {
         enable_version_flag: true,
     });
     if let Err(err) = run(args) {
-        eprintln!("environmentd: fatal: {}", err.display_with_causes());
-        process::exit(1);
+        panic!("environmentd: fatal: {}", err.display_with_causes());
     }
 }
 


### PR DESCRIPTION
This PR changes the error behavior of the Mz binaries to panic instead of printing to stderr and then exiting. This is to ensure that these errors end up in Sentry and we don't miss them.

[Relevant Slack thread.](https://materializeinc.slack.com/archives/CTESPM7FU/p1720468349254209)

### Motivation

  * This PR fixes a previously unreported bug.

When a binary, like `environmentd`, encounters an error that gets bubbled up to its `main` function, it exists the process in a way that prevents Sentry from observing the error.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A