### PR TITLE
adapter: Prohibit sinks on catalog objects

### DIFF
--- a/doc/user/content/sql/alter-sink.md
+++ b/doc/user/content/sql/alter-sink.md
@@ -30,6 +30,10 @@ the contents of the new upstream relation are known. Attempting to `ALTER` an
 unhealthy sink that can't make progress will result in the command timing out.
 {{</ note >}}
 
+A sink cannot be created directly on a catalog object. As a workaround you can
+create a materialized view on a catalog object and create a sink on the
+materialized view.
+
 ### Valid schema changes
 
 For `ALTER SINK` to be successful, the newly specified relation must lead to a

--- a/doc/user/content/sql/create-sink/_index.md
+++ b/doc/user/content/sql/create-sink/_index.md
@@ -44,6 +44,12 @@ the cluster. Colocating multiple sinks onto the same cluster can be more
 resource efficient when you have many low-traffic sinks that occasionally need
 some burst capacity.
 
+## Details
+
+A sink cannot be created directly on a catalog object. As a workaround you can
+create a materialized view on a catalog object and create a sink on the
+materialized view.
+
 [//]: # "TODO(morsapaes) Add best practices for sizing sinks."
 
 ## Privileges

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2627,6 +2627,9 @@ fn plan_sink(
 
     let from_name = &from;
     let from = scx.get_item_by_resolved_name(&from)?;
+    if from.id().is_system() {
+        bail_unsupported!("creating a sink directly on a catalog object");
+    }
     let desc = from.desc(&scx.catalog.resolve_full_name(from.name()))?;
     let key_indices = match &connection {
         CreateSinkConnection::Kafka { key, .. } => {

--- a/test/testdrive/alter-sink.td
+++ b/test/testdrive/alter-sink.td
@@ -25,12 +25,23 @@ $ set-arg-default single-replica-cluster=quickstart
 # collection when it changes.
 > INSERT INTO post_alter VALUES ('ignored', 0);
 
+! CREATE SINK sink
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM mz_tables
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-alter-sink-${testdrive.seed}')
+  FORMAT JSON
+  ENVELOPE DEBEZIUM;
+contains: creating a sink directly on a catalog object not yet supported
+
 > CREATE SINK sink
   IN CLUSTER ${arg.single-replica-cluster}
   FROM pre_alter
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-alter-sink-${testdrive.seed}')
   FORMAT JSON
   ENVELOPE DEBEZIUM;
+
+! ALTER SINK sink SET FROM mz_tables;
+contains: creating a sink directly on a catalog object not yet supported
 
 $ kafka-verify-data format=json sink=materialize.public.sink key=false
 {"before": null, "after": {"pre_name": "fish"}}


### PR DESCRIPTION
This commit prohibits users from creating sinks directly on catalog objects. Sinks sink out all columns of an object, but builtin migrations may cause the set of columns of a builtin object to change. So after an upgrade a sink may start emitting additional columns, which has the potential to break whatever is downstream. Until this issue is fixed it's better to prohibit sinking catalog objects, than to potentially have sinks break after an upgrade.

As a workaround, users can create materialized views over a catalog object and sink the materialized view. Though it's likely to be rare that a user wants to sink catalog objects directly.

Additionally, prohibiting this feature makes certain aspects of zero-downtime upgrades easier with respect to builtin migrations.

Works towards resolving #18767
Works towards resolving #27981

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Remove the ability to create sinks directly on catalog objects
