### PR TITLE
storage: increase the information written to logs on initialization

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -170,11 +170,6 @@ where
 {
     let worker_id = config.worker_id;
     let id = config.id;
-    info!(
-        %id,
-        as_of = %config.as_of.pretty(),
-        "timely-{worker_id} building source pipeline",
-    );
 
     let mut tokens = vec![];
 
@@ -549,7 +544,11 @@ where
                         Event::Messages(_, _) => unreachable!(),
                     });
                     source_upper.update_iter(progress);
-                    trace!("timely-{worker_id} remap({id}) received source upper: {}", source_upper.pretty());
+                    if source_upper.is_empty() {
+                        info!(%id, "timely-{worker_id} remap({id}) received source upper: {}", source_upper.pretty());
+                    } else {
+                        trace!("timely-{worker_id} remap({id}) received source upper: {}", source_upper.pretty());
+                    }
                 }
             }
         }
@@ -678,11 +677,21 @@ where
                         // orders, and simply write "classic" timely code here, whereby we store
                         // messages until we see frontiers progress.
                         source_upper.update_iter(changes);
-                        trace!(
-                            "timely-{worker_id} reclock({id}) \
-                            received source progress: source_upper={}",
-                            source_upper.pretty()
-                        );
+                        if source_upper.is_empty() {
+                            info!(
+                                %id,
+                                "timely-{worker_id} reclock({id}) \
+                                received source progress: source_upper={}",
+                                source_upper.pretty()
+                            );
+
+                        } else {
+                            trace!(
+                                "timely-{worker_id} reclock({id}) \
+                                received source progress: source_upper={}",
+                                source_upper.pretty()
+                            );
+                        }
                         work_to_do.notify_one();
                     }
                     Event::Messages(time, mut batch) => {
@@ -782,15 +791,21 @@ where
                     let into_ready_upper = timestamper
                         .reclock_frontier(ready_upper.borrow())
                         .expect("uninitialized reclock follower");
-                    trace!(
-                        "timely-{worker_id} reclock({id}) downgrading timestamper: since={}",
-                        into_ready_upper.pretty()
-                    );
 
                     cap_set.downgrade(into_ready_upper.elements());
                     timestamper.compact(into_ready_upper.clone());
                     if into_ready_upper.is_empty() {
+                        info!(
+                            %id,
+                            "timely-{worker_id} reclock({id}) downgrading timestamper: since={}",
+                            into_ready_upper.pretty()
+                        );
                         return;
+                    } else {
+                        trace!(
+                            "timely-{worker_id} reclock({id}) downgrading timestamper: since={}",
+                            into_ready_upper.pretty()
+                        );
                     }
                 }
             }


### PR DESCRIPTION


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR makes sure that we log important information (e.g resume uppers) of dataflow initialization at `INFO` level and that we additionally log at `INFO` level notable events. At the moment advancing to the empty frontier is considered a notable event and is recorded by various parts of the pipeline.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
