### PR TITLE
adapter: mz_objects includes cluster_id

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -327,6 +327,7 @@ Field       | Type                 | Meaning
 `name`      | [`text`]             | The name of the object.
 `type`      | [`text`]             | The type of the object: one of `table`, `source`, `view`, `materialized-view`, `sink`, `index`, `connection`, `secret`, `type`, or `function`.
 `owner_id`  | [`text`]             | The role ID of the owner of the object. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles).
+`cluster_id`| [`text`]             | The ID of the cluster maintaining the source, materialized view, index, or sink. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters). `NULL` for other object types.
 `privileges`| [`mz_aclitem array`] | The privileges belonging to the object.
 
 ### `mz_pseudo_types`
@@ -352,6 +353,7 @@ Field       | Type                 | Meaning
 `name`      | [`text`]             | The name of the relation.
 `type`      | [`text`]             | The type of the relation: either `table`, `source`, `view`, or `materialized view`.
 `owner_id`  | [`text`]             | The role ID of the owner of the relation. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles).
+`cluster_id`| [`text`]             | The ID of the cluster maintaining the source, materialized view, index, or sink. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters). `NULL` for other object types.
 `privileges`| [`mz_aclitem array`] | The privileges belonging to the relation.
 
 ### `mz_roles`

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -3261,12 +3261,12 @@ pub static MZ_RELATIONS: Lazy<BuiltinView> = Lazy::new(|| {
         name: "mz_relations",
         schema: MZ_CATALOG_SCHEMA,
         oid: oid::VIEW_MZ_RELATIONS_OID,
-        column_defs: Some("id, oid, schema_id, name, type, owner_id, privileges"),
+        column_defs: Some("id, oid, schema_id, name, type, owner_id, cluster_id, privileges"),
         sql: "
-      SELECT id, oid, schema_id, name, 'table', owner_id, privileges FROM mz_catalog.mz_tables
-UNION ALL SELECT id, oid, schema_id, name, 'source', owner_id, privileges FROM mz_catalog.mz_sources
-UNION ALL SELECT id, oid, schema_id, name, 'view', owner_id, privileges FROM mz_catalog.mz_views
-UNION ALL SELECT id, oid, schema_id, name, 'materialized-view', owner_id, privileges FROM mz_catalog.mz_materialized_views",
+      SELECT id, oid, schema_id, name, 'table', owner_id, NULL::text, privileges FROM mz_catalog.mz_tables
+UNION ALL SELECT id, oid, schema_id, name, 'source', owner_id, cluster_id, privileges FROM mz_catalog.mz_sources
+UNION ALL SELECT id, oid, schema_id, name, 'view', owner_id, NULL::text, privileges FROM mz_catalog.mz_views
+UNION ALL SELECT id, oid, schema_id, name, 'materialized-view', owner_id, cluster_id, privileges FROM mz_catalog.mz_materialized_views",
         access: vec![PUBLIC_SELECT],
     }
 });
@@ -3299,23 +3299,23 @@ pub static MZ_OBJECTS: Lazy<BuiltinView> = Lazy::new(|| {
         name: "mz_objects",
         schema: MZ_CATALOG_SCHEMA,
         oid: oid::VIEW_MZ_OBJECTS_OID,
-        column_defs: Some("id, oid, schema_id, name, type, owner_id, privileges"),
+        column_defs: Some("id, oid, schema_id, name, type, owner_id, cluster_id, privileges"),
         sql:
-        "SELECT id, oid, schema_id, name, type, owner_id, privileges FROM mz_catalog.mz_relations
+        "SELECT id, oid, schema_id, name, type, owner_id, cluster_id, privileges FROM mz_catalog.mz_relations
 UNION ALL
-    SELECT id, oid, schema_id, name, 'sink', owner_id, NULL::mz_catalog.mz_aclitem[] FROM mz_catalog.mz_sinks
+    SELECT id, oid, schema_id, name, 'sink', owner_id, cluster_id, NULL::mz_catalog.mz_aclitem[] FROM mz_catalog.mz_sinks
 UNION ALL
-    SELECT mz_indexes.id, mz_indexes.oid, mz_relations.schema_id, mz_indexes.name, 'index', mz_indexes.owner_id, NULL::mz_catalog.mz_aclitem[]
+    SELECT mz_indexes.id, mz_indexes.oid, mz_relations.schema_id, mz_indexes.name, 'index', mz_indexes.owner_id, mz_indexes.cluster_id, NULL::mz_catalog.mz_aclitem[]
     FROM mz_catalog.mz_indexes
     JOIN mz_catalog.mz_relations ON mz_indexes.on_id = mz_relations.id
 UNION ALL
-    SELECT id, oid, schema_id, name, 'connection', owner_id, privileges FROM mz_catalog.mz_connections
+    SELECT id, oid, schema_id, name, 'connection', owner_id, NULL::text, privileges FROM mz_catalog.mz_connections
 UNION ALL
-    SELECT id, oid, schema_id, name, 'type', owner_id, privileges FROM mz_catalog.mz_types
+    SELECT id, oid, schema_id, name, 'type', owner_id, NULL::text, privileges FROM mz_catalog.mz_types
 UNION ALL
-    SELECT id, oid, schema_id, name, 'function', owner_id, NULL::mz_catalog.mz_aclitem[] FROM mz_catalog.mz_functions
+    SELECT id, oid, schema_id, name, 'function', owner_id, NULL::text, NULL::mz_catalog.mz_aclitem[] FROM mz_catalog.mz_functions
 UNION ALL
-    SELECT id, oid, schema_id, name, 'secret', owner_id, privileges FROM mz_catalog.mz_secrets",
+    SELECT id, oid, schema_id, name, 'secret', owner_id, NULL::text, privileges FROM mz_catalog.mz_secrets",
         access: vec![PUBLIC_SELECT],
     }
 });

--- a/test/sqllogictest/autogenerated/mz_catalog.slt
+++ b/test/sqllogictest/autogenerated/mz_catalog.slt
@@ -228,7 +228,8 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 4  name  text
 5  type  text
 6  owner_id  text
-7  privileges  mz_aclitem[]
+7  cluster_id  text
+8  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_pseudo_types' ORDER BY position
@@ -244,7 +245,8 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 4  name  text
 5  type  text
 6  owner_id  text
-7  privileges  mz_aclitem[]
+7  cluster_id  text
+8  privileges  mz_aclitem[]
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_roles' ORDER BY position

--- a/test/sqllogictest/mz_catalog_server_index_accounting.slt
+++ b/test/sqllogictest/mz_catalog_server_index_accounting.slt
@@ -115,7 +115,7 @@ FROM mz_indexes i
 LEFT JOIN mz_internal.mz_object_transitive_dependencies d ON i.id = d.object_id
 LEFT JOIN mz_objects o ON o.id = d.referenced_object_id
 JOIN mz_columns co on co.id = o.id
-WHERE cluster_id =
+WHERE i.cluster_id =
   (SELECT id FROM mz_clusters WHERE name = 'mz_catalog_server')
 ORDER BY 1, 2
 ----
@@ -367,6 +367,7 @@ mz_object_lifetimes  occurred_at
 mz_object_lifetimes  previous_id
 mz_object_transitive_dependencies  object_id
 mz_object_transitive_dependencies  referenced_object_id
+mz_objects  cluster_id
 mz_objects  id
 mz_objects  name
 mz_objects  oid
@@ -428,6 +429,7 @@ mz_recent_activity_log_thinned  transient_index_id
 mz_recent_sql_text  redacted_sql
 mz_recent_sql_text  sql
 mz_recent_sql_text  sql_hash
+mz_relations  cluster_id
 mz_relations  id
 mz_relations  name
 mz_relations  oid


### PR DESCRIPTION
Adds a `cluster_id` column to `mz_objects` and `mz_relations`. 

~It's not clear to me if this warrants a release note or not. It is part of stable interface, so probably?~

### Motivation

  * This PR adds a feature that has not yet been specified.

We discussed this a couple of times ([Slack](https://materializeinc.slack.com/archives/C063H5S7NKE/p1715900705840139)). There was some concern about confusion since only some object types are installed on clusters, but the utility seems to outweigh the possible confusion IMO.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add `cluster_id` to [`mz_relations`](/sql/system-catalog/mz_catalog/#mz_relations) and [`mz_objects`](/sql/system-catalog/mz_catalog/#mz_objects).
