### PR TITLE
storage: Remove invalid assert from startup

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2302,7 +2302,7 @@ impl Coordinator {
     /// Invokes the optimizer on all indexes and materialized views in the catalog and inserts the
     /// resulting dataflow plans into the catalog state.
     ///
-    /// `ordered_catalog_entries` must by sorted in dependency order, with dependencies ordered
+    /// `ordered_catalog_entries` must be sorted in dependency order, with dependencies ordered
     /// before their dependants.
     ///
     /// This method does not perform timestamp selection for the dataflows, nor does it create them

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -276,33 +276,33 @@ impl Fingerprint for &BuiltinLog {
     }
 }
 
-impl Fingerprint for &BuiltinTable {
-    fn fingerprint(&self) -> String {
-        self.desc.fingerprint()
-    }
-}
-
 /// Allows tests to inject arbitrary amounts of whitespace to forcibly change the fingerprint and
 /// trigger a builtin migration. Ideally this would be guarded by a `#[cfg(test)]` but unfortunately,
 /// the builtin migrations are in a different crate and would not be able to modify this value.
 /// There is an open issue to move builtin migrations to this crate:
 /// <https://github.com/MaterializeInc/materialize/issues/22593>
-pub static REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_VIEW_FINGERPRINT_WHITESPACE: Mutex<
+pub static REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE: Mutex<
     Option<String>,
 > = Mutex::new(None);
 
-impl Fingerprint for &BuiltinView {
+impl Fingerprint for &BuiltinTable {
     fn fingerprint(&self) -> String {
-        // This is only called during bootstrapping so it's not that big of a deal to lock a mutex,
+        // This is only called during bootstrapping, so it's not that big of a deal to lock a mutex,
         // though it's not great.
-        let guard = REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_VIEW_FINGERPRINT_WHITESPACE
+        let guard = REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE
             .lock()
             .expect("lock poisoned");
         if let Some(whitespace) = &*guard {
-            format!("{}{}", self.sql, whitespace)
+            format!("{}{}", self.desc.fingerprint(), whitespace)
         } else {
-            self.sql.to_string()
+            self.desc.fingerprint()
         }
+    }
+}
+
+impl Fingerprint for &BuiltinView {
+    fn fingerprint(&self) -> String {
+        self.sql.to_string()
     }
 }
 

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1102,17 +1102,8 @@ where
         let existing_metadata: BTreeSet<_> = metadata.into_iter().map(|(id, _)| id).collect();
 
         // Determine which collections we do not yet have metadata for.
-        let new_collections: BTreeSet<GlobalId> = init_ids
-            .iter()
-            .filter(|id| !existing_metadata.contains(id))
-            .cloned()
-            .collect();
-
-        mz_ore::soft_assert_or_log!(
-                new_collections.iter().all(|id| id.is_system()),
-                "initializing collections should only be missing metadata for new system objects, but got {:?}",
-                new_collections
-            );
+        let new_collections: BTreeSet<GlobalId> =
+            init_ids.difference(&existing_metadata).cloned().collect();
 
         self.prepare_state(txn, new_collections, drop_ids).await?;
 
@@ -1523,7 +1514,7 @@ where
 
         for (id, mut description, write_handle, since_handle, metadata) in to_register {
             // Ensure that the ingestion has an export for its primary source.
-            // This is done in an akward spot to appease the borrow checker.
+            // This is done in an awkward spot to appease the borrow checker.
             if let DataSource::Ingestion(ingestion) = &mut description.data_source {
                 ingestion.source_exports.insert(
                     id,
@@ -1541,7 +1532,7 @@ where
             let storage_dependencies = self
                 .determine_collection_dependencies(&*self_collections, &description.data_source)?;
 
-            // Determine the intial since of the collection.
+            // Determine the initial since of the collection.
             let initial_since = match storage_dependencies
                 .iter()
                 .at_most_one()

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -664,7 +664,7 @@ where
             new_collections.insert(id);
 
             // Ensure that the ingestion has an export for its primary source.
-            // This is done in an akward spot to appease the borrow checker.
+            // This is done in an awkward spot to appease the borrow checker.
             if let DataSource::Ingestion(ingestion) = &mut description.data_source {
                 ingestion.source_exports.insert(
                     id,


### PR DESCRIPTION
One of the responsibilities of StorageCollectionsImpl::initialize_state is to take all the global IDs known by the adapter catalog and ensure that it is included in the storage metadata. Previously, there was an assert that asserted that all IDs known by the catalog but not known by storage MUST be system objects. The likely intuition of this assert is that catalog data and storage metadata are always updated atomically, so any IDs not know by storage must be new system objects added as part of a version upgrade. However, this is not correct. Builtin item migrations may also create new user objects (after dropping the old ones).

This commit removes the assert, which is not always correct as described above. Investigation into the surrounding code seems to indicate that this assertion was not needed for correctness, but was a sanity check.

Previous discussions of this assert have led to discussions about the fact that if any of the new user IDs are sinks, then the sink will produce duplicate data. This is a known issue, #18767. This commit adds an error log for this specific scenario.

Additionally, while we're touching `initialize_state`, this commit updates a set difference calculation to use the builtin `difference` function.

Finally, we update the builtin migration test to trigger a migration of all builtin tables AND views instead of just views, and the test now creates a user object that will be migrated. This stresses more of the builtin migration framework than was previously tested, but unfortunately would not have triggered the assert since the controller is excluded from the test.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
