### PR TITLE
storage/sources: Flatten values when using the value decoding errors inline option

### DIFF
--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -130,25 +130,21 @@ CREATE SOURCE kafka_upsert
   ENVELOPE UPSERT (VALUE DECODING ERRORS = INLINE);
 ```
 
-When this option is specified, the source will have the following schema,
-regardless of the specified `FORMAT`:
+When this option is specified the source will include an additional column named
+`error` with type `record(description: text)`.
 
-Field         | Type                                                                                       | Nullable | Meaning
---------------|--------------------------------------------------------------------------------------------|--------- |-----------
-`key`         | [[`record`](/sql/types/record/), [`bytea`](/sql/types/bytea/), [`text`](/sql/types/text/)] | `false`  | The Kafka message key. The type of this field depends on the specified `KEY FORMAT`. For unnamed formats (e.g., `TEXT`), the column name will be `key`. If the key is encoded using a format that includes schemas (e.g., `AVRO`), the column will take its name from the schema. The column can be renamed using the [`INCLUDE KEY AS...`](#key) syntax.
-`value`       | [`record`](/sql/types/record/)                                                    | `true`   | The message value for the given Kafka message key. If the most recent value cannot be decoded, this column will be `NULL`.
-`error`       | [`record`](/sql/types/record/)                                                    | `true`   | If the most recent value for the given Kafka message key cannot be decoded, this column column will contain the error message. If the most recent value for a key has been successfully decoded, this column will be `NULL`.
+This column and all value columns will be nullable, such that if the most recent value
+for the given Kafka message key cannot be decoded, this `error` column will contain
+the error message. If the most recent value for a key has been successfully decoded,
+this column will be `NULL`.
 
-We recommend creating a parsing view on top of your Kafka upsert source that
-maps the strongly-typed [`record`](/sql/types/record/) fields in
-`value` to columns, and optionally excludes keys with decoding errors:
+It might be convenient to implement a parsing view on top of your Kafka upsert source that
+excludes keys with decoding errors:
 
 ```mzsql
 CREATE VIEW kafka_upsert_parsed
-SELECT (value).*
+SELECT *
 FROM kafka_upsert
--- Optionally exclude messages for keys with values
--- that cannot be decoded
 WHERE error IS NULL;
 ```
 

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -659,7 +659,11 @@ ALTER SYSTEM SET enable_envelope_upsert_inline_errors = true
   VALUE FORMAT JSON
   ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE));
 
-> SELECT key, value::text, error::text FROM value_decode_error
+# there is now an additional 'error' column that should store the inline decoding errors, if any
+# since this is a json value record the output relation just has a single jsonb column named 'data'
+# though for other types (e.g. avro) the value columns should be present and flattened.
+
+> SELECT key, data, error::text FROM value_decode_error ORDER BY key
 val1 <null> "(\"Bytes: Failed to decode JSON: {\"\"a\"\":,\"\"c\"\":\"\"d\"\"} (original bytes: [7b, 22, 61, 22, 3a, 2c, 22, 63, 22, 3a, 22, 64, 22, 7d])\")"
 val2 <null> "(\"Bytes: Failed to decode JSON: [1,2, (original bytes: [5b, 31, 2c, 32, 2c])\")"
 
@@ -668,6 +672,15 @@ $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=inline-value
 val1:{"a": 1,"c":"d"}
 val2:[1,2,3]
 
-> SELECT key, value::text, error::text FROM value_decode_error
-val1 "(\"{\"\"a\"\":1,\"\"c\"\":\"\"d\"\"}\")" <null>
-val2 "(\"[1,2,3]\")" <null>
+> SELECT key, data, error::text FROM value_decode_error ORDER BY key
+val1 "{\"a\":1,\"c\":\"d\"}" <null>
+val2 [1,2,3] <null>
+
+! CREATE SOURCE value_decode_error_error
+  IN CLUSTER inline_error_cluster
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-inline-value-errors-1-${testdrive.seed}')
+  KEY FORMAT TEXT
+  VALUE FORMAT JSON
+  INCLUDE KEY AS error
+  ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE));
+contains: column "error" specified more than once


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This is a follow-on to https://github.com/MaterializeInc/materialize/pull/27802, as discussed in https://github.com/MaterializeInc/materialize/issues/28127, to switch back to flattening the value schema into the top-level of the source to remain consistent with normal upsert source semantics.

NOTE that with this implementation source creation will error if the value or key contain a column named `error` and there is no way to modify that column name. I will add an option to configure this but since I'm OOO tomorrow I figured we could potentially get this in ahead of time to make it in for the release cut. If we don't merge in time, I'll just add the rename option to this PR.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
