### PR TITLE
[persist] Enforce the one-batch expectation in BlobTraceUpdates

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -21,7 +21,7 @@ use differential_dataflow::trace::Description;
 use mz_dyncfg::{Config, ConfigSet, ConfigValHandle};
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::CastFrom;
-use mz_ore::{soft_assert_eq_no_log, soft_panic_no_log, soft_panic_or_log};
+use mz_ore::{soft_panic_no_log, soft_panic_or_log};
 use mz_persist::indexed::encoding::{BlobTraceBatchPart, BlobTraceUpdates};
 use mz_persist::location::{Blob, SeqNo};
 use mz_persist_types::columnar::{ColumnDecoder, Schema2};
@@ -393,9 +393,9 @@ where
             // data was corrupted, or if operations messes up deployment. In any
             // case, fail loudly.
             .expect("internal error: invalid encoded state");
-        read_metrics.part_goodbytes.inc_by(u64::cast_from(
-            parsed.updates.iter().map(|x| x.goodbytes()).sum::<usize>(),
-        ));
+        read_metrics
+            .part_goodbytes
+            .inc_by(u64::cast_from(parsed.updates.records().goodbytes()));
         EncodedPart::from_hollow(read_metrics.clone(), registered_desc, part, parsed)
     })
 }
@@ -841,7 +841,7 @@ where
         val: &mut Option<V>,
         result_override: Option<(K, V)>,
     ) -> Option<((Result<K, String>, Result<V, String>), T, D)> {
-        while let Some(((k, v, mut t, d), (part_idx, idx))) = self.part_cursor.pop(&self.part) {
+        while let Some(((k, v, mut t, d), idx)) = self.part_cursor.pop(&self.part) {
             if !self.ts_filter.filter_ts(&mut t) {
                 continue;
             }
@@ -894,8 +894,6 @@ where
                 // Note: We only provide structured columns, if they were originally written, and a
                 // dyncfg was specified to run validation.
                 if let Some(key_structured) = self.structured_part.0.as_ref() {
-                    // Structured data should always have at most 1 part.
-                    soft_assert_eq_no_log!(part_idx, 0);
                     let key_metrics = self.metrics.columnar.arrow().key();
 
                     let mut k_s = K::default();
@@ -909,8 +907,6 @@ where
                 }
 
                 if let Some(val_structured) = self.structured_part.1.as_ref() {
-                    // Structured data should always have at most 1 part.
-                    soft_assert_eq_no_log!(part_idx, 0);
                     let val_metrics = self.metrics.columnar.arrow().val();
 
                     let mut v_s = V::default();
@@ -945,7 +941,7 @@ where
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         // We don't know in advance how restrictive the filter will be.
-        let max_len = self.part.part.updates.iter().map(|x| x.len()).sum();
+        let max_len = self.part.part.updates.records().len();
         (0, Some(max_len))
     }
 }
@@ -1101,7 +1097,6 @@ where
 /// clone is very cheap.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Cursor {
-    part_idx: usize,
     idx: usize,
 }
 
@@ -1113,7 +1108,7 @@ impl Cursor {
         &self,
         encoded: &'a EncodedPart<T>,
     ) -> Option<(&'a [u8], &'a [u8], T, [u8; 8])> {
-        let part = encoded.part.updates.get(self.part_idx)?;
+        let part = encoded.part.updates.records();
         let ((k, v), t, d) = part.get(self.idx)?;
 
         let mut t = T::decode(t);
@@ -1161,10 +1156,10 @@ impl Cursor {
     pub fn pop<'a, T: Timestamp + Lattice + Codec64>(
         &mut self,
         part: &'a EncodedPart<T>,
-    ) -> Option<((&'a [u8], &'a [u8], T, [u8; 8]), (usize, usize))> {
+    ) -> Option<((&'a [u8], &'a [u8], T, [u8; 8]), usize)> {
         while !self.is_exhausted(part) {
             let current = self.get(part);
-            let popped_idx = (self.part_idx, self.idx);
+            let popped_idx = self.idx;
             self.advance(part);
             if current.is_some() {
                 return current.map(|p| (p, popped_idx));
@@ -1175,17 +1170,13 @@ impl Cursor {
 
     /// Returns true if the cursor is past the end of the part data.
     pub fn is_exhausted<T: Timestamp + Codec64>(&self, part: &EncodedPart<T>) -> bool {
-        self.part_idx >= part.part.updates.num_row_groups()
+        self.idx >= part.part.updates.records().len()
     }
 
     /// Advance the cursor just past the end of the most recent update, if there is one.
     pub fn advance<T: Timestamp + Codec64>(&mut self, part: &EncodedPart<T>) {
-        if let Some(part) = part.part.updates.get(self.part_idx) {
+        if !self.is_exhausted(part) {
             self.idx += 1;
-            if self.idx >= part.len() {
-                self.part_idx += 1;
-                self.idx = 0;
-            }
         }
     }
 }

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1420,15 +1420,6 @@ impl ProtoInlineBatchPart {
         lgbytes: &ColumnarMetrics,
         proto: Self,
     ) -> Result<BlobTraceBatchPart<T>, TryFromProtoError> {
-        // BlobTraceBatchPart has a Vec<ColumnarRecords>. Inline writes only
-        // needs one and it's nice to only have to model one at the
-        // ProtoInlineBatchPart level. I'm _pretty_ sure that the actual
-        // BlobTraceBatchPart we've serialized into parquet always have exactly
-        // one (_maaaaaybe_ zero or one), but that's a scary thing to start
-        // enforcing, so separate it out (so we can e.g. use sentry errors! to
-        // confirm before rolling anything out). In the meantime, just construct
-        // the ProtoInlineBatchPart directly in BatchParts where it still knows
-        // that it has exactly one ColumnarRecords.
         let updates = proto
             .updates
             .ok_or_else(|| TryFromProtoError::missing_field("ProtoInlineBatchPart::updates"))?;

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1436,7 +1436,7 @@ impl ProtoInlineBatchPart {
         Ok(BlobTraceBatchPart {
             desc: proto.desc.into_rust_if_some("ProtoInlineBatchPart::desc")?,
             index: proto.index.into_rust()?,
-            updates: BlobTraceUpdates::Row(vec![updates]),
+            updates: BlobTraceUpdates::Row(updates),
         })
     }
 }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -948,9 +948,9 @@ mod tests {
                                         BlobTraceBatchPart {
                                             desc: desc.clone(),
                                             index: 0,
-                                            updates: BlobTraceUpdates::Row(vec![
-                                                records.finish(&metrics.columnar)
-                                            ]),
+                                            updates: BlobTraceUpdates::Row(
+                                                records.finish(&metrics.columnar),
+                                            ),
                                         },
                                     );
                                     (ConsolidationPart::from_encoded(part, &filter, true), 0)

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -765,10 +765,8 @@ mod tests {
         let part =
             BlobTraceBatchPart::decode(&value, &metrics.columnar).expect("failed to decode part");
         let mut updates = Vec::new();
-        for chunk in part.updates.iter() {
-            for ((k, v), t, d) in chunk.iter() {
-                updates.push(((K::decode(k), V::decode(v)), T::decode(t), D::decode(d)));
-            }
+        for ((k, v), t, d) in part.updates.records().iter() {
+            updates.push(((K::decode(k), V::decode(v)), T::decode(t), D::decode(d)));
         }
         (part, updates)
     }


### PR DESCRIPTION
In practice we write down just a single batch of records per part, but the code carried around a `Vec` of batches. Flattening the vec into a single batch at the edge makes a bunch of the code that manages batches simpler, and reduces the difference between the old and new encoding path.

### Motivation

Previously-unspecified refactoring.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
