### PR TITLE
Fix null filter in outer join lowering to include the outer columns

### DIFF
--- a/test/sqllogictest/github-28174.slt
+++ b/test/sqllogictest/github-28174.slt
@@ -1,0 +1,280 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for #28174.
+
+# The setup is based on https://github.com/MaterializeInc/RQG/blob/main/conf/mz/simple.sql
+
+statement ok
+DROP TABLE IF EXISTS t1 CASCADE;
+
+statement ok
+DROP TABLE IF EXISTS t2 CASCADE;
+
+statement ok
+DROP TABLE IF EXISTS t3 CASCADE;
+
+statement ok
+CREATE TABLE t1 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE INDEX t1i1 ON t1(f1);
+
+statement ok
+CREATE INDEX t1i2 ON t1(f2, f1);
+
+# one NULL row in t1
+
+statement ok
+INSERT INTO t1 VALUES (NULL, 0);
+
+# values 1 and 2 have 2 rows each in t1
+
+statement ok
+INSERT INTO t1 VALUES (1, 1);
+
+statement ok
+INSERT INTO t1 VALUES (1, 1);
+
+statement ok
+INSERT INTO t1 VALUES (2, 2);
+
+statement ok
+INSERT INTO t1 VALUES (2, 2);
+
+statement ok
+INSERT INTO t1 VALUES (3, 3);
+
+statement ok
+INSERT INTO t1 VALUES (4, 4);
+
+statement ok
+INSERT INTO t1 VALUES (5, 5);
+
+statement ok
+INSERT INTO t1 VALUES (6, 6);
+
+statement ok
+INSERT INTO t1 VALUES (7, 7);
+
+statement ok
+INSERT INTO t1 VALUES (8, 8);
+
+# value 9 not present in either table
+
+statement ok
+CREATE TABLE t2 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE INDEX t2i1 ON t2(f1);
+
+statement ok
+CREATE INDEX i2i2 ON t2(f2, f1);
+
+# two NULL rows in t2
+
+statement ok
+INSERT INTO t2 VALUES (NULL, 0);
+
+statement ok
+INSERT INTO t2 VALUES (NULL, 0);
+
+statement ok
+INSERT INTO t2 VALUES (1, 1);
+
+# value 2 has 2 rows in t2
+
+statement ok
+INSERT INTO t2 VALUES (2, 2);
+
+statement ok
+INSERT INTO t2 VALUES (2, 2);
+
+# value 3 has no rows in t2
+
+statement ok
+INSERT INTO t2 VALUES (4, 4);
+
+statement ok
+INSERT INTO t2 VALUES (5, 5);
+
+statement ok
+INSERT INTO t2 VALUES (6, 6);
+
+statement ok
+INSERT INTO t2 VALUES (7, 7);
+
+statement ok
+INSERT INTO t2 VALUES (8, 8);
+
+# value 9 not present in either table
+
+statement ok
+CREATE TABLE t3 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE MATERIALIZED VIEW pk1 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t1 WHERE f1 IS NOT NULL AND f2 IS NOT NULL;
+
+statement ok
+CREATE MATERIALIZED VIEW pk2 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t2 WHERE f1 IS NOT NULL AND f2 IS NOT NULL;
+
+statement ok
+CREATE MATERIALIZED VIEW pk3 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t3 WHERE f1 IS NOT NULL AND f2 IS NOT NULL;
+
+query RRRIR
+SELECT (a1.f1) AS c1, (a2.f1) AS c2, (a1.f2) AS c3, (count(a1.f2)) AS agg1, (max(a1.f1 + a1.f1)) AS agg2
+FROM
+    pk2 AS a1
+        RIGHT JOIN
+            (
+                    SELECT avg(a2.f1) AS f1, count(a1.f1) AS f2
+                    FROM pk1 AS a1 RIGHT JOIN pk1 AS a2 ON (NULLIF (a2.f2, a1.f1) = a2.f2 + a2.f2 + a2.f1)
+                    WHERE
+                        a2.f2 + a2.f1 IS NOT NULL AND a2.f2 NOT IN ( 4, 9, 9 )
+                            AND
+                        a1.f2
+                        NOT IN (
+                        SELECT agg1 AS x1
+                        FROM
+                            (
+                                        SELECT
+                                            (a1.f1) AS c1,
+                                            (a2.f1) AS c2,
+                                            (a1.f2) AS c3,
+                                            (avg(NULLIF (a2.f2, a2.f2))) AS agg1,
+                                            (max(a2.f2)) AS agg2
+                                        FROM
+                                            (
+                                                        SELECT a1.f1 AS f1, a1.f2 AS f2
+                                                        FROM t2 AS a1 LEFT JOIN t2 AS a2 USING(f1)
+                                                        WHERE
+                                                            a2.f2 + a2.f2 IS NULL
+                                                                OR
+                                                            NOT (NULLIF (a2.f1, a2.f1) IN ( 6, 9, 4, 5, 1 ))
+                                                                AND
+                                                            NOT (a1.f2 + a2.f2 IS NULL)
+                                                                AND
+                                                            a1.f2 < a2.f1
+                                                        ORDER BY 1, 2
+                                                    )
+                                                    AS a1
+                                                LEFT JOIN t2 AS a2 USING(f2)
+                                        WHERE a2.f2 NOT IN ( 6, 0, 0 ) AND a2.f2 IS NOT NULL AND a2.f2 IN ( 4, 5 )
+                                        GROUP BY 1, 2, 3
+                                        UNION
+                                            SELECT DISTINCT
+                                                (a2.f2) AS c1,
+                                                (a1.f2) AS c2,
+                                                (NULLIF (a1.f2, a1.f2)) AS c3,
+                                                (avg(a1.f1 + a2.f2)) AS agg1,
+                                                (avg(DISTINCT a1.f1)) AS agg2
+                                            FROM
+                                                (
+                                                            SELECT
+                                                                count(a1.f2) AS f1,
+                                                                min(a2.f1 + NULLIF (a1.f2, a2.f2)) AS f2
+                                                            FROM
+                                                                pk1 AS a1
+                                                                    JOIN
+                                                                        t2 AS a2
+                                                                        ON
+                                                                            (
+                                                                                NOT
+                                                                                (
+                                                                                    NULLIF (a1.f2, a1.f2)
+                                                                                    NOT IN (
+                                                                                    4, 9, 3, 5
+                                                                                    )
+                                                                                )
+                                                                            )
+                                                            WHERE
+                                                                a1.f2 IS NULL
+                                                                    OR
+                                                                NULLIF (a1.f2, a2.f2) = a2.f2
+                                                                    AND
+                                                                a1.f1 + a1.f2 IN ( 7, 0, 4, 6 )
+                                                            ORDER BY 1, 2
+                                                        )
+                                                        AS a1
+                                                    JOIN t2 AS a2 USING(f1)
+                                            WHERE
+                                                a1.f2 IS NULL
+                                                    OR
+                                                NULLIF (a2.f2, a1.f1) IS NOT NULL
+                                                    AND
+                                                NOT (NOT (NOT (a1.f2 + NULLIF (a1.f2, a2.f2) IN ( 7, 8 ))))
+                                                    AND
+                                                NULLIF (a2.f2, a2.f2) < a1.f1 + NULLIF (a1.f1, a1.f2)
+                                                    AND
+                                                NOT (a1.f2 > NULLIF (a2.f2, a1.f1))
+                                            GROUP BY 1, 2, 3
+                                    )
+                                    AS dt
+                        ORDER BY 1
+                        )
+                    ORDER BY 1, 2
+                    LIMIT 1
+                )
+                AS a2
+            ON (NULLIF (a2.f2, a1.f2) = a1.f2)
+WHERE
+    a1.f1
+    NOT IN (
+    SELECT c1 AS x1
+    FROM
+        (
+                    SELECT
+                        (NULLIF (a1.f2, a2.f2)) AS c1,
+                        (NULLIF (a2.f1, a2.f1)) AS c2,
+                        (a2.f1) AS c3,
+                        (min(a2.f2)) AS agg1,
+                        (min(a2.f2 + a1.f1)) AS agg2
+                    FROM t1 AS a1 LEFT JOIN (SELECT * FROM (VALUES (1, 2)) AS pk1 (f1, f2)) AS a2 USING(f1, f2)
+                    WHERE a2.f2 < a1.f2 OR a1.f2 + a2.f2 > a1.f2 + a2.f2
+                    GROUP BY 1, 2, 3
+                    EXCEPT ALL
+                        SELECT
+                            (a1.f2) AS c1,
+                            (a1.f2 + a1.f2) AS c2,
+                            (a2.f2 + a2.f1) AS c3,
+                            (max(a1.f1 + a2.f1)) AS agg1,
+                            (max(a2.f2 + a2.f2)) AS agg2
+                        FROM
+                            pk1 AS a1
+                                JOIN
+                                    (
+                                            SELECT a1.f2 AS f1, NULLIF (a2.f2, a2.f2) AS f2
+                                            FROM pk1 AS a1 RIGHT JOIN t1 AS a2 ON (NULLIF (a2.f1, a2.f2) IS NULL)
+                                            WHERE
+                                                a1.f1 IS NOT NULL AND NULLIF (a2.f1, a2.f1) NOT IN ( 9, 6, 4 )
+                                                    AND
+                                                NULLIF (a2.f1, a2.f2) NOT IN ( 9, 1 )
+                                            ORDER BY 1, 2
+                                            LIMIT 1
+                                            OFFSET 4
+                                        )
+                                        AS a2
+                                    ON (a2.f2 + a2.f2 + a1.f2 < a2.f2)
+                        WHERE a2.f2 + a1.f1 + a1.f2 > a1.f2 + a1.f2 + a1.f1 OR a2.f1 = a2.f2
+                        GROUP BY 1, 2, 3
+                )
+                AS dt
+    ORDER BY 1
+    )
+        AND
+    a2.f2 NOT IN ( 1, 2, 6, 7 )
+        OR
+    NOT (NOT (a2.f2 + a1.f1 = a1.f2))
+GROUP BY 1, 2, 3;
+----
+NULL
+4.571
+NULL
+0
+NULL

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -287,7 +287,7 @@ Return // { arity: 6 }
                 Negate // { arity: 11 }
                   Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                     Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                      Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
+                      Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
                         Get l2 // { arity: 11 }
                       Distinct project=[#0{x}..=#2] // { arity: 3 }
                         Project (#17..=#19) // { arity: 3 }
@@ -349,7 +349,7 @@ Return // { arity: 6 }
                   Negate // { arity: 11 }
                     Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                       Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                        Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
+                        Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
                           Get l2 // { arity: 11 }
                         Distinct project=[#0{x}..=#2] // { arity: 3 }
                           Project (#17..=#19) // { arity: 3 }
@@ -479,7 +479,7 @@ Return // { arity: 6 }
                 Negate // { arity: 11 }
                   Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                     Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                      Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
+                      Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
                         Get l2 // { arity: 11 }
                       Distinct project=[#0{x}..=#2] // { arity: 3 }
                         Project (#17..=#19) // { arity: 3 }
@@ -545,7 +545,7 @@ Return // { arity: 6 }
                   Negate // { arity: 11 }
                     Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
                       Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                        Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
+                        Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
                           Get l2 // { arity: 11 }
                         Distinct project=[#0{x}..=#2] // { arity: 3 }
                           Project (#17..=#19) // { arity: 3 }
@@ -610,7 +610,7 @@ Return // { arity: 6 }
                   Negate // { arity: 8 }
                     Project (#0{x}..=#7{dim02_d05}) // { arity: 8 }
                       Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim02_k01}, #1{y}) = #10) // { arity: 11 }
-                        Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND (coalesce(#2{dim02_k01}, #1{y})) IS NOT NULL AND (#5{dim02_d03} < 24) // { arity: 8 }
+                        Filter (coalesce(#2{dim02_k01}, #1{y})) IS NOT NULL AND (#5{dim02_d03} < 24) // { arity: 8 }
                           Get l3 // { arity: 8 }
                         Get l5 // { arity: 3 }
                   Get l3 // { arity: 8 }
@@ -619,7 +619,7 @@ Return // { arity: 6 }
                 Negate // { arity: 8 }
                   Project (#0{x}..=#7{dim01_d05}) // { arity: 8 }
                     Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim01_k01}, #0{x}) = #10) // { arity: 11 }
-                      Filter (#0{x}) IS NOT NULL AND (#1{y}) IS NOT NULL AND (coalesce(#2{dim01_k01}, #0{x})) IS NOT NULL AND (#5{dim01_d03} > 42) // { arity: 8 }
+                      Filter (coalesce(#2{dim01_k01}, #0{x})) IS NOT NULL AND (#5{dim01_d03} > 42) // { arity: 8 }
                         Get l2 // { arity: 8 }
                       Get l5 // { arity: 3 }
                 Get l2 // { arity: 8 }


### PR DESCRIPTION
Fixes #28174. There was a very tricky bug introduced in https://github.com/MaterializeInc/materialize/pull/28018: I was adding null filters also for those equality conditions that were not part of the original ON clause, but were coming from equating outer columns, where "outer" is meant in the subquery sense, not in the outer join sense. These equalities are different from join equalities, in that they allow nulls to match nulls, so filtering out nulls for these was wrong. (See the last sentence of the doc comment of `eq_lhs`.)

I also refactored the `OnPredicate` enum: Now we more clearly separate the different kinds of predicates, so hopefully there is less room for mixing up what is coming from where and where could/should predicates be applied.

I've added the test from the issue.

All plan changes in slts are in situations where an outer join is inside a subquery, which is expected.

### Motivation

  * This PR fixes a recognized bug: #28174

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
  - Added the test from the issue.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
