### PR TITLE
storage: Prevent finalization in read-only mode

### DIFF
--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -2459,6 +2459,7 @@ async fn finalize_shards_task<T>(
     T: TimelyTimestamp + Lattice + Codec64,
 {
     if read_only {
+        info!("disabling shard finalization in read only mode");
         return;
     }
 

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -493,6 +493,7 @@ where
                 finalized_shards: Arc::clone(&finalized_shards),
                 persist_location: persist_location.clone(),
                 persist: Arc::clone(&persist_clients),
+                read_only,
             }),
         );
 
@@ -2441,6 +2442,7 @@ struct FinalizeShardsTaskConfig {
     finalized_shards: Arc<std::sync::Mutex<BTreeSet<ShardId>>>,
     persist_location: PersistLocation,
     persist: Arc<PersistClientCache>,
+    read_only: bool,
 }
 
 async fn finalize_shards_task<T>(
@@ -2451,10 +2453,15 @@ async fn finalize_shards_task<T>(
         finalized_shards,
         persist_location,
         persist,
+        read_only,
     }: FinalizeShardsTaskConfig,
 ) where
     T: TimelyTimestamp + Lattice + Codec64,
 {
+    if read_only {
+        return;
+    }
+
     let mut interval = tokio::time::interval(Duration::from_secs(5));
     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
     loop {


### PR DESCRIPTION
This commit prevents shard finalization in read-only mode. Read-only mode should not affect changes to external systems. Previously, if a shard was present in the unfinalized/finalizable shard list on a read only instance, which could happen as a result of a well-timed startup, the read-only instance would attempt to forcibly downgrade the shard's upper and since and finalize the shard.

Works towards resolving #27981

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
