### PR TITLE
storage/sources: Update definite error messaging to indicate source must be recreated to user

### DIFF
--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -400,11 +400,17 @@ impl Display for SourceErrorDetails {
             SourceErrorDetails::Initialization(e) => {
                 write!(
                     f,
-                    "failed during initialization, must be dropped and recreated: {}",
+                    "failed during initialization, source must be dropped and recreated: {}",
                     e
                 )
             }
-            SourceErrorDetails::Other(e) => write!(f, "{}", e),
+            SourceErrorDetails::Other(e) => {
+                write!(
+                    f,
+                    "source must be dropped and recreated due to failure: {}",
+                    e
+                )
+            }
         }
     }
 }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -320,7 +320,29 @@ pub enum DefiniteError {
 impl From<DefiniteError> for DataflowError {
     fn from(err: DefiniteError) -> Self {
         DataflowError::SourceError(Box::new(SourceError {
-            error: SourceErrorDetails::Other(err.to_string()),
+            error: match &err {
+                DefiniteError::SlotCompactedPastResumePoint(_, _) => {
+                    SourceErrorDetails::Other(err.to_string())
+                }
+                DefiniteError::TableTruncated => SourceErrorDetails::Other(err.to_string()),
+                DefiniteError::TableDropped => SourceErrorDetails::Other(err.to_string()),
+                DefiniteError::PublicationDropped(_) => {
+                    SourceErrorDetails::Initialization(err.to_string())
+                }
+                DefiniteError::InvalidReplicationSlot => {
+                    SourceErrorDetails::Initialization(err.to_string())
+                }
+                DefiniteError::MissingColumn => SourceErrorDetails::Other(err.to_string()),
+                DefiniteError::InvalidCopyInput => SourceErrorDetails::Other(err.to_string()),
+                DefiniteError::InvalidTimelineId { .. } => {
+                    SourceErrorDetails::Initialization(err.to_string())
+                }
+                DefiniteError::MissingToast => SourceErrorDetails::Other(err.to_string()),
+                DefiniteError::DefaultReplicaIdentity => SourceErrorDetails::Other(err.to_string()),
+                DefiniteError::IncompatibleSchema(_) => SourceErrorDetails::Other(err.to_string()),
+                DefiniteError::InvalidUTF8(_) => SourceErrorDetails::Other(err.to_string()),
+                DefiniteError::CastError(_) => SourceErrorDetails::Other(err.to_string()),
+            },
         }))
     }
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

A user was confused about recoverability when encountering a DefiniteError in a MySQL source due to an invalid system configuration. This PR updates the error string to indicate that source DefiniteErrors cannot be retracted and will require a source to be dropped and recreated.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
