### PR TITLE
RowPacker: directly copy Rows instead of using iterators

### DIFF
--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -36,7 +36,6 @@ use mz_compute_client::protocol::response::SubscribeBatch;
 use mz_controller_types::ClusterId;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_panic_or_log;
-use mz_repr::fixed_length::ToDatumIter;
 use mz_repr::optimize::OverrideFrom;
 use mz_repr::{Datum, GlobalId, Row};
 use mz_sql::catalog::SessionCatalog;
@@ -404,7 +403,7 @@ impl Coordinator {
         for (_time, row, diff) in updates {
             let mut packer = new_row.packer();
             packer.push(Datum::String(&replica_id));
-            packer.extend(row.to_datum_iter());
+            packer.extend_by_row(&row);
             new_updates.push((new_row.clone(), diff));
         }
 

--- a/src/repr/src/fixed_length.rs
+++ b/src/repr/src/fixed_length.rs
@@ -12,7 +12,6 @@
 //! representations only need to commit to implementing these traits.
 
 use std::borrow::Borrow;
-use std::iter::{empty, Empty};
 
 use crate::row::DatumListIter;
 use crate::{Datum, Row};
@@ -90,40 +89,5 @@ impl FromDatumIter for Row {
     {
         self.packer().try_extend(datum_iter)?;
         Ok(self.clone())
-    }
-}
-
-impl ToDatumIter for () {
-    /// Empty iterator for unit.
-    type DatumIter<'a> = Empty<Datum<'a>>;
-
-    /// Returns an empty iterator.
-    #[inline]
-    fn to_datum_iter<'a>(&'a self) -> Self::DatumIter<'a> {
-        empty()
-    }
-}
-
-impl FromDatumIter for () {
-    /// Obtains a unit value from an empty datum iterator.
-    #[inline]
-    fn from_datum_iter<'a, I, D>(&mut self, datum_iter: I) -> Self
-    where
-        I: IntoIterator<Item = D>,
-        D: Borrow<Datum<'a>>,
-    {
-        debug_assert!(datum_iter.into_iter().next().is_none());
-        ()
-    }
-
-    /// Obtains a unit value from an empty iterator of results of datums.
-    #[inline]
-    fn try_from_datum_iter<'a, I, D, E>(&mut self, datum_iter: I) -> Result<Self, E>
-    where
-        I: IntoIterator<Item = Result<D, E>>,
-        D: Borrow<Datum<'a>>,
-    {
-        debug_assert!(datum_iter.into_iter().next().is_none());
-        Ok(())
     }
 }

--- a/src/transform/src/fold_constants.rs
+++ b/src/transform/src/fold_constants.rs
@@ -366,9 +366,9 @@ impl FoldConstants {
                             let mut next_rows = Vec::new();
                             for (old_row, old_count) in old_rows {
                                 for (new_row, new_count) in rows.iter() {
-                                    row_buf
-                                        .packer()
-                                        .extend(old_row.iter().chain(new_row.iter()));
+                                    let mut packer = row_buf.packer();
+                                    packer.extend_by_row(&old_row);
+                                    packer.extend_by_row(new_row);
                                     next_rows.push((row_buf.clone(), old_count * *new_count));
                                 }
                             }
@@ -655,9 +655,9 @@ impl FoldConstants {
                 .collect::<Result<Vec<_>, _>>()?;
             let mut output_rows = func.eval(&datums, &temp_storage)?.fuse();
             for (output_row, diff2) in (&mut output_rows).take(limit - new_rows.len()) {
-                row_buf
-                    .packer()
-                    .extend(input_row.clone().into_iter().chain(output_row.into_iter()));
+                let mut packer = row_buf.packer();
+                packer.extend_by_row(input_row);
+                packer.extend_by_row(&output_row);
                 new_rows.push((row_buf.clone(), diff2 * *diff))
             }
             // If we still have records to enumerate, but dropped out of the iteration,


### PR DESCRIPTION
Instead of decoding and encoding each `Row` entry, directly copy the entire `Row` into a `RowPacker` where possible. 

Fixes #27976 

### Tips for reviewer

* Are there any specific tests to run for these changes?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
