### PR TITLE
README: Add reference to MySQL and make code sample work standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We support a large fraction of PostgreSQL, and are actively working on supportin
 
 ## Get data in
 
-Materialize can read data from [Kafka](https://materialize.com/docs/sql/create-source/kafka/) (and other Kafka API-compatible systems like [Redpanda](https://materialize.com/docs/integrations/redpanda/)), directly from a [PostgreSQL](https://materialize.com/docs/sql/create-source/postgres/) replication stream, or from SaaS applications [via webhooks](https://materialize.com/docs/sql/create-source/webhook/). It also supports regular database tables to which you can insert, update, and delete rows.
+Materialize can read data from [Kafka](https://materialize.com/docs/sql/create-source/kafka/) (and other Kafka API-compatible systems like [Redpanda](https://materialize.com/docs/integrations/redpanda/)), directly from a [PostgreSQL](https://materialize.com/docs/sql/create-source/postgres/) or [MySQL](https://materialize.com/docs/sql/create-source/mysql/) replication stream, or from SaaS applications [via webhooks](https://materialize.com/docs/sql/create-source/webhook/). It also supports regular database tables to which you can insert, update, and delete rows.
 
 ## Transform, manipulate, and read your data
 
@@ -62,6 +62,10 @@ Materialize supports a comprehensive variety of SQL features, all using the Post
 Here's an example join query that works fine in Materialize, `TPC-H` query 15:
 
 ```sql
+CREATE SOURCE tpch
+  FROM LOAD GENERATOR TPCH (SCALE FACTOR 1)
+  FOR ALL TABLES;
+
 -- Views define commonly reused subqueries.
 CREATE VIEW revenue (supplier_no, total_revenue) AS
     SELECT


### PR DESCRIPTION
We might want to wait for MySQL sources to be out of private preview first?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
