### PR TITLE
persist: re-use allocations when computing stats

### DIFF
--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -165,7 +165,7 @@ where
                         K::decode_from(k_buf, k, &mut k_storage)?;
                         V::decode_from(v_buf, v, &mut v_storage)?;
 
-                        builder.push(&k_buf, &v_buf, t, d);
+                        builder.push(k_buf, v_buf, t, d);
                     }
                     (_, _) => {
                         let k = K::decode(k)?;

--- a/src/persist-client/src/stats.rs
+++ b/src/persist-client/src/stats.rs
@@ -146,16 +146,37 @@ where
         }
     };
 
+    let mut k_buf: Option<K> = None;
+    let mut v_buf: Option<V> = None;
+
+    let mut k_storage = Some(K::Storage::default());
+    let mut v_storage = Some(V::Storage::default());
+
     if format.is_structured() {
         let mut builder = PartBuilder2::new(schemas.key.as_ref(), schemas.val.as_ref());
         for update in updates {
             for ((k, v), t, d) in update.iter() {
-                let k = K::decode(k)?;
-                let v = V::decode(v)?;
                 let t = i64::from_le_bytes(t);
                 let d = i64::from_le_bytes(d);
 
-                builder.push(&k, &v, t, d);
+                // Attempt to re-use allocations as much as possible.
+                match (k_buf.as_mut(), v_buf.as_mut()) {
+                    (Some(k_buf), Some(v_buf)) => {
+                        K::decode_from(k_buf, k, &mut k_storage)?;
+                        V::decode_from(v_buf, v, &mut v_storage)?;
+
+                        builder.push(&k_buf, &v_buf, t, d);
+                    }
+                    (_, _) => {
+                        let k = K::decode(k)?;
+                        let v = V::decode(v)?;
+
+                        builder.push(&k, &v, t, d);
+
+                        k_buf.replace(k);
+                        v_buf.replace(v);
+                    }
+                };
             }
         }
         let Part2 {

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -74,7 +74,7 @@ pub trait Codec: Sized + PartialEq + 'static {
 
     /// A type used with [Self::decode_from] for allocation reuse. Set to `()`
     /// if unnecessary.
-    type Storage;
+    type Storage: Default;
     /// An alternate form of [Self::decode] which enables amortizing allocs.
     ///
     /// First, instead of returning `Self`, it takes `&mut Self` as a parameter,


### PR DESCRIPTION
This PR updates the `encode_updates(...)` function to re-use instances of `K` and `V` when calculating stats, which reduce allocations and through benchmarking is shown to improve performance.

### Motivation

* This PR adds a feature that has not yet been specified.

Improves throughput of Persist encoding.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
