### PR TITLE
Render regions for object build and let bindings

### DIFF
--- a/src/compute-types/src/plan/flat_plan.rs
+++ b/src/compute-types/src/plan/flat_plan.rs
@@ -662,6 +662,20 @@ impl<T> FlatPlan<T> {
             }
         }
     }
+
+    /// Enumerate all identifiers referenced in `Get` operators.
+    pub fn depends(&self) -> BTreeSet<Id> {
+        self.nodes
+            .values()
+            .filter_map(|node| {
+                if let FlatPlanNode::Get { id, .. } = node {
+                    Some(id.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 impl<T: Clone> FlatPlan<T> {


### PR DESCRIPTION
Add rendering regions around dataflow "objects to build" as well as both `Let` ~and `LetRec`~ values and bodies. NB: No `LetRec`: Rust gets angry.

The intended outcome is that it becomes easier to map dataflow operator addresses back to LIR/MIR fragments by way of their CTE identifiers. Prior to this PR, all were in one scope and were undifferentiated, which meant one needed to understand the union of all CTEs rather than just one at a time.

cc: @sthm 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
