### PR TITLE
[default] Default the `roundtrip_spine` flag to true

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -790,18 +790,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=TxnWalFencing, "--seed=$BUILDKITE_JOB_ID"]
-
-      - id: checks-toggle-persist-roundtrip-spine
-        label: "Checks toggling persist roundtrip spine"
-        depends_on: build-aarch64
-        timeout_in_minutes: 45
-        agents:
-          queue: linux-aarch64-large
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: platform-checks
-              args: [--scenario=TogglePersistRoundtripSpine, "--seed=$BUILDKITE_JOB_ID"]
+              args: [ --scenario=TxnWalFencing, "--seed=$BUILDKITE_JOB_ID" ]
 
       - id: checks-toggle-persist-batch-columnar-format
         label: "Checks toggling persist batch columnar format"

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -320,22 +320,6 @@ class SystemVarChange(Scenario):
         ]
 
 
-class TogglePersistRoundtripSpine(SystemVarChange):
-    def __init__(self, checks: list[type[Check]], executor: Executor, seed: str | None):
-        super().__init__(
-            checks,
-            executor,
-            seed,
-            [
-                SystemVarChangeEntry(
-                    name="persist_roundtrip_spine",
-                    value_for_manipulate_phase_1="FALSE",
-                    value_for_manipulate_phase_2="TRUE",
-                )
-            ],
-        )
-
-
 class TogglePersistBatchColumnarFormat(SystemVarChange):
     def __init__(self, checks: list[type[Check]], executor: Executor, seed: str | None):
         super().__init__(

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -923,7 +923,6 @@ class FlipFlagsAction(Action):
         self.flags_with_values["persist_claim_unclaimed_compactions"] = (
             BOOLEAN_FLAG_VALUES
         )
-        self.flags_with_values["persist_roundtrip_spine"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_optimize_ignored_data_fetch"] = (
             BOOLEAN_FLAG_VALUES
         )

--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -84,7 +84,7 @@ impl<K, V, T: Clone, D> Clone for Applier<K, V, T, D> {
 /// If set, we round-trip the spine structure through Proto.
 pub(crate) const ROUNDTRIP_SPINE: Config<bool> = Config::new(
     "persist_roundtrip_spine",
-    false,
+    true,
     "Roundtrip the structure of Spine through Proto.",
 );
 

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -265,11 +265,9 @@ impl<T: Timestamp + Lattice> Trace<T> {
             mut merges,
         } = value;
 
-        // If the flattened representation has spine batches, we know to preserve the structure for
-        // this trace.
-        // Note that for empty spines, roundtrip_structure will default to false. This is done for
-        // backwards-compatability.
-        let roundtrip_structure = !spine_batches.is_empty();
+        // If the flattened representation has spine batches (or is empty)
+        // we know to preserve the structure for this trace.
+        let roundtrip_structure = !spine_batches.is_empty() || legacy_batches.is_empty();
 
         // We need to look up legacy batches somehow, but we don't have a spine id for them.
         // Instead, we rely on the fact that the spine must store them in antichain order.


### PR DESCRIPTION
### Motivation

This has been enabled globally for a few weeks; lock in the default in preparation for removing the old path.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
