### PR TITLE
output consistency: add jsonb_agg and jsonb_object_agg

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/aggregate_operations_provider.py
@@ -171,6 +171,3 @@ AGGREGATE_OPERATION_TYPES.append(
         comment="with ordering",
     ),
 )
-
-# TODO: requires subquery / lateral query functionality: jsonb_agg(expression)
-# TODO: requires subquery / lateral query functionality: jsonb_object_agg(keys, values)

--- a/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
@@ -36,6 +36,7 @@ from materialize.output_consistency.operation.operation import (
     DbFunction,
     DbOperation,
     DbOperationOrFunction,
+    OperationRelevance,
 )
 
 JSONB_OPERATION_TYPES: list[DbOperationOrFunction] = []
@@ -159,10 +160,35 @@ JSONB_OPERATION_TYPES.append(
 JSONB_OPERATION_TYPES.append(
     DbFunction(
         "jsonb_agg",
+        [AnyOperationParam()],
+        JsonbReturnTypeSpec(),
+        # this is not aggregating the rows from the original source but only the provided value
+        is_aggregation=False,
+        relevance=OperationRelevance.LOW,
+        comment="generic variant",
+    ),
+)
+
+JSONB_OPERATION_TYPES.append(
+    DbFunction(
+        "jsonb_agg",
         [RecordOperationParam()],
         JsonbReturnTypeSpec(),
         # this is not aggregating the rows from the original source but only the provided records
         is_aggregation=False,
+        comment="additional overlapping variant only for records",
+    ),
+)
+
+JSONB_OPERATION_TYPES.append(
+    DbFunction(
+        "jsonb_object_agg",
+        [AnyOperationParam(), AnyOperationParam()],
+        JsonbReturnTypeSpec(),
+        # this is not aggregating the rows from the original source but only the provided value
+        is_aggregation=False,
+        relevance=OperationRelevance.LOW,
+        comment="generic variant",
     ),
 )
 
@@ -173,5 +199,6 @@ JSONB_OPERATION_TYPES.append(
         JsonbReturnTypeSpec(),
         # this is not aggregating the rows from the original source but only the provided records
         is_aggregation=False,
+        comment="additional overlapping variant only for records",
     ),
 )

--- a/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
@@ -20,6 +20,9 @@ from materialize.output_consistency.input_data.params.jsonb_operation_param impo
 from materialize.output_consistency.input_data.params.record_operation_param import (
     RecordOperationParam,
 )
+from materialize.output_consistency.input_data.params.same_operation_param import (
+    SameOperationParam,
+)
 from materialize.output_consistency.input_data.return_specs.boolean_return_spec import (
     BooleanReturnTypeSpec,
 )
@@ -34,6 +37,7 @@ from materialize.output_consistency.input_data.return_specs.string_return_spec i
 )
 from materialize.output_consistency.operation.operation import (
     DbFunction,
+    DbFunctionWithCustomPattern,
     DbOperation,
     DbOperationOrFunction,
     OperationRelevance,
@@ -158,9 +162,10 @@ JSONB_OPERATION_TYPES.append(
 )
 
 JSONB_OPERATION_TYPES.append(
-    DbFunction(
+    DbFunctionWithCustomPattern(
         "jsonb_agg",
-        [AnyOperationParam()],
+        {2: "jsonb_agg($ ORDER BY row_index, $)"},
+        [AnyOperationParam(), SameOperationParam(index_of_previous_param=0)],
         JsonbReturnTypeSpec(),
         is_aggregation=True,
         relevance=OperationRelevance.LOW,
@@ -169,9 +174,10 @@ JSONB_OPERATION_TYPES.append(
 )
 
 JSONB_OPERATION_TYPES.append(
-    DbFunction(
+    DbFunctionWithCustomPattern(
         "jsonb_agg",
-        [RecordOperationParam()],
+        {2: "jsonb_agg($ ORDER BY row_index, $)"},
+        [RecordOperationParam(), SameOperationParam(index_of_previous_param=0)],
         JsonbReturnTypeSpec(),
         is_aggregation=True,
         comment="additional overlapping variant only for records",
@@ -179,9 +185,14 @@ JSONB_OPERATION_TYPES.append(
 )
 
 JSONB_OPERATION_TYPES.append(
-    DbFunction(
+    DbFunctionWithCustomPattern(
         "jsonb_object_agg",
-        [AnyOperationParam(), AnyOperationParam()],
+        {3: "jsonb_object_agg($, $ ORDER BY row_index, $)"},
+        [
+            AnyOperationParam(),
+            AnyOperationParam(),
+            SameOperationParam(index_of_previous_param=0),
+        ],
         JsonbReturnTypeSpec(),
         is_aggregation=True,
         relevance=OperationRelevance.LOW,
@@ -190,9 +201,14 @@ JSONB_OPERATION_TYPES.append(
 )
 
 JSONB_OPERATION_TYPES.append(
-    DbFunction(
+    DbFunctionWithCustomPattern(
         "jsonb_object_agg",
-        [AnyOperationParam(), RecordOperationParam()],
+        {3: "jsonb_object_agg($, $ ORDER BY row_index, $)"},
+        [
+            AnyOperationParam(),
+            RecordOperationParam(),
+            SameOperationParam(index_of_previous_param=0),
+        ],
         JsonbReturnTypeSpec(),
         is_aggregation=True,
         comment="additional overlapping variant only for records",

--- a/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
@@ -165,11 +165,14 @@ JSONB_OPERATION_TYPES.append(
     DbFunctionWithCustomPattern(
         "jsonb_agg",
         {2: "jsonb_agg($ ORDER BY row_index, $)"},
-        [AnyOperationParam(), SameOperationParam(index_of_previous_param=0)],
+        [
+            AnyOperationParam(include_record_type=False),
+            SameOperationParam(index_of_previous_param=0),
+        ],
         JsonbReturnTypeSpec(),
         is_aggregation=True,
         relevance=OperationRelevance.LOW,
-        comment="generic variant",
+        comment="generic variant without records",
     ),
 )
 
@@ -190,13 +193,13 @@ JSONB_OPERATION_TYPES.append(
         {3: "jsonb_object_agg($, $ ORDER BY row_index, $)"},
         [
             AnyOperationParam(),
-            AnyOperationParam(),
+            AnyOperationParam(include_record_type=False),
             SameOperationParam(index_of_previous_param=0),
         ],
         JsonbReturnTypeSpec(),
         is_aggregation=True,
         relevance=OperationRelevance.LOW,
-        comment="generic variant",
+        comment="generic variant without record values",
     ),
 )
 

--- a/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
@@ -46,6 +46,7 @@ from materialize.output_consistency.operation.operation import (
 JSONB_OPERATION_TYPES: list[DbOperationOrFunction] = []
 
 TAG_JSONB_TO_TEXT = "jsonb_to_text"
+TAG_JSONB_AGGREGATION = "jsonb_aggregation"
 
 JSONB_OPERATION_TYPES.append(
     DbOperation(
@@ -172,6 +173,7 @@ JSONB_OPERATION_TYPES.append(
         JsonbReturnTypeSpec(),
         is_aggregation=True,
         relevance=OperationRelevance.LOW,
+        tags={TAG_JSONB_AGGREGATION},
         comment="generic variant without records",
     ),
 )
@@ -183,6 +185,7 @@ JSONB_OPERATION_TYPES.append(
         [RecordOperationParam(), SameOperationParam(index_of_previous_param=0)],
         JsonbReturnTypeSpec(),
         is_aggregation=True,
+        tags={TAG_JSONB_AGGREGATION},
         comment="additional overlapping variant only for records",
     ),
 )
@@ -199,6 +202,7 @@ JSONB_OPERATION_TYPES.append(
         JsonbReturnTypeSpec(),
         is_aggregation=True,
         relevance=OperationRelevance.LOW,
+        tags={TAG_JSONB_AGGREGATION},
         comment="generic variant without record values",
     ),
 )
@@ -214,6 +218,7 @@ JSONB_OPERATION_TYPES.append(
         ],
         JsonbReturnTypeSpec(),
         is_aggregation=True,
+        tags={TAG_JSONB_AGGREGATION},
         comment="additional overlapping variant only for records",
     ),
 )

--- a/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
@@ -6,7 +6,9 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-
+from materialize.output_consistency.input_data.params.any_operation_param import (
+    AnyOperationParam,
+)
 from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
     JSON_FIELD_INDEX_PARAM,
     JSON_FIELD_NAME_PARAM,
@@ -14,6 +16,9 @@ from materialize.output_consistency.input_data.params.enum_constant_operation_pa
 )
 from materialize.output_consistency.input_data.params.jsonb_operation_param import (
     JsonbOperationParam,
+)
+from materialize.output_consistency.input_data.params.record_operation_param import (
+    RecordOperationParam,
 )
 from materialize.output_consistency.input_data.return_specs.boolean_return_spec import (
     BooleanReturnTypeSpec,
@@ -149,4 +154,24 @@ JSONB_OPERATION_TYPES.append(
         [JsonbOperationParam()],
         JsonbReturnTypeSpec(),
     )
+)
+
+JSONB_OPERATION_TYPES.append(
+    DbFunction(
+        "jsonb_agg",
+        [RecordOperationParam()],
+        JsonbReturnTypeSpec(),
+        # this is not aggregating the rows from the original source but only the provided records
+        is_aggregation=False,
+    ),
+)
+
+JSONB_OPERATION_TYPES.append(
+    DbFunction(
+        "jsonb_object_agg",
+        [AnyOperationParam(), RecordOperationParam()],
+        JsonbReturnTypeSpec(),
+        # this is not aggregating the rows from the original source but only the provided records
+        is_aggregation=False,
+    ),
 )

--- a/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
@@ -162,8 +162,7 @@ JSONB_OPERATION_TYPES.append(
         "jsonb_agg",
         [AnyOperationParam()],
         JsonbReturnTypeSpec(),
-        # this is not aggregating the rows from the original source but only the provided value
-        is_aggregation=False,
+        is_aggregation=True,
         relevance=OperationRelevance.LOW,
         comment="generic variant",
     ),
@@ -174,8 +173,7 @@ JSONB_OPERATION_TYPES.append(
         "jsonb_agg",
         [RecordOperationParam()],
         JsonbReturnTypeSpec(),
-        # this is not aggregating the rows from the original source but only the provided records
-        is_aggregation=False,
+        is_aggregation=True,
         comment="additional overlapping variant only for records",
     ),
 )
@@ -185,8 +183,7 @@ JSONB_OPERATION_TYPES.append(
         "jsonb_object_agg",
         [AnyOperationParam(), AnyOperationParam()],
         JsonbReturnTypeSpec(),
-        # this is not aggregating the rows from the original source but only the provided value
-        is_aggregation=False,
+        is_aggregation=True,
         relevance=OperationRelevance.LOW,
         comment="generic variant",
     ),
@@ -197,8 +194,7 @@ JSONB_OPERATION_TYPES.append(
         "jsonb_object_agg",
         [AnyOperationParam(), RecordOperationParam()],
         JsonbReturnTypeSpec(),
-        # this is not aggregating the rows from the original source but only the provided records
-        is_aggregation=False,
+        is_aggregation=True,
         comment="additional overlapping variant only for records",
     ),
 )

--- a/misc/python/materialize/output_consistency/operation/operation.py
+++ b/misc/python/materialize/output_consistency/operation/operation.py
@@ -262,6 +262,7 @@ class DbFunctionWithCustomPattern(DbFunction):
         relevance: OperationRelevance = OperationRelevance.DEFAULT,
         comment: str | None = None,
         is_enabled: bool = True,
+        tags: set[str] | None = None,
     ):
         super().__init__(
             function_name,
@@ -272,6 +273,7 @@ class DbFunctionWithCustomPattern(DbFunction):
             relevance=relevance,
             comment=comment,
             is_enabled=is_enabled,
+            tags=tags,
         )
         self.pattern_per_param_count = pattern_per_param_count
 

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -404,6 +404,10 @@ class ResultComparator:
         if len(collection1) != len(collection2):
             return False
 
+        if self.ignore_order_when_comparing_collection(expression):
+            collection1 = sorted(collection1)
+            collection2 = sorted(collection2)
+
         for value1, value2 in zip(collection1, collection2):
             # use is_tolerant because tuples may contain all values as strings
             if not self.is_value_equal(value1, value2, expression, is_tolerant=True):
@@ -428,3 +432,6 @@ class ResultComparator:
                 return False
 
         return True
+
+    def ignore_order_when_comparing_collection(self, expression: Expression) -> bool:
+        return False

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -378,6 +378,9 @@ class ResultComparator:
         if isinstance(value1, tuple) and isinstance(value2, tuple):
             return self.is_list_or_tuple_equal(value1, value2, expression)
 
+        if isinstance(value1, dict) and isinstance(value2, dict):
+            return self.is_dict_equal(value1, value2, expression)
+
         if isinstance(value1, Decimal) and isinstance(value2, Decimal):
             if value1.is_nan() and value2.is_nan():
                 return True
@@ -404,6 +407,24 @@ class ResultComparator:
         for value1, value2 in zip(collection1, collection2):
             # use is_tolerant because tuples may contain all values as strings
             if not self.is_value_equal(value1, value2, expression, is_tolerant=True):
+                return False
+
+        return True
+
+    def is_dict_equal(
+        self,
+        dict1: dict[Any, Any],
+        dict2: dict[Any, Any],
+        expression: Expression,
+    ) -> bool:
+        if len(dict1) != len(dict2):
+            return False
+
+        if not self.is_value_equal(dict1.keys(), dict2.keys(), expression):
+            return False
+
+        for key in dict1.keys():
+            if not self.is_value_equal(dict1[key], dict2[key], expression):
                 return False
 
         return True

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -12,6 +12,7 @@ import re
 from decimal import Decimal
 from typing import Any
 
+from materialize.output_consistency.expression.expression import Expression
 from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter import (
     GenericInconsistencyIgnoreFilter,
 )
@@ -49,9 +50,13 @@ class PostgresResultComparator(ResultComparator):
         return False
 
     def is_value_equal(
-        self, value1: Any, value2: Any, is_tolerant: bool = False
+        self,
+        value1: Any,
+        value2: Any,
+        expression: Expression,
+        is_tolerant: bool = False,
     ) -> bool:
-        if super().is_value_equal(value1, value2, is_tolerant=is_tolerant):
+        if super().is_value_equal(value1, value2, expression, is_tolerant=is_tolerant):
             return True
 
         if isinstance(value1, Decimal):

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -27,6 +27,14 @@ from materialize.output_consistency.validation.result_comparator import ResultCo
 TIMESTAMP_PATTERN = re.compile(r"\d{4,}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d+)?")
 
 # Examples:
+# * NaN
+# * 1
+# * -1.23
+# * 1.23e-3
+# * 1.23e+3
+DECIMAL_PATTERN = re.compile(r"NaN|[+-]?\d+(\.\d+)?(e[+-]?\d+)?")
+
+# Examples:
 # * ["1","2"]
 # * [1,2]
 # * [1, 2]
@@ -112,10 +120,7 @@ class PostgresResultComparator(ResultComparator):
         return value1 == value2
 
     def is_decimal(self, value: str):
-        if value == "NaN":
-            return True
-
-        return value.replace(".", "", 1).isdigit()
+        return DECIMAL_PATTERN.match(value) is not None
 
     def is_timestamp(self, value: str) -> bool:
         return TIMESTAMP_PATTERN.match(value) is not None


### PR DESCRIPTION
### Commits
9bf1bcea06 output consistency: jsonb: add jsonb_agg and jsonb_object_agg
b03424fe48 output consistency: jsonb: add additional overloadings for jsonb_agg and jsonb_object_agg
2e3474685f output consistency: jsonb: specify jsonb_agg and jsonb_object_agg as aggregations
75cd9604a6 output consistency: jsonb: use jsonb_agg and jsonb_object_agg with order
22c031baf1 output consistency: jsonb: limit generic jsonb_agg variant
fa99381d0d output consistency: jsonb: add ignore entry
fd901e430b output consistency: value comparison: provide expression
1051e95021 output consistency: value comparison: dict comparison
5381fb0c30 output consistency: value comparison: allow ignoring the order in returned collections
8df01cb51c postgres consistency: value comparison: improve detection of decimal string values
4150d15bc2 postgres consistency: jsonb: ignore order for jsonb_object_agg
c67ae4487b postgres consistency: jsonb: adjust timestamp pattern, normalize timestamps
d4e35fed85 postgres consistency: jsonb: add ignore entries


### Identified issues
* https://github.com/MaterializeInc/materialize/issues/28137
* https://github.com/MaterializeInc/materialize/issues/28141
* https://github.com/MaterializeInc/materialize/issues/28143
* https://github.com/MaterializeInc/materialize/issues/28169
* https://github.com/MaterializeInc/materialize/issues/28192
* https://github.com/MaterializeInc/materialize/issues/28193

### Nightly
https://buildkite.com/materialize/nightly/builds?branch=nrainer-materialize%3Aoutput-consistency%2Fjsonb-agg