### PR TITLE
qa canary: fix error collection

### DIFF
--- a/test/canary-load/mzcompose.py
+++ b/test/canary-load/mzcompose.py
@@ -66,7 +66,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ):
         c.up("testdrive", persistent=True)
 
-        failures = []
+        failures: list[TestFailureDetails] = []
 
         count_chunk = 0
         while time.time() - start_time < args.runtime:
@@ -142,7 +142,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                     continue
                 print(f"Test failure occurred ({msg}), collecting it, and continuing.")
                 # collect, continue, and rethrow at the end
-                failures.append(msg)
+                failures.append(TestFailureDetails(message=msg, details=None))
 
         if len(failures) > 0:
             # reset test case name to remove current iteration and chunk, which does not apply to collected errors


### PR DESCRIPTION
This addresses
```
  File "/var/lib/buildkite-agent/builds/buildkite-aarch64-small-d306b64-i-063725630d802b460-1/materialize/qa-canary/misc/python/materialize/cli/mzcompose.py", line 682, in append_to_junit_suite
    error.test_case_name_override
AttributeError: 'str' object has no attribute 'test_case_name_override'
```

observed in https://buildkite.com/materialize/qa-canary/builds/165#0190b3b5-9434-4a76-b6d8-540cb204f00d.