### PR TITLE
catalog: Remove [] operator from apply

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -534,11 +534,15 @@ impl CatalogState {
             .get(&system_object_mapping.description)
             .expect("missing builtin")
             .1;
-        let schema_id = self.ambient_schemas_by_name[builtin.schema()];
+        let schema_name = builtin.schema();
+        let schema_id = self
+            .ambient_schemas_by_name
+            .get(schema_name)
+            .unwrap_or_else(|| panic!("unknown ambient schema: {schema_name}"));
         let name = QualifiedItemName {
             qualifiers: ItemQualifiers {
                 database_spec: ResolvedDatabaseSpecifier::Ambient,
-                schema_spec: SchemaSpecifier::Id(schema_id),
+                schema_spec: SchemaSpecifier::Id(*schema_id),
             },
             item: builtin.name().into(),
         };
@@ -1109,11 +1113,14 @@ impl CatalogState {
                 Ok(item) => {
                     // Add item to catalog.
                     let view = views.remove(&id).expect("must exist");
-                    let schema_id = state.ambient_schemas_by_name[view.schema];
+                    let schema_id = state
+                        .ambient_schemas_by_name
+                        .get(view.schema)
+                        .unwrap_or_else(|| panic!("unknown ambient schema: {}", view.schema));
                     let qname = QualifiedItemName {
                         qualifiers: ItemQualifiers {
                             database_spec: ResolvedDatabaseSpecifier::Ambient,
-                            schema_spec: SchemaSpecifier::Id(schema_id),
+                            schema_spec: SchemaSpecifier::Id(*schema_id),
                         },
                         item: view.name.into(),
                     };


### PR DESCRIPTION
This commit removes the `[]` operator for indexing a collection from all catalog apply methods. It is instead replaced with `.get(_).unwrap_or_else(|| panic!(_))`, which provides a much more useful error message.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
