### PR TITLE
persist: Add stats only override

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -934,6 +934,7 @@ class FlipFlagsAction(Action):
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_columnar_format"] = ["row", "both_v2"]
         self.flags_with_values["persist_batch_record_part_format"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["persist_batch_columnar_stats_only_override"] = BOOLEAN_FLAG_VALUES
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -934,7 +934,9 @@ class FlipFlagsAction(Action):
         self.flags_with_values["enable_eager_delta_joins"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_batch_columnar_format"] = ["row", "both_v2"]
         self.flags_with_values["persist_batch_record_part_format"] = BOOLEAN_FLAG_VALUES
-        self.flags_with_values["persist_batch_columnar_stats_only_override"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["persist_batch_columnar_stats_only_override"] = (
+            BOOLEAN_FLAG_VALUES
+        )
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -324,6 +324,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     mz_persist::cfg::all_dyn_configs(configs)
         .add(&crate::batch::BATCH_DELETE_ENABLED)
         .add(&crate::batch::BATCH_COLUMNAR_FORMAT)
+        .add(&crate::batch::BATCH_COLUMNAR_STATS_ONLY_OVERRIDE)
         .add(&crate::batch::BATCH_RECORD_PART_FORMAT)
         .add(&crate::batch::BLOB_TARGET_SIZE)
         .add(&crate::batch::INLINE_WRITES_TOTAL_MAX_BYTES)


### PR DESCRIPTION
While we work on rolling out Columnar V2 it would be great to rollout the statistics collection separately from durably recording the data.

### Motivation

Faster rollout

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
