### PR TITLE
parallel-workload: Add 0dt deploy scenario, platform-checks: Enable read-only mode during upgrades, data-ingest: 0dt deployment disruptions

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1305,7 +1305,7 @@ steps:
   - id: data-ingest
     label: "Data Ingest"
     depends_on: build-aarch64
-    timeout_in_minutes: 60
+    timeout_in_minutes: 120
     retry:
       automatic:
         - exit_status: 75

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1430,6 +1430,18 @@ steps:
               composition: parallel-workload
               args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers, --threads=16]
 
+      - id: parallel-workload-0dt
+        label: "Parallel Workload (0dt deploy)"
+        depends_on: build-aarch64
+        artifact_paths: [parallel-workload-queries.log.zst]
+        timeout_in_minutes: 60
+        agents:
+          queue: linux-aarch64-large
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: parallel-workload
+              args: [--runtime=1500, --scenario=0dt-deploy, --threads=16]
+
   - id: incident-70
     label: "Test for incident 70"
     depends_on: build-aarch64

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -784,9 +784,9 @@ steps:
       - id: checks-0dt-restart-entire-mz
         label: "Checks 0dt restart of the entire Mz"
         depends_on: build-aarch64
-        timeout_in_minutes: 90
+        timeout_in_minutes: 120
         agents:
-          queue: linux-aarch64-medium
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -795,9 +795,9 @@ steps:
       - id: checks-0dt-upgrade-entire-mz
         label: "Checks 0dt upgrade, whole-Mz restart"
         depends_on: build-aarch64
-        timeout_in_minutes: 90
+        timeout_in_minutes: 120
         agents:
-          queue: linux-aarch64-medium
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -806,24 +806,24 @@ steps:
       - id: checks-0dt-upgrade-entire-mz-two-versions
         label: "Checks 0dt upgrade across two versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 90
+        timeout_in_minutes: 120
         agents:
-          queue: linux-aarch64-medium
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeUpgradeEntireMzTwoVersions, "--seed=$BUILDKITE_JOB_ID"]
 
-      - id: checks-0dt-upgrade-entire-mz-four-versions
-        label: "Checks 0dt upgrade across four versions"
+      - id: checks-0dt-upgrade-entire-mz-three-versions
+        label: "Checks 0dt upgrade across three versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 90
+        timeout_in_minutes: 120
         agents:
-          queue: linux-aarch64-medium
+          queue: linux-aarch64-large
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=ZeroDowntimeUpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
+              args: [--scenario=ZeroDowntimeUpgradeEntireMzThreeVersions, "--seed=$BUILDKITE_JOB_ID"]
 
       - id: cloudtest-upgrade
         label: "Platform checks upgrade in Cloudtest/K8s"

--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -946,7 +946,7 @@ class AlterSink(Check):
                 > ALTER SINK sink_alter SET FROM table_alter2;
 
                 # Wait for the actual restart to have occurred before inserting
-                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=4s
+                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=8s
 
                 > INSERT INTO table_alter1 VALUES (10, 'aa')
                 > INSERT INTO table_alter2 VALUES (11, 'bb')
@@ -956,7 +956,7 @@ class AlterSink(Check):
                 > ALTER SINK sink_alter SET FROM table_alter3;
 
                 # Wait for the actual restart to have occurred before inserting
-                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=4s
+                $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=8s
 
                 > INSERT INTO table_alter1 VALUES (100, 'aaa')
                 > INSERT INTO table_alter2 VALUES (101, 'bbb')

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -43,6 +43,7 @@ class StartMz(MzcomposeAction):
         platform: str | None = None,
         healthcheck: list[str] | None = None,
         deploy_generation: int | None = None,
+        restart: str | None = None,
     ) -> None:
         if healthcheck is None:
             healthcheck = ["CMD", "curl", "-f", "localhost:6878/api/readyz"]
@@ -54,6 +55,7 @@ class StartMz(MzcomposeAction):
         self.mz_service = mz_service
         self.platform = platform
         self.deploy_generation = deploy_generation
+        self.restart = restart
 
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
@@ -73,6 +75,7 @@ class StartMz(MzcomposeAction):
             platform=self.platform,
             healthcheck=self.healthcheck,
             deploy_generation=self.deploy_generation,
+            restart=self.restart,
         )
 
         # Don't fail since we are careful to explicitly kill and collect logs
@@ -221,6 +224,15 @@ class KillMz(MzcomposeAction):
 
             if self.capture_logs:
                 c.capture_logs(self.mz_service)
+
+
+class Stop(MzcomposeAction):
+    def __init__(self, service: str = "materialized") -> None:
+        self.service = service
+
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+        c.stop(self.service, wait=True)
 
 
 class Down(MzcomposeAction):

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -71,6 +71,7 @@ def start_mz_read_only(
             "-f",
             "localhost:6878/api/leader/status",
         ],
+        restart="unless-stopped",
     )
 
 

--- a/misc/python/materialize/checks/scenarios_zero_downtime.py
+++ b/misc/python/materialize/checks/scenarios_zero_downtime.py
@@ -15,7 +15,6 @@ from materialize.checks.mzcompose_actions import (
     MzcomposeAction,
     PromoteMz,
     StartMz,
-    Stop,
     WaitReadyMz,
 )
 from materialize.checks.scenarios import Scenario
@@ -28,10 +27,8 @@ from materialize.checks.scenarios_upgrade import (
 from materialize.mz_version import MzVersion
 
 
-def wait_ready_and_promote(mz_service: str, stop_service: str) -> list[MzcomposeAction]:
-    # TODO(def-, aljoscha): This should work without stopping the old service,
-    # why is it required?
-    return [WaitReadyMz(mz_service), PromoteMz(mz_service), Stop(stop_service)]
+def wait_ready_and_promote(mz_service: str) -> list[MzcomposeAction]:
+    return [WaitReadyMz(mz_service), PromoteMz(mz_service)]
 
 
 class ZeroDowntimeRestartEntireMz(Scenario):
@@ -41,13 +38,13 @@ class ZeroDowntimeRestartEntireMz(Scenario):
             Initialize(self, mz_service="mz_1"),
             start_mz_read_only(self, deploy_generation=1, mz_service="mz_2"),
             Manipulate(self, phase=1, mz_service="mz_1"),
-            *wait_ready_and_promote("mz_2", stop_service="mz_1"),
+            *wait_ready_and_promote("mz_2"),
             start_mz_read_only(self, deploy_generation=2, mz_service="mz_3"),
             Manipulate(self, phase=2, mz_service="mz_2"),
-            *wait_ready_and_promote("mz_3", stop_service="mz_2"),
+            *wait_ready_and_promote("mz_3"),
             start_mz_read_only(self, deploy_generation=3, mz_service="mz_4"),
             Validate(self, mz_service="mz_3"),
-            *wait_ready_and_promote("mz_4", stop_service="mz_3"),
+            *wait_ready_and_promote("mz_4"),
             Validate(self, mz_service="mz_4"),
         ]
 
@@ -65,11 +62,11 @@ class ZeroDowntimeUpgradeEntireMz(Scenario):
             Initialize(self, mz_service="mz_1"),
             start_mz_read_only(self, tag=None, deploy_generation=1, mz_service="mz_2"),
             Manipulate(self, phase=1, mz_service="mz_1"),
-            *wait_ready_and_promote("mz_2", stop_service="mz_1"),
+            *wait_ready_and_promote("mz_2"),
             Manipulate(self, phase=2, mz_service="mz_2"),
             start_mz_read_only(self, tag=None, deploy_generation=2, mz_service="mz_3"),
             Validate(self, mz_service="mz_2"),
-            *wait_ready_and_promote("mz_3", stop_service="mz_2"),
+            *wait_ready_and_promote("mz_3"),
             Validate(self, mz_service="mz_3"),
         ]
 
@@ -92,14 +89,14 @@ class ZeroDowntimeUpgradeEntireMzTwoVersions(Scenario):
                 self, tag=get_last_version(), deploy_generation=1, mz_service="mz_2"
             ),
             Manipulate(self, phase=1, mz_service="mz_1"),
-            *wait_ready_and_promote("mz_2", stop_service="mz_1"),
+            *wait_ready_and_promote("mz_2"),
             # Upgrade to current source
             start_mz_read_only(self, tag=None, deploy_generation=2, mz_service="mz_3"),
             Manipulate(self, phase=2, mz_service="mz_2"),
-            *wait_ready_and_promote("mz_3", stop_service="mz_2"),
+            *wait_ready_and_promote("mz_3"),
             start_mz_read_only(self, tag=None, deploy_generation=3, mz_service="mz_4"),
             Validate(self, mz_service="mz_3"),
-            *wait_ready_and_promote("mz_4", stop_service="mz_3"),
+            *wait_ready_and_promote("mz_4"),
             Validate(self, mz_service="mz_4"),
         ]
 
@@ -128,14 +125,14 @@ class ZeroDowntimeUpgradeEntireMzThreeVersions(Scenario):
                 self, tag=get_previous_version(), deploy_generation=1, mz_service="mz_2"
             ),
             Manipulate(self, phase=1, mz_service="mz_1"),
-            *wait_ready_and_promote("mz_2", stop_service="mz_1"),
+            *wait_ready_and_promote("mz_2"),
             start_mz_read_only(
                 self, tag=get_last_version(), deploy_generation=2, mz_service="mz_3"
             ),
             Manipulate(self, phase=2, mz_service="mz_2"),
-            *wait_ready_and_promote("mz_3", stop_service="mz_2"),
+            *wait_ready_and_promote("mz_3"),
             start_mz_read_only(self, tag=None, deploy_generation=3, mz_service="mz_4"),
             Validate(self, mz_service="mz_3"),
-            *wait_ready_and_promote("mz_4", stop_service="mz_3"),
+            *wait_ready_and_promote("mz_4"),
             Validate(self, mz_service="mz_4"),
         ]

--- a/misc/python/materialize/checks/scenarios_zero_downtime.py
+++ b/misc/python/materialize/checks/scenarios_zero_downtime.py
@@ -15,6 +15,7 @@ from materialize.checks.mzcompose_actions import (
     MzcomposeAction,
     PromoteMz,
     StartMz,
+    Stop,
     WaitReadyMz,
 )
 from materialize.checks.scenarios import Scenario
@@ -27,8 +28,10 @@ from materialize.checks.scenarios_upgrade import (
 from materialize.mz_version import MzVersion
 
 
-def wait_ready_and_promote(mz_service: str = "materialized") -> list[MzcomposeAction]:
-    return [WaitReadyMz(mz_service=mz_service), PromoteMz(mz_service=mz_service)]
+def wait_ready_and_promote(mz_service: str, stop_service: str) -> list[MzcomposeAction]:
+    # TODO(def-, aljoscha): This should work without stopping the old service,
+    # why is it required?
+    return [WaitReadyMz(mz_service), PromoteMz(mz_service), Stop(stop_service)]
 
 
 class ZeroDowntimeRestartEntireMz(Scenario):
@@ -38,14 +41,14 @@ class ZeroDowntimeRestartEntireMz(Scenario):
             Initialize(self, mz_service="mz_1"),
             start_mz_read_only(self, deploy_generation=1, mz_service="mz_2"),
             Manipulate(self, phase=1, mz_service="mz_1"),
-            *wait_ready_and_promote(mz_service="mz_2"),
-            start_mz_read_only(self, deploy_generation=2, mz_service="mz_1"),
+            *wait_ready_and_promote("mz_2", stop_service="mz_1"),
+            start_mz_read_only(self, deploy_generation=2, mz_service="mz_3"),
             Manipulate(self, phase=2, mz_service="mz_2"),
-            *wait_ready_and_promote(mz_service="mz_1"),
-            start_mz_read_only(self, deploy_generation=3, mz_service="mz_2"),
-            Validate(self, mz_service="mz_1"),
-            *wait_ready_and_promote(mz_service="mz_2"),
-            Validate(self, mz_service="mz_2"),
+            *wait_ready_and_promote("mz_3", stop_service="mz_2"),
+            start_mz_read_only(self, deploy_generation=3, mz_service="mz_4"),
+            Validate(self, mz_service="mz_3"),
+            *wait_ready_and_promote("mz_4", stop_service="mz_3"),
+            Validate(self, mz_service="mz_4"),
         ]
 
 
@@ -62,12 +65,12 @@ class ZeroDowntimeUpgradeEntireMz(Scenario):
             Initialize(self, mz_service="mz_1"),
             start_mz_read_only(self, tag=None, deploy_generation=1, mz_service="mz_2"),
             Manipulate(self, phase=1, mz_service="mz_1"),
-            *wait_ready_and_promote(mz_service="mz_2"),
+            *wait_ready_and_promote("mz_2", stop_service="mz_1"),
             Manipulate(self, phase=2, mz_service="mz_2"),
-            start_mz_read_only(self, tag=None, deploy_generation=2, mz_service="mz_1"),
+            start_mz_read_only(self, tag=None, deploy_generation=2, mz_service="mz_3"),
             Validate(self, mz_service="mz_2"),
-            *wait_ready_and_promote(mz_service="mz_1"),
-            Validate(self, mz_service="mz_1"),
+            *wait_ready_and_promote("mz_3", stop_service="mz_2"),
+            Validate(self, mz_service="mz_3"),
         ]
 
 
@@ -89,20 +92,21 @@ class ZeroDowntimeUpgradeEntireMzTwoVersions(Scenario):
                 self, tag=get_last_version(), deploy_generation=1, mz_service="mz_2"
             ),
             Manipulate(self, phase=1, mz_service="mz_1"),
-            *wait_ready_and_promote(mz_service="mz_2"),
+            *wait_ready_and_promote("mz_2", stop_service="mz_1"),
             # Upgrade to current source
-            start_mz_read_only(self, tag=None, deploy_generation=2, mz_service="mz_1"),
+            start_mz_read_only(self, tag=None, deploy_generation=2, mz_service="mz_3"),
             Manipulate(self, phase=2, mz_service="mz_2"),
-            *wait_ready_and_promote(mz_service="mz_1"),
-            start_mz_read_only(self, tag=None, deploy_generation=3, mz_service="mz_2"),
-            Validate(self, mz_service="mz_1"),
-            *wait_ready_and_promote(mz_service="mz_2"),
-            Validate(self, mz_service="mz_2"),
+            *wait_ready_and_promote("mz_3", stop_service="mz_2"),
+            start_mz_read_only(self, tag=None, deploy_generation=3, mz_service="mz_4"),
+            Validate(self, mz_service="mz_3"),
+            *wait_ready_and_promote("mz_4", stop_service="mz_3"),
+            Validate(self, mz_service="mz_4"),
         ]
 
 
-class ZeroDowntimeUpgradeEntireMzFourVersions(Scenario):
-    """Test 0dt upgrade from X-4 -> X-3 -> X-2 -> X-1 -> X"""
+# TODO(def-): Make this use X-4 in a week
+class ZeroDowntimeUpgradeEntireMzThreeVersions(Scenario):
+    """Test 0dt upgrade from X-3 -> X-2 -> X-1 -> X"""
 
     def __init__(
         self, checks: list[type[Check]], executor: Executor, seed: str | None = None
@@ -115,28 +119,23 @@ class ZeroDowntimeUpgradeEntireMzFourVersions(Scenario):
 
     def actions(self) -> list[Action]:
         print(
-            f"Upgrade path: {self.minor_versions[3]} -> {self.minor_versions[2]} -> {get_previous_version()} -> {get_last_version()} -> current"
+            f"Upgrade path: {self.minor_versions[2]} -> {get_previous_version()} -> {get_last_version()} -> current"
         )
         return [
-            StartMz(self, tag=self.minor_versions[3], mz_service="mz_1"),
+            StartMz(self, tag=self.minor_versions[2], mz_service="mz_1"),
             Initialize(self, mz_service="mz_1"),
             start_mz_read_only(
-                self, tag=self.minor_versions[2], deploy_generation=1, mz_service="mz_2"
+                self, tag=get_previous_version(), deploy_generation=1, mz_service="mz_2"
             ),
             Manipulate(self, phase=1, mz_service="mz_1"),
-            *wait_ready_and_promote(mz_service="mz_2"),
+            *wait_ready_and_promote("mz_2", stop_service="mz_1"),
             start_mz_read_only(
-                self, tag=get_previous_version(), deploy_generation=2, mz_service="mz_1"
+                self, tag=get_last_version(), deploy_generation=2, mz_service="mz_3"
             ),
             Manipulate(self, phase=2, mz_service="mz_2"),
-            *wait_ready_and_promote(mz_service="mz_1"),
-            start_mz_read_only(
-                self, tag=get_last_version(), deploy_generation=3, mz_service="mz_2"
-            ),
-            Validate(self, mz_service="mz_1"),
-            *wait_ready_and_promote(mz_service="mz_2"),
-            start_mz_read_only(self, tag=None, deploy_generation=4, mz_service="mz_1"),
-            Validate(self, mz_service="mz_2"),
-            *wait_ready_and_promote(mz_service="mz_1"),
-            Validate(self, mz_service="mz_1"),
+            *wait_ready_and_promote("mz_3", stop_service="mz_2"),
+            start_mz_read_only(self, tag=None, deploy_generation=3, mz_service="mz_4"),
+            Validate(self, mz_service="mz_3"),
+            *wait_ready_and_promote("mz_4", stop_service="mz_3"),
+            Validate(self, mz_service="mz_4"),
         ]

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -139,25 +139,17 @@ IGNORE_RE = re.compile(
     | larger\ sizes\ prevent\ running\ out\ of\ memory
     # Old versions won't support new parameters
     | (platform-checks|legacy-upgrade|upgrade-matrix|feature-benchmark)-materialized-.* \| .*cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
-    # Fencing warnings are OK in fencing tests
-    | txn-wal-fencing-mz_first-.* \| .*unexpected\ fence\ epoch
-    | txn-wal-fencing-mz_first-.* \| .*fenced\ by\ new\ catalog\ upper
-    | txn-wal-fencing-mz_first-.* \| .*fenced\ by\ new\ catalog\ epoch
-    | platform-checks-mz_txn_tables.* \| .*unexpected\ fence\ epoch
-    | platform-checks-mz_txn_tables.* \| .*fenced\ by\ new\ catalog\ upper
-    | platform-checks-mz_txn_tables.* \| .*fenced\ by\ new\ catalog\ epoch
-    # For platform-checks upgrade tests
-    | platform-checks-clusterd.* \| .* received\ persist\ state\ from\ the\ future
-    | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage(\ to\ set\ (default|configured)\ parameter)?
+    # Fencing warnings are OK in fencing/0dt tests
+    | (txn-wal-fencing-mz_first-|platform-checks-mz_|parallel-workload-).* \| .*unexpected\ fence\ epoch
+    | (txn-wal-fencing-mz_first-|platform-checks-mz_|parallel-workload-).* \| .*fenced\ by\ new\ catalog
     | internal\ error:\ no\ AWS\ external\ ID\ prefix\ configured
+    # For platform-checks upgrade tests
+    | platform-checks-.* \| .* received\ persist\ state\ from\ the\ future
+    | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage(\ to\ set\ (default|configured)\ parameter)?
     # For tests we purposely trigger this error
     | skip-version-upgrade-materialized.* \| .* incompatible\ persist\ version\ \d+\.\d+\.\d+(-dev)?,\ current:\ \d+\.\d+\.\d+(-dev)?,\ make\ sure\ to\ upgrade\ the\ catalog\ one\ version\ at\ a\ time
     # For 0dt upgrades
-    | halting\ process:\ unable\ to\ confirm\ leadership
-    | halting\ process:\ fenced\ out\ old\ deployment;\ rebooting\ as\ leader
-    | parallel-workload-.*\ halting\ process:\ this\ deployment\ has\ been\ fenced\ out
-    | parallel-workload-.*\ fenced\ by\ new\ catalog\ upper
-    | parallel-workload-.*\ fenced\ by\ new\ catalog\ epoch
+    | halting\ process:\ (unable\ to\ confirm\ leadership|fenced\ out\ old\ deployment;\ rebooting\ as\ leader|this\ deployment\ has\ been\ fenced\ out)
     )
     """,
     re.VERBOSE | re.MULTILINE,

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -155,6 +155,9 @@ IGNORE_RE = re.compile(
     # For 0dt upgrades
     | halting\ process:\ unable\ to\ confirm\ leadership
     | halting\ process:\ fenced\ out\ old\ deployment;\ rebooting\ as\ leader
+    | parallel-workload-.*\ halting\ process:\ this\ deployment\ has\ been\ fenced\ out
+    | parallel-workload-.*\ fenced\ by\ new\ catalog\ upper
+    | parallel-workload-.*\ fenced\ by\ new\ catalog\ epoch
     )
     """,
     re.VERBOSE | re.MULTILINE,

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -140,8 +140,8 @@ IGNORE_RE = re.compile(
     # Old versions won't support new parameters
     | (platform-checks|legacy-upgrade|upgrade-matrix|feature-benchmark)-materialized-.* \| .*cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
     # Fencing warnings are OK in fencing/0dt tests
-    | (txn-wal-fencing-mz_first-|platform-checks-mz_|parallel-workload-).* \| .*unexpected\ fence\ epoch
-    | (txn-wal-fencing-mz_first-|platform-checks-mz_|parallel-workload-).* \| .*fenced\ by\ new\ catalog
+    | (txn-wal-fencing-mz_first-|platform-checks-mz_|parallel-workload-data-ingest-).* \| .*unexpected\ fence\ epoch
+    | (txn-wal-fencing-mz_first-|platform-checks-mz_|parallel-workload-|data-ingest-).* \| .*fenced\ by\ new\ catalog
     | internal\ error:\ no\ AWS\ external\ ID\ prefix\ configured
     # For platform-checks upgrade tests
     | platform-checks-.* \| .* received\ persist\ state\ from\ the\ future

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -42,6 +42,7 @@ class Executor:
     schema: str
     cluster: str | None
     logging_exe: Any | None
+    mz_service: str | None = None
 
     def __init__(
         self,
@@ -50,6 +51,7 @@ class Executor:
         database: str = "",
         schema: str = "public",
         cluster: str | None = None,
+        mz_service: str | None = None,
     ) -> None:
         self.num_transactions = 0
         self.ports = ports
@@ -57,19 +59,21 @@ class Executor:
         self.database = database
         self.schema = schema
         self.cluster = cluster
+        self.mz_service = mz_service
         self.logging_exe = None
         self.reconnect()
 
     def reconnect(self) -> None:
+        mz_service = self.mz_service
+        if not mz_service:
+            mz_service = (
+                random.choice(["materialized", "materialized2"])
+                if "materialized2" in self.ports
+                else "materialized"
+            )
         self.mz_conn = pg8000.connect(
             host="localhost",
-            port=self.ports[
-                (
-                    random.choice(["materialized", "materialized2"])
-                    if "materialized2" in self.ports
-                    else "materialized"
-                )
-            ],
+            port=self.ports[mz_service],
             user="materialize",
             database=self.database,
         )
@@ -149,8 +153,9 @@ class KafkaExecutor(Executor):
         database: str,
         schema: str = "public",
         cluster: str | None = None,
+        mz_service: str | None = None,
     ):
-        super().__init__(ports, fields, database, schema, cluster)
+        super().__init__(ports, fields, database, schema, cluster, mz_service)
 
         self.topic = f"data-ingest-{num}"
         self.table = f"kafka_table{num}"
@@ -309,8 +314,9 @@ class MySqlExecutor(Executor):
         database: str,
         schema: str = "public",
         cluster: str | None = None,
+        mz_service: str | None = None,
     ):
-        super().__init__(ports, fields, database, schema, cluster)
+        super().__init__(ports, fields, database, schema, cluster, mz_service)
         self.table = f"mytable{num}"
         self.source = f"mysql_source{num}"
         self.num = num
@@ -434,8 +440,9 @@ class PgExecutor(Executor):
         database: str,
         schema: str = "public",
         cluster: str | None = None,
+        mz_service: str | None = None,
     ):
-        super().__init__(ports, fields, database, schema, cluster)
+        super().__init__(ports, fields, database, schema, cluster, mz_service)
         self.table = f"table{num}"
         self.source = f"postgres_source{num}"
         self.num = num
@@ -559,8 +566,9 @@ class KafkaRoundtripExecutor(Executor):
         database: str,
         schema: str = "public",
         cluster: str | None = None,
+        mz_service: str | None = None,
     ):
-        super().__init__(ports, fields, database, schema, cluster)
+        super().__init__(ports, fields, database, schema, cluster, mz_service)
         self.table_original = f"table_rt_source{num}"
         self.table = f"table_rt{num}"
         self.topic = f"data-ingest-rt-{num}"

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import json
+import random
 import time
 from typing import Any
 
@@ -62,7 +63,13 @@ class Executor:
     def reconnect(self) -> None:
         self.mz_conn = pg8000.connect(
             host="localhost",
-            port=self.ports["materialized"],
+            port=self.ports[
+                (
+                    random.choice(["materialized", "materialized2"])
+                    if "materialized2" in self.ports
+                    else "materialized"
+                )
+            ],
             user="materialize",
             database=self.database,
         )

--- a/misc/python/materialize/data_ingest/transaction_def.py
+++ b/misc/python/materialize/data_ingest/transaction_def.py
@@ -142,6 +142,7 @@ class ZeroDowntimeDeploy(TransactionDef):
                         self.composition.exec(
                             self.workload.mz_service,
                             "curl",
+                            "-s",
                             "localhost:6878/api/leader/status",
                             capture=True,
                         ).stdout
@@ -159,6 +160,7 @@ class ZeroDowntimeDeploy(TransactionDef):
                     self.composition.exec(
                         self.workload.mz_service,
                         "curl",
+                        "-s",
                         "-X",
                         "POST",
                         "http://127.0.0.1:6878/api/leader/promote",
@@ -167,7 +169,7 @@ class ZeroDowntimeDeploy(TransactionDef):
                 )
                 assert result["result"] == "Success", f"Unexpected result {result}"
 
-                time.sleep(20)
+                time.sleep(5)
 
                 # Wait until new Materialize is ready to handle queries
                 for i in range(300):
@@ -176,13 +178,23 @@ class ZeroDowntimeDeploy(TransactionDef):
                             self.composition.exec(
                                 self.workload.mz_service,
                                 "curl",
-                                "http://127.0.0.1:6878/api/leader/status",
+                                "-s",
+                                "localhost:6878/api/leader/status",
                                 capture=True,
                             ).stdout
                         )
-                        assert (
-                            result["status"] == "IsLeader"
-                        ), f"Unexpected result {result}"
+                        assert result["status"] == "IsLeader"
+                        result = self.composition.exec(
+                            self.workload.mz_service,
+                            "curl",
+                            "-s",
+                            "http://127.0.0.1:6878/api/readyz",
+                            capture=True,
+                        ).stdout
+                        assert result == "ready", f"Unexpected result {result}"
+                        assert self.composition.sql_query(
+                            "SELECT 1", service=self.workload.mz_service
+                        ) == ([1],)
                     except:
                         time.sleep(1)
                         continue

--- a/misc/python/materialize/data_ingest/transaction_def.py
+++ b/misc/python/materialize/data_ingest/transaction_def.py
@@ -7,16 +7,22 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import json
 import random
 import time
 from collections.abc import Iterator
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from materialize.data_ingest.definition import Definition
 from materialize.data_ingest.field import Field
 from materialize.data_ingest.rowlist import RowList
 from materialize.data_ingest.transaction import Transaction
 from materialize.mzcompose.composition import Composition
+from materialize.mzcompose.services.materialized import Materialized
+
+if TYPE_CHECKING:
+    from materialize.data_ingest.workload import Workload
 
 
 class TransactionSize(Enum):
@@ -51,14 +57,135 @@ class TransactionDef:
 class RestartMz(TransactionDef):
     composition: Composition
     probability: float
+    workload: "Workload"
 
-    def __init__(self, composition: Composition, probability: float):
+    def __init__(
+        self, composition: Composition, probability: float, workload: "Workload"
+    ):
         self.composition = composition
         self.probability = probability
+        self.workload = workload
 
     def generate(self, fields: list[Field]) -> Iterator[Transaction | None]:
         if random.random() < self.probability:
-            self.composition.kill("materialized")
-            time.sleep(1)
-            self.composition.up("materialized")
+            ports = (
+                ["16875:6875"]
+                if self.workload.mz_service == "materialized"
+                else ["26875:6875"]
+            )
+
+            with self.composition.override(
+                Materialized(
+                    name=self.workload.mz_service,
+                    ports=ports,
+                    external_minio=True,
+                    external_cockroach=True,
+                    additional_system_parameter_defaults={"enable_table_keys": "true"},
+                    deploy_generation=self.workload.deploy_generation,
+                ),
+            ):
+                self.composition.kill(self.workload.mz_service)
+                time.sleep(1)
+                self.composition.up(self.workload.mz_service)
+        yield None
+
+
+class ZeroDowntimeDeploy(TransactionDef):
+    composition: Composition
+    probability: float
+    workload: "Workload"
+
+    def __init__(
+        self, composition: Composition, probability: float, workload: "Workload"
+    ):
+        self.composition = composition
+        self.probability = probability
+        self.workload = workload
+
+    def generate(self, fields: list[Field]) -> Iterator[Transaction | None]:
+        if random.random() < self.probability:
+            self.workload.deploy_generation += 1
+
+            if self.workload.deploy_generation % 2 == 0:
+                self.workload.mz_service = "materialized"
+                ports = ["16875:6875"]
+            else:
+                self.workload.mz_service = "materialized2"
+                ports = ["26875:6875"]
+
+            print(
+                f"Deploying generation {self.workload.deploy_generation} on {self.workload.mz_service}"
+            )
+
+            with self.composition.override(
+                Materialized(
+                    name=self.workload.mz_service,
+                    ports=ports,
+                    external_minio=True,
+                    external_cockroach=True,
+                    additional_system_parameter_defaults={"enable_table_keys": "true"},
+                    deploy_generation=self.workload.deploy_generation,
+                    restart="on-failure",
+                    healthcheck=[
+                        "CMD",
+                        "curl",
+                        "-f",
+                        "localhost:6878/api/leader/status",
+                    ],
+                ),
+            ):
+                self.composition.up(self.workload.mz_service, detach=True)
+
+                # Wait until ready to promote
+                while True:
+                    result = json.loads(
+                        self.composition.exec(
+                            self.workload.mz_service,
+                            "curl",
+                            "localhost:6878/api/leader/status",
+                            capture=True,
+                        ).stdout
+                    )
+                    if result["status"] == "ReadyToPromote":
+                        break
+                    assert (
+                        result["status"] == "Initializing"
+                    ), f"Unexpected status {result}"
+                    print("Not ready yet, waiting 1 s")
+                    time.sleep(1)
+
+                # Promote new Mz service
+                result = json.loads(
+                    self.composition.exec(
+                        self.workload.mz_service,
+                        "curl",
+                        "-X",
+                        "POST",
+                        "http://127.0.0.1:6878/api/leader/promote",
+                        capture=True,
+                    ).stdout
+                )
+                assert result["result"] == "Success", f"Unexpected result {result}"
+
+                time.sleep(20)
+
+                # Wait until new Materialize is ready to handle queries
+                for i in range(300):
+                    try:
+                        result = json.loads(
+                            self.composition.exec(
+                                self.workload.mz_service,
+                                "curl",
+                                "http://127.0.0.1:6878/api/leader/status",
+                                capture=True,
+                            ).stdout
+                        )
+                        assert (
+                            result["status"] == "IsLeader"
+                        ), f"Unexpected result {result}"
+                    except:
+                        time.sleep(1)
+                        continue
+                    break
+
         yield None

--- a/misc/python/materialize/data_ingest/workload.py
+++ b/misc/python/materialize/data_ingest/workload.py
@@ -9,6 +9,7 @@
 
 import random
 import time
+import traceback
 from collections.abc import Iterator
 from typing import Any
 
@@ -33,6 +34,7 @@ from materialize.data_ingest.transaction_def import (
     RestartMz,
     TransactionDef,
     TransactionSize,
+    ZeroDowntimeDeploy,
 )
 from materialize.mzcompose.composition import Composition
 from materialize.util import all_subclasses
@@ -40,9 +42,12 @@ from materialize.util import all_subclasses
 
 class Workload:
     cycle: list[TransactionDef]
+    mz_service: str
+    deploy_generation: int
 
-    def __init__(self, composition: Composition | None) -> None:
-        raise NotImplementedError
+    def __init__(self, mz_service: str, deploy_generation: int) -> None:
+        self.mz_service = mz_service
+        self.deploy_generation = deploy_generation
 
     def generate(self, fields: list[Field]) -> Iterator[Transaction]:
         while True:
@@ -53,7 +58,10 @@ class Workload:
 
 
 class SingleSensorUpdating(Workload):
-    def __init__(self, composition: Composition | None) -> None:
+    def __init__(
+        self, composition: Composition | None, mz_service: str, deploy_generation: int
+    ) -> None:
+        super().__init__(mz_service, deploy_generation)
         self.cycle = [
             TransactionDef(
                 [
@@ -68,7 +76,10 @@ class SingleSensorUpdating(Workload):
 
 
 class SingleSensorUpdatingDisruptions(Workload):
-    def __init__(self, composition: Composition | None) -> None:
+    def __init__(
+        self, composition: Composition | None, mz_service: str, deploy_generation: int
+    ) -> None:
+        super().__init__(mz_service, deploy_generation)
         self.cycle = [
             TransactionDef(
                 [
@@ -81,11 +92,36 @@ class SingleSensorUpdatingDisruptions(Workload):
             ),
         ]
         if composition:
-            self.cycle.append(RestartMz(composition, probability=0.1))
+            self.cycle.append(RestartMz(composition, probability=0.1, workload=self))
+
+
+class SingleSensorUpdating0dtDeploy(Workload):
+    def __init__(
+        self, composition: Composition | None, mz_service: str, deploy_generation: int
+    ) -> None:
+        super().__init__(mz_service, deploy_generation)
+        self.cycle = [
+            TransactionDef(
+                [
+                    Upsert(
+                        keyspace=Keyspace.SINGLE_VALUE,
+                        count=Records.ONE,
+                        record_size=RecordSize.SMALL,
+                    ),
+                ]
+            ),
+        ]
+        if composition:
+            self.cycle.append(
+                ZeroDowntimeDeploy(composition, probability=0.1, workload=self)
+            )
 
 
 class DeleteDataAtEndOfDay(Workload):
-    def __init__(self, composition: Composition | None) -> None:
+    def __init__(
+        self, composition: Composition | None, mz_service: str, deploy_generation: int
+    ) -> None:
+        super().__init__(mz_service, deploy_generation)
         insert = Insert(
             count=Records.SOME,
             record_size=RecordSize.SMALL,
@@ -111,7 +147,10 @@ class DeleteDataAtEndOfDay(Workload):
 
 
 class DeleteDataAtEndOfDayDisruptions(Workload):
-    def __init__(self, composition: Composition | None) -> None:
+    def __init__(
+        self, composition: Composition | None, mz_service: str, deploy_generation: int
+    ) -> None:
+        super().__init__(mz_service, deploy_generation)
         insert = Insert(
             count=Records.SOME,
             record_size=RecordSize.SMALL,
@@ -136,12 +175,49 @@ class DeleteDataAtEndOfDayDisruptions(Workload):
         ]
 
         if composition:
-            self.cycle.append(RestartMz(composition, probability=0.1))
+            self.cycle.append(RestartMz(composition, probability=0.1, workload=self))
+
+
+class DeleteDataAtEndOfDay0dtDeploys(Workload):
+    def __init__(
+        self, composition: Composition | None, mz_service: str, deploy_generation: int
+    ) -> None:
+        super().__init__(mz_service, deploy_generation)
+        insert = Insert(
+            count=Records.SOME,
+            record_size=RecordSize.SMALL,
+        )
+        insert_phase = TransactionDef(
+            size=TransactionSize.HUGE,
+            operations=[insert],
+        )
+        # Delete all records in a single transaction
+        delete_phase = TransactionDef(
+            [
+                Delete(
+                    number_of_records=Records.ALL,
+                    record_size=RecordSize.SMALL,
+                    num=insert.max_key(),
+                )
+            ]
+        )
+        self.cycle = [
+            insert_phase,
+            delete_phase,
+        ]
+
+        if composition:
+            self.cycle.append(
+                ZeroDowntimeDeploy(composition, probability=0.1, workload=self)
+            )
 
 
 # TODO: Implement
 # class ProgressivelyEnrichRecords(Workload):
-#    def __init__(self) -> None:
+#    def __init__(
+#        self, composition: Composition | None, mz_service: str, deploy_generation: int
+#    ) -> None:
+#        super().__init__(mz_service, deploy_generation)
 #        self.cycle: list[Definition] = [
 #        ]
 
@@ -166,7 +242,9 @@ def execute_workload(
     print(f"With fields: {fields}")
 
     executors = [
-        executor_class(num, ports, fields, "materialize")
+        executor_class(
+            num, ports, fields, "materialize", mz_service=workload.mz_service
+        )
         for executor_class in [PgExecutor] + executor_classes
     ]
     pg_executor = executors[0]
@@ -183,6 +261,7 @@ def execute_workload(
             assert i > 0
             break
         for executor in run_executors:
+            executor.mz_service = workload.mz_service
             executor.run(transaction)
 
     order_str = ", ".join(str(i + 1) for i in range(len(fields)))
@@ -195,12 +274,13 @@ def execute_workload(
     # Reconnect as Mz disruptions may have destroyed the previous connection
     conn = pg8000.connect(
         host="localhost",
-        port=ports["materialized"],
+        port=ports[workload.mz_service],
         user="materialize",
         database="materialize",
     )
 
     for executor in executors:
+        executor.mz_service = workload.mz_service
         conn.autocommit = True
         with conn.cursor() as cur:
             try:
@@ -208,8 +288,9 @@ def execute_workload(
                 cur.execute(f"SELECT * FROM {executor.table} ORDER BY {order_str}")
                 actual_result = cur.fetchall()
                 cur.execute("SET REAL_TIME_RECENCY TO FALSE")
-            except:
-                print(f"Comparing against {type(executor).__name__} failed")
+            except Exception as e:
+                print(f"Comparing against {type(executor).__name__} failed: {e}")
+                print(traceback.format_exc())
                 raise
         conn.autocommit = False
         if actual_result != expected_result:

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -59,6 +59,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "compute_dataflow_max_inflight_bytes": "134217728",  # 128 MiB
     "compute_hydration_concurrency": 2,
     "disk_cluster_replicas_default": "true",
+    "enable_0dt_deployment": "true",
     "enable_alter_swap": "true",
     "enable_assert_not_null": "true",
     "enable_columnation_lgalloc": "true",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -96,8 +96,8 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_stats_audit_percent": "100",
     "persist_txn_tables": "lazy",  # removed, but keep value for older versions
     "persist_use_critical_since_catalog": "true",
-    "persist_use_critical_since_snapshot": "true",
-    "persist_use_critical_since_source": "true",
+    "persist_use_critical_since_snapshot": "false",  # Disabled because of 0dt upgrades, TODO: reenable
+    "persist_use_critical_since_source": "false",  # Disabled because of 0dt upgrades, TODO: reenable
     "persist_part_decode_format": "row_with_validate",
     "statement_logging_default_sample_rate": "0.01",
     "statement_logging_max_sample_rate": "0.01",

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1570,14 +1570,13 @@ class ZeroDowntimeDeployAction(Action):
         ):
             self.composition.up(mz_service, detach=True)
 
-            # TODO: Allow read-only queries on mz_service
-
             # Wait until ready to promote
             while True:
                 result = json.loads(
                     self.composition.exec(
                         mz_service,
                         "curl",
+                        "-s",
                         "localhost:6878/api/leader/status",
                         capture=True,
                     ).stdout
@@ -1593,6 +1592,7 @@ class ZeroDowntimeDeployAction(Action):
                 self.composition.exec(
                     mz_service,
                     "curl",
+                    "-s",
                     "-X",
                     "POST",
                     "http://127.0.0.1:6878/api/leader/promote",
@@ -1601,7 +1601,7 @@ class ZeroDowntimeDeployAction(Action):
             )
             assert result["result"] == "Success", f"Unexpected result {result}"
 
-        time.sleep(self.rng.uniform(10, 30))
+        time.sleep(self.rng.uniform(60, 120))
         return True
 
 

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -148,9 +148,18 @@ class Action:
                     "canceling statement due to user request",
                 ]
             )
+        if exe.db.scenario == Scenario.ZeroDowntimeDeploy:
+            result.extend(
+                [
+                    "cannot write in read-only mode",
+                    "500: internal storage failure! ReadOnly",
+                    "was at a timestamp before its since",  # TODO: #28219
+                ]
+            )
         if exe.db.scenario in (
             Scenario.Kill,
             Scenario.BackupRestore,
+            Scenario.ZeroDowntimeDeploy,
         ):
             result.extend(
                 [
@@ -158,10 +167,16 @@ class Action:
                     "network error",
                     "Can't create a connection to host",
                     "Connection refused",
+                    "Cursor closed",
                     # websockets
                     "Connection to remote host was lost.",
                     "socket is already closed.",
                     "Broken pipe",
+                    "WS connect",
+                    # http
+                    "Remote end closed connection without response",
+                    "Connection aborted",
+                    "Connection refused",
                 ]
             )
         if exe.db.scenario in (Scenario.Kill,):
@@ -362,6 +377,7 @@ class SQLsmithAction(Action):
             if exe.db.scenario not in (
                 Scenario.Kill,
                 Scenario.BackupRestore,
+                Scenario.ZeroDowntimeDeploy,
             ):
                 raise
         finally:
@@ -940,6 +956,13 @@ class FlipFlagsAction(Action):
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))
+
+        # TODO: Remove when #27345 is fixed
+        if exe.db.scenario == Scenario.ZeroDowntimeDeploy and flag_name.startswith(
+            "persist_use_critical_since_"
+        ):
+            return False
+
         flag_value = self.rng.choice(self.flags_with_values[flag_name])
 
         conn = None
@@ -954,6 +977,8 @@ class FlipFlagsAction(Action):
 
             # ignore it
             return False
+        except Exception as e:
+            raise QueryError(str(e), "FlipFlags")
 
     def create_system_connection(
         self, exe: Executor, num_attempts: int = 10
@@ -961,7 +986,9 @@ class FlipFlagsAction(Action):
         try:
             conn = pg8000.connect(
                 host=exe.db.host,
-                port=exe.db.ports["mz_system"],
+                port=exe.db.ports[
+                    "mz_system" if exe.mz_service == "materialized" else "mz_system2"
+                ],
                 user="mz_system",
                 database="materialize",
             )
@@ -1333,9 +1360,9 @@ class ReconnectAction(Action):
         self.random_role = random_role
 
     def run(self, exe: Executor) -> bool:
-        autocommit = exe.cur._c.autocommit
+        exe.mz_service = "materialized"
         host = exe.db.host
-        port = exe.db.ports["materialized"]
+        port = exe.db.ports[exe.mz_service]
         with exe.db.lock:
             if self.random_role and exe.db.roles:
                 user = self.rng.choice(
@@ -1363,13 +1390,29 @@ class ReconnectAction(Action):
         NUM_ATTEMPTS = 20
         if exe.ws:
             threading.current_thread().getName()
-            for i in range(NUM_ATTEMPTS):
+            for i in range(
+                NUM_ATTEMPTS
+                if exe.db.scenario != Scenario.ZeroDowntimeDeploy
+                else 1000000
+            ):
                 exe.ws = websocket.WebSocket()
                 try:
                     ws_conn_id, ws_secret_key = ws_connect(
-                        exe.ws, host, exe.db.ports["http"], user
+                        exe.ws,
+                        host,
+                        exe.db.ports[
+                            "http" if exe.mz_service == "materialized" else "http2"
+                        ],
+                        user,
                     )
                 except Exception as e:
+                    if exe.db.scenario == Scenario.ZeroDowntimeDeploy:
+                        exe.mz_service = (
+                            "materialized2"
+                            if exe.mz_service == "materialized"
+                            else "materialized"
+                        )
+                        continue
                     if i < NUM_ATTEMPTS - 1:
                         time.sleep(1)
                         continue
@@ -1378,12 +1421,14 @@ class ReconnectAction(Action):
                     exe.pg_pid = ws_conn_id
                 break
 
-        for i in range(NUM_ATTEMPTS):
+        for i in range(
+            NUM_ATTEMPTS if exe.db.scenario != Scenario.ZeroDowntimeDeploy else 1000000
+        ):
             try:
                 conn = pg8000.connect(
                     host=host, port=port, user=user, database="materialize"
                 )
-                conn.autocommit = autocommit
+                conn.autocommit = exe.autocommit
                 cur = conn.cursor()
                 exe.cur = cur
                 exe.set_isolation("SERIALIZABLE")
@@ -1391,6 +1436,13 @@ class ReconnectAction(Action):
                 if not exe.use_ws:
                     exe.pg_pid = cur.fetchall()[0][0]
             except Exception as e:
+                if exe.db.scenario == Scenario.ZeroDowntimeDeploy:
+                    exe.mz_service = (
+                        "materialized2"
+                        if exe.mz_service == "materialized"
+                        else "materialized"
+                    )
+                    continue
                 if i < NUM_ATTEMPTS - 1 and (
                     "network error" in str(e)
                     or "Can't create a connection to host" in str(e)
@@ -1458,8 +1510,6 @@ class KillAction(Action):
     def run(self, exe: Executor) -> bool:
         assert self.composition
         self.composition.kill("materialized")
-        # Otherwise getting failure on "up" locally
-        time.sleep(1)
         self.system_parameters = self.system_param_fn(self.system_parameters)
         with self.composition.override(
             Materialized(
@@ -1472,7 +1522,7 @@ class KillAction(Action):
             )
         ):
             self.composition.up("materialized", detach=True)
-        time.sleep(self.rng.uniform(120, 240))
+        time.sleep(self.rng.uniform(60, 120))
         return True
 
 
@@ -1482,35 +1532,80 @@ class ZeroDowntimeDeployAction(Action):
         rng: random.Random,
         composition: Composition | None,
         sanity_restart: bool,
-        system_param_fn: Callable[[dict[str, str]], dict[str, str]] = lambda x: x,
     ):
         super().__init__(rng, composition)
-        self.system_param_fn = system_param_fn
-        self.system_parameters = {}
         self.sanity_restart = sanity_restart
+        self.deploy_generation = 0
 
     def run(self, exe: Executor) -> bool:
         assert self.composition
-        self.composition.kill("materialized")
-        # Otherwise getting failure on "up" locally
-        time.sleep(1)
-        self.system_parameters = self.system_param_fn(self.system_parameters)
+
+        self.deploy_generation += 1
+
+        if self.deploy_generation % 2 == 0:
+            mz_service = "materialized"
+            ports = ["6975:6875", "6976:6876", "6977:6877"]
+        else:
+            mz_service = "materialized2"
+            ports = ["7075:6875", "7076:6876", "7077:6877"]
+
+        print(f"Deploying generation {self.deploy_generation} on {mz_service}")
+
         with self.composition.override(
             Materialized(
-                restart="on-failure",
+                name=mz_service,
                 external_minio="toxiproxy",
                 external_cockroach="toxiproxy",
-                ports=["6975:6875", "6976:6876", "6977:6877"],
+                ports=ports,
                 sanity_restart=self.sanity_restart,
-                additional_system_parameter_defaults=self.system_parameters,
-            )
+                deploy_generation=self.deploy_generation,
+                restart="on-failure",
+                healthcheck=[
+                    "CMD",
+                    "curl",
+                    "-f",
+                    "localhost:6878/api/leader/status",
+                ],
+            ),
         ):
-            self.composition.up("materialized", detach=True)
-        time.sleep(self.rng.uniform(120, 240))
+            self.composition.up(mz_service, detach=True)
+
+            # TODO: Allow read-only queries on mz_service
+
+            # Wait until ready to promote
+            while True:
+                result = json.loads(
+                    self.composition.exec(
+                        mz_service,
+                        "curl",
+                        "localhost:6878/api/leader/status",
+                        capture=True,
+                    ).stdout
+                )
+                if result["status"] == "ReadyToPromote":
+                    break
+                assert result["status"] == "Initializing", f"Unexpected status {result}"
+                print("Not ready yet, waiting 1 s")
+                time.sleep(1)
+
+            # Promote new Mz service
+            result = json.loads(
+                self.composition.exec(
+                    mz_service,
+                    "curl",
+                    "-X",
+                    "POST",
+                    "http://127.0.0.1:6878/api/leader/promote",
+                    capture=True,
+                ).stdout
+            )
+            assert result["result"] == "Success", f"Unexpected result {result}"
+
+        time.sleep(self.rng.uniform(10, 30))
         return True
 
 
-# TODO: Don't restore immediately, keep copy Database objects
+# TODO: Don't restore immediately, keep copy of Database objects
 class BackupRestoreAction(Action):
     composition: Composition
     db: Database
@@ -1661,7 +1756,10 @@ class CreateKafkaSourceAction(Action):
                 source.create(exe)
                 exe.db.kafka_sources.append(source)
             except:
-                if exe.db.scenario not in (Scenario.Kill,):
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.ZeroDowntimeDeploy,
+                ):
                     raise
         return True
 
@@ -1730,7 +1828,10 @@ class CreateMySqlSourceAction(Action):
                 source.create(exe)
                 exe.db.mysql_sources.append(source)
             except:
-                if exe.db.scenario not in (Scenario.Kill,):
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.ZeroDowntimeDeploy,
+                ):
                     raise
         return True
 
@@ -1799,7 +1900,10 @@ class CreatePostgresSourceAction(Action):
                 source.create(exe)
                 exe.db.postgres_sources.append(source)
             except:
-                if exe.db.scenario not in (Scenario.Kill,):
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.ZeroDowntimeDeploy,
+                ):
                     raise
         return True
 
@@ -1911,7 +2015,7 @@ class HttpPostAction(Action):
             if source not in exe.db.webhook_sources:
                 return False
 
-            url = f"http://{exe.db.host}:{exe.db.ports['http']}/api/webhook/{urllib.parse.quote(source.schema.db.name(), safe='')}/{urllib.parse.quote(source.schema.name(), safe='')}/{urllib.parse.quote(source.name(), safe='')}"
+            url = f"http://{exe.db.host}:{exe.db.ports['http' if exe.mz_service == 'materialized' else 'http2']}/api/webhook/{urllib.parse.quote(source.schema.db.name(), safe='')}/{urllib.parse.quote(source.schema.name(), safe='')}/{urllib.parse.quote(source.name(), safe='')}"
 
             payload = source.body_format.to_data_type().random_value(self.rng)
 
@@ -1943,13 +2047,16 @@ class HttpPostAction(Action):
                 if exe.db.scenario not in (
                     Scenario.Kill,
                     Scenario.BackupRestore,
+                    Scenario.ZeroDowntimeDeploy,
                 ):
                     raise
             except QueryError as e:
                 # expected, see #20465
-                if exe.db.scenario not in (Scenario.Kill,) or (
-                    "404: no object was found at the path" not in e.msg
-                ):
+                # TODO(def-): Why in 0dt?
+                if exe.db.scenario not in (
+                    Scenario.Kill,
+                    Scenario.ZeroDowntimeDeploy,
+                ) or ("404: no object was found at the path" not in e.msg):
                     raise e
         return True
 

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -516,7 +516,7 @@ class KafkaSource(DBObject):
             schema.name(),
             cluster.name(),
         )
-        workload = rng.choice(list(WORKLOADS))(None)
+        workload = rng.choice(list(WORKLOADS))("materialized", 0)
         for transaction_def in workload.cycle:
             for definition in transaction_def.operations:
                 if type(definition) == Insert and definition.count > MAX_ROWS:
@@ -658,7 +658,7 @@ class MySqlSource(DBObject):
             schema.name(),
             cluster.name(),
         )
-        self.generator = rng.choice(list(WORKLOADS))(None).generate(fields)
+        self.generator = rng.choice(list(WORKLOADS))("materialized", 0).generate(fields)
         self.lock = threading.Lock()
 
     def name(self) -> str:
@@ -726,7 +726,7 @@ class PostgresSource(DBObject):
             schema.name(),
             cluster.name(),
         )
-        self.generator = rng.choice(list(WORKLOADS))(None).generate(fields)
+        self.generator = rng.choice(list(WORKLOADS))("materialized", 0).generate(fields)
         self.lock = threading.Lock()
 
     def name(self) -> str:

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -367,7 +367,17 @@ def run(
             os._exit(0)
         os._exit(1)
 
-    conn = pg8000.connect(host=host, port=ports["materialized"], user="materialize")
+    try:
+        conn = pg8000.connect(host=host, port=ports["materialized"], user="materialize")
+    except Exception:
+        if scenario == Scenario.ZeroDowntimeDeploy:
+            print("Failed connecting to materialized, using materialized2: {e}")
+            conn = pg8000.connect(
+                host=host, port=ports["materialized2"], user="materialize"
+            )
+        else:
+            raise
+
     conn.autocommit = True
     with conn.cursor() as cur:
         # Dropping the database also releases the long running connections

--- a/test/0dt/mzcompose.py
+++ b/test/0dt/mzcompose.py
@@ -235,6 +235,7 @@ def workflow_read_only(c: Composition) -> None:
                 c.exec(
                     "mz_old",
                     "curl",
+                    "-s",
                     "localhost:6878/api/leader/status",
                     capture=True,
                 ).stdout
@@ -248,6 +249,7 @@ def workflow_read_only(c: Composition) -> None:
             c.exec(
                 "mz_old",
                 "curl",
+                "-s",
                 "-X",
                 "POST",
                 "localhost:6878/api/leader/promote",
@@ -603,7 +605,7 @@ def workflow_basic(c: Composition) -> None:
                 c.exec(
                     "mz_new",
                     "curl",
-                    "localhost:6878/api/leader/status",
+                    "-s" "localhost:6878/api/leader/status",
                     capture=True,
                 ).stdout
             )
@@ -616,6 +618,7 @@ def workflow_basic(c: Composition) -> None:
             c.exec(
                 "mz_new",
                 "curl",
+                "-s",
                 "-X",
                 "POST",
                 "localhost:6878/api/leader/promote",

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -44,6 +44,7 @@ SERVICES = [
     Minio(setup_materialize=True, additional_directories=["copytos3"]),
     Mc(),
     Materialized(),
+    Materialized(name="materialized2"),
     Service("sqlsmith", {"mzbuild": "sqlsmith"}),
     Service(
         name="persistcli",
@@ -76,7 +77,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     with c.override(
         Materialized(
-            restart="on-failure",
             external_minio="toxiproxy",
             external_cockroach="toxiproxy",
             ports=["6975:6875", "6976:6876", "6977:6877"],
@@ -102,6 +102,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         ports = {s: c.default_port(s) for s in service_names}
         ports["http"] = c.port("materialized", 6876)
         ports["mz_system"] = c.port("materialized", 6877)
+        if scenario == Scenario.ZeroDowntimeDeploy:
+            ports["materialized2"] = 7075
+            ports["http2"] = 7076
+            ports["mz_system2"] = 7077
         # try:
         run(
             "localhost",

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -101,6 +101,7 @@ SERVICES = [
         external_cockroach=True,
         external_minio=True,
         sanity_restart=False,
+        restart="unless-stopped",
         volumes_extra=["secrets:/share/secrets"],
     ),
     Materialized(
@@ -108,6 +109,23 @@ SERVICES = [
         external_cockroach=True,
         external_minio=True,
         sanity_restart=False,
+        restart="unless-stopped",
+        volumes_extra=["secrets:/share/secrets"],
+    ),
+    Materialized(
+        name="mz_3",
+        external_cockroach=True,
+        external_minio=True,
+        sanity_restart=False,
+        restart="unless-stopped",
+        volumes_extra=["secrets:/share/secrets"],
+    ),
+    Materialized(
+        name="mz_4",
+        external_cockroach=True,
+        external_minio=True,
+        sanity_restart=False,
+        restart="unless-stopped",
         volumes_extra=["secrets:/share/secrets"],
     ),
     TestdriveService(


### PR DESCRIPTION
Currently blocked on https://github.com/MaterializeInc/materialize/issues/28216

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
