### PR TITLE
output consistency: further date values

### DIFF
--- a/misc/python/materialize/output_consistency/expression/expression_characteristics.py
+++ b/misc/python/materialize/output_consistency/expression/expression_characteristics.py
@@ -32,6 +32,8 @@ class ExpressionCharacteristics(Enum):
 
     INTERVAL_WITH_MONTHS = 130
     """time interval containing months or years"""
+    DATE_WITH_SHORT_YEAR = 131
+    INCOMPLETE_TIME_VALUE = 132
 
     STRING_EMPTY = 140
     STRING_WITH_SPECIAL_SPACE_CHARS = 141

--- a/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
@@ -65,7 +65,11 @@ DATE_TYPE = DateTimeDataType(
     # BC, AD not working, see: https://github.com/MaterializeInc/materialize/issues/19637
     "0001-01-01",
     "99999-12-31",
-    [("2023-06-01", set()), ("2024-02-29", set())],
+    [
+        ("2023-06-01", set()),
+        ("2024-02-29", set()),
+        ("01-02-03", {ExpressionCharacteristics.DATE_WITH_SHORT_YEAR}),
+    ],
     is_max_value_pg_compatible=False,
 )
 TIME_TYPE = DateTimeDataType(
@@ -73,7 +77,10 @@ TIME_TYPE = DateTimeDataType(
     "TIME",
     "00:00:00",
     "23:59:59.999999",
-    [("01:02:03.000001", set())],
+    [
+        ("01:02:03.000001", set()),
+        ("11:", {ExpressionCharacteristics.INCOMPLETE_TIME_VALUE}),
+    ],
 )
 TIMESTAMP_TYPE = DateTimeDataType(
     TIMESTAMP_TYPE_IDENTIFIER,
@@ -84,6 +91,13 @@ TIMESTAMP_TYPE = DateTimeDataType(
     [
         ("2023-02-28 11:22:33.44444", set()),
         ("2024-02-29 23:50:00", set()),
+        (
+            "01-02-03 11:",
+            {
+                ExpressionCharacteristics.DATE_WITH_SHORT_YEAR,
+                ExpressionCharacteristics.INCOMPLETE_TIME_VALUE,
+            },
+        ),
     ],
     is_max_value_pg_compatible=False,
 )

--- a/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
@@ -26,7 +26,7 @@ class DateTimeDataType(DataType):
         type_name: str,
         min_value: str,
         max_value: str,
-        further_values: list[str],
+        further_values: list[tuple[str, set[ExpressionCharacteristics]]],
         further_values_with_fixed_timezone: list[str] = [],
         has_time_zone: bool = False,
         is_pg_compatible: bool = True,
@@ -65,11 +65,15 @@ DATE_TYPE = DateTimeDataType(
     # BC, AD not working, see: https://github.com/MaterializeInc/materialize/issues/19637
     "0001-01-01",
     "99999-12-31",
-    ["2023-06-01", "2024-02-29"],
+    [("2023-06-01", set()), ("2024-02-29", set())],
     is_max_value_pg_compatible=False,
 )
 TIME_TYPE = DateTimeDataType(
-    TIME_TYPE_IDENTIFIER, "TIME", "00:00:00", "23:59:59.999999", ["01:02:03.000001"]
+    TIME_TYPE_IDENTIFIER,
+    "TIME",
+    "00:00:00",
+    "23:59:59.999999",
+    [("01:02:03.000001", set())],
 )
 TIMESTAMP_TYPE = DateTimeDataType(
     TIMESTAMP_TYPE_IDENTIFIER,
@@ -77,7 +81,10 @@ TIMESTAMP_TYPE = DateTimeDataType(
     # BC, AD not working, see: https://github.com/MaterializeInc/materialize/issues/19637
     "0001-01-01 00:00:00",
     "99999-12-31 23:59:59",
-    ["2023-02-28 11:22:33.44444", "2024-02-29 23:50:00"],
+    [
+        ("2023-02-28 11:22:33.44444", set()),
+        ("2024-02-29 23:50:00", set()),
+    ],
     is_max_value_pg_compatible=False,
 )
 TIMESTAMPTZ_TYPE = DateTimeDataType(
@@ -86,7 +93,7 @@ TIMESTAMPTZ_TYPE = DateTimeDataType(
     # BC, AD not working, see: https://github.com/MaterializeInc/materialize/issues/19637
     "0001-01-01 00:00:00",
     "99999-12-31 23:59:59",
-    further_values=["2023-06-01 11:22:33.44444"],
+    further_values=[("2023-06-01 11:22:33.44444", set())],
     further_values_with_fixed_timezone=[
         # leap year
         "2024-02-29 11:50:00 EST",
@@ -105,11 +112,11 @@ INTERVAL_TYPE = DateTimeDataType(
     "-178956970 years -8 months -2147483648 days -2562047788:00:54.775808",
     "178956970 years 7 months 2147483647 days 2562047788:00:54.775807",
     [
-        "2 years 3 months 4 days 11:22:33.456789",
-        "100 months 100 days",
-        "44:45:45",
-        "45 minutes",
-        "70 minutes",
+        ("2 years 3 months 4 days 11:22:33.456789", set()),
+        ("100 months 100 days", set()),
+        ("44:45:45", set()),
+        ("45 minutes", set()),
+        ("70 minutes", set()),
     ],
     # type is compatible but causes too many issues for now
     is_pg_compatible=False,

--- a/misc/python/materialize/output_consistency/input_data/values/date_time_values_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/values/date_time_values_provider.py
@@ -50,11 +50,15 @@ def __create_values(
             is_pg_compatible=_date_time_data_type.is_max_value_pg_compatible,
         )
 
-        for index, value in enumerate(_date_time_data_type.further_values):
+        for index, value_and_characteristics in enumerate(
+            _date_time_data_type.further_values
+        ):
+            value = value_and_characteristics[0]
+            characteristics = value_and_characteristics[1]
             _values_of_type.add_raw_value(
                 f"'{value}{timezone_value_suffix}'",
                 f"VAL_{index + 1}{timezone_column_suffix}",
-                set(),
+                characteristics,
             )
 
     if _timezone is None:

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -911,6 +911,12 @@ class PgPostExecutionInconsistencyIgnoreFilter(
             ):
                 return YesIgnore("#28143: non-quoted numbers")
 
+        if (
+            ExpressionCharacteristics.DATE_WITH_SHORT_YEAR
+            in all_involved_characteristics
+        ):
+            return YesIgnore("#28284: short date format")
+
         return NoIgnore()
 
     def _shall_ignore_row_count_mismatch(

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -27,8 +27,11 @@ from materialize.output_consistency.validation.result_comparator import ResultCo
 # * 2038-01-19 03:14:18.123
 # * 2038-01-19 03:14:18.123+00
 # * 2038-01-19 03:14:18+00
+# * 2038-01-19 03:14:18-03:00
 # * 2038-01-19T03:14:18+00 (when used in JSONB)
-TIMESTAMP_PATTERN = re.compile(r"^\d{4,}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?$")
+TIMESTAMP_PATTERN = re.compile(
+    r"^\d{4,}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d+(:\d+)?)?$"
+)
 
 # Examples:
 # * NaN

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -28,7 +28,7 @@ from materialize.output_consistency.validation.result_comparator import ResultCo
 # * 2038-01-19 03:14:18.123+00
 # * 2038-01-19 03:14:18+00
 # * 2038-01-19T03:14:18+00 (when used in JSONB)
-TIMESTAMP_PATTERN = re.compile(r"\d{4,}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?")
+TIMESTAMP_PATTERN = re.compile(r"^\d{4,}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?$")
 
 # Examples:
 # * NaN
@@ -36,7 +36,7 @@ TIMESTAMP_PATTERN = re.compile(r"\d{4,}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?
 # * -1.23
 # * 1.23e-3
 # * 1.23e+3
-DECIMAL_PATTERN = re.compile(r"NaN|[+-]?\d+(\.\d+)?(e[+-]?\d+)?")
+DECIMAL_PATTERN = re.compile(r"^NaN|[+-]?\d+(\.\d+)?(e[+-]?\d+)?$")
 
 # Examples:
 # * ["1","2"]
@@ -119,7 +119,10 @@ class PostgresResultComparator(ResultComparator):
         value2 = value2.replace(" month", " mon")
 
         if is_tolerant and self.is_decimal(value1) and self.is_decimal(value2):
-            return self.is_decimal_equal(Decimal(value1), Decimal(value2))
+            try:
+                return self.is_decimal_equal(Decimal(value1), Decimal(value2))
+            except Exception:
+                return True
 
         return value1 == value2
 


### PR DESCRIPTION
Seen in https://materializeinc.slack.com/archives/C02FWJ94HME/p1721109385290219.

### Nightly
https://buildkite.com/materialize/nightly/builds?branch=nrainer-materialize%3Aoutput-consistency%2Fdate-values