### PR TITLE
[WIP] frontegg-mock: implement SSO config endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,10 +1282,8 @@ checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-targets 0.52.4",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,8 +1282,10 @@ checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.4",
 ]
 
@@ -5069,6 +5071,8 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.0",
+ "chrono",
  "clap",
  "hyper 0.14.27",
  "jsonwebtoken",

--- a/src/frontegg-mock/Cargo.toml
+++ b/src/frontegg-mock/Cargo.toml
@@ -12,6 +12,8 @@ workspace = true
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 axum = { version = "0.6.20", features = ["headers"] }
+base64 = "0.22.0"
+chrono = { version = "0.4.35", features = ["serde"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
 hyper = { version = "0.14.23", features = ["http1", "server"] }
 jsonwebtoken = "9.2.0"

--- a/src/frontegg-mock/Cargo.toml
+++ b/src/frontegg-mock/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 axum = { version = "0.6.20", features = ["headers"] }
 base64 = "0.22.0"
-chrono = { version = "0.4.35", features = ["serde"] }
+chrono = { version = "0.4.35", default-features = false, features = ["serde"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
 hyper = { version = "0.14.23", features = ["http1", "server"] }
 jsonwebtoken = "9.2.0"


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

As per the discussions [here](https://github.com/MaterializeInc/terraform-provider-materialize/issues/461) for consolidating the two existing Frontegg mock services, this PR transfers over another batch of endpoints:

- `/frontegg/team/resources/sso/v1/configurations`
  - `GET`, `POST`: Handle SSO configuration requests
- `/frontegg/team/resources/sso/v1/configurations/{id}`
  - `GET`, `PATCH`, `DELETE`: Handle specific SSO configuration and domain requests
- `/frontegg/team/resources/sso/v1/configurations/{id}/domains`
  - `GET`, `POST`: Handle domain requests for a specific SSO configuration
- `/frontegg/team/resources/sso/v1/configurations/{id}/domains/{domainId}`
  - `GET`, `PATCH`, `DELETE`: Handle requests for a specific domain
- `/frontegg/team/resources/sso/v1/configurations/{id}/groups`
  - `GET`, `POST`: Handle group mapping requests for a specific SSO configuration
- `/frontegg/team/resources/sso/v1/configurations/{id}/groups/{groupId}`
  - `GET`, `PATCH`, `DELETE`: Handle requests for a specific group mapping
- `/frontegg/team/resources/sso/v1/configurations/{id}/roles`
  - `GET`, `PUT`, `DELETE`: Handle default roles requests for a specific SSO configuration

These endpoints have been implemented in the Rust-based Frontegg mock service, ensuring consistency with the existing Go implementation.
