### PR TITLE
Change `REHYDRATION TIME ESTIMATE` to `HYDRATION TIME ESTIMATE`

### DIFF
--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -40,7 +40,7 @@ ALTER CLUSTER c1 SET (SIZE '100cc');
 {{< private-preview />}}
 
 ```sql
-ALTER CLUSTER c1 SET (SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour'));
+ALTER CLUSTER c1 SET (SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'));
 ```
 
 See the reference documentation for [`CREATE CLUSTER`](../create-cluster/#scheduling)

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -244,7 +244,7 @@ you can configure a cluster to automatically turn on and off using the
 ```mzsql
 CREATE CLUSTER my_scheduled_cluster (
   SIZE = '3200cc',
-  SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour')
+  SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour')
 );
 ```
 
@@ -267,17 +267,17 @@ To re-enable scheduling:
 
 ```mzsql
 ALTER CLUSTER my_scheduled_cluster
-SET (SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour'));
+SET (SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'));
 ```
 
-#### Rehydration time estimate
+#### Hydration time estimate
 
-<p style="font-size:14px"><b>Syntax:</b> <code>REHYDRATION TIME ESTIMATE</code> <i>interval</i></p>
+<p style="font-size:14px"><b>Syntax:</b> <code>HYDRATION TIME ESTIMATE</code> <i>interval</i></p>
 
 By default, scheduled clusters will turn on at the scheduled refresh time. To
 avoid [unavailability of the objects scheduled for refresh](/sql/create-materialized-view/#querying-materialized-views-with-refresh-strategies) during the refresh
 operation, we recommend turning the cluster on ahead of the scheduled time to
-allow rehydration to complete. This can be controlled using the `REHYDRATION
+allow rehydration to complete. This can be controlled using the `HYDRATION
 TIME ESTIMATE` clause.
 
 #### Introspection
@@ -290,7 +290,7 @@ system catalog table:
 SELECT c.id AS cluster_id,
        c.name AS cluster_name,
        cs.type AS schedule_type,
-       cs.refresh_rehydration_time_estimate
+       cs.refresh_hydration_time_estimate
 FROM mz_internal.mz_cluster_schedules cs
 JOIN mz_clusters c ON cs.cluster_id = c.id
 WHERE c.name = 'my_refresh_cluster';

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -244,7 +244,7 @@ have a period of unavailability around the scheduled refresh times — during
 this period, the view **will not return any results**. To avoid unavailability
 during the refresh operation, we recommend hosting these views in
 [**scheduled clusters**](/sql/create-cluster/#scheduling) configured to
-automatically [turn on ahead of the scheduled refresh time](/sql/create-cluster/#rehydration-time-estimate).
+automatically [turn on ahead of the scheduled refresh time](/sql/create-cluster/#hydration-time-estimate).
 
 **Example**
 
@@ -254,7 +254,7 @@ refresh times:
 ```mzsql
 CREATE CLUSTER my_scheduled_cluster (
   SIZE = '3200cc',
-  SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour')
+  SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour')
 );
 ```
 
@@ -283,18 +283,18 @@ backfill the view with pre-existing data — a process known as [_hydration_](/t
 of the view** to just the duration of the refresh.
 
 If the cluster is **not** configured to turn on ahead of scheduled refreshes
-(i.e., using the `REHYDRATION TIME ESTIMATE` option), the total unavailability
+(i.e., using the `HYDRATION TIME ESTIMATE` option), the total unavailability
 window of the view will be a combination of the hydration time for all objects
 in the cluster (typically long) and the duration of the refresh for the
 materialized view (typically short).
 
 Depending on the actual time it takes to hydrate the view or set of views in the
-cluster, you can later adjust the rehydration time estimate value for the
+cluster, you can later adjust the hydration time estimate value for the
 cluster using [`ALTER CLUSTER`](../alter-cluster/#schedule):
 
 ```mzsql
 ALTER CLUSTER my_scheduled_cluster
-SET (SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '30 minutes'));
+SET (SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '30 minutes'));
 ```
 
 #### Introspection

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -135,11 +135,11 @@ the most recent status for each AWS PrivateLink connection in the system.
 The `mz_cluster_schedules` table shows the `SCHEDULE` option specified for each cluster.
 
 <!-- RELATION_SPEC mz_internal.mz_cluster_schedules -->
-| Field                               | Type         | Meaning                                                       |
-|-------------------------------------|--------------|---------------------------------------------------------------|
-| `cluster_id`                        | [`text`]     | The ID of the cluster. Corresponds to [`mz_clusters.id`](../mz_catalog/#mz_clusters).|
-| `type`                              | [`text`]     | `on-refresh`, or `manual`. Default: `manual`                       |
-| `refresh_rehydration_time_estimate` | [`interval`] | The interval given in the `REHYDRATION TIME ESTIMATE` option. |
+| Field                               | Type         | Meaning                                                        |
+|-------------------------------------|--------------|----------------------------------------------------------------|
+| `cluster_id`                        | [`text`]     | The ID of the cluster. Corresponds to [`mz_clusters.id`](../mz_catalog/#mz_clusters). |
+| `type`                              | [`text`]     | `on-refresh`, or `manual`. Default: `manual`                   |
+| `refresh_hydration_time_estimate`   | [`interval`] | The interval given in the `HYDRATION TIME ESTIMATE` option.    |
 
 ## `mz_cluster_replica_frontiers`
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql
@@ -21,20 +21,20 @@ This macro creates a cluster with the specified properties.
   - size (str): The size of the cluster. This parameter is required.
   - replication_factor (int, optional): The replication factor for the cluster. Only applicable when schedule_type is 'manual'.
   - schedule_type (str, optional): The type of schedule for the cluster. Accepts 'manual' or 'on-refresh'.
-  - refresh_rehydration_time_estimate (str, optional): The estimated rehydration time for the cluster. Only applicable when schedule_type is 'on-refresh'.
+  - refresh_hydration_time_estimate (str, optional): The estimated hydration time for the cluster. Only applicable when schedule_type is 'on-refresh'.
   - ignore_existing_objects (bool, optional): Whether to ignore existing objects in the cluster. Defaults to false.
   - force_deploy_suffix (bool, optional): Whether to forcefully add a deploy suffix to the cluster name. Defaults to false.
 
   Incompatibilities:
   - replication_factor is only applicable when schedule_type is 'manual'.
-  - refresh_rehydration_time_estimate is only applicable when schedule_type is 'on-refresh'.
+  - refresh_hydration_time_estimate is only applicable when schedule_type is 'on-refresh'.
 #}
 {% macro create_cluster(
     cluster_name,
     size,
     replication_factor=none,
     schedule_type=none,
-    refresh_rehydration_time_estimate=none,
+    refresh_hydration_time_estimate=none,
     ignore_existing_objects=false,
     force_deploy_suffix=false
 ) %}
@@ -116,8 +116,8 @@ This macro creates a cluster with the specified properties.
                 {% if replication_factor is not none and ( schedule_type == 'manual' or schedule_type is none ) %}
                     , REPLICATION FACTOR = {{ replication_factor }}
                 {% elif schedule_type == 'on-refresh' %}
-                    {% if refresh_rehydration_time_estimate is not none %}
-                        , SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = {{ dbt.string_literal(refresh_rehydration_time_estimate) }})
+                    {% if refresh_hydration_time_estimate is not none %}
+                        , SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = {{ dbt.string_literal(refresh_hydration_time_estimate) }})
                     {% else %}
                         , SCHEDULE = ON REFRESH
                     {% endif %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_init.sql
@@ -115,7 +115,7 @@
             c.id AS cluster_id,
             c.name AS cluster_name,
             cs.type AS schedule_type,
-            cs.refresh_rehydration_time_estimate
+            cs.refresh_hydration_time_estimate
         FROM mz_clusters c
         LEFT JOIN mz_internal.mz_cluster_schedules cs ON cs.cluster_id = c.id
         WHERE c.name = {{ dbt.string_literal(cluster) }}
@@ -130,7 +130,7 @@
         {% set size = results[1] %}
         {% set replication_factor = results[2] %}
         {% set schedule_type = results[5] %}
-        {% set refresh_rehydration_time_estimate = results[6] %}
+        {% set refresh_hydration_time_estimate = results[6] %}
 
         {% if not managed %}
             {{ exceptions.raise_compiler_error("Production cluster " ~ cluster ~ " is not managed") }}
@@ -141,7 +141,7 @@
             size=size,
             replication_factor=replication_factor,
             schedule_type=schedule_type,
-            refresh_rehydration_time_estimate=refresh_rehydration_time_estimate,
+            refresh_hydration_time_estimate=refresh_hydration_time_estimate,
             ignore_existing_objects=ignore_existing_objects,
             force_deploy_suffix=True
         ) %}

--- a/misc/dbt-materialize/tests/adapter/test_ci.py
+++ b/misc/dbt-materialize/tests/adapter/test_ci.py
@@ -212,7 +212,7 @@ class TestClusterOps:
                 "run-operation",
                 "create_cluster",
                 "--args",
-                '{"cluster_name": "test_on_refresh_schedule", "size": "1", "schedule_type": "on-refresh", "refresh_rehydration_time_estimate": "10m", "ignore_existing_objects": true, "force_deploy_suffix": true}',
+                '{"cluster_name": "test_on_refresh_schedule", "size": "1", "schedule_type": "on-refresh", "refresh_hydration_time_estimate": "10m", "ignore_existing_objects": true, "force_deploy_suffix": true}',
             ]
         )
 
@@ -324,7 +324,7 @@ def get_cluster_properties(project, cluster_name):
         c.id AS cluster_id,
         c.name AS cluster_name,
         cs.type AS schedule_type,
-        cs.refresh_rehydration_time_estimate
+        cs.refresh_hydration_time_estimate
     FROM mz_clusters c
     LEFT JOIN mz_internal.mz_cluster_schedules cs ON cs.cluster_id = c.id
     WHERE c.name = '{cluster_name}'

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -507,9 +507,9 @@ class TestTargetDeploy:
 
         run_dbt(["run-operation", "deploy_init"], expect_pass=False)
 
-    def test_dbt_deploy_init_with_refresh_rehydration_time(self, project):
+    def test_dbt_deploy_init_with_refresh_hydration_time(self, project):
         project.run_sql(
-            "CREATE CLUSTER prod (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour'))"
+            "CREATE CLUSTER prod (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'))"
         )
         project.run_sql("CREATE SCHEMA prod")
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -318,12 +318,12 @@ impl CatalogState {
                     Datum::Null,
                 ]),
                 ClusterSchedule::Refresh {
-                    rehydration_time_estimate,
+                    hydration_time_estimate,
                 } => Row::pack_slice(&[
                     Datum::String(&id.to_string()),
                     Datum::String("on-refresh"),
                     Datum::Interval(
-                        Interval::from_duration(&rehydration_time_estimate)
+                        Interval::from_duration(&hydration_time_estimate)
                             .expect("planning ensured that this is convertible back to Interval"),
                     ),
                 ]),

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -295,8 +295,8 @@ pub struct RefreshDecisionWithReasonV1 {
     /// Objects that currently need a refresh on the cluster (taking into account the rehydration
     /// time estimate).
     pub objects_needing_refresh: Vec<String>,
-    /// The REHYDRATION TIME ESTIMATE setting of the cluster.
-    pub rehydration_time_estimate: String,
+    /// The HYDRATION TIME ESTIMATE setting of the cluster.
+    pub hydration_time_estimate: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash, Arbitrary)]

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2510,7 +2510,7 @@ pub static MZ_CLUSTER_SCHEDULES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable 
         .with_column("cluster_id", ScalarType::String.nullable(false))
         .with_column("type", ScalarType::String.nullable(false))
         .with_column(
-            "refresh_rehydration_time_estimate",
+            "refresh_hydration_time_estimate",
             ScalarType::Interval.nullable(true),
         ),
     is_retained_metrics_object: false,

--- a/src/catalog/src/durable/objects/serialization.rs
+++ b/src/catalog/src/durable/objects/serialization.rs
@@ -92,11 +92,11 @@ impl RustType<proto::ClusterSchedule> for ClusterSchedule {
                 value: Some(cluster_schedule::Value::Manual(Empty {})),
             },
             ClusterSchedule::Refresh {
-                rehydration_time_estimate,
+                hydration_time_estimate,
             } => proto::ClusterSchedule {
                 value: Some(cluster_schedule::Value::Refresh(
                     ClusterScheduleRefreshOptions {
-                        rehydration_time_estimate: Some(rehydration_time_estimate.into_proto()),
+                        rehydration_time_estimate: Some(hydration_time_estimate.into_proto()),
                     },
                 )),
             },
@@ -108,7 +108,7 @@ impl RustType<proto::ClusterSchedule> for ClusterSchedule {
             None => Ok(Default::default()),
             Some(cluster_schedule::Value::Manual(Empty {})) => Ok(ClusterSchedule::Manual),
             Some(cluster_schedule::Value::Refresh(csro)) => Ok(ClusterSchedule::Refresh {
-                rehydration_time_estimate: csro
+                hydration_time_estimate: csro
                     .rehydration_time_estimate
                     .into_rust_if_some("rehydration_time_estimate")?,
             }),
@@ -1841,7 +1841,7 @@ impl RustType<proto::audit_log_event_v1::RefreshDecisionWithReasonV1>
         proto::audit_log_event_v1::RefreshDecisionWithReasonV1 {
             decision: Some(decision),
             objects_needing_refresh: self.objects_needing_refresh.clone(),
-            rehydration_time_estimate: self.rehydration_time_estimate.clone(),
+            rehydration_time_estimate: self.hydration_time_estimate.clone(),
         }
     }
 
@@ -1864,7 +1864,7 @@ impl RustType<proto::audit_log_event_v1::RefreshDecisionWithReasonV1>
         Ok(RefreshDecisionWithReasonV1 {
             decision,
             objects_needing_refresh: proto.objects_needing_refresh,
-            rehydration_time_estimate: proto.rehydration_time_estimate,
+            hydration_time_estimate: proto.rehydration_time_estimate,
         })
     }
 }

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -248,7 +248,7 @@ async fn test_audit_logs(openable_state: Box<dyn OpenableDurableCatalogState>) {
                     on_refresh: mz_audit_log::RefreshDecisionWithReasonV1 {
                         decision: mz_audit_log::SchedulingDecisionV1::On,
                         objects_needing_refresh: vec!["u42".to_string(), "u90".to_string()],
-                        rehydration_time_estimate: "1000s".to_string(),
+                        hydration_time_estimate: "1000s".to_string(),
                     },
                 }),
             }),

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -190,6 +190,7 @@ Host
 Hour
 Hours
 Humanized
+Hydration
 Id
 Identifiers
 Ids

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3729,7 +3729,7 @@ impl<T: AstInfo> AstDisplay for RefreshOptionValue<T> {
 pub enum ClusterScheduleOptionValue {
     Manual,
     Refresh {
-        rehydration_time_estimate: Option<IntervalValue>,
+        hydration_time_estimate: Option<IntervalValue>,
     },
 }
 
@@ -3747,12 +3747,12 @@ impl AstDisplay for ClusterScheduleOptionValue {
                 f.write_str("MANUAL");
             }
             ClusterScheduleOptionValue::Refresh {
-                rehydration_time_estimate,
+                hydration_time_estimate,
             } => {
                 f.write_str("ON REFRESH");
-                if let Some(rehydration_time_estimate) = rehydration_time_estimate {
-                    f.write_str(" (REHYDRATION TIME ESTIMATE = '");
-                    f.write_node(rehydration_time_estimate);
+                if let Some(hydration_time_estimate) = hydration_time_estimate {
+                    f.write_str(" (HYDRATION TIME ESTIMATE = '");
+                    f.write_node(hydration_time_estimate);
                     f.write_str(")");
                 }
             }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3881,9 +3881,12 @@ impl<'a> Parser<'a> {
             MANUAL => ClusterScheduleOptionValue::Manual,
             ON => {
                 self.expect_keyword(REFRESH)?;
-                // Parse optional `(REHYDRATION TIME ESTIMATE ...)`
-                let rehydration_time_estimate = if self.consume_token(&Token::LParen) {
-                    self.expect_keywords(&[REHYDRATION, TIME, ESTIMATE])?;
+                // Parse optional `(HYDRATION TIME ESTIMATE ...)`
+                let hydration_time_estimate = if self.consume_token(&Token::LParen) {
+                    // `REHYDRATION` is the legacy way of writing this. We'd like to eventually
+                    // remove this, and allow only `HYDRATION`. (Dbt needs to be updated for this.)
+                    self.expect_one_of_keywords(&[HYDRATION, REHYDRATION])?;
+                    self.expect_keywords(&[TIME, ESTIMATE])?;
                     let _ = self.consume_token(&Token::Eq);
                     let interval = self.parse_interval_value()?;
                     self.expect_token(&Token::RParen)?;
@@ -3892,7 +3895,7 @@ impl<'a> Parser<'a> {
                     None
                 };
                 ClusterScheduleOptionValue::Refresh {
-                    rehydration_time_estimate,
+                    hydration_time_estimate,
                 }
             }
             _ => unreachable!(),

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1685,49 +1685,57 @@ CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH)
 ----
 CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH)
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { rehydration_time_estimate: None })) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: None })) }], features: [] })
 
+parse-statement
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'))
+----
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'))
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [] })
+
+# Legacy version: `REHYDRATION TIME ESTIMATE`
 parse-statement
 CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour'))
 ----
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour'))
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { rehydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [] })
 
 parse-statement
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE '1 hour'))
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE '1 hour'))
 ----
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour'))
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { rehydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [] })
 
 parse-statement
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE))
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE))
 ----
 error: Expected literal string, found right parenthesis
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE))
-                                                                                    ^
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE))
+                                                                                  ^
 
 parse-statement
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = ))
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = ))
 ----
 error: Expected literal string, found right parenthesis
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = ))
-                                                                                       ^
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = ))
+                                                                                     ^
 
 parse-statement
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION))
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION))
 ----
 error: Expected TIME, found right parenthesis
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION))
-                                                                      ^
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION))
+                                                                    ^
 
 parse-statement
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour')
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour')
 ----
 error: Expected right parenthesis, found EOF
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour')
-                                                                                                ^
+CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour')
+                                                                                              ^
 
 parse-statement
 ALTER CLUSTER cluster SET (SIZE '1')

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -590,9 +590,9 @@ pub enum ClusterSchedule {
     /// The system won't automatically turn the cluster On or Off.
     Manual,
     /// The cluster will be On when a REFRESH materialized view on it needs to refresh.
-    /// `rehydration_time_estimate` determines how much time before a refresh to turn the
+    /// `hydration_time_estimate` determines how much time before a refresh to turn the
     /// cluster On, so that it can rehydrate already before the refresh time.
-    Refresh { rehydration_time_estimate: Duration },
+    Refresh { hydration_time_estimate: Duration },
 }
 
 impl Default for ClusterSchedule {

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -99,7 +99,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 ----
 1  cluster_id  text
 2  type  text
-3  refresh_rehydration_time_estimate  interval
+3  refresh_hydration_time_estimate  interval
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_frontiers' ORDER BY position

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -1339,7 +1339,7 @@ statement ok
 ALTER CLUSTER c_schedule_1 SET (MANAGED = true, SIZE = '1');
 
 statement ok
-ALTER CLUSTER c_schedule_1 SET (SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '0 seconds'));
+ALTER CLUSTER c_schedule_1 SET (SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '0 seconds'));
 
 # Setting some other cluster option in ALTER CLUSTER shouldn't change the SCHEDULE.
 # (The sleep is needed so that if the following ALTER erroneously sets the SCHEDULE to MANUAL, then we should be in a
@@ -1465,22 +1465,22 @@ SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'c_schedule_4
 ----
 0
 
-## REHYDRATION TIME ESTIMATE
+## HYDRATION TIME ESTIMATE
 
 statement error db error: ERROR: Expected literal string, found number "0"
-CREATE CLUSTER c_bad (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = 0));
+CREATE CLUSTER c_bad (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = 0));
 
-statement error db error: ERROR: REHYDRATION TIME ESTIMATE must be non\-negative; got: \-01:00:00
-CREATE CLUSTER c_bad (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '-1 hour'));
+statement error db error: ERROR: HYDRATION TIME ESTIMATE must be non\-negative; got: \-01:00:00
+CREATE CLUSTER c_bad (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '-1 hour'));
 
 statement error db error: ERROR: invalid input syntax for type interval: unknown units aaaa: "1 aaaa"
-CREATE CLUSTER c_bad (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 aaaa'));
+CREATE CLUSTER c_bad (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 aaaa'));
 
-statement error db error: ERROR: REHYDRATION TIME ESTIMATE must not involve units larger than days
-CREATE CLUSTER c_bad (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 month'));
+statement error db error: ERROR: HYDRATION TIME ESTIMATE must not involve units larger than days
+CREATE CLUSTER c_bad (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 month'));
 
 statement error db error: ERROR: invalid input syntax for type interval: Overflows maximum days; cannot exceed 2147483647/\-2147483648 days: "1000000000000 days"
-CREATE CLUSTER c_bad (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1000000000000 days'));
+CREATE CLUSTER c_bad (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1000000000000 days'));
 
 # ----------------------------------------
 # Introspection
@@ -1533,16 +1533,16 @@ mvi3  at  NULL  NULL  true
 mvi3  at  NULL  NULL  true
 
 statement ok
-CREATE CLUSTER c_schedule_rehydration_time_estimate (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '995 seconds'));
+CREATE CLUSTER c_schedule_hydration_time_estimate (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '995 seconds'));
 
-# Make the above cluster turn on, so that we can test how the REHYDRATION TIME ESTIMATE looks in `mz_audit_events`.
+# Make the above cluster turn on, so that we can test how the HYDRATION TIME ESTIMATE looks in `mz_audit_events`.
 statement ok
 CREATE MATERIALIZED VIEW mv_rte
-IN CLUSTER c_schedule_rehydration_time_estimate
+IN CLUSTER c_schedule_hydration_time_estimate
 WITH (REFRESH EVERY '1 sec') AS SELECT * FROM t2;
 
 query TTT
-SELECT name, cs.type, cs.refresh_rehydration_time_estimate
+SELECT name, cs.type, cs.refresh_hydration_time_estimate
 FROM mz_internal.mz_cluster_schedules cs, mz_catalog.mz_clusters c
 WHERE c.id = cs.cluster_id
 ORDER BY name;
@@ -1552,7 +1552,7 @@ c_schedule_2  manual  NULL
 c_schedule_3  on-refresh  00:00:00
 c_schedule_4  manual  NULL
 c_schedule_5  manual  NULL
-c_schedule_rehydration_time_estimate  on-refresh  00:16:35
+c_schedule_hydration_time_estimate  on-refresh  00:16:35
 mz_catalog_server  manual  NULL
 mz_probe  manual  NULL
 mz_support  manual  NULL
@@ -1582,12 +1582,12 @@ drop  cluster-replica  "c_schedule_4"  "manual"  true  NULL
 create  cluster-replica  "c_schedule_1"  "manual"  true  NULL
 create  cluster-replica  "c_schedule_2"  "manual"  true  NULL
 create  cluster-replica  "c_schedule_5"  "manual"  true  NULL
-drop  cluster-replica  "c_schedule_1"  "schedule"  false  {"decision":"off","objects_needing_refresh":[],"rehydration_time_estimate":"00:00:00"}
-drop  cluster-replica  "c_schedule_3"  "schedule"  false  {"decision":"off","objects_needing_refresh":[],"rehydration_time_estimate":"00:00:00"}
-create  cluster-replica  "c_schedule_1"  "schedule"  false  {"decision":"on","objects_needing_refresh":["uXXX"],"rehydration_time_estimate":"00:00:00"}
-create  cluster-replica  "c_schedule_3"  "schedule"  false  {"decision":"on","objects_needing_refresh":["uXXX"],"rehydration_time_estimate":"00:00:00"}
-create  cluster-replica  "c_schedule_4"  "schedule"  false  {"decision":"on","objects_needing_refresh":["uXXX"],"rehydration_time_estimate":"00:00:00"}
-create  cluster-replica  "c_schedule_rehydration_time_estimate"  "schedule"  false  {"decision":"on","objects_needing_refresh":["uXXX"],"rehydration_time_estimate":"00:16:35"}
+drop  cluster-replica  "c_schedule_1"  "schedule"  false  {"decision":"off","hydration_time_estimate":"00:00:00","objects_needing_refresh":[]}
+drop  cluster-replica  "c_schedule_3"  "schedule"  false  {"decision":"off","hydration_time_estimate":"00:00:00","objects_needing_refresh":[]}
+create  cluster-replica  "c_schedule_1"  "schedule"  false  {"decision":"on","hydration_time_estimate":"00:00:00","objects_needing_refresh":["uXXX"]}
+create  cluster-replica  "c_schedule_3"  "schedule"  false  {"decision":"on","hydration_time_estimate":"00:00:00","objects_needing_refresh":["uXXX"]}
+create  cluster-replica  "c_schedule_4"  "schedule"  false  {"decision":"on","hydration_time_estimate":"00:00:00","objects_needing_refresh":["uXXX"]}
+create  cluster-replica  "c_schedule_hydration_time_estimate"  "schedule"  false  {"decision":"on","hydration_time_estimate":"00:16:35","objects_needing_refresh":["uXXX"]}
 
 # Materialized views in this file can be explained
 

--- a/test/testdrive/materialized-view-refresh-options.td
+++ b/test/testdrive/materialized-view-refresh-options.td
@@ -516,11 +516,11 @@ DROP CLUSTER REPLICA scheduled_cluster.unbilled;
 > SELECT * FROM mv11;
 3
 
-## REHYDRATION TIME ESTIMATE
+## HYDRATION TIME ESTIMATE
 
-> CREATE CLUSTER c_schedule_6 (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '995 seconds'));
+> CREATE CLUSTER c_schedule_6 (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '995 seconds'));
 > CREATE CLUSTER c_schedule_7 (SIZE = '1');
-> ALTER CLUSTER c_schedule_7 SET (SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '995 seconds'));
+> ALTER CLUSTER c_schedule_7 SET (SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '995 seconds'));
 
 # Create MVs whose first refresh is 1000 seconds from now.
 > CREATE MATERIALIZED VIEW mv13
@@ -532,7 +532,7 @@ DROP CLUSTER REPLICA scheduled_cluster.unbilled;
   WITH (REFRESH AT mz_now()::string::int8 + 1000 * 1000)
   AS SELECT count(*) FROM t2;
 
-# Should be turned on soon due to the REHYDRATION TIME ESTIMATE.
+# Should be turned on soon due to the HYDRATION TIME ESTIMATE.
 > SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'c_schedule_6';
 1
 > SELECT replication_factor FROM mz_catalog.mz_clusters WHERE name = 'c_schedule_7';
@@ -635,7 +635,7 @@ true <null>
   SELECT mz_unsafe.mz_sleep(a)
   FROM t6;
 
-# Wait for the first rehydration to complete
+# Wait for the first hydration to complete
 > SELECT * FROM mv_long_hydration;
 <null>
 
@@ -644,10 +644,10 @@ true <null>
   WHERE name = 'mv_long_hydration';
 true
 
-# Make the next rehydration take 1000000 ms.
+# Make the next hydration take 1000000 ms.
 > INSERT INTO t6 VALUES (1000000);
 
-# Restart the cluster to force a rehydration.
+# Restart the cluster to force a hydration.
 > ALTER CLUSTER cluster_to_be_bricked SET (REPLICATION FACTOR 0);
 > ALTER CLUSTER cluster_to_be_bricked SET (REPLICATION FACTOR 1);
 


### PR DESCRIPTION
Discussed with Marta and Nikhil [here](https://materializeinc.slack.com/archives/C075QPD99PV/p1720532814941859?thread_ts=1720530181.988819&cid=C075QPD99PV).

This changes the `REHYDRATION TIME ESTIMATE` cluster option to `HYDRATION TIME ESTIMATE`. The parser still accepts the old version. Eventually, the old version will be completely removed, once users move to the new version. They'll move to the new syntax automatically when they start using a new dbt adapter version. Created an issue: https://github.com/MaterializeInc/materialize/issues/28140

I think I changed the dbt adapter (`misc/dbt-materialize/dbt/include/materialize/macros/ci/create_cluster.sql`). @morsapaes, can you confirm?

(I changed the `mz_internal.mz_cluster_schedules.refresh_hydration_time_estimate` column. This is in `mz_internal`, so should be fine.)

(I haven't changed the protobuf for the catalog objects, but I think this is not externally visible anywhere.)

### Motivation

  * This PR does a minor syntax change, using a cleaner term as a keyword.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
