### PR TITLE
catalog: Resolve temp OID collisions

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1039,6 +1039,7 @@ fn add_new_builtin_clusters_migration(
                         schedule: Default::default(),
                     }),
                 },
+                BTreeSet::new(),
             )?;
         }
     }
@@ -1075,7 +1076,7 @@ fn add_new_remove_old_builtin_introspection_source_migration(
                 .map(|name| (cluster.id, name)),
         );
     }
-    txn.insert_introspection_source_indexes(new_indexes)?;
+    txn.insert_introspection_source_indexes(new_indexes, BTreeSet::new())?;
     txn.remove_introspection_source_indexes(removed_indexes)?;
     Ok(())
 }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1039,7 +1039,7 @@ fn add_new_builtin_clusters_migration(
                         schedule: Default::default(),
                     }),
                 },
-                BTreeSet::new(),
+                &HashSet::new(),
             )?;
         }
     }
@@ -1076,7 +1076,7 @@ fn add_new_remove_old_builtin_introspection_source_migration(
                 .map(|name| (cluster.id, name)),
         );
     }
-    txn.insert_introspection_source_indexes(new_indexes, BTreeSet::new())?;
+    txn.insert_introspection_source_indexes(new_indexes, &HashSet::new())?;
     txn.remove_introspection_source_indexes(removed_indexes)?;
     Ok(())
 }

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1226,6 +1226,25 @@ impl CatalogState {
         Ok(())
     }
 
+    /// Return all OIDs that are allocated to temporary objects.
+    pub(crate) fn get_temporary_oids(&self) -> impl Iterator<Item = u32> + '_ {
+        std::iter::empty()
+            .chain(self.ambient_schemas_by_id.values().filter_map(|schema| {
+                if schema.id.is_temporary() {
+                    Some(schema.oid)
+                } else {
+                    None
+                }
+            }))
+            .chain(self.entry_by_id.values().filter_map(|entry| {
+                if entry.item().is_temporary() {
+                    Some(entry.oid)
+                } else {
+                    None
+                }
+            }))
+    }
+
     /// Optimized lookup for a builtin table.
     ///
     /// Panics if the builtin table doesn't exist in the catalog.

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use itertools::max;
@@ -165,6 +166,7 @@ pub(crate) async fn initialize(
             attributes.clone(),
             membership.clone(),
             vars.clone(),
+            BTreeSet::new(),
         )?;
 
         audit_events.push((
@@ -298,7 +300,7 @@ pub(crate) async fn initialize(
         })
     };
 
-    let materialize_db_oid = tx.allocate_oid()?;
+    let materialize_db_oid = tx.allocate_oid(BTreeSet::new())?;
     tx.insert_database(
         MATERIALIZE_DATABASE_ID,
         "materialize",
@@ -410,7 +412,7 @@ pub(crate) async fn initialize(
         owner_id: MZ_SYSTEM_ROLE_ID,
         privileges: schema_privileges.clone(),
     };
-    let public_schema_oid = tx.allocate_oid()?;
+    let public_schema_oid = tx.allocate_oid(BTreeSet::new())?;
     let public_schema = Schema {
         id: SchemaId::User(PUBLIC_SCHEMA_ID),
         oid: public_schema_oid,
@@ -523,6 +525,7 @@ pub(crate) async fn initialize(
         MZ_SYSTEM_ROLE_ID,
         cluster_privileges,
         default_cluster_config(options),
+        BTreeSet::new(),
     )?;
     audit_events.extend([
         (

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -7,13 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeSet;
 use std::time::Duration;
 
 use itertools::max;
 use mz_audit_log::{CreateOrDropClusterReplicaReasonV1, EventV1, VersionedEvent};
 use mz_controller::clusters::ReplicaLogging;
 use mz_controller_types::{is_cluster_size_v2, ClusterId, ReplicaId};
+use mz_ore::collections::HashSet;
 use mz_ore::now::EpochMillis;
 use mz_pgrepr::oid::{
     FIRST_USER_OID, ROLE_PUBLIC_OID, SCHEMA_INFORMATION_SCHEMA_OID, SCHEMA_MZ_CATALOG_OID,
@@ -166,7 +166,7 @@ pub(crate) async fn initialize(
             attributes.clone(),
             membership.clone(),
             vars.clone(),
-            BTreeSet::new(),
+            &HashSet::new(),
         )?;
 
         audit_events.push((
@@ -300,7 +300,7 @@ pub(crate) async fn initialize(
         })
     };
 
-    let materialize_db_oid = tx.allocate_oid(BTreeSet::new())?;
+    let materialize_db_oid = tx.allocate_oid(&HashSet::new())?;
     tx.insert_database(
         MATERIALIZE_DATABASE_ID,
         "materialize",
@@ -412,7 +412,7 @@ pub(crate) async fn initialize(
         owner_id: MZ_SYSTEM_ROLE_ID,
         privileges: schema_privileges.clone(),
     };
-    let public_schema_oid = tx.allocate_oid(BTreeSet::new())?;
+    let public_schema_oid = tx.allocate_oid(&HashSet::new())?;
     let public_schema = Schema {
         id: SchemaId::User(PUBLIC_SCHEMA_ID),
         oid: public_schema_oid,
@@ -525,7 +525,7 @@ pub(crate) async fn initialize(
         MZ_SYSTEM_ROLE_ID,
         cluster_privileges,
         default_cluster_config(options),
-        BTreeSet::new(),
+        &HashSet::new(),
     )?;
     audit_events.extend([
         (

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -216,10 +216,11 @@ impl<'a> Transaction<'a> {
         database_name: &str,
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
+        temporary_oids: BTreeSet<u32>,
     ) -> Result<(DatabaseId, u32), CatalogError> {
         let id = self.get_and_increment_id(DATABASE_ID_ALLOC_KEY.to_string())?;
         let id = DatabaseId::User(id);
-        let oid = self.allocate_oid()?;
+        let oid = self.allocate_oid(temporary_oids)?;
         self.insert_database(id, database_name, owner_id, privileges, oid)?;
         Ok((id, oid))
     }
@@ -253,10 +254,11 @@ impl<'a> Transaction<'a> {
         schema_name: &str,
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
+        temporary_oids: BTreeSet<u32>,
     ) -> Result<(SchemaId, u32), CatalogError> {
         let id = self.get_and_increment_id(SCHEMA_ID_ALLOC_KEY.to_string())?;
         let id = SchemaId::User(id);
-        let oid = self.allocate_oid()?;
+        let oid = self.allocate_oid(temporary_oids)?;
         self.insert_schema(
             id,
             Some(database_id),
@@ -325,10 +327,11 @@ impl<'a> Transaction<'a> {
         attributes: RoleAttributes,
         membership: RoleMembership,
         vars: RoleVars,
+        temporary_oids: BTreeSet<u32>,
     ) -> Result<(RoleId, u32), CatalogError> {
         let id = self.get_and_increment_id(USER_ROLE_ID_ALLOC_KEY.to_string())?;
         let id = RoleId::User(id);
-        let oid = self.allocate_oid()?;
+        let oid = self.allocate_oid(temporary_oids)?;
         self.insert_role(id, name, attributes, membership, vars, oid)?;
         Ok((id, oid))
     }
@@ -367,6 +370,7 @@ impl<'a> Transaction<'a> {
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
         config: ClusterConfig,
+        temporary_oids: BTreeSet<u32>,
     ) -> Result<(), CatalogError> {
         self.insert_cluster(
             cluster_id,
@@ -375,6 +379,7 @@ impl<'a> Transaction<'a> {
             owner_id,
             privileges,
             config,
+            temporary_oids,
         )
     }
 
@@ -387,6 +392,7 @@ impl<'a> Transaction<'a> {
         privileges: Vec<MzAclItem>,
         owner_id: RoleId,
         config: ClusterConfig,
+        temporary_oids: BTreeSet<u32>,
     ) -> Result<(), CatalogError> {
         self.insert_cluster(
             cluster_id,
@@ -395,6 +401,7 @@ impl<'a> Transaction<'a> {
             owner_id,
             privileges,
             config,
+            temporary_oids,
         )
     }
 
@@ -406,6 +413,7 @@ impl<'a> Transaction<'a> {
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
         config: ClusterConfig,
+        temporary_oids: BTreeSet<u32>,
     ) -> Result<(), CatalogError> {
         if let Err(_) = self.clusters.insert(
             ClusterKey { id: cluster_id },
@@ -420,7 +428,8 @@ impl<'a> Transaction<'a> {
             return Err(SqlCatalogError::ClusterAlreadyExists(cluster_name.to_owned()).into());
         };
 
-        let oids = self.allocate_oids(usize_to_u64(introspection_source_indexes.len()))?;
+        let amount = usize_to_u64(introspection_source_indexes.len());
+        let oids = self.allocate_oids(amount, temporary_oids)?;
         let introspection_source_indexes: Vec<_> = introspection_source_indexes
             .into_iter()
             .zip(oids.into_iter())
@@ -566,8 +575,9 @@ impl<'a> Transaction<'a> {
         create_sql: String,
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
+        temporary_oids: BTreeSet<u32>,
     ) -> Result<u32, CatalogError> {
-        let oid = self.allocate_oid()?;
+        let oid = self.allocate_oid(temporary_oids)?;
         self.insert_item(
             id, oid, schema_id, item_name, create_sql, owner_id, privileges,
         )?;
@@ -661,7 +671,11 @@ impl<'a> Transaction<'a> {
     /// Allocates `amount` OIDs. OIDs can be recycled if they aren't currently assigned to any
     /// object.
     #[mz_ore::instrument]
-    fn allocate_oids(&mut self, amount: u64) -> Result<Vec<u32>, CatalogError> {
+    fn allocate_oids(
+        &mut self,
+        amount: u64,
+        temporary_oids: BTreeSet<u32>,
+    ) -> Result<Vec<u32>, CatalogError> {
         /// Struct representing an OID for a user object. Allocated OIDs can be recycled, so when we've
         /// allocated [`u32::MAX`] we'll wrap back around to [`FIRST_USER_OID`].
         struct UserOid(u32);
@@ -697,13 +711,12 @@ impl<'a> Transaction<'a> {
                 + self.schemas.items().len()
                 + self.roles.items().len()
                 + self.items.items().len()
-                + self.introspection_sources.items().len(),
+                + self.introspection_sources.items().len()
+                + temporary_oids.len(),
         );
         allocated_oids.extend(
-            self.databases
-                .items()
-                .values()
-                .map(|value| value.oid)
+            std::iter::empty()
+                .chain(self.databases.items().values().map(|value| value.oid))
                 .chain(self.schemas.items().values().map(|value| value.oid))
                 .chain(self.roles.items().values().map(|value| value.oid))
                 .chain(self.items.items().values().map(|value| value.oid))
@@ -712,7 +725,8 @@ impl<'a> Transaction<'a> {
                         .items()
                         .values()
                         .map(|value| value.oid),
-                ),
+                )
+                .chain(temporary_oids.into_iter()),
         );
 
         let start_oid: u32 = self
@@ -762,8 +776,9 @@ impl<'a> Transaction<'a> {
 
     /// Allocates a single OID. OIDs can be recycled if they aren't currently assigned to any
     /// object.
-    pub fn allocate_oid(&mut self) -> Result<u32, CatalogError> {
-        self.allocate_oids(1).map(|oids| oids.into_element())
+    pub fn allocate_oid(&mut self, temporary_oids: BTreeSet<u32>) -> Result<u32, CatalogError> {
+        self.allocate_oids(1, temporary_oids)
+            .map(|oids| oids.into_element())
     }
 
     pub(crate) fn insert_id_allocator(
@@ -1511,8 +1526,10 @@ impl<'a> Transaction<'a> {
     pub fn insert_introspection_source_indexes(
         &mut self,
         introspection_source_indexes: Vec<(ClusterId, String, GlobalId)>,
+        temporary_oids: BTreeSet<u32>,
     ) -> Result<Vec<IntrospectionSourceIndex>, CatalogError> {
-        let oids = self.allocate_oids(usize_to_u64(introspection_source_indexes.len()))?;
+        let amount = usize_to_u64(introspection_source_indexes.len());
+        let oids = self.allocate_oids(amount, temporary_oids)?;
         let introspection_source_indexes: Vec<_> = introspection_source_indexes
             .into_iter()
             .zip(oids.into_iter())

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -24,7 +24,7 @@ use mz_persist_client::{PersistClient, PersistLocation};
 use mz_proto::RustType;
 use mz_repr::role_id::RoleId;
 use mz_sql::catalog::{RoleAttributes, RoleMembership, RoleVars};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Debug, Formatter};
 use uuid::Uuid;
 
@@ -270,10 +270,21 @@ async fn test_open_savepoint(
         let mut db_schemas = Vec::new();
         for i in 0..10 {
             let (db_id, db_oid) = txn
-                .insert_user_database(&format!("db{i}"), RoleId::User(i), Vec::new())
+                .insert_user_database(
+                    &format!("db{i}"),
+                    RoleId::User(i),
+                    Vec::new(),
+                    BTreeSet::new(),
+                )
                 .unwrap();
             let (schema_id, schema_oid) = txn
-                .insert_user_schema(db_id, &format!("sc{i}"), RoleId::User(i), Vec::new())
+                .insert_user_schema(
+                    db_id,
+                    &format!("sc{i}"),
+                    RoleId::User(i),
+                    Vec::new(),
+                    BTreeSet::new(),
+                )
                 .unwrap();
             ids.push((db_id.clone(), schema_id.clone()));
             db_schemas.push((
@@ -439,6 +450,7 @@ async fn test_open_read_only(
             RoleAttributes::new(),
             RoleMembership::new(),
             RoleVars::default(),
+            BTreeSet::new(),
         )
         .unwrap();
     // Drain txn updates.

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -7,6 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeMap;
+use std::fmt::{Debug, Formatter};
+
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use mz_catalog::durable::initialize::USER_VERSION_KEY;
@@ -18,14 +21,13 @@ use mz_catalog::durable::{
     Epoch, OpenableDurableCatalogState, Schema, CATALOG_VERSION,
 };
 use mz_ore::cast::usize_to_u64;
+use mz_ore::collections::HashSet;
 use mz_ore::now::{NOW_ZERO, SYSTEM_TIME};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistClient, PersistLocation};
 use mz_proto::RustType;
 use mz_repr::role_id::RoleId;
 use mz_sql::catalog::{RoleAttributes, RoleMembership, RoleVars};
-use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::{Debug, Formatter};
 use uuid::Uuid;
 
 /// A new type for [`Snapshot`] that excludes the user_version from the debug output. The
@@ -274,7 +276,7 @@ async fn test_open_savepoint(
                     &format!("db{i}"),
                     RoleId::User(i),
                     Vec::new(),
-                    BTreeSet::new(),
+                    HashSet::new(),
                 )
                 .unwrap();
             let (schema_id, schema_oid) = txn
@@ -283,7 +285,7 @@ async fn test_open_savepoint(
                     &format!("sc{i}"),
                     RoleId::User(i),
                     Vec::new(),
-                    BTreeSet::new(),
+                    HashSet::new(),
                 )
                 .unwrap();
             ids.push((db_id.clone(), schema_id.clone()));
@@ -450,7 +452,7 @@ async fn test_open_read_only(
             RoleAttributes::new(),
             RoleMembership::new(),
             RoleVars::default(),
-            BTreeSet::new(),
+            HashSet::new(),
         )
         .unwrap();
     // Drain txn updates.

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -276,7 +276,7 @@ async fn test_open_savepoint(
                     &format!("db{i}"),
                     RoleId::User(i),
                     Vec::new(),
-                    HashSet::new(),
+                    &HashSet::new(),
                 )
                 .unwrap();
             let (schema_id, schema_oid) = txn
@@ -285,7 +285,7 @@ async fn test_open_savepoint(
                     &format!("sc{i}"),
                     RoleId::User(i),
                     Vec::new(),
-                    HashSet::new(),
+                    &HashSet::new(),
                 )
                 .unwrap();
             ids.push((db_id.clone(), schema_id.clone()));
@@ -452,7 +452,7 @@ async fn test_open_read_only(
             RoleAttributes::new(),
             RoleMembership::new(),
             RoleVars::default(),
-            HashSet::new(),
+            &HashSet::new(),
         )
         .unwrap();
     // Drain txn updates.

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeSet;
 use std::time::Duration;
 
 use insta::assert_debug_snapshot;
@@ -23,7 +22,7 @@ use mz_catalog::durable::{
     Item, OpenableDurableCatalogState, USER_ITEM_ALLOC_KEY,
 };
 use mz_ore::assert_ok;
-use mz_ore::collections::CollectionExt;
+use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::PersistClient;
 use mz_proto::RustType;
@@ -407,7 +406,7 @@ async fn test_schemas(openable_state: Box<dyn OpenableDurableCatalogState>) {
             "foo",
             RoleId::User(1),
             vec![],
-            BTreeSet::new(),
+            &HashSet::new(),
         )
         .unwrap();
     // Drain txn updates.
@@ -498,7 +497,7 @@ async fn test_non_writer_commits(
                 RoleAttributes::new(),
                 RoleMembership::new(),
                 RoleVars::default(),
-                BTreeSet::new(),
+                &HashSet::new(),
             )
             .unwrap();
         // Drain updates.
@@ -521,7 +520,7 @@ async fn test_non_writer_commits(
         let db_name = "db";
         let mut txn = savepoint_state.transaction().await.unwrap();
         let (db_id, _) = txn
-            .insert_user_database(db_name, RoleId::User(42), Vec::new(), BTreeSet::new())
+            .insert_user_database(db_name, RoleId::User(42), Vec::new(), &HashSet::new())
             .unwrap();
         let DatabaseId::User(db_id) = db_id else {
             panic!("unexpected id variant: {db_id:?}");


### PR DESCRIPTION
To allocate a unique OID, the durable catalog compares potential OIDs against all known OIDs. The issue with that approach is that the durable catalog does not know about any OIDs allocated to a temporary object, since temporary objects are not stored in the catalog. Therefore, it's possible to allocate a new OID that was already allocated to a temporary object.

This commit resolves this issue by requiring callers to pass the durable catalog a set of existing temporary OIDs before a new one can be allocated.

Fixes #27719

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
