### PR TITLE
tests: Add sink-kafka-restart test

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -163,6 +163,18 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-multi-broker
 
+      - id: redpanda-resumption
+        label: ":panda_face: resumption tests"
+        depends_on: build-aarch64
+        timeout_in_minutes: 30
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: kafka-resumption
+              args: [--redpanda]
+        agents:
+          queue: linux-aarch64
+
+
   - group: Testdrive
     key: testdrive
     steps:

--- a/misc/python/materialize/cloudtest/k8s/redpanda.py
+++ b/misc/python/materialize/cloudtest/k8s/redpanda.py
@@ -31,7 +31,7 @@ class RedpandaDeployment(K8sDeployment):
         super().__init__(namespace)
         container = V1Container(
             name="redpanda",
-            image="vectorized/redpanda:v23.3.5",
+            image="vectorized/redpanda:v24.1.9",
             command=[
                 "/usr/bin/rpk",
                 "redpanda",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -29,7 +29,7 @@ T = TypeVar("T")
 say = ui.speaker("C> ")
 
 
-DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.5.2"
+DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.6.0"
 
 DEFAULT_MZ_VOLUMES = [
     "mzdata:/mzdata",

--- a/misc/python/materialize/mzcompose/services/redpanda.py
+++ b/misc/python/materialize/mzcompose/services/redpanda.py
@@ -18,7 +18,7 @@ class Redpanda(Service):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v23.3.5",
+        version: str = "v24.1.9",
         auto_create_topics: bool = False,
         image: str | None = None,
         aliases: list[str] | None = None,

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -409,6 +409,8 @@ impl TransactionalProducer {
             .key(&self.progress_key);
         self.producer.send(record).map_err(|(e, _)| e)?;
 
+        fail::fail_point!("kafka_sink_commit_transaction");
+
         let timeout = self.socket_timeout;
         match self
             .spawn_blocking(move |p| p.commit_transaction(timeout))

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -16,16 +16,17 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
 
-REDPANDA_VERSIONS = ["v22.3.25", "v23.1.21", "v23.2.25", "v23.3.5"]
+REDPANDA_VERSIONS = ["v22.3.25", "v23.1.21", "v23.2.29", "v23.3.18", "v24.1.9"]
 
 CONFLUENT_PLATFORM_VERSIONS = [
-    "6.2.14",
-    "7.0.13",
-    "7.1.11",
-    "7.2.9",
-    "7.3.7",
+    "6.2.15",
+    "7.0.14",
+    "7.1.12",
+    "7.2.10",
+    "7.3.8",
     "7.4.4",
-    "7.5.2",
+    "7.5.4",
+    "7.6.0",
     "latest",
 ]
 

--- a/test/kafka-resumption/sink-kafka-restart/cleanup.td
+++ b/test/kafka-resumption/sink-kafka-restart/cleanup.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> DROP SINK output CASCADE;
+
+> DROP TABLE t CASCADE;
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET kafka_transaction_timeout;

--- a/test/kafka-resumption/sink-kafka-restart/setup.td
+++ b/test/kafka-resumption/sink-kafka-restart/setup.td
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET kafka_transaction_timeout = '10min';
+
+> CREATE TABLE t (c1 TEXT, c2 INT);
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> INSERT INTO t VALUES ('A', 1);
+
+> CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+> CREATE SINK output FROM t
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'table-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+> INSERT INTO t VALUES ('B', 2);
+
+$ kafka-verify-data format=avro sink=materialize.public.output sort-messages=true
+{"before": null, "after": {"row": {"c1": {"string": "A"}, "c2": {"int": 1}}}}
+{"before": null, "after": {"row": {"c1": {"string": "B"}, "c2": {"int": 2}}}}

--- a/test/kafka-resumption/sink-kafka-restart/verify.td
+++ b/test/kafka-resumption/sink-kafka-restart/verify.td
@@ -1,0 +1,13 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> INSERT INTO t VALUES ('C', 3);
+
+$ kafka-verify-data format=avro sink=materialize.public.output sort-messages=true
+{"before": null, "after": {"row": {"c1": {"string": "C"}, "c2": {"int": 3}}}}


### PR DESCRIPTION
Maybe I'm missing something. This currently works with --redpanda. I followed the description from https://materializeinc.slack.com/archives/C01LKF361MZ/p1720682554959769

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
