### PR TITLE
storage/persist-sink: suspend sources while processing a chunk of input

### DIFF
--- a/src/storage/src/render.rs
+++ b/src/storage/src/render.rs
@@ -375,6 +375,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     storage_state,
                     metrics,
                     export.ingestion_output,
+                    Arc::clone(&busy_signal),
                 );
                 upper_streams.push(upper_stream);
                 tokens.extend(sink_tokens);

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -99,6 +99,7 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use either::Either;
 use futures::StreamExt;
+use itertools::Itertools;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::HashMap;
 use mz_persist_client::batch::{Batch, ProtoBatch};
@@ -120,6 +121,7 @@ use timely::dataflow::operators::{Broadcast, Capability, CapabilitySet, Inspect}
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
+use tokio::sync::Semaphore;
 use tracing::trace;
 
 use crate::metrics::source::SourcePersistSinkMetrics;
@@ -317,6 +319,7 @@ pub(crate) fn render<G>(
     storage_state: &StorageState,
     metrics: SourcePersistSinkMetrics,
     output_index: usize,
+    busy_signal: Arc<Semaphore>,
 ) -> (
     Stream<G, ()>,
     Stream<G, Rc<anyhow::Error>>,
@@ -347,6 +350,7 @@ where
         &passthrough_desired_stream.as_collection(),
         Arc::clone(&persist_clients),
         storage_state,
+        Arc::clone(&busy_signal),
     );
 
     let (upper_stream, append_errors, append_token) = append_batches(
@@ -360,6 +364,7 @@ where
         storage_state,
         output_index,
         metrics,
+        Arc::clone(&busy_signal),
     );
 
     (
@@ -568,6 +573,7 @@ fn write_batches<G>(
     desired_collection: &Collection<G, Result<Row, DataflowError>, Diff>,
     persist_clients: Arc<PersistClientCache>,
     storage_state: &StorageState,
+    busy_signal: Arc<Semaphore>,
 ) -> (
     Stream<G, HollowBatchAndMetadata<SourceData, (), mz_repr::Timestamp, Diff>>,
     PressOnDropButton,
@@ -630,7 +636,10 @@ where
                 Arc::new(UnitSchema),
                 Diagnostics {
                     shard_name: collection_id.to_string(),
-                    handle_purpose: format!("storage::persist_sink::write_batches {}", collection_id),
+                    handle_purpose: format!(
+                        "storage::persist_sink::write_batches {}",
+                        collection_id
+                    ),
                 },
             )
             .await
@@ -647,126 +656,126 @@ where
         // A "safe" choice for the lower of new batches we are creating.
         let mut operator_batch_lower = Antichain::from_elem(Timestamp::minimum());
 
-        loop {
+        while !(batch_descriptions_frontier.is_empty() && desired_frontier.is_empty()) {
+            // Wait for either inputs to become ready
             tokio::select! {
-                Some(event) = descriptions_input.next() => {
-                    match event {
-                        Event::Data(cap, data) => {
-                            // Ingest new batch descriptions.
-                            for description in data {
-                                if collection_id.is_user() {
-                                    trace!(
-                                        "persist_sink {collection_id}/{shard_id}: \
-                                            write_batches: \
-                                            new_description: {:?}, \
-                                            desired_frontier: {:?}, \
-                                            batch_descriptions_frontier: {:?}",
-                                        description,
-                                        desired_frontier,
-                                        batch_descriptions_frontier,
-                                    );
-                                }
-                                match in_flight_batches.entry(
-                                    description,
-                                ){
-                                    std::collections::hash_map::Entry::Vacant(v) => {
-                                        // This _should_ be `.retain`, but rust
-                                        // currently thinks we can't use `cap`
-                                        // as an owned value when using the
-                                        // match guard `Some(event)`
-                                        v.insert(cap.delayed(cap.time()));
-                                    }
-                                    std::collections::hash_map::Entry::Occupied(o) => {
-                                        let (description, _) = o.remove_entry();
-                                        panic!(
-                                            "write_batches: sink {} got more than one \
-                                                batch for description {:?}, in-flight: {:?}",
-                                            collection_id,
-                                            description,
-                                            in_flight_batches
-                                        );
-                                    }
-                                }
-                            }
+                _ = descriptions_input.ready() => {},
+                _ = desired_input.ready() => {},
+            }
 
-                            continue;
-                        }
-                        Event::Progress(frontier) => {
-                            batch_descriptions_frontier = frontier;
-                        }
-                    }
-                }
-                Some(event) = desired_input.next() => {
-                    match event {
-                        Event::Data(_cap, data) => {
-                            // Extract desired rows as positive contributions to `correction`.
-                            if collection_id.is_user() && !data.is_empty() {
+            // Collect ready work from both inputs
+            while let Some(event) = descriptions_input.next_sync() {
+                match event {
+                    Event::Data(cap, data) => {
+                        // Ingest new batch descriptions.
+                        for description in data {
+                            if collection_id.is_user() {
                                 trace!(
                                     "persist_sink {collection_id}/{shard_id}: \
-                                        updates: {:?}, \
-                                        in-flight-batches: {:?}, \
+                                        write_batches: \
+                                        new_description: {:?}, \
                                         desired_frontier: {:?}, \
                                         batch_descriptions_frontier: {:?}",
-                                    data,
-                                    in_flight_batches,
+                                    description,
                                     desired_frontier,
                                     batch_descriptions_frontier,
                                 );
                             }
-
-                            let minimum_batch_updates = persist_clients.cfg().storage_sink_minimum_batch_updates();
-                            for (row, ts, diff) in data {
-                                if write.upper().less_equal(&ts){
-                                    let builder = stashed_batches.entry(ts).or_insert_with(|| {
-                                        BatchBuilderAndMetadata::new()
-                                    });
-
-                                    let is_value = row.is_ok();
-                                    builder
-                                        .add(
-                                            minimum_batch_updates,
-                                            || write.builder(operator_batch_lower.clone()),
-                                            SourceData(row),
-                                            (),
-                                            ts,
-                                            diff
-                                        ).await;
-
-                                    source_statistics.inc_updates_staged_by(1);
-
-                                    // Note that we assume `diff` is either +1 or -1 here, being anything
-                                    // else is a logic bug we can't handle at the metric layer. We also
-                                    // assume this addition doesn't overflow.
-                                    match (is_value, diff.is_positive()) {
-                                        (true, true) => {
-                                            builder.metrics.inserts += diff.unsigned_abs()
-                                        },
-                                        (true, false) => {
-                                            builder.metrics.retractions += diff.unsigned_abs()
-                                        },
-                                        (false, true) => {
-                                            builder.metrics.error_inserts += diff.unsigned_abs()
-                                        },
-                                        (false, false) => {
-                                            builder.metrics.error_retractions += diff.unsigned_abs()
-                                        },
-                                    }
+                            match in_flight_batches.entry(description) {
+                                std::collections::hash_map::Entry::Vacant(v) => {
+                                    // This _should_ be `.retain`, but rust
+                                    // currently thinks we can't use `cap`
+                                    // as an owned value when using the
+                                    // match guard `Some(event)`
+                                    v.insert(cap.delayed(cap.time()));
+                                }
+                                std::collections::hash_map::Entry::Occupied(o) => {
+                                    let (description, _) = o.remove_entry();
+                                    panic!(
+                                        "write_batches: sink {} got more than one \
+                                            batch for description {:?}, in-flight: {:?}",
+                                        collection_id, description, in_flight_batches
+                                    );
                                 }
                             }
-
-                            continue;
-                        }
-                        Event::Progress(frontier) => {
-                            desired_frontier = frontier;
                         }
                     }
-                }
-                else => {
-                    // All inputs are exhausted, so we can shut down.
-                    return;
+                    Event::Progress(frontier) => {
+                        batch_descriptions_frontier = frontier;
+                    }
                 }
             }
 
+            let ready_events = std::iter::from_fn(|| desired_input.next_sync()).collect_vec();
+
+            // We know start the async work for the input we received. Until we finish the dataflow
+            // should be marked as busy.
+            let permit = busy_signal.acquire().await;
+
+            for event in ready_events {
+                match event {
+                    Event::Data(_cap, data) => {
+                        // Extract desired rows as positive contributions to `correction`.
+                        if collection_id.is_user() && !data.is_empty() {
+                            trace!(
+                                "persist_sink {collection_id}/{shard_id}: \
+                                    updates: {:?}, \
+                                    in-flight-batches: {:?}, \
+                                    desired_frontier: {:?}, \
+                                    batch_descriptions_frontier: {:?}",
+                                data,
+                                in_flight_batches,
+                                desired_frontier,
+                                batch_descriptions_frontier,
+                            );
+                        }
+
+                        let minimum_batch_updates =
+                            persist_clients.cfg().storage_sink_minimum_batch_updates();
+                        for (row, ts, diff) in data {
+                            if write.upper().less_equal(&ts) {
+                                let builder = stashed_batches
+                                    .entry(ts)
+                                    .or_insert_with(BatchBuilderAndMetadata::new);
+
+                                let is_value = row.is_ok();
+
+                                builder
+                                    .add(
+                                        minimum_batch_updates,
+                                        || write.builder(operator_batch_lower.clone()),
+                                        SourceData(row),
+                                        (),
+                                        ts,
+                                        diff,
+                                    )
+                                    .await;
+
+                                source_statistics.inc_updates_staged_by(1);
+
+                                // Note that we assume `diff` is either +1 or -1 here, being anything
+                                // else is a logic bug we can't handle at the metric layer. We also
+                                // assume this addition doesn't overflow.
+                                match (is_value, diff.is_positive()) {
+                                    (true, true) => builder.metrics.inserts += diff.unsigned_abs(),
+                                    (true, false) => {
+                                        builder.metrics.retractions += diff.unsigned_abs()
+                                    }
+                                    (false, true) => {
+                                        builder.metrics.error_inserts += diff.unsigned_abs()
+                                    }
+                                    (false, false) => {
+                                        builder.metrics.error_retractions += diff.unsigned_abs()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Event::Progress(frontier) => {
+                        desired_frontier = frontier;
+                    }
+                }
+            }
             // We may have the opportunity to commit updates, if either frontier
             // has moved
             if PartialOrder::less_equal(&processed_desired_frontier, &desired_frontier)
@@ -889,6 +898,7 @@ where
                     desired_frontier
                 );
             }
+            drop(permit);
         }
     });
 
@@ -919,6 +929,7 @@ fn append_batches<G>(
     storage_state: &StorageState,
     output_index: usize,
     metrics: SourcePersistSinkMetrics,
+    busy_signal: Arc<Semaphore>,
 ) -> (
     Stream<G, ()>,
     Stream<G, Rc<anyhow::Error>>,
@@ -1210,14 +1221,16 @@ where
                     futures::future::pending().await
                 }
 
-                let result = write
-                    .compare_and_append_batch(
+                let result = {
+                    let _permit = busy_signal.acquire().await;
+                    write.compare_and_append_batch(
                         &mut to_append[..],
                         batch_lower.clone(),
                         batch_upper.clone(),
                     )
                     .await
-                    .expect("Invalid usage");
+                    .expect("Invalid usage")
+                };
 
                 source_statistics
                     .inc_updates_committed_by(batch_metrics.inserts + batch_metrics.retractions);

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -16,7 +16,7 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::task::{Context, Poll, Waker};
+use std::task::{ready, Context, Poll, Waker};
 
 use futures_util::task::ArcWake;
 use futures_util::Stream;
@@ -154,27 +154,43 @@ pub struct AsyncInputHandle<T: Timestamp, D: Container, C: InputConnection<T>> {
     done: bool,
 }
 
+impl<T: Timestamp, D: Container, C: InputConnection<T>> AsyncInputHandle<T, D, C> {
+    pub fn next_sync(&mut self) -> Option<Event<T, C::Capability, D>> {
+        let mut queue = self.queue.borrow_mut();
+        match queue.pop_front()? {
+            Event::Data(cap, data) => Some(Event::Data(cap, data)),
+            Event::Progress(frontier) => {
+                self.done = frontier.is_empty();
+                Some(Event::Progress(frontier))
+            }
+        }
+    }
+
+    /// Waits for the handle to have data. After this function returns it is guaranteed that at
+    /// least one call to `next_sync` will be `Some(_)`.
+    pub async fn ready(&self) {
+        std::future::poll_fn(|cx| self.poll_ready(cx)).await
+    }
+
+    fn poll_ready(&self, cx: &mut Context<'_>) -> Poll<()> {
+        if self.queue.borrow().is_empty() {
+            self.waker.set(Some(cx.waker().clone()));
+            Poll::Pending
+        } else {
+            Poll::Ready(())
+        }
+    }
+}
+
 impl<T: Timestamp, D: Container, C: InputConnection<T>> Stream for AsyncInputHandle<T, D, C> {
     type Item = Event<T, C::Capability, D>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = &mut *self;
-        if this.done {
+        if self.done {
             return Poll::Ready(None);
         }
-        let mut queue = this.queue.borrow_mut();
-        match queue.pop_front() {
-            Some(event @ Event::Data(_, _)) => Poll::Ready(Some(event)),
-            Some(Event::Progress(frontier)) => {
-                this.done = frontier.is_empty();
-                Poll::Ready(Some(Event::Progress(frontier)))
-            }
-            None => {
-                // Nothing else to produce so install the provided waker
-                this.waker.set(Some(cx.waker().clone()));
-                Poll::Pending
-            }
-        }
+        ready!(self.poll_ready(cx));
+        Poll::Ready(self.next_sync())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR integrates the persist sink in storage dataflows with the suspendable source mechanism introduced in #28226. The general idea is that the persist sink operator peels off the chunk of input that is currently available in its input handle synchronously, takes the busy signal permit, and then proceeds to work on that chunk of input asynchronously. While that chunk of input is being processed the upstream source operators won't be allowed to make progress, preventing the machine from running out of memory.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

This PR also has indentation changes so it's better reviewed with whitespace hidden.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
