### PR TITLE
add gmt timezone to fix pg_fdw

### DIFF
--- a/src/sql/src/session/vars/value.rs
+++ b/src/sql/src/session/vars/value.rs
@@ -763,6 +763,8 @@ impl Value for ClientSeverity {
 pub enum TimeZone {
     /// UTC
     UTC,
+    /// GMT
+    GMT,
     /// Fixed offset from UTC, currently only "+00:00" is supported.
     /// A string representation is kept here for compatibility with Postgres.
     FixedOffset(&'static str),
@@ -772,6 +774,7 @@ impl TimeZone {
     fn as_str(&self) -> &'static str {
         match self {
             TimeZone::UTC => "UTC",
+            TimeZone::GMT => "GMT",
             TimeZone::FixedOffset(s) => s,
         }
     }
@@ -795,6 +798,8 @@ impl Value for TimeZone {
 
         if s == TimeZone::UTC.as_str() {
             Ok(TimeZone::UTC)
+        } else if s == TimeZone::GMT.as_str() {
+            Ok(TimeZone::GMT)
         } else if s == "+00:00" {
             Ok(TimeZone::FixedOffset("+00:00"))
         } else {


### PR DESCRIPTION
 - Adds GMT to support PG switch from UTC to GMT for FDW in https://github.com/postgres/postgres/commit/a3021aafcecbc5225bf99f235db4130546d543c1

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Materialize no longer worked with pg foreign data wrapper because it does not support SET TIMEZONE GMT.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
I don't know the implications of adding GMT

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
