### PR TITLE
catalog: Fixup savepoint catalog commit and sync

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -380,7 +380,7 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
         // Savepoint catalogs do not yet know how to update themselves in response to concurrent
         // writes from writer catalogs.
         if self.mode == Mode::Savepoint {
-            self.upper = target_upper;
+            self.upper = max(self.upper, target_upper);
             return Ok(());
         }
 
@@ -1419,6 +1419,7 @@ impl DurableCatalogState for PersistCatalogState {
                         .into_iter()
                         .map(|(kind, diff)| StateUpdate { kind, ts, diff });
                 catalog.apply_updates(updates)?;
+                catalog.upper = catalog.upper.step_forward();
             }
 
             Ok(())


### PR DESCRIPTION
This commit is a followup to cef629e91d81eab91a7f200e7e72c056d8fabe27 that adds the following fixup features:

  - Commits in savepoint catalogs increment the in-memory catalog upper. This isn't strictly necessary in savepoint mode since the upper isn't used for anything, however it matches the behavior of write mode.
  - Sync sets the current upper to the max of the target upper and the current upper, instead of blindly setting it to the target upper. This protects against a caller trying to sync in the past and causing the upper to decrease, which should be impossible. There is no current code path where a caller would pass a timestamp less than the current upper, but it's better to protect against it.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
