### PR TITLE
ore: Add `assert_none!`, `assert_ok!`, and `assert_err!` macros

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -62,7 +62,7 @@ use mz_catalog::memory::objects::{
     CatalogItem, Cluster, Connection, DataSourceDesc, Sink, Source, Table, Type,
 };
 use mz_ore::cast::CastFrom;
-use mz_ore::instrument;
+use mz_ore::{assert_none, instrument};
 use mz_persist_client::stats::SnapshotPartStats;
 use mz_sql::ast::AlterSourceAddSubsourceOption;
 use mz_sql::plan::{
@@ -424,7 +424,7 @@ impl Coordinator {
         // source needs to know its shard ID, and the easiest way of
         // guaranteeing that the shard ID is discoverable is to create this
         // collection first.
-        assert!(progress_stmt.of_source.is_none());
+        assert_none!(progress_stmt.of_source);
         let progress_plan = self
             .plan_subsource(ctx.session(), &params, progress_stmt)
             .await?;

--- a/src/adapter/src/coord/validity.rs
+++ b/src/adapter/src/coord/validity.rs
@@ -130,7 +130,7 @@ mod tests {
     use mz_adapter_types::connection::ConnectionId;
     use mz_cluster_client::ReplicaId;
     use mz_controller_types::ClusterId;
-    use mz_ore::assert_contains;
+    use mz_ore::{assert_contains, assert_ok};
     use mz_repr::role_id::RoleId;
     use mz_repr::{GlobalId, Timestamp};
     use mz_sql::catalog::RoleAttributes;
@@ -194,7 +194,7 @@ mod tests {
             )] = &[
                 (
                     Box::new(|_validity| {}),
-                    Box::new(|res| assert!(res.is_ok(), "{res:?}")),
+                    Box::new(|res| assert_ok!(res)),
                 ),
                 (
                     Box::new(|validity| {

--- a/src/adapter/src/coord/validity.rs
+++ b/src/adapter/src/coord/validity.rs
@@ -192,10 +192,7 @@ mod tests {
                 Box<dyn Fn(&mut PlanValidity)>,
                 Box<dyn Fn(Result<(), AdapterError>)>,
             )] = &[
-                (
-                    Box::new(|_validity| {}),
-                    Box::new(|res| assert_ok!(res)),
-                ),
+                (Box::new(|_validity| {}), Box::new(|res| assert_ok!(res))),
                 (
                     Box::new(|validity| {
                         validity.cluster_id = Some(ClusterId::User(3));

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -427,6 +427,8 @@ impl Default for WebhookConcurrencyLimiter {
 
 #[cfg(test)]
 mod test {
+    use mz_ore::assert_err;
+
     use super::WebhookConcurrencyLimiter;
 
     #[mz_ore::test(tokio::test)]
@@ -438,7 +440,7 @@ mod test {
         let _permit_a = semaphore_a.try_acquire_many(10).expect("acquire");
 
         let semaphore_b = limiter.semaphore();
-        assert!(semaphore_b.try_acquire().is_err());
+        assert_err!(semaphore_b.try_acquire());
 
         // Increase our limit.
         limiter.set_limit(15);
@@ -452,6 +454,6 @@ mod test {
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
         // This should fail again.
-        assert!(semaphore_b.try_acquire().is_err());
+        assert_err!(semaphore_b.try_acquire());
     }
 }

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -359,6 +359,8 @@ pub use crate::writer::{to_avro_datum, write_avro_datum, ValidationError, Writer
 mod tests {
     use std::str::FromStr;
 
+    use mz_ore::{assert_err, assert_none};
+
     use crate::reader::Reader;
     use crate::schema::Schema;
     use crate::types::{Record, Value};
@@ -416,7 +418,7 @@ mod tests {
                 ("c".to_string(), Value::Enum(1, "spades".to_string())),
             ])
         );
-        assert!(reader.next().is_none());
+        assert_none!(reader.next());
     }
 
     //TODO: move where it fits better
@@ -460,7 +462,7 @@ mod tests {
                 ("c".to_string(), Value::Enum(2, "clubs".to_string())),
             ])
         );
-        assert!(reader.next().is_none());
+        assert_none!(reader.next());
     }
 
     //TODO: move where it fits better
@@ -516,8 +518,8 @@ mod tests {
         writer.flush().unwrap();
         let input = writer.into_inner();
         let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
-        assert!(reader.next().unwrap().is_err());
-        assert!(reader.next().is_none());
+        assert_err!(reader.next().unwrap());
+        assert_none!(reader.next());
     }
 
     //TODO: move where it fits better
@@ -611,6 +613,6 @@ mod tests {
         let malformed: &[u8] = &[0x3e, 0x15, 0xff, 0x1f, 0x15, 0xff];
 
         let value = from_avro_datum(&schema, &mut &malformed[..]);
-        assert!(value.is_err());
+        assert_err!(value);
     }
 }

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -933,6 +933,8 @@ pub fn from_avro_datum<R: AvroRead>(schema: &Schema, reader: &mut R) -> Result<V
 mod tests {
     use std::io::Cursor;
 
+    use mz_ore::assert_err;
+
     use crate::types::{Record, ToAvro};
     use crate::Reader;
 
@@ -1040,7 +1042,7 @@ mod tests {
             .collect::<Vec<u8>>();
         let reader = Reader::with_schema(&schema, &invalid[..]).unwrap();
         for value in reader {
-            assert!(value.is_err());
+            assert_err!(value);
         }
     }
 
@@ -1055,7 +1057,7 @@ mod tests {
         let invalid = ENCODED.iter().copied().take(165).collect::<Vec<u8>>();
         let reader = Reader::new(&invalid[..]).unwrap();
         for value in reader {
-            assert!(value.is_err());
+            assert_err!(value);
         }
     }
 

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -33,6 +33,7 @@ use std::str::FromStr;
 
 use digest::Digest;
 use itertools::Itertools;
+use mz_ore::assert_none;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::ser::{SerializeMap, SerializeSeq};
@@ -911,7 +912,7 @@ impl SchemaParser {
     }
 
     fn insert(&mut self, index: usize, schema: NamedSchemaPiece) {
-        assert!(self.named[index].is_none());
+        assert_none!(self.named[index]);
         self.named[index] = Some(schema);
     }
 
@@ -2282,6 +2283,8 @@ fn field_ordering_position(field: &str) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::{assert_err, assert_ok};
+
     use crate::types::{Record, ToAvro};
 
     use super::*;
@@ -2336,7 +2339,7 @@ mod tests {
     #[mz_ore::test]
     fn test_multi_union_schema() {
         let schema = Schema::from_str(r#"["null", "int", "float", "string", "bytes"]"#);
-        assert!(schema.is_ok());
+        assert_ok!(schema);
         let schema = schema.unwrap();
         let node = schema.top_node();
         assert_eq!(SchemaKind::from(&schema), SchemaKind::Union);
@@ -2435,7 +2438,7 @@ mod tests {
             r#"{"type": "enum", "name": "Suit", "symbols": ["diamonds", "spades", "jokers", "clubs", "hearts"], "default": "blah"}"#,
         );
 
-        assert!(bad_schema.is_err());
+        assert_err!(bad_schema);
     }
 
     #[mz_ore::test]
@@ -2711,7 +2714,7 @@ mod tests {
             _ => panic!(),
         };
 
-        assert!(doc.is_none());
+        assert_none!(doc);
     }
 
     #[mz_ore::test]

--- a/src/avro/src/util.rs
+++ b/src/avro/src/util.rs
@@ -137,6 +137,7 @@ pub fn safe_len(len: usize) -> Result<usize, AvroError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mz_ore::assert_err;
 
     #[mz_ore::test]
     fn test_zigzag() {
@@ -204,12 +205,12 @@ mod tests {
     #[mz_ore::test]
     fn test_overflow() {
         let causes_left_shift_overflow: &[u8] = &[0xe1, 0xe1, 0xe1, 0xe1, 0xe1];
-        assert!(decode_variable(&mut &causes_left_shift_overflow[..]).is_err());
+        assert_err!(decode_variable(&mut &causes_left_shift_overflow[..]));
     }
 
     #[mz_ore::test]
     fn test_safe_len() {
         assert_eq!(42usize, safe_len(42usize).unwrap());
-        assert!(safe_len(1024 * 1024 * 1024).is_err());
+        assert_err!(safe_len(1024 * 1024 * 1024));
     }
 }

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -31,6 +31,7 @@ use mz_avro::error::Error as AvroError;
 use mz_avro::schema::resolve_schemas;
 use mz_avro::types::{DecimalValue, Value};
 use mz_avro::{from_avro_datum, to_avro_datum, Schema, ValidationError};
+use mz_ore::assert_err;
 use once_cell::sync::Lazy;
 
 static SCHEMAS_TO_VALIDATE: Lazy<Vec<(&'static str, Value)>> = Lazy::new(|| {
@@ -256,7 +257,7 @@ fn test_unknown_symbol() {
     let encoded = to_avro_datum(&writer_schema, original_value).unwrap();
     let resolved_schema = resolve_schemas(&writer_schema, &reader_schema).unwrap();
     let decoded = from_avro_datum(&resolved_schema, &mut Cursor::new(encoded));
-    assert!(decoded.is_err());
+    assert_err!(decoded);
 }
 
 #[mz_ore::test]

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -29,7 +29,7 @@ use mz_ore::id_gen::{conn_id_org_uuid, org_id_conn_bits};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::retry::Retry;
-use mz_ore::{assert_contains, task};
+use mz_ore::{assert_contains, assert_err, assert_ok, task};
 use mz_server_core::TlsCertConfig;
 use openssl::ssl::{SslConnectorBuilder, SslVerifyMode};
 use openssl::x509::X509;
@@ -254,7 +254,7 @@ async fn test_balancer() {
         let (tx, rx) = oneshot::channel();
         reload_tx.try_send(Some(tx)).unwrap();
         let res = rx.await.unwrap();
-        assert!(res.is_err());
+        assert_err!(res);
 
         // We should still be on the old cert because now the cert and key mismatch.
         let resp = client
@@ -275,7 +275,7 @@ async fn test_balancer() {
         let (tx, rx) = oneshot::channel();
         reload_tx.try_send(Some(tx)).unwrap();
         let res = rx.await.unwrap();
-        assert!(res.is_ok());
+        assert_ok!(res);
         let resp = client
             .post(&https_url)
             .header("Content-Type", "application/json")

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -19,6 +19,7 @@ use mz_catalog::durable::{
     Item, OpenableDurableCatalogState, USER_ITEM_ALLOC_KEY,
 };
 use mz_catalog::memory::objects::{StateDiff, StateUpdateKind};
+use mz_ore::assert_ok;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::PersistClient;
@@ -54,7 +55,7 @@ async fn test_confirm_leadership(
         )
         .await
         .unwrap();
-    assert!(state1.confirm_leadership().await.is_ok());
+    assert_ok!(state1.confirm_leadership().await);
 
     let mut state2 = openable_state2
         .open(
@@ -65,7 +66,7 @@ async fn test_confirm_leadership(
         )
         .await
         .unwrap();
-    assert!(state2.confirm_leadership().await.is_ok());
+    assert_ok!(state2.confirm_leadership().await);
 
     let err = state1.confirm_leadership().await.unwrap_err();
     assert!(matches!(

--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -205,6 +205,7 @@ pub struct ClusterReplicaLocation {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::ProptestConfig;
     use proptest::proptest;
@@ -218,7 +219,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // slow
         fn timely_config_protobuf_roundtrip(expect in any::<TimelyConfig>() ) {
             let actual = protobuf_roundtrip::<_, ProtoTimelyConfig>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 
@@ -226,7 +227,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // slow
         fn cluster_startup_epoch_protobuf_roundtrip(expect in any::<ClusterStartupEpoch>() ) {
             let actual = protobuf_roundtrip::<_, ProtoClusterStartupEpoch>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -505,6 +505,7 @@ impl LogVariant {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -514,7 +515,7 @@ mod tests {
         #[mz_ore::test]
         fn logging_config_protobuf_roundtrip(expect in any::<LoggingConfig>()) {
             let actual = protobuf_roundtrip::<_, ProtoLoggingConfig>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -604,6 +604,7 @@ impl TryIntoTimelyConfig for ComputeCommand {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::ProptestConfig;
     use proptest::proptest;
@@ -617,14 +618,14 @@ mod tests {
         #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn peek_protobuf_roundtrip(expect in any::<Peek>() ) {
             let actual = protobuf_roundtrip::<_, ProtoPeek>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 
         #[mz_ore::test]
         fn compute_command_protobuf_roundtrip(expect in any::<ComputeCommand<mz_repr::Timestamp>>() ) {
             let actual = protobuf_roundtrip::<_, ProtoComputeCommand>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -14,7 +14,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::UIntGauge;
-use mz_ore::soft_assert_or_log;
+use mz_ore::{assert_none, soft_assert_or_log};
 use timely::progress::Antichain;
 use timely::PartialOrder;
 
@@ -105,12 +105,12 @@ where
         for command in self.commands.drain(..) {
             match command {
                 create_timely @ ComputeCommand::CreateTimely { .. } => {
-                    assert!(create_timely_command.is_none());
+                    assert_none!(create_timely_command);
                     create_timely_command = Some(create_timely);
                 }
                 // We should be able to handle the Create* commands, should this client need to be restartable.
                 create_inst @ ComputeCommand::CreateInstance(_) => {
-                    assert!(create_inst_command.is_none());
+                    assert_none!(create_inst_command);
                     create_inst_command = Some(create_inst);
                 }
                 ComputeCommand::InitializationComplete => {

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -651,6 +651,7 @@ impl RustType<ProtoOperatorHydrationStatus> for OperatorHydrationStatus {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::ProptestConfig;
     use proptest::proptest;
@@ -663,7 +664,7 @@ mod tests {
         #[mz_ore::test]
         fn compute_response_protobuf_roundtrip(expect in any::<ComputeResponse<mz_repr::Timestamp>>() ) {
             let actual = protobuf_roundtrip::<_, ProtoComputeResponse>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use bytesize::ByteSize;
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::lattice::Lattice;
+use mz_ore::assert_none;
 use mz_ore::cast::CastFrom;
 use mz_repr::{Diff, GlobalId, Row, RowCollection};
 use mz_service::client::{GenericClient, Partitionable, PartitionedState};
@@ -308,7 +309,7 @@ where
                     .entry(uuid)
                     .or_insert_with(Default::default);
                 let novel = entry.insert(shard_id, response);
-                assert!(novel.is_none(), "Duplicate peek response");
+                assert_none!(novel, "Duplicate peek response");
                 // We may be ready to respond.
                 if entry.len() == self.parts {
                     let mut response = PeekResponse::Rows(RowCollection::default());
@@ -441,7 +442,7 @@ where
                     .entry(id)
                     .or_insert_with(Default::default);
                 let novel = entry.insert(shard_id, response);
-                assert!(novel.is_none(), "Duplicate copy to response");
+                assert_none!(novel, "Duplicate copy to response");
                 // We may be ready to respond.
                 if entry.len() == self.parts {
                     let mut response = CopyToResponse::RowCount(0);

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -837,6 +837,7 @@ impl RustType<ProtoBuildDesc> for BuildDesc<FlatPlan> {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::ProptestConfig;
     use proptest::proptest;
@@ -852,7 +853,7 @@ mod tests {
         #[mz_ore::test]
         fn dataflow_description_protobuf_roundtrip(expect in any::<DataflowDescription<FlatPlan, CollectionMetadata, mz_repr::Timestamp>>()) {
             let actual = protobuf_roundtrip::<_, ProtoDataflowDescription>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -1144,6 +1144,7 @@ fn bucketing_of_expected_group_size(expected_group_size: Option<u64>) -> Vec<u64
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
 
     use super::*;
@@ -1154,7 +1155,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn available_collections_protobuf_roundtrip(expect in any::<AvailableCollections>() ) {
             let actual = protobuf_roundtrip::<_, ProtoAvailableCollections>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }
@@ -1165,7 +1166,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn get_plan_protobuf_roundtrip(expect in any::<GetPlan>()) {
             let actual = protobuf_roundtrip::<_, ProtoGetPlan>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/compute-types/src/plan/flat_plan.rs
+++ b/src/compute-types/src/plan/flat_plan.rs
@@ -1131,6 +1131,7 @@ impl RustType<proto_flat_plan_node::ProtoUpdate> for (Row, mz_repr::Timestamp, i
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
 
     use super::*;
@@ -1140,7 +1141,7 @@ mod tests {
         #[mz_ore::test]
         fn flat_plan_protobuf_roundtrip(expect in any::<FlatPlan>()) {
             let actual = protobuf_roundtrip::<_, ProtoFlatPlan>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -23,8 +23,8 @@ use mz_expr::{
     RECURSION_LIMIT,
 };
 use mz_ore::cast::CastFrom;
-use mz_ore::soft_panic_or_log;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
+use mz_ore::{assert_none, soft_panic_or_log};
 use mz_repr::{Diff, Row};
 
 use crate::plan::join::JoinPlan;
@@ -275,7 +275,7 @@ where
                         .ctx
                         .bindings
                         .insert(*id, ContextEntry::of_let(res_value));
-                    assert!(old_entry.is_none(), "No shadowing");
+                    assert_none!(old_entry, "No shadowing");
 
                     // Descend into `body` with the extended context.
                     let res_body = self.apply_rec(body, rg);
@@ -300,7 +300,7 @@ where
                     for id in ids.iter() {
                         let new_entry = ContextEntry::of_let_rec(I::Domain::bottom());
                         let old_entry = self.ctx.bindings.insert(*id, new_entry);
-                        assert!(old_entry.is_none());
+                        assert_none!(old_entry);
                     }
 
                     let min_max_iter = LetRecLimit::min_max_iter(limits);
@@ -563,7 +563,7 @@ where
                         .ctx
                         .bindings
                         .insert(*id, ContextEntry::of_let(res_value));
-                    assert!(old_entry.is_none(), "No shadowing");
+                    assert_none!(old_entry, "No shadowing");
 
                     // Descend into `body` with the extended context.
                     let res_body = self.apply_rec(body, rg);
@@ -588,7 +588,7 @@ where
                     for id in ids.iter() {
                         let new_entry = ContextEntry::of_let_rec(I::Domain::bottom());
                         let old_entry = self.ctx.bindings.insert(*id, new_entry);
-                        assert!(old_entry.is_none());
+                        assert_none!(old_entry);
                     }
 
                     let min_max_iter = LetRecLimit::min_max_iter(limits);

--- a/src/compute-types/src/plan/join.rs
+++ b/src/compute-types/src/plan/join.rs
@@ -415,6 +415,7 @@ impl JoinBuildState {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
 
     use super::*;
@@ -426,7 +427,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn join_plan_protobuf_roundtrip(expect in any::<JoinPlan>() ) {
             let actual = protobuf_roundtrip::<_, ProtoJoinPlan>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/compute-types/src/plan/lowering.rs
+++ b/src/compute-types/src/plan/lowering.rs
@@ -16,7 +16,7 @@ use mz_expr::{
     permutation_for_arrangement, Id, JoinInputMapper, MapFilterProject, MirRelationExpr,
     MirScalarExpr, OptimizedMirRelationExpr,
 };
-use mz_ore::{soft_assert_eq_or_log, soft_panic_or_log};
+use mz_ore::{assert_none, soft_assert_eq_or_log, soft_panic_or_log};
 use mz_repr::optimize::OptimizerFeatures;
 use mz_repr::GlobalId;
 use timely::progress::Timestamp;
@@ -274,7 +274,7 @@ impl Context {
                 // introduce any resulting arrangements bound to `id`.
                 let (value, v_keys) = self.lower_mir_expr(value)?;
                 let pre_existing = self.arrangements.insert(Id::Local(*id), v_keys);
-                assert!(pre_existing.is_none());
+                assert_none!(pre_existing);
                 // Plan the body using initial and `value` arrangements,
                 // and then remove reference to the value arrangements.
                 let (body, b_keys) = self.lower_mir_expr(body)?;
@@ -353,7 +353,7 @@ impl Context {
                         v_keys.raw = true;
                     }
                     let pre_existing = self.arrangements.insert(Id::Local(*id), v_keys);
-                    assert!(pre_existing.is_none());
+                    assert_none!(pre_existing);
                     lir_values.push(lir_value);
                 }
                 // As we exit the iterative scope, we must leave all arrangements behind,

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -65,7 +65,7 @@ use std::collections::BTreeMap;
 use mz_expr::{
     permutation_for_arrangement, AggregateExpr, AggregateFunc, MapFilterProject, MirScalarExpr,
 };
-use mz_ore::soft_assert_or_log;
+use mz_ore::{assert_none, soft_assert_or_log};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use proptest::prelude::{any, Arbitrary, BoxedStrategy};
 use proptest::strategy::Strategy;
@@ -638,15 +638,15 @@ impl ReducePlan {
         for expr in plan.into_iter() {
             match expr {
                 ReducePlan::Accumulable(e) => {
-                    assert!(collation.accumulable.is_none());
+                    assert_none!(collation.accumulable);
                     collation.accumulable = Some(e);
                 }
                 ReducePlan::Hierarchical(e) => {
-                    assert!(collation.hierarchical.is_none());
+                    assert_none!(collation.hierarchical);
                     collation.hierarchical = Some(e);
                 }
                 ReducePlan::Basic(e) => {
-                    assert!(collation.basic.is_none());
+                    assert_none!(collation.basic);
                     collation.basic = Some(e);
                 }
                 ReducePlan::Distinct | ReducePlan::Collation(_) => {
@@ -1003,6 +1003,7 @@ pub fn reduction_type(func: &AggregateFunc) -> ReductionType {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -1015,7 +1016,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn reduce_plan_protobuf_roundtrip(expect in any::<ReducePlan>() ) {
             let actual = protobuf_roundtrip::<_, ProtoReducePlan>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/compute-types/src/plan/threshold.rs
+++ b/src/compute-types/src/plan/threshold.rs
@@ -163,6 +163,7 @@ impl ThresholdPlan {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -172,7 +173,7 @@ mod tests {
        #[mz_ore::test]
         fn threshold_plan_protobuf_roundtrip(expect in any::<ThresholdPlan>() ) {
             let actual = protobuf_roundtrip::<_, ProtoThresholdPlan>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/compute-types/src/plan/top_k.rs
+++ b/src/compute-types/src/plan/top_k.rs
@@ -293,6 +293,7 @@ impl RustType<ProtoBasicTopKPlan> for BasicTopKPlan {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -302,7 +303,7 @@ mod tests {
         #[mz_ore::test]
         fn top_k_plan_protobuf_roundtrip(expect in any::<TopKPlan>()) {
             let actual = protobuf_roundtrip::<_, ProtoTopKPlan>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -19,6 +19,7 @@ use differential_dataflow::{Collection, Hashable};
 use futures::StreamExt;
 use mz_compute_types::dyncfgs::PERSIST_SINK_OBEY_READ_ONLY;
 use mz_compute_types::sinks::{ComputeSinkDesc, PersistSinkConnection};
+use mz_ore::assert_none;
 use mz_ore::cast::CastFrom;
 use mz_persist_client::batch::{Batch, BatchBuilder, ProtoBatch};
 use mz_persist_client::cache::PersistClientCache;
@@ -1182,7 +1183,7 @@ where
                 // We're not keeping this batch, make sure that the above loop
                 // cleared and deleted all the batches.
                 assert!(batch_set.finished.is_empty());
-                assert!(batch_set.incomplete.is_none());
+                assert_none!(batch_set.incomplete);
 
                 false
             });

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -409,6 +409,7 @@ mod tests {
     use bytes::Bytes;
     use http::StatusCode;
     use mz_adapter::AppendWebhookError;
+    use mz_ore::assert_none;
     use mz_repr::{GlobalId, Row};
     use mz_sql::plan::{WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders};
     use mz_storage_types::controller::StorageError;
@@ -488,14 +489,14 @@ mod tests {
         let mut h = filter_headers(&headers, &filters);
         assert_eq!(h.next().unwrap().0, "bar");
         assert_eq!(h.next().unwrap().0, "baz");
-        assert!(h.next().is_none());
+        assert_none!(h.next());
 
         let mut filters = WebhookHeaderFilters::default();
         filters.allow.clone_from(&allow);
 
         let mut h = filter_headers(&headers, &filters);
         assert_eq!(h.next().unwrap().0, "bar");
-        assert!(h.next().is_none());
+        assert_none!(h.next());
 
         let mut filters = WebhookHeaderFilters::default();
         filters.allow = allow;
@@ -503,7 +504,7 @@ mod tests {
 
         let mut h = filter_headers(&headers, &filters);
         assert_eq!(h.next().unwrap().0, "bar");
-        assert!(h.next().is_none());
+        assert_none!(h.next());
     }
 
     #[mz_ore::test]
@@ -520,7 +521,7 @@ mod tests {
 
         // We should yield nothing since we block the only thing we allow.
         let mut h = filter_headers(&headers, &filters);
-        assert!(h.next().is_none());
+        assert_none!(h.next());
     }
 
     #[mz_ore::test]

--- a/src/environmentd/src/telemetry.rs
+++ b/src/environmentd/src/telemetry.rs
@@ -79,7 +79,7 @@
 
 use mz_adapter::telemetry::{EventDetails, SegmentClientExt};
 use mz_ore::retry::Retry;
-use mz_ore::task;
+use mz_ore::{assert_none, task};
 use mz_repr::adt::jsonb::Jsonb;
 use mz_sql::catalog::EnvironmentId;
 use serde_json::json;
@@ -168,7 +168,7 @@ async fn report_loop(
                 )).await?;
 
                 let row = rows.next().expect("expected at least one row").to_owned();
-                assert!(rows.next().is_none(), "introspection query had more than one row?");
+                assert_none!(rows.next(), "introspection query had more than one row?");
 
                 let jsonb = Jsonb::from_row(row);
                 Ok::<_, anyhow::Error>(jsonb.as_ref().to_serde_json())

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -20,6 +20,7 @@ use mz_adapter::session::DEFAULT_DATABASE_NAME;
 use mz_environmentd::test_util::{self, PostgresErrorExt};
 use mz_ore::collections::CollectionExt;
 use mz_ore::retry::Retry;
+use mz_ore::{assert_err, assert_ok};
 use mz_pgrepr::{Numeric, Record};
 use postgres::binary_copy::BinaryCopyOutIter;
 use postgres::error::SqlState;
@@ -349,9 +350,9 @@ fn test_conn_user() {
 fn test_simple_query_no_hang() {
     let server = test_util::TestHarness::default().start_blocking();
     let mut client = server.connect(postgres::NoTls).unwrap();
-    assert!(client.simple_query("asdfjkl;").is_err());
+    assert_err!(client.simple_query("asdfjkl;"));
     // This will hang if #2880 is not fixed.
-    assert!(client.simple_query("SELECT 1").is_ok());
+    assert_ok!(client.simple_query("SELECT 1"));
 }
 
 #[mz_ore::test]

--- a/src/environmentd/tests/timezones.rs
+++ b/src/environmentd/tests/timezones.rs
@@ -31,6 +31,7 @@ use std::fs;
 use std::path::Path;
 
 use mz_environmentd::test_util;
+use mz_ore::assert_none;
 use mz_pgrepr::Interval;
 
 #[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
@@ -97,7 +98,7 @@ async fn test_pg_timezone_abbrevs() {
                 continue;
             }
             let key = line.split_once(',').unwrap().0;
-            assert!(pg_map.insert(key, line).is_none());
+            assert_none!(pg_map.insert(key, line));
         }
 
         client

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -134,6 +134,7 @@ impl fmt::Display for SourceInstanceId {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -143,7 +144,7 @@ mod tests {
         #[mz_ore::test]
         fn id_protobuf_roundtrip(expect in any::<Id>()) {
             let actual = protobuf_roundtrip::<_, ProtoId>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1969,6 +1969,7 @@ pub mod plan {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
 
     use crate::linear::plan::*;
@@ -1982,7 +1983,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn mfp_plan_protobuf_roundtrip(expect in any::<MfpPlan>()) {
             let actual = protobuf_roundtrip::<_, ProtoMfpPlan>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -3458,6 +3458,7 @@ pub enum AccessStrategy {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use mz_repr::explain::text::text_string_at;
     use proptest::prelude::*;
@@ -3470,7 +3471,7 @@ mod tests {
         #[mz_ore::test]
         fn column_order_protobuf_roundtrip(expect in any::<ColumnOrder>()) {
             let actual = protobuf_roundtrip::<_, ProtoColumnOrder>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }
@@ -3480,7 +3481,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn aggregate_expr_protobuf_roundtrip(expect in any::<AggregateExpr>()) {
             let actual = protobuf_roundtrip::<_, ProtoAggregateExpr>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }
@@ -3489,7 +3490,7 @@ mod tests {
         #[mz_ore::test]
         fn window_frame_units_protobuf_roundtrip(expect in any::<WindowFrameUnits>()) {
             let actual = protobuf_roundtrip::<_, proto_window_frame::ProtoWindowFrameUnits>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }
@@ -3498,7 +3499,7 @@ mod tests {
         #[mz_ore::test]
         fn window_frame_bound_protobuf_roundtrip(expect in any::<WindowFrameBound>()) {
             let actual = protobuf_roundtrip::<_, proto_window_frame::ProtoWindowFrameBound>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }
@@ -3507,7 +3508,7 @@ mod tests {
         #[mz_ore::test]
         fn window_frame_protobuf_roundtrip(expect in any::<WindowFrame>()) {
             let actual = protobuf_roundtrip::<_, ProtoWindowFrame>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -3050,6 +3050,7 @@ impl fmt::Display for TableFunc {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -3060,7 +3061,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn aggregate_func_protobuf_roundtrip(expect in any::<AggregateFunc>() ) {
             let actual = protobuf_roundtrip::<_, ProtoAggregateFunc>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }
@@ -3070,7 +3071,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn table_func_protobuf_roundtrip(expect in any::<TableFunc>() ) {
             let actual = protobuf_roundtrip::<_, ProtoTableFunc>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -3090,6 +3090,7 @@ impl RustType<ProtoDims> for (usize, usize) {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
 
     use super::*;
@@ -3206,7 +3207,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
         fn mir_scalar_expr_protobuf_roundtrip(expect in any::<MirScalarExpr>()) {
             let actual = protobuf_roundtrip::<_, ProtoMirScalarExpr>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }
@@ -3215,7 +3216,7 @@ mod tests {
         #[mz_ore::test]
         fn domain_limit_protobuf_roundtrip(expect in any::<DomainLimit>()) {
             let actual = protobuf_roundtrip::<_, ProtoDomainLimit>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }
@@ -3225,7 +3226,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn eval_error_protobuf_roundtrip(expect in any::<EvalError>()) {
             let actual = protobuf_roundtrip::<_, ProtoEvalError>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -8427,6 +8427,7 @@ impl RustType<ProtoVariadicFunc> for VariadicFunc {
 #[cfg(test)]
 mod test {
     use chrono::prelude::*;
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -8495,7 +8496,7 @@ mod test {
         #[cfg_attr(miri, ignore)] // too slow
         fn unmaterializable_func_protobuf_roundtrip(expect in any::<UnmaterializableFunc>()) {
             let actual = protobuf_roundtrip::<_, ProtoUnmaterializableFunc>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 
@@ -8503,7 +8504,7 @@ mod test {
         #[cfg_attr(miri, ignore)] // too slow
         fn unary_func_protobuf_roundtrip(expect in any::<UnaryFunc>()) {
             let actual = protobuf_roundtrip::<_, ProtoUnaryFunc>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 
@@ -8511,7 +8512,7 @@ mod test {
         #[cfg_attr(miri, ignore)] // too slow
         fn binary_func_protobuf_roundtrip(expect in any::<BinaryFunc>()) {
             let actual = protobuf_roundtrip::<_, ProtoBinaryFunc>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 
@@ -8519,7 +8520,7 @@ mod test {
         #[cfg_attr(miri, ignore)] // too slow
         fn variadic_func_protobuf_roundtrip(expect in any::<VariadicFunc>()) {
             let actual = protobuf_roundtrip::<_, ProtoVariadicFunc>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -777,6 +777,8 @@ impl<T: VisitChildren<T>> StackSafeVisit<T> {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
+
     use super::*;
 
     #[derive(Debug, Eq, PartialEq)]
@@ -1148,7 +1150,7 @@ mod tests {
             _ => (),
         });
 
-        assert!(res.is_ok());
+        assert_ok!(res);
         assert_eq!(act, exp);
     }
 
@@ -1181,7 +1183,7 @@ mod tests {
             _ => (),
         });
 
-        assert!(res.is_ok());
+        assert_ok!(res);
         assert_eq!(act, exp);
     }
 }

--- a/src/frontegg-auth/src/client/tokens.rs
+++ b/src/frontegg-auth/src/client/tokens.rs
@@ -84,6 +84,7 @@ pub struct ApiTokenResponse {
 mod tests {
     use axum::{routing::post, Router};
     use mz_ore::metrics::MetricsRegistry;
+    use mz_ore::{assert_err, assert_ok};
     use reqwest::StatusCode;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -165,13 +166,13 @@ mod tests {
         }
 
         // Should get retried which results in eventual success.
-        assert!(test_case(&client, &addr, &count, 500, true).await.is_ok());
-        assert!(test_case(&client, &addr, &count, 502, true).await.is_ok());
-        assert!(test_case(&client, &addr, &count, 429, true).await.is_ok());
-        assert!(test_case(&client, &addr, &count, 408, true).await.is_ok());
+        assert_ok!(test_case(&client, &addr, &count, 500, true).await);
+        assert_ok!(test_case(&client, &addr, &count, 502, true).await);
+        assert_ok!(test_case(&client, &addr, &count, 429, true).await);
+        assert_ok!(test_case(&client, &addr, &count, 408, true).await);
 
         // Should not get retried, and thus return an error.
-        assert!(test_case(&client, &addr, &count, 404, false).await.is_err());
-        assert!(test_case(&client, &addr, &count, 400, false).await.is_err());
+        assert_err!(test_case(&client, &addr, &count, 404, false).await);
+        assert_err!(test_case(&client, &addr, &count, 400, false).await);
     }
 }

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -42,6 +42,7 @@ pub struct Decoder {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_err;
     use mz_repr::{Datum, Row};
 
     use crate::avro::Decoder;
@@ -56,7 +57,7 @@ mod tests {
         let mut decoder = Decoder::new(schema, None, "Test".to_string(), false).unwrap();
         // This is not a valid Avro blob for the given schema
         let mut bad_bytes: &[u8] = &[0];
-        assert!(decoder.decode(&mut bad_bytes).await.unwrap().is_err());
+        assert_err!(decoder.decode(&mut bad_bytes).await.unwrap());
         // This is the blob that will make both ints in the value zero.
         let mut good_bytes: &[u8] = &[0, 0];
         // The decode should succeed with the correct value.

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -323,13 +323,13 @@ macro_rules! assert_contains {
 #[macro_export]
 macro_rules! assert_none {
     ($val:expr, $($msg:tt)+) => {{
-        if let Some(y) = $val {
+        if let Some(y) = &$val {
             let formatted_msg = format!($($msg)+);
             panic!("assertion failed: expected None found Some({y:?}), {formatted_msg}");
         }
     }};
     ($val:expr) => {{
-        if let Some(y) = $val {
+        if let Some(y) = &$val {
             panic!("assertion failed: expected None found Some({y:?})");
         }
     }}
@@ -371,13 +371,13 @@ macro_rules! assert_none {
 #[macro_export]
 macro_rules! assert_ok {
     ($val:expr, $($msg:tt)+) => {{
-        if let Err(y) = $val {
+        if let Err(y) = &$val {
             let formatted_msg = format!($($msg)+);
             panic!("assertion failed: expected Ok found Err({y:?}), {formatted_msg}");
         }
     }};
     ($val:expr) => {{
-        if let Err(y) = $val {
+        if let Err(y) = &$val {
             panic!("assertion failed: expected Ok found Err({y:?})");
         }
     }}
@@ -419,13 +419,13 @@ macro_rules! assert_ok {
 #[macro_export]
 macro_rules! assert_err {
     ($val:expr, $($msg:tt)+) => {{
-        if let Ok(y) = $val {
+        if let Ok(y) = &$val {
             let formatted_msg = format!($($msg)+);
             panic!("assertion failed: expected Err found Ok({y:?}), {formatted_msg}");
         }
     }};
     ($val:expr) => {{
-        if let Ok(y) = $val {
+        if let Ok(y) = &$val {
             panic!("assertion failed: expected Err found Ok({y:?})");
         }
     }}

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -289,6 +289,148 @@ macro_rules! assert_contains {
     }};
 }
 
+/// Asserts that the provided expression, that returns an `Option`, is `None`.
+///
+/// # Motivation
+///
+/// The standard pattern for asserting a value is `None` using the `assert!` macro is:
+///
+/// ```
+/// # let x: Option<usize> = None;
+/// assert!(x.is_none());
+/// ```
+///
+/// The issue with this pattern is when the assertion fails it only prints `false`
+/// and not the value contained in the `Some(_)` variant which makes debugging difficult.
+///
+/// # Examples
+///
+/// ### Basic Use
+///
+/// ```should_panic
+/// use mz_ore::assert_none;
+/// assert_none!(Some(42));
+/// ```
+///
+/// ### With extra message
+///
+/// ```should_panic
+/// use mz_ore::assert_none;
+/// let other_val = 100;
+/// assert_none!(Some(42), "ohh noo! x {other_val}");
+/// ```
+///
+#[macro_export]
+macro_rules! assert_none {
+    ($val:expr, $($msg:tt)+) => {{
+        if let Some(y) = $val {
+            let formatted_msg = format!($($msg)+);
+            panic!("assertion failed: expected None found Some({y:?}), {formatted_msg}");
+        }
+    }};
+    ($val:expr) => {{
+        if let Some(y) = $val {
+            panic!("assertion failed: expected None found Some({y:?})");
+        }
+    }}
+}
+
+/// Asserts that the provided expression, that returns a `Result`, is `Ok`.
+///
+/// # Motivation
+///
+/// The standard pattern for asserting a value is `Ok` using the `assert!` macro is:
+///
+/// ```
+/// # let x: Result<usize, usize> = Ok(42);
+/// assert!(x.is_ok());
+/// ```
+///
+/// The issue with this pattern is when the assertion fails it only prints `false`
+/// and not the value contained in the `Err(_)` variant which makes debugging difficult.
+///
+/// # Examples
+///
+/// ### Basic Use
+///
+/// ```should_panic
+/// use mz_ore::assert_ok;
+/// let error: Result<usize, usize> = Err(42);
+/// assert_ok!(error);
+/// ```
+///
+/// ### With extra message
+///
+/// ```should_panic
+/// use mz_ore::assert_ok;
+/// let other_val = 100;
+/// let error: Result<usize, usize> = Err(42);
+/// assert_ok!(error, "ohh noo! x {other_val}");
+/// ```
+///
+#[macro_export]
+macro_rules! assert_ok {
+    ($val:expr, $($msg:tt)+) => {{
+        if let Err(y) = $val {
+            let formatted_msg = format!($($msg)+);
+            panic!("assertion failed: expected Ok found Err({y:?}), {formatted_msg}");
+        }
+    }};
+    ($val:expr) => {{
+        if let Err(y) = $val {
+            panic!("assertion failed: expected Ok found Err({y:?})");
+        }
+    }}
+}
+
+/// Asserts that the provided expression, that returns a `Result`, is `Err`.
+///
+/// # Motivation
+///
+/// The standard pattern for asserting a value is `Err` using the `assert!` macro is:
+///
+/// ```
+/// # let x: Result<usize, usize> = Err(42);
+/// assert!(x.is_err());
+/// ```
+///
+/// The issue with this pattern is when the assertion fails it only prints `false`
+/// and not the value contained in the `Ok(_)` variant which makes debugging difficult.
+///
+/// # Examples
+///
+/// ### Basic Use
+///
+/// ```should_panic
+/// use mz_ore::assert_err;
+/// let error: Result<usize, usize> = Ok(42);
+/// assert_err!(error);
+/// ```
+///
+/// ### With extra message
+///
+/// ```should_panic
+/// use mz_ore::assert_err;
+/// let other_val = 100;
+/// let error: Result<usize, usize> = Ok(42);
+/// assert_err!(error, "ohh noo! x {other_val}");
+/// ```
+///
+#[macro_export]
+macro_rules! assert_err {
+    ($val:expr, $($msg:tt)+) => {{
+        if let Ok(y) = $val {
+            let formatted_msg = format!($($msg)+);
+            panic!("assertion failed: expected Err found Ok({y:?}), {formatted_msg}");
+        }
+    }};
+    ($val:expr) => {{
+        if let Ok(y) = $val {
+            panic!("assertion failed: expected Err found Ok({y:?})");
+        }
+    }}
+}
+
 #[cfg(test)]
 mod tests {
     #[crate::test]
@@ -307,5 +449,51 @@ mod tests {
  right: `\"yellow\"`")]
     fn test_assert_contains_fail() {
         assert_contains!("hello", "yellow");
+    }
+
+    #[crate::test]
+    #[should_panic(expected = "assertion failed: expected None found Some(42)")]
+    fn test_assert_none_fail() {
+        assert_none!(Some(42));
+    }
+
+    #[crate::test]
+    #[should_panic(expected = "assertion failed: expected None found Some(42), ohh no!")]
+    fn test_assert_none_fail_with_msg() {
+        assert_none!(Some(42), "ohh no!");
+    }
+
+    #[crate::test]
+    fn test_assert_ok() {
+        assert_ok!(Ok::<_, usize>(42));
+    }
+
+    #[crate::test]
+    #[should_panic(expected = "assertion failed: expected Ok found Err(42)")]
+    fn test_assert_ok_fail() {
+        assert_ok!(Err::<usize, _>(42));
+    }
+
+    #[crate::test]
+    #[should_panic(expected = "assertion failed: expected Ok found Err(42), ohh no!")]
+    fn test_assert_ok_fail_with_msg() {
+        assert_ok!(Err::<usize, _>(42), "ohh no!");
+    }
+
+    #[crate::test]
+    fn test_assert_err() {
+        assert_err!(Err::<usize, _>(42));
+    }
+
+    #[crate::test]
+    #[should_panic(expected = "assertion failed: expected Err found Ok(42)")]
+    fn test_assert_err_fail() {
+        assert_err!(Ok::<_, usize>(42));
+    }
+
+    #[crate::test]
+    #[should_panic(expected = "assertion failed: expected Err found Ok(42), ohh no!")]
+    fn test_assert_err_fail_with_msg() {
+        assert_err!(Ok::<_, usize>(42), "ohh no!");
     }
 }

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -324,8 +324,7 @@ macro_rules! assert_contains {
 macro_rules! assert_none {
     ($val:expr, $($msg:tt)+) => {{
         if let Some(y) = &$val {
-            let formatted_msg = format!($($msg)+);
-            panic!("assertion failed: expected None found Some({y:?}), {formatted_msg}");
+            panic!("assertion failed: expected None found Some({y:?}), {}", format!($($msg)+));
         }
     }};
     ($val:expr) => {{
@@ -372,8 +371,7 @@ macro_rules! assert_none {
 macro_rules! assert_ok {
     ($val:expr, $($msg:tt)+) => {{
         if let Err(y) = &$val {
-            let formatted_msg = format!($($msg)+);
-            panic!("assertion failed: expected Ok found Err({y:?}), {formatted_msg}");
+            panic!("assertion failed: expected Ok found Err({y:?}), {}", format!($($msg)+));
         }
     }};
     ($val:expr) => {{
@@ -420,8 +418,7 @@ macro_rules! assert_ok {
 macro_rules! assert_err {
     ($val:expr, $($msg:tt)+) => {{
         if let Ok(y) = &$val {
-            let formatted_msg = format!($($msg)+);
-            panic!("assertion failed: expected Err found Ok({y:?}), {formatted_msg}");
+            panic!("assertion failed: expected Err found Ok({y:?}), {}", format!($($msg)+));
         }
     }};
     ($val:expr) => {{

--- a/src/ore/src/channel.rs
+++ b/src/ore/src/channel.rs
@@ -260,6 +260,8 @@ mod tests {
     use futures::FutureExt;
     use tokio::sync::mpsc;
 
+    use crate::assert_none;
+
     use super::ReceiverExt;
 
     #[crate::test]
@@ -340,7 +342,7 @@ mod tests {
             std::task::Poll::Ready(elements) => elements,
             std::task::Poll::Pending => panic!("future didn't immediately return"),
         };
-        assert!(elements.is_none());
+        assert_none!(elements);
     }
 
     #[crate::test]
@@ -351,7 +353,7 @@ mod tests {
         drop(tx);
 
         let elements = block_on(recv_many);
-        assert!(elements.is_none());
+        assert_none!(elements);
     }
 
     #[crate::test]
@@ -419,6 +421,6 @@ mod tests {
         assert_eq!(elements, [1, 2, 3]);
 
         // Receiving again should return None.
-        assert!(block_on(rx.mz_recv_many(4)).is_none());
+        assert_none!(block_on(rx.mz_recv_many(4)));
     }
 }

--- a/src/ore/src/id_gen.rs
+++ b/src/ore/src/id_gen.rs
@@ -401,6 +401,8 @@ pub fn temp_id() -> String {
 mod tests {
     use std::collections::BTreeMap;
 
+    use crate::assert_none;
+
     use super::*;
 
     #[crate::test]
@@ -501,7 +503,7 @@ mod tests {
 
         // There are only two slots, so trying to allocate 2 more should fail the second time.
         let _id_b = allocator.alloc().unwrap();
-        assert!(allocator.alloc().is_none());
+        assert_none!(allocator.alloc());
 
         // a should get freed since all outstanding references have been dropped.
         drop(id_a_clone);

--- a/src/ore/src/metrics.rs
+++ b/src/ore/src/metrics.rs
@@ -201,6 +201,8 @@ pub type UIntGaugeVec = DeleteOnDropWrapper<raw::UIntGaugeVec>;
 
 pub use prometheus::{Counter, Histogram, IntCounter, IntGauge};
 
+use crate::assert_none;
+
 /// Access to non-delete-on-drop vector types
 pub mod raw {
     use prometheus::core::{AtomicU64, GenericGaugeVec};
@@ -277,7 +279,7 @@ where
     T: Atomic + 'static,
 {
     fn make_collector(mk_opts: MakeCollectorOpts) -> Self {
-        assert!(mk_opts.buckets.is_none());
+        assert_none!(mk_opts.buckets);
         Self::with_opts(mk_opts.opts).expect("defining a counter")
     }
 }
@@ -287,7 +289,7 @@ where
     T: Atomic + 'static,
 {
     fn make_collector(mk_opts: MakeCollectorOpts) -> Self {
-        assert!(mk_opts.buckets.is_none());
+        assert_none!(mk_opts.buckets);
         let labels: Vec<String> = mk_opts.opts.variable_labels.clone();
         let label_refs: Vec<&str> = labels.iter().map(String::as_str).collect();
         Self::new(mk_opts.opts, label_refs.as_slice()).expect("defining a counter vec")
@@ -299,7 +301,7 @@ where
     T: Atomic + 'static,
 {
     fn make_collector(mk_opts: MakeCollectorOpts) -> Self {
-        assert!(mk_opts.buckets.is_none());
+        assert_none!(mk_opts.buckets);
         Self::with_opts(mk_opts.opts).expect("defining a gauge")
     }
 }
@@ -309,7 +311,7 @@ where
     T: Atomic + 'static,
 {
     fn make_collector(mk_opts: MakeCollectorOpts) -> Self {
-        assert!(mk_opts.buckets.is_none());
+        assert_none!(mk_opts.buckets);
         let labels = mk_opts.opts.variable_labels.clone();
         let labels = &labels.iter().map(|x| x.as_str()).collect::<Vec<_>>();
         Self::new(mk_opts.opts, labels).expect("defining a gauge vec")

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -680,6 +680,7 @@ mod tests {
     use futures::stream::{FuturesUnordered, StreamExt};
     use mz_build_info::DUMMY_BUILD_INFO;
     use mz_ore::task::spawn;
+    use mz_ore::{assert_err, assert_none};
 
     use super::*;
 
@@ -795,7 +796,7 @@ mod tests {
             .await
         })
         .await;
-        assert!(res.is_err());
+        assert_err!(res);
         assert_eq!(states.initialized_count(), 0);
 
         // Returning an error from init_fn doesn't initialize an entry in the cache.
@@ -811,7 +812,7 @@ mod tests {
                 &Diagnostics::for_tests(),
             )
             .await;
-        assert!(res.is_err());
+        assert_err!(res);
         assert_eq!(states.initialized_count(), 0);
 
         // Initialize one shard.
@@ -908,7 +909,7 @@ mod tests {
         drop(s1_state2);
         assert_eq!(states.strong_count(), 1);
         assert_eq!(states.initialized_count(), 2);
-        assert!(states.get_cached(&s1).is_none());
+        assert_none!(states.get_cached(&s1));
 
         // But we can re-init that shard if necessary.
         let s1_state1 = states

--- a/src/persist-client/src/internal/cache.rs
+++ b/src/persist-client/src/internal/cache.rs
@@ -379,6 +379,7 @@ mod lru {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_none;
     use proptest::arbitrary::any;
     use proptest::proptest;
     use proptest_derive::Arbitrary;
@@ -491,7 +492,7 @@ mod tests {
         assert_eq!(cache.keys(), &["e", "d"]);
 
         // Remove a non-existent element.
-        assert!(cache.remove("f").is_none());
+        assert_none!(cache.remove("f"));
         assert_eq!(cache.entry_count(), 2);
         assert_eq!(cache.entry_weight(), 2);
         assert_eq!(cache.keys(), &["e", "d"]);

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -18,7 +18,7 @@ use bytes::{Buf, Bytes};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use mz_ore::cast::CastInto;
-use mz_ore::halt;
+use mz_ore::{assert_none, halt};
 use mz_persist::indexed::columnar::ColumnarRecords;
 use mz_persist::indexed::encoding::{BatchColumnarFormat, BlobTraceBatchPart, BlobTraceUpdates};
 use mz_persist::location::{SeqNo, VersionedData};
@@ -1318,8 +1318,8 @@ impl<T: Timestamp + Codec64> RustType<ProtoHollowBatchPart> for BatchPart<T> {
             Some(proto_hollow_batch_part::Kind::Inline(x)) => {
                 assert_eq!(proto.encoded_size_bytes, 0);
                 assert_eq!(proto.key_lower.len(), 0);
-                assert!(proto.key_stats.is_none());
-                assert!(proto.diffs_sum.is_none());
+                assert_none!(proto.key_stats);
+                assert_none!(proto.diffs_sum);
                 let updates = LazyInlineBatchPart(x.into_rust()?);
                 Ok(BatchPart::Inline {
                     updates,
@@ -1553,6 +1553,7 @@ mod tests {
     use bytes::Bytes;
     use mz_build_info::DUMMY_BUILD_INFO;
     use mz_dyncfg::ConfigUpdates;
+    use mz_ore::assert_err;
     use mz_persist::location::SeqNo;
     use proptest::prelude::*;
 
@@ -1599,7 +1600,7 @@ mod tests {
         // of code.
         let v1_res =
             mz_ore::panic::catch_unwind(|| UntypedState::<u64>::decode(&v1, bytes.clone()));
-        assert!(v1_res.is_err());
+        assert_err!(v1_res);
     }
 
     #[mz_ore::test]
@@ -1628,7 +1629,7 @@ mod tests {
         // losing or misinterpreting something written out by a future version
         // of code.
         let v1_res = mz_ore::panic::catch_unwind(|| StateDiff::<u64>::decode(&v1, bytes));
-        assert!(v1_res.is_err());
+        assert_err!(v1_res);
     }
 
     #[mz_ore::test]
@@ -1812,7 +1813,7 @@ mod tests {
             &mut field_diffs_writer,
         );
 
-        assert!(diff_proto.field_diffs.is_none());
+        assert_none!(diff_proto.field_diffs);
         diff_proto.field_diffs = Some(field_diffs_writer.into_proto());
 
         let diff = StateDiff::<u64>::from_proto(diff_proto.clone()).unwrap();

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -20,6 +20,7 @@ use differential_dataflow::lattice::Lattice;
 use futures::stream::{FuturesUnordered, StreamExt};
 use futures::FutureExt;
 use mz_dyncfg::{Config, ConfigSet};
+use mz_ore::assert_none;
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
 #[allow(unused_imports)] // False positive.
@@ -478,7 +479,7 @@ where
                     // of the inputs and independent of anything in persist
                     // state. It's handed back via a Break, so we never even try
                     // to commit it. No network, no Indeterminate.
-                    assert!(indeterminate.is_none());
+                    assert_none!(indeterminate);
                     return CompareAndAppendRes::InvalidUsage(err);
                 }
                 Err(CompareAndAppendBreak::InlineBackpressure) => {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1863,6 +1863,7 @@ pub(crate) mod tests {
     use mz_build_info::DUMMY_BUILD_INFO;
     use mz_dyncfg::ConfigUpdates;
     use mz_ore::now::SYSTEM_TIME;
+    use mz_ore::{assert_none, assert_ok};
     use mz_proto::RustType;
     use proptest::prelude::*;
     use proptest::strategy::ValueTree;
@@ -2763,13 +2764,13 @@ pub(crate) mod tests {
 
         // shouldn't need a rollup at the seqno of the rollup
         state.seqno = SeqNo(5);
-        assert!(state.need_rollup(ROLLUP_THRESHOLD).is_none());
+        assert_none!(state.need_rollup(ROLLUP_THRESHOLD));
 
         // shouldn't need a rollup at seqnos less than our threshold
         state.seqno = SeqNo(6);
-        assert!(state.need_rollup(ROLLUP_THRESHOLD).is_none());
+        assert_none!(state.need_rollup(ROLLUP_THRESHOLD));
         state.seqno = SeqNo(7);
-        assert!(state.need_rollup(ROLLUP_THRESHOLD).is_none());
+        assert_none!(state.need_rollup(ROLLUP_THRESHOLD));
 
         // hit our threshold! we should need a rollup
         state.seqno = SeqNo(8);
@@ -2780,7 +2781,7 @@ pub(crate) mod tests {
 
         // but we don't need rollups for every seqno > the threshold
         state.seqno = SeqNo(9);
-        assert!(state.need_rollup(ROLLUP_THRESHOLD).is_none());
+        assert_none!(state.need_rollup(ROLLUP_THRESHOLD));
 
         // we only need a rollup each `ROLLUP_THRESHOLD` beyond our current seqno
         state.seqno = SeqNo(11);
@@ -2801,7 +2802,7 @@ pub(crate) mod tests {
             .is_continue());
 
         state.seqno = SeqNo(8);
-        assert!(state.need_rollup(ROLLUP_THRESHOLD).is_none());
+        assert_none!(state.need_rollup(ROLLUP_THRESHOLD));
         state.seqno = SeqNo(9);
         assert_eq!(
             state.need_rollup(ROLLUP_THRESHOLD).expect("rollup"),
@@ -2883,15 +2884,15 @@ pub(crate) mod tests {
 
         // Start at v0.10.0.
         let res = open_and_write(&mut clients, Version::new(0, 10, 0), shard_id).await;
-        assert!(res.is_ok());
+        assert_ok!(res);
 
         // Upgrade to v0.11.0 is allowed.
         let res = open_and_write(&mut clients, Version::new(0, 11, 0), shard_id).await;
-        assert!(res.is_ok());
+        assert_ok!(res);
 
         // Downgrade to v0.10.0 is allowed.
         let res = open_and_write(&mut clients, Version::new(0, 10, 0), shard_id).await;
-        assert!(res.is_ok());
+        assert_ok!(res);
 
         // Downgrade to v0.9.0 is _NOT_ allowed.
         let res = open_and_write(&mut clients, Version::new(0, 9, 0), shard_id).await;

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use bytes::{Bytes, BytesMut};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
+use mz_ore::assert_none;
 use mz_ore::cast::CastFrom;
 use mz_persist::location::{SeqNo, VersionedData};
 use mz_persist_types::Codec64;
@@ -823,7 +824,7 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
 
     let batches = {
         let mut batches = BTreeMap::new();
-        trace.map_batches(|b| assert!(batches.insert(b.clone(), ()).is_none()));
+        trace.map_batches(|b| assert_none!(batches.insert(b.clone(), ())));
         apply_diffs_map("spine", diffs.clone(), &mut batches).map(|_ok| batches)
     };
 
@@ -851,7 +852,7 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
             });
 
             let mut batches = BTreeMap::new();
-            reconstructed_spine.map_batches(|b| assert!(batches.insert(b.clone(), ()).is_none()));
+            reconstructed_spine.map_batches(|b| assert_none!(batches.insert(b.clone(), ())));
             apply_diffs_map("spine", diffs, &mut batches)?;
             batches
         }

--- a/src/persist-client/src/internal/watch.rs
+++ b/src/persist-client/src/internal/watch.rs
@@ -145,6 +145,7 @@ mod tests {
     use mz_dyncfg::ConfigUpdates;
     use mz_ore::cast::CastFrom;
     use mz_ore::metrics::MetricsRegistry;
+    use mz_ore::{assert_none, assert_ok};
     use timely::progress::Antichain;
 
     use crate::cache::StateCache;
@@ -206,7 +207,7 @@ mod tests {
         let mut w1 = StateWatch::new(Arc::clone(&state), Arc::clone(&metrics));
         let _ = w1.wait_for_seqno_ge(SeqNo(0)).await;
         let _ = w1.wait_for_seqno_ge(SeqNo(1)).await;
-        assert!(w1.wait_for_seqno_ge(SeqNo(2)).now_or_never().is_none());
+        assert_none!(w1.wait_for_seqno_ge(SeqNo(2)).now_or_never());
     }
 
     #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
@@ -271,10 +272,10 @@ mod tests {
             })
             .collect::<Vec<_>>();
         for watch in watches {
-            assert!(watch.await.is_ok());
+            assert_ok!(watch.await);
         }
         for write in writes {
-            assert!(write.await.is_ok());
+            assert_ok!(write.await);
         }
     }
 

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -681,6 +681,7 @@ mod tests {
     use differential_dataflow::lattice::Lattice;
     use futures_task::noop_waker;
     use mz_dyncfg::ConfigUpdates;
+    use mz_ore::assert_ok;
     use mz_persist::indexed::encoding::BlobTraceBatchPart;
     use mz_persist::workload::DataGenerator;
     use mz_persist_types::codec_impls::{StringSchema, VecU8Schema};
@@ -1836,7 +1837,7 @@ mod tests {
             .finalize_shard::<(), (), u64, i64>(shard_id, Diagnostics::for_tests())
             .await;
 
-        assert!(finalize.is_ok(), "finalization must succeed");
+        assert_ok!(finalize, "finalization must succeed");
 
         let is_finalized = persist_client
             .is_finalized::<(), (), u64, i64>(shard_id, Diagnostics::for_tests())
@@ -1899,7 +1900,7 @@ mod tests {
             .finalize_shard::<(), (), u64, i64>(shard_id, Diagnostics::for_tests())
             .await;
 
-        assert!(finalize.is_ok(), "finalization must succeed");
+        assert_ok!(finalize, "finalization must succeed");
 
         let is_finalized = persist_client
             .is_finalized::<(), (), u64, i64>(shard_id, Diagnostics::for_tests())
@@ -1915,7 +1916,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn shard_id_protobuf_roundtrip(expect in any::<ShardId>() ) {
             let actual = protobuf_roundtrip::<_, String>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -23,6 +23,7 @@ use arrow::datatypes::{
     UInt64Type, UInt8Type,
 };
 use bytes::BufMut;
+use mz_ore::assert_none;
 use timely::order::Product;
 
 use crate::columnar::sealed::{ColumnMut, ColumnRef};
@@ -926,7 +927,7 @@ impl ColumnMut<()> for BinaryBuilder {
 
 impl ColumnPush<Vec<u8>> for BinaryBuilder {
     fn push<'a>(&mut self, val: &'a [u8]) {
-        assert!(self.validity_slice().is_none());
+        assert_none!(self.validity_slice());
         <BinaryBuilder>::append_value(self, val)
     }
 
@@ -999,7 +1000,7 @@ impl ColumnMut<()> for StringBuilder {
 
 impl ColumnPush<String> for StringBuilder {
     fn push<'a>(&mut self, val: &'a str) {
-        assert!(self.validity_slice().is_none());
+        assert_none!(self.validity_slice());
         <StringBuilder>::append_value(self, val)
     }
 
@@ -1040,7 +1041,7 @@ impl ColumnGet<Option<OpaqueData>> for BinaryArray {
 
 impl ColumnPush<OpaqueData> for BinaryBuilder {
     fn push<'a>(&mut self, val: <OpaqueData as Data>::Ref<'a>) {
-        assert!(self.validity_slice().is_none());
+        assert_none!(self.validity_slice());
         <BinaryBuilder>::append_value(self, val)
     }
 

--- a/src/persist-types/src/dyn_struct.rs
+++ b/src/persist-types/src/dyn_struct.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use arrow::array::{Array, BooleanBufferBuilder, NullArray, StructArray};
 use arrow::buffer::NullBuffer;
 use arrow::datatypes::{Field, Fields};
+use mz_ore::assert_none;
 
 use crate::columnar::sealed::{ColumnMut, ColumnRef};
 use crate::columnar::{ColumnGet, ColumnPush, Data, DataType};
@@ -110,7 +111,7 @@ impl ColumnGet<DynStruct> for DynStructCol {
         // columnar struct into components via ColumnsRef, so this is unused. We
         // keep it for completeness and also so that any future changes to the
         // code consider it.
-        assert!(self.validity.is_none());
+        assert_none!(self.validity);
         DynStructRef::Idx {
             idx,
             cols: &self.cols,
@@ -164,7 +165,7 @@ impl DynStructCol {
     ///
     /// Panics if this struct is optional.
     pub fn as_ref(&self) -> ColumnsRef {
-        assert!(self.validity.is_none());
+        assert_none!(self.validity);
         ColumnsRef {
             validity: (),
             cols: self
@@ -318,7 +319,7 @@ impl ColumnPush<DynStruct> for DynStructMut {
         // columnar struct into components via ColumnsMut, so this is unused. We
         // keep it for completeness and also so that any future changes to the
         // code consider it.
-        assert!(self.validity.is_none());
+        assert_none!(self.validity);
         self.push_cols(val);
     }
 
@@ -392,7 +393,7 @@ impl DynStructMut {
             validity,
             cols,
         } = self.as_opt_mut();
-        assert!(validity.validity.is_none());
+        assert_none!(validity.validity);
         ColumnsMut {
             len,
             validity: (),

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use arrow::array::{Array, Int64Array, PrimitiveArray, StructArray};
 use arrow::buffer::ScalarBuffer;
 use arrow::datatypes::{Field, Int64Type};
+use mz_ore::assert_none;
 use mz_ore::iter::IteratorExt;
 
 use crate::columnar::sealed::{ColumnMut, ColumnRef};
@@ -176,7 +177,7 @@ impl Part {
                     diff.data_type()
                 )
             })?;
-        assert!(diff.logical_nulls().is_none());
+        assert_none!(diff.logical_nulls());
         let diff = diff.values().clone();
 
         let ts = ts
@@ -188,7 +189,7 @@ impl Part {
                     ts.data_type()
                 )
             })?;
-        assert!(ts.logical_nulls().is_none());
+        assert_none!(ts.logical_nulls());
         let ts = ts.values().clone();
 
         let part = Part {

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -15,8 +15,8 @@ use std::fmt::Debug;
 
 use arrow::array::Array;
 use mz_ore::cast::CastFrom;
-use mz_ore::metric;
 use mz_ore::metrics::{IntCounter, MetricsRegistry};
+use mz_ore::{assert_none, metric};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use proptest::prelude::*;
 use proptest::strategy::{Strategy, Union};
@@ -368,7 +368,7 @@ impl<T: DynStats> DynStats for OptionStats<T> {
 
     fn into_columnar_stats(self) -> ColumnarStats {
         let inner = self.some.into_columnar_stats();
-        assert!(inner.nulls.is_none(), "we don't support nested OptionStats");
+        assert_none!(inner.nulls, "we don't support nested OptionStats");
 
         ColumnarStats {
             nulls: Some(ColumnNullStats { count: self.none }),
@@ -452,7 +452,7 @@ where
 
 impl<T: Array> StatsFrom<T> for NoneStats {
     fn stats_from(col: &T, _validity: ValidityRef) -> Self {
-        assert!(col.logical_nulls().is_none());
+        assert_none!(col.logical_nulls());
         NoneStats
     }
 }

--- a/src/persist-types/src/stats/primitive.rs
+++ b/src/persist-types/src/stats/primitive.rs
@@ -12,6 +12,7 @@ use std::fmt::{self, Debug};
 use arrow::array::{Array, BinaryArray, BooleanArray, PrimitiveArray, StringArray};
 use arrow::buffer::BooleanBuffer;
 use arrow::datatypes::ArrowPrimitiveType;
+use mz_ore::assert_none;
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use proptest::arbitrary::Arbitrary;
 use proptest::strategy::Strategy;
@@ -281,7 +282,7 @@ impl StatsFrom<BooleanArray> for OptionStats<PrimitiveStats<bool>> {
 
 impl<T: ArrowPrimitiveType> StatsFrom<PrimitiveArray<T>> for PrimitiveStats<T::Native> {
     fn stats_from(col: &PrimitiveArray<T>, validity: ValidityRef) -> Self {
-        assert!(col.logical_nulls().is_none());
+        assert_none!(col.logical_nulls());
 
         // Create a new array with the provided validity.
         let array = PrimitiveArray::<T>::new(col.values().clone(), validity.0.as_ref().cloned());
@@ -311,7 +312,7 @@ impl<T: ArrowPrimitiveType> StatsFrom<PrimitiveArray<T>>
 
 impl StatsFrom<StringArray> for PrimitiveStats<String> {
     fn stats_from(col: &StringArray, validity: ValidityRef) -> Self {
-        assert!(col.logical_nulls().is_none());
+        assert_none!(col.logical_nulls());
 
         // Create a new array with the provided validity.
         let array = StringArray::new(
@@ -358,7 +359,7 @@ impl StatsFrom<StringArray> for OptionStats<PrimitiveStats<String>> {
 
 impl StatsFrom<BinaryArray> for PrimitiveStats<Vec<u8>> {
     fn stats_from(col: &BinaryArray, validity: ValidityRef) -> Self {
-        assert!(col.logical_nulls().is_none());
+        assert_none!(col.logical_nulls());
 
         // Create a new array with the provided validity.
         let array = BinaryArray::new(

--- a/src/persist-types/src/stats/structured.rs
+++ b/src/persist-types/src/stats/structured.rs
@@ -9,6 +9,7 @@
 
 use std::collections::BTreeMap;
 
+use mz_ore::assert_none;
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use proptest::prelude::*;
 use proptest::strategy::Strategy;
@@ -139,7 +140,7 @@ impl ColumnStats<Option<DynStruct>> for OptionStats<StructStats> {
 
 impl StatsFrom<DynStructCol> for StructStats {
     fn stats_from(col: &DynStructCol, validity: ValidityRef) -> Self {
-        assert!(col.validity.is_none());
+        assert_none!(col.validity);
         col.stats(validity).expect("valid stats").some
     }
 }

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -399,6 +399,7 @@ impl Consensus for PostgresConsensus {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_err;
     use tracing::info;
     use uuid::Uuid;
 
@@ -466,7 +467,7 @@ mod tests {
         // And finally, we should see the next connect time out.
         let conn3 = consensus.get_connection().await;
 
-        assert!(conn3.is_err());
+        assert_err!(conn3);
 
         Ok(())
     }

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -234,6 +234,8 @@ impl Consensus for UnreliableConsensus {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::{assert_err, assert_ok};
+
     use crate::mem::{MemBlob, MemBlobConfig, MemConsensus};
 
     use super::*;
@@ -263,11 +265,11 @@ mod tests {
 
         // Reliable doesn't error.
         handle.totally_available();
-        assert!(blob.get("a").await.is_ok());
+        assert_ok!(blob.get("a").await);
 
         // Unreliable does error.
         handle.totally_unavailable();
-        assert!(blob.get("a").await.is_err());
+        assert_err!(blob.get("a").await);
     }
 
     #[mz_ore::test(tokio::test)]
@@ -295,10 +297,10 @@ mod tests {
 
         // Reliable doesn't error.
         handle.totally_available();
-        assert!(consensus.head("key").await.is_ok());
+        assert_ok!(consensus.head("key").await);
 
         // Unreliable does error.
         handle.totally_unavailable();
-        assert!(consensus.head("key").await.is_err());
+        assert_err!(consensus.head("key").await);
     }
 }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -28,9 +28,9 @@ use mz_adapter::{
 };
 use mz_frontegg_auth::Authenticator as FronteggAuthentication;
 use mz_ore::cast::CastFrom;
-use mz_ore::instrument;
 use mz_ore::netio::AsyncReady;
 use mz_ore::str::StrExt;
+use mz_ore::{assert_none, assert_ok, instrument};
 use mz_pgcopy::{CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams};
 use mz_pgwire_common::{ErrorResponse, Format, FrontendMessage, Severity, VERSIONS, VERSION_3};
 use mz_repr::{
@@ -654,7 +654,7 @@ where
         // start_transaction can't error (but assert that just in case it changes in
         // the future.
         let res = self.adapter_client.start_transaction(Some(num_stmts));
-        assert!(res.is_ok());
+        assert_ok!(res);
         Ok(())
     }
 
@@ -1745,7 +1745,7 @@ where
             }
         };
 
-        assert!(tag.is_none(), "tag created but not consumed: {:?}", tag);
+        assert_none!(tag, "tag created but not consumed: {:?}", tag);
         r
     }
 

--- a/src/proto/src/chrono.rs
+++ b/src/proto/src/chrono.rs
@@ -160,6 +160,7 @@ pub fn any_timezone() -> impl Strategy<Value = Tz> {
 #[cfg(test)]
 mod tests {
     use crate::protobuf_roundtrip;
+    use mz_ore::assert_ok;
     use proptest::prelude::*;
 
     use super::*;
@@ -171,7 +172,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn naive_date_protobuf_roundtrip(expect in any_naive_date() ) {
             let actual = protobuf_roundtrip::<_, ProtoNaiveDate>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 
@@ -179,7 +180,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn naive_date_time_protobuf_roundtrip(expect in any_naive_datetime() ) {
             let actual = protobuf_roundtrip::<_, ProtoNaiveDateTime>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 
@@ -187,7 +188,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn date_time_protobuf_roundtrip(expect in any_datetime() ) {
             let actual = protobuf_roundtrip::<_, ProtoNaiveDateTime>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 
@@ -195,7 +196,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn fixed_offset_protobuf_roundtrip(expect in any_fixed_offset() ) {
             let actual = protobuf_roundtrip::<_, ProtoFixedOffset>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -623,6 +623,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use proptest::prelude::*;
 
     use super::*;
@@ -634,7 +635,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn duration_protobuf_roundtrip(expect in any_duration() ) {
             let actual = protobuf_roundtrip::<_, ProtoDuration>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/repr/src/adt/array.rs
+++ b/src/repr/src/adt/array.rs
@@ -289,6 +289,7 @@ impl FixedSizeCodec<ArrayDimension> for PackedArrayDimension {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -298,7 +299,7 @@ mod tests {
         #[mz_ore::test]
         fn invalid_array_error_protobuf_roundtrip(expect in any::<InvalidArrayError>()) {
             let actual = protobuf_roundtrip::<_, ProtoInvalidArrayError>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/repr/src/adt/char.rs
+++ b/src/repr/src/adt/char.rs
@@ -193,6 +193,7 @@ impl RustType<ProtoCharLength> for CharLength {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -202,7 +203,7 @@ mod tests {
         #[mz_ore::test]
         fn char_length_protobuf_roundtrip(expect in any::<CharLength>()) {
             let actual = protobuf_roundtrip::<_, ProtoCharLength>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1961,6 +1961,7 @@ impl FixedSizeCodec<NaiveTime> for PackedNaiveTime {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::any;
     use proptest::{prop_assert_eq, proptest};
@@ -3560,7 +3561,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // slow, large amount of memory
         fn datetimeunits_serialization_roundtrip(expect in any::<DateTimeUnits>() ) {
             let actual = protobuf_roundtrip::<_, ProtoDateTimeUnits>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/repr/src/adt/mz_acl_item.rs
+++ b/src/repr/src/adt/mz_acl_item.rs
@@ -907,11 +907,11 @@ fn test_mz_acl_parsing() {
     assert!(mz_acl.acl_mode.contains(AclMode::CREATE_CLUSTER));
     assert_eq!(s, mz_acl.to_string());
 
-    assert!("u42/rw=u666".parse::<MzAclItem>().is_err());
-    assert!("u32=C/".parse::<MzAclItem>().is_err());
-    assert!("=/".parse::<MzAclItem>().is_err());
-    assert!("f62hfiuew827fhh".parse::<MzAclItem>().is_err());
-    assert!("u2=rw/s66=CU/u33".parse::<MzAclItem>().is_err());
+    mz_ore::assert_err!("u42/rw=u666".parse::<MzAclItem>());
+    mz_ore::assert_err!("u32=C/".parse::<MzAclItem>());
+    mz_ore::assert_err!("=/".parse::<MzAclItem>());
+    mz_ore::assert_err!("f62hfiuew827fhh".parse::<MzAclItem>());
+    mz_ore::assert_err!("u2=rw/s66=CU/u33".parse::<MzAclItem>());
 }
 
 #[mz_ore::test]
@@ -962,7 +962,7 @@ fn test_mz_acl_item_binary() {
         MzAclItem::decode_binary(&mz_acl_item.encode_binary()).unwrap()
     );
 
-    assert!(MzAclItem::decode_binary(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]).is_err())
+    mz_ore::assert_err!(MzAclItem::decode_binary(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]))
 }
 
 #[mz_ore::test]
@@ -1047,13 +1047,13 @@ fn test_acl_parsing() {
     assert!(acl.acl_mode.contains(AclMode::CREATE_CLUSTER));
     assert_eq!(s, acl.to_string());
 
-    assert!("42/rw=666".parse::<AclItem>().is_err());
-    assert!("u42=rw/u666".parse::<AclItem>().is_err());
-    assert!("s42=rw/s666".parse::<AclItem>().is_err());
-    assert!("u32=C/".parse::<AclItem>().is_err());
-    assert!("=/".parse::<AclItem>().is_err());
-    assert!("f62hfiuew827fhh".parse::<AclItem>().is_err());
-    assert!("u2=rw/s66=CU/u33".parse::<AclItem>().is_err());
+    mz_ore::assert_err!("42/rw=666".parse::<AclItem>());
+    mz_ore::assert_err!("u42=rw/u666".parse::<AclItem>());
+    mz_ore::assert_err!("s42=rw/s666".parse::<AclItem>());
+    mz_ore::assert_err!("u32=C/".parse::<AclItem>());
+    mz_ore::assert_err!("=/".parse::<AclItem>());
+    mz_ore::assert_err!("f62hfiuew827fhh".parse::<AclItem>());
+    mz_ore::assert_err!("u2=rw/s66=CU/u33".parse::<AclItem>());
 }
 
 #[mz_ore::test]
@@ -1104,7 +1104,7 @@ fn test_acl_item_binary() {
         AclItem::decode_binary(&acl_item.encode_binary()).unwrap()
     );
 
-    assert!(AclItem::decode_binary(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]).is_err())
+    mz_ore::assert_err!(AclItem::decode_binary(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]))
 }
 
 #[mz_ore::test]

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -601,7 +601,7 @@ fn test_twos_comp_numeric_primitive() {
 fn test_twos_complement_to_numeric_fail() {
     fn inner(b: &mut [u8]) {
         let r = twos_complement_be_to_numeric(b, 0);
-        assert!(r.is_err());
+        mz_ore::assert_err!(r);
     }
     // 17-byte signed digit's max value exceeds 39 digits of precision
     let mut e = [0xFF; Numeric::TWOS_COMPLEMENT_BYTE_WIDTH];
@@ -828,6 +828,7 @@ impl FixedSizeCodec<Numeric> for PackedNumeric {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -839,14 +840,14 @@ mod tests {
         #[mz_ore::test]
         fn numeric_max_scale_protobuf_roundtrip(expect in any::<NumericMaxScale>()) {
             let actual = protobuf_roundtrip::<_, ProtoNumericMaxScale>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 
         #[mz_ore::test]
         fn optional_numeric_max_scale_protobuf_roundtrip(expect in any::<Option<NumericMaxScale>>()) {
             let actual = protobuf_roundtrip::<_, ProtoOptionalNumericMaxScale>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }
@@ -860,7 +861,7 @@ mod tests {
         assert_eq!(og, rnd);
 
         // Returns an error if the size of the slice is invalid.
-        assert!(PackedNumeric::from_bytes(&[0, 0, 0, 0]).is_err());
+        mz_ore::assert_err!(PackedNumeric::from_bytes(&[0, 0, 0, 0]));
     }
 
     #[mz_ore::test]

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -308,6 +308,7 @@ prop_compose! {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -318,7 +319,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn regex_protobuf_roundtrip( expect in any_regex() ) {
             let actual =  protobuf_roundtrip::<_, ProtoRegex>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -977,6 +977,7 @@ impl Arbitrary for CheckedTimestamp<DateTime<Utc>> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use mz_ore::assert_err;
     use proptest::prelude::*;
 
     #[mz_ore::test]
@@ -1062,7 +1063,7 @@ mod test {
             .unwrap();
             let _ = date.round_to_precision(Some(TimestampPrecision(7)));
         });
-        assert!(result.is_err());
+        assert_err!(result);
 
         let date = CheckedTimestamp::try_from(
             DateTime::from_timestamp_micros(123456).unwrap().naive_utc(),

--- a/src/repr/src/adt/varchar.rs
+++ b/src/repr/src/adt/varchar.rs
@@ -129,6 +129,7 @@ pub fn format_str(
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -138,7 +139,7 @@ mod tests {
         #[mz_ore::test]
         fn var_char_max_length_protobuf_roundtrip(expect in any::<VarCharMaxLength>()) {
             let actual = protobuf_roundtrip::<_, ProtoVarCharMaxLength>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/repr/src/bytes.rs
+++ b/src/repr/src/bytes.rs
@@ -196,6 +196,7 @@ impl FromStr for BytesUnit {
 #[cfg(test)]
 mod tests {
     use crate::bytes::ByteSize;
+    use mz_ore::assert_err;
     use proptest::prelude::*;
     use proptest::proptest;
 
@@ -241,13 +242,13 @@ mod tests {
         assert_eq!(parse("521  TB"), ByteSize::tb(521));
 
         // parsing errors
-        assert!("".parse::<ByteSize>().is_err());
-        assert!("a124GB".parse::<ByteSize>().is_err());
-        assert!("1K".parse::<ByteSize>().is_err());
-        assert!("B".parse::<ByteSize>().is_err());
+        assert_err!("".parse::<ByteSize>());
+        assert_err!("a124GB".parse::<ByteSize>());
+        assert_err!("1K".parse::<ByteSize>());
+        assert_err!("B".parse::<ByteSize>());
         // postgres is strict about matching capitalization
-        assert!("1gb".parse::<ByteSize>().is_err());
-        assert!("1KB".parse::<ByteSize>().is_err());
+        assert_err!("1gb".parse::<ByteSize>());
+        assert_err!("1KB".parse::<ByteSize>());
     }
 
     #[mz_ore::test]

--- a/src/repr/src/explain.rs
+++ b/src/repr/src/explain.rs
@@ -831,6 +831,8 @@ impl IndexUsageType {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
+
     use super::*;
 
     struct Environment {
@@ -954,7 +956,7 @@ mod tests {
         let act = do_explain(&mut env, frontiers);
         let exp = "expr = 1 + 2\nat t ∊ [3, 7)\nenv = test env\n".to_string();
 
-        assert!(act.is_ok());
+        assert_ok!(act);
         assert_eq!(act.unwrap(), exp);
     }
 }

--- a/src/repr/src/role_id.rs
+++ b/src/repr/src/role_id.rs
@@ -225,16 +225,16 @@ fn test_role_id_parsing() {
     assert_eq!(s, role_id.to_string());
 
     let s = "p23";
-    assert!(s.parse::<RoleId>().is_err());
+    mz_ore::assert_err!(s.parse::<RoleId>());
 
     let s = "d23";
-    assert!(s.parse::<RoleId>().is_err());
+    mz_ore::assert_err!(s.parse::<RoleId>());
 
     let s = "asfje90uf23i";
-    assert!(s.parse::<RoleId>().is_err());
+    mz_ore::assert_err!(s.parse::<RoleId>());
 
     let s = "";
-    assert!(s.parse::<RoleId>().is_err());
+    mz_ore::assert_err!(s.parse::<RoleId>());
 }
 
 #[mz_ore::test]
@@ -263,7 +263,7 @@ fn test_role_id_binary() {
         RoleId::decode_binary(&role_id.encode_binary()).unwrap()
     );
 
-    assert!(RoleId::decode_binary(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]).is_err())
+    mz_ore::assert_err!(RoleId::decode_binary(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]))
 }
 
 #[mz_ore::test]

--- a/src/repr/src/row/collection.rs
+++ b/src/repr/src/row/collection.rs
@@ -426,6 +426,7 @@ impl IntoRowIterator for SortedRowCollection {
 mod tests {
     use std::borrow::Borrow;
 
+    use mz_ore::assert_none;
     use proptest::prelude::*;
     use proptest::test_runner::Config;
 
@@ -612,8 +613,8 @@ mod tests {
         assert!(mapped.next().is_some());
         assert!(mapped.next().is_some());
         assert!(mapped.next().is_some());
-        assert!(mapped.next().is_none());
-        assert!(mapped.next().is_none());
+        assert_none!(mapped.next());
+        assert_none!(mapped.next());
     }
 
     #[mz_ore::test]

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -4328,6 +4328,7 @@ fn verify_base_eq_record_nullability() {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
 
     use super::*;
@@ -4337,7 +4338,7 @@ mod tests {
        #[cfg_attr(miri, ignore)] // too slow
         fn scalar_type_protobuf_roundtrip(expect in any::<ScalarType>() ) {
             let actual = protobuf_roundtrip::<_, ProtoScalarType>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -2120,6 +2120,7 @@ impl RustType<ProtoParseHexError> for ParseHexError {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -2130,7 +2131,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn parse_error_protobuf_roundtrip(expect in any::<ParseError>()) {
             let actual = protobuf_roundtrip::<_, ProtoParseError>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }
@@ -2140,7 +2141,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn parse_hex_error_protobuf_roundtrip(expect in any::<ParseHexError>()) {
             let actual = protobuf_roundtrip::<_, ProtoParseHexError>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/repr/src/url.rs
+++ b/src/repr/src/url.rs
@@ -33,6 +33,7 @@ pub fn any_url() -> impl Strategy<Value = Url> {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -45,7 +46,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn url_protobuf_roundtrip(expect in any_url() ) {
             let actual = protobuf_roundtrip::<_, ProtoUrl>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/rocksdb-types/src/config.rs
+++ b/src/rocksdb-types/src/config.rs
@@ -502,6 +502,7 @@ pub mod defaults {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
@@ -537,7 +538,7 @@ mod tests {
     fn rocksdb_tuning_roundtrip() {
         proptest!(|(expect in any::<RocksDBTuningParameters>())| {
             let actual = protobuf_roundtrip::<_, ProtoRocksDbTuningParameters>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
 
         });

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -23,6 +23,7 @@ use std::iter;
 
 use datadriven::walk;
 use itertools::Itertools;
+use mz_ore::assert_ok;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::visit::Visit;
 use mz_sql_parser::ast::visit_mut::{self, VisitMut};
@@ -254,9 +255,9 @@ fn test_max_statement_batch_size() {
     let max_statement_count = MAX_STATEMENT_BATCH_SIZE / size;
     let statements = iter::repeat(statement).take(max_statement_count).join("");
 
-    assert!(parse_statements_with_limit(&statements).is_ok());
+    assert_ok!(parse_statements_with_limit(&statements));
     let statements = format!("{statements}{statement}");
     let err = parse_statements_with_limit(&statements).expect_err("statements should be too big");
     assert!(err.contains("statement batch size cannot exceed "));
-    assert!(parse_statements(&statements).is_ok());
+    assert_ok!(parse_statements(&statements));
 }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1656,7 +1656,7 @@ macro_rules! builtins {
                 assert_eq!(imp.return_is_set, expect_set_return, "wrong set return value for func with oid {}", imp.oid);
             }
             let old = builtins.insert($name, func);
-            assert!(old.is_none(), "duplicate entry in builtins list {:?}", old);
+            mz_ore::assert_none!(old, "duplicate entry in builtins list");
         )+
         builtins
     }};

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -41,6 +41,7 @@ use std::{iter, mem};
 use itertools::Itertools;
 use mz_expr::virtual_syntax::AlgExcept;
 use mz_expr::{func as expr_func, Id, LetRecLimit, LocalId, MirScalarExpr, RowSetFinishing};
+use mz_ore::assert_none;
 use mz_ore::collections::CollectionExt;
 use mz_ore::option::FallibleMapExt;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
@@ -2987,8 +2988,8 @@ fn plan_table_function_internal(
     with_ordinality: bool,
     table_name: Option<FullItemName>,
 ) -> Result<(HirRelationExpr, Scope), PlanError> {
-    assert!(filter.is_none(), "cannot parse table function with FILTER");
-    assert!(over.is_none(), "cannot parse table function with OVER");
+    assert_none!(filter, "cannot parse table function with FILTER");
+    assert_none!(over, "cannot parse table function with OVER");
     assert!(!*distinct, "cannot parse table function with DISTINCT");
 
     let ecx = &ExprContext {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -27,9 +27,9 @@ use mz_interchange::avro::{AvroSchemaGenerator, AvroSchemaOptions, DocTarget};
 use mz_ore::cast::{CastFrom, TryCastFrom};
 use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::num::NonNeg;
-use mz_ore::soft_panic_or_log;
 use mz_ore::str::StrExt;
 use mz_ore::vec::VecExt;
+use mz_ore::{assert_none, soft_panic_or_log};
 use mz_proto::RustType;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
@@ -994,7 +994,7 @@ pub fn plan_create_source(
                     column_casts.push((cast_type, mir_cast));
                 }
                 let r = table_casts.insert(i + 1, column_casts);
-                assert!(r.is_none(), "cannot have table defined multiple times");
+                assert_none!(r, "cannot have table defined multiple times");
             }
 
             let connection =

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -16,6 +16,7 @@
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
+use mz_ore::assert_none;
 use mz_ore::collections::CollectionExt;
 use mz_repr::{Datum, GlobalId, RelationDesc, Row, ScalarType};
 use mz_sql_parser::ast::display::AstDisplay;
@@ -289,15 +290,15 @@ pub fn show_objects<'a>(
         ShowObjectType::Type => show_types(scx, from, filter),
         ShowObjectType::Object => show_all_objects(scx, from, filter),
         ShowObjectType::Role => {
-            assert!(from.is_none(), "parser should reject from");
+            assert_none!(from, "parser should reject from");
             show_roles(scx, filter)
         }
         ShowObjectType::Cluster => {
-            assert!(from.is_none(), "parser should reject from");
+            assert_none!(from, "parser should reject from");
             show_clusters(scx, filter)
         }
         ShowObjectType::ClusterReplica => {
-            assert!(from.is_none(), "parser should reject from");
+            assert_none!(from, "parser should reject from");
             show_cluster_replicas(scx, filter)
         }
         ShowObjectType::Secret => show_secrets(scx, from, filter),
@@ -310,23 +311,23 @@ pub fn show_objects<'a>(
             on_object,
         } => show_indexes(scx, from, on_object, in_cluster, filter),
         ShowObjectType::Database => {
-            assert!(from.is_none(), "parser should reject from");
+            assert_none!(from, "parser should reject from");
             show_databases(scx, filter)
         }
         ShowObjectType::Schema { from: db_from } => {
-            assert!(from.is_none(), "parser should reject from");
+            assert_none!(from, "parser should reject from");
             show_schemas(scx, db_from, filter)
         }
         ShowObjectType::Privileges { object_type, role } => {
-            assert!(from.is_none(), "parser should reject from");
+            assert_none!(from, "parser should reject from");
             show_privileges(scx, object_type, role, filter)
         }
         ShowObjectType::DefaultPrivileges { object_type, role } => {
-            assert!(from.is_none(), "parser should reject from");
+            assert_none!(from, "parser should reject from");
             show_default_privileges(scx, object_type, role, filter)
         }
         ShowObjectType::RoleMembership { role } => {
-            assert!(from.is_none(), "parser should reject from");
+            assert_none!(from, "parser should reject from");
             show_role_membership(scx, role, filter)
         }
     }

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -17,6 +17,7 @@ use dynfmt::{Format, SimpleCurlyFormat};
 use itertools::Itertools;
 use mz_expr::func::{CastArrayToJsonb, CastListToJsonb};
 use mz_expr::{func, VariadicFunc};
+use mz_ore::assert_none;
 use mz_repr::{ColumnName, ColumnType, Datum, RelationType, ScalarBaseType, ScalarType};
 use once_cell::sync::Lazy;
 
@@ -1135,7 +1136,7 @@ pub fn plan_coerce<'a>(
 
         Parameter(n) => {
             let prev = ecx.param_types().borrow_mut().insert(n, coerce_to.clone());
-            assert!(prev.is_none());
+            assert_none!(prev);
             HirScalarExpr::Parameter(n)
         }
     })

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -22,6 +22,7 @@ use itertools::Itertools;
 use mz_ccsr::{Client, GetByIdError, GetBySubjectError, Schema as CcsrSchema};
 use mz_controller_types::ClusterId;
 use mz_kafka_util::client::MzClientContext;
+use mz_ore::assert_none;
 use mz_ore::error::ErrorExt;
 use mz_ore::future::InTask;
 use mz_ore::iter::IteratorExt;
@@ -1251,7 +1252,7 @@ async fn purify_alter_source(
         details,
         seen: _,
     } = options.clone().try_into()?;
-    assert!(details.is_none(), "details cannot be explicitly set");
+    assert_none!(details, "details cannot be explicitly set");
 
     let mut create_subsource_stmts = vec![];
 

--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -1156,6 +1156,8 @@ impl_value_for_simple!(CompressionType, "rocksdb_compression_type");
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_err;
+
     use super::*;
 
     #[mz_ore::test]
@@ -1207,7 +1209,7 @@ mod tests {
         );
 
         fn errs(t: &'static str) {
-            assert!(Duration::parse(VarInput::Flat(t)).is_err());
+            assert_err!(Duration::parse(VarInput::Flat(t)));
         }
         errs("1 m");
         errs("1 sec");

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -824,6 +824,7 @@ impl TryIntoTimelyConfig for StorageCommand {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_ok;
     use mz_proto::protobuf_roundtrip;
     use proptest::prelude::ProptestConfig;
     use proptest::proptest;
@@ -837,7 +838,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn storage_command_protobuf_roundtrip(expect in any::<StorageCommand<mz_repr::Timestamp>>() ) {
             let actual = protobuf_roundtrip::<_, ProtoStorageCommand>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
 
@@ -845,7 +846,7 @@ mod tests {
         #[cfg_attr(miri, ignore)] // too slow
         fn storage_response_protobuf_roundtrip(expect in any::<StorageResponse<mz_repr::Timestamp>>() ) {
             let actual = protobuf_roundtrip::<_, ProtoStorageResponse>(&expect);
-            assert!(actual.is_ok());
+            assert_ok!(actual);
             assert_eq!(actual.unwrap(), expect);
         }
     }

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -23,9 +23,9 @@ use futures::{Future, FutureExt, StreamExt};
 use itertools::Itertools;
 
 use mz_ore::collections::CollectionExt;
-use mz_ore::instrument;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_ore::task::AbortOnDropHandle;
+use mz_ore::{assert_none, instrument};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::USE_CRITICAL_SINCE_SNAPSHOT;
 use mz_persist_client::critical::SinceHandle;
@@ -1957,7 +1957,7 @@ where
             Self::Critical(handle) => handle.compare_and_downgrade_since(expected, new).await,
             Self::Leased(handle) => {
                 let (opaque, since) = new;
-                assert!(opaque.0.is_none());
+                assert_none!(opaque.0);
 
                 handle.downgrade_since(since).await;
 
@@ -1979,7 +1979,7 @@ where
             }
             Self::Leased(handle) => {
                 let (opaque, since) = new;
-                assert!(opaque.0.is_none());
+                assert_none!(opaque.0);
 
                 handle.maybe_downgrade_since(since).await;
 
@@ -2650,6 +2650,7 @@ mod tests {
 
     use mz_build_info::DUMMY_BUILD_INFO;
     use mz_dyncfg::ConfigSet;
+    use mz_ore::assert_err;
     use mz_ore::metrics::MetricsRegistry;
     use mz_ore::now::SYSTEM_TIME;
     use mz_persist_client::cache::PersistClientCache;
@@ -2726,11 +2727,11 @@ mod tests {
         // No stats for unknown GlobalId.
         let stats =
             snapshot_stats(&cmds_tx, GlobalId::User(2), Antichain::from_elem(0.into())).await;
-        assert!(stats.is_err());
+        assert_err!(stats);
 
         // Stats don't resolve for as_of past the upper.
         let stats_fut = snapshot_stats(&cmds_tx, GlobalId::User(1), Antichain::from_elem(1.into()));
-        assert!(stats_fut.now_or_never().is_none());
+        assert_none!(stats_fut.now_or_never());
 
         // // Call it again because now_or_never consumed our future and it's not clone-able.
         let stats_ts1_fut =

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -35,9 +35,9 @@ use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
 use mz_storage_client::storage_collections::{CollectionFrontiers, StorageCollections};
 use timely::progress::Timestamp as TimelyTimestamp;
 
-use mz_ore::{assert_none, instrument};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
+use mz_ore::{assert_none, instrument};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::USE_CRITICAL_SINCE_SNAPSHOT;
 use mz_persist_client::read::ReadHandle;

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -35,7 +35,7 @@ use mz_persist_client::stats::{SnapshotPartsStats, SnapshotStats};
 use mz_storage_client::storage_collections::{CollectionFrontiers, StorageCollections};
 use timely::progress::Timestamp as TimelyTimestamp;
 
-use mz_ore::instrument;
+use mz_ore::{assert_none, instrument};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_persist_client::cache::PersistClientCache;
@@ -454,7 +454,7 @@ where
             self.config.parameters.clone(),
         ));
         let old_client = self.clients.insert(id, client);
-        assert!(old_client.is_none(), "storage instance {id} already exists");
+        assert_none!(old_client, "storage instance {id} already exists");
     }
 
     fn drop_instance(&mut self, id: StorageInstanceId) {

--- a/src/storage-operators/src/s3_oneshot_sink/pgcopy.rs
+++ b/src/storage-operators/src/s3_oneshot_sink/pgcopy.rs
@@ -12,6 +12,7 @@ use aws_types::sdk_config::SdkConfig;
 use mz_aws_util::s3_uploader::{
     CompletedUpload, S3MultiPartUploadError, S3MultiPartUploader, S3MultiPartUploaderConfig,
 };
+use mz_ore::assert_none;
 use mz_ore::cast::CastFrom;
 use mz_ore::task::JoinHandleExt;
 use mz_pgcopy::{encode_copy_format, encode_copy_format_header, CopyFormatParams};
@@ -124,7 +125,7 @@ impl PgCopyUploader {
     /// Creates the uploader for the next file and starts the multi part upload.
     async fn start_new_file_upload(&mut self) -> Result<(), anyhow::Error> {
         self.finish().await?;
-        assert!(self.current_file_uploader.is_none());
+        assert_none!(self.current_file_uploader);
 
         self.file_index += 1;
         let object_key =

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -22,6 +22,7 @@ use mz_dyncfg::ConfigSet;
 use mz_kafka_util::client::{
     BrokerAddr, BrokerRewrite, MzClientContext, MzKafkaError, TunnelConfig, TunnelingClientContext,
 };
+use mz_ore::assert_none;
 use mz_ore::error::ErrorExt;
 use mz_ore::future::{InTask, OreFutureExt};
 use mz_ore::netio::resolve_address;
@@ -1175,7 +1176,7 @@ impl CsrConnection {
                     });
             }
             Tunnel::AwsPrivatelink(connection) => {
-                assert!(connection.port.is_none());
+                assert_none!(connection.port);
 
                 let privatelink_host = mz_cloud_resources::vpc_endpoint_host(
                     connection.connection_id,
@@ -1499,7 +1500,7 @@ impl PostgresConnection<InlinedConnection> {
                 }
             }
             Tunnel::AwsPrivatelink(connection) => {
-                assert!(connection.port.is_none());
+                assert_none!(connection.port);
                 mz_postgres_util::TunnelConfig::AwsPrivatelink {
                     connection_id: connection.connection_id,
                 }
@@ -1878,7 +1879,7 @@ impl MySqlConnection<InlinedConnection> {
                 }
             }
             Tunnel::AwsPrivatelink(connection) => {
-                assert!(connection.port.is_none());
+                assert_none!(connection.port);
                 mz_mysql_util::TunnelConfig::AwsPrivatelink {
                     connection_id: connection.connection_id,
                 }

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -11,6 +11,7 @@ use std::error::Error;
 use std::fmt::{self, Debug, Display};
 
 use itertools::Itertools;
+use mz_ore::assert_none;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::columnar::Data;
 use mz_persist_types::dyn_struct::DynStruct;
@@ -457,7 +458,7 @@ impl TxnsCodec for TxnsCodecRow {
         let ts = datums.next().expect("valid entry");
         let ts = u64::to_le_bytes(ts.unwrap_uint64());
         let batch = datums.next().expect("valid entry");
-        assert!(datums.next().is_none());
+        assert_none!(datums.next());
         if batch.is_null() {
             TxnsEntry::Register(data_id, ts)
         } else {

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -23,6 +23,7 @@ use bytes::BufMut;
 use columnation::Columnation;
 use itertools::EitherOrBoth::Both;
 use itertools::Itertools;
+use mz_ore::assert_none;
 use mz_persist_types::columnar::{ColumnDecoder, ColumnEncoder, Schema2};
 use mz_persist_types::columnar::{
     ColumnFormat, ColumnGet, ColumnPush, Data, DataType, PartDecoder, PartEncoder, Schema,
@@ -1570,7 +1571,7 @@ impl<'a> SubsourceResolver {
             .flatten()
             .expect("must have provided the item name");
 
-        assert!(names.next().is_none(), "expected a 3-element iterator");
+        assert_none!(names.next(), "expected a 3-element iterator");
 
         let schemas =
             self.inner
@@ -1877,6 +1878,7 @@ impl Schema2<SourceData> for RelationDesc {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
+    use mz_ore::assert_err;
     use mz_repr::{arb_datum_for_scalar, ScalarType};
     use proptest::prelude::*;
     use proptest::strategy::{Union, ValueTree};
@@ -1891,11 +1893,11 @@ mod tests {
         assert_eq!(Ok(Timeline::External("JOE".to_string())), "E.JOE".parse());
         assert_eq!(Ok(Timeline::User("MIKE".to_string())), "U.MIKE".parse());
 
-        assert!("Materialize".parse::<Timeline>().is_err());
-        assert!("Ejoe".parse::<Timeline>().is_err());
-        assert!("Umike".parse::<Timeline>().is_err());
-        assert!("Dance".parse::<Timeline>().is_err());
-        assert!("".parse::<Timeline>().is_err());
+        assert_err!("Materialize".parse::<Timeline>());
+        assert_err!("Ejoe".parse::<Timeline>());
+        assert_err!("Umike".parse::<Timeline>());
+        assert_err!("Dance".parse::<Timeline>());
+        assert_err!("".parse::<Timeline>());
     }
 
     #[track_caller]

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -596,6 +596,8 @@ pub fn gtid_set_frontier(gtid_set_str: &str) -> Result<Antichain<GtidPartition>,
 #[cfg(test)]
 mod tests {
 
+    use mz_ore::assert_err;
+
     use super::*;
     use std::num::NonZeroU64;
 
@@ -649,7 +651,7 @@ mod tests {
         let gtid_set_str =
             "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-19, 2174B383-5441-11E8-B90A-C80AA9429562:1-3";
         let result = gtid_set_frontier(gtid_set_str);
-        assert!(result.is_err());
+        assert_err!(result);
     }
 
     #[mz_ore::test]
@@ -657,7 +659,7 @@ mod tests {
         let gtid_set_str =
             "2174B383-5441-11E8-B90A-C80AA9429562:1-3:5-8, 3E11FA47-71CA-11E1-9E33-C80AA9429562:1-19";
         let result = gtid_set_frontier(gtid_set_str);
-        assert!(result.is_err());
+        assert_err!(result);
     }
 
     #[mz_ore::test]
@@ -665,7 +667,7 @@ mod tests {
         let gtid_set_str =
             "14c1b43a-eb64-11eb-8a9a-0242ac130002:1-5,24DA167-0C0C-11E8-8442-00059A3C7B00:1";
         let result = gtid_set_frontier(gtid_set_str);
-        assert!(result.is_err());
+        assert_err!(result);
     }
 
     #[mz_ore::test]
@@ -673,7 +675,7 @@ mod tests {
         let gtid_set_str =
             "14c1b43a-eb64-11eb-8a9a-0242ac130002:1-5,14c1b43a-eb64-11eb-8a9a-0242ac130003:1-3:4";
         let result = gtid_set_frontier(gtid_set_str);
-        assert!(result.is_err());
+        assert_err!(result);
     }
 
     #[mz_ore::test]

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -970,6 +970,7 @@ mod tests {
 
     // The below is ALL test infrastructure for the above
 
+    use mz_ore::assert_err;
     use timely::container::CapacityContainerBuilder;
     use timely::dataflow::operators::exchange::Exchange;
     use timely::dataflow::Scope;
@@ -1157,7 +1158,7 @@ mod tests {
                     }
 
                     // Assert that nothing is left in the channel.
-                    assert!(out_rx.try_recv().is_err());
+                    assert_err!(out_rx.try_recv());
                 }
             },
         )

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -1250,11 +1250,13 @@ fn encode_headers(datum: Datum) -> Vec<KafkaHeader> {
 
 #[cfg(test)]
 mod test {
+    use mz_ore::assert_err;
+
     use super::*;
 
     #[mz_ore::test]
     fn progress_record_migration() {
-        assert!(parse_progress_record(b"{}").is_err());
+        assert_err!(parse_progress_record(b"{}"));
 
         assert_eq!(
             parse_progress_record(b"{\"timestamp\":1}").unwrap(),
@@ -1296,6 +1298,6 @@ mod test {
             }
         );
 
-        assert!(parse_progress_record(b"{\"frontier\":null}").is_err());
+        assert_err!(parse_progress_record(b"{\"frontier\":null}"));
     }
 }

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -20,6 +20,7 @@ use differential_dataflow::AsCollection;
 use futures::StreamExt;
 use maplit::btreemap;
 use mz_kafka_util::client::{get_partitions, MzClientContext, PartitionId, TunnelingClientContext};
+use mz_ore::assert_none;
 use mz_ore::error::ErrorExt;
 use mz_ore::future::InTask;
 use mz_ore::thread::{JoinHandleExt, UnparkOnDropHandle};
@@ -907,8 +908,7 @@ impl KafkaSourceReader {
         self.create_partition_queue(pid, Offset::Offset(start_offset));
 
         let prev = self.last_offsets.insert(pid, start_offset - 1);
-
-        assert!(prev.is_none());
+        assert_none!(prev);
     }
 
     /// Creates a new partition queue for `partition_id`.

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -82,6 +82,7 @@ pub mod common {
 
     use mz_expr::LocalId;
     use mz_expr::MirRelationExpr;
+    use mz_ore::assert_none;
     use mz_repr::optimize::OptimizerFeatures;
 
     use super::subtree::SubtreeSize;
@@ -351,7 +352,7 @@ pub mod common {
                     Err(local_id) => {
                         // Capture the *remaining* work, which we'll need to flip around.
                         let prior = self.result.bindings.insert(local_id, rev_post_order.len());
-                        assert!(prior.is_none(), "Shadowing not allowed");
+                        assert_none!(prior, "Shadowing not allowed");
                     }
                 }
             }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -18,8 +18,8 @@ use mz_expr::{
     func, EvalError, LetRecLimit, MirRelationExpr, MirScalarExpr, UnaryFunc, RECURSION_LIMIT,
 };
 use mz_ore::cast::CastFrom;
-use mz_ore::soft_panic_or_log;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
+use mz_ore::{assert_none, soft_panic_or_log};
 use mz_repr::{ColumnType, Datum, RelationType, Row, ScalarType};
 
 use crate::{TransformCtx, TransformError};
@@ -121,7 +121,7 @@ impl ColumnKnowledge {
                         let id = mz_expr::Id::Local(id.clone());
                         let knowledge_new = vec![DatumKnowledge::bottom(); value.arity()];
                         let knowledge_old = knowledge.insert(id, knowledge_new);
-                        assert!(knowledge_old.is_none());
+                        assert_none!(knowledge_old);
                     }
 
                     // Sum up the arity of all ids in the enclosing LetRec node.

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -23,7 +23,7 @@ use mz_expr::{
     MirRelationExpr, MirScalarExpr, RECURSION_LIMIT,
 };
 use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
-use mz_ore::{soft_assert_eq_or_log, soft_assert_or_log, soft_panic_or_log};
+use mz_ore::{assert_none, soft_assert_eq_or_log, soft_assert_or_log, soft_panic_or_log};
 use mz_repr::explain::{DeltaJoinIndexUsageType, IndexUsageType, UsedIndexes};
 use mz_repr::GlobalId;
 
@@ -1052,7 +1052,7 @@ impl<'a> CollectIndexRequests<'a> {
                 MirRelationExpr::Let { id, value, body } => {
                     let shadowed_context = this.context_across_lets.insert(id.clone(), Vec::new());
                     // No shadowing in MIR
-                    assert!(shadowed_context.is_none());
+                    assert_none!(shadowed_context);
                     // We go backwards: Recurse on the body and then the value.
                     this.collect_index_reqs_inner(body, contexts)?;
                     // The above call filled in the entry for `id` in `context_across_lets` (if it
@@ -1073,7 +1073,7 @@ impl<'a> CollectIndexRequests<'a> {
                 } => {
                     for id in ids.iter() {
                         let shadowed_context = this.context_across_lets.insert(id.clone(), Vec::new());
-                        assert!(shadowed_context.is_none()); // No shadowing in MIR
+                        assert_none!(shadowed_context); // No shadowing in MIR
                     }
                     // We go backwards: Recurse on the body first.
                     this.collect_index_reqs_inner(body, contexts)?;

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -10,6 +10,7 @@
 //! Transformation based on pushing demand information about columns toward sources.
 
 use itertools::Itertools;
+use mz_ore::assert_none;
 use std::collections::{BTreeMap, BTreeSet};
 
 use mz_expr::{
@@ -122,7 +123,7 @@ impl Demand {
                     // and pushes the union of the requirements at its value.
                     let id = Id::Local(*id);
                     let prior = gets.insert(id, BTreeSet::new());
-                    assert!(prior.is_none()); // no shadowing
+                    assert_none!(prior); // no shadowing
                     self.action(body, columns, gets)?;
                     let needs = gets.remove(&id).expect("existing gets entry");
                     if let Some(prior) = prior {
@@ -144,7 +145,7 @@ impl Demand {
                     let ids = ids.iter().map(|id| Id::Local(*id)).collect_vec();
                     for id in ids.iter() {
                         let prior = gets.insert(id.clone(), BTreeSet::new());
-                        assert!(prior.is_none()); // no shadowing
+                        assert_none!(prior); // no shadowing
                     }
                     self.action(body, columns, gets)?;
                     for (id, value) in ids.iter().rev().zip_eq(values.iter_mut().rev()) {

--- a/src/transform/src/movement/projection_pushdown.rs
+++ b/src/transform/src/movement/projection_pushdown.rs
@@ -34,6 +34,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use itertools::zip_eq;
 use mz_expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr, RECURSION_LIMIT};
+use mz_ore::assert_none;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 
 use crate::{TransformCtx, TransformError};
@@ -151,7 +152,7 @@ impl ProjectionPushdown {
                     // Seed the gets map with empty demand for each non-recursive ID.
                     for id in ids.iter().filter(|id| !rec_ids.contains(id)) {
                         let prior = gets.insert(Id::Local(*id), BTreeSet::new());
-                        assert!(prior.is_none());
+                        assert_none!(prior);
                     }
 
                     // Descend into the body with the supplied desired_projection.

--- a/src/transform/src/non_null_requirements.rs
+++ b/src/transform/src/non_null_requirements.rs
@@ -26,6 +26,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use itertools::{zip_eq, Either, Itertools};
 use mz_expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr, RECURSION_LIMIT};
+use mz_ore::assert_none;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 
 use crate::TransformCtx;
@@ -123,7 +124,7 @@ impl NonNullRequirements {
                     // Seed the gets map with an empty vector for each ID.
                     for id in ids.iter() {
                         let prior = gets.insert(Id::Local(*id), vec![]);
-                        assert!(prior.is_none());
+                        assert_none!(prior);
                     }
 
                     // Descend into the body with the supplied columns.

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -25,6 +25,7 @@
 //! `IdGen`, which is used to prepare distinct expressions for inlining.
 
 use mz_expr::{visit::Visit, MirRelationExpr};
+use mz_ore::assert_none;
 use mz_ore::{id_gen::IdGen, stack::RecursionLimitError};
 use mz_repr::optimize::OptimizerFeatures;
 
@@ -142,7 +143,7 @@ impl NormalizeLets {
                 support::replace_bindings_from_map(bindings, ids, values, limits);
             } else {
                 for (id, (value, max_iter)) in bindings.into_iter().rev() {
-                    assert!(max_iter.is_none());
+                    assert_none!(max_iter);
                     *relation = MirRelationExpr::Let {
                         id,
                         value: Box::new(value),
@@ -199,6 +200,7 @@ mod support {
     use itertools::Itertools;
 
     use mz_expr::{Id, LetRecLimit, LocalId, MirRelationExpr};
+    use mz_ore::assert_none;
     use mz_repr::optimize::OptimizerFeatures;
 
     pub(super) fn replace_bindings_from_map(
@@ -330,7 +332,7 @@ mod support {
                 } else {
                     let typ = value.typ();
                     let prior = types.insert(*id, typ);
-                    assert!(prior.is_none());
+                    assert_none!(prior);
                 }
             }
             refresh_types_helper(body, types, features)?;

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -27,8 +27,8 @@ use std::collections::BTreeMap;
 use itertools::Itertools;
 use mz_expr::visit::Visit;
 use mz_expr::{Id, JoinInputMapper, LocalId, MirRelationExpr, MirScalarExpr, RECURSION_LIMIT};
-use mz_ore::soft_panic_or_log;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
+use mz_ore::{assert_none, soft_panic_or_log};
 
 use crate::{all, TransformCtx};
 
@@ -100,7 +100,7 @@ impl RedundantJoin {
 
                     // Extend the lets context with an entry for this binding.
                     let prov_old = ctx.insert(*id, value_prov);
-                    assert!(prov_old.is_none(), "No shadowing");
+                    assert_none!(prov_old, "No shadowing");
 
                     // Determine provenance of the body.
                     let result = self.action(body, ctx)?;
@@ -122,7 +122,7 @@ impl RedundantJoin {
                     // context with the empty vec![] for each id.
                     for id in ids.iter() {
                         let prov_old = ctx.insert(*id, vec![]);
-                        assert!(prov_old.is_none(), "No shadowing");
+                        assert_none!(prov_old, "No shadowing");
                     }
 
                     // In other words, we don't attempt to derive additional

--- a/src/txn-wal/src/txn_cache.rs
+++ b/src/txn-wal/src/txn_cache.rs
@@ -1114,6 +1114,7 @@ pub(crate) enum Unapplied<'a> {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::assert_err;
     use mz_persist_client::PersistClient;
     use mz_persist_types::codec_impls::{ShardIdSchema, VecU8Schema};
     use DataListenNext::*;
@@ -1214,7 +1215,7 @@ mod tests {
 
         // empty
         assert_eq!(c.progress_exclusive, 0);
-        assert!(mz_ore::panic::catch_unwind(|| c.data_snapshot(d0, 0)).is_err());
+        assert_err!(mz_ore::panic::catch_unwind(|| c.data_snapshot(d0, 0)));
         assert_eq!(c.data_listen_next(&d0, &0), WaitForTxnsProgress);
 
         // ts 0 (never registered)
@@ -1481,7 +1482,7 @@ mod tests {
         let mut c = TxnsCacheState::new(ShardId::new(), 10, None);
         c.progress_exclusive = 20;
 
-        assert!(mz_ore::panic::catch_unwind(|| c.data_listen_next(&d0, &0)).is_err());
+        assert_err!(mz_ore::panic::catch_unwind(|| c.data_listen_next(&d0, &0)));
 
         let ds = c.data_snapshot(d0, 0);
         assert_eq!(

--- a/src/txn-wal/src/txn_write.rs
+++ b/src/txn-wal/src/txn_write.rs
@@ -395,6 +395,7 @@ mod tests {
 
     use futures::stream::FuturesUnordered;
     use futures::StreamExt;
+    use mz_ore::assert_err;
     use mz_persist_client::PersistClient;
 
     use crate::tests::writer;
@@ -660,7 +661,7 @@ mod tests {
                 txn.commit_at(&mut txns, 1).await
             }
         });
-        assert!(commit.await.is_err());
+        assert_err!(commit.await);
 
         let d0 = txns.expect_register(2).await;
         txns.forget(3, [d0]).await.unwrap();
@@ -675,7 +676,7 @@ mod tests {
                 txn.commit_at(&mut txns, 4).await
             }
         });
-        assert!(commit.await.is_err());
+        assert_err!(commit.await);
     }
 
     #[mz_ore::test(tokio::test)]


### PR DESCRIPTION
This PR adds three macros to the `mz_ore` crate with the goal of improving debug-ability of code.

Note: I didn't add an `assert_some!` macro because there isn't any extra debug info to print when you get a `None`.

### Motivation

   * This PR refactors existing code.

For the most part when you have an `Option` or `Result` type you want to assert its state by doing something like `assert!(my_val.is_ok())`. This issue with this is when `my_val` isn't a `Ok` the only debugging info you get is `assertion failed: false`. Ideally you would get what the actual `Err` variant is.

### Tips for reviewer

This PR is split into two commits:

1. The implementation of the three new macros.
2. Migrating all obvious call sites to use them.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
