### PR TITLE
compute: remove `DataflowDescription::is_single_time` asserts

### DIFF
--- a/src/compute-types/src/plan.rs
+++ b/src/compute-types/src/plan.rs
@@ -799,7 +799,7 @@ impl<T: timely::progress::Timestamp> Plan<T> {
             Self::refine_union_negate_consolidation(&mut dataflow);
         }
 
-        if dataflow.is_single_time() {
+        if dataflow.is_single_or_empty_time() {
             Self::refine_single_time_operator_selection(&mut dataflow);
 
             // The relaxation of the `must_consolidate` flag performs an LIR-based
@@ -955,9 +955,9 @@ impl<T: timely::progress::Timestamp> Plan<T> {
         fields(path.segment = "refine_single_time_operator_selection")
     )]
     fn refine_single_time_operator_selection(dataflow: &mut DataflowDescription<Self>) {
-        // We should only reach here if we have a one-shot SELECT query, i.e.,
-        // a single-time dataflow.
-        assert!(dataflow.is_single_time());
+        // This refinement is only valid if the given dataflow is known to produce a single or no
+        // times.
+        assert!(dataflow.is_single_or_empty_time());
 
         // Upgrade single-time plans to monotonic.
         for build_desc in dataflow.objects_to_build.iter_mut() {
@@ -1009,9 +1009,9 @@ impl<T: timely::progress::Timestamp> Plan<T> {
         dataflow: &mut DataflowDescription<Self>,
         config: &TransformConfig,
     ) -> Result<(), String> {
-        // We should only reach here if we have a one-shot SELECT query, i.e.,
-        // a single-time dataflow.
-        assert!(dataflow.is_single_time());
+        // This refinement is only valid if the given dataflow is known to produce a single or no
+        // times.
+        assert!(dataflow.is_single_or_empty_time());
 
         let transform = transform::RelaxMustConsolidate::<T>::new();
         for build_desc in dataflow.objects_to_build.iter_mut() {


### PR DESCRIPTION
This PR removes the two asserts from `DataflowDescription::is_single_time`:

 * `as_of == MAX -> until.is_empty()`: This assert could be trivially triggered from SQL by running a subscribe with both `AS OF` and `UP TO` set to the maximum timestamp.
 * `as_of <= until`: This assert could not be triggered from SQL, but `DataflowDescription` does not document this as a required invariant, so asserting it seems wrong.

This PR also deals with the question of what `is_single_time` should return if `as_of => until`, i.e. the dataflow produces zero times. Previously it would return `false`, disabling single-time optimizations even though they clearly would have been applicable. To not lose the optimization, this commit takes the approach of returning `true` in this case instead. The avoid confusion, the method is renamed accordingly to `is_single_or_empty_time`.

Note that for empty-time dataflows we could apply an even more aggressive optimization where we simply return the empty result set. Given that we expect empty-time dataflows to be a rare occurrence, it doesn't seem worth to optimize for this edge case.

### Motivation

  * This PR fixes a recognized bug.

Fixes MaterializeInc/database-issues#8224 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
