### PR TITLE
storage/sources: allow aliasing name of error column when using 'value decoding errors = inline'

### DIFF
--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -138,6 +138,13 @@ for the given Kafka message key cannot be decoded, this `error` column will cont
 the error message. If the most recent value for a key has been successfully decoded,
 this column will be `NULL`.
 
+To use an alternative name for the error column, use `INLINE AS ..` to specify the
+column name to use:
+
+```mzsql
+ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE AS my_error_col))
+```
+
 It might be convenient to implement a parsing view on top of your Kafka upsert source that
 excludes keys with decoding errors:
 

--- a/doc/user/layouts/partials/sql-grammar/create-source-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="739" height="1233">
+<svg xmlns="http://www.w3.org/2000/svg" width="915" height="1265">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -20,236 +20,236 @@
    <rect x="371" y="3" width="82" height="32"/>
    <rect x="369" y="1" width="82" height="32" class="nonterminal"/>
    <text class="nonterminal" x="379" y="21">src_name</text>
-   <rect x="118" y="145" width="26" height="32" rx="10"/>
-   <rect x="116"
+   <rect x="206" y="145" width="26" height="32" rx="10"/>
+   <rect x="204"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="126" y="163">(</text>
-   <rect x="184" y="145" width="82" height="32"/>
-   <rect x="182" y="143" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="192" y="163">col_name</text>
-   <rect x="184" y="101" width="24" height="32" rx="10"/>
-   <rect x="182"
+   <text class="terminal" x="214" y="163">(</text>
+   <rect x="272" y="145" width="82" height="32"/>
+   <rect x="270" y="143" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="280" y="163">col_name</text>
+   <rect x="272" y="101" width="24" height="32" rx="10"/>
+   <rect x="270"
          y="99"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="192" y="119">,</text>
-   <rect x="306" y="145" width="26" height="32" rx="10"/>
-   <rect x="304"
+   <text class="terminal" x="280" y="119">,</text>
+   <rect x="394" y="145" width="26" height="32" rx="10"/>
+   <rect x="392"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="314" y="163">)</text>
-   <rect x="392" y="177" width="104" height="32" rx="10"/>
-   <rect x="390"
+   <text class="terminal" x="402" y="163">)</text>
+   <rect x="480" y="177" width="104" height="32" rx="10"/>
+   <rect x="478"
          y="175"
          width="104"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="400" y="195">IN CLUSTER</text>
-   <rect x="516" y="177" width="108" height="32"/>
-   <rect x="514" y="175" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="524" y="195">cluster_name</text>
-   <rect x="128" y="243" width="60" height="32" rx="10"/>
-   <rect x="126"
+   <text class="terminal" x="488" y="195">IN CLUSTER</text>
+   <rect x="604" y="177" width="108" height="32"/>
+   <rect x="602" y="175" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="612" y="195">cluster_name</text>
+   <rect x="216" y="243" width="60" height="32" rx="10"/>
+   <rect x="214"
          y="241"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="136" y="261">FROM</text>
-   <rect x="208" y="243" width="68" height="32" rx="10"/>
-   <rect x="206"
+   <text class="terminal" x="224" y="261">FROM</text>
+   <rect x="296" y="243" width="68" height="32" rx="10"/>
+   <rect x="294"
          y="241"
          width="68"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="216" y="261">KAFKA</text>
-   <rect x="296" y="243" width="116" height="32" rx="10"/>
-   <rect x="294"
+   <text class="terminal" x="304" y="261">KAFKA</text>
+   <rect x="384" y="243" width="116" height="32" rx="10"/>
+   <rect x="382"
          y="241"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="304" y="261">CONNECTION</text>
-   <rect x="432" y="243" width="136" height="32"/>
-   <rect x="430" y="241" width="136" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="440" y="261">connection_name</text>
-   <rect x="588" y="243" width="26" height="32" rx="10"/>
-   <rect x="586"
+   <text class="terminal" x="392" y="261">CONNECTION</text>
+   <rect x="520" y="243" width="136" height="32"/>
+   <rect x="518" y="241" width="136" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="528" y="261">connection_name</text>
+   <rect x="676" y="243" width="26" height="32" rx="10"/>
+   <rect x="674"
          y="241"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="596" y="261">(</text>
-   <rect x="158" y="309" width="64" height="32" rx="10"/>
-   <rect x="156"
+   <text class="terminal" x="684" y="261">(</text>
+   <rect x="246" y="309" width="64" height="32" rx="10"/>
+   <rect x="244"
          y="307"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="166" y="327">TOPIC</text>
-   <rect x="242" y="309" width="52" height="32"/>
-   <rect x="240" y="307" width="52" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="250" y="327">topic</text>
-   <rect x="334" y="341" width="24" height="32" rx="10"/>
-   <rect x="332"
+   <text class="terminal" x="254" y="327">TOPIC</text>
+   <rect x="330" y="309" width="52" height="32"/>
+   <rect x="328" y="307" width="52" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="338" y="327">topic</text>
+   <rect x="422" y="341" width="24" height="32" rx="10"/>
+   <rect x="420"
          y="339"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="342" y="359">,</text>
-   <rect x="378" y="341" width="140" height="32"/>
-   <rect x="376" y="339" width="140" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="386" y="359">connection_option</text>
-   <rect x="558" y="309" width="26" height="32" rx="10"/>
-   <rect x="556"
+   <text class="terminal" x="430" y="359">,</text>
+   <rect x="466" y="341" width="140" height="32"/>
+   <rect x="464" y="339" width="140" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="474" y="359">connection_option</text>
+   <rect x="646" y="309" width="26" height="32" rx="10"/>
+   <rect x="644"
          y="307"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="566" y="327">)</text>
-   <rect x="116" y="407" width="114" height="32" rx="10"/>
-   <rect x="114"
+   <text class="terminal" x="654" y="327">)</text>
+   <rect x="204" y="407" width="114" height="32" rx="10"/>
+   <rect x="202"
          y="405"
          width="114"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="124" y="425">KEY FORMAT</text>
-   <rect x="250" y="407" width="102" height="32"/>
-   <rect x="248" y="405" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="258" y="425">format_spec</text>
-   <rect x="372" y="407" width="132" height="32" rx="10"/>
-   <rect x="370"
+   <text class="terminal" x="212" y="425">KEY FORMAT</text>
+   <rect x="338" y="407" width="102" height="32"/>
+   <rect x="336" y="405" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="346" y="425">format_spec</text>
+   <rect x="460" y="407" width="132" height="32" rx="10"/>
+   <rect x="458"
          y="405"
          width="132"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="380" y="425">VALUE FORMAT</text>
-   <rect x="116" y="451" width="80" height="32" rx="10"/>
-   <rect x="114"
+   <text class="terminal" x="468" y="425">VALUE FORMAT</text>
+   <rect x="204" y="451" width="80" height="32" rx="10"/>
+   <rect x="202"
          y="449"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="124" y="469">FORMAT</text>
-   <rect x="544" y="407" width="102" height="32"/>
-   <rect x="542" y="405" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="552" y="425">format_spec</text>
-   <rect x="78" y="561" width="82" height="32" rx="10"/>
-   <rect x="76"
+   <text class="terminal" x="212" y="469">FORMAT</text>
+   <rect x="632" y="407" width="102" height="32"/>
+   <rect x="630" y="405" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="640" y="425">format_spec</text>
+   <rect x="166" y="561" width="82" height="32" rx="10"/>
+   <rect x="164"
          y="559"
          width="82"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="86" y="579">INCLUDE</text>
-   <rect x="240" y="561" width="48" height="32" rx="10"/>
-   <rect x="238"
+   <text class="terminal" x="174" y="579">INCLUDE</text>
+   <rect x="328" y="561" width="48" height="32" rx="10"/>
+   <rect x="326"
          y="559"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="248" y="579">KEY</text>
-   <rect x="240" y="605" width="96" height="32" rx="10"/>
-   <rect x="238"
+   <text class="terminal" x="336" y="579">KEY</text>
+   <rect x="328" y="605" width="96" height="32" rx="10"/>
+   <rect x="326"
          y="603"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="248" y="623">PARTITION</text>
-   <rect x="240" y="649" width="74" height="32" rx="10"/>
-   <rect x="238"
+   <text class="terminal" x="336" y="623">PARTITION</text>
+   <rect x="328" y="649" width="74" height="32" rx="10"/>
+   <rect x="326"
          y="647"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="248" y="667">OFFSET</text>
-   <rect x="240" y="693" width="106" height="32" rx="10"/>
-   <rect x="238"
+   <text class="terminal" x="336" y="667">OFFSET</text>
+   <rect x="328" y="693" width="106" height="32" rx="10"/>
+   <rect x="326"
          y="691"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="248" y="711">TIMESTAMP</text>
-   <rect x="240" y="737" width="86" height="32" rx="10"/>
-   <rect x="238"
+   <text class="terminal" x="336" y="711">TIMESTAMP</text>
+   <rect x="328" y="737" width="86" height="32" rx="10"/>
+   <rect x="326"
          y="735"
          width="86"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="248" y="755">HEADERS</text>
-   <rect x="406" y="593" width="40" height="32" rx="10"/>
-   <rect x="404"
+   <text class="terminal" x="336" y="755">HEADERS</text>
+   <rect x="494" y="593" width="40" height="32" rx="10"/>
+   <rect x="492"
          y="591"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="414" y="611">AS</text>
-   <rect x="466" y="593" width="56" height="32"/>
-   <rect x="464" y="591" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="474" y="611">name</text>
-   <rect x="220" y="781" width="78" height="32" rx="10"/>
-   <rect x="218"
+   <text class="terminal" x="502" y="611">AS</text>
+   <rect x="554" y="593" width="56" height="32"/>
+   <rect x="552" y="591" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="562" y="611">name</text>
+   <rect x="308" y="781" width="78" height="32" rx="10"/>
+   <rect x="306"
          y="779"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="228" y="799">HEADER</text>
-   <rect x="318" y="781" width="44" height="32"/>
-   <rect x="316" y="779" width="44" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="326" y="799">key</text>
-   <rect x="382" y="781" width="40" height="32" rx="10"/>
-   <rect x="380"
+   <text class="terminal" x="316" y="799">HEADER</text>
+   <rect x="406" y="781" width="44" height="32"/>
+   <rect x="404" y="779" width="44" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="414" y="799">key</text>
+   <rect x="470" y="781" width="40" height="32" rx="10"/>
+   <rect x="468"
          y="779"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="390" y="799">AS</text>
-   <rect x="442" y="781" width="56" height="32"/>
-   <rect x="440" y="779" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="450" y="799">name</text>
-   <rect x="538" y="813" width="66" height="32" rx="10"/>
-   <rect x="536"
+   <text class="terminal" x="478" y="799">AS</text>
+   <rect x="530" y="781" width="56" height="32"/>
+   <rect x="528" y="779" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="538" y="799">name</text>
+   <rect x="626" y="813" width="66" height="32" rx="10"/>
+   <rect x="624"
          y="811"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="546" y="831">BYTES</text>
-   <rect x="200" y="517" width="24" height="32" rx="10"/>
-   <rect x="198"
+   <text class="terminal" x="634" y="831">BYTES</text>
+   <rect x="288" y="517" width="24" height="32" rx="10"/>
+   <rect x="286"
          y="515"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="208" y="535">,</text>
+   <text class="terminal" x="296" y="535">,</text>
    <rect x="45" y="911" width="94" height="32" rx="10"/>
    <rect x="43"
          y="909"
@@ -298,54 +298,65 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="349" y="1049">VALUE DECODING ERRORS = INLINE</text>
-   <rect x="631" y="1031" width="26" height="32" rx="10"/>
-   <rect x="629"
+   <rect x="651" y="1063" width="40" height="32" rx="10"/>
+   <rect x="649"
+         y="1061"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="659" y="1081">AS</text>
+   <rect x="711" y="1063" width="56" height="32"/>
+   <rect x="709" y="1061" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="719" y="1081">name</text>
+   <rect x="807" y="1031" width="26" height="32" rx="10"/>
+   <rect x="805"
          y="1029"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="639" y="1049">)</text>
-   <rect x="137" y="1113" width="76" height="32" rx="10"/>
-   <rect x="135"
-         y="1111"
+   <text class="terminal" x="815" y="1049">)</text>
+   <rect x="225" y="1145" width="76" height="32" rx="10"/>
+   <rect x="223"
+         y="1143"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="145" y="1131">EXPOSE</text>
-   <rect x="233" y="1113" width="96" height="32" rx="10"/>
-   <rect x="231"
-         y="1111"
+   <text class="terminal" x="233" y="1163">EXPOSE</text>
+   <rect x="321" y="1145" width="96" height="32" rx="10"/>
+   <rect x="319"
+         y="1143"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="241" y="1131">PROGRESS</text>
-   <rect x="349" y="1113" width="40" height="32" rx="10"/>
-   <rect x="347"
-         y="1111"
+   <text class="terminal" x="329" y="1163">PROGRESS</text>
+   <rect x="437" y="1145" width="40" height="32" rx="10"/>
+   <rect x="435"
+         y="1143"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="357" y="1131">AS</text>
-   <rect x="409" y="1113" width="196" height="32"/>
-   <rect x="407"
-         y="1111"
+   <text class="terminal" x="445" y="1163">AS</text>
+   <rect x="497" y="1145" width="196" height="32"/>
+   <rect x="495"
+         y="1143"
          width="196"
          height="32"
          class="nonterminal"/>
-   <text class="nonterminal" x="417" y="1131">progress_subsource_name</text>
-   <rect x="589" y="1199" width="102" height="32"/>
-   <rect x="587"
-         y="1197"
+   <text class="nonterminal" x="505" y="1163">progress_subsource_name</text>
+   <rect x="765" y="1231" width="102" height="32"/>
+   <rect x="763"
+         y="1229"
          width="102"
          height="32"
          class="nonterminal"/>
-   <text class="nonterminal" x="597" y="1217">with_options</text>
+   <text class="nonterminal" x="773" y="1249">with_options</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-399 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m20 44 h10 m26 0 h10 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v14 m254 0 v-14 m-254 14 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m0 0 h224 m40 -34 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-560 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m60 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-500 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m24 0 h10 m0 0 h10 m140 0 h10 m20 -32 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-532 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m114 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m132 0 h10 m-428 0 h20 m408 0 h20 m-448 0 q10 0 10 10 m428 0 q0 -10 10 -10 m-438 10 v24 m428 0 v-24 m-428 24 q0 10 10 10 m408 0 q10 0 10 -10 m-418 10 h10 m80 0 h10 m0 0 h308 m20 -44 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-632 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m60 0 h10 m48 0 h10 m0 0 h58 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m96 0 h10 m0 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m74 0 h10 m0 0 h32 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m86 0 h10 m0 0 h20 m40 -176 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m20 -32 h82 m-444 0 h20 m424 0 h20 m-464 0 q10 0 10 10 m444 0 q0 -10 10 -10 m-454 10 v200 m444 0 v-200 m-444 200 q0 10 10 10 m424 0 q10 0 10 -10 m-434 10 h10 m78 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m-444 -252 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m464 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-464 0 h10 m24 0 h10 m0 0 h420 m-606 44 h20 m606 0 h20 m-646 0 q10 0 10 10 m626 0 q0 -10 10 -10 m-636 10 v266 m626 0 v-266 m-626 266 q0 10 10 10 m606 0 q10 0 10 -10 m-616 10 h10 m0 0 h596 m22 -286 l2 0 m2 0 l2 0 m2 0 l2 0 m-703 318 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h662 m-692 0 h20 m672 0 h20 m-712 0 q10 0 10 10 m692 0 q0 -10 10 -10 m-702 10 v12 m692 0 v-12 m-692 12 q0 10 10 10 m672 0 q10 0 10 -10 m-682 10 h10 m94 0 h10 m20 0 h10 m60 0 h10 m0 0 h438 m-538 0 h20 m518 0 h20 m-558 0 q10 0 10 10 m538 0 q0 -10 10 -10 m-548 10 v24 m538 0 v-24 m-538 24 q0 10 10 10 m518 0 q10 0 10 -10 m-528 10 h10 m92 0 h10 m0 0 h406 m-528 -10 v20 m538 0 v-20 m-538 20 v24 m538 0 v-24 m-538 24 q0 10 10 10 m518 0 q10 0 10 -10 m-528 10 h10 m76 0 h10 m20 0 h10 m0 0 h372 m-402 0 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v12 m402 0 v-12 m-402 12 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m26 0 h10 m0 0 h10 m270 0 h10 m0 0 h10 m26 0 h10 m62 -152 l2 0 m2 0 l2 0 m2 0 l2 0 m-644 202 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-100 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m23 -32 h-3"/>
-   <polygon points="729 1181 737 1177 737 1185"/>
-   <polygon points="729 1181 721 1177 721 1185"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-311 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m20 44 h10 m26 0 h10 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v14 m254 0 v-14 m-254 14 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m0 0 h224 m40 -34 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-560 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m60 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-500 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m24 0 h10 m0 0 h10 m140 0 h10 m20 -32 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-532 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m114 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m132 0 h10 m-428 0 h20 m408 0 h20 m-448 0 q10 0 10 10 m428 0 q0 -10 10 -10 m-438 10 v24 m428 0 v-24 m-428 24 q0 10 10 10 m408 0 q10 0 10 -10 m-418 10 h10 m80 0 h10 m0 0 h308 m20 -44 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-632 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m60 0 h10 m48 0 h10 m0 0 h58 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m96 0 h10 m0 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m74 0 h10 m0 0 h32 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m86 0 h10 m0 0 h20 m40 -176 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m20 -32 h82 m-444 0 h20 m424 0 h20 m-464 0 q10 0 10 10 m444 0 q0 -10 10 -10 m-454 10 v200 m444 0 v-200 m-444 200 q0 10 10 10 m424 0 q10 0 10 -10 m-434 10 h10 m78 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m-444 -252 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m464 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-464 0 h10 m24 0 h10 m0 0 h420 m-606 44 h20 m606 0 h20 m-646 0 q10 0 10 10 m626 0 q0 -10 10 -10 m-636 10 v266 m626 0 v-266 m-626 266 q0 10 10 10 m606 0 q10 0 10 -10 m-616 10 h10 m0 0 h596 m22 -286 l2 0 m2 0 l2 0 m2 0 l2 0 m-791 318 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h838 m-868 0 h20 m848 0 h20 m-888 0 q10 0 10 10 m868 0 q0 -10 10 -10 m-878 10 v12 m868 0 v-12 m-868 12 q0 10 10 10 m848 0 q10 0 10 -10 m-858 10 h10 m94 0 h10 m20 0 h10 m60 0 h10 m0 0 h614 m-714 0 h20 m694 0 h20 m-734 0 q10 0 10 10 m714 0 q0 -10 10 -10 m-724 10 v24 m714 0 v-24 m-714 24 q0 10 10 10 m694 0 q10 0 10 -10 m-704 10 h10 m92 0 h10 m0 0 h582 m-704 -10 v20 m714 0 v-20 m-714 20 v24 m714 0 v-24 m-714 24 q0 10 10 10 m694 0 q10 0 10 -10 m-704 10 h10 m76 0 h10 m20 0 h10 m0 0 h548 m-578 0 h20 m558 0 h20 m-598 0 q10 0 10 10 m578 0 q0 -10 10 -10 m-588 10 v12 m578 0 v-12 m-578 12 q0 10 10 10 m558 0 q10 0 10 -10 m-568 10 h10 m26 0 h10 m0 0 h10 m270 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m20 -32 h10 m26 0 h10 m62 -152 l2 0 m2 0 l2 0 m2 0 l2 0 m-732 234 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-12 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m23 -32 h-3"/>
+   <polygon points="905 1213 913 1209 913 1217"/>
+   <polygon points="905 1213 897 1209 897 1217"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/sink-definition.svg
+++ b/doc/user/layouts/partials/sql-grammar/sink-definition.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="589" height="571">
+<svg xmlns="http://www.w3.org/2000/svg" width="701" height="611">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="51" y="35" width="104" height="32" rx="10"/>
@@ -31,111 +31,130 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="521" y="21">INTO</text>
-   <rect x="212" y="101" width="168" height="32"/>
-   <rect x="210" y="99" width="168" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="220" y="119">kafka_sink_connection</text>
-   <rect x="52" y="211" width="48" height="32" rx="10"/>
-   <rect x="50"
+   <rect x="268" y="101" width="168" height="32"/>
+   <rect x="266" y="99" width="168" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="276" y="119">kafka_sink_connection</text>
+   <rect x="108" y="211" width="48" height="32" rx="10"/>
+   <rect x="106"
          y="209"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="60" y="229">KEY</text>
-   <rect x="120" y="211" width="26" height="32" rx="10"/>
-   <rect x="118"
+   <text class="terminal" x="116" y="229">KEY</text>
+   <rect x="176" y="211" width="26" height="32" rx="10"/>
+   <rect x="174"
          y="209"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="128" y="229">(</text>
-   <rect x="186" y="211" width="98" height="32"/>
-   <rect x="184" y="209" width="98" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="194" y="229">key_column</text>
-   <rect x="186" y="167" width="24" height="32" rx="10"/>
-   <rect x="184"
+   <text class="terminal" x="184" y="229">(</text>
+   <rect x="242" y="211" width="98" height="32"/>
+   <rect x="240" y="209" width="98" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="250" y="229">key_column</text>
+   <rect x="242" y="167" width="24" height="32" rx="10"/>
+   <rect x="240"
          y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="194" y="185">,</text>
-   <rect x="324" y="211" width="26" height="32" rx="10"/>
-   <rect x="322"
+   <text class="terminal" x="250" y="185">,</text>
+   <rect x="380" y="211" width="26" height="32" rx="10"/>
+   <rect x="378"
          y="209"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="332" y="229">)</text>
-   <rect x="390" y="243" width="130" height="32" rx="10"/>
-   <rect x="388"
+   <text class="terminal" x="388" y="229">)</text>
+   <rect x="446" y="243" width="130" height="32" rx="10"/>
+   <rect x="444"
          y="241"
          width="130"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="398" y="261">NOT ENFORCED</text>
-   <rect x="179" y="341" width="86" height="32" rx="10"/>
-   <rect x="177"
+   <text class="terminal" x="454" y="261">NOT ENFORCED</text>
+   <rect x="235" y="341" width="86" height="32" rx="10"/>
+   <rect x="233"
          y="339"
          width="86"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="187" y="359">HEADERS</text>
-   <rect x="285" y="341" width="128" height="32"/>
-   <rect x="283" y="339" width="128" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="293" y="359">headers_column</text>
-   <rect x="46" y="439" width="80" height="32" rx="10"/>
-   <rect x="44"
-         y="437"
+   <text class="terminal" x="243" y="359">HEADERS</text>
+   <rect x="341" y="341" width="128" height="32"/>
+   <rect x="339" y="339" width="128" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="349" y="359">headers_column</text>
+   <rect x="65" y="423" width="80" height="32" rx="10"/>
+   <rect x="63"
+         y="421"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="54" y="457">FORMAT</text>
-   <rect x="146" y="439" width="134" height="32"/>
-   <rect x="144" y="437" width="134" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="154" y="457">sink_format_spec</text>
-   <rect x="320" y="407" width="94" height="32" rx="10"/>
-   <rect x="318"
-         y="405"
+   <text class="terminal" x="73" y="441">FORMAT</text>
+   <rect x="65" y="467" width="114" height="32" rx="10"/>
+   <rect x="63"
+         y="465"
+         width="114"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="485">KEY FORMAT</text>
+   <rect x="199" y="467" width="134" height="32"/>
+   <rect x="197" y="465" width="134" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="207" y="485">sink_format_spec</text>
+   <rect x="353" y="467" width="132" height="32" rx="10"/>
+   <rect x="351"
+         y="465"
+         width="132"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="361" y="485">VALUE FORMAT</text>
+   <rect x="525" y="423" width="134" height="32"/>
+   <rect x="523" y="421" width="134" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="533" y="441">sink_format_spec</text>
+   <rect x="187" y="533" width="94" height="32" rx="10"/>
+   <rect x="185"
+         y="531"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="328" y="425">ENVELOPE</text>
-   <rect x="454" y="407" width="92" height="32" rx="10"/>
-   <rect x="452"
-         y="405"
+   <text class="terminal" x="195" y="551">ENVELOPE</text>
+   <rect x="321" y="533" width="92" height="32" rx="10"/>
+   <rect x="319"
+         y="531"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="462" y="425">DEBEZIUM</text>
-   <rect x="454" y="451" width="76" height="32" rx="10"/>
-   <rect x="452"
-         y="449"
+   <text class="terminal" x="329" y="551">DEBEZIUM</text>
+   <rect x="321" y="577" width="76" height="32" rx="10"/>
+   <rect x="319"
+         y="575"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="462" y="469">UPSERT</text>
-   <rect x="361" y="537" width="58" height="32" rx="10"/>
-   <rect x="359"
-         y="535"
+   <text class="terminal" x="329" y="595">UPSERT</text>
+   <rect x="473" y="565" width="58" height="32" rx="10"/>
+   <rect x="471"
+         y="563"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="369" y="555">WITH</text>
-   <rect x="439" y="537" width="102" height="32"/>
-   <rect x="437" y="535" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="447" y="555">with_options</text>
+   <text class="terminal" x="481" y="583">WITH</text>
+   <rect x="551" y="565" width="102" height="32"/>
+   <rect x="549" y="563" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="559" y="583">with_options</text>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m54 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-399 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-392 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h10 m26 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m-508 -32 h20 m508 0 h20 m-548 0 q10 0 10 10 m528 0 q0 -10 10 -10 m-538 10 v46 m528 0 v-46 m-528 46 q0 10 10 10 m508 0 q10 0 10 -10 m-518 10 h10 m0 0 h498 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-445 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h10 m128 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-451 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h10 m134 0 h10 m20 -32 h10 m94 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-269 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m58 0 h10 m0 0 h10 m102 0 h10 m23 -32 h-3"/>
-   <polygon points="579 519 587 515 587 523"/>
-   <polygon points="579 519 571 515 571 523"/>
+         d="m17 17 h2 m20 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m54 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-343 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-392 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h10 m26 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m-508 -32 h20 m508 0 h20 m-548 0 q10 0 10 10 m528 0 q0 -10 10 -10 m-538 10 v46 m528 0 v-46 m-528 46 q0 10 10 10 m508 0 q10 0 10 -10 m-518 10 h10 m0 0 h498 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-445 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h10 m128 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-508 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h624 m-654 0 h20 m634 0 h20 m-674 0 q10 0 10 10 m654 0 q0 -10 10 -10 m-664 10 v12 m654 0 v-12 m-654 12 q0 10 10 10 m634 0 q10 0 10 -10 m-624 10 h10 m80 0 h10 m0 0 h340 m-460 0 h20 m440 0 h20 m-480 0 q10 0 10 10 m460 0 q0 -10 10 -10 m-470 10 v24 m460 0 v-24 m-460 24 q0 10 10 10 m440 0 q10 0 10 -10 m-450 10 h10 m114 0 h10 m0 0 h10 m134 0 h10 m0 0 h10 m132 0 h10 m20 -44 h10 m134 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-536 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m40 -44 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m58 0 h10 m0 0 h10 m102 0 h10 m23 -32 h-3"/>
+   <polygon points="691 547 699 543 699 551"/>
+   <polygon points="691 547 683 543 683 551"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/sink-format-spec.svg
+++ b/doc/user/layouts/partials/sql-grammar/sink-format-spec.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="349" height="81">
+<svg xmlns="http://www.w3.org/2000/svg" width="349" height="169">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="51" y="3" width="110" height="32" rx="10"/>
@@ -20,8 +20,24 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="59" y="65">JSON</text>
+   <rect x="51" y="91" width="56" height="32" rx="10"/>
+   <rect x="49"
+         y="89"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="109">TEXT</text>
+   <rect x="51" y="135" width="66" height="32" rx="10"/>
+   <rect x="49"
+         y="133"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="153">BYTES</text>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m110 0 h10 m0 0 h10 m120 0 h10 m-290 0 h20 m270 0 h20 m-310 0 q10 0 10 10 m290 0 q0 -10 10 -10 m-300 10 v24 m290 0 v-24 m-290 24 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m58 0 h10 m0 0 h192 m23 -44 h-3"/>
+         d="m17 17 h2 m20 0 h10 m110 0 h10 m0 0 h10 m120 0 h10 m-290 0 h20 m270 0 h20 m-310 0 q10 0 10 10 m290 0 q0 -10 10 -10 m-300 10 v24 m290 0 v-24 m-290 24 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m58 0 h10 m0 0 h192 m-280 -10 v20 m290 0 v-20 m-290 20 v24 m290 0 v-24 m-290 24 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m56 0 h10 m0 0 h194 m-280 -10 v20 m290 0 v-20 m-290 20 v24 m290 0 v-24 m-290 24 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m66 0 h10 m0 0 h184 m23 -132 h-3"/>
    <polygon points="339 17 347 13 347 21"/>
    <polygon points="339 17 331 13 331 21"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -188,7 +188,7 @@ create_source_kafka ::=
     (',' ( ('KEY' | 'PARTITION' | 'OFFSET' | 'TIMESTAMP' | 'HEADERS' ) ('AS' name)? | 'HEADER' key 'AS' name ('BYTES')? ) )*
   )?
   ('ENVELOPE' ('NONE' | 'DEBEZIUM' | 'UPSERT'
-    ( '(' 'VALUE DECODING ERRORS = INLINE'  ')' )?
+    ( '(' 'VALUE DECODING ERRORS = INLINE' ('AS' name)? ')' )?
   ))?
   ('EXPOSE' 'PROGRESS' 'AS' progress_subsource_name)?
   with_options?

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -545,14 +545,21 @@ impl_display!(SourceIncludeMetadata);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SourceErrorPolicy {
-    Inline,
+    Inline {
+        /// The alias to use for the error column. If unspecified will be `error`.
+        alias: Option<Ident>,
+    },
 }
 
 impl AstDisplay for SourceErrorPolicy {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            Self::Inline => {
+            Self::Inline { alias } => {
                 f.write_str("INLINE");
+                if let Some(alias) = alias {
+                    f.write_str(" AS ");
+                    f.write_node(alias);
+                }
             }
         }
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2202,7 +2202,9 @@ impl<'a> Parser<'a> {
 
     fn parse_source_error_policy_option(&mut self) -> Result<SourceErrorPolicy, ParserError> {
         match self.expect_one_of_keywords(&[INLINE])? {
-            INLINE => Ok(SourceErrorPolicy::Inline),
+            INLINE => Ok(SourceErrorPolicy::Inline {
+                alias: self.parse_alias()?,
+            }),
             _ => unreachable!(),
         }
     }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -3017,14 +3017,21 @@ CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT 
 ----
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE))
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline { alias: None }] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = INLINE)
 ----
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE))
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline { alias: None }] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+
+parse-statement
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = INLINE AS my_col)
+----
+CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE AS my_col))
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline { alias: Some(Ident("my_col")) }] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS)

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1224,14 +1224,22 @@ pub fn plan_create_source(
                 key_envelope = get_unnamed_key_envelope(key_encoding)?;
             }
             // If the value decode error policy is not set we use the default upsert style.
-            let style = if value_decode_err_policy.is_empty() {
-                UpsertStyle::Default(key_envelope)
-            } else if value_decode_err_policy.contains(&SourceErrorPolicy::Inline) {
-                scx.require_feature_flag(&vars::ENABLE_ENVELOPE_UPSERT_INLINE_ERRORS)?;
-                UpsertStyle::ValueErrInline { key_envelope }
-            } else {
-                bail_unsupported!("ENVELOPE UPSERT with unsupported value decode error policy")
+            let style = match value_decode_err_policy.as_slice() {
+                [] => UpsertStyle::Default(key_envelope),
+                [SourceErrorPolicy::Inline { alias }] => {
+                    scx.require_feature_flag(&vars::ENABLE_ENVELOPE_UPSERT_INLINE_ERRORS)?;
+                    UpsertStyle::ValueErrInline {
+                        key_envelope,
+                        error_column: alias
+                            .as_ref()
+                            .map_or_else(|| "error".to_string(), |a| a.to_string()),
+                    }
+                }
+                _ => {
+                    bail_unsupported!("ENVELOPE UPSERT with unsupported value decode error policy")
+                }
             };
+
             UnplannedSourceEnvelope::Upsert { style }
         }
         ast::SourceEnvelope::CdcV2 => {

--- a/src/storage-types/src/sources/envelope.proto
+++ b/src/storage-types/src/sources/envelope.proto
@@ -51,6 +51,7 @@ message ProtoUpsertStyle {
 
     message ProtoValueErrInline {
         ProtoKeyEnvelope key_envelope = 1;
+        string error_column = 2;
     }
 
     oneof kind {

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -543,11 +543,13 @@ fn upsert_commands<G: Scope, FromTime: Timestamp>(
             | UpsertStyle::Default(KeyEnvelope::Flattened)
             | UpsertStyle::ValueErrInline {
                 key_envelope: KeyEnvelope::Flattened,
+                error_column: _,
             } => key,
             // named
             UpsertStyle::Default(KeyEnvelope::Named(_))
             | UpsertStyle::ValueErrInline {
                 key_envelope: KeyEnvelope::Named(_),
+                error_column: _,
             } => {
                 if key.iter().nth(1).is_none() {
                     key
@@ -559,6 +561,7 @@ fn upsert_commands<G: Scope, FromTime: Timestamp>(
             UpsertStyle::Default(KeyEnvelope::None)
             | UpsertStyle::ValueErrInline {
                 key_envelope: KeyEnvelope::None,
+                error_column: _,
             } => unreachable!(),
         };
 

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -628,7 +628,7 @@ $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json-
 
 
 #
-# Test Inline error handling with value decode failures
+# Test Inline error handling with value decode failures for a JSON source
 #
 
 $ kafka-create-topic topic=inline-value-errors-1 partitions=1
@@ -684,3 +684,46 @@ val2 [1,2,3] <null>
   INCLUDE KEY AS error
   ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE));
 contains: column "error" specified more than once
+
+
+#
+# Test Inline error handling with value decode failures for an AVRO source
+#
+
+$ kafka-create-topic topic=inline-value-errors-2 partitions=1
+
+$ kafka-ingest format=avro topic=inline-value-errors-2 key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "fish", "f2": 1000}
+{"key": "bird1"} {"f1":"goose", "f2": 1}
+{"key": "birdmore"} {"f1":"geese", "f2": 2}
+{"key": "mammal1"} {"f1": "moose", "f2": 1}
+{"key": "bird1"}
+
+> CREATE CLUSTER inline_error_cluster_avro SIZE '${arg.default-storage-size}';
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_envelope_upsert_inline_errors = true
+
+# This source will inline errors and not propagate them
+> CREATE SOURCE value_decode_error_avro
+  IN CLUSTER inline_error_cluster_avro
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-inline-value-errors-2-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE));
+
+# there is now an additional 'error' column that should store the inline decoding errors, if any
+
+> SELECT key, f1, f2, error::text from value_decode_error_avro ORDER BY key
+birdmore      geese    2         <null>
+fish          fish     1000      <null>
+mammal1       moose    1         <null>
+
+# insert a bad record for the birdmore key
+$ kafka-ingest format=bytes key-format=avro key-schema=${keyschema} topic=inline-value-errors-2
+{"key": "birdmore"} "notvalidavro"
+
+> SELECT key, f1, f2, error::text from value_decode_error_avro ORDER BY key
+birdmore      <null>   <null>    "(\"Text: avro deserialization error: wrong Confluent-style avro serialization magic: expected 0, got 32 (original bytes: [20, 22, 6e, 6f, 74, 76, 61, 6c, 69, 64, 61, 76, 72, 6f, 22])\")"
+fish          fish     1000      <null>
+mammal1       moose    1         <null>
+

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -688,6 +688,7 @@ contains: column "error" specified more than once
 
 #
 # Test Inline error handling with value decode failures for an AVRO source
+# that also uses a custom error column name
 #
 
 $ kafka-create-topic topic=inline-value-errors-2 partitions=1
@@ -709,11 +710,11 @@ ALTER SYSTEM SET enable_envelope_upsert_inline_errors = true
   IN CLUSTER inline_error_cluster_avro
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-inline-value-errors-2-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE));
+  ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE AS decode_error));
 
 # there is now an additional 'error' column that should store the inline decoding errors, if any
 
-> SELECT key, f1, f2, error::text from value_decode_error_avro ORDER BY key
+> SELECT key, f1, f2, decode_error::text from value_decode_error_avro ORDER BY key
 birdmore      geese    2         <null>
 fish          fish     1000      <null>
 mammal1       moose    1         <null>
@@ -722,7 +723,7 @@ mammal1       moose    1         <null>
 $ kafka-ingest format=bytes key-format=avro key-schema=${keyschema} topic=inline-value-errors-2
 {"key": "birdmore"} "notvalidavro"
 
-> SELECT key, f1, f2, error::text from value_decode_error_avro ORDER BY key
+> SELECT key, f1, f2, decode_error::text from value_decode_error_avro ORDER BY key
 birdmore      <null>   <null>    "(\"Text: avro deserialization error: wrong Confluent-style avro serialization magic: expected 0, got 32 (original bytes: [20, 22, 6e, 6f, 74, 76, 61, 6c, 69, 64, 61, 76, 72, 6f, 22])\")"
 fish          fish     1000      <null>
 mammal1       moose    1         <null>

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -727,4 +727,3 @@ $ kafka-ingest format=bytes key-format=avro key-schema=${keyschema} topic=inline
 birdmore      <null>   <null>    "(\"Text: avro deserialization error: wrong Confluent-style avro serialization magic: expected 0, got 32 (original bytes: [20, 22, 6e, 6f, 74, 76, 61, 6c, 69, 64, 61, 76, 72, 6f, 22])\")"
 fish          fish     1000      <null>
 mammal1       moose    1         <null>
-


### PR DESCRIPTION
### Motivation

Next step of https://github.com/MaterializeInc/materialize/issues/28127.

Follow up to #28152 :
- Add a test that validates the new `VALUE DECODING ERRORS = INLINE` option for Avro format source
- Allow choosing an alternative name for the 'error' column when using the inline error feature.

The syntax I've implemented adds an optional ` AS <alias>` to the `INLINE` option such that a user can do:
```
ENVELOPE UPSERT (VALUE DECODING ERRORS = INLINE AS new_error_column)
```

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
