### PR TITLE
ci annotations: Ignore empty XML files & warn about failed runs

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from itertools import chain
 from textwrap import dedent
 from typing import Any
+from xml.etree.ElementTree import ParseError
 
 from junitparser.junitparser import Error, Failure, JUnitXml
 
@@ -612,7 +613,14 @@ def get_errors(log_file_names: list[str]) -> list[ErrorLog | JunitError]:
 
 def _get_errors_from_junit_file(log_file_name: str) -> list[JunitError]:
     error_logs = []
-    xml = JUnitXml.fromfile(log_file_name)
+    try:
+        xml = JUnitXml.fromfile(log_file_name)
+    except ParseError as e:
+        # Ignore empty files
+        if "no element found: line 1, column 0" in str(e):
+            return error_logs
+        else:
+            raise
     for suite in xml:
         for testcase in suite:
             for result in testcase.result:


### PR DESCRIPTION
Otherwise we might never hear about them since the run probably fails anyway because an actual test/problem issue. See https://materializeinc.slack.com/archives/C01LKF361MZ/p1720648897088559

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
