### PR TITLE
cloudtest: Print node selectors error value

### DIFF
--- a/test/cloudtest/test_compute.py
+++ b/test/cloudtest/test_compute.py
@@ -233,7 +233,9 @@ def test_cluster_replica_sizes(mz: MaterializeApplication) -> None:
         assert replica_id is not None
 
         expected = value.get("selectors", {}) | {"materialize.cloud/disk": "true"}
-        node_selectors = json.loads(get_node_selector(mz, cluster_id, replica_id)[1:-1])
+        node_selectors_raw = get_node_selector(mz, cluster_id, replica_id)
+        print(f"node selectors raw: {node_selectors_raw}")
+        node_selectors = json.loads(node_selectors_raw[1:-1])
         assert (
             node_selectors == expected
         ), f"actual: {node_selectors}, but expected {expected}"


### PR DESCRIPTION
Flakes in CI, not sure why:
https://buildkite.com/materialize/test/builds/85883#0190b684-8296-4385-9e3d-352a502d73fb

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
