### PR TITLE
cloudtest: Fix node selector getting

### DIFF
--- a/test/cloudtest/test_compute.py
+++ b/test/cloudtest/test_compute.py
@@ -233,8 +233,13 @@ def test_cluster_replica_sizes(mz: MaterializeApplication) -> None:
         assert replica_id is not None
 
         expected = value.get("selectors", {}) | {"materialize.cloud/disk": "true"}
-        node_selectors_raw = get_node_selector(mz, cluster_id, replica_id)
-        print(f"node selectors raw: {node_selectors_raw}")
+        node_selectors_raw = ""
+        for i in range(1, 10):
+            node_selectors_raw = get_node_selector(mz, cluster_id, replica_id)
+            if node_selectors_raw:
+                break
+            print("No node selectors available yet, sleeping")
+            time.sleep(5)
         node_selectors = json.loads(node_selectors_raw[1:-1])
         assert (
             node_selectors == expected


### PR DESCRIPTION
Can take a bit to have the values available

Failed in https://buildkite.com/materialize/test/builds/85929#0190b7a5-5a20-4b3a-87a9-f0f3bb388c26

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
