### PR TITLE
testdrive: Reenable kafka avro sink tests

### DIFF
--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -51,31 +51,29 @@ $ kafka-verify-data format=avro sink=materialize.public.interval_data_sink sort-
 {"before": null, "after": {"row": {"interval": [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]}}}
 {"before": null, "after": {"row": {"interval": [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]}}}
 
-# See #9723
-#> CREATE MATERIALIZED VIEW unnamed_cols AS SELECT 1, 2 AS b, 3;
-#
-#> CREATE SINK unnamed_cols_sink
-# IN CLUSTER ${arg.single-replica-cluster}
-# FROM unnamed_cols
-#  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-unnamed-cols-sink-${testdrive.seed}')
-#  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-#
-#$ kafka-verify-data format=avro sink=materialize.public.unnamed_cols_sink
-#{"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}}
+> CREATE MATERIALIZED VIEW unnamed_cols AS SELECT 1, 2 AS b, 3;
+
+> CREATE SINK unnamed_cols_sink
+ IN CLUSTER ${arg.single-replica-cluster}
+ FROM unnamed_cols
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-unnamed-cols-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+
+$ kafka-verify-data format=avro sink=materialize.public.unnamed_cols_sink
+{"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}}
 
 # Test that invented field names do not clash with named columns.
 
-# See #9723
-#> CREATE MATERIALIZED VIEW clashing_cols AS SELECT 1, 2 AS column1, 3 as b, 4 as b2, 5 as b3;
-#
-#> CREATE SINK clashing_cols_sink
-# IN CLUSTER ${arg.single-replica-cluster}
-# FROM clashing_cols
-#  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-clashing-cols-sink-${testdrive.seed}')
-#  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-#
-#$ kafka-verify-data format=avro sink=materialize.public.clashing_cols_sink
-#{"before": null, "after": {"row": {"column1": 1, "column1_1": 2, "b": 3, "b2": 4, "b3": 5}}}
+> CREATE MATERIALIZED VIEW clashing_cols AS SELECT 1, 2 AS column1, 3 as b, 4 as b2, 5 as b3;
+
+> CREATE SINK clashing_cols_sink
+ IN CLUSTER ${arg.single-replica-cluster}
+ FROM clashing_cols
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-clashing-cols-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+
+$ kafka-verify-data format=avro sink=materialize.public.clashing_cols_sink
+{"before": null, "after": {"row": {"column1": 1, "column1_1": 2, "b": 3, "b2": 4, "b3": 5}}}
 
 # Test date/time types.
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
