### PR TITLE
ci: Detect issues in cloud/incidents-and-escalations repo being closed

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -237,6 +237,9 @@ case "$cmd" in
             --env SCHEMA_REGISTRY_URL
             --env POSTGRES_URL
             --env COCKROACH_URL
+            # For ci-closed-issues-detect
+            --env GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN
+            --env GITHUB_TOKEN
         )
 
         if [[ $detach_container == "true" ]]; then


### PR DESCRIPTION
Test run: https://buildkite.com/materialize/nightly/builds/8566#0190b748-414f-41db-bfab-5cbe75f33c82

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
