### PR TITLE
catalog: Fix off by one error in sync_updates

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -233,12 +233,15 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
         &mut self,
     ) -> Result<Vec<memory::objects::StateUpdate>, CatalogError>;
 
-    /// Listen and return all updates in the catalog up to and including `ts`.
+    // TODO(jkosh44) The fact that the timestamp argument is an exclusive upper bound makes
+    // it difficult to use for readers. For now it's correct and easy to implement, but we should
+    // consider a better API.
+    /// Listen and return all updates in the catalog up to `target_upper`.
     ///
     /// Returns an error if this instance has been fenced out.
     async fn sync_updates(
         &mut self,
-        ts: Timestamp,
+        target_upper: Timestamp,
     ) -> Result<Vec<memory::objects::StateUpdate>, CatalogError>;
 }
 
@@ -252,8 +255,12 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     async fn transaction(&mut self) -> Result<Transaction, CatalogError>;
 
     /// Commits a durable catalog state transaction.
-    async fn commit_transaction(&mut self, txn_batch: TransactionBatch)
-        -> Result<(), CatalogError>;
+    ///
+    /// Returns the upper that the transaction was committed at.
+    async fn commit_transaction(
+        &mut self,
+        txn_batch: TransactionBatch,
+    ) -> Result<Timestamp, CatalogError>;
 
     /// Confirms that this catalog is connected as the current leader.
     ///


### PR DESCRIPTION
Previously, the `sync_updates` function in the durable catalog claimed to return all updates up to and including the provided timestamp. In reality, it was only returning all updates up to (not including) the provided timestamp.

This commit fixes the documentation of `sync_updates` and all callers. This function only has a single caller, which uses its output for a soft_assert. Fixing the function itself to include the timestamp would be much more useful, but much harder to implement. Since it's not heavily used, we opt for the easy route.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
