### PR TITLE
bazel: Enforce minimum macOS version for `cmake` builds

### DIFF
--- a/misc/bazel/c_deps/rust-sys/BUILD.librdkafka.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.librdkafka.bazel
@@ -57,7 +57,10 @@ cmake(
         "-DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=0",
         # Uncomment this if you ever need to debug what library cmake is resolving.
         # "-DCMAKE_FIND_DEBUG_MODE=TRUE",
-    ],
+    ] + select({
+        "@platforms//os:macos": ["-DCMAKE_OSX_DEPLOYMENT_TARGET=14.0"],
+        "//conditions:default": [],
+    }),
     env = {
         # Note: casing here is important.
         "OpenSSL_ROOT": "$(execpath @openssl//:openssl_root)",

--- a/misc/bazel/c_deps/rust-sys/BUILD.rocksdb.bazel
+++ b/misc/bazel/c_deps/rust-sys/BUILD.rocksdb.bazel
@@ -146,7 +146,10 @@ cmake(
         "-DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=0",
         # Uncomment this if you ever need to debug what library cmake is resolving.
         # "-DCMAKE_FIND_DEBUG_MODE=TRUE",
-    ],
+    ] + select({
+        "@platforms//os:macos": ["-DCMAKE_OSX_DEPLOYMENT_TARGET=14.0"],
+        "//conditions:default": [],
+    }),
     lib_source = ":rocksdb_srcs",
     targets = ["rocksdb"],
     out_static_libs = ["librocksdb.a"],


### PR DESCRIPTION
### Motivation

This allows cmake to pick the most up-to-date version of the macOS SDK that is available. It avoids some edge cases where we get errors for APIs being unsupported on an old version of macOS.

Note: even though macOS 14 is fairly new, Electric is good at keeping our machines up-to-date so internally we should all be running a version > 14

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
