### PR TITLE
kafka: Rename a dyncfg/LaunchDarkly flag

### DIFF
--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -640,8 +640,8 @@ impl KafkaConnection {
             Tunnel::AwsPrivatelink(t) => {
                 assert!(&self.brokers.is_empty());
 
-                let algo =
-                    KAFKA_DEFAULT_AWS_PRIVATELINK_ENDPOINT_IDENTIFICATION_ALGORITHM.get(storage_configuration.config_set());
+                let algo = KAFKA_DEFAULT_AWS_PRIVATELINK_ENDPOINT_IDENTIFICATION_ALGORITHM
+                    .get(storage_configuration.config_set());
                 options.insert("ssl.endpoint.identification.algorithm".into(), algo.into());
 
                 // When using a default privatelink tunnel broker/brokers cannot be specified

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -55,7 +55,7 @@ use crate::connections::aws::{AwsConnection, AwsConnectionValidationError};
 use crate::controller::AlterError;
 use crate::dyncfgs::{
     ENFORCE_EXTERNAL_ADDRESSES, KAFKA_CLIENT_ID_ENRICHMENT_RULES,
-    KAFKA_ENDPOINT_IDENTIFICATION_ALGORITHM,
+    KAFKA_DEFAULT_AWS_PRIVATELINK_ENDPOINT_IDENTIFICATION_ALGORITHM,
 };
 use crate::errors::{ContextCreationError, CsrConnectError};
 use crate::AlterCompatible;
@@ -641,7 +641,7 @@ impl KafkaConnection {
                 assert!(&self.brokers.is_empty());
 
                 let algo =
-                    KAFKA_ENDPOINT_IDENTIFICATION_ALGORITHM.get(storage_configuration.config_set());
+                    KAFKA_DEFAULT_AWS_PRIVATELINK_ENDPOINT_IDENTIFICATION_ALGORITHM.get(storage_configuration.config_set());
                 options.insert("ssl.endpoint.identification.algorithm".into(), algo.into());
 
                 // When using a default privatelink tunnel broker/brokers cannot be specified

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -75,13 +75,14 @@ pub const KAFKA_POLL_MAX_WAIT: Config<Duration> = Config::new(
     available.",
 );
 
-pub const KAFKA_DEFAULT_AWS_PRIVATELINK_ENDPOINT_IDENTIFICATION_ALGORITHM: Config<&'static str> = Config::new(
-    "kafka_default_aws_privatelink_endpoint_identification_algorithm",
-    // Default to no hostname verification, which is the default in versions of `librdkafka <1.9.2`.
-    "none",
-    "The value we set for the 'ssl.endpoint.identification.algorithm' option in the Kafka \
+pub const KAFKA_DEFAULT_AWS_PRIVATELINK_ENDPOINT_IDENTIFICATION_ALGORITHM: Config<&'static str> =
+    Config::new(
+        "kafka_default_aws_privatelink_endpoint_identification_algorithm",
+        // Default to no hostname verification, which is the default in versions of `librdkafka <1.9.2`.
+        "none",
+        "The value we set for the 'ssl.endpoint.identification.algorithm' option in the Kafka \
     Connection config. default: 'none'",
-);
+    );
 
 // MySQL
 

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -75,8 +75,8 @@ pub const KAFKA_POLL_MAX_WAIT: Config<Duration> = Config::new(
     available.",
 );
 
-pub const KAFKA_ENDPOINT_IDENTIFICATION_ALGORITHM: Config<&'static str> = Config::new(
-    "kafka_endpoint_identification_algorithm",
+pub const KAFKA_DEFAULT_AWS_PRIVATELINK_ENDPOINT_IDENTIFICATION_ALGORITHM: Config<&'static str> = Config::new(
+    "kafka_default_aws_privatelink_endpoint_identification_algorithm",
     // Default to no hostname verification, which is the default in versions of `librdkafka <1.9.2`.
     "none",
     "The value we set for the 'ssl.endpoint.identification.algorithm' option in the Kafka \
@@ -189,7 +189,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION)
         .add(&KAFKA_CLIENT_ID_ENRICHMENT_RULES)
         .add(&KAFKA_POLL_MAX_WAIT)
-        .add(&KAFKA_ENDPOINT_IDENTIFICATION_ALGORITHM)
+        .add(&KAFKA_DEFAULT_AWS_PRIVATELINK_ENDPOINT_IDENTIFICATION_ALGORITHM)
         .add(&MYSQL_REPLICATION_HEARTBEAT_INTERVAL)
         .add(&MYSQL_OFFSET_KNOWN_INTERVAL)
         .add(&PG_FETCH_SLOT_RESUME_LSN_INTERVAL)


### PR DESCRIPTION
Renames the dyncfg introduced in https://github.com/MaterializeInc/materialize/pull/28178 to `kafka_default_aws_privatelink_endpoint_identification_algorithm`.

### Motivation

Slack: https://materializeinc.slack.com/archives/C06CQC8LW4V/p1720800069242729

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
