### PR TITLE
Consolidate threshold elision logic into `NonNegative` analysis

### DIFF
--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -771,11 +771,40 @@ mod non_negative {
                 MirRelationExpr::Negate { .. } => false,
                 // Threshold ensures non-negativity.
                 MirRelationExpr::Threshold { .. } => true,
-                MirRelationExpr::Join { .. } | MirRelationExpr::Union { .. } => {
+                MirRelationExpr::Join { .. } => {
                     // These two cases require all of their inputs to be non-negative.
                     depends
                         .children_of_rev(index, expr.children().count())
                         .all(|off| results[off])
+                }
+                MirRelationExpr::Union { base, inputs } => {
+                    // If all inputs are non-negative, the union is non-negative.
+                    let all_non_negative = depends
+                        .children_of_rev(index, expr.children().count())
+                        .all(|off| results[off]);
+
+                    if all_non_negative {
+                        return true;
+                    }
+
+                    // We look for the pattern `Union { base, Negate(Subset(base)) }`.
+                    // TODO: take some care to ensure that union fusion does not introduce a regression.
+                    if inputs.len() == 1 {
+                        if let MirRelationExpr::Negate { input } = &inputs[0] {
+                            // If `base` is non-negative, and `is_superset_of(base, input)`, return true.
+                            // TODO: this is not correct until we have `is_superset_of` validate non-negativity
+                            // as it goes, but it matches the current implementation.
+                            let mut children = depends.children_of_rev(index, 2);
+                            let _negate = children.next().unwrap();
+                            let base_id = children.next().unwrap();
+                            debug_assert_eq!(children.next(), None);
+                            if results[base_id] && is_superset_of(&*base, &*input) {
+                                return true;
+                            }
+                        }
+                    }
+
+                    false
                 }
                 _ => results[index - 1],
             }
@@ -797,6 +826,71 @@ mod non_negative {
             *into = *into && item;
             changed
         }
+    }
+
+    /// Returns true only if `rhs.negate().union(lhs)` contains only non-negative multiplicities.
+    ///
+    /// Informally, this happens when `rhs` is a multiset subset of `lhs`, meaning the multiplicity
+    /// of any record in `rhs` is at most the multiplicity of the same record in `lhs`.
+    ///
+    /// This method recursively descends each of `lhs` and `rhs` and performs a great many equality
+    /// tests, which has the potential to be quadratic. We should consider restricting its attention
+    /// to `Get` identifiers, under the premise that equal AST nodes would necessarily be identified
+    /// by common subexpression elimination. This requires care around recursively bound identifiers.
+    ///
+    /// These rules are .. somewhat arbitrary, and likely reflect observed opportunities. For example,
+    /// while we do relate `distinct(filter(A)) <= distinct(A)`, we do not relate `distinct(A) <= A`.
+    pub fn is_superset_of(mut lhs: &MirRelationExpr, mut rhs: &MirRelationExpr) -> bool {
+        // This implementation is iterative.
+        // Before converting this implementation to recursive (e.g. to improve its accuracy)
+        // make sure to use the `CheckedRecursion` struct to avoid blowing the stack.
+        while lhs != rhs {
+            match rhs {
+                MirRelationExpr::Filter { input, .. } => rhs = &**input,
+                MirRelationExpr::TopK { input, .. } => rhs = &**input,
+                // Descend in both sides if the current roots are
+                // projections with the same `outputs` vector.
+                MirRelationExpr::Project {
+                    input: rhs_input,
+                    outputs: rhs_outputs,
+                } => match lhs {
+                    MirRelationExpr::Project {
+                        input: lhs_input,
+                        outputs: lhs_outputs,
+                    } if lhs_outputs == rhs_outputs => {
+                        rhs = &**rhs_input;
+                        lhs = &**lhs_input;
+                    }
+                    _ => return false,
+                },
+                // Descend in both sides if the current roots are reduces with empty aggregates
+                // on the same set of keys (that is, a distinct operation on those keys).
+                MirRelationExpr::Reduce {
+                    input: rhs_input,
+                    group_key: rhs_group_key,
+                    aggregates: rhs_aggregates,
+                    monotonic: _,
+                    expected_group_size: _,
+                } if rhs_aggregates.is_empty() => match lhs {
+                    MirRelationExpr::Reduce {
+                        input: lhs_input,
+                        group_key: lhs_group_key,
+                        aggregates: lhs_aggregates,
+                        monotonic: _,
+                        expected_group_size: _,
+                    } if lhs_aggregates.is_empty() && lhs_group_key == rhs_group_key => {
+                        rhs = &**rhs_input;
+                        lhs = &**lhs_input;
+                    }
+                    _ => return false,
+                },
+                _ => {
+                    // TODO: Imagine more complex reasoning here!
+                    return false;
+                }
+            }
+        }
+        true
     }
 }
 

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -111,17 +111,6 @@ pub mod common {
             }
             None
         }
-        /// Return an owned version of analysis results derived so far,
-        /// replacing them with an empty vector.
-        pub fn take_results<A: Analysis>(&mut self) -> Option<Vec<A::Value>> {
-            let type_id = TypeId::of::<Bundle<A>>();
-            if let Some(bundle) = self.analyses.get_mut(&type_id) {
-                if let Some(bundle) = bundle.as_any_mut().downcast_mut::<Bundle<A>>() {
-                    return Some(std::mem::take(&mut bundle.results));
-                }
-            }
-            None
-        }
         /// Bindings from local identifiers to result offsets for analysis values.
         pub fn bindings(&self) -> &BTreeMap<LocalId, usize> {
             &self.bindings
@@ -385,10 +374,6 @@ pub mod common {
         ///
         /// NOTE: This is required until <https://github.com/rust-lang/rfcs/issues/2765> is fixed
         fn as_any(&self) -> &dyn std::any::Any;
-        /// Upcasts `self` to a `&mut dyn Any`.
-        ///
-        /// NOTE: This is required until <https://github.com/rust-lang/rfcs/issues/2765> is fixed
-        fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
     }
 
     /// A wrapper for analysis state.
@@ -426,9 +411,6 @@ pub mod common {
             update
         }
         fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
-        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
             self
         }
     }

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -754,7 +754,7 @@ mod non_negative {
                 // Threshold ensures non-negativity.
                 MirRelationExpr::Threshold { .. } => true,
                 MirRelationExpr::Join { .. } => {
-                    // These two cases require all of their inputs to be non-negative.
+                    // If all inputs are non-negative, the join is non-negative.
                     depends
                         .children_of_rev(index, expr.children().count())
                         .all(|off| results[off])
@@ -822,7 +822,7 @@ mod non_negative {
     ///
     /// These rules are .. somewhat arbitrary, and likely reflect observed opportunities. For example,
     /// while we do relate `distinct(filter(A)) <= distinct(A)`, we do not relate `distinct(A) <= A`.
-    pub fn is_superset_of(mut lhs: &MirRelationExpr, mut rhs: &MirRelationExpr) -> bool {
+    fn is_superset_of(mut lhs: &MirRelationExpr, mut rhs: &MirRelationExpr) -> bool {
         // This implementation is iterative.
         // Before converting this implementation to recursive (e.g. to improve its accuracy)
         // make sure to use the `CheckedRecursion` struct to avoid blowing the stack.

--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -810,7 +810,8 @@ mod non_negative {
         }
     }
 
-    /// Returns true only if `rhs.negate().union(lhs)` contains only non-negative multiplicities.
+    /// Returns true only if `rhs.negate().union(lhs)` contains only non-negative multiplicities
+    /// once consolidated.
     ///
     /// Informally, this happens when `rhs` is a multiset subset of `lhs`, meaning the multiplicity
     /// of any record in `rhs` is at most the multiplicity of the same record in `lhs`.
@@ -822,6 +823,8 @@ mod non_negative {
     ///
     /// These rules are .. somewhat arbitrary, and likely reflect observed opportunities. For example,
     /// while we do relate `distinct(filter(A)) <= distinct(A)`, we do not relate `distinct(A) <= A`.
+    /// Further thoughts about the class of optimizations, and whether there should be more or fewer,
+    /// can be found here: <https://github.com/MaterializeInc/materialize/issues/14142>.
     fn is_superset_of(mut lhs: &MirRelationExpr, mut rhs: &MirRelationExpr) -> bool {
         // This implementation is iterative.
         // Before converting this implementation to recursive (e.g. to improve its accuracy)

--- a/src/transform/src/threshold_elision.rs
+++ b/src/transform/src/threshold_elision.rs
@@ -15,10 +15,9 @@
 //! The Subset(X) notation means that the collection is a multiset subset of X:
 //! multiplicities of each record in Subset(X) are at most that of X.
 
-use mz_expr::visit::{Visit, VisitorMut};
 use mz_expr::MirRelationExpr;
 
-use crate::analysis::{Analysis, DerivedBuilder, NonNegative, SubtreeSize};
+use crate::analysis::{DerivedBuilder, NonNegative, SubtreeSize};
 use crate::TransformCtx;
 
 /// Remove Threshold operators that have no effect.
@@ -39,148 +38,25 @@ impl crate::Transform for ThresholdElision {
         let mut builder = DerivedBuilder::new(ctx.features);
         builder.require(NonNegative);
         builder.require(SubtreeSize);
-        let mut derived = builder.visit(&*relation);
-        let subtree_size = derived.take_results::<SubtreeSize>().unwrap();
-        let non_negative = derived.take_results::<NonNegative>().unwrap();
+        let derived = builder.visit(&*relation);
 
-        let mut visitor = Action::new(subtree_size, non_negative);
-        let result = relation.visit_mut(&mut visitor).map_err(From::from);
+        // Descend the AST, removing `Threshold` operators whose inputs are non-negative.
+        let mut todo = vec![(&mut *relation, derived.as_view())];
+        while let Some((expr, mut view)) = todo.pop() {
+            if let MirRelationExpr::Threshold { input } = expr {
+                if *view
+                    .last_child()
+                    .value::<NonNegative>()
+                    .expect("NonNegative required")
+                {
+                    *expr = input.take_dangerous();
+                    view = view.last_child();
+                }
+            }
+            todo.extend(expr.children_mut().rev().zip(view.children_rev()))
+        }
+
         mz_repr::explain::trace_plan(&*relation);
-        result
+        Ok(())
     }
-}
-
-struct Action {
-    subtree_size: Vec<<SubtreeSize as Analysis>::Value>,
-    non_negative: Vec<<NonNegative as Analysis>::Value>,
-    index: usize,
-}
-
-impl VisitorMut<MirRelationExpr> for Action {
-    fn pre_visit(&mut self, _expr: &mut MirRelationExpr) {}
-
-    fn post_visit(&mut self, expr: &mut MirRelationExpr) {
-        self.action(expr);
-    }
-}
-
-impl Action {
-    fn new(
-        subtree_size: Vec<<SubtreeSize as Analysis>::Value>,
-        non_negative: Vec<<NonNegative as Analysis>::Value>,
-    ) -> Self {
-        Self {
-            subtree_size,
-            non_negative,
-            index: 0,
-        }
-    }
-
-    /// Remove Threshold operators with no effect.
-    pub fn action(&mut self, expr: &mut MirRelationExpr) {
-        // The result result vectors should be equal after each step.
-        debug_assert_eq!(self.non_negative.len(), self.subtree_size.len());
-
-        if let MirRelationExpr::Threshold { input } = expr {
-            // We look for the pattern `Union { base, Negate(Subset(base)) }`.
-            let mut should_replace = false;
-            if let MirRelationExpr::Union { base, inputs } = &mut **input {
-                if inputs.len() == 1 {
-                    if let MirRelationExpr::Negate { input } = &inputs[0] {
-                        // This is somewhat convoluted way to access the non_negative result for the base:
-                        // - the Threshold is at position n - 1,
-                        // - the Union (i.e., the Threshold input) is n - 2,
-                        // - the Union input[0] is at position n - 3 and its subtree size is m,
-                        // - the Union base therefore is at position n - m - 3
-                        let n = self.index;
-                        let m = self.subtree_size[n - 3];
-                        if self.non_negative[n - m - 3] && is_superset_of(base, &*input) {
-                            should_replace = true;
-                        }
-                    }
-                }
-            }
-            if should_replace {
-                // Trim the attribute result vectors inferred so far to adjust for the above change.
-                self.subtree_size.remove(self.index);
-                self.non_negative.remove(self.index);
-
-                // We can be a bit smarter when adjusting the NonNegative result. Since the Threshold
-                // at the root can only be safely elided iff its input is non-negative, we can overwrite
-                // the new last value to be `true`.
-                if let Some(result) = self.non_negative.get_mut(self.index - 1) {
-                    *result = true;
-                }
-
-                // Replace the root Threshold with its input.
-                *expr = input.take_dangerous();
-
-                // Adjust index by -1 to account for removing the current root.
-                self.index -= 1;
-            }
-        }
-
-        // Advance the index to the next node in post-visit order.
-        self.index += 1;
-    }
-}
-
-/// Returns true iff `rhs` is always a subset of `lhs`.
-///
-/// This method is a conservative approximation and is known to miss not-hard cases.
-///
-/// We iteratively descend `rhs` through a few operators, looking for `lhs`.
-/// In addition, we descend simultaneously through `lhs` and `rhs` if the root node
-/// on both sides is identical.
-pub fn is_superset_of(mut lhs: &MirRelationExpr, mut rhs: &MirRelationExpr) -> bool {
-    // This implementation is iterative.
-    // Before converting this implementation to recursive (e.g. to improve its accuracy)
-    // make sure to use the `CheckedRecursion` struct to avoid blowing the stack.
-    while lhs != rhs {
-        match rhs {
-            MirRelationExpr::Filter { input, .. } => rhs = &**input,
-            MirRelationExpr::TopK { input, .. } => rhs = &**input,
-            // Descend in both sides if the current roots are
-            // projections with the same `outputs` vector.
-            MirRelationExpr::Project {
-                input: rhs_input,
-                outputs: rhs_outputs,
-            } => match lhs {
-                MirRelationExpr::Project {
-                    input: lhs_input,
-                    outputs: lhs_outputs,
-                } if lhs_outputs == rhs_outputs => {
-                    rhs = &**rhs_input;
-                    lhs = &**lhs_input;
-                }
-                _ => return false,
-            },
-            // Descend in both sides if the current roots are reduces with empty aggregates
-            // on the same set of keys (that is, a distinct operation on those keys).
-            MirRelationExpr::Reduce {
-                input: rhs_input,
-                group_key: rhs_group_key,
-                aggregates: rhs_aggregates,
-                monotonic: _,
-                expected_group_size: _,
-            } if rhs_aggregates.is_empty() => match lhs {
-                MirRelationExpr::Reduce {
-                    input: lhs_input,
-                    group_key: lhs_group_key,
-                    aggregates: lhs_aggregates,
-                    monotonic: _,
-                    expected_group_size: _,
-                } if lhs_aggregates.is_empty() && lhs_group_key == rhs_group_key => {
-                    rhs = &**rhs_input;
-                    lhs = &**lhs_input;
-                }
-                _ => return false,
-            },
-            _ => {
-                // TODO: Imagine more complex reasoning here!
-                return false;
-            }
-        }
-    }
-    true
 }

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -73,7 +73,7 @@ EXCEPT
 )
 ----
 Explained Query:
-  Union // { non_negative: false }
+  Union // { non_negative: true }
     Project (#0) // { non_negative: true }
       ReadStorage materialize.public.people // { non_negative: true }
     Negate // { non_negative: false }
@@ -99,7 +99,7 @@ EXCEPT ALL
 )
 ----
 Explained Query:
-  Union // { non_negative: false }
+  Union // { non_negative: true }
     Project (#0) // { non_negative: true }
       ReadStorage materialize.public.people // { non_negative: true }
     Negate // { non_negative: false }
@@ -121,7 +121,7 @@ EXCEPT
 SELECT name FROM people WHERE id > 1
 ----
 Explained Query:
-  Union // { non_negative: false }
+  Union // { non_negative: true }
     Distinct project=[#0] // { non_negative: true }
       Project (#1) // { non_negative: true }
         ReadStorage materialize.public.people // { non_negative: true }
@@ -191,8 +191,8 @@ EXCEPT ALL
 )
 ----
 Explained Query:
-  Return // { non_negative: false }
-    Union // { non_negative: false }
+  Return // { non_negative: true }
+    Union // { non_negative: true }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
         TopK group_by=[#0] limit=1 // { non_negative: true }
@@ -234,8 +234,8 @@ EXCEPT
 )
 ----
 Explained Query:
-  Return // { non_negative: false }
-    Union // { non_negative: false }
+  Return // { non_negative: true }
+    Union // { non_negative: true }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
         TopK group_by=[#0] limit=1 // { non_negative: true }
@@ -258,8 +258,8 @@ WITH cte AS (SELECT people.id FROM people, bands)
 SELECT * FROM cte EXCEPT ALL SELECT * FROM cte where id > 5;
 ----
 Explained Query:
-  Return // { non_negative: false }
-    Union // { non_negative: false }
+  Return // { non_negative: true }
+    Union // { non_negative: true }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
         Filter (#0 > 5) // { non_negative: true }
@@ -288,8 +288,8 @@ WITH cte AS (SELECT DISTINCT name FROM people)
 SELECT * FROM cte EXCEPT ALL SELECT * FROM cte WHERE name LIKE 'J%'
 ----
 Explained Query:
-  Return // { non_negative: false }
-    Union // { non_negative: false }
+  Return // { non_negative: true }
+    Union // { non_negative: true }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
         Filter like["J%"](#0) // { non_negative: true }
@@ -317,8 +317,8 @@ WITH a(birth_year, no_people_born) AS (
 SELECT * FROM a EXCEPT (SELECT * FROM a WHERE birth_year > 1940);
 ----
 Explained Query:
-  Return // { non_negative: false }
-    Union // { non_negative: false }
+  Return // { non_negative: true }
+    Union // { non_negative: true }
       Get l0 // { non_negative: true }
       Negate // { non_negative: false }
         Filter (#0 > 1940) // { non_negative: true }
@@ -356,16 +356,16 @@ EXCEPT
 SELECT * FROM cte2 WHERE name LIKE 'P%';
 ----
 Explained Query:
-  Return // { non_negative: false }
-    Union // { non_negative: false }
-      Get l0 // { non_negative: false }
+  Return // { non_negative: true }
+    Union // { non_negative: true }
+      Get l0 // { non_negative: true }
       Negate // { non_negative: false }
-        Filter like["P%"](#1) // { non_negative: false }
-          Get l0 // { non_negative: false }
+        Filter like["P%"](#1) // { non_negative: true }
+          Get l0 // { non_negative: true }
   With
     cte l0 =
-      Distinct project=[#0..=#3] // { non_negative: false }
-        Union // { non_negative: false }
+      Distinct project=[#0..=#3] // { non_negative: true }
+        Union // { non_negative: true }
           ReadStorage materialize.public.people // { non_negative: true }
           Negate // { non_negative: false }
             Filter like["J%"](#1) // { non_negative: true }
@@ -431,24 +431,24 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c1
 ----
 Explained Query:
-  Return // { non_negative: false }
-    Get l0 // { non_negative: false }
+  Return // { non_negative: true }
+    Get l0 // { non_negative: true }
   With Mutually Recursive
     cte l0 =
-      Distinct project=[#0, #1] // { non_negative: false }
-        Union // { non_negative: false }
-          Project (#0, #2) // { non_negative: false }
-            Map ((#1 || "_init")) // { non_negative: false }
-              Union // { non_negative: false }
+      Distinct project=[#0, #1] // { non_negative: true }
+        Union // { non_negative: true }
+          Project (#0, #2) // { non_negative: true }
+            Map ((#1 || "_init")) // { non_negative: true }
+              Union // { non_negative: true }
                 Project (#0, #1) // { non_negative: true }
                   ReadStorage materialize.public.people // { non_negative: true }
                 Negate // { non_negative: false }
                   Project (#0, #1) // { non_negative: true }
                     Filter (#0 > 1) // { non_negative: true }
                       ReadStorage materialize.public.people // { non_negative: true }
-          Project (#0, #2) // { non_negative: false }
-            Map ((#1 || "_iter")) // { non_negative: false }
-              Get l0 // { non_negative: false }
+          Project (#0, #2) // { non_negative: true }
+            Map ((#1 || "_iter")) // { non_negative: true }
+              Get l0 // { non_negative: true }
 
 Source materialize.public.people
 
@@ -479,29 +479,27 @@ WITH MUTUALLY RECURSIVE
 SELECT * FROM c1
 ----
 Explained Query:
-  Return // { non_negative: true }
-    Get l0 // { non_negative: true }
+  Return // { non_negative: false }
+    Get l0 // { non_negative: false }
   With Mutually Recursive
     cte l1 =
       Union // { non_negative: false }
-        Get l0 // { non_negative: true }
+        Get l0 // { non_negative: false }
         Negate // { non_negative: false }
-          Filter (#0 > 2) // { non_negative: true }
-            Get l0 // { non_negative: true }
+          Filter (#0 > 2) // { non_negative: false }
+            Get l0 // { non_negative: false }
     cte l0 =
-      Distinct project=[#0, #1] // { non_negative: true }
-        Union // { non_negative: true }
+      Distinct project=[#0, #1] // { non_negative: false }
+        Union // { non_negative: false }
           Project (#0, #4) // { non_negative: true }
             Map ((#1 || "_init")) // { non_negative: true }
               ReadStorage materialize.public.people // { non_negative: true }
-          Threshold // { non_negative: true }
-            Union // { non_negative: false }
-              Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
+          Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
+            Get l1 // { non_negative: false }
+          Negate // { non_negative: false }
+            Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
+              Filter (#0 > 1) // { non_negative: false }
                 Get l1 // { non_negative: false }
-              Negate // { non_negative: false }
-                Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
-                  Filter (#0 > 1) // { non_negative: false }
-                    Get l1 // { non_negative: false }
 
 Source materialize.public.people
 

--- a/test/sqllogictest/transform/union_cancel.slt
+++ b/test/sqllogictest/transform/union_cancel.slt
@@ -109,8 +109,7 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 UNION ALL SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1
 ----
 Explained Query:
-  Threshold // { arity: 2 }
-    ReadStorage materialize.public.t1 // { arity: 2 }
+  ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 
@@ -148,8 +147,7 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 UNION ALL SELECT * FROM t2 EXCEPT ALL SELECT * FROM t1
 ----
 Explained Query:
-  Threshold // { arity: 2 }
-    ReadStorage materialize.public.t2 // { arity: 2 }
+  ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t2
 
@@ -167,8 +165,7 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t2 UNION ALL SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1
 ----
 Explained Query:
-  Threshold // { arity: 2 }
-    ReadStorage materialize.public.t2 // { arity: 2 }
+  ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t2
 


### PR DESCRIPTION
Our `threshold_elision.rs` transform uses the `NonNegative` analysis, but adds a bit more. That bit more could just be part of the `NonNegative` analysis, simplifying the threshold elision transform. Once simplified, we no longer need the ability to mutate derived analysis results.

The prior behavior should be preserved, but I think it has a bug. The `is_superset_of` function should require `lhs` be non-negative for some of its rules, but we only verify it for the `lhs` with which it first gets called (which isn't strictly required). I think we should fix this too, but I'm starting with a direct translation of the existing logic.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
