### PR TITLE
storage/sql: Refactor subsource purification (prep for source-fed table purification)

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -521,28 +521,28 @@ impl Coordinator {
             PurifiedStatement::PurifiedCreateSource {
                 create_progress_subsource_stmt,
                 create_source_stmt,
-                create_subsource_stmts,
+                subsources,
             } => {
                 self.plan_purified_create_source(
                     &ctx,
                     params,
                     create_progress_subsource_stmt,
                     create_source_stmt,
-                    create_subsource_stmts,
+                    subsources,
                 )
                 .await
             }
             PurifiedStatement::PurifiedAlterSourceAddSubsources {
-                altered_id,
+                source_name,
                 options,
-                create_subsource_stmts,
+                subsources,
             } => {
                 self.plan_purified_alter_source_add_subsource(
                     ctx.session(),
                     params,
-                    altered_id,
+                    source_name,
                     options,
-                    create_subsource_stmts,
+                    subsources,
                 )
                 .await
             }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2764,14 +2764,14 @@ impl<'a> Parser<'a> {
             self.expect_token(&Token::LParen)?;
             let subsources = self.parse_comma_separated(Parser::parse_subsource_references)?;
             self.expect_token(&Token::RParen)?;
-            Some(ReferencedSubsources::SubsetTables(subsources))
+            Some(ExternalReferences::SubsetTables(subsources))
         } else if self.parse_keywords(&[FOR, SCHEMAS]) {
             self.expect_token(&Token::LParen)?;
             let schemas = self.parse_comma_separated(Parser::parse_identifier)?;
             self.expect_token(&Token::RParen)?;
-            Some(ReferencedSubsources::SubsetSchemas(schemas))
+            Some(ExternalReferences::SubsetSchemas(schemas))
         } else if self.parse_keywords(&[FOR, ALL, TABLES]) {
-            Some(ReferencedSubsources::All)
+            Some(ExternalReferences::All)
         } else {
             None
         };
@@ -2802,13 +2802,13 @@ impl<'a> Parser<'a> {
             envelope,
             if_not_exists,
             key_constraint,
-            referenced_subsources,
+            external_references: referenced_subsources,
             progress_subsource,
             with_options,
         }))
     }
 
-    fn parse_subsource_references(&mut self) -> Result<CreateSourceSubsource, ParserError> {
+    fn parse_subsource_references(&mut self) -> Result<ExternalReferenceExport, ParserError> {
         let reference = self.parse_item_name()?;
         let subsource = if self.parse_one_of_keywords(&[AS, INTO]).is_some() {
             Some(self.parse_item_name()?)
@@ -2816,9 +2816,9 @@ impl<'a> Parser<'a> {
             None
         };
 
-        Ok(CreateSourceSubsource {
+        Ok(ExternalReferenceExport {
             reference,
-            subsource,
+            alias: subsource,
         })
     }
 
@@ -4843,7 +4843,7 @@ impl<'a> Parser<'a> {
                         source_name,
                         if_exists,
                         action: AlterSourceAction::AddSubsources {
-                            subsources,
+                            external_references: subsources,
                             options,
                         },
                     })

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -524,7 +524,7 @@ CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES (foo, bar as 
 ----
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES (foo, bar AS qux, baz AS zop)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(SubsetTables([CreateSourceSubsource { reference: UnresolvedItemName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("bar")]), subsource: Some(UnresolvedItemName([Ident("qux")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(UnresolvedItemName([Ident("zop")])) }])), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(SubsetTables([ExternalReferenceExport { reference: UnresolvedItemName([Ident("foo")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("bar")]), alias: Some(UnresolvedItemName([Ident("qux")])) }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("baz")]), alias: Some(UnresolvedItemName([Ident("zop")])) }])), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn FOR TABLES ([s1 AS foo.bar]);
@@ -538,28 +538,28 @@ CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (TEXT COLUMNS (public.fo
 ----
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (TEXT COLUMNS = (public.foo.bar)) FOR ALL TABLES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS (public.foo.bar)) FOR ALL TABLES;
 ----
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS = (public.foo.bar)) FOR ALL TABLES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: IgnoreColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: IgnoreColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS (public.foo.bar), TEXT COLUMNS (public.foo.baz)) FOR ALL TABLES;
 ----
 CREATE SOURCE mz_source FROM MYSQL CONNECTION mysqlconn (IGNORE COLUMNS = (public.foo.bar), TEXT COLUMNS = (public.foo.baz)) FOR ALL TABLES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: IgnoreColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }, MySqlConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("baz")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: MySql { connection: Name(UnresolvedItemName([Ident("mysqlconn")])), options: [MySqlConfigOption { name: IgnoreColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))])) }, MySqlConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("baz")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red');
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic', PROGRESS GROUP ID PREFIX 'prefix', COMPRESSION TYPE = gzip) FORMAT BYTES
@@ -608,7 +608,7 @@ CREATE SOURCE psychic IN CLUSTER c FROM POSTGRES CONNECTION pgconn (PUBLICATION 
 ----
 CREATE SOURCE psychic IN CLUSTER c FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') INCLUDE TIMESTAMP
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: Some(Unresolved(Ident("c"))), col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [Timestamp { alias: None }], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: Some(Unresolved(Ident("c"))), col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [Timestamp { alias: None }], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SINK IF NOT EXISTS foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY (a, b) FORMAT BYTES ENVELOPE NONE
@@ -1389,49 +1389,49 @@ ALTER SOURCE n ADD SUBSOURCE a.b.c.d
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: None }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), alias: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), alias: None }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), alias: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), alias: None }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a, b.c, c, d.e
 ----
 ALTER SOURCE n ADD SUBSOURCE a, b.c, c, d.e
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("d"), Ident("e")]), subsource: None }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("b"), Ident("c")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("c")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("d"), Ident("e")]), alias: None }], options: [] } })
 
 
 parse-statement
@@ -1439,56 +1439,56 @@ ALTER SOURCE n ADD SUBSOURCE a.b.c.d WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), alias: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), alias: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d, a.b.c AS d.e.f.g, a.b.c WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), alias: Some(UnresolvedItemName([Ident("d"), Ident("e"), Ident("f"), Ident("g")])) }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), alias: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a.b.c.d AS e.f.g, a.b.c, a.b.c.d AS e.f.g WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), subsource: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("a"), Ident("b"), Ident("c"), Ident("d")]), alias: Some(UnresolvedItemName([Ident("e"), Ident("f"), Ident("g")])) }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE n ADD SUBSOURCE a, b.c, c, d.e WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE n ADD SUBSOURCE a, b.c, c, d.e WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("d"), Ident("e")]), subsource: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: false, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("b"), Ident("c")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("c")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("d"), Ident("e")]), alias: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH (TEXT COLUMNS [a.b, c.d])
 ----
 ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH (TEXT COLUMNS = (a.b, c.d))
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("b"), Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("c")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("d"), Ident("e")]), subsource: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("b"), Ident("c")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("c")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("d"), Ident("e")]), alias: None }], options: [AlterSourceAddSubsourceOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("a"), Ident("b")])), UnresolvedItemName(UnresolvedItemName([Ident("c"), Ident("d")]))])) }] } })
 
 parse-statement
 ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c, c, d.e WITH ()
@@ -1502,7 +1502,7 @@ ALTER SOURCE IF EXISTS n ADD TABLE a, b.c AS d
 ----
 ALTER SOURCE IF EXISTS n ADD SUBSOURCE a, b.c AS d
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: AddSubsources { subsources: [CreateSourceSubsource { reference: UnresolvedItemName([Ident("a")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("b"), Ident("c")]), subsource: Some(UnresolvedItemName([Ident("d")])) }], options: [] } })
+AlterSource(AlterSourceStatement { source_name: UnresolvedItemName([Ident("n")]), if_exists: true, action: AddSubsources { external_references: [ExternalReferenceExport { reference: UnresolvedItemName([Ident("a")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("b"), Ident("c")]), alias: Some(UnresolvedItemName([Ident("d")])) }], options: [] } })
 
 parse-statement
 ALTER SOURCE IF EXISTS n ADD SOURCE a, b.c AS d
@@ -2228,7 +2228,7 @@ CREATE SOURCE IF NOT EXISTS src1 (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA
 ----
 CREATE SOURCE IF NOT EXISTS src1 (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [Ident("a"), Ident("b")], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Bytes)), envelope: None, if_not_exists: true, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }), with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [Ident("a"), Ident("b")], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Bytes)), envelope: None, if_not_exists: true, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }), with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') KEY (a, b) FORMAT BYTES
@@ -2242,7 +2242,7 @@ CREATE SOURCE src1 (PRIMARY KEY (key1, key2) NOT ENFORCED) FROM KAFKA CONNECTION
 ----
 CREATE SOURCE src1 (PRIMARY KEY (key1, key2) NOT ENFORCED) FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Bytes)), envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("key1"), Ident("key2")] }), with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Bytes)), envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("key1"), Ident("key2")] }), with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL 'http://localhost:8081', USERNAME 'user', PASSWORD 'word', PORT 1234, AWS PRIVATELINK apl
@@ -2285,7 +2285,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING C
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } }))), envelope: Some(Debezium), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } }))), envelope: Some(Debezium), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 
 parse-statement
@@ -2293,7 +2293,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USI
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, seed: None } }))), envelope: Some(Debezium), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("conn2")])), options: [] }, seed: None } }))), envelope: Some(Debezium), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 
 parse-statement
@@ -2331,35 +2331,35 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING S
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING SCHEMA 'schema'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(InlineSchema { schema: Schema { schema: "schema" }, with_options: [] }))), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(InlineSchema { schema: Schema { schema: "schema" }, with_options: [] }))), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING SCHEMA 'schema' (CONFLUENT WIRE FORMAT = false)
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING SCHEMA 'schema' (CONFLUENT WIRE FORMAT = false)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(InlineSchema { schema: Schema { schema: "schema" }, with_options: [AvroSchemaOption { name: ConfluentWireFormat, value: Some(Value(Boolean(false))) }] }))), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(InlineSchema { schema: Schema { schema: "schema" }, with_options: [AvroSchemaOption { name: ConfluentWireFormat, value: Some(Value(Boolean(false))) }] }))), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING SCHEMA 'schema' (CONFLUENT WIRE FORMAT = true)
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING SCHEMA 'schema' (CONFLUENT WIRE FORMAT = true)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(InlineSchema { schema: Schema { schema: "schema" }, with_options: [AvroSchemaOption { name: ConfluentWireFormat, value: Some(Value(Boolean(true))) }] }))), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(InlineSchema { schema: Schema { schema: "schema" }, with_options: [AvroSchemaOption { name: ConfluentWireFormat, value: Some(Value(Boolean(true))) }] }))), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF MESSAGE 'Batch' USING SCHEMA '\x0a300a0d62696'
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF MESSAGE 'Batch' USING SCHEMA '\x0a300a0d62696'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(InlineSchema { message_name: "Batch", schema: Schema { schema: "\\x0a300a0d62696" } }))), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(InlineSchema { message_name: "Batch", schema: Schema { schema: "\\x0a300a0d62696" } }))), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED VALUE SCHEMA '{"some": "seed"}' MESSAGE 'Batch' ENVELOPE DEBEZIUM
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED VALUE SCHEMA '{"some": "seed"}' MESSAGE 'Batch' ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: None, value: CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" } }) } }))), envelope: Some(Debezium), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: None, value: CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" } }) } }))), envelope: Some(Debezium), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 
 parse-statement
@@ -2367,77 +2367,77 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USI
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(Debezium), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(Debezium), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE UPSERT
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(Upsert { value_decode_err_policy: [] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(Upsert { value_decode_err_policy: [] }), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE MATERIALIZE
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE MATERIALIZE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(CdcV2), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(CdcV2), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE NONE
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "seed"}' MESSAGE 'Batch' VALUE SCHEMA '123' MESSAGE 'M' ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, seed: Some(CsrSeedProtobuf { key: Some(CsrSeedProtobufSchema { schema: "{\"some\": \"seed\"}", message_name: "Batch" }), value: CsrSeedProtobufSchema { schema: "123", message_name: "M" } }) } }))), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') KEY FORMAT TEXT VALUE FORMAT REGEX '(?P<animal>[^,]+),(?P<food>\w+)' INCLUDE KEY
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') KEY FORMAT TEXT VALUE FORMAT REGEX '(?P<animal>[^,]+),(?P<food>\w+)' INCLUDE KEY
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [Key { alias: None }], format: Some(KeyValue { key: Text, value: Regex("(?P<animal>[^,]+),(?P<food>\\w+)") }), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [Key { alias: None }], format: Some(KeyValue { key: Text, value: Regex("(?P<animal>[^,]+),(?P<food>\\w+)") }), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') KEY FORMAT TEXT VALUE FORMAT CSV WITH 2 COLUMNS DELIMITED BY ','
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') KEY FORMAT TEXT VALUE FORMAT CSV WITH 2 COLUMNS
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Csv { columns: Count(2), delimiter: ',' } }), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Csv { columns: Count(2), delimiter: ',' } }), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') KEY FORMAT TEXT VALUE FORMAT CSV WITH 2 COLUMNS DELIMITED BY ';'
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') KEY FORMAT TEXT VALUE FORMAT CSV WITH 2 COLUMNS DELIMITED BY ';'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Csv { columns: Count(2), delimiter: ';' } }), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Csv { columns: Count(2), delimiter: ';' } }), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.foo', AVRO VALUE FULLNAME = 'some.neat.class.bar')
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.foo', AVRO VALUE FULLNAME = 'some.neat.class.bar')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [CsrConfigOption { name: AvroKeyFullname, value: Some(Value(String("some.neat.class.foo"))) }, CsrConfigOption { name: AvroValueFullname, value: Some(Value(String("some.neat.class.bar"))) }] }, key_strategy: None, value_strategy: None, seed: None } }))), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [CsrConfigOption { name: AvroKeyFullname, value: Some(Value(String("some.neat.class.foo"))) }, CsrConfigOption { name: AvroValueFullname, value: Some(Value(String("some.neat.class.bar"))) }] }, key_strategy: None, value_strategy: None, seed: None } }))), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED VALUE SCHEMA '{"some": "schema"}' ENVELOPE NONE
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED VALUE SCHEMA '{"some": "schema"}' ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: Some(CsrSeedAvro { key_schema: None, value_schema: "{\"some\": \"schema\"}" }) } }))), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: Some(CsrSeedAvro { key_schema: None, value_schema: "{\"some\": \"schema\"}" }) } }))), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "schema"}' VALUE SCHEMA '123' ENVELOPE NONE
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "schema"}' VALUE SCHEMA '123' ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: Some(CsrSeedAvro { key_schema: Some("{\"some\": \"schema\"}"), value_schema: "123" }) } }))), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: Some(CsrSeedAvro { key_schema: Some("{\"some\": \"schema\"}"), value_schema: "123" }) } }))), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "schema"}' VALUE SCHEMA '123' ENVELOPE NONE
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "schema"}' VALUE SCHEMA '123' ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(KeyValue { key: Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } }), value: Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: Some(CsrSeedAvro { key_schema: Some("{\"some\": \"schema\"}"), value_schema: "123" }) } }) }), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(KeyValue { key: Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } }), value: Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: Some(CsrSeedAvro { key_schema: Some("{\"some\": \"schema\"}"), value_schema: "123" }) } }) }), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 
 parse-statement
@@ -2445,7 +2445,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') KEY FORMAT AVRO USI
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn SEED KEY SCHEMA '{"some": "schema"}' VALUE SCHEMA '123' INCLUDE KEY, TIMESTAMP, PARTITION AS "PART2", OFFSET, HEADERS ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [Key { alias: None }, Timestamp { alias: None }, Partition { alias: Some(Ident("PART2")) }, Offset { alias: None }, Headers { alias: None }], format: Some(KeyValue { key: Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } }), value: Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: Some(CsrSeedAvro { key_schema: Some("{\"some\": \"schema\"}"), value_schema: "123" }) } }) }), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [Key { alias: None }, Timestamp { alias: None }, Partition { alias: Some(Ident("PART2")) }, Offset { alias: None }, Headers { alias: None }], format: Some(KeyValue { key: Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } }), value: Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedItemName([Ident("csr_conn")])), options: [] }, key_strategy: None, value_strategy: None, seed: Some(CsrSeedAvro { key_schema: Some("{\"some\": \"schema\"}"), value_schema: "123" }) } }) }), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE
@@ -2459,14 +2459,14 @@ CREATE SOURCE example FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT CSV WIT
 ----
 CREATE SOURCE example FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT CSV WITH HEADER (id, value)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("example")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Csv { columns: Header { names: [Ident("id"), Ident("value")] }, delimiter: ',' })), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("example")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Csv { columns: Header { names: [Ident("id"), Ident("value")] }, delimiter: ',' })), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE example FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT CSV WITH 5 COLUMNS
 ----
 CREATE SOURCE example FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT CSV WITH 5 COLUMNS
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("example")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Csv { columns: Count(5), delimiter: ',' })), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("example")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, include_metadata: [], format: Some(Bare(Csv { columns: Count(5), delimiter: ',' })), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, USER 'blah'
@@ -2485,56 +2485,56 @@ CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE lg FROM LOAD GENERATOR KEY VALUE (KEYS 1, PARTITIONS 2, TICK INTERVAL '1m', BATCH SIZE 100, SEED 200, VALUE SIZE 150, SNAPSHOT ROUNDS 3, TRANSACTIONAL SNAPSHOT = false)
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR KEY VALUE (KEYS = 1, PARTITIONS = 2, TICK INTERVAL = '1m', BATCH SIZE = 100, SEED = 200, VALUE SIZE = 150, SNAPSHOT ROUNDS = 3, TRANSACTIONAL SNAPSHOT = false)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: KeyValue, options: [LoadGeneratorOption { name: Keys, value: Some(Value(Number("1"))) }, LoadGeneratorOption { name: Partitions, value: Some(Value(Number("2"))) }, LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1m"))) }, LoadGeneratorOption { name: BatchSize, value: Some(Value(Number("100"))) }, LoadGeneratorOption { name: Seed, value: Some(Value(Number("200"))) }, LoadGeneratorOption { name: ValueSize, value: Some(Value(Number("150"))) }, LoadGeneratorOption { name: SnapshotRounds, value: Some(Value(Number("3"))) }, LoadGeneratorOption { name: TransactionalSnapshot, value: Some(Value(Boolean(false))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: KeyValue, options: [LoadGeneratorOption { name: Keys, value: Some(Value(Number("1"))) }, LoadGeneratorOption { name: Partitions, value: Some(Value(Number("2"))) }, LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1m"))) }, LoadGeneratorOption { name: BatchSize, value: Some(Value(Number("100"))) }, LoadGeneratorOption { name: Seed, value: Some(Value(Number("200"))) }, LoadGeneratorOption { name: ValueSize, value: Some(Value(Number("150"))) }, LoadGeneratorOption { name: SnapshotRounds, value: Some(Value(Number("3"))) }, LoadGeneratorOption { name: TransactionalSnapshot, value: Some(Value(Boolean(false))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1s', SCALE FACTOR 1, MAX CARDINALITY 100, UP TO 5, AS OF 5)
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL = '1s', SCALE FACTOR = 1, MAX CARDINALITY = 100, UP TO = 5, AS OF = 5)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1s"))) }, LoadGeneratorOption { name: ScaleFactor, value: Some(Value(Number("1"))) }, LoadGeneratorOption { name: MaxCardinality, value: Some(Value(Number("100"))) }, LoadGeneratorOption { name: UpTo, value: Some(Value(Number("5"))) }, LoadGeneratorOption { name: AsOf, value: Some(Value(Number("5"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1s"))) }, LoadGeneratorOption { name: ScaleFactor, value: Some(Value(Number("1"))) }, LoadGeneratorOption { name: MaxCardinality, value: Some(Value(Number("100"))) }, LoadGeneratorOption { name: UpTo, value: Some(Value(Number("5"))) }, LoadGeneratorOption { name: AsOf, value: Some(Value(Number("5"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE lg FROM LOAD GENERATOR MARKETING
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR MARKETING
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Marketing, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Marketing, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE lg FROM LOAD GENERATOR AUCTION
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR AUCTION
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Auction, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Auction, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE lg FROM LOAD GENERATOR DATUMS
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR DATUMS
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Datums, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Datums, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE lg FROM LOAD GENERATOR TPCH
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR TPCH
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Tpch, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("lg")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Tpch, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red') with (IGNORE KEYS 'true', TIMELINE 'timeline', TIMESTAMP INTERVAL 'interval')
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') WITH (IGNORE KEYS = 'true', TIMELINE = 'timeline', TIMESTAMP INTERVAL = 'interval')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: IgnoreKeys, value: Some(Value(String("true"))) }, CreateSourceOption { name: Timeline, value: Some(Value(String("timeline"))) }, CreateSourceOption { name: TimestampInterval, value: Some(Value(String("interval"))) }], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: IgnoreKeys, value: Some(Value(String("true"))) }, CreateSourceOption { name: Timeline, value: Some(Value(String("timeline"))) }, CreateSourceOption { name: TimestampInterval, value: Some(Value(String("interval"))) }], external_references: None, progress_subsource: None })
 
 parse-statement
 ALTER SYSTEM SET wal_level TO logical
@@ -2660,35 +2660,35 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FO
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR ALL TABLES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR SCHEMAS (one, two);
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR SCHEMAS (one, two)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(SubsetSchemas([Ident("one"), Ident("two")])), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(SubsetSchemas([Ident("one"), Ident("two")])), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR ALL TABLES;
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR ALL TABLES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (TEXT COLUMNS = [foo, foo.bar, foo.bar.qux, foo.bar.qux.qax, foo.bar.qux.qax.baz], DETAILS = 'details') FOR ALL TABLES;
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (TEXT COLUMNS = (foo, foo.bar, foo.bar.qux, foo.bar.qux.qax, foo.bar.qux.qax.baz), DETAILS = 'details') FOR ALL TABLES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("foo")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar"), Ident("qux")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar"), Ident("qux"), Ident("qax")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar"), Ident("qux"), Ident("qax"), Ident("baz")]))])) }, PgConfigOption { name: Details, value: Some(Value(String("details"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedItemName(UnresolvedItemName([Ident("foo")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar"), Ident("qux")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar"), Ident("qux"), Ident("qax")])), UnresolvedItemName(UnresolvedItemName([Ident("foo"), Ident("bar"), Ident("qux"), Ident("qax"), Ident("baz")]))])) }, PgConfigOption { name: Details, value: Some(Value(String("details"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES (foo, bar as qux, baz into zop);
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR TABLES (foo, bar AS qux, baz AS zop)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(SubsetTables([CreateSourceSubsource { reference: UnresolvedItemName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("bar")]), subsource: Some(UnresolvedItemName([Ident("qux")])) }, CreateSourceSubsource { reference: UnresolvedItemName([Ident("baz")]), subsource: Some(UnresolvedItemName([Ident("zop")])) }])), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(SubsetTables([ExternalReferenceExport { reference: UnresolvedItemName([Ident("foo")]), alias: None }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("bar")]), alias: Some(UnresolvedItemName([Ident("qux")])) }, ExternalReferenceExport { reference: UnresolvedItemName([Ident("baz")]), alias: Some(UnresolvedItemName([Ident("zop")])) }])), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar]);
@@ -2716,14 +2716,14 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FO
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR ALL TABLES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: None })
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR ALL TABLES EXPOSE PROGRESS AS foo.bar;
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR ALL TABLES EXPOSE PROGRESS AS foo.bar
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: Some(All), progress_subsource: Some(Deferred(UnresolvedItemName([Ident("foo"), Ident("bar")]))) })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("mz_source")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: Some(All), progress_subsource: Some(Deferred(UnresolvedItemName([Ident("foo"), Ident("bar")]))) })
 
 parse-statement
 ALTER CLUSTER foo RENAME TO joe
@@ -3031,35 +3031,35 @@ CREATE SOURCE header1 FROM KAFKA CONNECTION conn (TOPIC 'test') FORMAT JSON INCL
 ----
 CREATE SOURCE header1 FROM KAFKA CONNECTION conn (TOPIC = 'test') FORMAT JSON INCLUDE HEADERS, HEADER 'header3' AS h3, HEADER 'header5' AS h5 BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Headers { alias: None }, Header { key: "header3", alias: Ident("h3"), use_bytes: false }, Header { key: "header5", alias: Ident("h5"), use_bytes: true }], format: Some(Bare(Json { array: false })), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header1")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Headers { alias: None }, Header { key: "header3", alias: Ident("h3"), use_bytes: false }, Header { key: "header5", alias: Ident("h5"), use_bytes: true }], format: Some(Bare(Json { array: false })), envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE header2 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON INCLUDE HEADER 'header1' AS h1, HEADER 'header2' AS h2 BYTES ENVELOPE UPSERT
 ----
 CREATE SOURCE header2 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON INCLUDE HEADER 'header1' AS h1, HEADER 'header2' AS h2 BYTES ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header2")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Header { key: "header1", alias: Ident("h1"), use_bytes: false }, Header { key: "header2", alias: Ident("h2"), use_bytes: true }], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header2")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [Header { key: "header1", alias: Ident("h1"), use_bytes: false }, Header { key: "header2", alias: Ident("h2"), use_bytes: true }], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [] }), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE))
 ----
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE))
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline { alias: None }] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline { alias: None }] }), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = INLINE)
 ----
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE))
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline { alias: None }] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline { alias: None }] }), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = INLINE AS my_col)
 ----
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC = 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS = (INLINE AS my_col))
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline { alias: Some(Ident("my_col")) }] }), if_not_exists: false, key_constraint: None, with_options: [], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("header3")]), in_cluster: None, col_names: [], connection: Kafka { connection: Name(UnresolvedItemName([Ident("conn")])), options: [KafkaSourceConfigOption { name: Topic, value: Some(Value(String("test"))) }] }, include_metadata: [], format: Some(KeyValue { key: Text, value: Json { array: false } }), envelope: Some(Upsert { value_decode_err_policy: [Inline { alias: Some(Ident("my_col")) }] }), if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SOURCE header3 FROM KAFKA CONNECTION conn (TOPIC 'test') KEY FORMAT TEXT VALUE FORMAT JSON ENVELOPE UPSERT (VALUE DECODING ERRORS)
@@ -3073,7 +3073,7 @@ CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (RETAIN HISTORY FOR '1s');
 ----
 CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (RETAIN HISTORY = FOR '1s')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("s")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1s"))) }], referenced_subsources: None, progress_subsource: None })
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("s")]), in_cluster: None, col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: RetainHistory, value: Some(RetainHistoryFor(String("1s"))) }], external_references: None, progress_subsource: None })
 
 parse-statement
 ALTER MATERIALIZED VIEW mv SET (RETAIN HISTORY FOR '3m')

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -270,7 +270,7 @@ pub fn create_statement(
             if_not_exists,
             key_constraint: _,
             with_options: _,
-            referenced_subsources: _,
+            external_references: _,
             progress_subsource: _,
         }) => {
             *name = allocate_name(name)?;

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -30,7 +30,7 @@ use mz_repr::{strconv, ColumnName, GlobalId};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{IdentError, UnresolvedItemName};
 use mz_sql_parser::parser::{ParserError, ParserStatementError};
-use mz_storage_types::sources::SubsourceResolutionError;
+use mz_storage_types::sources::ExternalReferenceResolutionError;
 
 use crate::catalog::{
     CatalogError, CatalogItemType, ErrorMessageObjectDescription, SystemObjectType,
@@ -262,7 +262,7 @@ pub enum PlanError {
         limit: Duration,
     },
     RetainHistoryRequired,
-    SubsourceResolutionError(SubsourceResolutionError),
+    SubsourceResolutionError(ExternalReferenceResolutionError),
     Replan(String),
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
@@ -884,8 +884,8 @@ impl From<IdentError> for PlanError {
     }
 }
 
-impl From<SubsourceResolutionError> for PlanError {
-    fn from(e: SubsourceResolutionError) -> Self {
+impl From<ExternalReferenceResolutionError> for PlanError {
+    fn from(e: ExternalReferenceResolutionError) -> Self {
         PlanError::SubsourceResolutionError(e)
     }
 }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -21,7 +21,7 @@ use mz_ore::collections::CollectionExt;
 use mz_repr::{Datum, GlobalId, RelationDesc, Row, ScalarType};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
-    CreateSourceSubsource, ObjectType, ReferencedSubsources, ShowCreateClusterStatement,
+    ExternalReferenceExport, ExternalReferences, ObjectType, ShowCreateClusterStatement,
     ShowCreateConnectionStatement, ShowCreateMaterializedViewStatement, ShowObjectType,
     SystemObjectType, UnresolvedItemName, WithOptionValue,
 };
@@ -1041,7 +1041,7 @@ fn humanize_sql_for_show_create(
                     // `FOR ALL TABLES`. However, this would change if #26765
                     // landed.
                     curr_references.clear();
-                    stmt.referenced_subsources = Some(ReferencedSubsources::All);
+                    stmt.external_references = Some(ExternalReferences::All);
                 }
                 CreateSourceConnection::Kafka { .. }
                 | CreateSourceConnection::LoadGenerator { .. } => {}
@@ -1051,13 +1051,13 @@ fn humanize_sql_for_show_create(
             if !curr_references.is_empty() {
                 let mut subsources: Vec<_> = curr_references
                     .into_iter()
-                    .map(|(reference, name)| CreateSourceSubsource {
+                    .map(|(reference, name)| ExternalReferenceExport {
                         reference,
-                        subsource: Some(name),
+                        alias: Some(name),
                     })
                     .collect();
                 subsources.sort();
-                stmt.referenced_subsources = Some(ReferencedSubsources::SubsetTables(subsources));
+                stmt.external_references = Some(ExternalReferences::SubsetTables(subsources));
             }
         }
         _ => (),

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -24,13 +24,12 @@ use mz_storage_types::sources::SubsourceResolver;
 use tokio_postgres::types::Oid;
 use tokio_postgres::Client;
 
-use crate::catalog::SessionCatalog;
-use crate::names::{Aug, PartialItemName, ResolvedItemName};
+use crate::names::{Aug, ResolvedItemName};
 use crate::normalize;
 use crate::plan::{PlanError, StatementContext};
 
 use super::error::PgSourcePurificationError;
-use super::RequestedSubsource;
+use super::{PartialItemName, PurifiedExportDetails, PurifiedSourceExport, RequestedSubsource};
 
 /// Ensure that we have select permissions on all tables; we have to do this before we
 /// start snapshotting because if we discover we cannot `COPY` from a table while
@@ -127,47 +126,37 @@ pub(super) fn generate_text_columns(
     Ok(text_cols_dict)
 }
 
-pub(crate) fn generate_targeted_subsources(
+pub fn generate_create_subsource_statements(
     scx: &StatementContext,
-    source_name: Option<ResolvedItemName>,
-    validated_requested_subsources: Vec<RequestedSubsource<'_, PostgresTableDesc>>,
-    mut text_cols_dict: BTreeMap<u32, BTreeSet<String>>,
-    publication_tables: &[PostgresTableDesc],
-) -> Result<
-    (
-        Vec<CreateSubsourceStatement<Aug>>,
-        // These are the tables referenced by the subsources. We want this set
-        // of tables separately so we can retain only table definitions that are
-        // referenced by subsources. This helps avoid issues when generating PG
-        // source table casts.
-        Vec<PostgresTableDesc>,
-    ),
-    PlanError,
-> {
-    let mut subsources = vec![];
-    let mut referenced_tables = vec![];
-
+    source_name: ResolvedItemName,
+    requested_subsources: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
+) -> Result<Vec<CreateSubsourceStatement<Aug>>, PlanError> {
     // Aggregate all unrecognized types.
     let mut unsupported_cols = vec![];
 
     // Now that we have an explicit list of validated requested subsources we can create them
-    for RequestedSubsource {
-        upstream_name,
-        subsource_name,
-        table,
-    } in validated_requested_subsources.into_iter()
-    {
+    let mut subsources = Vec::with_capacity(requested_subsources.len());
+
+    for (subsource_name, purified_export) in requested_subsources {
+        let (text_columns, table) = match &purified_export.details {
+            PurifiedExportDetails::Postgres {
+                text_columns,
+                table,
+            } => (text_columns, table),
+            _ => unreachable!("purified export details must be postgres"),
+        };
+
         // Figure out the schema of the subsource
         let mut columns = vec![];
-        let text_cols_dict = text_cols_dict.remove(&table.oid);
         for c in table.columns.iter() {
             let name = Ident::new(c.name.clone())?;
-            let ty = match &text_cols_dict {
+
+            let ty = match text_columns {
                 Some(names) if names.contains(&c.name) => mz_pgrepr::Type::Text,
                 _ => match mz_pgrepr::Type::from_oid_and_typmod(c.type_oid, c.type_mod) {
                     Ok(t) => t,
                     Err(_) => {
-                        let mut full_name = upstream_name.0.clone();
+                        let mut full_name = purified_export.external_reference.0.clone();
                         full_name.push(name);
                         unsupported_cols.push((
                             UnresolvedItemName(full_name).to_ast_string(),
@@ -234,7 +223,7 @@ pub(crate) fn generate_targeted_subsources(
             columns,
             // We might not know the primary source's `GlobalId` yet; if not,
             // we'll fill it in once we generate it.
-            of_source: source_name.clone(),
+            of_source: Some(source_name.clone()),
             // TODO(petrosagg): nothing stops us from getting the constraints of the
             // upstream tables and mirroring them here which will lead to more optimization
             // opportunities if for example there is a primary key or an index.
@@ -247,11 +236,12 @@ pub(crate) fn generate_targeted_subsources(
             if_not_exists: false,
             with_options: vec![CreateSubsourceOption {
                 name: CreateSubsourceOptionName::ExternalReference,
-                value: Some(WithOptionValue::UnresolvedItemName(upstream_name)),
+                value: Some(WithOptionValue::UnresolvedItemName(
+                    purified_export.external_reference,
+                )),
             }],
         };
         subsources.push(subsource);
-        referenced_tables.push(table.clone())
     }
 
     if !unsupported_cols.is_empty() {
@@ -261,35 +251,11 @@ pub(crate) fn generate_targeted_subsources(
         })?;
     }
 
-    // If any any item was not removed from the text_cols dict, it wasn't being
-    // added.
-    let mut dangling_text_column_refs = vec![];
-
-    for id in text_cols_dict.keys() {
-        let desc = publication_tables
-            .iter()
-            .find(|t| t.oid == *id)
-            .expect("validated when generating text columns");
-
-        dangling_text_column_refs.push(PartialItemName {
-            database: None,
-            schema: Some(desc.namespace.clone()),
-            item: desc.name.clone(),
-        });
-    }
-
-    if !dangling_text_column_refs.is_empty() {
-        dangling_text_column_refs.sort();
-        Err(PgSourcePurificationError::DanglingTextColumns {
-            items: dangling_text_column_refs,
-        })?;
-    }
-
-    Ok((subsources, referenced_tables))
+    Ok(subsources)
 }
 
 pub(super) struct PurifiedSubsources {
-    pub(super) new_subsources: Vec<CreateSubsourceStatement<Aug>>,
+    pub(super) subsources: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
     pub(super) referenced_tables: Vec<PostgresTableDesc>,
     pub(super) normalized_text_columns: Vec<WithOptionValue<Aug>>,
 }
@@ -304,11 +270,9 @@ pub(super) async fn purify_subsources(
     connection: &PostgresConnection,
     referenced_subsources: &mut Option<ReferencedSubsources>,
     mut text_columns: Vec<UnresolvedItemName>,
-    resolved_source_name: Option<ResolvedItemName>,
     unresolved_source_name: &UnresolvedItemName,
-    catalog: &impl SessionCatalog,
 ) -> Result<PurifiedSubsources, PlanError> {
-    let publication_tables = mz_postgres_util::publication_info(client, publication).await?;
+    let mut publication_tables = mz_postgres_util::publication_info(client, publication).await?;
 
     if publication_tables.is_empty() {
         Err(PgSourcePurificationError::EmptyPublication(
@@ -325,7 +289,7 @@ pub(super) async fn purify_subsources(
     {
         ReferencedSubsources::All => {
             for table in &publication_tables {
-                let upstream_name = UnresolvedItemName::qualified(&[
+                let external_reference = UnresolvedItemName::qualified(&[
                     Ident::new(&connection.database)?,
                     Ident::new(&table.namespace)?,
                     Ident::new(&table.name)?,
@@ -333,7 +297,7 @@ pub(super) async fn purify_subsources(
                 let subsource_name =
                     super::subsource_name_gen(unresolved_source_name, &table.name)?;
                 validated_requested_subsources.push(RequestedSubsource {
-                    upstream_name,
+                    external_reference,
                     subsource_name,
                     table,
                 });
@@ -366,7 +330,7 @@ pub(super) async fn purify_subsources(
                     continue;
                 }
 
-                let upstream_name = UnresolvedItemName::qualified(&[
+                let external_reference = UnresolvedItemName::qualified(&[
                     Ident::new(&connection.database)?,
                     Ident::new(&table.namespace)?,
                     Ident::new(&table.name)?,
@@ -374,7 +338,7 @@ pub(super) async fn purify_subsources(
                 let subsource_name =
                     super::subsource_name_gen(unresolved_source_name, &table.name)?;
                 validated_requested_subsources.push(RequestedSubsource {
-                    upstream_name,
+                    external_reference,
                     subsource_name,
                     table,
                 });
@@ -409,7 +373,7 @@ pub(super) async fn purify_subsources(
 
     validate_requested_subsources_privileges(config, client, &table_oids).await?;
 
-    let text_cols_dict =
+    let mut text_column_map =
         generate_text_columns(&subsource_resolver, &publication_tables, &mut text_columns)?;
 
     // Normalize options to contain full qualified values.
@@ -420,18 +384,52 @@ pub(super) async fn purify_subsources(
         .map(WithOptionValue::UnresolvedItemName)
         .collect();
 
-    let scx = StatementContext::new(None, catalog);
-    let (new_subsources, referenced_tables) = generate_targeted_subsources(
-        &scx,
-        resolved_source_name,
-        validated_requested_subsources,
-        text_cols_dict,
-        &publication_tables,
-    )?;
+    let requested_subsources = validated_requested_subsources
+        .into_iter()
+        .map(|r| {
+            (
+                r.subsource_name,
+                PurifiedSourceExport {
+                    external_reference: r.external_reference,
+                    details: PurifiedExportDetails::Postgres {
+                        table: r.table.clone(),
+                        text_columns: text_column_map.remove(&r.table.oid),
+                    },
+                },
+            )
+        })
+        .collect();
+
+    // If any any item was not removed from the text_column_map, it wasn't being
+    // added.
+    let mut dangling_text_column_refs = vec![];
+
+    for id in text_column_map.keys() {
+        let desc = publication_tables
+            .iter()
+            .find(|t| t.oid == *id)
+            .expect("validated when generating text columns");
+
+        dangling_text_column_refs.push(PartialItemName {
+            database: None,
+            schema: Some(desc.namespace.clone()),
+            item: desc.name.clone(),
+        });
+    }
+
+    if !dangling_text_column_refs.is_empty() {
+        dangling_text_column_refs.sort();
+        Err(PgSourcePurificationError::DanglingTextColumns {
+            items: dangling_text_column_refs,
+        })?;
+    }
+
+    // Trim any un-referred-to tables
+    publication_tables.retain(|t| table_oids.contains(&t.oid));
 
     Ok(PurifiedSubsources {
-        new_subsources,
-        referenced_tables,
+        subsources: requested_subsources,
+        referenced_tables: publication_tables,
         normalized_text_columns,
     })
 }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2235,7 +2235,7 @@ where
                         .await
                         .map_err(|_| StorageError::ReadBeforeSince(remap_id))?;
 
-                    tracing::debug!(?id, type_ = source_conn.name(), upstream = ?source_conn.upstream_name(), "fetching real time recency");
+                    tracing::debug!(?id, type_ = source_conn.name(), upstream = ?source_conn.external_reference(), "fetching real time recency");
 
                     let result = rtr::real_time_recency_ts(source_conn, id, config, as_of, remap_subscribe)
                         .await.map_err(|e| {

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -887,7 +887,7 @@ where
                     .desc
                     .alter_compatible(ingestion_id, source_desc)?;
 
-                let subsource_resolver = cur_ingestion.desc.connection.get_subsource_resolver();
+                let reference_resolver = cur_ingestion.desc.connection.get_reference_resolver();
 
                 // Ensure updated `SourceDesc` contains reference to all
                 // current external references.
@@ -913,7 +913,7 @@ where
                         }
                     };
 
-                    if subsource_resolver
+                    if reference_resolver
                         .resolve_idx(&external_reference.0)
                         .is_err()
                     {

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -713,7 +713,7 @@ pub trait SourceConnection: Debug + Clone + PartialEq + AlterCompatible {
     fn name(&self) -> &'static str;
 
     /// The name of the resource in the external system (e.g kafka topic) if any
-    fn upstream_name(&self) -> Option<&str>;
+    fn external_reference(&self) -> Option<&str>;
 
     /// The schema of this connection's key rows.
     // This is mostly setting the stage for the subsequent PRs that will attempt to compute and
@@ -986,12 +986,12 @@ impl<C: ConnectionAccess> SourceConnection for GenericSourceConnection<C> {
         }
     }
 
-    fn upstream_name(&self) -> Option<&str> {
+    fn external_reference(&self) -> Option<&str> {
         match self {
-            Self::Kafka(conn) => conn.upstream_name(),
-            Self::Postgres(conn) => conn.upstream_name(),
-            Self::MySql(conn) => conn.upstream_name(),
-            Self::LoadGenerator(conn) => conn.upstream_name(),
+            Self::Kafka(conn) => conn.external_reference(),
+            Self::Postgres(conn) => conn.external_reference(),
+            Self::MySql(conn) => conn.external_reference(),
+            Self::LoadGenerator(conn) => conn.external_reference(),
         }
     }
 

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -189,7 +189,7 @@ impl<C: ConnectionAccess> SourceConnection for KafkaSourceConnection<C> {
         "kafka"
     }
 
-    fn upstream_name(&self) -> Option<&str> {
+    fn external_reference(&self) -> Option<&str> {
         Some(self.topic.as_str())
     }
 

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -254,8 +254,8 @@ impl<C: ConnectionAccess> SourceConnection for KafkaSourceConnection<C> {
             .collect()
     }
 
-    fn get_subsource_resolver(&self) -> super::SubsourceResolver {
-        super::SubsourceResolver::default()
+    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
+        super::SourceReferenceResolver::default()
     }
 }
 

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -54,7 +54,7 @@ impl SourceConnection for LoadGeneratorSourceConnection {
         "load-generator"
     }
 
-    fn upstream_name(&self) -> Option<&str> {
+    fn external_reference(&self) -> Option<&str> {
         None
     }
 

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -123,15 +123,15 @@ impl SourceConnection for LoadGeneratorSourceConnection {
         vec![]
     }
 
-    fn get_subsource_resolver(&self) -> super::SubsourceResolver {
+    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
         let views: Vec<_> = self
             .load_generator
             .views()
             .into_iter()
             .map(|(name, _)| (self.load_generator.schema_name(), name))
             .collect();
-        super::SubsourceResolver::new(LOAD_GENERATOR_DATABASE_NAME, &views)
-            .expect("already validated that SubsourceResolver elements are valid")
+        super::SourceReferenceResolver::new(LOAD_GENERATOR_DATABASE_NAME, &views)
+            .expect("already validated that SourceReferenceResolver elements are valid")
     }
 }
 

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -196,9 +196,9 @@ impl<C: ConnectionAccess> SourceConnection for MySqlSourceConnection<C> {
         vec![]
     }
 
-    fn get_subsource_resolver(&self) -> super::SubsourceResolver {
-        super::SubsourceResolver::new("mysql", &self.details.tables)
-            .expect("already validated that SubsourceResolver elements are valid")
+    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
+        super::SourceReferenceResolver::new("mysql", &self.details.tables)
+            .expect("already validated that SourceReferenceResolver elements are valid")
     }
 }
 

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -170,7 +170,7 @@ impl<C: ConnectionAccess> SourceConnection for MySqlSourceConnection<C> {
         "mysql"
     }
 
-    fn upstream_name(&self) -> Option<&str> {
+    fn external_reference(&self) -> Option<&str> {
         None
     }
 

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -133,12 +133,12 @@ impl<C: ConnectionAccess> SourceConnection for PostgresSourceConnection<C> {
         vec![]
     }
 
-    fn get_subsource_resolver(&self) -> super::SubsourceResolver {
-        super::SubsourceResolver::new(
+    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
+        super::SourceReferenceResolver::new(
             &self.publication_details.database,
             &self.publication_details.tables,
         )
-        .expect("already validated that SubsourceResolver elements are valid")
+        .expect("already validated that SourceReferenceResolver elements are valid")
     }
 }
 

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -107,7 +107,7 @@ impl<C: ConnectionAccess> SourceConnection for PostgresSourceConnection<C> {
         "postgres"
     }
 
-    fn upstream_name(&self) -> Option<&str> {
+    fn external_reference(&self) -> Option<&str> {
         None
     }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Inspired by & replaces Sean's draft PR https://github.com/MaterializeInc/materialize/pull/27320/  to shuffle when subsource statements are generated.

This PR is prep work for the implementation described in https://github.com/MaterializeInc/materialize/pull/27907

This PR shouldn't introduce any functional changes -- it is a refactor of subsource purification such that we now generate `CreateSubsourceStatement`s after purification and using the same method in both 'create source' and 'alter source' statements.

The intent is to tease apart the purification logic (obtaining state from external systems) from the statement generation logic, such that I can re-use as much of the subsource purification logic as possible to purify & plan `CREATE TABLE .. FROM SOURCE` statements in subsequent PRs.

In the spirit of yesterday's cluster-team whiteboard discussions I also cleaned up the naming in much of the purification code.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

The first commit is the actual refactor

The 2nd and 3rd commits are a rename of many overloaded structs/variables using the word 'subsource', to clarify whether they were referring to an 'external reference' (e.g. upstream postgres table) or a 'source export' - the object (e.g. either a subsource or table) being exported by a source. This ended up more LOC than expected but clarifying these terms will likely make later PRs easier to grok.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
