### PR TITLE
output consistency: add ignore for order

### DIFF
--- a/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
+++ b/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
@@ -11,9 +11,6 @@
 from materialize.output_consistency.execution.evaluation_strategy import (
     EvaluationStrategy,
 )
-from materialize.output_consistency.expression.expression_characteristics import (
-    ExpressionCharacteristics,
-)
 from materialize.output_consistency.input_data.test_input_data import (
     ConsistencyTestInputData,
 )
@@ -108,8 +105,8 @@ class ReproductionCodePrinter(BaseOutputPrinter):
         )
         self.print_separator_line()
 
-        characteristics = self.__get_involved_characteristics(
-            query_template, query_column_selection
+        characteristics = query_template.get_involved_characteristics(
+            query_column_selection
         )
         characteristic_names = ", ".join([char.name for char in characteristics])
         self._print_text(
@@ -182,23 +179,3 @@ class ReproductionCodePrinter(BaseOutputPrinter):
                 column_names.add(leaf_expression.column_name)
 
         return column_names
-
-    def __get_involved_characteristics(
-        self,
-        query_template: QueryTemplate,
-        query_column_selection: QueryColumnByIndexSelection,
-    ) -> set[ExpressionCharacteristics]:
-        all_involved_characteristics: set[ExpressionCharacteristics] = set()
-
-        for index, expression in enumerate(query_template.select_expressions):
-            if not query_column_selection.is_included(index):
-                continue
-
-            characteristics = expression.recursively_collect_involved_characteristics(
-                query_template.row_selection
-            )
-            all_involved_characteristics = all_involved_characteristics.union(
-                characteristics
-            )
-
-        return all_involved_characteristics


### PR DESCRIPTION
This addresses

```
ValidationErrorType.ERROR_MISMATCH: Error message differs.
  Value 1 (Dataflow rendering): 'function casting double precision to numeric is only defined for finite arguments' (type: <class 'str'>)
  Value 2 (Constant folding): 'numeric field overflow' (type: <class 'str'>)
  Query 1: SELECT jsonb_object_agg(char_6_val, double_val ORDER BY row_index, char_6_val) FROM t_dfr_vert WHERE (row_index IN (1, 3, 8, 11, 13));
  Query 2: SELECT jsonb_object_agg(char_6_val, double_val ORDER BY row_index, char_6_val) FROM v_ctf_vert WHERE (row_index IN (1, 3, 8, 11, 13));
```

seen in https://buildkite.com/materialize/nightly/builds/8591#0190bbf1-dc3f-4456-adb0-04cb49a00f6f and also in https://buildkite.com/materialize/nightly/builds/8599.