### PR TITLE
adapter: move getting the Config for `PostgresConnection` later in the drop flow

### DIFF
--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -242,17 +242,9 @@ def test_missing_secret(mz: MaterializeApplication) -> None:
               WHERE name = 'source_with_deleted_secret';
             true
 
-            ! DROP CLUSTER to_be_killed CASCADE;
-            contains:error creating Postgres client for dropping acquired slots
-
-            # The cluster should still be there.
-            > SELECT name from mz_clusters where name = 'to_be_killed';
-            to_be_killed
-
-            # Try and put the secret in place again.
-            > ALTER SECRET to_be_deleted AS 'postgres';
-
-            # Cluster can now be deleted.
+            # The secret missing is similar to if the user dropped their
+            # upstream Postgres DB, and we don't want to block dropping objects
+            # because of that.
             > DROP CLUSTER to_be_killed CASCADE;
             """
         ),


### PR DESCRIPTION
This PR moves getting the config for a Postgres connection later into the drop flow. Without this, if the upstream Postgres database doesn't exist then it's not possible to drop the corresponding `CONNECTION`.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/28185

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
