### PR TITLE
storage: infrastructure for suspendable sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6360,6 +6360,7 @@ dependencies = [
  "mz-txn-wal",
  "num_cpus",
  "once_cell",
+ "pin-project",
  "postgres-protocol",
  "prometheus",
  "prost",

--- a/src/storage-operators/src/s3_oneshot_sink.rs
+++ b/src/storage-operators/src/s3_oneshot_sink.rs
@@ -16,6 +16,7 @@ use std::str::FromStr;
 use anyhow::anyhow;
 use aws_types::sdk_config::SdkConfig;
 use differential_dataflow::{Collection, Hashable};
+use futures::StreamExt;
 use http::Uri;
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;

--- a/src/storage-types/src/dyncfgs.rs
+++ b/src/storage-types/src/dyncfgs.rs
@@ -36,6 +36,15 @@ pub const DELAY_SOURCES_PAST_REHYDRATION: Config<bool> = Config::new(
         (namely, upsert) till after rehydration is finished",
 );
 
+/// Whether storage dataflows should suspend execution while downstream operators are still
+/// processing data.
+pub const SUSPENDABLE_SOURCES: Config<bool> = Config::new(
+    "storage_dataflow_suspendable_sources",
+    true,
+    "Whether storage dataflows should suspend execution while downstream operators are still \
+        processing data.",
+);
+
 // Controller
 
 /// When enabled, force-downgrade the controller's since handle on the shard
@@ -187,6 +196,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
         .add(&CLUSTER_SHUTDOWN_GRACE_PERIOD)
         .add(&DELAY_SOURCES_PAST_REHYDRATION)
+        .add(&SUSPENDABLE_SOURCES)
         .add(&STORAGE_DOWNGRADE_SINCE_DURING_FINALIZATION)
         .add(&KAFKA_CLIENT_ID_ENRICHMENT_RULES)
         .add(&KAFKA_POLL_MAX_WAIT)

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -66,6 +66,7 @@ mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 mz-txn-wal = { path = "../txn-wal" }
 once_cell = { version = "1.16.0" }
+pin-project = "1.0.12"
 postgres-protocol = { version = "0.6.5" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }

--- a/src/storage/examples/upsert_open_loop.rs
+++ b/src/storage/examples/upsert_open_loop.rs
@@ -105,6 +105,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::bail;
 use differential_dataflow::Hashable;
+use futures::StreamExt;
 use itertools::Itertools;
 use mz_build_info::{build_info, BuildInfo};
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};

--- a/src/storage/src/decode.rs
+++ b/src/storage/src/decode.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use differential_dataflow::capture::{Message, Progress};
 use differential_dataflow::{AsCollection, Collection, Hashable};
+use futures::StreamExt;
 use mz_ore::error::ErrorExt;
 use mz_ore::future::InTask;
 use mz_repr::{Datum, Diff, Row};

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use differential_dataflow::Hashable;
+use futures::StreamExt;
 use mz_ore::cast::CastFrom;
 use mz_ore::now::NowFn;
 use mz_repr::GlobalId;

--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -214,6 +214,7 @@ use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
+use crate::source::RawSourceCreationConfig;
 use crate::storage_state::StorageState;
 
 mod persist_sink;
@@ -257,6 +258,34 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 source_resume_uppers = ?source_resume_uppers,
                 "timely-{worker_id} building {} source pipeline", connection.name(),
             );
+
+            let base_source_config = RawSourceCreationConfig {
+                name: format!("{}-{}", connection.name(), primary_source_id),
+                id: primary_source_id,
+                source_exports: description.source_exports_with_output_indices(),
+                timestamp_interval: description.desc.timestamp_interval,
+                worker_id: mz_scope.index(),
+                worker_count: mz_scope.peers(),
+                now: storage_state.now.clone(),
+                metrics: storage_state.metrics.clone(),
+                as_of: as_of.clone(),
+                resume_uppers: resume_uppers.clone(),
+                source_resume_uppers,
+                storage_metadata: description.ingestion_metadata.clone(),
+                persist_clients: Arc::clone(&storage_state.persist_clients),
+                source_statistics: storage_state
+                    .aggregated_statistics
+                    .get_source(&primary_source_id)
+                    .expect("statistics initialized")
+                    .clone(),
+                shared_remap_upper: Rc::clone(
+                    &storage_state.source_uppers[&description.remap_collection_id],
+                ),
+                // This might quite a large clone, but its just during rendering
+                config: storage_state.storage_configuration.clone(),
+                remap_collection_id: description.remap_collection_id.clone(),
+            };
+
             let (mut outputs, source_health, source_tokens) = match connection {
                 GenericSourceConnection::Kafka(c) => crate::render::sources::render_source(
                     mz_scope,
@@ -264,11 +293,9 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     primary_source_id,
                     c,
                     description.clone(),
-                    as_of.clone(),
-                    resume_uppers.clone(),
-                    source_resume_uppers,
                     &feedback,
                     storage_state,
+                    base_source_config,
                 ),
                 GenericSourceConnection::Postgres(c) => crate::render::sources::render_source(
                     mz_scope,
@@ -276,11 +303,9 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     primary_source_id,
                     c,
                     description.clone(),
-                    as_of.clone(),
-                    resume_uppers.clone(),
-                    source_resume_uppers,
                     &feedback,
                     storage_state,
+                    base_source_config,
                 ),
                 GenericSourceConnection::MySql(c) => crate::render::sources::render_source(
                     mz_scope,
@@ -288,11 +313,9 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     primary_source_id,
                     c,
                     description.clone(),
-                    as_of.clone(),
-                    resume_uppers.clone(),
-                    source_resume_uppers,
                     &feedback,
                     storage_state,
+                    base_source_config,
                 ),
                 GenericSourceConnection::LoadGenerator(c) => crate::render::sources::render_source(
                     mz_scope,
@@ -300,11 +323,9 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     primary_source_id,
                     c,
                     description.clone(),
-                    as_of.clone(),
-                    resume_uppers.clone(),
-                    source_resume_uppers,
                     &feedback,
                     storage_state,
+                    base_source_config,
                 ),
             };
             tokens.extend(source_tokens);

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -98,6 +98,7 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use either::Either;
+use futures::StreamExt;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::HashMap;
 use mz_persist_client::batch::{Batch, ProtoBatch};

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -11,9 +11,7 @@
 //!
 //! See [`render_source`] for more details.
 
-use std::collections::BTreeMap;
 use std::iter;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use differential_dataflow::{collection, AsCollection, Collection};

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -66,11 +66,9 @@ pub fn render_source<'g, G, C>(
     id: GlobalId,
     connection: C,
     description: IngestionDescription<CollectionMetadata>,
-    as_of: Antichain<mz_repr::Timestamp>,
-    resume_uppers: BTreeMap<GlobalId, Antichain<mz_repr::Timestamp>>,
-    source_resume_uppers: BTreeMap<GlobalId, Vec<Row>>,
     resume_stream: &Stream<Child<'g, G, mz_repr::Timestamp>, ()>,
     storage_state: &crate::storage_state::StorageState,
+    base_source_config: RawSourceCreationConfig,
 ) -> (
     Vec<(
         Collection<Child<'g, G, mz_repr::Timestamp>, Row, Diff>,
@@ -91,35 +89,6 @@ where
     // source type does not support multiple instances. `render_source`
     // is called on each timely worker as part of
     // [`super::build_storage_dataflow`].
-
-    let source_name = format!("{}-{}", connection.name(), id);
-
-    let base_source_config = RawSourceCreationConfig {
-        name: source_name,
-        id,
-        source_exports: description.source_exports_with_output_indices(),
-        timestamp_interval: description.desc.timestamp_interval,
-        worker_id: scope.index(),
-        worker_count: scope.peers(),
-        now: storage_state.now.clone(),
-        metrics: storage_state.metrics.clone(),
-        as_of: as_of.clone(),
-        resume_uppers,
-        source_resume_uppers,
-        storage_metadata: description.ingestion_metadata.clone(),
-        persist_clients: Arc::clone(&storage_state.persist_clients),
-        source_statistics: storage_state
-            .aggregated_statistics
-            .get_source(&id)
-            .expect("statistics initialized")
-            .clone(),
-        shared_remap_upper: Rc::clone(
-            &storage_state.source_uppers[&description.remap_collection_id],
-        ),
-        // This might quite a large clone, but its just during rendering
-        config: storage_state.storage_configuration.clone(),
-        remap_collection_id: description.remap_collection_id.clone(),
-    };
 
     // A set of channels (1 per worker) used to signal rehydration being finished
     // to raw sources. These are channels and not timely streams because they

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -79,6 +79,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
 use differential_dataflow::{AsCollection, Collection, Hashable};
+use futures::StreamExt;
 use maplit::btreemap;
 use mz_interchange::avro::AvroEncoder;
 use mz_interchange::encode::Encode;

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::convert::Infallible;
+use std::sync::Arc;
 use std::time::Duration;
 
 use differential_dataflow::AsCollection;
@@ -25,7 +26,9 @@ use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
-use crate::source::types::{ProgressStatisticsUpdate, SourceRender, StackedCollection};
+use crate::source::types::{
+    ProgressStatisticsUpdate, SignaledFuture, SourceRender, StackedCollection,
+};
 use crate::source::{RawSourceCreationConfig, SourceMessage};
 
 mod auction;
@@ -212,144 +215,147 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
     let (mut data_output, stream) = builder.new_output::<AccountedStackBuilder<_>>();
     let (mut stats_output, stats_stream) = builder.new_output();
 
-    let button = builder.build(move |caps| async move {
-        // Do not run the load generator until we have all of our source
-        // exports. Waiting here is fine because we know that their creation and
-        // scheduling of this dataflow is imminent.
-        //
-        // TODO(#26765): can this limitation be removed?
-        if required_exports != config.source_exports.len() {
-            std::future::pending().await
-        }
+    let busy_signal = Arc::clone(&config.busy_signal);
+    let button = builder.build(move |caps| {
+        SignaledFuture::new(busy_signal, async move {
+            // Do not run the load generator until we have all of our source
+            // exports. Waiting here is fine because we know that their creation and
+            // scheduling of this dataflow is imminent.
+            //
+            // TODO(#26765): can this limitation be removed?
+            if required_exports != config.source_exports.len() {
+                std::future::pending().await
+            }
 
-        let [mut cap, stats_cap]: [_; 2] = caps.try_into().unwrap();
+            let [mut cap, stats_cap]: [_; 2] = caps.try_into().unwrap();
 
-        if !config.responsible_for(()) {
-            // Emit 0, to mark this worker as having started up correctly.
-            stats_output.give(
-                &stats_cap,
-                ProgressStatisticsUpdate::SteadyState {
-                    offset_known: 0,
-                    offset_committed: 0,
-                },
+            if !config.responsible_for(()) {
+                // Emit 0, to mark this worker as having started up correctly.
+                stats_output.give(
+                    &stats_cap,
+                    ProgressStatisticsUpdate::SteadyState {
+                        offset_known: 0,
+                        offset_committed: 0,
+                    },
+                );
+                return;
+            }
+
+            let resume_upper = Antichain::from_iter(
+                config.source_resume_uppers[&config.id]
+                    .iter()
+                    .map(MzOffset::decode_row),
             );
-            return;
-        }
 
-        let resume_upper = Antichain::from_iter(
-            config.source_resume_uppers[&config.id]
-                .iter()
-                .map(MzOffset::decode_row),
-        );
+            let Some(resume_offset) = resume_upper.into_option() else {
+                return;
+            };
 
-        let Some(resume_offset) = resume_upper.into_option() else {
-            return;
-        };
+            let mut rows = generator.by_seed(mz_ore::now::SYSTEM_TIME.clone(), None, resume_offset);
 
-        let mut rows = generator.by_seed(mz_ore::now::SYSTEM_TIME.clone(), None, resume_offset);
+            let tick = Duration::from_micros(tick_micros.unwrap_or(1_000_000));
 
-        let tick = Duration::from_micros(tick_micros.unwrap_or(1_000_000));
+            let mut committed_uppers = std::pin::pin!(committed_uppers);
 
-        let mut committed_uppers = std::pin::pin!(committed_uppers);
+            // If we are just starting up, report 0 as our `offset_committed`.
+            let mut offset_committed = if resume_offset.offset == 0 {
+                Some(0)
+            } else {
+                None
+            };
 
-        // If we are just starting up, report 0 as our `offset_committed`.
-        let mut offset_committed = if resume_offset.offset == 0 {
-            Some(0)
-        } else {
-            None
-        };
+            while let Some((output, event)) = rows.next() {
+                match event {
+                    Event::Message(mut offset, (value, diff)) => {
+                        // Fast forward any data before the requested as of.
+                        if offset <= as_of {
+                            offset = as_of;
+                        }
 
-        while let Some((output, event)) = rows.next() {
-            match event {
-                Event::Message(mut offset, (value, diff)) => {
-                    // Fast forward any data before the requested as of.
-                    if offset <= as_of {
-                        offset = as_of;
+                        // If the load generator produces data at or beyond the
+                        // requested `up_to`, drop it. We'll terminate the load
+                        // generator when the capability advances to the `up_to`,
+                        // but the load generator might produce data far in advance
+                        // of its capability.
+                        if offset >= up_to {
+                            continue;
+                        }
+
+                        let message = (
+                            output,
+                            Ok(SourceMessage {
+                                key: Row::default(),
+                                value,
+                                metadata: Row::default(),
+                            }),
+                        );
+
+                        // Some generators always reproduce their TVC from the beginning which can
+                        // generate a significant amount of data that will overwhelm the dataflow.
+                        // Since those are not required downstream we eagerly ignore them here.
+                        if resume_offset <= offset {
+                            data_output.give_fueled(&cap, (message, offset, diff)).await;
+                        }
                     }
+                    Event::Progress(Some(offset)) => {
+                        // If we've reached the requested maximum offset, cease.
+                        if offset >= up_to {
+                            break;
+                        }
 
-                    // If the load generator produces data at or beyond the
-                    // requested `up_to`, drop it. We'll terminate the load
-                    // generator when the capability advances to the `up_to`,
-                    // but the load generator might produce data far in advance
-                    // of its capability.
-                    if offset >= up_to {
-                        continue;
-                    }
+                        // If the offset is at or below the requested `as_of`, don't
+                        // downgrade the capability.
+                        if offset <= as_of {
+                            continue;
+                        }
 
-                    let message = (
-                        output,
-                        Ok(SourceMessage {
-                            key: Row::default(),
-                            value,
-                            metadata: Row::default(),
-                        }),
-                    );
+                        cap.downgrade(&offset);
 
-                    // Some generators always reproduce their TVC from the beginning which can
-                    // generate a significant amount of data that will overwhelm the dataflow.
-                    // Since those are not required downstream we eagerly ignore them here.
-                    if resume_offset <= offset {
-                        data_output.give_fueled(&cap, (message, offset, diff)).await;
-                    }
-                }
-                Event::Progress(Some(offset)) => {
-                    // If we've reached the requested maximum offset, cease.
-                    if offset >= up_to {
-                        break;
-                    }
+                        // We only sleep if we have surpassed the resume offset so that we can
+                        // quickly go over any historical updates that a generator might choose to
+                        // emit.
+                        // TODO(petrosagg): Remove the sleep below and make generators return an
+                        // async stream so that they can drive the rate of production directly
+                        if resume_offset < offset {
+                            let mut sleep = std::pin::pin!(tokio::time::sleep(tick));
 
-                    // If the offset is at or below the requested `as_of`, don't
-                    // downgrade the capability.
-                    if offset <= as_of {
-                        continue;
-                    }
-
-                    cap.downgrade(&offset);
-
-                    // We only sleep if we have surpassed the resume offset so that we can
-                    // quickly go over any historical updates that a generator might choose to
-                    // emit.
-                    // TODO(petrosagg): Remove the sleep below and make generators return an
-                    // async stream so that they can drive the rate of production directly
-                    if resume_offset < offset {
-                        let mut sleep = std::pin::pin!(tokio::time::sleep(tick));
-
-                        loop {
-                            tokio::select! {
-                                _ = &mut sleep => {
-                                    break;
-                                }
-                                Some(frontier) = committed_uppers.next() => {
-                                    if let Some(offset) = frontier.as_option() {
-                                        // Offset N means we have committed N offsets (offsets are
-                                        // 0-indexed)
-                                        offset_committed = Some(offset.offset);
+                            loop {
+                                tokio::select! {
+                                    _ = &mut sleep => {
+                                        break;
+                                    }
+                                    Some(frontier) = committed_uppers.next() => {
+                                        if let Some(offset) = frontier.as_option() {
+                                            // Offset N means we have committed N offsets (offsets are
+                                            // 0-indexed)
+                                            offset_committed = Some(offset.offset);
+                                        }
                                     }
                                 }
                             }
-                        }
 
-                        // TODO(guswynn): generators have various definitions of "snapshot", so
-                        // we are not going to implement snapshot progress statistics for them
-                        // right now, but will come back to it.
-                        if let Some(offset_committed) = offset_committed {
-                            stats_output.give(
-                                &stats_cap,
-                                ProgressStatisticsUpdate::SteadyState {
-                                    // technically we could have _known_ a larger offset
-                                    // than the one that has been committed, but we can
-                                    // never recover that known amount on restart, so we
-                                    // just advance these in lock step.
-                                    offset_known: offset_committed,
-                                    offset_committed,
-                                },
-                            );
+                            // TODO(guswynn): generators have various definitions of "snapshot", so
+                            // we are not going to implement snapshot progress statistics for them
+                            // right now, but will come back to it.
+                            if let Some(offset_committed) = offset_committed {
+                                stats_output.give(
+                                    &stats_cap,
+                                    ProgressStatisticsUpdate::SteadyState {
+                                        // technically we could have _known_ a larger offset
+                                        // than the one that has been committed, but we can
+                                        // never recover that known amount on restart, so we
+                                        // just advance these in lock step.
+                                        offset_known: offset_committed,
+                                        offset_committed,
+                                    },
+                                );
+                            }
                         }
                     }
+                    Event::Progress(None) => return,
                 }
-                Event::Progress(None) => return,
             }
-        }
+        })
     });
 
     let status = [HealthStatusMessage {

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -57,7 +57,9 @@ use tracing::{error, info, trace};
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::metrics::source::kafka::KafkaSourceMetrics;
-use crate::source::types::{ProgressStatisticsUpdate, SourceRender, StackedCollection};
+use crate::source::types::{
+    ProgressStatisticsUpdate, SignaledFuture, SourceRender, StackedCollection,
+};
 use crate::source::{RawSourceCreationConfig, SourceMessage};
 
 #[derive(Default)]
@@ -183,541 +185,482 @@ impl SourceRender for KafkaSourceConnection {
         let (mut health_output, health_stream) = builder.new_output();
         let (mut stats_output, stats_stream) = builder.new_output();
 
-        let button = builder.build(move |caps| async move {
-            let [mut data_cap, mut progress_cap, health_cap, stats_cap]: [_; 4] =
-                caps.try_into().unwrap();
+        let busy_signal = Arc::clone(&config.busy_signal);
+        let button = builder.build(move |caps| {
+            SignaledFuture::new(busy_signal, async move {
+                let [mut data_cap, mut progress_cap, health_cap, stats_cap]: [_; 4] =
+                    caps.try_into().unwrap();
 
-            let client_id = self.client_id(
-                config.config.config_set(),
-                &config.config.connection_context,
-                config.id,
-            );
-            let group_id = self.group_id(&config.config.connection_context, config.id);
-            let KafkaSourceConnection {
-                connection,
-                topic,
-                topic_metadata_refresh_interval,
-                start_offsets,
-                metadata_columns,
-                // Exhaustive match protects against forgetting to apply an
-                // option. Ignored fields are justified below.
-                connection_id: _,   // not needed here
-                group_id_prefix: _, // used above via `self.group_id`
-            } = self;
+                let client_id = self.client_id(
+                    config.config.config_set(),
+                    &config.config.connection_context,
+                    config.id,
+                );
+                let group_id = self.group_id(&config.config.connection_context, config.id);
+                let KafkaSourceConnection {
+                    connection,
+                    topic,
+                    topic_metadata_refresh_interval,
+                    start_offsets,
+                    metadata_columns,
+                    // Exhaustive match protects against forgetting to apply an
+                    // option. Ignored fields are justified below.
+                    connection_id: _,   // not needed here
+                    group_id_prefix: _, // used above via `self.group_id`
+                } = self;
 
-            // Start offsets is a map from partition to the next offset to read from.
-            let mut start_offsets: BTreeMap<_, i64> = start_offsets
-                .clone()
-                .into_iter()
-                .filter(|(pid, _offset)| responsible_for_pid(&config, *pid))
-                .map(|(k, v)| (k, v))
-                .collect();
+                // Start offsets is a map from partition to the next offset to read from.
+                let mut start_offsets: BTreeMap<_, i64> = start_offsets
+                    .clone()
+                    .into_iter()
+                    .filter(|(pid, _offset)| responsible_for_pid(&config, *pid))
+                    .map(|(k, v)| (k, v))
+                    .collect();
 
-            let mut partition_capabilities = BTreeMap::new();
-            let mut max_pid = None;
-            let resume_upper = Antichain::from_iter(
-                config.source_resume_uppers[&config.id]
-                    .iter()
-                    .map(Partitioned::<RangeBound<PartitionId>, MzOffset>::decode_row),
-            );
-
-            // Whether or not this instance of the dataflow is performing a snapshot.
-            let mut is_snapshotting = &*resume_upper == &[Partitioned::minimum()];
-
-            for ts in resume_upper.elements() {
-                if let Some(pid) = ts.interval().singleton() {
-                    let pid = pid.unwrap_exact();
-                    max_pid = std::cmp::max(max_pid, Some(*pid));
-                    if responsible_for_pid(&config, *pid) {
-                        let restored_offset = i64::try_from(ts.timestamp().offset)
-                            .expect("restored kafka offsets must fit into i64");
-                        if let Some(start_offset) = start_offsets.get_mut(pid) {
-                            *start_offset = std::cmp::max(restored_offset, *start_offset);
-                        } else {
-                            start_offsets.insert(*pid, restored_offset);
-                        }
-
-                        let part_ts = Partitioned::new_singleton(
-                            RangeBound::exact(*pid),
-                            ts.timestamp().clone(),
-                        );
-                        let part_cap = PartitionCapability {
-                            data: data_cap.delayed(&part_ts),
-                            progress: progress_cap.delayed(&part_ts),
-                        };
-                        partition_capabilities.insert(*pid, part_cap);
-                    }
-                }
-            }
-            let lower = max_pid
-                .map(RangeBound::after)
-                .unwrap_or(RangeBound::NegInfinity);
-            let future_ts =
-                Partitioned::new_range(lower, RangeBound::PosInfinity, MzOffset::from(0));
-            data_cap.downgrade(&future_ts);
-            progress_cap.downgrade(&future_ts);
-
-            info!(
-                source_id = config.id.to_string(),
-                worker_id = config.worker_id,
-                num_workers = config.worker_count,
-                "instantiating Kafka source reader at offsets {start_offsets:?}"
-            );
-
-            let (stats_tx, stats_rx) = crossbeam_channel::unbounded();
-            let health_status = Arc::new(Mutex::new(Default::default()));
-            let notificator = Arc::new(Notify::new());
-            let consumer: Result<BaseConsumer<_>, _> = connection
-                .create_with_context(
-                    &config.config,
-                    GlueConsumerContext {
-                        notificator: Arc::clone(&notificator),
-                        stats_tx,
-                        inner: MzClientContext::default(),
-                    },
-                    &btreemap! {
-                        // Disable Kafka auto commit. We manually commit offsets
-                        // to Kafka once we have reclocked those offsets, so
-                        // that users can use standard Kafka tools for progress
-                        // tracking.
-                        "enable.auto.commit" => "false".into(),
-                        // Always begin ingest at 0 when restarted, even if Kafka
-                        // contains committed consumer read offsets
-                        "auto.offset.reset" => "earliest".into(),
-                        // Use the user-configured topic metadata refresh
-                        // interval.
-                        "topic.metadata.refresh.interval.ms" =>
-                            topic_metadata_refresh_interval
-                            .as_millis()
-                            .to_string(),
-                        // TODO: document the rationale for this.
-                        "fetch.message.max.bytes" => "134217728".into(),
-                        // Consumer group ID, which may have been overridden by
-                        // the user. librdkafka requires this, and we use offset
-                        // committing to provide a way for users to monitor
-                        // ingest progress, though we do not rely on the
-                        // committed offsets for any functionality.
-                        "group.id" => group_id.clone(),
-                        // Allow Kafka monitoring tools to identify this
-                        // consumer.
-                        "client.id" => client_id.clone(),
-                    },
-                    InTask::Yes,
-                )
-                .await;
-
-            let consumer = match consumer {
-                Ok(consumer) => Arc::new(consumer),
-                Err(e) => {
-                    let update = HealthStatusUpdate::halting(
-                        format!(
-                            "failed creating kafka consumer: {}",
-                            e.display_with_causes()
-                        ),
-                        None,
-                    );
-                    health_output.give(
-                        &health_cap,
-                        HealthStatusMessage {
-                            index: 0,
-                            namespace: if matches!(e, ContextCreationError::Ssh(_)) {
-                                StatusNamespace::Ssh
-                            } else {
-                                Self::STATUS_NAMESPACE.clone()
-                            },
-                            update,
-                        },
-                    );
-                    // IMPORTANT: wedge forever until the `SuspendAndRestart` is processed.
-                    // Returning would incorrectly present to the remap operator as progress to the
-                    // empty frontier which would be incorrectly recorded to the remap shard.
-                    std::future::pending::<()>().await;
-                    unreachable!("pending future never returns");
-                }
-            };
-
-            // Note that we wait for this AFTER we downgrade to the source `resume_upper`. This
-            // allows downstream operators (namely, the `reclock_operator`) to downgrade to the
-            // `resume_upper`, which is necessary for this basic form of backpressure to work.
-            start_signal.await;
-            info!(
-                source_id = config.id.to_string(),
-                worker_id = config.worker_id,
-                num_workers = config.worker_count,
-                "kafka worker noticed rehydration is finished, starting partition queues..."
-            );
-
-            let partition_info = Arc::new(Mutex::new(None));
-            let metadata_thread_handle = {
-                let partition_info = Arc::downgrade(&partition_info);
-                let topic = topic.clone();
-                let consumer = Arc::clone(&consumer);
-
-                // We want a fairly low ceiling on our polling frequency, since we rely
-                // on this heartbeat to determine the health of our Kafka connection.
-                let poll_interval = topic_metadata_refresh_interval.min(
-                    config
-                        .config
-                        .parameters
-                        .kafka_timeout_config
-                        .default_metadata_fetch_interval,
+                let mut partition_capabilities = BTreeMap::new();
+                let mut max_pid = None;
+                let resume_upper = Antichain::from_iter(
+                    config.source_resume_uppers[&config.id]
+                        .iter()
+                        .map(Partitioned::<RangeBound<PartitionId>, MzOffset>::decode_row),
                 );
 
-                let status_report = Arc::clone(&health_status);
+                // Whether or not this instance of the dataflow is performing a snapshot.
+                let mut is_snapshotting = &*resume_upper == &[Partitioned::minimum()];
 
-                thread::Builder::new()
-                    .name("kafka-metadata".to_string())
-                    .spawn(move || {
-                        trace!(
-                            source_id = config.id.to_string(),
-                            worker_id = config.worker_id,
-                            num_workers = config.worker_count,
-                            poll_interval =? poll_interval,
-                            "kafka metadata thread: starting..."
-                        );
-                        while let Some(partition_info) = partition_info.upgrade() {
-                            let result = fetch_partition_info(
-                                consumer.client(),
-                                &topic,
-                                config
-                                    .config
-                                    .parameters
-                                    .kafka_timeout_config
-                                    .fetch_metadata_timeout,
+                for ts in resume_upper.elements() {
+                    if let Some(pid) = ts.interval().singleton() {
+                        let pid = pid.unwrap_exact();
+                        max_pid = std::cmp::max(max_pid, Some(*pid));
+                        if responsible_for_pid(&config, *pid) {
+                            let restored_offset = i64::try_from(ts.timestamp().offset)
+                                .expect("restored kafka offsets must fit into i64");
+                            if let Some(start_offset) = start_offsets.get_mut(pid) {
+                                *start_offset = std::cmp::max(restored_offset, *start_offset);
+                            } else {
+                                start_offsets.insert(*pid, restored_offset);
+                            }
+
+                            let part_ts = Partitioned::new_singleton(
+                                RangeBound::exact(*pid),
+                                ts.timestamp().clone(),
                             );
+                            let part_cap = PartitionCapability {
+                                data: data_cap.delayed(&part_ts),
+                                progress: progress_cap.delayed(&part_ts),
+                            };
+                            partition_capabilities.insert(*pid, part_cap);
+                        }
+                    }
+                }
+                let lower = max_pid
+                    .map(RangeBound::after)
+                    .unwrap_or(RangeBound::NegInfinity);
+                let future_ts =
+                    Partitioned::new_range(lower, RangeBound::PosInfinity, MzOffset::from(0));
+                data_cap.downgrade(&future_ts);
+                progress_cap.downgrade(&future_ts);
+
+                info!(
+                    source_id = config.id.to_string(),
+                    worker_id = config.worker_id,
+                    num_workers = config.worker_count,
+                    "instantiating Kafka source reader at offsets {start_offsets:?}"
+                );
+
+                let (stats_tx, stats_rx) = crossbeam_channel::unbounded();
+                let health_status = Arc::new(Mutex::new(Default::default()));
+                let notificator = Arc::new(Notify::new());
+                let consumer: Result<BaseConsumer<_>, _> = connection
+                    .create_with_context(
+                        &config.config,
+                        GlueConsumerContext {
+                            notificator: Arc::clone(&notificator),
+                            stats_tx,
+                            inner: MzClientContext::default(),
+                        },
+                        &btreemap! {
+                            // Disable Kafka auto commit. We manually commit offsets
+                            // to Kafka once we have reclocked those offsets, so
+                            // that users can use standard Kafka tools for progress
+                            // tracking.
+                            "enable.auto.commit" => "false".into(),
+                            // Always begin ingest at 0 when restarted, even if Kafka
+                            // contains committed consumer read offsets
+                            "auto.offset.reset" => "earliest".into(),
+                            // Use the user-configured topic metadata refresh
+                            // interval.
+                            "topic.metadata.refresh.interval.ms" =>
+                                topic_metadata_refresh_interval
+                                .as_millis()
+                                .to_string(),
+                            // TODO: document the rationale for this.
+                            "fetch.message.max.bytes" => "134217728".into(),
+                            // Consumer group ID, which may have been overridden by
+                            // the user. librdkafka requires this, and we use offset
+                            // committing to provide a way for users to monitor
+                            // ingest progress, though we do not rely on the
+                            // committed offsets for any functionality.
+                            "group.id" => group_id.clone(),
+                            // Allow Kafka monitoring tools to identify this
+                            // consumer.
+                            "client.id" => client_id.clone(),
+                        },
+                        InTask::Yes,
+                    )
+                    .await;
+
+                let consumer = match consumer {
+                    Ok(consumer) => Arc::new(consumer),
+                    Err(e) => {
+                        let update = HealthStatusUpdate::halting(
+                            format!(
+                                "failed creating kafka consumer: {}",
+                                e.display_with_causes()
+                            ),
+                            None,
+                        );
+                        health_output.give(
+                            &health_cap,
+                            HealthStatusMessage {
+                                index: 0,
+                                namespace: if matches!(e, ContextCreationError::Ssh(_)) {
+                                    StatusNamespace::Ssh
+                                } else {
+                                    Self::STATUS_NAMESPACE.clone()
+                                },
+                                update,
+                            },
+                        );
+                        // IMPORTANT: wedge forever until the `SuspendAndRestart` is processed.
+                        // Returning would incorrectly present to the remap operator as progress to the
+                        // empty frontier which would be incorrectly recorded to the remap shard.
+                        std::future::pending::<()>().await;
+                        unreachable!("pending future never returns");
+                    }
+                };
+
+                // Note that we wait for this AFTER we downgrade to the source `resume_upper`. This
+                // allows downstream operators (namely, the `reclock_operator`) to downgrade to the
+                // `resume_upper`, which is necessary for this basic form of backpressure to work.
+                start_signal.await;
+                info!(
+                    source_id = config.id.to_string(),
+                    worker_id = config.worker_id,
+                    num_workers = config.worker_count,
+                    "kafka worker noticed rehydration is finished, starting partition queues..."
+                );
+
+                let partition_info = Arc::new(Mutex::new(None));
+                let metadata_thread_handle = {
+                    let partition_info = Arc::downgrade(&partition_info);
+                    let topic = topic.clone();
+                    let consumer = Arc::clone(&consumer);
+
+                    // We want a fairly low ceiling on our polling frequency, since we rely
+                    // on this heartbeat to determine the health of our Kafka connection.
+                    let poll_interval = topic_metadata_refresh_interval.min(
+                        config
+                            .config
+                            .parameters
+                            .kafka_timeout_config
+                            .default_metadata_fetch_interval,
+                    );
+
+                    let status_report = Arc::clone(&health_status);
+
+                    thread::Builder::new()
+                        .name("kafka-metadata".to_string())
+                        .spawn(move || {
                             trace!(
                                 source_id = config.id.to_string(),
                                 worker_id = config.worker_id,
                                 num_workers = config.worker_count,
-                                "kafka metadata thread: metadata fetch result: {:?}",
-                                result
+                                poll_interval =? poll_interval,
+                                "kafka metadata thread: starting..."
                             );
-                            match result {
-                                Ok(info) => {
-                                    *partition_info.lock().unwrap() = Some(info);
-                                    trace!(
+                            while let Some(partition_info) = partition_info.upgrade() {
+                                let result = fetch_partition_info(
+                                    consumer.client(),
+                                    &topic,
+                                    config
+                                        .config
+                                        .parameters
+                                        .kafka_timeout_config
+                                        .fetch_metadata_timeout,
+                                );
+                                trace!(
+                                    source_id = config.id.to_string(),
+                                    worker_id = config.worker_id,
+                                    num_workers = config.worker_count,
+                                    "kafka metadata thread: metadata fetch result: {:?}",
+                                    result
+                                );
+                                match result {
+                                    Ok(info) => {
+                                        *partition_info.lock().unwrap() = Some(info);
+                                        trace!(
                                         source_id = config.id.to_string(),
                                         worker_id = config.worker_id,
                                         num_workers = config.worker_count,
                                         "kafka metadata thread: updated partition metadata info",
                                     );
 
-                                    // Clear all the health namespaces we know about.
-                                    // Note that many kafka sources's don't have an ssh tunnel, but
-                                    // the `health_operator` handles this fine.
-                                    *status_report.lock().unwrap() = HealthStatus {
-                                        kafka: Some(HealthStatusUpdate::running()),
-                                        ssh: Some(HealthStatusUpdate::running()),
-                                    };
-                                }
-                                Err(e) => {
-                                    let kafka_status = Some(HealthStatusUpdate::stalled(
-                                        format!("{}", e.display_with_causes()),
-                                        None,
-                                    ));
+                                        // Clear all the health namespaces we know about.
+                                        // Note that many kafka sources's don't have an ssh tunnel, but
+                                        // the `health_operator` handles this fine.
+                                        *status_report.lock().unwrap() = HealthStatus {
+                                            kafka: Some(HealthStatusUpdate::running()),
+                                            ssh: Some(HealthStatusUpdate::running()),
+                                        };
+                                    }
+                                    Err(e) => {
+                                        let kafka_status = Some(HealthStatusUpdate::stalled(
+                                            format!("{}", e.display_with_causes()),
+                                            None,
+                                        ));
 
-                                    let ssh_status = consumer.client().context().tunnel_status();
-                                    let ssh_status = match ssh_status {
-                                        SshTunnelStatus::Running => {
-                                            Some(HealthStatusUpdate::running())
-                                        }
-                                        SshTunnelStatus::Errored(e) => {
-                                            Some(HealthStatusUpdate::stalled(e, None))
-                                        }
-                                    };
+                                        let ssh_status =
+                                            consumer.client().context().tunnel_status();
+                                        let ssh_status = match ssh_status {
+                                            SshTunnelStatus::Running => {
+                                                Some(HealthStatusUpdate::running())
+                                            }
+                                            SshTunnelStatus::Errored(e) => {
+                                                Some(HealthStatusUpdate::stalled(e, None))
+                                            }
+                                        };
 
-                                    *status_report.lock().unwrap() = HealthStatus {
-                                        kafka: kafka_status,
-                                        ssh: ssh_status,
+                                        *status_report.lock().unwrap() = HealthStatus {
+                                            kafka: kafka_status,
+                                            ssh: ssh_status,
+                                        }
                                     }
                                 }
+                                thread::park_timeout(poll_interval);
                             }
-                            thread::park_timeout(poll_interval);
-                        }
-                        info!(
+                            info!(
                             source_id = config.id.to_string(),
                             worker_id = config.worker_id,
                             num_workers = config.worker_count,
                             "kafka metadata thread: partition info has been dropped; shutting down."
                         )
-                    })
-                    .unwrap()
-                    .unpark_on_drop()
-            };
-            let partition_ids = start_offsets.keys().copied().collect();
+                        })
+                        .unwrap()
+                        .unpark_on_drop()
+                };
+                let partition_ids = start_offsets.keys().copied().collect();
 
-            let offset_commit_metrics = config.metrics.get_offset_commit_metrics(config.id);
+                let offset_commit_metrics = config.metrics.get_offset_commit_metrics(config.id);
 
-            let mut reader = KafkaSourceReader {
-                topic_name: topic.clone(),
-                source_name: config.name.clone(),
-                id: config.id,
-                partition_consumers: Vec::new(),
-                consumer: Arc::clone(&consumer),
-                worker_id: config.worker_id,
-                worker_count: config.worker_count,
-                last_offsets: BTreeMap::new(),
-                start_offsets,
-                stats_rx,
-                progress_statistics: Default::default(),
-                partition_info,
-                metadata_columns: metadata_columns
-                    .into_iter()
-                    .map(|(_name, kind)| kind)
-                    .collect(),
-                _metadata_thread_handle: metadata_thread_handle,
-                partition_metrics: config.metrics.get_kafka_source_metrics(
-                    partition_ids,
-                    topic.clone(),
-                    config.id,
-                ),
-                health_status,
-                partition_capabilities,
-            };
-
-            let offset_committer = KafkaResumeUpperProcessor {
-                config: config.clone(),
-                topic_name: topic.clone(),
-                consumer,
-                progress_statistics: Arc::clone(&reader.progress_statistics),
-            };
-
-            // Seed the progress metrics with `0` if we are snapshotting.
-            if is_snapshotting {
-                if let Err(e) = offset_committer
-                    .process_frontier(resume_upper.clone())
-                    .await
-                {
-                    offset_commit_metrics.offset_commit_failures.inc();
-                    tracing::warn!(
-                        %e,
-                        "timely-{} source({}) failed to commit offsets: resume_upper={}",
+                let mut reader = KafkaSourceReader {
+                    topic_name: topic.clone(),
+                    source_name: config.name.clone(),
+                    id: config.id,
+                    partition_consumers: Vec::new(),
+                    consumer: Arc::clone(&consumer),
+                    worker_id: config.worker_id,
+                    worker_count: config.worker_count,
+                    last_offsets: BTreeMap::new(),
+                    start_offsets,
+                    stats_rx,
+                    progress_statistics: Default::default(),
+                    partition_info,
+                    metadata_columns: metadata_columns
+                        .into_iter()
+                        .map(|(_name, kind)| kind)
+                        .collect(),
+                    _metadata_thread_handle: metadata_thread_handle,
+                    partition_metrics: config.metrics.get_kafka_source_metrics(
+                        partition_ids,
+                        topic.clone(),
                         config.id,
-                        config.worker_id,
-                        resume_upper.pretty()
-                    );
-                }
-            }
+                    ),
+                    health_status,
+                    partition_capabilities,
+                };
 
-            let resume_uppers_process_loop = async move {
-                tokio::pin!(resume_uppers);
-                while let Some(frontier) = resume_uppers.next().await {
-                    if let Err(e) = offset_committer.process_frontier(frontier.clone()).await {
+                let offset_committer = KafkaResumeUpperProcessor {
+                    config: config.clone(),
+                    topic_name: topic.clone(),
+                    consumer,
+                    progress_statistics: Arc::clone(&reader.progress_statistics),
+                };
+
+                // Seed the progress metrics with `0` if we are snapshotting.
+                if is_snapshotting {
+                    if let Err(e) = offset_committer
+                        .process_frontier(resume_upper.clone())
+                        .await
+                    {
                         offset_commit_metrics.offset_commit_failures.inc();
                         tracing::warn!(
                             %e,
                             "timely-{} source({}) failed to commit offsets: resume_upper={}",
                             config.id,
                             config.worker_id,
-                            frontier.pretty()
+                            resume_upper.pretty()
                         );
                     }
                 }
-                // During dataflow shutdown this loop can end due to the general chaos caused by
-                // dropping tokens as a means to shutdown. This call ensures this future never ends
-                // and we instead rely on this operator being dropped altogether when *its* token
-                // is dropped.
-                std::future::pending::<()>().await;
-            };
-            tokio::pin!(resume_uppers_process_loop);
 
-            let mut prev_pid_info: Option<BTreeMap<PartitionId, WatermarkOffsets>> = None;
-            let mut snapshot_total = None;
+                let resume_uppers_process_loop = async move {
+                    tokio::pin!(resume_uppers);
+                    while let Some(frontier) = resume_uppers.next().await {
+                        if let Err(e) = offset_committer.process_frontier(frontier.clone()).await {
+                            offset_commit_metrics.offset_commit_failures.inc();
+                            tracing::warn!(
+                                %e,
+                                "timely-{} source({}) failed to commit offsets: resume_upper={}",
+                                config.id,
+                                config.worker_id,
+                                frontier.pretty()
+                            );
+                        }
+                    }
+                    // During dataflow shutdown this loop can end due to the general chaos caused by
+                    // dropping tokens as a means to shutdown. This call ensures this future never ends
+                    // and we instead rely on this operator being dropped altogether when *its* token
+                    // is dropped.
+                    std::future::pending::<()>().await;
+                };
+                tokio::pin!(resume_uppers_process_loop);
 
-            let max_wait_time =
-                mz_storage_types::dyncfgs::KAFKA_POLL_MAX_WAIT.get(config.config.config_set());
-            loop {
-                let partition_info = reader.partition_info.lock().unwrap().take();
-                if let Some(partitions) = partition_info {
-                    let max_pid = partitions.keys().last().cloned();
-                    let lower = max_pid
-                        .map(RangeBound::after)
-                        .unwrap_or(RangeBound::NegInfinity);
-                    let future_ts =
-                        Partitioned::new_range(lower, RangeBound::PosInfinity, MzOffset::from(0));
+                let mut prev_pid_info: Option<BTreeMap<PartitionId, WatermarkOffsets>> = None;
+                let mut snapshot_total = None;
 
-                    // Topics are identified by name but it's possible that a user recreates a
-                    // topic with the same name but different configuration. Ideally we'd want to
-                    // catch all of these cases and immediately error out the source, since the
-                    // data is effectively gone. Unfortunately this is not possible without
-                    // something like KIP-516 so we're left with heuristics.
-                    //
-                    // The first heuristic is whether the reported number of partitions went down
-                    if !PartialOrder::less_equal(data_cap.time(), &future_ts) {
-                        let prev_pid_count = prev_pid_info.map(|info| info.len()).unwrap_or(0);
-                        let pid_count = partitions.len();
-                        let err = DataflowError::SourceError(Box::new(SourceError {
-                            error: SourceErrorDetails::Other(format!(
-                                "topic was recreated: partition \
+                let max_wait_time =
+                    mz_storage_types::dyncfgs::KAFKA_POLL_MAX_WAIT.get(config.config.config_set());
+                loop {
+                    let partition_info = reader.partition_info.lock().unwrap().take();
+                    if let Some(partitions) = partition_info {
+                        let max_pid = partitions.keys().last().cloned();
+                        let lower = max_pid
+                            .map(RangeBound::after)
+                            .unwrap_or(RangeBound::NegInfinity);
+                        let future_ts = Partitioned::new_range(
+                            lower,
+                            RangeBound::PosInfinity,
+                            MzOffset::from(0),
+                        );
+
+                        // Topics are identified by name but it's possible that a user recreates a
+                        // topic with the same name but different configuration. Ideally we'd want to
+                        // catch all of these cases and immediately error out the source, since the
+                        // data is effectively gone. Unfortunately this is not possible without
+                        // something like KIP-516 so we're left with heuristics.
+                        //
+                        // The first heuristic is whether the reported number of partitions went down
+                        if !PartialOrder::less_equal(data_cap.time(), &future_ts) {
+                            let prev_pid_count = prev_pid_info.map(|info| info.len()).unwrap_or(0);
+                            let pid_count = partitions.len();
+                            let err = DataflowError::SourceError(Box::new(SourceError {
+                                error: SourceErrorDetails::Other(format!(
+                                    "topic was recreated: partition \
                                      count regressed from {prev_pid_count} to {pid_count}"
-                            )),
-                        }));
-                        let time = data_cap.time().clone();
-                        data_output
-                            .give_fueled(&data_cap, ((0, Err(err)), time, 1))
-                            .await;
-                        return;
-                    }
+                                )),
+                            }));
+                            let time = data_cap.time().clone();
+                            data_output
+                                .give_fueled(&data_cap, ((0, Err(err)), time, 1))
+                                .await;
+                            return;
+                        }
 
-                    // The second heuristic is whether the high watermark regressed
-                    if let Some(prev_pid_info) = prev_pid_info {
-                        for (pid, prev_watermarks) in prev_pid_info {
-                            let watermarks = &partitions[&pid];
-                            if !(prev_watermarks.high <= watermarks.high) {
-                                let err = DataflowError::SourceError(Box::new(SourceError {
-                                    error: SourceErrorDetails::Other(format!(
-                                        "topic was recreated: high watermark of \
+                        // The second heuristic is whether the high watermark regressed
+                        if let Some(prev_pid_info) = prev_pid_info {
+                            for (pid, prev_watermarks) in prev_pid_info {
+                                let watermarks = &partitions[&pid];
+                                if !(prev_watermarks.high <= watermarks.high) {
+                                    let err = DataflowError::SourceError(Box::new(SourceError {
+                                        error: SourceErrorDetails::Other(format!(
+                                            "topic was recreated: high watermark of \
                                         partition {pid} regressed from {} to {}",
-                                        prev_watermarks.high, watermarks.high
-                                    )),
-                                }));
-                                let time = data_cap.time().clone();
-                                data_output
-                                    .give_fueled(&data_cap, ((0, Err(err)), time, 1))
-                                    .await;
-                                return;
+                                            prev_watermarks.high, watermarks.high
+                                        )),
+                                    }));
+                                    let time = data_cap.time().clone();
+                                    data_output
+                                        .give_fueled(&data_cap, ((0, Err(err)), time, 1))
+                                        .await;
+                                    return;
+                                }
                             }
                         }
-                    }
 
-                    let mut upstream_stat = 0;
-                    for (&pid, watermarks) in &partitions {
-                        if responsible_for_pid(&config, pid) {
-                            upstream_stat += watermarks.high;
-                            reader.ensure_partition(pid);
-                            if let Entry::Vacant(entry) = reader.partition_capabilities.entry(pid) {
-                                let start_offset = match reader.start_offsets.get(&pid) {
-                                    Some(&offset) => offset.try_into().unwrap(),
-                                    None => 0u64,
-                                };
-                                let start_offset = std::cmp::max(start_offset, watermarks.low);
-                                let part_since_ts = Partitioned::new_singleton(
-                                    RangeBound::exact(pid),
-                                    MzOffset::from(start_offset),
-                                );
-                                let part_upper_ts = Partitioned::new_singleton(
-                                    RangeBound::exact(pid),
-                                    MzOffset::from(watermarks.high),
-                                );
+                        let mut upstream_stat = 0;
+                        for (&pid, watermarks) in &partitions {
+                            if responsible_for_pid(&config, pid) {
+                                upstream_stat += watermarks.high;
+                                reader.ensure_partition(pid);
+                                if let Entry::Vacant(entry) =
+                                    reader.partition_capabilities.entry(pid)
+                                {
+                                    let start_offset = match reader.start_offsets.get(&pid) {
+                                        Some(&offset) => offset.try_into().unwrap(),
+                                        None => 0u64,
+                                    };
+                                    let start_offset = std::cmp::max(start_offset, watermarks.low);
+                                    let part_since_ts = Partitioned::new_singleton(
+                                        RangeBound::exact(pid),
+                                        MzOffset::from(start_offset),
+                                    );
+                                    let part_upper_ts = Partitioned::new_singleton(
+                                        RangeBound::exact(pid),
+                                        MzOffset::from(watermarks.high),
+                                    );
 
-                                // This is the moment at which we have discovered a new partition
-                                // and we need to make sure we produce its initial snapshot at a,
-                                // single timestamp so that the source transitions from no data
-                                // from this partition to all the data of this partition. We do
-                                // this by initializing the data capability to the starting offset
-                                // and, importantly, the progress capability directly to the high
-                                // watermark. This jump of the progress capability ensures that
-                                // everything until the high watermark will be reclocked to a
-                                // single point.
-                                entry.insert(PartitionCapability {
-                                    data: data_cap.delayed(&part_since_ts),
-                                    progress: progress_cap.delayed(&part_upper_ts),
-                                });
+                                    // This is the moment at which we have discovered a new partition
+                                    // and we need to make sure we produce its initial snapshot at a,
+                                    // single timestamp so that the source transitions from no data
+                                    // from this partition to all the data of this partition. We do
+                                    // this by initializing the data capability to the starting offset
+                                    // and, importantly, the progress capability directly to the high
+                                    // watermark. This jump of the progress capability ensures that
+                                    // everything until the high watermark will be reclocked to a
+                                    // single point.
+                                    entry.insert(PartitionCapability {
+                                        data: data_cap.delayed(&part_since_ts),
+                                        progress: progress_cap.delayed(&part_upper_ts),
+                                    });
+                                }
                             }
                         }
+
+                        // If we are snapshotting, record our first set of partitions as the snapshot
+                        // size.
+                        if is_snapshotting && snapshot_total.is_none() {
+                            // Note that we want to represent the _number of offsets_, which
+                            // means the watermark's frontier semantics is correct, without
+                            // subtracting (Kafka offsets start at 0).
+                            snapshot_total = Some(upstream_stat);
+                        }
+
+                        reader
+                            .progress_statistics
+                            .lock()
+                            .expect("poisoned")
+                            .offset_known = Some(upstream_stat);
+                        data_cap.downgrade(&future_ts);
+                        progress_cap.downgrade(&future_ts);
+                        prev_pid_info = Some(partitions);
                     }
 
-                    // If we are snapshotting, record our first set of partitions as the snapshot
-                    // size.
-                    if is_snapshotting && snapshot_total.is_none() {
-                        // Note that we want to represent the _number of offsets_, which
-                        // means the watermark's frontier semantics is correct, without
-                        // subtracting (Kafka offsets start at 0).
-                        snapshot_total = Some(upstream_stat);
-                    }
-
-                    reader
-                        .progress_statistics
-                        .lock()
-                        .expect("poisoned")
-                        .offset_known = Some(upstream_stat);
-                    data_cap.downgrade(&future_ts);
-                    progress_cap.downgrade(&future_ts);
-                    prev_pid_info = Some(partitions);
-                }
-
-                // Poll the consumer once. We split the consumer's partitions out into separate
-                // queues and poll those individually, but it's still necessary to drive logic that
-                // consumes from rdkafka's internal event queue, such as statistics callbacks.
-                //
-                // Additionally, assigning topics and splitting them off into separate queues is
-                // not atomic, so we expect to see at least some messages to show up when polling
-                // the consumer directly.
-                while let Some(result) = reader.consumer.poll(Duration::from_secs(0)) {
-                    match result {
-                        Err(e) => {
-                            let error = format!(
+                    // Poll the consumer once. We split the consumer's partitions out into separate
+                    // queues and poll those individually, but it's still necessary to drive logic that
+                    // consumes from rdkafka's internal event queue, such as statistics callbacks.
+                    //
+                    // Additionally, assigning topics and splitting them off into separate queues is
+                    // not atomic, so we expect to see at least some messages to show up when polling
+                    // the consumer directly.
+                    while let Some(result) = reader.consumer.poll(Duration::from_secs(0)) {
+                        match result {
+                            Err(e) => {
+                                let error = format!(
                                 "kafka error when polling consumer for source: {} topic: {} : {}",
                                 reader.source_name, reader.topic_name, e
                             );
-                            let status = HealthStatusUpdate::stalled(error, None);
-                            health_output.give(
-                                &health_cap,
-                                HealthStatusMessage {
-                                    index: 0,
-                                    namespace: Self::STATUS_NAMESPACE.clone(),
-                                    update: status,
-                                },
-                            );
-                        }
-                        Ok(message) => {
-                            let (message, ts) =
-                                construct_source_message(&message, &reader.metadata_columns);
-                            if let Some((msg, time, diff)) = reader.handle_message(message, ts) {
-                                let pid = time.interval().singleton().unwrap().unwrap_exact();
-                                let part_cap = &reader.partition_capabilities[pid].data;
-                                let msg = msg.map_err(|e| {
-                                    DataflowError::SourceError(Box::new(SourceError {
-                                        error: SourceErrorDetails::Other(format!("{}", e)),
-                                    }))
-                                });
-                                data_output
-                                    .give_fueled(part_cap, ((0, msg), time, diff))
-                                    .await;
-                            }
-                        }
-                    }
-                }
-
-                reader.update_stats();
-
-                // Take the consumers temporarily to get around borrow checker errors
-                let mut consumers = std::mem::take(&mut reader.partition_consumers);
-                for consumer in consumers.iter_mut() {
-                    while let Some(message) = consumer.get_next_message().transpose() {
-                        let message = match message {
-                            Ok((msg, ts)) => Ok(reader.handle_message(msg, ts)),
-                            Err(err) => Err(err),
-                        };
-                        match message {
-                            Ok(Some((msg, time, diff))) => {
-                                let pid = time.interval().singleton().unwrap().unwrap_exact();
-                                let part_cap = &reader.partition_capabilities[pid].data;
-                                let msg = msg.map_err(|e| {
-                                    DataflowError::SourceError(Box::new(SourceError {
-                                        error: SourceErrorDetails::Other(format!("{}", e)),
-                                    }))
-                                });
-                                data_output
-                                    .give_fueled(part_cap, ((0, msg), time, diff))
-                                    .await;
-                            }
-                            Ok(None) => continue,
-                            Err(err) => {
-                                let pid = consumer.pid();
-                                let last_offset = reader
-                                    .last_offsets
-                                    .get(&pid)
-                                    .expect("partition known to be installed");
-
-                                let status = HealthStatusUpdate::stalled(
-                                    format!(
-                                        "error consuming from source: {} topic: {topic}: partition:\
-                                        {pid} last processed offset: {last_offset} : {err}",
-                                        config.name
-                                    ),
-                                    None,
-                                );
+                                let status = HealthStatusUpdate::stalled(error, None);
                                 health_output.give(
                                     &health_cap,
                                     HealthStatusMessage {
@@ -727,124 +670,194 @@ impl SourceRender for KafkaSourceConnection {
                                     },
                                 );
                             }
-                        }
-                    }
-                }
-                // We can now put them back
-                assert!(reader.partition_consumers.is_empty());
-                reader.partition_consumers = consumers;
-
-                let positions = reader.consumer.position().unwrap();
-                let topic_positions = positions.elements_for_topic(&reader.topic_name);
-                let mut snapshot_staged = 0;
-
-                for position in topic_positions {
-                    // The offset begins in the `Offset::Invalid` state in which case we simply
-                    // skip this partition.
-                    if let Offset::Offset(offset) = position.offset() {
-                        let pid = position.partition();
-                        let upper_offset = MzOffset::from(u64::try_from(offset).unwrap());
-                        let upper =
-                            Partitioned::new_singleton(RangeBound::exact(pid), upper_offset);
-
-                        let part_cap = reader.partition_capabilities.get_mut(&pid).unwrap();
-                        part_cap.data.downgrade(&upper);
-
-                        if is_snapshotting {
-                            // The `.position()` of the consumer represents what offset we have
-                            // read up to.
-                            snapshot_staged += offset.try_into().unwrap_or(0u64);
-                            // This will always be `Some` at this point.
-                            if let Some(snapshot_total) = snapshot_total {
-                                // We will eventually read past the snapshot total, so we need
-                                // to bound it here.
-                                snapshot_staged = std::cmp::min(snapshot_staged, snapshot_total);
+                            Ok(message) => {
+                                let (message, ts) =
+                                    construct_source_message(&message, &reader.metadata_columns);
+                                if let Some((msg, time, diff)) = reader.handle_message(message, ts)
+                                {
+                                    let pid = time.interval().singleton().unwrap().unwrap_exact();
+                                    let part_cap = &reader.partition_capabilities[pid].data;
+                                    let msg = msg.map_err(|e| {
+                                        DataflowError::SourceError(Box::new(SourceError {
+                                            error: SourceErrorDetails::Other(format!("{}", e)),
+                                        }))
+                                    });
+                                    data_output
+                                        .give_fueled(part_cap, ((0, msg), time, diff))
+                                        .await;
+                                }
                             }
                         }
+                    }
 
-                        // We use try_downgrade here because during the initial snapshot phase the
-                        // data capability is not beyond the progress capability and therefore a
-                        // normal downgrade would panic. Once it catches up though the data
-                        // capbility is what's pushing the progress capability forward.
-                        let _ = part_cap.progress.try_downgrade(&upper);
+                    reader.update_stats();
+
+                    // Take the consumers temporarily to get around borrow checker errors
+                    let mut consumers = std::mem::take(&mut reader.partition_consumers);
+                    for consumer in consumers.iter_mut() {
+                        while let Some(message) = consumer.get_next_message().transpose() {
+                            let message = match message {
+                                Ok((msg, ts)) => Ok(reader.handle_message(msg, ts)),
+                                Err(err) => Err(err),
+                            };
+                            match message {
+                                Ok(Some((msg, time, diff))) => {
+                                    let pid = time.interval().singleton().unwrap().unwrap_exact();
+                                    let part_cap = &reader.partition_capabilities[pid].data;
+                                    let msg = msg.map_err(|e| {
+                                        DataflowError::SourceError(Box::new(SourceError {
+                                            error: SourceErrorDetails::Other(format!("{}", e)),
+                                        }))
+                                    });
+                                    data_output
+                                        .give_fueled(part_cap, ((0, msg), time, diff))
+                                        .await;
+                                }
+                                Ok(None) => continue,
+                                Err(err) => {
+                                    let pid = consumer.pid();
+                                    let last_offset = reader
+                                        .last_offsets
+                                        .get(&pid)
+                                        .expect("partition known to be installed");
+
+                                    let status = HealthStatusUpdate::stalled(
+                                        format!(
+                                        "error consuming from source: {} topic: {topic}: partition:\
+                                        {pid} last processed offset: {last_offset} : {err}",
+                                        config.name
+                                    ),
+                                        None,
+                                    );
+                                    health_output.give(
+                                        &health_cap,
+                                        HealthStatusMessage {
+                                            index: 0,
+                                            namespace: Self::STATUS_NAMESPACE.clone(),
+                                            update: status,
+                                        },
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    // We can now put them back
+                    assert!(reader.partition_consumers.is_empty());
+                    reader.partition_consumers = consumers;
+
+                    let positions = reader.consumer.position().unwrap();
+                    let topic_positions = positions.elements_for_topic(&reader.topic_name);
+                    let mut snapshot_staged = 0;
+
+                    for position in topic_positions {
+                        // The offset begins in the `Offset::Invalid` state in which case we simply
+                        // skip this partition.
+                        if let Offset::Offset(offset) = position.offset() {
+                            let pid = position.partition();
+                            let upper_offset = MzOffset::from(u64::try_from(offset).unwrap());
+                            let upper =
+                                Partitioned::new_singleton(RangeBound::exact(pid), upper_offset);
+
+                            let part_cap = reader.partition_capabilities.get_mut(&pid).unwrap();
+                            part_cap.data.downgrade(&upper);
+
+                            if is_snapshotting {
+                                // The `.position()` of the consumer represents what offset we have
+                                // read up to.
+                                snapshot_staged += offset.try_into().unwrap_or(0u64);
+                                // This will always be `Some` at this point.
+                                if let Some(snapshot_total) = snapshot_total {
+                                    // We will eventually read past the snapshot total, so we need
+                                    // to bound it here.
+                                    snapshot_staged =
+                                        std::cmp::min(snapshot_staged, snapshot_total);
+                                }
+                            }
+
+                            // We use try_downgrade here because during the initial snapshot phase the
+                            // data capability is not beyond the progress capability and therefore a
+                            // normal downgrade would panic. Once it catches up though the data
+                            // capbility is what's pushing the progress capability forward.
+                            let _ = part_cap.progress.try_downgrade(&upper);
+                        }
+                    }
+
+                    let (kafka_status, ssh_status) = {
+                        let mut health_status = reader.health_status.lock().unwrap();
+                        (health_status.kafka.take(), health_status.ssh.take())
+                    };
+                    if let Some(status) = kafka_status {
+                        health_output.give(
+                            &health_cap,
+                            HealthStatusMessage {
+                                index: 0,
+                                namespace: Self::STATUS_NAMESPACE.clone(),
+                                update: status,
+                            },
+                        );
+                    }
+                    if let Some(status) = ssh_status {
+                        health_output.give(
+                            &health_cap,
+                            HealthStatusMessage {
+                                index: 0,
+                                namespace: StatusNamespace::Ssh,
+                                update: status,
+                            },
+                        );
+                    }
+
+                    // If we have a new `offset_known` from the partition metadata thread, and
+                    // `committed` from reading the `resume_uppers` stream, we can emit a
+                    // progress stats update.
+                    let progress_statistics = {
+                        let mut stats = reader.progress_statistics.lock().expect("poisoned");
+
+                        if stats.offset_committed.is_some() && stats.offset_known.is_some() {
+                            Some((
+                                stats.offset_known.take().unwrap(),
+                                stats.offset_committed.take().unwrap(),
+                            ))
+                        } else {
+                            None
+                        }
+                    };
+                    if let Some((offset_known, offset_committed)) = progress_statistics {
+                        stats_output.give(
+                            &stats_cap,
+                            ProgressStatisticsUpdate::SteadyState {
+                                offset_committed,
+                                offset_known,
+                            },
+                        );
+                    }
+
+                    if let (Some(snapshot_total), true) = (snapshot_total, is_snapshotting) {
+                        stats_output.give(
+                            &stats_cap,
+                            ProgressStatisticsUpdate::Snapshot {
+                                records_known: snapshot_total,
+                                records_staged: snapshot_staged,
+                            },
+                        );
+
+                        if snapshot_total == snapshot_staged {
+                            is_snapshotting = false;
+                        }
+                    }
+
+                    // Wait to be notified while also making progress with offset committing
+                    tokio::select! {
+                        // TODO(petrosagg): remove the timeout and rely purely on librdkafka waking us
+                        // up
+                        _  = tokio::time::timeout(max_wait_time, notificator.notified()) => {},
+                        // This future is not cancel safe but we are only passing a reference to it in
+                        // the select! loop so the future stays on the stack and never gets cancelled
+                        // until the end of the function.
+                        _ = resume_uppers_process_loop.as_mut() => {},
                     }
                 }
-
-                let (kafka_status, ssh_status) = {
-                    let mut health_status = reader.health_status.lock().unwrap();
-                    (health_status.kafka.take(), health_status.ssh.take())
-                };
-                if let Some(status) = kafka_status {
-                    health_output.give(
-                        &health_cap,
-                        HealthStatusMessage {
-                            index: 0,
-                            namespace: Self::STATUS_NAMESPACE.clone(),
-                            update: status,
-                        },
-                    );
-                }
-                if let Some(status) = ssh_status {
-                    health_output.give(
-                        &health_cap,
-                        HealthStatusMessage {
-                            index: 0,
-                            namespace: StatusNamespace::Ssh,
-                            update: status,
-                        },
-                    );
-                }
-
-                // If we have a new `offset_known` from the partition metadata thread, and
-                // `committed` from reading the `resume_uppers` stream, we can emit a
-                // progress stats update.
-                let progress_statistics = {
-                    let mut stats = reader.progress_statistics.lock().expect("poisoned");
-
-                    if stats.offset_committed.is_some() && stats.offset_known.is_some() {
-                        Some((
-                            stats.offset_known.take().unwrap(),
-                            stats.offset_committed.take().unwrap(),
-                        ))
-                    } else {
-                        None
-                    }
-                };
-                if let Some((offset_known, offset_committed)) = progress_statistics {
-                    stats_output.give(
-                        &stats_cap,
-                        ProgressStatisticsUpdate::SteadyState {
-                            offset_committed,
-                            offset_known,
-                        },
-                    );
-                }
-
-                if let (Some(snapshot_total), true) = (snapshot_total, is_snapshotting) {
-                    stats_output.give(
-                        &stats_cap,
-                        ProgressStatisticsUpdate::Snapshot {
-                            records_known: snapshot_total,
-                            records_staged: snapshot_staged,
-                        },
-                    );
-
-                    if snapshot_total == snapshot_staged {
-                        is_snapshotting = false;
-                    }
-                }
-
-                // Wait to be notified while also making progress with offset committing
-                tokio::select! {
-                    // TODO(petrosagg): remove the timeout and rely purely on librdkafka waking us
-                    // up
-                    _  = tokio::time::timeout(max_wait_time, notificator.notified()) => {},
-                    // This future is not cancel safe but we are only passing a reference to it in
-                    // the select! loop so the future stays on the stack and never gets cancelled
-                    // until the end of the function.
-                    _ = resume_uppers_process_loop.as_mut() => {},
-                }
-            }
+            })
         });
 
         (

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -139,7 +139,7 @@ use std::time::Duration;
 
 use anyhow::bail;
 use differential_dataflow::AsCollection;
-use futures::TryStreamExt;
+use futures::{StreamExt as _, TryStreamExt};
 use mz_expr::MirScalarExpr;
 use mz_ore::future::InTask;
 use mz_postgres_util::desc::PostgresTableDesc;

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -69,6 +69,7 @@ use timely::order::TotalOrder;
 use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, Timestamp};
 use timely::{Container, PartialOrder};
+use tokio::sync::Semaphore;
 use tokio_stream::wrappers::WatchStream;
 use tracing::{info, trace};
 
@@ -124,6 +125,9 @@ pub struct RawSourceCreationConfig {
     pub config: StorageConfiguration,
     /// The ID of this source remap/progress collection.
     pub remap_collection_id: GlobalId,
+    // A semaphore that should be acquired by async operators in order to signal that upstream
+    // operators should slow down.
+    pub busy_signal: Arc<Semaphore>,
 }
 
 impl RawSourceCreationConfig {
@@ -442,6 +446,7 @@ where
         shared_remap_upper,
         config: _,
         remap_collection_id,
+        busy_signal: _,
     } = config;
 
     let chosen_worker = usize::cast_from(id.hashed() % u64::cast_from(worker_count));
@@ -604,6 +609,7 @@ where
         shared_remap_upper: _,
         config: _,
         remap_collection_id: _,
+        busy_signal: _,
     } = config;
 
     // TODO(guswynn): expose function

--- a/src/storage/src/source/statistics.rs
+++ b/src/storage/src/source/statistics.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use futures::StreamExt;
 use mz_repr::GlobalId;
 use mz_storage_types::sources::SourceTimestamp;
 use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};

--- a/src/storage/src/upsert.rs
+++ b/src/storage/src/upsert.rs
@@ -18,6 +18,7 @@ use differential_dataflow::consolidation;
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::{AsCollection, Collection};
 use futures::future::FutureExt;
+use futures::StreamExt;
 use indexmap::map::Entry;
 use itertools::Itertools;
 use mz_ore::cast::CastFrom;

--- a/src/txn-wal/src/operator.rs
+++ b/src/txn-wal/src/operator.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::Hashable;
+use futures::StreamExt;
 use mz_dyncfg::{Config, ConfigSet, ConfigUpdates};
 use mz_ore::cast::CastFrom;
 use mz_ore::task::JoinHandleExt;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Traditionally, the mechanism by which timely operators prevent upstream operators from producing more data while they are processing their current batch of input is by actively working on the data and blocking the worker thread. This approach is a poor fit when the kind of processing is asynchronous and not CPU bound because the worker might have other useful things to do and blocking it prevents it from doing so.

This PR adds the ability for an operator in a storage dataflow to yield control back to timely but prevent upstream operators **of the same dataflow** from producing more work for it until it finishes. This allows timely to schedule **other** dataflows running concurrently that may have useful work to do.

The mechanism by which this is accomplished is using a semaphore containing a single permit that is made available to all operators of the dataflow. There are two kinds of non-source operators:

1. Synchronous run-to-completion operators (e.g decoding): These operators don't need to be aware of the permit since they process each input chunk in one go without yielding back to timely. 
2. Asynchronous operators that perform non CPU bound work: These operators first receive a chunk of input from timely's input change in a synchronous way, then acquire the permit, then process its input (which may include yielding back when reaching await-points), and finally put back the permit back when this chunk of input is processed and output is produced.

This PR only introduces the permit and wires up source operators (those that introduce data into the dataflow) to respect the permit. Since no operator ever acquires the permit and holds if across a scheduling this is a no-op. A follow up PR will wire up `persist_sink` and `upsert` to acquire the permit before working on their inputs.



### Tips for reviewer

There were a bunch of indentation changes so reviewing with whitespace hidden will be much easier. 

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
