### PR TITLE
platform-checks: Add zero-downtime upgrade scenarios

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -815,6 +815,51 @@ steps:
               composition: platform-checks
               args: [--scenario=TogglePersistBatchColumnarFormat, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-0dt-restart-entire-mz
+        label: "Checks 0dt restart of the entire Mz"
+        depends_on: build-aarch64
+        timeout_in_minutes: 60
+        agents:
+          # A larger instance is needed due to frequent OOMs
+          queue: linux-aarch64-large
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=ZeroDowntimeRestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
+
+      - id: checks-0dt-upgrade-entire-mz
+        label: "Checks 0dt upgrade, whole-Mz restart"
+        depends_on: build-aarch64
+        timeout_in_minutes: 60
+        agents:
+          queue: linux-aarch64-large
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=ZeroDowntimeUpgradeEntireMz]
+
+      - id: checks-0dt-upgrade-entire-mz-two-versions
+        label: "Checks 0dt upgrade across two versions"
+        depends_on: build-aarch64
+        timeout_in_minutes: 60
+        agents:
+          queue: linux-aarch64-large
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=ZeroDowntimeUpgradeEntireMzTwoVersions]
+
+      - id: checks-0dt-upgrade-entire-mz-four-versions
+        label: "Checks 0dt upgrade across four versions"
+        depends_on: build-aarch64
+        timeout_in_minutes: 90
+        agents:
+          queue: linux-aarch64-large
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=ZeroDowntimeUpgradeEntireMzFourVersions]
+
       - id: cloudtest-upgrade
         label: "Platform checks upgrade in Cloudtest/K8s"
         depends_on: build-aarch64

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -513,7 +513,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 60
         agents:
-          # A larger instance is needed due to frequent OOMs
+          # A larger instance is needed due to frequent OOMs, same in all other platform-checks
           queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
@@ -525,7 +525,6 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 60
         agents:
-          # A larger instance is needed due to frequent OOMs
           queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
@@ -586,7 +585,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=DropCreateDefaultReplica, --execution-mode=parallel]
+              args: [--scenario=DropCreateDefaultReplica, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-restart-clusterd-compute
         label: "Checks parallel + restart compute clusterd"
@@ -598,7 +597,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=RestartClusterdCompute, --execution-mode=parallel]
+              args: [--scenario=RestartClusterdCompute, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-restart-entire-mz
         label: "Checks parallel + restart of the entire Mz"
@@ -610,7 +609,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=RestartEntireMz, --execution-mode=parallel]
+              args: [--scenario=RestartEntireMz, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-restart-environmentd-clusterd-storage
         label: "Checks parallel + restart of environmentd & storage clusterd"
@@ -622,7 +621,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=RestartEnvironmentdClusterdStorage, --execution-mode=parallel]
+              args: [--scenario=RestartEnvironmentdClusterdStorage, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-kill-clusterd-storage
         label: "Checks parallel + kill storage clusterd"
@@ -634,7 +633,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=KillClusterdStorage, --execution-mode=parallel]
+              args: [--scenario=KillClusterdStorage, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-parallel-restart-redpanda
         label: "Checks parallel + restart Redpanda & Debezium"
@@ -646,7 +645,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=RestartRedpandaDebezium, --execution-mode=parallel]
+              args: [--scenario=RestartRedpandaDebezium, --execution-mode=parallel, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-upgrade-entire-mz
         label: "Checks upgrade, whole-Mz restart"
@@ -657,7 +656,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=UpgradeEntireMz]
+              args: [--scenario=UpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-preflight-check-continue
         label: "Checks preflight-check and continue upgrade"
@@ -668,7 +667,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=PreflightCheckContinue]
+              args: [--scenario=PreflightCheckContinue, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-preflight-check-rollback
         label: "Checks preflight-check and roll back upgrade"
@@ -679,7 +678,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=PreflightCheckRollback]
+              args: [--scenario=PreflightCheckRollback, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-upgrade-entire-mz-two-versions
         label: "Checks upgrade across two versions"
@@ -690,7 +689,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=UpgradeEntireMzTwoVersions]
+              args: [--scenario=UpgradeEntireMzTwoVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-upgrade-entire-mz-four-versions
         label: "Checks upgrade across four versions"
@@ -701,7 +700,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=UpgradeEntireMzFourVersions]
+              args: [--scenario=UpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-upgrade-clusterd-compute-first
         label: "Platform checks upgrade, restarting compute clusterd first"
@@ -712,7 +711,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=UpgradeClusterdComputeFirst]
+              args: [--scenario=UpgradeClusterdComputeFirst, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-upgrade-clusterd-compute-last
         label: "Platform checks upgrade, restarting compute clusterd last"
@@ -723,7 +722,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=UpgradeClusterdComputeLast]
+              args: [--scenario=UpgradeClusterdComputeLast, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-kill-clusterd-storage
         label: "Checks + kill storage clusterd"
@@ -820,7 +819,6 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 60
         agents:
-          # A larger instance is needed due to frequent OOMs
           queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
@@ -836,7 +834,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=ZeroDowntimeUpgradeEntireMz]
+              args: [--scenario=ZeroDowntimeUpgradeEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz-two-versions
         label: "Checks 0dt upgrade across two versions"
@@ -847,7 +845,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=ZeroDowntimeUpgradeEntireMzTwoVersions]
+              args: [--scenario=ZeroDowntimeUpgradeEntireMzTwoVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: checks-0dt-upgrade-entire-mz-four-versions
         label: "Checks 0dt upgrade across four versions"
@@ -858,7 +856,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=ZeroDowntimeUpgradeEntireMzFourVersions]
+              args: [--scenario=ZeroDowntimeUpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: cloudtest-upgrade
         label: "Platform checks upgrade in Cloudtest/K8s"

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -84,10 +84,7 @@ class Scenario:
 
         for index, action in enumerate(actions):
             # Implicitly call configure to raise version-dependent limits
-            if isinstance(action, StartMz) and not any(
-                env.startswith("MZ_DEPLOY_GENERATION=")
-                for env in action.environment_extra
-            ):
+            if isinstance(action, StartMz) and not action.deploy_generation:
                 actions.insert(
                     index + 1, ConfigureMz(self, mz_service=action.mz_service)
                 )

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -247,13 +247,13 @@ class PreflightCheckContinue(Scenario):
             StartMz(
                 self,
                 tag=None,
-                environment_extra=["MZ_DEPLOY_GENERATION=1"],
                 healthcheck=[
                     "CMD",
                     "curl",
                     "-f",
                     "localhost:6878/api/leader/status",
                 ],
+                deploy_generation=1,
             ),
             WaitReadyMz(),
             PromoteMz(),
@@ -264,7 +264,7 @@ class PreflightCheckContinue(Scenario):
             StartMz(
                 self,
                 tag=None,
-                environment_extra=["MZ_DEPLOY_GENERATION=1"],
+                deploy_generation=1,
             ),
             Validate(self),
         ]
@@ -288,13 +288,13 @@ class PreflightCheckRollback(Scenario):
             StartMz(
                 self,
                 tag=None,
-                environment_extra=["MZ_DEPLOY_GENERATION=1"],
                 healthcheck=[
                     "CMD",
                     "curl",
                     "-f",
                     "localhost:6878/api/leader/status",
                 ],
+                deploy_generation=1,
             ),
             WaitReadyMz(),
             KillMz(capture_logs=True),

--- a/misc/python/materialize/checks/scenarios_zero_downtime.py
+++ b/misc/python/materialize/checks/scenarios_zero_downtime.py
@@ -1,0 +1,169 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.checks.actions import Action, Initialize, Manipulate, Validate
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.checks.mzcompose_actions import (
+    KillMz,
+    PromoteMz,
+    StartMz,
+    WaitReadyMz,
+)
+from materialize.checks.scenarios import Scenario
+from materialize.checks.scenarios_upgrade import (
+    get_last_version,
+    get_minor_versions,
+    get_previous_version,
+)
+from materialize.mz_version import MzVersion
+
+
+def start_mz_in_read_only_and_deploy(
+    scenario: Scenario,
+    deploy_generation: int,
+    mz_service: str = "materialized",
+    tag: MzVersion | None = None,
+) -> list[Action]:
+    result: list[Action] = []
+    result.extend(
+        [
+            StartMz(
+                scenario,
+                tag=tag,
+                mz_service=mz_service,
+                deploy_generation=deploy_generation,
+                healthcheck=[
+                    "CMD",
+                    "curl",
+                    "-f",
+                    "localhost:6878/api/leader/status",
+                ],
+            ),
+            WaitReadyMz(mz_service=mz_service),
+            PromoteMz(mz_service=mz_service),
+        ]
+    )
+    return result
+
+
+class ZeroDowntimeRestartEntireMz(Scenario):
+    def actions(self) -> list[Action]:
+        return [
+            StartMz(self, mz_service="mz_1"),
+            Initialize(self, mz_service="mz_1"),
+            *start_mz_in_read_only_and_deploy(
+                self, deploy_generation=1, mz_service="mz_2"
+            ),
+            Manipulate(self, phase=1, mz_service="mz_2"),
+            *start_mz_in_read_only_and_deploy(
+                self, deploy_generation=2, mz_service="mz_1"
+            ),
+            Manipulate(self, phase=2, mz_service="mz_1"),
+            *start_mz_in_read_only_and_deploy(
+                self, deploy_generation=3, mz_service="mz_2"
+            ),
+            Validate(self, mz_service="mz_2"),
+        ]
+
+
+class ZeroDowntimeUpgradeEntireMz(Scenario):
+    """0dt upgrade of the entire Mz instance from the last released version."""
+
+    def base_version(self) -> MzVersion:
+        return get_last_version()
+
+    def actions(self) -> list[Action]:
+        print(f"Upgrading from tag {self.base_version()}")
+        return [
+            StartMz(self, tag=self.base_version(), mz_service="mz_1"),
+            Initialize(self, mz_service="mz_1"),
+            Manipulate(self, phase=1, mz_service="mz_1"),
+            *start_mz_in_read_only_and_deploy(
+                self, deploy_generation=1, mz_service="mz_2"
+            ),
+            Manipulate(self, phase=2, mz_service="mz_2"),
+            Validate(self, mz_service="mz_2"),
+            # A second restart while already on the new version
+            KillMz(capture_logs=True, mz_service="mz_2"),
+            StartMz(self, tag=None, mz_service="mz_2", deploy_generation=1),
+            Validate(self, mz_service="mz_2"),
+        ]
+
+
+class ZeroDowntimeUpgradeEntireMzTwoVersions(Scenario):
+    """0dt upgrade of the entire Mz instance starting from the previous
+    released version and passing through the last released version."""
+
+    def base_version(self) -> MzVersion:
+        return get_previous_version()
+
+    def actions(self) -> list[Action]:
+        print(f"Upgrade path: {self.base_version()} -> {get_last_version()} -> current")
+        return [
+            # Start with previous_version
+            StartMz(self, tag=self.base_version(), mz_service="mz_1"),
+            Initialize(self, mz_service="mz_1"),
+            # Upgrade to last_version
+            *start_mz_in_read_only_and_deploy(
+                self, deploy_generation=1, mz_service="mz_2"
+            ),
+            Manipulate(self, phase=1, mz_service="mz_2"),
+            # Upgrade to current source
+            *start_mz_in_read_only_and_deploy(
+                self, deploy_generation=2, mz_service="mz_1"
+            ),
+            Manipulate(self, phase=2, mz_service="mz_1"),
+            Validate(self, mz_service="mz_1"),
+            # A second restart while already on the current source
+            KillMz(mz_service="mz_1"),
+            StartMz(self, tag=None, mz_service="mz_1", deploy_generation=2),
+            Validate(self, mz_service="mz_1"),
+        ]
+
+
+class ZeroDowntimeUpgradeEntireMzFourVersions(Scenario):
+    """Test 0dt upgrade from X-4 -> X-3 -> X-2 -> X-1 -> X"""
+
+    def __init__(
+        self, checks: list[type[Check]], executor: Executor, seed: str | None = None
+    ):
+        self.minor_versions = get_minor_versions()
+        super().__init__(checks, executor, seed)
+
+    def base_version(self) -> MzVersion:
+        return self.minor_versions[3]
+
+    def actions(self) -> list[Action]:
+        print(
+            f"Upgrade path: {self.minor_versions[3]} -> {self.minor_versions[2]} -> {get_previous_version()} -> {get_last_version()} -> current"
+        )
+        return [
+            StartMz(self, tag=self.minor_versions[3], mz_service="mz_1"),
+            Initialize(self, mz_service="mz_1"),
+            *start_mz_in_read_only_and_deploy(
+                self, tag=self.minor_versions[2], deploy_generation=1, mz_service="mz_2"
+            ),
+            Manipulate(self, phase=1, mz_service="mz_2"),
+            *start_mz_in_read_only_and_deploy(
+                self, tag=get_previous_version(), deploy_generation=2, mz_service="mz_1"
+            ),
+            Manipulate(self, phase=2, mz_service="mz_1"),
+            *start_mz_in_read_only_and_deploy(
+                self, tag=get_last_version(), deploy_generation=3, mz_service="mz_2"
+            ),
+            *start_mz_in_read_only_and_deploy(
+                self, tag=None, deploy_generation=4, mz_service="mz_1"
+            ),
+            Validate(self, mz_service="mz_1"),
+            KillMz(mz_service="mz_1"),
+            StartMz(self, tag=None, mz_service="mz_1", deploy_generation=4),
+            Validate(self, mz_service="mz_1"),
+        ]

--- a/misc/python/materialize/parallel_workload/settings.py
+++ b/misc/python/materialize/parallel_workload/settings.py
@@ -30,6 +30,7 @@ class Scenario(Enum):
     Rename = "rename"
     BackupRestore = "backup-restore"
     ToggleTxnWal = "toggle-txn-wal"
+    ZeroDowntimeDeploy = "0dt-deploy"
 
     @classmethod
     def _missing_(cls, value):

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -19,6 +19,7 @@ from materialize.checks.scenarios import Scenario, SystemVarChange
 from materialize.checks.scenarios_backup_restore import *  # noqa: F401 F403
 from materialize.checks.scenarios_platform_v2 import *  # noqa: F401 F403
 from materialize.checks.scenarios_upgrade import *  # noqa: F401 F403
+from materialize.checks.scenarios_zero_downtime import *  # noqa: F401 F403
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -91,6 +92,20 @@ SERVICES = [
         name="clusterd_compute_1"
     ),  # Started by some Scenarios, defined here only for the teardown
     Materialized(
+        external_cockroach=True,
+        external_minio=True,
+        sanity_restart=False,
+        volumes_extra=["secrets:/share/secrets"],
+    ),
+    Materialized(
+        name="mz_1",
+        external_cockroach=True,
+        external_minio=True,
+        sanity_restart=False,
+        volumes_extra=["secrets:/share/secrets"],
+    ),
+    Materialized(
+        name="mz_2",
         external_cockroach=True,
         external_minio=True,
         sanity_restart=False,


### PR DESCRIPTION
with two Mz instances running in parallel during upgrade

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
