### PR TITLE
Catalog persist fixup

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -276,9 +276,15 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
         }
     }
 
+    /// Fetch the current upper of the catalog state.
     #[mz_ore::instrument]
     async fn current_upper(&mut self) -> Timestamp {
-        current_upper(&mut self.write_handle).await
+        self.write_handle
+            .fetch_recent_upper()
+            .await
+            .as_option()
+            .cloned()
+            .expect("we use a totally ordered time and never finalize the shard")
     }
 
     /// Appends `updates` iff the current global upper of the catalog is `self.upper`.
@@ -312,10 +318,11 @@ impl<T: TryIntoStateUpdateKind, U: ApplyUpdate<T>> PersistHandle<T, U> {
         // Lag the shard's upper by 1 to keep it readable.
         let downgrade_to = Antichain::from_elem(next_upper.saturating_sub(1));
 
-        // The since handle gives us the ability to fence out other writes using an opaque token.
+        // The since handle gives us the ability to fence out other downgraders using an opaque token.
         // (See the method documentation for details.)
-        // That's not needed here, so we use a constant opaque token to avoid any comparison failures.
-        let opaque = i64::initial();
+        // That's not needed here, so we the since handle's opaque token to avoid any comparison
+        // failures.
+        let opaque = *self.since_handle.opaque();
         let downgrade = self
             .since_handle
             .maybe_compare_and_downgrade_since(&opaque, (&opaque, &downgrade_to))
@@ -786,17 +793,23 @@ impl UnopenedPersistCatalogState {
             .expect("invalid usage");
 
         // Commit an empty write at the minimum timestamp so the catalog is always readable.
-        const EMPTY_UPDATES: &[((SourceData, ()), Timestamp, Diff)] = &[];
-        let _ = write_handle
-            .compare_and_append(
-                EMPTY_UPDATES,
-                Antichain::from_elem(Timestamp::minimum()),
-                Antichain::from_elem(Timestamp::minimum().step_forward()),
-            )
-            .await
-            .expect("invalid usage");
+        let upper = {
+            const EMPTY_UPDATES: &[((SourceData, ()), Timestamp, Diff)] = &[];
+            let upper = Antichain::from_elem(Timestamp::minimum());
+            let next_upper = Timestamp::minimum().step_forward();
+            match write_handle
+                .compare_and_append(EMPTY_UPDATES, upper, Antichain::from_elem(next_upper))
+                .await
+                .expect("invalid usage")
+            {
+                Ok(()) => next_upper,
+                Err(mismatch) => mismatch
+                    .current
+                    .into_option()
+                    .expect("we use a totally ordered time and never finalize the shard"),
+            }
+        };
 
-        let upper = current_upper(&mut write_handle).await;
         let as_of = as_of(&mut read_handle, upper);
         let snapshot: Vec<_> = snapshot_binary(&mut read_handle, as_of, &metrics)
             .await
@@ -1491,18 +1504,6 @@ fn desc() -> RelationDesc {
     RelationDesc::empty().with_column("data", ScalarType::Jsonb.nullable(false))
 }
 
-/// Fetch the current upper of the catalog state.
-async fn current_upper(
-    write_handle: &mut WriteHandle<SourceData, (), Timestamp, Diff>,
-) -> Timestamp {
-    write_handle
-        .fetch_recent_upper()
-        .await
-        .as_option()
-        .cloned()
-        .expect("we use a totally ordered time and never finalize the shard")
-}
-
 /// Generates a timestamp for reading from `read_handle` that is as fresh as possible, given
 /// `upper`.
 fn as_of(read_handle: &ReadHandle<SourceData, (), Timestamp, Diff>, upper: Timestamp) -> Timestamp {
@@ -1512,6 +1513,7 @@ fn as_of(read_handle: &ReadHandle<SourceData, (), Timestamp, Diff>, upper: Times
     );
     let since = read_handle.since().clone();
     let mut as_of = upper.saturating_sub(1);
+    soft_assert_or_log!(since.less_equal(&as_of), "")
     as_of.advance_by(since.borrow());
     as_of
 }


### PR DESCRIPTION
### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
