### PR TITLE
ci: Reduce memory consumption in post-command hook

### DIFF
--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -36,6 +36,9 @@ ps aux > ps-aux.log
 docker ps -a --no-trunc > docker-ps-a.log
 docker stats --all --no-stream > docker-stats.log
 
+# Down docker containers to save memory
+run --mz-quiet down --volumes
+
 mv "$HOME"/cores .
 
 if find cores -name 'core.*' | grep -q .; then
@@ -90,7 +93,6 @@ export_cov() {
 
 if [ -n "${CI_COVERAGE_ENABLED:-}" ] && [ -z "${BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_COVERAGE:-}" ];  then
     ci_unimportant_heading "Generate coverage information"
-    run --mz-quiet down --volumes
     if [ -n "$(find . -name '*.profraw')" ]; then
         # Workaround for "invalid instrumentation profile data (file header is corrupt)"
         rm -rf profraws

--- a/test/get-cloud-hostname/mzcompose.py
+++ b/test/get-cloud-hostname/mzcompose.py
@@ -11,24 +11,18 @@ import os
 
 from materialize.mz_env_util import get_cloud_hostname
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
-from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz import Mz
 
 SERVICES = [
-    Materialized(),
     Mz(app_password=""),
 ]
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    c.up("materialized")
-
     parser.add_argument("--app-password-env-var", type=str)
     args = parser.parse_args()
 
     app_password = os.environ[args.app_password_env_var]
-
-    c.up("materialized")
 
     hostname = get_cloud_hostname(c, app_password=app_password, quiet=True)
 


### PR DESCRIPTION
Ran OoM: https://buildkite.com/materialize/test/builds/85985#0190bbaa-19d0-459d-a762-351b5ee83138

It is unfortunate how few tests we can run on small agents (again)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
