### PR TITLE
storage-controller: use legacy table writes in read-only mode

### DIFF
--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -129,6 +129,18 @@ async fn append_work<T2: Timestamp + Lattice + Codec64>(
 }
 
 impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistTableWriteWorker<T> {
+    pub(crate) fn new_read_only_mode() -> Self {
+        let (tx, rx) =
+            tokio::sync::mpsc::unbounded_channel::<(tracing::Span, PersistTableWriteCmd<T>)>();
+        mz_ore::task::spawn(
+            || "PersistTableWriteWorker",
+            read_only_mode_table_worker(rx),
+        );
+        Self {
+            inner: Arc::new(PersistTableWriteWorkerInner::new(tx)),
+        }
+    }
+
     pub(crate) fn new_txns(
         txns: TxnsHandle<SourceData, (), T, i64, PersistEpoch, TxnsCodecRow>,
     ) -> Self {
@@ -273,6 +285,7 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
                 panic!("already registered a WriteHandle for collection {:?}", id);
             }
         }
+
         // Registering also advances the logical upper of all shards in the txns set.
         let new_ids = ids_handles.iter().map(|(id, _)| *id).collect_vec();
         let handles = ids_handles.into_iter().map(|(_, handle)| handle);
@@ -403,6 +416,152 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
         // It is not an error for the other end to hang up.
         let _ = tx.send(response);
     }
+}
+
+/// Handles table updates in read only mode.
+///
+/// In read only mode, we write to tables outside of the txn-wal system. This is
+/// a gross hack, but it is a quick fix to allow us to perform migrations of the
+/// built-in tables in the new generation during a deployment. We need to write
+/// to the new shards for migrated built-in tables so that dataflows that depend
+/// on those tables can catch up, but we don't want to register them into the
+/// existing txn-wal shard, as that would mutate the state of the old generation
+/// while it's still running. We could instead create a new txn shard in the new
+/// generation for *just* system catalog tables, but then we'd have to do a
+/// complicated dance to move the system catalog tables back to the original txn
+/// shard during promotion, without ever losing track of a shard or registering
+/// it in two txn shards simultaneously.
+///
+/// This code is a nearly line-for-line reintroduction of the code that managed
+/// writing to tables before the txn-wal system. This code can (again) be
+/// deleted when we switch to using native persist schema migrations to perform
+/// mgirations of built-in tables.
+async fn read_only_mode_table_worker<T: Timestamp + Lattice + Codec64 + TimestampManipulation>(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<(Span, PersistTableWriteCmd<T>)>,
+) {
+    let mut write_handles = BTreeMap::<GlobalId, WriteHandle<SourceData, (), T, Diff>>::new();
+
+    let mut shutdown = false;
+    while let Some(cmd) = rx.recv().await {
+        // Peel off all available commands.
+        // We do this in case we can consolidate commands.
+        // It would be surprising to receive multiple concurrent `Append` commands,
+        // but we might receive multiple *empty* `Append` commands.
+        let mut commands = VecDeque::new();
+        commands.push_back(cmd);
+        while let Ok(cmd) = rx.try_recv() {
+            commands.push_back(cmd);
+        }
+
+        // Accumulated updates and upper frontier.
+        let mut all_updates = BTreeMap::default();
+        let mut all_responses = Vec::default();
+
+        while let Some((span, command)) = commands.pop_front() {
+            match command {
+                PersistTableWriteCmd::Register(_register_ts, ids_handles, tx) => {
+                    for (id, write_handle) in ids_handles {
+                        let previous = write_handles.insert(id, write_handle);
+                        if previous.is_some() {
+                            panic!("already registered a WriteHandle for collection {:?}", id);
+                        }
+                    }
+                    // We don't care if our waiter has gone away.
+                    let _ = tx.send(());
+                }
+                PersistTableWriteCmd::Update(id, write_handle) => {
+                    write_handles.insert(id, write_handle).expect(
+                        "PersistTableWriteCmd::Update only valid for updating extant write handles",
+                    );
+                }
+                PersistTableWriteCmd::DropHandles {
+                    forget_ts: _,
+                    ids,
+                    tx,
+                } => {
+                    // n.b. this should only remove the
+                    // handle from the persist worker and
+                    // not take any additional action such
+                    // as closing the shard it's connected
+                    // to because dataflows might still be
+                    // using it.
+                    for id in ids {
+                        write_handles.remove(&id);
+                    }
+                    // We don't care if our waiter has gone away.
+                    let _ = tx.send(());
+                }
+                PersistTableWriteCmd::Append {
+                    write_ts,
+                    advance_to,
+                    updates,
+                    tx,
+                } => {
+                    let mut ids = BTreeSet::new();
+                    for (id, updates_no_ts) in updates {
+                        ids.insert(id);
+                        let (old_span, updates, _expected_upper, old_new_upper) =
+                            all_updates.entry(id).or_insert_with(|| {
+                                (
+                                    span.clone(),
+                                    Vec::default(),
+                                    Antichain::from_elem(write_ts.clone()),
+                                    Antichain::from_elem(T::minimum()),
+                                )
+                            });
+
+                        if old_span.id() != span.id() {
+                            // Link in any spans for `Append` operations that we
+                            // lump together by doing this. This is not ideal,
+                            // because we only have a true tracing history for
+                            // the "first" span that we process, but it's better
+                            // than nothing.
+                            old_span.follows_from(span.id());
+                        }
+                        let updates_with_ts = updates_no_ts.into_iter().map(|x| Update {
+                            row: x.row,
+                            timestamp: write_ts.clone(),
+                            diff: x.diff,
+                        });
+                        updates.extend(updates_with_ts);
+                        old_new_upper.join_assign(&Antichain::from_elem(advance_to.clone()));
+                    }
+                    all_responses.push((ids, tx));
+                }
+                PersistTableWriteCmd::Shutdown => shutdown = true,
+            }
+        }
+
+        let result = append_work(&mut write_handles, all_updates).await;
+
+        for (ids, response) in all_responses {
+            let result = match &result {
+                Err(bad_ids) => {
+                    let filtered: Vec<_> = bad_ids
+                        .iter()
+                        .filter(|(id, _)| ids.contains(id))
+                        .cloned()
+                        .map(|(id, current_upper)| InvalidUpper { id, current_upper })
+                        .collect();
+                    if filtered.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(StorageError::InvalidUppers(filtered))
+                    }
+                }
+                Ok(()) => Ok(()),
+            };
+            // It is not an error for the other end to hang up.
+            let _ = response.send(result);
+        }
+
+        if shutdown {
+            tracing::trace!("shutting down persist write append task");
+            break;
+        }
+    }
+
+    tracing::info!("PersistTableWriteWorker shutting down");
 }
 
 /// Contains the components necessary for sending commands to a `PersistTableWriteWorker`.


### PR DESCRIPTION
This commit changes the storage controller to write to system tables in read-only mode using the legacy (non-txn-wal) implementation. This is a gross hack, but it is a quick fix for allowing migrations of builtin tables (see #28124). See the comment within the patch for details.

Touches #27981.
Touches #28124.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Short on time, so I haven't tested this at all, but I wanted to demonstrate the idea.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
