### PR TITLE
catalog: Reduce memory usage during startup

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -1209,7 +1209,8 @@ impl ApplyUpdate<StateUpdateKind> for CatalogStateInner {
                 .add(update.diff);
         }
 
-        {
+        // Storage usage events are skipped due to their size.
+        if !matches!(update.kind, StateUpdateKind::StorageUsage(..)) {
             let update: Option<memory::objects::StateUpdate> = (&update).try_into()?;
             if let Some(update) = update {
                 self.updates.push_back(update);
@@ -1278,31 +1279,6 @@ impl ReadOnlyDurableCatalogState for PersistCatalogState {
             .collect::<Result<_, _>>()?;
         audit_logs.sort_by(|a, b| a.sortable_id().cmp(&b.sortable_id()));
         Ok(audit_logs)
-    }
-
-    async fn get_storage_usage(&mut self) -> Result<Vec<VersionedStorageUsage>, CatalogError> {
-        self.sync_to_current_upper().await?;
-        let storage_usage: Vec<_> = self
-            .persist_snapshot()
-            .await
-            .filter_map(
-                |StateUpdate {
-                     kind,
-                     ts: _,
-                     diff: _,
-                 }| match kind {
-                    StateUpdateKind::StorageUsage(key, ()) => Some(key),
-                    _ => None,
-                },
-            )
-            .collect();
-        let mut storage_usage: Vec<_> = storage_usage
-            .into_iter()
-            .map(RustType::from_proto)
-            .map_ok(|key: StorageUsageKey| key.metric)
-            .collect::<Result<_, _>>()?;
-        storage_usage.sort_by(|a, b| a.sortable_id().cmp(&b.sortable_id()));
-        Ok(storage_usage)
     }
 
     #[mz_ore::instrument(level = "debug")]
@@ -1461,16 +1437,12 @@ impl DurableCatalogState for PersistCatalogState {
     }
 
     #[mz_ore::instrument]
-    async fn prune_storage_usage(
+    async fn get_and_prune_storage_usage(
         &mut self,
         retention_period: Option<Duration>,
         boot_ts: mz_repr::Timestamp,
-    ) -> Result<Vec<memory::objects::StateUpdate>, CatalogError> {
+    ) -> Result<Vec<VersionedStorageUsage>, CatalogError> {
         self.sync_to_current_upper().await?;
-
-        if self.is_read_only() {
-            return Ok(Vec::new());
-        }
 
         // If no usage retention period is set, set the cutoff to MIN so nothing
         // is removed.
@@ -1502,22 +1474,26 @@ impl DurableCatalogState for PersistCatalogState {
             .into_iter()
             .map(RustType::from_proto)
             .map_ok(|key: StorageUsageKey| key.metric);
+        let mut events = Vec::new();
         let mut expired = Vec::new();
 
         for event in storage_usage {
             let event = event?;
-            if u128::from(event.timestamp()) < cutoff_ts {
+            if u128::from(event.timestamp()) >= cutoff_ts {
+                events.push(event);
+            } else if retention_period.is_some() {
                 debug!("pruning storage event {event:?}");
                 expired.push(event);
             }
         }
 
-        let mut txn = self.transaction().await?;
-        txn.remove_storage_usage_events(expired);
-        let updates = txn.get_and_commit_op_updates();
-        txn.commit().await?;
+        if !self.is_read_only() {
+            let mut txn = self.transaction().await?;
+            txn.remove_storage_usage_events(expired);
+            txn.commit_internal().await?;
+        }
 
-        Ok(updates)
+        Ok(events)
     }
 }
 

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -1493,6 +1493,8 @@ impl DurableCatalogState for PersistCatalogState {
             txn.commit_internal().await?;
         }
 
+        events.sort_by(|event1, event2| event1.sortable_id().cmp(&event2.sortable_id()));
+
         Ok(events)
     }
 }

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -19,7 +19,6 @@ use mz_catalog::durable::{
     test_bootstrap_args, test_persist_backed_catalog_state, CatalogError, DurableCatalogError,
     Item, OpenableDurableCatalogState, USER_ITEM_ALLOC_KEY,
 };
-use mz_catalog::memory::objects::{StateDiff, StateUpdateKind};
 use mz_ore::assert_ok;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::SYSTEM_TIME;

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -150,26 +150,19 @@ async fn test_get_and_prune_storage_usage(openable_state: Box<dyn OpenableDurabl
     let recent_event = VersionedStorageUsage::V1(recent_event);
 
     // Test with no retention period.
-    let updates = state.prune_storage_usage(None, boot_ts).await.unwrap();
-    let events = state.get_storage_usage().await.unwrap();
-    assert!(updates.is_empty(), "updates should be empty: {updates:?}");
+    let events = state
+        .get_and_prune_storage_usage(None, boot_ts)
+        .await
+        .unwrap();
     assert_eq!(events.len(), 2, "unexpected events len: {events:?}");
     assert!(events.contains(&old_event));
     assert!(events.contains(&recent_event));
 
     // Test with some retention period.
-    let updates = state
-        .prune_storage_usage(Some(Duration::from_millis(10)), boot_ts)
+    let events = state
+        .get_and_prune_storage_usage(Some(Duration::from_millis(10)), boot_ts)
         .await
         .unwrap();
-    let events = state.get_storage_usage().await.unwrap();
-    assert_eq!(updates.len(), 1, "unexpected updates len: {updates:?}");
-    let update = updates.into_element();
-    assert_eq!(update.diff, StateDiff::Retraction);
-    let StateUpdateKind::StorageUsage(update_usage) = update.kind else {
-        panic!("unexpected update kind: {:?}", update.kind);
-    };
-    assert_eq!(update_usage.metric, old_event);
     assert_eq!(events.len(), 1, "unexpected events len: {events:?}");
     assert_eq!(events.into_element(), recent_event);
     Box::new(state).expire().await;


### PR DESCRIPTION
Previously, we would keep two copies of each storage usage event in memory during startup. One copy was used to generate builtin table updates while the other copy was used to prune old storage usage events. In some environments, storage usage events are so large, that this duplication had significant memory impacts during startup.

This commit fixes the issue by condensing the two copies into a single copy that is used for both pruning and generating builtin table updates.

As a consequence, catalogs will not receive any storage usage event updates while subscribing to the durable catalog. For now this is fine, because we only use the subscription during startup, which special cases storage usage events. In the future we'll likely have to resolve this somehow.

The duplication was introduced by
https://github.com/jkosh44/materialize/commit/b33485487bf439ac2e4cd2557fdaea0cd043da12, so in spirit this commit is a
partial revert of https://github.com/jkosh44/materialize/commit/b33485487bf439ac2e4cd2557fdaea0cd043da12.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
