### PR TITLE
Save plan hashes in `Fixpoint` rather than full plans

### DIFF
--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -86,7 +86,14 @@ pub trait CollectionPlan {
 ///
 /// The AST is meant to reflect the capabilities of the `differential_dataflow::Collection` type,
 /// written generically enough to avoid run-time compilation work.
-#[derive(Clone, Debug, Ord, PartialOrd, Serialize, Deserialize, MzReflect)]
+///
+/// `derived_hash_with_manual_eq` was complaining for the wrong reason: This lint exists because
+/// it's bad when `Eq` doesn't agree with `Hash`, which is often quite likely if one of them is
+/// implemented manually. However, our manual implementation of `Eq` _will_ agree with the derived
+/// one. This is because the reason for the manual implementation is not to change the semantics
+/// from the derived one, but to avoid stack overflows.
+#[allow(clippy::derived_hash_with_manual_eq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Serialize, Deserialize, MzReflect, Hash)]
 pub enum MirRelationExpr {
     /// A constant relation containing specified rows.
     ///

--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -13,6 +13,7 @@ use std::cmp::{max, Ordering};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fmt::{Display, Formatter};
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::num::NonZeroU64;
 use std::time::Instant;
 
@@ -1925,6 +1926,14 @@ impl MirRelationExpr {
             result |= matches!(e, FlatMap { .. } | Reduce { .. });
         });
         result
+    }
+
+    /// Hash to an u64 using Rust's default Hasher. (Which is a somewhat slower, but better Hasher
+    /// than what `Hashable::hashed` would give us.)
+    pub fn hash_to_u64(&self) -> u64 {
+        let mut h = DefaultHasher::new();
+        self.hash(&mut h);
+        h.finish()
     }
 }
 

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -101,6 +101,8 @@ pub struct TransformCtx<'a> {
     pub df_meta: &'a mut DataflowMetainfo,
 }
 
+const FOLD_CONSTANTS_LIMIT: usize = 10000;
+
 impl<'a> TransformCtx<'a> {
     /// Generates a [`TransformCtx`] instance for the local MIR optimization
     /// stage.
@@ -465,7 +467,9 @@ impl Default for FuseAndCollapse {
                 // Some optimizations fight against this, and we want to be sure to end as a
                 // `MirRelationExpr::Constant` if that is the case, so that subsequent use can
                 // clearly see this.
-                Box::new(fold_constants::FoldConstants { limit: Some(10000) }),
+                Box::new(fold_constants::FoldConstants {
+                    limit: Some(FOLD_CONSTANTS_LIMIT),
+                }),
             ],
         }
     }
@@ -645,7 +649,9 @@ impl Optimizer {
                 limit: 100,
                 transforms: vec![
                     Box::new(column_knowledge::ColumnKnowledge::default()),
-                    Box::new(fold_constants::FoldConstants { limit: Some(10000) }),
+                    Box::new(fold_constants::FoldConstants {
+                        limit: Some(FOLD_CONSTANTS_LIMIT),
+                    }),
                     Box::new(demand::Demand::default()),
                     Box::new(literal_lifting::LiteralLifting::default()),
                 ],
@@ -659,7 +665,9 @@ impl Optimizer {
             Box::new(canonicalize_mfp::CanonicalizeMfp),
             // Identifies common relation subexpressions.
             Box::new(cse::relation_cse::RelationCSE::new(false)),
-            Box::new(fold_constants::FoldConstants { limit: Some(10000) }),
+            Box::new(fold_constants::FoldConstants {
+                limit: Some(FOLD_CONSTANTS_LIMIT),
+            }),
             // Remove threshold operators which have no effect.
             // Must be done at the very end of the physical pass, because before
             // that (at least at the moment) we cannot be sure that all trees
@@ -717,7 +725,9 @@ impl Optimizer {
                     // The last RelationCSE before JoinImplementation should be with
                     // inline_mfp = true.
                     Box::new(cse::relation_cse::RelationCSE::new(true)),
-                    Box::new(fold_constants::FoldConstants { limit: Some(10000) }),
+                    Box::new(fold_constants::FoldConstants {
+                        limit: Some(FOLD_CONSTANTS_LIMIT),
+                    }),
                 ],
             }),
             Box::new(

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -26,7 +26,6 @@ use std::error::Error;
 use std::sync::Arc;
 use std::{fmt, iter};
 
-use differential_dataflow::Hashable;
 use mz_expr::{MirRelationExpr, MirScalarExpr};
 use mz_ore::id_gen::IdGen;
 use mz_ore::stack::RecursionLimitError;
@@ -322,7 +321,7 @@ impl Transform for Fixpoint {
         // stable shape.
         let mut iter_no = 0;
         let mut seen = BTreeMap::new();
-        seen.insert(relation.hashed(), iter_no);
+        seen.insert(relation.hash_to_u64(), iter_no);
         let original = relation.clone();
         loop {
             let prev_size = relation.size();
@@ -333,7 +332,7 @@ impl Transform for Fixpoint {
                     mz_repr::explain::trace_plan(relation);
                     return Ok(());
                 }
-                let seen_i = seen.insert(relation.hashed(), i);
+                let seen_i = seen.insert(relation.hash_to_u64(), i);
                 if let Some(seen_i) = seen_i {
                     // Let's see whether this is just a hash collision, or a real loop: Run the
                     // whole thing from the beginning up until `seen_i`, and compare all the plans

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -326,9 +326,9 @@ impl Transform for Fixpoint {
         loop {
             let prev_size = relation.size();
             for i in iter_no..iter_no + self.limit {
-                let original = relation.clone();
+                let prev = relation.clone();
                 self.apply_transforms(relation, ctx, format!("{i:04}"))?;
-                if *relation == original {
+                if *relation == prev {
                     mz_repr::explain::trace_plan(relation);
                     return Ok(());
                 }
@@ -344,7 +344,7 @@ impl Transform for Fixpoint {
                     // the chances of this are negligible.)
                     mz_repr::explain::trace_plan(relation);
                     soft_panic_or_log!(
-                        "Fixpoint {} detected a loop of length {} after {} iterations",
+                        "Fixpoint `{}` detected a loop of length {} after {} iterations",
                         self.name,
                         i - seen_i,
                         i

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -329,6 +329,9 @@ impl Transform for Fixpoint {
                 let prev = relation.clone();
                 self.apply_transforms(relation, ctx, format!("{i:04}"))?;
                 if *relation == prev {
+                    if prev_size > 100000 {
+                        tracing::warn!(%prev_size, "Very big MIR plan");
+                    }
                     mz_repr::explain::trace_plan(relation);
                     return Ok(());
                 }


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/pull/27977 introduced a memory regression, which turned out to be non-trivial: https://github.com/MaterializeInc/materialize/issues/28244

This PR makes `Fixpoint` save the hashes of plans rather than the full plans.

Additionally, I factored out the limit of FoldConstants in a constant, in case we want to change it in the future (and for experimentation with changing it). I haven't actually changed the limit, though. 

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/28244

   * This PR refactors existing code: The limit of FoldConstants was given 4 times, making it annoying to experiment with different values. This PR factors it out.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
