### PR TITLE
adapter: enforce a lower bound for max_result_size

### DIFF
--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -38,7 +38,8 @@ use uncased::UncasedStr;
 
 use crate::session::user::{User, SUPPORT_USER, SYSTEM_USER};
 use crate::session::vars::constraints::{
-    DomainConstraint, ValueConstraint, NUMERIC_BOUNDED_0_1_INCLUSIVE, NUMERIC_NON_NEGATIVE,
+    DomainConstraint, ValueConstraint, BYTESIZE_AT_LEAST_1MB, NUMERIC_BOUNDED_0_1_INCLUSIVE,
+    NUMERIC_NON_NEGATIVE,
 };
 use crate::session::vars::errors::VarError;
 use crate::session::vars::polyfill::{lazy_value, value, LazyValueFn};
@@ -533,13 +534,18 @@ pub static MAX_ROLES: VarDefinition = VarDefinition::new(
 
 // Cloud environmentd is configured with 4 GiB of RAM, so 1 GiB is a good heuristic for a single
 // query.
+//
+// We constrain this parameter to a minimum of 1MB, to avoid accidental usage of values that will
+// interfer with queries executed by the system itself.
+//
 // TODO(jkosh44) Eventually we want to be able to return arbitrary sized results.
 pub static MAX_RESULT_SIZE: VarDefinition = VarDefinition::new(
     "max_result_size",
     value!(ByteSize; ByteSize::gb(1)),
     "The maximum size in bytes for an internal query result (Materialize).",
     false,
-);
+)
+.with_constraint(&BYTESIZE_AT_LEAST_1MB);
 
 pub static MAX_QUERY_RESULT_SIZE: VarDefinition = VarDefinition::new(
     "max_query_result_size",

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -196,9 +196,9 @@ def workflow_default(c: Composition) -> None:
         assert "stopping system parameter frontend" in logs.stdout
         # (4) After that, it should be safe to alter a value directly.
         #     The new value should not be replaced, even after 15 seconds
-        sys("ALTER SYSTEM SET max_result_size=1234")
+        sys("ALTER SYSTEM SET max_result_size=1234567")
         sleep(15)
-        c.testdrive("\n".join(["> SHOW max_result_size", "1234B"]))
+        c.testdrive("\n".join(["> SHOW max_result_size", "1234567B"]))
         # (5) The value should be reset after we turn the kill switch back off
         sys("ALTER SYSTEM SET enable_launchdarkly=on")
         c.testdrive("\n".join(["> SHOW max_result_size", "3GB"]))

--- a/test/sqllogictest/max_result_size.slt
+++ b/test/sqllogictest/max_result_size.slt
@@ -10,7 +10,12 @@
 mode cockroach
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET max_result_size TO 10000;
+ALTER SYSTEM SET max_result_size TO 1;
+----
+db error: ERROR: parameter "max_result_size" cannot have value "1B": only supports values in range ByteSize(1048576)..
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET max_result_size TO '1MB';
 ----
 COMPLETE 0
 
@@ -27,15 +32,15 @@ SELECT workers FROM mz_catalog.mz_cluster_replica_sizes JOIN mz_cluster_replicas
 8
 
 statement ok
-CREATE TABLE t1 (a int);
+CREATE TABLE t1 (a int, b text);
 
 statement ok
-INSERT INTO t1 SELECT * FROM generate_series(1, 1000);
+INSERT INTO t1 SELECT * FROM generate_series(1, 10000), repeat('a', 100);
 
 statement ok
 SET cluster TO 'c1';
 
 # Note: 'total' in the error message here is important because it indicates we failed when
 # aggregating the result from multiple workers, as opposed to on any single worker.
-query error db error: ERROR: total result exceeds max size of 10.0 KB
+query error db error: ERROR: total result exceeds max size of 1048.6 KB
 SELECT * FROM t1;

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -173,18 +173,22 @@ EOF
 
 # Check that we bound result set size correctly
 
+statement ok
+CREATE TABLE large_rows (a int, b text)
+
+statement ok
+INSERT INTO large_rows SELECT * FROM generate_series(1, 100), repeat('a', 100000)
+
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET max_result_size TO 100;
+ALTER SYSTEM SET max_result_size TO '1MB';
 ----
 COMPLETE 0
 
-query T
-SELECT * FROM numbers LIMIT 1;
-----
-1
+statement ok
+SELECT * FROM large_rows LIMIT 1;
 
-query error db error: ERROR: result exceeds max size of 100 B
-SELECT * FROM numbers LIMIT 99;
+query error db error: ERROR: result exceeds max size of 1048.6 KB
+SELECT * FROM large_rows LIMIT 99;
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM RESET max_result_size

--- a/test/sqllogictest/updates.slt
+++ b/test/sqllogictest/updates.slt
@@ -183,16 +183,22 @@ statement ok
 SET max_query_result_size = '8B';
 
 query error db error: ERROR: result exceeds max size of 8 B
-SELECT generate_series(1, 100)
+SELECT generate_series(1, 1000000)
 
 statement ok
-INSERT INTO t SELECT * FROM t
+CREATE TABLE t_big (a int);
+
+statement ok
+INSERT INTO t_big SELECT generate_series(1, 1000000)
+
+statement ok
+INSERT INTO t SELECT * FROM t_big
 
 # But the internal var does limit.
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET max_result_size = 1
+ALTER SYSTEM SET max_result_size = '1MB'
 ----
 COMPLETE 0
 
-statement error db error: ERROR: result exceeds max size of 1 B
-INSERT INTO t SELECT * FROM t
+statement error db error: ERROR: result exceeds max size of 1048.6 KB
+INSERT INTO t SELECT * FROM t_big

--- a/test/testdrive/oom.td
+++ b/test/testdrive/oom.td
@@ -12,39 +12,27 @@
 $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = 128
+ALTER SYSTEM SET max_result_size = '1MB'
 
 # In environmentd each Row requires 24 bytes + number of bytes to encode. But we'll also de-dupe
 # repeated values by incrementing the diff.
 
-> SELECT 1::int4 FROM generate_series(1, 10);
-1
-1
-1
-1
-1
-1
-1
-1
-1
-1
+> SELECT 1::int4 FROM generate_series(1, 10000), repeat('a', 100);
+10000 values hashing to b223cca8b360eae4e49568512e2de29f
 
-! SELECT * FROM generate_series(1, 6);
-contains:result exceeds max size of 128 B
+! SELECT * FROM generate_series(1, 10000), repeat('a', 100);
+contains:result exceeds max size of 1048.6 KB
 
-> CREATE TABLE t1 (a int4)
-
-> INSERT INTO t1 SELECT * FROM generate_series(1, 5);
-
-> INSERT INTO t1 VALUES (6);
+> CREATE TABLE t1 (a int4, b text)
+> INSERT INTO t1 SELECT * FROM generate_series(1, 10000), repeat('a', 100);
 
 ! SELECT * FROM t1
-contains:result exceeds max size of 128 B
+contains:result exceeds max size of 1048.6 KB
 
 ! INSERT INTO t1 SELECT * FROM t1;
-contains:result exceeds max size of 128 B
+contains:result exceeds max size of 1048.6 KB
 
-> INSERT INTO t1 SELECT * FROM generate_series(1, 100);
+> INSERT INTO t1 SELECT * FROM generate_series(1, 100), repeat('a', 100);
 
 > BEGIN
 
@@ -52,15 +40,13 @@ contains:result exceeds max size of 128 B
 
 # No output should be produced. Instead an error .. notice?
 ! FETCH 1 c;
-contains:result exceeds max size of 128 B
+contains:result exceeds max size of 1048.6 KB
 
 > ROLLBACK;
 
 # Constants with less than or equal to 10,000 rows will be evaluated in environmentd. Anything in excess of this will
-# be sent to computed to be executed. Therefore, we need to set the size high enough such that it will be evaluated by
+# be sent to computed to be executed. Therefore, we need to set the number of rows high enough such that it will be evaluated by
 # computed to test the computed side of things.
-$ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = 240000;
 
 > SELECT generate_series::int4 FROM generate_series(1, 4);
 1
@@ -68,48 +54,25 @@ ALTER SYSTEM SET max_result_size = 240000;
 3
 4
 
-! SELECT generate_series::int4 FROM generate_series(1, 10001)
-contains:result exceeds max size of 240.0 KB
+! SELECT * FROM generate_series(1, 10001), repeat('a', 100)
+contains:result exceeds max size of 1048.6 KB
 
 > SELECT 1::int4 FROM generate_series(1, 10001)
 10001 values hashing to 7e844fba503f0b3f02daa3de7c80938e
 
-> CREATE TABLE t2 (a int4)
+> CREATE TABLE t2 (a int4, b text)
 
-! INSERT INTO t2 SELECT generate_series::int4 FROM generate_series(1, 10001);
-contains:result exceeds max size of 240.0 KB
+! INSERT INTO t2 SELECT * FROM generate_series(1, 10001), repeat('a', 100);
+contains:result exceeds max size of 1048.6 KB
 
-> INSERT INTO t2 SELECT generate_series::int4 FROM generate_series(1, 10000);
-
-> INSERT INTO t2 VALUES (10000);
+> INSERT INTO t2 SELECT * FROM generate_series(1, 5000), repeat('a', 100);
+> INSERT INTO t2 SELECT * FROM generate_series(5001, 10000), repeat('a', 100);
 
 ! SELECT * FROM t2
-contains:result exceeds max size of 240.0 KB
+contains:result exceeds max size of 1048.6 KB
 
 ! INSERT INTO t2 SELECT * FROM t2;
-contains:result exceeds max size of 240.0 KB
-
-# Rows keep 23 bytes inline, after that the row is spilled to the heap. int4 takes 5 bytes,
-# 4 for the int and 1 for the tag. A row of 5 int4's will spill to the heap, but any less will
-# be kept inline. A row of 5 int4's should then take 25 + 24 = 49 bytes.
-#
-# Large numbers are used to avoid this test being defeated
-# by the optimization in https://github.com/MaterializeInc/materialize/pull/21016
-
-$ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = 49
-
-> SELECT 17000000, 17000001, 17000002, 17000003;
-17000000 17000001 17000002 17000003
-
-> SELECT 17000000, 17000001, 17000002, 17000003, 17000004;
-17000000 17000001 17000002 17000003 17000004
-
-$ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = 48
-
-! SELECT 17000000, 17000001, 17000002, 17000003, 17000004;
-contains:result exceeds max size of 48 B
+contains:result exceeds max size of 1048.6 KB
 
 $ postgres-execute connection=mz_system
 ALTER SYSTEM RESET max_result_size


### PR DESCRIPTION
This PR enforces a lower bound of 1MB for the `max_result_size` parameter. This parameter is meant to prevent environmentd OOMs and should therefore be set to a value proportional to environmentd's available memory size. It's save to assume that we'll never try to run environmentd with available memory in the order of megabytes.

Enforcing a lower bound ensures that nobody can accidentially set `max_result_size` to a value that is small enough to interfere with system queries, like introspection subscribes or those performed by our metrics infrastructure.

### Motivation

  * This PR fixes a recognized bug.

Fixes #28113 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
