### PR TITLE
storage/kafka: round-robin partition/worker assignment

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -145,6 +145,14 @@ pub struct KafkaResumeUpperProcessor {
     progress_statistics: Arc<Mutex<PartialProgressStatistics>>,
 }
 
+/// Computes whether this worker is responsible for consuming a partition. It assigns partitions to
+/// workers in a round-robin fashion, starting at an arbitrary worker based on the hash of the
+/// source id.
+fn responsible_for_pid(config: &RawSourceCreationConfig, pid: i32) -> bool {
+    let pid = usize::try_from(pid).expect("positive pid");
+    ((config.responsible_worker(config.id) + pid) % config.worker_count) == config.worker_id
+}
+
 impl SourceRender for KafkaSourceConnection {
     // TODO(petrosagg): The type used for the partition (RangeBound<PartitionId>) doesn't need to
     // be so complicated and we could instead use `Partitioned<PartitionId, Option<u64>>` where all
@@ -201,7 +209,7 @@ impl SourceRender for KafkaSourceConnection {
             let mut start_offsets: BTreeMap<_, i64> = start_offsets
                 .clone()
                 .into_iter()
-                .filter(|(pid, _offset)| config.responsible_for(pid))
+                .filter(|(pid, _offset)| responsible_for_pid(&config, *pid))
                 .map(|(k, v)| (k, v))
                 .collect();
 
@@ -220,7 +228,7 @@ impl SourceRender for KafkaSourceConnection {
                 if let Some(pid) = ts.interval().singleton() {
                     let pid = pid.unwrap_exact();
                     max_pid = std::cmp::max(max_pid, Some(*pid));
-                    if config.responsible_for(pid) {
+                    if responsible_for_pid(&config, *pid) {
                         let restored_offset = i64::try_from(ts.timestamp().offset)
                             .expect("restored kafka offsets must fit into i64");
                         if let Some(start_offset) = start_offsets.get_mut(pid) {
@@ -574,7 +582,7 @@ impl SourceRender for KafkaSourceConnection {
 
                     let mut upstream_stat = 0;
                     for (&pid, watermarks) in &partitions {
-                        if config.responsible_for(pid) {
+                        if responsible_for_pid(&config, pid) {
                             upstream_stat += watermarks.high;
                             reader.ensure_partition(pid);
                             if let Entry::Vacant(entry) = reader.partition_capabilities.entry(pid) {
@@ -862,7 +870,7 @@ impl KafkaResumeUpperProcessor {
         for ts in frontier.iter() {
             if let Some(pid) = ts.interval().singleton() {
                 let pid = pid.unwrap_exact();
-                if self.config.responsible_for(pid) {
+                if responsible_for_pid(&self.config, *pid) {
                     offsets.push((pid.clone(), *ts.timestamp()));
 
                     // Note that we do not subtract 1 from the frontier. Imagine


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Assign kafka partitions to workers in a round-robin fashion, starting at an arbitrary worker based on the hash of the source id. This leads to an even distribution of partitions to workers

[Discussed here](https://materializeinc.slack.com/archives/C0761MZ3QD9/p1719945086325879)
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
