### PR TITLE
test: attempt to deflake source-statistics.td

### DIFF
--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -86,7 +86,10 @@ mammalmore    moosemoose   2
 $ set-sql-timeout duration=2minutes
 
 # Also test a source with multiple sub-sources.
-> CREATE SOURCE auction_house
+# NOTE: We give this source a unique name because we want to query for it with
+# a `SUBSCRIBE ... AS OF AT LEAST 0` below and want to avoid receiving results
+# for sources created by previous tests.
+> CREATE SOURCE auction_house_in_source_statistics_td
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
@@ -112,11 +115,11 @@ metrics_test_source true 2 2 2 true true
   SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0, bool_and(u.rehydration_latency IS NOT NULL)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics_raw u ON s.id = u.id
-  WHERE s.name IN ('accounts', 'auction_house', 'auctions', 'bids', 'organizations', 'users')
+  WHERE s.name IN ('accounts', 'auction_house_in_source_statistics_td', 'auctions', 'bids', 'organizations', 'users')
   GROUP BY s.name
   ORDER BY s.name
 accounts       true      false   true  true  false   true
-auction_house  true      true    false false true    true
+auction_house_in_source_statistics_td true true false false true true
 auctions       true      false   true  true  false   true
 bids           true      false   true  true  false   true
 organizations  true      false   true  true  false   true
@@ -131,7 +134,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
     SELECT u.messages_received
       FROM mz_sources s
       JOIN mz_internal.mz_source_statistics_with_history u ON s.id = u.id
-      WHERE s.name = 'auction_house'
+      WHERE s.name = 'auction_house_in_source_statistics_td'
     )
   AS OF AT LEAST 0
 
@@ -140,7 +143,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 > COMMIT
 
-> DROP SOURCE auction_house CASCADE
+> DROP SOURCE auction_house_in_source_statistics_td CASCADE
 
 # Test upsert
 


### PR DESCRIPTION
Because the environment is not reset between testdrive runs, and we are querying retained-metrics collections with `AS OF AT LEAST 0`, there is a risk that we are seeing contents from previously run testdrive files. Avoid this possibility by using a unique name for the load generator source we filter on.

### Motivation

  * This PR fixes a previously unreported bug.

`source-statistics.td` is flaky: https://buildkite.com/materialize/nightly/builds/8406#01909368-2a7c-4932-ac32-463f8e28a97e

### Tips for reviewer

Not sure how to reproduce the flake, so this fix might or might not be the correct one to prevent the flake.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A