### PR TITLE
adapter: serialize DDL

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -228,6 +228,7 @@ pub enum Message<T = mz_repr::Timestamp> {
         /// Permit which limits how many group commits we run at once.
         Option<GroupCommitPermit>,
     ),
+    DeferredStatementReady,
     AdvanceTimelines,
     DropReadHolds(Vec<ReadHoldsInner<Timestamp>>),
     ClusterEvent(ClusterEvent),
@@ -363,6 +364,7 @@ impl Message {
             Message::PrivateLinkVpcEndpointEvents(_) => "private_link_vpc_endpoint_events",
             Message::CheckSchedulingPolicies => "check_scheduling_policies",
             Message::SchedulingDecisions { .. } => "scheduling_decision",
+            Message::DeferredStatementReady => "deferred_statement_ready",
         }
     }
 }
@@ -994,6 +996,10 @@ pub struct ConnMeta {
     /// any, is cleared.
     drop_sinks: BTreeSet<GlobalId>,
 
+    /// Lock for the Coordinator's deferred statements that is dropped on transaction clear.
+    #[serde(skip)]
+    deferred_lock: Option<OwnedMutexGuard<()>>,
+
     /// Channel on which to send notices to a session.
     #[serde(skip)]
     notice_tx: mpsc::UnboundedSender<AdapterNotice>,
@@ -1596,10 +1602,8 @@ pub struct Coordinator {
     /// Active introspection subscribes.
     introspection_subscribes: BTreeMap<GlobalId, IntrospectionSubscribe>,
 
-    /// Serializes accesses to write critical sections.
-    write_lock: Arc<tokio::sync::Mutex<()>>,
     /// Holds plans deferred due to write lock.
-    write_lock_wait_group: VecDeque<Deferred>,
+    write_lock_wait_group: LockedVecDeque<Deferred>,
     /// Pending writes waiting for a group commit.
     pending_writes: Vec<PendingWriteTxn>,
     /// For the realtime timeline, an explicit SELECT or INSERT on a table will bump the
@@ -1612,6 +1616,16 @@ pub struct Coordinator {
     /// For non-realtime timelines, nothing pushes the timestamps forward, so we must do
     /// it manually.
     advance_timelines_interval: tokio::time::Interval,
+
+    /// Serialized DDL. DDL must be serialized because:
+    /// - Many of them do off-thread work and need to verify the catalog is in a valid state, but
+    ///   [`PlanValidity`] does not currently support tracking all changes. Doing that correctly
+    ///   seems to be more difficult than it's worth, so we would instead re-plan and re-sequence
+    ///   the statements.
+    /// - Re-planning a statement is hard because Coordinator and Session state is mutated at
+    ///   various points, and we would need to correctly reset those changes before re-planning and
+    ///   re-sequencing.
+    serialized_ddl: LockedVecDeque<DeferredPlanStatement>,
 
     /// Handle to secret manager that can create and delete secrets from
     /// an arbitrary secret storage engine.
@@ -3468,12 +3482,12 @@ pub fn serve(
                     pending_peeks: BTreeMap::new(),
                     client_pending_peeks: BTreeMap::new(),
                     pending_linearize_read_txns: BTreeMap::new(),
+                    serialized_ddl: LockedVecDeque::new(),
                     active_compute_sinks: BTreeMap::new(),
                     active_webhooks: BTreeMap::new(),
                     staged_cancellation: BTreeMap::new(),
                     introspection_subscribes: BTreeMap::new(),
-                    write_lock: Arc::new(tokio::sync::Mutex::new(())),
-                    write_lock_wait_group: VecDeque::new(),
+                    write_lock_wait_group: LockedVecDeque::new(),
                     pending_writes: Vec::new(),
                     advance_timelines_interval,
                     secrets_controller,
@@ -3747,4 +3761,66 @@ impl Drop for AlterSinkReadyContext {
             ctx.retire(Err(AdapterError::Canceled));
         }
     }
+}
+
+/// todo: document
+#[derive(Debug)]
+struct LockedVecDeque<T> {
+    items: VecDeque<T>,
+    lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl<T> LockedVecDeque<T> {
+    pub fn new() -> Self {
+        Self {
+            items: VecDeque::new(),
+            lock: Arc::new(tokio::sync::Mutex::new(())),
+        }
+    }
+
+    pub fn mutex(&self) -> Arc<tokio::sync::Mutex<()>> {
+        Arc::clone(&self.lock)
+    }
+
+    pub fn try_lock_owned(&self) -> Result<OwnedMutexGuard<()>, tokio::sync::TryLockError> {
+        Arc::clone(&self.lock).try_lock_owned()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn push_back(&mut self, value: T) {
+        self.items.push_back(value)
+    }
+
+    pub fn pop_front(&mut self) -> Option<T> {
+        self.items.pop_front()
+    }
+
+    pub fn remove(&mut self, index: usize) -> Option<T> {
+        self.items.remove(index)
+    }
+
+    pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, T> {
+        self.items.iter()
+    }
+}
+
+#[derive(Debug)]
+struct DeferredPlanStatement {
+    ctx: ExecuteContext,
+    ps: PlanStatement,
+}
+
+#[derive(Debug)]
+enum PlanStatement {
+    Statement {
+        stmt: Arc<Statement<Raw>>,
+        params: Params,
+    },
+    Plan {
+        plan: mz_sql::plan::Plan,
+        resolved_ids: ResolvedIds,
+    },
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3763,7 +3763,8 @@ impl Drop for AlterSinkReadyContext {
     }
 }
 
-/// todo: document
+/// A struct for tracking the ownership of a lock and a VecDeque to store to-be-done work after the
+/// lock is freed.
 #[derive(Debug)]
 struct LockedVecDeque<T> {
     items: VecDeque<T>,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -624,6 +624,7 @@ impl Coordinator {
                         // any cluster (no RETURNING) is always safe.
                     }
 
+                    // These statements must be kept in-sync with `must_serialize_ddl()`.
                     Statement::AlterObjectRename(_) | Statement::AlterObjectSwap(_) => {
                         let state = self.catalog().for_session(ctx.session()).state().clone();
                         let revision = self.catalog().transient_revision();
@@ -931,7 +932,7 @@ impl Coordinator {
         if Self::must_spawn_purification(stmt) {
             return false;
         }
-        // Some DDL is exempt. It is not great that weqkw are matching on Statements here, but
+        // Some DDL is exempt. It is not great that we are matching on Statements here because
         // different plans can be produced from the same top-level statement type (i.e., `ALTER
         // CONNECTION ROTATE KEYS`). But the whole point of this is to prevent things from being
         // planned in the first place, so we accept the abstraction leak.

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -162,7 +162,7 @@ impl Coordinator {
         match result {
             // We purposefully fail with this error to prevent committing the transaction.
             Err(AdapterError::TransactionDryRun { new_ops, new_state }) => {
-                // Adds these ops to our transaction, bailing if the Catalog has changed since we
+                // Sets these ops to our transaction, bailing if the Catalog has changed since we
                 // ran the transaction.
                 session.transaction_mut().add_ops(TransactionOps::DDL {
                     ops: new_ops,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -231,6 +231,9 @@ impl Coordinator {
                 Message::SchedulingDecisions(decisions) => {
                     self.handle_scheduling_decisions(decisions).await;
                 }
+                Message::DeferredStatementReady => {
+                    self.handle_deferred_statement().await;
+                }
             }
         }
         .instrument(span)

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -285,7 +285,8 @@ impl Coordinator {
                 | Plan::AbortTransaction(AbortTransactionPlan {
                     ref transaction_type,
                 }) => {
-                    // Serialize DDL transactions.
+                    // Serialize DDL transactions. Statements that use this mode must return false
+                    // in `must_serialize_ddl()`.
                     if ctx.session().transaction().is_ddl() {
                         if let Ok(guard) = self.serialized_ddl.try_lock_owned() {
                             let prev = self

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -7,15 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeSet;
-
 use mz_catalog::memory::objects::ClusterVariantManaged;
 use mz_controller::clusters::ReplicaLogging;
 use mz_controller_types::DEFAULT_REPLICA_LOGGING_INTERVAL;
 use mz_ore::instrument;
 use mz_sql::catalog::ObjectType;
+use mz_sql::plan;
 use mz_sql::plan::{AlterClusterPlan, AlterOptionParameter};
-use mz_sql::{plan, session::metadata::SessionMetadata};
 use tracing::Span;
 
 use crate::catalog::ReplicaCreateDropReason;
@@ -70,23 +68,17 @@ impl Coordinator {
         ctx: ExecuteContext,
         plan: plan::AlterClusterPlan,
     ) {
-        let stage = return_if_err!(self.alter_cluster_validate(ctx.session(), plan).await, ctx);
+        let stage = return_if_err!(self.alter_cluster_validate(plan).await, ctx);
         self.sequence_staged(ctx, Span::current(), stage).await;
     }
 
     #[instrument]
     async fn alter_cluster_validate(
         &mut self,
-        session: &Session,
         plan: plan::AlterClusterPlan,
     ) -> Result<ClusterStage, AdapterError> {
-        let validity = PlanValidity::new(
-            self.catalog().transient_revision(),
-            BTreeSet::new(),
-            Some(plan.id.clone()),
-            None,
-            session.role_metadata().clone(),
-        );
+        let validity =
+            PlanValidity::require_transient_revision(self.catalog().transient_revision());
         Ok(ClusterStage::Alter(AlterCluster { validity, plan }))
     }
 

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -356,13 +356,8 @@ impl Coordinator {
             });
         }
 
-        let validity = PlanValidity::new(
-            self.catalog().transient_revision(),
-            expr_depends_on.clone(),
-            Some(*cluster_id),
-            None,
-            session.role_metadata().clone(),
-        );
+        let validity =
+            PlanValidity::require_transient_revision(self.catalog().transient_revision());
 
         // Check whether we can read all inputs at all the REFRESH AT times.
         if let Some(refresh_schedule) = refresh_schedule {

--- a/src/adapter/src/coord/validity.rs
+++ b/src/adapter/src/coord/validity.rs
@@ -25,14 +25,19 @@ use crate::AdapterError;
 /// A struct to hold information about the validity of plans and if they should be abandoned after
 /// doing work off of the Coordinator thread.
 #[derive(Debug, Clone)]
-pub struct PlanValidity {
-    /// The most recent revision at which this plan was verified as valid.
-    transient_revision: u64,
-    /// Objects on which the plan depends.
-    dependency_ids: BTreeSet<GlobalId>,
-    cluster_id: Option<ComputeInstanceId>,
-    replica_id: Option<ReplicaId>,
-    role_metadata: RoleMetadata,
+pub enum PlanValidity {
+    /// Requires a specific transient revision.
+    RequireRevision { required_revision: u64 },
+    /// Checks various catalog IDs. Uses the transient revision only as a cache marker.
+    Checks {
+        /// The most recent revision at which this plan was verified as valid.
+        transient_revision: u64,
+        /// Objects on which the plan depends.
+        dependency_ids: BTreeSet<GlobalId>,
+        cluster_id: Option<ComputeInstanceId>,
+        replica_id: Option<ReplicaId>,
+        role_metadata: RoleMetadata,
+    },
 }
 
 impl PlanValidity {
@@ -43,7 +48,7 @@ impl PlanValidity {
         replica_id: Option<ReplicaId>,
         role_metadata: RoleMetadata,
     ) -> Self {
-        PlanValidity {
+        PlanValidity::Checks {
             transient_revision,
             dependency_ids,
             cluster_id,
@@ -52,74 +57,95 @@ impl PlanValidity {
         }
     }
 
+    /// Sets the required `transient_revision` of the catalog. Should only be used by serialized
+    /// statements (and thus should never fail for users), but here as an internal failsafe against
+    /// programming errors.
+    pub fn require_transient_revision(required_revision: u64) -> Self {
+        PlanValidity::RequireRevision { required_revision }
+    }
+
+    /// Panics if not called on a Checks variant.
     pub fn extend_dependencies(&mut self, ids: impl Iterator<Item = GlobalId>) {
-        self.dependency_ids.extend(ids);
+        let Self::Checks { dependency_ids, .. } = self else {
+            unreachable!();
+        };
+        dependency_ids.extend(ids);
     }
 
     /// Returns an error if the current catalog no longer has all dependencies.
     pub fn check(&mut self, catalog: &Catalog) -> Result<(), AdapterError> {
-        if self.transient_revision == catalog.transient_revision() {
-            return Ok(());
-        }
-        // If the transient revision changed, we have to recheck. If successful, bump the revision
-        // so next check uses the above fast path.
-        if let Some(cluster_id) = self.cluster_id {
-            let Some(cluster) = catalog.try_get_cluster(cluster_id) else {
-                return Err(AdapterError::ChangedPlan(format!(
-                    "cluster {} was removed",
-                    cluster_id
-                )));
-            };
-
-            if let Some(replica_id) = self.replica_id {
-                if cluster.replica(replica_id).is_none() {
-                    return Err(AdapterError::ChangedPlan(format!(
-                        "replica {} of cluster {} was removed",
-                        replica_id, cluster_id
-                    )));
+        match self {
+            PlanValidity::RequireRevision { required_revision } => {
+                if catalog.transient_revision() != *required_revision {
+                    return Err(AdapterError::DDLTransactionRace);
                 }
+                Ok(())
             }
-        }
-        // It is sufficient to check that all the dependency_ids still exist because we assume:
-        // - Ids do not mutate.
-        // - Ids are not reused.
-        // - If an id was dropped, this will detect it and error.
-        for id in &self.dependency_ids {
-            if catalog.try_get_entry(id).is_none() {
-                return Err(AdapterError::ChangedPlan(format!(
-                    "dependency was removed: {id}",
-                )));
-            }
-        }
-        if catalog
-            .try_get_role(&self.role_metadata.current_role)
-            .is_none()
-        {
-            return Err(AdapterError::Unauthorized(
-                UnauthorizedError::ConcurrentRoleDrop(self.role_metadata.current_role.clone()),
-            ));
-        }
-        if catalog
-            .try_get_role(&self.role_metadata.session_role)
-            .is_none()
-        {
-            return Err(AdapterError::Unauthorized(
-                UnauthorizedError::ConcurrentRoleDrop(self.role_metadata.session_role.clone()),
-            ));
-        }
+            PlanValidity::Checks {
+                transient_revision,
+                dependency_ids,
+                cluster_id,
+                replica_id,
+                role_metadata,
+            } => {
+                if *transient_revision == catalog.transient_revision() {
+                    return Ok(());
+                }
+                // If the transient revision changed, we have to recheck. If successful, bump the revision
+                // so next check uses the above fast path.
+                if let Some(cluster_id) = cluster_id {
+                    let Some(cluster) = catalog.try_get_cluster(*cluster_id) else {
+                        return Err(AdapterError::ChangedPlan(format!(
+                            "cluster {} was removed",
+                            cluster_id
+                        )));
+                    };
 
-        if catalog
-            .try_get_role(&self.role_metadata.authenticated_role)
-            .is_none()
-        {
-            return Err(AdapterError::Unauthorized(
-                UnauthorizedError::ConcurrentRoleDrop(
-                    self.role_metadata.authenticated_role.clone(),
-                ),
-            ));
+                    if let Some(replica_id) = replica_id {
+                        if cluster.replica(*replica_id).is_none() {
+                            return Err(AdapterError::ChangedPlan(format!(
+                                "replica {} of cluster {} was removed",
+                                replica_id, cluster_id
+                            )));
+                        }
+                    }
+                }
+                // It is sufficient to check that all the dependency_ids still exist because we assume:
+                // - Ids do not mutate.
+                // - Ids are not reused.
+                // - If an id was dropped, this will detect it and error.
+                for id in dependency_ids.iter() {
+                    if catalog.try_get_entry(id).is_none() {
+                        return Err(AdapterError::ChangedPlan(format!(
+                            "dependency was removed: {id}",
+                        )));
+                    }
+                }
+                if catalog.try_get_role(&role_metadata.current_role).is_none() {
+                    return Err(AdapterError::Unauthorized(
+                        UnauthorizedError::ConcurrentRoleDrop(role_metadata.current_role.clone()),
+                    ));
+                }
+                if catalog.try_get_role(&role_metadata.session_role).is_none() {
+                    return Err(AdapterError::Unauthorized(
+                        UnauthorizedError::ConcurrentRoleDrop(role_metadata.session_role.clone()),
+                    ));
+                }
+
+                if catalog
+                    .try_get_role(&role_metadata.authenticated_role)
+                    .is_none()
+                {
+                    return Err(AdapterError::Unauthorized(
+                        UnauthorizedError::ConcurrentRoleDrop(
+                            role_metadata.authenticated_role.clone(),
+                        ),
+                    ));
+                }
+                *transient_revision = catalog.transient_revision();
+                Ok(())
+            }
         }
-        self.transient_revision = catalog.transient_revision();
-        Ok(())
     }
 }
 
@@ -201,7 +227,10 @@ mod tests {
                 (Box::new(|_validity| {}), Box::new(|res| assert_ok!(res))),
                 (
                     Box::new(|validity| {
-                        validity.cluster_id = Some(ClusterId::User(3));
+                        let PlanValidity::Checks { cluster_id, .. } = validity else {
+                            panic!();
+                        };
+                        *cluster_id = Some(ClusterId::User(3));
                     }),
                     Box::new(|res| {
                         assert_contains!(
@@ -212,8 +241,16 @@ mod tests {
                 ),
                 (
                     Box::new(|validity| {
-                        validity.cluster_id = Some(some_system_cluster.id);
-                        validity.replica_id = Some(ReplicaId::User(4));
+                        let PlanValidity::Checks {
+                            cluster_id,
+                            replica_id,
+                            ..
+                        } = validity
+                        else {
+                            panic!();
+                        };
+                        *cluster_id = Some(some_system_cluster.id);
+                        *replica_id = Some(ReplicaId::User(4));
                     }),
                     Box::new(|res| {
                         assert_contains!(
@@ -238,7 +275,10 @@ mod tests {
                 ),
                 (
                     Box::new(|validity| {
-                        validity.role_metadata.current_role = RoleId::User(5);
+                        let PlanValidity::Checks { role_metadata, .. } = validity else {
+                            panic!();
+                        };
+                        role_metadata.current_role = RoleId::User(5);
                     }),
                     Box::new(|res| {
                         assert_contains!(
@@ -249,7 +289,10 @@ mod tests {
                 ),
                 (
                     Box::new(|validity| {
-                        validity.role_metadata.session_role = RoleId::User(5);
+                        let PlanValidity::Checks { role_metadata, .. } = validity else {
+                            panic!();
+                        };
+                        role_metadata.session_role = RoleId::User(5);
                     }),
                     Box::new(|res| {
                         assert_contains!(
@@ -260,13 +303,36 @@ mod tests {
                 ),
                 (
                     Box::new(|validity| {
-                        validity.role_metadata.authenticated_role = RoleId::User(5);
+                        let PlanValidity::Checks { role_metadata, .. } = validity else {
+                            panic!();
+                        };
+                        role_metadata.authenticated_role = RoleId::User(5);
                     }),
                     Box::new(|res| {
                         assert_contains!(
                             res.expect_err("must err").to_string(),
                             "role u5 was concurrently dropped"
                         )
+                    }),
+                ),
+                (
+                    Box::new(|validity| {
+                        *validity = PlanValidity::require_transient_revision(100);
+                    }),
+                    Box::new(|res| {
+                        assert_contains!(
+                            res.expect_err("must err").to_string(),
+                            "object state changed while transaction was in progress"
+                        )
+                    }),
+                ),
+                (
+                    Box::new(|validity| {
+                        *validity =
+                            PlanValidity::require_transient_revision(catalog.transient_revision());
+                    }),
+                    Box::new(|res| {
+                        assert!(res.is_ok());
                     }),
                 ),
             ];

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1381,7 +1381,9 @@ pub enum TransactionOps<T> {
         /// The statement params.
         params: mz_sql::plan::Params,
     },
-    /// This transaction has run some _simple_ DDL and must do nothing else.
+    /// This transaction has run some _simple_ DDL and must do nothing else. Any statement/plan that
+    /// uses this must return false in `must_serialize_ddl()` because this is serialized instead in
+    /// `sequence_plan()` during `COMMIT`.
     DDL {
         /// Catalog operations that have already run, and must run before each subsequent op.
         ops: Vec<crate::catalog::Op>,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -102,8 +102,8 @@ pub use statement::ddl::{
     PlannedAlterRoleOption, PlannedRoleVariable,
 };
 pub use statement::{
-    describe, plan, plan_copy_from, resolve_cluster_for_materialized_view, StatementContext,
-    StatementDesc,
+    describe, plan, plan_copy_from, resolve_cluster_for_materialized_view, StatementClassification,
+    StatementContext, StatementDesc,
 };
 
 use self::statement::ddl::ClusterAlterOptionExtracted;

--- a/test/sqllogictest/serial-ddl.slt
+++ b/test/sqllogictest/serial-ddl.slt
@@ -16,6 +16,7 @@ BEGIN;
 CREATE VIEW serial_ddl_v AS SELECT 1;
 ----
 COMPLETE 0
+COMPLETE 0
 
 # While conn1 has an open txn and is in single statement delayed txn mode, execute a DDL in another
 # connection which should not be blocked and succeed.
@@ -25,7 +26,9 @@ BEGIN;
 CREATE VIEW serial_ddl_w AS SELECT 1;
 ----
 COMPLETE 0
+COMPLETE 0
 
 simple conn=conn1
 COMMIT;
 ----
+COMPLETE 0

--- a/test/sqllogictest/serial-ddl.slt
+++ b/test/sqllogictest/serial-ddl.slt
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that delayed single statement DDL doesn't block other DDLs while mid transaction.
+
+mode cockroach
+
+simple conn=conn1
+BEGIN;
+CREATE VIEW serial_ddl_v AS SELECT 1;
+----
+COMPLETE 0
+
+# While conn1 has an open txn and is in single statement delayed txn mode, execute a DDL in another
+# connection which should not be blocked and succeed.
+
+simple conn=conn2
+BEGIN;
+CREATE VIEW serial_ddl_w AS SELECT 1;
+----
+COMPLETE 0
+
+simple conn=conn1
+COMMIT;
+----


### PR DESCRIPTION
Serialize all DDL by queueing DDL while another is executing.

Fixes #27821

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a