### PR TITLE
sink-kafka-restart test: Bump timeout to 40s

### DIFF
--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -112,7 +112,7 @@ def workflow_sink_kafka_restart(c: Composition, parser: WorkflowArgumentParser) 
             "--max-errors=1",
             f"--seed={seed}",
             f"--temp-dir=/share/tmp/kafka-resumption-{seed}",
-            "--default-timeout=20s",
+            "--default-timeout=40s",
             "sink-kafka-restart/setup.td",
         )
         c.kill("redpanda" if args.redpanda else "kafka")
@@ -122,7 +122,7 @@ def workflow_sink_kafka_restart(c: Composition, parser: WorkflowArgumentParser) 
             "--max-errors=1",
             f"--seed={seed}",
             f"--temp-dir=/share/tmp/kafka-resumption-{seed}",
-            "--default-timeout=20s",
+            "--default-timeout=40s",
             "sink-kafka-restart/verify.td",
             "sink-kafka-restart/cleanup.td",
         )


### PR DESCRIPTION
Even Kafka seems not able to reliably recover in 20s

Seen in https://buildkite.com/materialize/test/builds/86096#0190c07e-0c96-47ca-8cd7-9a0167f79cad

I'm checking logs and running the test locally in an endless loop locally to see if this is something more serious.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
