### PR TITLE
adapter: Allow specifying a version for columns and items

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -41,7 +41,7 @@ use mz_ore::{instrument, soft_assert_no_log};
 use mz_pgrepr::oid::INVALID_OID;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
 use mz_repr::role_id::RoleId;
-use mz_repr::{GlobalId, Timestamp};
+use mz_repr::{GlobalId, Timestamp, VersionedRelationDesc};
 use mz_sql::catalog::CatalogError as SqlCatalogError;
 use mz_sql::catalog::{
     CatalogItem as SqlCatalogItem, CatalogItemType, CatalogSchema, CatalogType, NameReference,
@@ -574,7 +574,7 @@ impl CatalogState {
                     name.clone(),
                     CatalogItem::Table(Table {
                         create_sql: None,
-                        desc: table.desc.clone(),
+                        desc: VersionedRelationDesc::new(table.desc.clone()),
                         defaults: vec![Expr::null(); table.desc.arity()],
                         conn_id: None,
                         resolved_ids: ResolvedIds(BTreeSet::new()),

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -14,7 +14,7 @@
 
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_repr::role_id::RoleId;
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, RelationVersion};
 use mz_sql::catalog::{CatalogItem, DefaultPrivilegeObject};
 use mz_sql::names::{
     CommentObjectId, DatabaseId, QualifiedItemName, ResolvedDatabaseSpecifier, SchemaId,
@@ -245,7 +245,7 @@ impl CatalogState {
                         Some(entry) => {
                             // TODO: Refactor this to use if-let chains, once they're stable.
                             #[allow(clippy::unnecessary_unwrap)]
-                            if !entry.has_columns() && col_pos.is_some() {
+                            if !entry.has_columns(RelationVersion::Latest) && col_pos.is_some() {
                                 let col_pos = col_pos.expect("checked above");
                                 comment_inconsistencies.push(CommentInconsistency::NonRelation(
                                     comment_object_id,

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -342,7 +342,7 @@ fn assign_new_user_global_ids(
 
     impl<'a> VisitMut<'_, Raw> for IdUpdater<'a> {
         fn visit_item_name_mut(&mut self, node: &'_ mut <Raw as mz_sql::ast::AstInfo>::ItemName) {
-            if let RawItemName::Id(id, _) = node {
+            if let RawItemName::Id(id, _, _) = node {
                 match GlobalId::from_str(id.as_str()) {
                     Ok(curr_id) => {
                         if let Some(new_id) = self.new_id_mapping.get(&curr_id) {
@@ -475,7 +475,7 @@ fn ast_rewrite_create_source_pg_database_details(
                                 .resolve_item(&connection)
                                 .expect("PG source connection must exist")
                         }
-                        RawItemName::Id(id, _) => {
+                        RawItemName::Id(id, _, _) => {
                             let gid = id
                                 .parse()
                                 .expect("RawItenName::Id must be uncorrupted GlobalId");

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1319,7 +1319,8 @@ mod builtin_migration_tests {
                     create_sql: Some("CREATE TABLE materialize.public.t (a INT)".to_string()),
                     desc: RelationDesc::empty()
                         .with_column("a", ScalarType::Int32.nullable(true))
-                        .with_key(vec![0]),
+                        .with_key(vec![0])
+                        .into(),
                     defaults: vec![Expr::null(); 1],
                     conn_id: None,
                     resolved_ids: ResolvedIds(BTreeSet::new()),

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -115,7 +115,7 @@ use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::global_id::TransientIdGen;
 use mz_repr::role_id::RoleId;
-use mz_repr::{GlobalId, RelationDesc, Timestamp};
+use mz_repr::{GlobalId, RelationDesc, RelationVersion, Timestamp};
 use mz_secrets::cache::CachingSecretsReader;
 use mz_secrets::{SecretsController, SecretsReader};
 use mz_sql::ast::{Raw, Statement};
@@ -2267,7 +2267,7 @@ impl Coordinator {
                     CatalogItem::Source(source) => Some((id, source_desc(source))),
                     CatalogItem::Table(table) => {
                         let collection_desc = CollectionDescription::from_desc(
-                            table.desc.clone(),
+                            table.desc.at_version(RelationVersion::Latest),
                             DataSourceOther::TableWrites,
                         );
                         Some((id, collection_desc))

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -35,7 +35,7 @@ use mz_ore::retry::Retry;
 use mz_ore::str::StrExt;
 use mz_ore::task;
 use mz_repr::adt::numeric::Numeric;
-use mz_repr::{GlobalId, Timestamp};
+use mz_repr::{GlobalId, RelationVersion, Timestamp};
 use mz_sql::catalog::{CatalogCluster, CatalogSchema};
 use mz_sql::names::ResolvedDatabaseSpecifier;
 use mz_sql::session::metadata::SessionMetadata;
@@ -1194,10 +1194,13 @@ impl Coordinator {
         let storage_sink_desc = mz_storage_types::sinks::StorageSinkDesc {
             from: sink.from,
             from_desc: storage_sink_from_entry
-                .desc(&self.catalog().resolve_full_name(
-                    storage_sink_from_entry.name(),
-                    storage_sink_from_entry.conn_id(),
-                ))
+                .desc(
+                    &self.catalog().resolve_full_name(
+                        storage_sink_from_entry.name(),
+                        storage_sink_from_entry.conn_id(),
+                    ),
+                    RelationVersion::Latest,
+                )
                 .expect("indexes can only be built on items with descs")
                 .into_owned(),
             connection: sink

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -17,7 +17,7 @@ use futures::FutureExt;
 use inner::return_if_err;
 use mz_expr::{MirRelationExpr, RowSetFinishing};
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::{Diff, GlobalId, RowCollection};
+use mz_repr::{Diff, GlobalId, RelationVersion, RowCollection};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{
@@ -702,7 +702,8 @@ impl Coordinator {
         // Insert can be queued, so we need to re-verify the id exists.
         let desc = match catalog.try_get_entry(&id) {
             Some(table) => {
-                table.desc(&catalog.resolve_full_name(table.name(), Some(session.conn_id())))?
+                let name = catalog.resolve_full_name(table.name(), Some(session.conn_id()));
+                table.desc(&name, RelationVersion::Latest)?
             }
             None => {
                 return Err(AdapterError::Catalog(mz_catalog::memory::error::Error {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -36,7 +36,9 @@ use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
 use mz_repr::explain::json::json_string;
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::role_id::RoleId;
-use mz_repr::{Datum, Diff, GlobalId, IntoRowIterator, Row, RowArena, RowIterator, Timestamp};
+use mz_repr::{
+    Datum, Diff, GlobalId, IntoRowIterator, RelationVersion, Row, RowArena, RowIterator, Timestamp,
+};
 use mz_sql::ast::{
     CreateSubsourceStatement, Ident, MySqlConfigOptionName, UnresolvedItemName, Value,
 };
@@ -436,6 +438,7 @@ impl Coordinator {
             qualifiers: progress_plan.plan.name.qualifiers.clone(),
             full_name: progress_full_name,
             print_id: true,
+            version: RelationVersion::Latest,
         };
 
         create_source_plans.push(progress_plan);
@@ -466,6 +469,7 @@ impl Coordinator {
             qualifiers: source_plan.name.qualifiers.clone(),
             full_name: source_full_name,
             print_id: true,
+            version: RelationVersion::Latest,
         };
 
         create_source_plans.push(CreateSourcePlanBundle {

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -14,7 +14,7 @@ use mz_catalog::memory::objects::{CatalogItem, Index};
 use mz_ore::instrument;
 use mz_repr::explain::{ExprHumanizerExt, TransientItem};
 use mz_repr::optimize::{OptimizerFeatures, OverrideFrom};
-use mz_repr::{Datum, Row};
+use mz_repr::{Datum, RelationVersion, Row};
 use mz_sql::ast::ExplainStage;
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::ResolvedIds;
@@ -568,7 +568,7 @@ impl Coordinator {
             let on_entry = self.catalog.get_entry(&index.on);
             let full_name = self.catalog.resolve_full_name(&name, on_entry.conn_id());
             let on_desc = on_entry
-                .desc(&full_name)
+                .desc(&full_name, RelationVersion::Latest)
                 .expect("can only create indexes on items with a valid description");
 
             let transient_items = btreemap! {

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -31,7 +31,7 @@ use std::time::{Duration, Instant};
 use mz_compute_types::dataflows::IndexDesc;
 use mz_compute_types::plan::Plan;
 use mz_repr::explain::trace_plan;
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, RelationVersion};
 use mz_sql::names::QualifiedItemName;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
@@ -152,7 +152,7 @@ impl Optimize<Index> for Optimizer {
         let on_entry = state.get_entry(&index.on);
         let full_name = state.resolve_full_name(&index.name, on_entry.conn_id());
         let on_desc = on_entry
-            .desc(&full_name)
+            .desc(&full_name, RelationVersion::Latest)
             .expect("can only create indexes on items with a valid description");
 
         let mut df_builder = {

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -20,7 +20,7 @@ use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, SubscribeS
 use mz_compute_types::ComputeInstanceId;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_assert_or_log;
-use mz_repr::{GlobalId, RelationDesc, Timestamp};
+use mz_repr::{GlobalId, RelationDesc, RelationVersion, Timestamp};
 use mz_sql::plan::SubscribeFrom;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
@@ -194,13 +194,12 @@ impl Optimize<SubscribeFrom> for Optimizer {
         match plan {
             SubscribeFrom::Id(from_id) => {
                 let from = self.catalog.get_entry(&from_id);
+                let name = self
+                    .catalog
+                    .state()
+                    .resolve_full_name(from.name(), self.conn_id.as_ref());
                 let from_desc = from
-                    .desc(
-                        &self
-                            .catalog
-                            .state()
-                            .resolve_full_name(from.name(), self.conn_id.as_ref()),
-                    )
+                    .desc(&name, RelationVersion::Latest)
                     .expect("subscribes can only be run on items with descs")
                     .into_owned();
 

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -94,7 +94,7 @@ async fn datadriven() {
                                                 schema_name,
                                                 test_case.input.trim_end()
                                             )),
-                                            desc: RelationDesc::empty(),
+                                            desc: RelationDesc::empty().into(),
                                             defaults: vec![],
                                             conn_id: None,
                                             resolved_ids: ResolvedIds(BTreeSet::new()),

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -52,6 +52,7 @@ pub use crate::global_id::GlobalId;
 pub use crate::relation::{
     arb_row_for_relation, ColumnName, ColumnType, NotNullViolation, ProtoColumnName,
     ProtoColumnType, ProtoRelationDesc, ProtoRelationType, RelationDesc, RelationType,
+    RelationVersion, VersionedRelationDesc,
 };
 pub use crate::row::collection::{ProtoRowCollection, RowCollection, SortedRowCollectionIter};
 pub use crate::row::encoding::{

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -645,3 +645,28 @@ pub enum RelationVersion {
     Specific(u64),
     Latest,
 }
+
+/// A [`RelationDesc`] that maintains a history of the changes made to it.
+#[derive(Debug, Clone, Serialize)]
+pub struct VersionedRelationDesc {
+    root: RelationDesc,
+}
+
+impl VersionedRelationDesc {
+    pub fn new(root: RelationDesc) -> Self {
+        VersionedRelationDesc { root }
+    }
+
+    pub fn at_version(&self, version: RelationVersion) -> RelationDesc {
+        match version {
+            RelationVersion::Latest => self.root.clone(),
+            RelationVersion::Specific(_) => panic!("don't yet support versioning RelationDesc"),
+        }
+    }
+}
+
+impl From<RelationDesc> for VersionedRelationDesc {
+    fn from(value: RelationDesc) -> Self {
+        VersionedRelationDesc::new(value)
+    }
+}

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -638,3 +638,10 @@ impl fmt::Display for NotNullViolation {
         )
     }
 }
+
+/// Describes a [`RelationDesc`] at a specific version of a [`VersionedRelationDesc`].
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RelationVersion {
+    Specific(u64),
+    Latest,
+}

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -25,6 +25,7 @@
 
 Access
 Add
+Added
 Addresses
 Aggregate
 Aligned
@@ -134,6 +135,7 @@ Doc
 Dot
 Double
 Drop
+Dropped
 Eager
 Element
 Else

--- a/src/sql-parser/src/ast/metadata.rs
+++ b/src/sql-parser/src/ast/metadata.rs
@@ -85,21 +85,21 @@ impl AstInfo for Raw {
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
 pub enum RawItemName {
     Name(UnresolvedItemName),
-    Id(String, UnresolvedItemName),
+    Id(String, UnresolvedItemName, Option<Version>),
 }
 
 impl RawItemName {
     pub fn name(&self) -> &UnresolvedItemName {
         match self {
             RawItemName::Name(name) => name,
-            RawItemName::Id(_, name) => name,
+            RawItemName::Id(_, name, _) => name,
         }
     }
 
     pub fn name_mut(&mut self) -> &mut UnresolvedItemName {
         match self {
             RawItemName::Name(name) => name,
-            RawItemName::Id(_, name) => name,
+            RawItemName::Id(_, name, _) => name,
         }
     }
 }
@@ -108,9 +108,13 @@ impl AstDisplay for RawItemName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             RawItemName::Name(o) => f.write_node(o),
-            RawItemName::Id(id, o) => {
+            RawItemName::Id(id, o, v) => {
                 f.write_str(format!("[{} AS ", id));
                 f.write_node(o);
+                if let Some(v) = v {
+                    f.write_str(" WITH VERSION ");
+                    f.write_node(v);
+                }
                 f.write_str("]");
             }
         }
@@ -231,3 +235,26 @@ where
         f.fold_data_type(self)
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Version(u64);
+
+impl Version {
+    pub fn new(val: u64) -> Self {
+        Version(val)
+    }
+
+    pub fn into_inner(self) -> u64 {
+        self.0
+    }
+}
+
+impl AstDisplay for Version {
+    fn fmt<W>(&self, f: &mut AstFormatter<W>)
+    where
+        W: fmt::Write,
+    {
+        f.write_node(&self.0);
+    }
+}
+impl_display!(Version);

--- a/src/sql-parser/src/ast/visit.rs
+++ b/src/sql-parser/src/ast/visit.rs
@@ -119,7 +119,7 @@
 //!     }
 //!     fn visit_item_name(&mut self, name: &'ast <Raw as AstInfo>::ItemName) {
 //!         match name {
-//!             RawItemName::Name(n) | RawItemName::Id(_, n) => {
+//!             RawItemName::Name(n) | RawItemName::Id(_, n, _) => {
 //!                 for node in &n.0 {
 //!                     self.idents.push(node);
 //!                     visit::visit_ident(self, node);

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -249,6 +249,13 @@ CREATE TABLE t (x int4) WITH (RETAIN HISTORY = FOR '1 day')
 CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false, with_options: [TableOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1 day"))) }] })
 
 parse-statement
+CREATE TABLE t (x int, y text VERSION ADDED 1, z text VERSION ADDED 2 VERSION DROPPED 3 VERSION ADDED 4) WITH (RETAIN HISTORY = FOR '1 day')
+----
+CREATE TABLE t (x int4, y text VERSION ADDED 1, z text VERSION ADDED 2 VERSION DROPPED 3 VERSION ADDED 4) WITH (RETAIN HISTORY = FOR '1 day')
+=>
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("x"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("y"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Versioned { action: Added, version: Number("1") } }] }, ColumnDef { name: Ident("z"), data_type: Other { name: Name(UnresolvedItemName([Ident("text")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Versioned { action: Added, version: Number("2") } }, ColumnOptionDef { name: None, option: Versioned { action: Dropped, version: Number("3") } }, ColumnOptionDef { name: None, option: Versioned { action: Added, version: Number("4") } }] }], constraints: [], if_not_exists: false, temporary: false, with_options: [TableOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1 day"))) }] })
+
+parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS

--- a/src/sql-parser/tests/testdata/id
+++ b/src/sql-parser/tests/testdata/id
@@ -18,14 +18,14 @@ SELECT * FROM [u123 AS materialize.public.foo]
 ----
 SELECT * FROM [u123 AS materialize.public.foo]
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Id("u123", UnresolvedItemName([Ident("materialize"), Ident("public"), Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Id("u123", UnresolvedItemName([Ident("materialize"), Ident("public"), Ident("foo")]), None), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT [u123 AS materialize.public.foo](1)
 ----
 SELECT [u123 AS materialize.public.foo](1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Id("u123", UnresolvedItemName([Ident("materialize"), Ident("public"), Ident("foo")])), args: Args { args: [Value(Number("1"))], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Id("u123", UnresolvedItemName([Ident("materialize"), Ident("public"), Ident("foo")]), None), args: Args { args: [Value(Number("1"))], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM [u123 AS foo]
@@ -47,3 +47,10 @@ SELECT * FROM [u123 AS materialize.public.foo
 error: Expected right square bracket, found EOF
 SELECT * FROM [u123 AS materialize.public.foo
                                              ^
+
+parse-statement
+CREATE VIEW v1 AS SELECT * FROM [ u1 as materialize.public.t1 WITH VERSION 5]
+----
+CREATE VIEW v1 AS SELECT * FROM [u1 AS materialize.public.t1 WITH VERSION 5]
+=>
+CreateView(CreateViewStatement { if_exists: Error, temporary: false, definition: ViewDefinition { name: UnresolvedItemName([Ident("v1")]), columns: [], query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Id("u1", UnresolvedItemName([Ident("materialize"), Ident("public"), Ident("t1")]), Some(Version(5))), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -122,7 +122,7 @@ impl<'a, 'ast> VisitMut<'ast, Raw> for CreateSqlRewriteSchema<'a> {
         item_name: &'ast mut <mz_sql_parser::ast::Raw as AstInfo>::ItemName,
     ) {
         match item_name {
-            RawItemName::Name(n) | RawItemName::Id(_, n) => self.maybe_rewrite_idents(&mut n.0),
+            RawItemName::Name(n) | RawItemName::Id(_, n, _) => self.maybe_rewrite_idents(&mut n.0),
         }
     }
 }
@@ -383,7 +383,7 @@ impl<'a, 'ast> Visit<'ast, Raw> for QueryIdentAgg<'a> {
 
     fn visit_item_name(&mut self, item_name: &'ast <Raw as AstInfo>::ItemName) {
         match item_name {
-            RawItemName::Name(n) | RawItemName::Id(_, n) => self.visit_unresolved_item_name(n),
+            RawItemName::Name(n) | RawItemName::Id(_, n, _) => self.visit_unresolved_item_name(n),
         }
     }
 }
@@ -450,7 +450,7 @@ impl<'ast> VisitMut<'ast, Raw> for CreateSqlRewriter {
         item_name: &'ast mut <mz_sql_parser::ast::Raw as AstInfo>::ItemName,
     ) {
         match item_name {
-            RawItemName::Name(n) | RawItemName::Id(_, n) => self.maybe_rewrite_idents(&mut n.0),
+            RawItemName::Name(n) | RawItemName::Id(_, n, _) => self.maybe_rewrite_idents(&mut n.0),
         }
     }
 }
@@ -474,7 +474,7 @@ impl<'ast> VisitMut<'ast, Raw> for CreateSqlIdReplacer<'_> {
         item_name: &'ast mut <mz_sql_parser::ast::Raw as AstInfo>::ItemName,
     ) {
         match item_name {
-            RawItemName::Id(id, _) => {
+            RawItemName::Id(id, _, _) => {
                 let old_id = match id.parse() {
                     Ok(old_id) => old_id,
                     Err(_) => panic!("invalid persisted global id {id}"),

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -28,7 +28,7 @@ use mz_ore::str::StrExt;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::role_id::RoleId;
-use mz_repr::{ColumnName, GlobalId, RelationDesc};
+use mz_repr::{ColumnName, GlobalId, RelationDesc, RelationVersion};
 use mz_sql_parser::ast::{Expr, QualifiedReplica, UnresolvedItemName};
 use mz_storage_types::connections::inline::{ConnectionResolver, ReferencedConnection};
 use mz_storage_types::connections::{Connection, ConnectionContext};
@@ -573,7 +573,11 @@ pub trait CatalogItem {
     ///
     /// If the catalog item is not of a type that produces data (i.e., a sink or
     /// an index), it returns an error.
-    fn desc(&self, name: &FullItemName) -> Result<Cow<RelationDesc>, CatalogError>;
+    fn desc(
+        &self,
+        name: &FullItemName,
+        version: RelationVersion,
+    ) -> Result<Cow<RelationDesc>, CatalogError>;
 
     /// Returns the resolved function.
     ///

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1623,7 +1623,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
             ResolvedItemName::Item { id, full_name, .. } => {
                 let item = self.catalog.get_item(id);
 
-                let desc = match item.desc(full_name) {
+                let desc = match item.desc(full_name, RelationVersion::Latest) {
                     Ok(desc) => desc,
                     Err(e) => {
                         if self.status.is_ok() {

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1285,10 +1285,12 @@ impl<'a> NameResolver<'a> {
                         let full_name = self.catalog.resolve_full_name(item.name());
                         (full_name, item)
                     }
-                    RawItemName::Id(id, name) => {
+                    RawItemName::Id(id, name, version) => {
                         let gid: GlobalId = id.parse()?;
                         let item = self.catalog.get_item(&gid);
                         let full_name = normalize::full_name(name)?;
+                        assert!(version.is_none(), "no support for versioning data types");
+
                         (full_name, item)
                     }
                 };
@@ -1322,7 +1324,9 @@ impl<'a> NameResolver<'a> {
     ) -> ResolvedItemName {
         match item_name {
             RawItemName::Name(name) => self.resolve_item_name_name(name, config),
-            RawItemName::Id(id, raw_name) => self.resolve_item_name_id(id, raw_name),
+            RawItemName::Id(id, raw_name, version) => {
+                self.resolve_item_name_id(id, raw_name, version)
+            }
         }
     }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -43,7 +43,9 @@ use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::optimize::OptimizerFeatureOverrides;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::role_id::RoleId;
-use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType, Timestamp};
+use mz_repr::{
+    ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType, Timestamp, VersionedRelationDesc,
+};
 use mz_sql_parser::ast::{
     AlterSourceAddSubsourceOption, ClusterAlterOptionValue, ConnectionOptionName, QualifiedReplica,
     SelectStatement, TransactionIsolationLevel, TransactionMode, UnresolvedItemName, Value,
@@ -1307,7 +1309,7 @@ pub struct CommentPlan {
 #[derive(Clone, Debug)]
 pub struct Table {
     pub create_sql: String,
-    pub desc: RelationDesc,
+    pub desc: VersionedRelationDesc,
     pub defaults: Vec<Expr<Aug>>,
     pub temporary: bool,
     pub compaction_window: Option<CompactionWindow>,

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -709,7 +709,7 @@ impl<'a> StatementContext<'a> {
                 let name = normalize::unresolved_item_name(name)?;
                 Ok(self.catalog.resolve_item(&name)?)
             }
-            RawItemName::Id(id, _) => {
+            RawItemName::Id(id, _, _) => {
                 let gid = id.parse()?;
                 Ok(self.catalog.get_item(&gid))
             }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 
 use mz_repr::namespaces::is_system_schema;
-use mz_repr::{ColumnType, GlobalId, RelationDesc, ScalarType};
+use mz_repr::{ColumnType, GlobalId, RelationDesc, RelationVersion, ScalarType};
 use mz_sql_parser::ast::{
     ColumnDef, ColumnName, ConnectionDefaultAwsPrivatelink, CreateMaterializedViewStatement,
     RawItemName, ShowStatement, StatementKind, TableConstraint, UnresolvedDatabaseName,
@@ -631,6 +631,7 @@ impl<'a> StatementContext<'a> {
             qualifiers: qualified.qualifiers,
             full_name,
             print_id: true,
+            version: RelationVersion::Latest,
         })
     }
 
@@ -976,6 +977,7 @@ impl<'a> StatementContext<'a> {
             qualifiers: entry.name().qualifiers.clone(),
             full_name,
             print_id: true,
+            version: RelationVersion::Latest,
         }
     }
 }

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use mz_repr::adt::interval::Interval;
 use mz_repr::bytes::ByteSize;
-use mz_repr::{strconv, GlobalId};
+use mz_repr::{strconv, GlobalId, RelationVersion};
 use mz_sql_parser::ast::{
     ClusterAlterOptionValue, ClusterScheduleOptionValue, ConnectionDefaultAwsPrivatelink, Ident,
     KafkaBroker, RefreshOptionValue, ReplicaDefinition,
@@ -63,6 +63,7 @@ impl TryFromValue<WithOptionValue<Aug>> for Secret {
             qualifiers: secret.name().qualifiers.clone(),
             full_name: catalog.resolve_full_name(secret.name()),
             print_id: false,
+            version: RelationVersion::Latest,
         };
         Some(WithOptionValue::Secret(name))
     }
@@ -108,6 +109,7 @@ impl TryFromValue<WithOptionValue<Aug>> for Object {
             qualifiers: item.name().qualifiers.clone(),
             full_name: catalog.resolve_full_name(item.name()),
             print_id: false,
+            version: RelationVersion::Latest,
         };
         Some(WithOptionValue::Item(name))
     }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -315,6 +315,7 @@ pub(crate) fn add_materialize_comments(
                     item.item_type(),
                     CatalogItemType::Func | CatalogItemType::Type
                 ),
+                version: RelationVersion::Latest,
             };
 
             if let Some(comments_map) = catalog.get_item_comments(&object_id) {
@@ -1114,6 +1115,7 @@ async fn purify_alter_source(
         qualifiers: item.name().qualifiers.clone(),
         full_name,
         print_id: true,
+        version: RelationVersion::Latest,
     };
     let connection_name = desc.connection.name();
 
@@ -1675,6 +1677,7 @@ pub fn purify_create_materialized_view_options(
                     qualifiers: item.name().qualifiers.clone(),
                     full_name: catalog.resolve_full_name(item.name()),
                     print_id: false,
+                    version: RelationVersion::Latest,
                 },
                 args: FunctionArgs::Args {
                     args: Vec::new(),

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -29,7 +29,7 @@ use mz_ore::iter::IteratorExt;
 use mz_ore::str::StrExt;
 use mz_postgres_util::replication::WalLevel;
 use mz_proto::RustType;
-use mz_repr::{strconv, Timestamp};
+use mz_repr::{strconv, RelationVersion, Timestamp};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::visit::{visit_function, Visit};
 use mz_sql_parser::ast::visit_mut::{visit_expr_mut, VisitMut};
@@ -336,7 +336,7 @@ pub(crate) fn add_materialize_comments(
                 }
 
                 // Getting comments on columns in the item
-                if let Ok(desc) = item.desc(&full_name) {
+                if let Ok(desc) = item.desc(&full_name, RelationVersion::Latest) {
                     for (pos, column_name) in desc.iter_names().enumerate() {
                         let comment = comments_map.get(&Some(pos + 1));
                         if let Some(comment_str) = comment {


### PR DESCRIPTION
This PR makes it possible to version a `RelationDesc`. It does three things:

1. Extends the SQL parser to support `[<item name> AS <id> WITH VERSION <version>]` when specifying items, and support `VERSION [ADDED | DROPPED] <version>` as a column constraint.
2. Adds a `version` field to `RawItemName::Id` and `ResolvedItemNAme::Item`
3. Updates the `CatalogEntry::desc(...)` method to take a `RelationVersion` as an argument. At the moment everything passes `RelationVersion::Latest`

The goal of adding versions to `RelationDesc` is the ability to add columns to tables. Because we don't yet have https://github.com/MaterializeInc/materialize/issues/16650 if we didn't version `RelationDesc`s when we add a column to a table that column would now show up in downstream views, potentially breaking them.

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/28082

### Tips for reviewer

The PR is split into individual commits which might be easier to review separately

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
