### PR TITLE
compute: dataflow wallclock lag metric

### DIFF
--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -657,6 +657,14 @@ where
             tracing::info!("starting controllers in read-only mode!");
         }
 
+        let now_fn = config.now.clone();
+        let wallclock_lag = move |time: &T| {
+            let now = mz_repr::Timestamp::new(now_fn());
+            let time_ts: mz_repr::Timestamp = time.clone().into();
+            let lag_ts = now.saturating_sub(time_ts);
+            Duration::from(lag_ts)
+        };
+
         let txns_metrics = Arc::new(TxnMetrics::new(&config.metrics_registry));
         let collections_ctl = storage_collections::StorageCollectionsImpl::new(
             config.persist_location.clone(),
@@ -697,6 +705,7 @@ where
             envd_epoch,
             read_only,
             config.metrics_registry.clone(),
+            Arc::new(wallclock_lag),
         );
         let (metrics_tx, metrics_rx) = mpsc::unbounded_channel();
 

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -267,6 +267,12 @@ impl From<Timestamp> for Numeric {
     }
 }
 
+impl From<Timestamp> for Duration {
+    fn from(ts: Timestamp) -> Self {
+        Duration::from_millis(ts.internal)
+    }
+}
+
 impl std::ops::Rem<Timestamp> for Timestamp {
     type Output = Timestamp;
 


### PR DESCRIPTION
This PR adds a new Prometheus metric, `mz_dataflow_wallclock_lag_seconds`, that exposes a histogram describing the lag of compute collections behind the system wallclock time.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/materialize/issues/28097

### Tips for reviewer

I have this deployed in my staging env, if you want to play around. [Here is a dashboard](https://grafana.dev.materialize.com/d/ddrjiac717qpsf/jan-freshness?orgId=1&from=now-1h&to=now&var-datasource=JKT0Oh1Vk&var-namespace=environment-df0c80c6-2467-41a8-9ca9-caece68c4d60-0&var-cluster_id=All&var-replica_id=All&var-collection_id=All&var-freshold=2) showing some views of the metric.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
