### PR TITLE
Improve several MIR constructors

### DIFF
--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -1212,6 +1212,7 @@ impl MirRelationExpr {
         };
         // Normalize collection of predicates.
         new_predicates.extend(predicates);
+        new_predicates.retain(|p| !p.is_literal_true());
         new_predicates.sort();
         new_predicates.dedup();
         // Introduce a `Filter` only if we have predicates.
@@ -1301,9 +1302,12 @@ impl MirRelationExpr {
 
     /// Constructs a join operator from inputs and required-equal scalar expressions.
     pub fn join_scalars(
-        inputs: Vec<MirRelationExpr>,
+        mut inputs: Vec<MirRelationExpr>,
         equivalences: Vec<Vec<MirScalarExpr>>,
     ) -> Self {
+        // Remove all constant inputs that are the identity for join.
+        // They neither introduce nor modify any column references.
+        inputs.retain(|i| !i.is_constant_singleton());
         MirRelationExpr::Join {
             inputs,
             equivalences,

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -95,24 +95,23 @@ FROM x,
              SELECT * FROM a);
 ----
 Return // { arity: 2 }
-  Filter true // { arity: 2 }
-    Project (#0, #2) // { arity: 2 }
-      Join on=(#0 = #1) // { arity: 3 }
-        Get l0 // { arity: 1 }
-        Union // { arity: 2 }
-          Get l2 // { arity: 2 }
-          CrossJoin // { arity: 2 }
-            Project (#0) // { arity: 1 }
-              Join on=(#0 = #1) // { arity: 2 }
-                Union // { arity: 1 }
-                  Negate // { arity: 1 }
-                    Distinct project=[#0] // { arity: 1 }
-                      Get l2 // { arity: 2 }
+  Project (#0, #2) // { arity: 2 }
+    Join on=(#0 = #1) // { arity: 3 }
+      Get l0 // { arity: 1 }
+      Union // { arity: 2 }
+        Get l2 // { arity: 2 }
+        CrossJoin // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Join on=(#0 = #1) // { arity: 2 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
                   Distinct project=[#0] // { arity: 1 }
-                    Get l1 // { arity: 1 }
-                Get l1 // { arity: 1 }
-            Constant // { arity: 1 }
-              - (null)
+                    Get l2 // { arity: 2 }
+                Distinct project=[#0] // { arity: 1 }
+                  Get l1 // { arity: 1 }
+              Get l1 // { arity: 1 }
+          Constant // { arity: 1 }
+            - (null)
 With
   cte l2 =
     Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
@@ -155,32 +154,31 @@ FROM x,
              SELECT (SELECT m FROM a) FROM y) b;
 ----
 Return // { arity: 2 }
-  Filter true // { arity: 2 }
-    Project (#0, #2) // { arity: 2 }
-      Join on=(#0 = #1) // { arity: 3 }
-        Get l0 // { arity: 1 }
-        Project (#0, #2) // { arity: 2 }
-          Project (#0, #1, #5) // { arity: 3 }
-            Map (#4) // { arity: 6 }
-              Join on=(#0 = #2 AND #1 = #3) // { arity: 5 }
-                Get l3 // { arity: 2 }
-                Project (#0, #1, #3) // { arity: 3 }
-                  Join on=(#0 = #2) // { arity: 4 }
-                    Get l4 // { arity: 2 }
-                    Union // { arity: 2 }
-                      Get l7 // { arity: 2 }
-                      CrossJoin // { arity: 2 }
-                        Project (#0) // { arity: 1 }
-                          Join on=(#0 = #1) // { arity: 2 }
-                            Union // { arity: 1 }
-                              Negate // { arity: 1 }
-                                Distinct project=[#0] // { arity: 1 }
-                                  Get l7 // { arity: 2 }
+  Project (#0, #2) // { arity: 2 }
+    Join on=(#0 = #1) // { arity: 3 }
+      Get l0 // { arity: 1 }
+      Project (#0, #2) // { arity: 2 }
+        Project (#0, #1, #5) // { arity: 3 }
+          Map (#4) // { arity: 6 }
+            Join on=(#0 = #2 AND #1 = #3) // { arity: 5 }
+              Get l3 // { arity: 2 }
+              Project (#0, #1, #3) // { arity: 3 }
+                Join on=(#0 = #2) // { arity: 4 }
+                  Get l4 // { arity: 2 }
+                  Union // { arity: 2 }
+                    Get l7 // { arity: 2 }
+                    CrossJoin // { arity: 2 }
+                      Project (#0) // { arity: 1 }
+                        Join on=(#0 = #1) // { arity: 2 }
+                          Union // { arity: 1 }
+                            Negate // { arity: 1 }
                               Distinct project=[#0] // { arity: 1 }
-                                Get l5 // { arity: 1 }
-                            Get l5 // { arity: 1 }
-                        Constant // { arity: 1 }
-                          - (null)
+                                Get l7 // { arity: 2 }
+                            Distinct project=[#0] // { arity: 1 }
+                              Get l5 // { arity: 1 }
+                          Get l5 // { arity: 1 }
+                      Constant // { arity: 1 }
+                        - (null)
 With
   cte l7 =
     Union // { arity: 2 }
@@ -247,15 +245,14 @@ FROM x,
              SELECT * FROM a INNER JOIN a b ON a.m = b.m);
 ----
 Return // { arity: 3 }
-  Filter true // { arity: 3 }
-    Project (#0, #2, #3) // { arity: 3 }
-      Join on=(#0 = #1) // { arity: 4 }
-        Get l0 // { arity: 1 }
-        Filter (#1 = #2) // { arity: 3 }
-          Project (#0, #1, #3) // { arity: 3 }
-            Join on=(#0 = #2) // { arity: 4 }
-              Get l3 // { arity: 2 }
-              Get l3 // { arity: 2 }
+  Project (#0, #2, #3) // { arity: 3 }
+    Join on=(#0 = #1) // { arity: 4 }
+      Get l0 // { arity: 1 }
+      Filter (#1 = #2) // { arity: 3 }
+        Project (#0, #1, #3) // { arity: 3 }
+          Join on=(#0 = #2) // { arity: 4 }
+            Get l3 // { arity: 2 }
+            Get l3 // { arity: 2 }
 With
   cte l3 =
     Union // { arity: 2 }
@@ -319,35 +316,33 @@ FROM x,
              SELECT * FROM a INNER JOIN (SELECT (SELECT m FROM a) FROM y) b ON true);
 ----
 Return // { arity: 3 }
-  Filter true // { arity: 3 }
-    Project (#0, #2, #3) // { arity: 3 }
-      Join on=(#0 = #1) // { arity: 4 }
-        Get l0 // { arity: 1 }
-        Filter true // { arity: 3 }
-          Project (#0, #1, #3) // { arity: 3 }
-            Join on=(#0 = #2) // { arity: 4 }
-              Get l3 // { arity: 2 }
-              Project (#0, #5) // { arity: 2 }
-                Map (#4) // { arity: 6 }
-                  Join on=(#0 = #2 AND #1 = #3) // { arity: 5 }
-                    Get l4 // { arity: 2 }
-                    Project (#0, #1, #3) // { arity: 3 }
-                      Join on=(#0 = #2) // { arity: 4 }
-                        Get l5 // { arity: 2 }
-                        Union // { arity: 2 }
-                          Get l8 // { arity: 2 }
-                          CrossJoin // { arity: 2 }
-                            Project (#0) // { arity: 1 }
-                              Join on=(#0 = #1) // { arity: 2 }
-                                Union // { arity: 1 }
-                                  Negate // { arity: 1 }
-                                    Distinct project=[#0] // { arity: 1 }
-                                      Get l8 // { arity: 2 }
-                                  Distinct project=[#0] // { arity: 1 }
-                                    Get l6 // { arity: 1 }
+  Project (#0, #2, #3) // { arity: 3 }
+    Join on=(#0 = #1) // { arity: 4 }
+      Get l0 // { arity: 1 }
+      Project (#0, #1, #3) // { arity: 3 }
+        Join on=(#0 = #2) // { arity: 4 }
+          Get l3 // { arity: 2 }
+          Project (#0, #5) // { arity: 2 }
+            Map (#4) // { arity: 6 }
+              Join on=(#0 = #2 AND #1 = #3) // { arity: 5 }
+                Get l4 // { arity: 2 }
+                Project (#0, #1, #3) // { arity: 3 }
+                  Join on=(#0 = #2) // { arity: 4 }
+                    Get l5 // { arity: 2 }
+                    Union // { arity: 2 }
+                      Get l8 // { arity: 2 }
+                      CrossJoin // { arity: 2 }
+                        Project (#0) // { arity: 1 }
+                          Join on=(#0 = #1) // { arity: 2 }
+                            Union // { arity: 1 }
+                              Negate // { arity: 1 }
+                                Distinct project=[#0] // { arity: 1 }
+                                  Get l8 // { arity: 2 }
+                              Distinct project=[#0] // { arity: 1 }
                                 Get l6 // { arity: 1 }
-                            Constant // { arity: 1 }
-                              - (null)
+                            Get l6 // { arity: 1 }
+                        Constant // { arity: 1 }
+                          - (null)
 With
   cte l8 =
     Union // { arity: 2 }
@@ -432,35 +427,33 @@ FROM x,
              SELECT * FROM y INNER JOIN LATERAL(SELECT y.a FROM x WHERE (SELECT m FROM a) > 0) ON true);
 ----
 Return // { arity: 3 }
-  Filter true // { arity: 3 }
-    Project (#0, #2, #3) // { arity: 3 }
-      Join on=(#0 = #1) // { arity: 4 }
-        Get l0 // { arity: 1 }
-        Filter true // { arity: 3 }
-          Project (#0, #1, #3) // { arity: 3 }
-            Join on=(#1 = #2) // { arity: 4 }
-              Get l3 // { arity: 2 }
-              Project (#0, #2) // { arity: 2 }
-                Map (#0) // { arity: 3 }
-                  Project (#0, #1) // { arity: 2 }
-                    Filter (#2 > 0) // { arity: 3 }
-                      Project (#0, #1, #3) // { arity: 3 }
-                        Join on=(#0 = #2) // { arity: 4 }
-                          Get l4 // { arity: 2 }
-                          Union // { arity: 2 }
-                            Get l7 // { arity: 2 }
-                            CrossJoin // { arity: 2 }
-                              Project (#0) // { arity: 1 }
-                                Join on=(#0 = #1) // { arity: 2 }
-                                  Union // { arity: 1 }
-                                    Negate // { arity: 1 }
-                                      Distinct project=[#0] // { arity: 1 }
-                                        Get l7 // { arity: 2 }
-                                    Distinct project=[#0] // { arity: 1 }
-                                      Get l5 // { arity: 1 }
+  Project (#0, #2, #3) // { arity: 3 }
+    Join on=(#0 = #1) // { arity: 4 }
+      Get l0 // { arity: 1 }
+      Project (#0, #1, #3) // { arity: 3 }
+        Join on=(#1 = #2) // { arity: 4 }
+          Get l3 // { arity: 2 }
+          Project (#0, #2) // { arity: 2 }
+            Map (#0) // { arity: 3 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (#2 > 0) // { arity: 3 }
+                  Project (#0, #1, #3) // { arity: 3 }
+                    Join on=(#0 = #2) // { arity: 4 }
+                      Get l4 // { arity: 2 }
+                      Union // { arity: 2 }
+                        Get l7 // { arity: 2 }
+                        CrossJoin // { arity: 2 }
+                          Project (#0) // { arity: 1 }
+                            Join on=(#0 = #1) // { arity: 2 }
+                              Union // { arity: 1 }
+                                Negate // { arity: 1 }
+                                  Distinct project=[#0] // { arity: 1 }
+                                    Get l7 // { arity: 2 }
+                                Distinct project=[#0] // { arity: 1 }
                                   Get l5 // { arity: 1 }
-                              Constant // { arity: 1 }
-                                - (null)
+                              Get l5 // { arity: 1 }
+                          Constant // { arity: 1 }
+                            - (null)
 With
   cte l7 =
     Union // { arity: 2 }
@@ -492,11 +485,10 @@ With
     Distinct project=[#0] // { arity: 1 }
       Get l4 // { arity: 2 }
   cte l4 =
-    Filter true // { arity: 2 }
-      CrossJoin // { arity: 2 }
-        Distinct project=[#1] // { arity: 1 }
-          Get l3 // { arity: 2 }
-        Get materialize.public.x // { arity: 1 }
+    CrossJoin // { arity: 2 }
+      Distinct project=[#1] // { arity: 1 }
+        Get l3 // { arity: 2 }
+      Get materialize.public.x // { arity: 1 }
   cte l3 =
     CrossJoin // { arity: 2 }
       Get l1 // { arity: 1 }

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -657,69 +657,48 @@ SELECT generate_series(a, b) from t
               }
             },
             "body": {
-              "Filter": {
+              "FlatMap": {
                 "input": {
-                  "FlatMap": {
-                    "input": {
-                      "Get": {
-                        "id": {
-                          "Local": 1
-                        },
-                        "typ": {
-                          "column_types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ],
-                          "keys": []
-                        },
-                        "access_strategy": "UnknownOrLocal"
-                      }
+                  "Get": {
+                    "id": {
+                      "Local": 1
                     },
-                    "func": "GenerateSeriesInt32",
-                    "exprs": [
-                      {
-                        "Column": 0
-                      },
-                      {
-                        "Column": 1
-                      },
-                      {
-                        "Literal": [
-                          {
-                            "Ok": {
-                              "data": [
-                                42,
-                                1
-                              ]
-                            }
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": false
-                          }
-                        ]
-                      }
-                    ]
+                    "typ": {
+                      "column_types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        }
+                      ],
+                      "keys": []
+                    },
+                    "access_strategy": "UnknownOrLocal"
                   }
                 },
-                "predicates": [
+                "func": "GenerateSeriesInt32",
+                "exprs": [
+                  {
+                    "Column": 0
+                  },
+                  {
+                    "Column": 1
+                  },
                   {
                     "Literal": [
                       {
                         "Ok": {
                           "data": [
-                            2
+                            42,
+                            1
                           ]
                         }
                       },
                       {
-                        "scalar_type": "Bool",
+                        "scalar_type": "Int32",
                         "nullable": false
                       }
                     ]
@@ -4011,83 +3990,62 @@ SELECT t1.a, t2.a FROM t as t1, t as t2
                   "Let": {
                     "id": 3,
                     "value": {
-                      "Filter": {
+                      "Project": {
                         "input": {
-                          "Project": {
-                            "input": {
-                              "Join": {
-                                "inputs": [
-                                  {
-                                    "Get": {
-                                      "id": {
-                                        "Local": 1
-                                      },
-                                      "typ": {
-                                        "column_types": [
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          },
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          }
-                                        ],
-                                        "keys": []
-                                      },
-                                      "access_strategy": "UnknownOrLocal"
-                                    }
-                                  },
-                                  {
-                                    "Get": {
-                                      "id": {
-                                        "Local": 2
-                                      },
-                                      "typ": {
-                                        "column_types": [
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          },
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          }
-                                        ],
-                                        "keys": []
-                                      },
-                                      "access_strategy": "UnknownOrLocal"
-                                    }
-                                  }
-                                ],
-                                "equivalences": [],
-                                "implementation": "Unimplemented"
-                              }
-                            },
-                            "outputs": [
-                              0,
-                              1,
-                              2,
-                              3
-                            ]
-                          }
-                        },
-                        "predicates": [
-                          {
-                            "Literal": [
+                          "Join": {
+                            "inputs": [
                               {
-                                "Ok": {
-                                  "data": [
-                                    2
-                                  ]
+                                "Get": {
+                                  "id": {
+                                    "Local": 1
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  },
+                                  "access_strategy": "UnknownOrLocal"
                                 }
                               },
                               {
-                                "scalar_type": "Bool",
-                                "nullable": false
+                                "Get": {
+                                  "id": {
+                                    "Local": 2
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  },
+                                  "access_strategy": "UnknownOrLocal"
+                                }
                               }
-                            ]
+                            ],
+                            "equivalences": [],
+                            "implementation": "Unimplemented"
                           }
+                        },
+                        "outputs": [
+                          0,
+                          1,
+                          2,
+                          3
                         ]
                       }
                     },
@@ -4264,83 +4222,62 @@ SELECT t1.a, t2.a FROM t as t1 INNER JOIN t as t2 ON true
                   "Let": {
                     "id": 3,
                     "value": {
-                      "Filter": {
+                      "Project": {
                         "input": {
-                          "Project": {
-                            "input": {
-                              "Join": {
-                                "inputs": [
-                                  {
-                                    "Get": {
-                                      "id": {
-                                        "Local": 1
-                                      },
-                                      "typ": {
-                                        "column_types": [
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          },
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          }
-                                        ],
-                                        "keys": []
-                                      },
-                                      "access_strategy": "UnknownOrLocal"
-                                    }
-                                  },
-                                  {
-                                    "Get": {
-                                      "id": {
-                                        "Local": 2
-                                      },
-                                      "typ": {
-                                        "column_types": [
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          },
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          }
-                                        ],
-                                        "keys": []
-                                      },
-                                      "access_strategy": "UnknownOrLocal"
-                                    }
-                                  }
-                                ],
-                                "equivalences": [],
-                                "implementation": "Unimplemented"
-                              }
-                            },
-                            "outputs": [
-                              0,
-                              1,
-                              2,
-                              3
-                            ]
-                          }
-                        },
-                        "predicates": [
-                          {
-                            "Literal": [
+                          "Join": {
+                            "inputs": [
                               {
-                                "Ok": {
-                                  "data": [
-                                    2
-                                  ]
+                                "Get": {
+                                  "id": {
+                                    "Local": 1
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  },
+                                  "access_strategy": "UnknownOrLocal"
                                 }
                               },
                               {
-                                "scalar_type": "Bool",
-                                "nullable": false
+                                "Get": {
+                                  "id": {
+                                    "Local": 2
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  },
+                                  "access_strategy": "UnknownOrLocal"
+                                }
                               }
-                            ]
+                            ],
+                            "equivalences": [],
+                            "implementation": "Unimplemented"
                           }
+                        },
+                        "outputs": [
+                          0,
+                          1,
+                          2,
+                          3
                         ]
                       }
                     },
@@ -4527,83 +4464,62 @@ WHERE t1.b = t2.b AND t2.b = t3.b
                           "Let": {
                             "id": 3,
                             "value": {
-                              "Filter": {
+                              "Project": {
                                 "input": {
-                                  "Project": {
-                                    "input": {
-                                      "Join": {
-                                        "inputs": [
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 1
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              },
-                                              "access_strategy": "UnknownOrLocal"
-                                            }
-                                          },
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 2
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              },
-                                              "access_strategy": "UnknownOrLocal"
-                                            }
-                                          }
-                                        ],
-                                        "equivalences": [],
-                                        "implementation": "Unimplemented"
-                                      }
-                                    },
-                                    "outputs": [
-                                      0,
-                                      1,
-                                      2,
-                                      3
-                                    ]
-                                  }
-                                },
-                                "predicates": [
-                                  {
-                                    "Literal": [
+                                  "Join": {
+                                    "inputs": [
                                       {
-                                        "Ok": {
-                                          "data": [
-                                            2
-                                          ]
+                                        "Get": {
+                                          "id": {
+                                            "Local": 1
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          },
+                                          "access_strategy": "UnknownOrLocal"
                                         }
                                       },
                                       {
-                                        "scalar_type": "Bool",
-                                        "nullable": false
+                                        "Get": {
+                                          "id": {
+                                            "Local": 2
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          },
+                                          "access_strategy": "UnknownOrLocal"
+                                        }
                                       }
-                                    ]
+                                    ],
+                                    "equivalences": [],
+                                    "implementation": "Unimplemented"
                                   }
+                                },
+                                "outputs": [
+                                  0,
+                                  1,
+                                  2,
+                                  3
                                 ]
                               }
                             },
@@ -4694,93 +4610,72 @@ WHERE t1.b = t2.b AND t2.b = t3.b
                       "Let": {
                         "id": 6,
                         "value": {
-                          "Filter": {
+                          "Project": {
                             "input": {
-                              "Project": {
-                                "input": {
-                                  "Join": {
-                                    "inputs": [
-                                      {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 4
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          },
-                                          "access_strategy": "UnknownOrLocal"
-                                        }
-                                      },
-                                      {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 5
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          },
-                                          "access_strategy": "UnknownOrLocal"
-                                        }
-                                      }
-                                    ],
-                                    "equivalences": [],
-                                    "implementation": "Unimplemented"
-                                  }
-                                },
-                                "outputs": [
-                                  0,
-                                  1,
-                                  2,
-                                  3,
-                                  4,
-                                  5
-                                ]
-                              }
-                            },
-                            "predicates": [
-                              {
-                                "Literal": [
+                              "Join": {
+                                "inputs": [
                                   {
-                                    "Ok": {
-                                      "data": [
-                                        2
-                                      ]
+                                    "Get": {
+                                      "id": {
+                                        "Local": 4
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      },
+                                      "access_strategy": "UnknownOrLocal"
                                     }
                                   },
                                   {
-                                    "scalar_type": "Bool",
-                                    "nullable": false
+                                    "Get": {
+                                      "id": {
+                                        "Local": 5
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      },
+                                      "access_strategy": "UnknownOrLocal"
+                                    }
                                   }
-                                ]
+                                ],
+                                "equivalences": [],
+                                "implementation": "Unimplemented"
                               }
+                            },
+                            "outputs": [
+                              0,
+                              1,
+                              2,
+                              3,
+                              4,
+                              5
                             ]
                           }
                         },
@@ -6361,73 +6256,52 @@ WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
                           "Let": {
                             "id": 3,
                             "value": {
-                              "Filter": {
+                              "Project": {
                                 "input": {
-                                  "Project": {
-                                    "input": {
-                                      "Join": {
-                                        "inputs": [
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 2
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              },
-                                              "access_strategy": "UnknownOrLocal"
-                                            }
-                                          },
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 2
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              },
-                                              "access_strategy": "UnknownOrLocal"
-                                            }
-                                          }
-                                        ],
-                                        "equivalences": [],
-                                        "implementation": "Unimplemented"
-                                      }
-                                    },
-                                    "outputs": [
-                                      0,
-                                      1
-                                    ]
-                                  }
-                                },
-                                "predicates": [
-                                  {
-                                    "Literal": [
+                                  "Join": {
+                                    "inputs": [
                                       {
-                                        "Ok": {
-                                          "data": [
-                                            2
-                                          ]
+                                        "Get": {
+                                          "id": {
+                                            "Local": 2
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          },
+                                          "access_strategy": "UnknownOrLocal"
                                         }
                                       },
                                       {
-                                        "scalar_type": "Bool",
-                                        "nullable": false
+                                        "Get": {
+                                          "id": {
+                                            "Local": 2
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          },
+                                          "access_strategy": "UnknownOrLocal"
+                                        }
                                       }
-                                    ]
+                                    ],
+                                    "equivalences": [],
+                                    "implementation": "Unimplemented"
                                   }
+                                },
+                                "outputs": [
+                                  0,
+                                  1
                                 ]
                               }
                             },
@@ -6606,1008 +6480,6 @@ FROM
               }
             },
             "body": {
-              "Filter": {
-                "input": {
-                  "Let": {
-                    "id": 2,
-                    "value": {
-                      "Reduce": {
-                        "input": {
-                          "Get": {
-                            "id": {
-                              "Local": 1
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": []
-                            },
-                            "access_strategy": "UnknownOrLocal"
-                          }
-                        },
-                        "group_key": [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        "aggregates": [],
-                        "monotonic": false,
-                        "expected_group_size": null
-                      }
-                    },
-                    "body": {
-                      "Project": {
-                        "input": {
-                          "Join": {
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 1
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  },
-                                  "access_strategy": "UnknownOrLocal"
-                                }
-                              },
-                              {
-                                "Let": {
-                                  "id": 4,
-                                  "value": {
-                                    "Let": {
-                                      "id": 3,
-                                      "value": {
-                                        "Reduce": {
-                                          "input": {
-                                            "Join": {
-                                              "inputs": [
-                                                {
-                                                  "Get": {
-                                                    "id": {
-                                                      "Local": 2
-                                                    },
-                                                    "typ": {
-                                                      "column_types": [
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": true
-                                                        }
-                                                      ],
-                                                      "keys": [
-                                                        [
-                                                          0
-                                                        ]
-                                                      ]
-                                                    },
-                                                    "access_strategy": "UnknownOrLocal"
-                                                  }
-                                                },
-                                                {
-                                                  "Get": {
-                                                    "id": {
-                                                      "Global": {
-                                                        "User": 1
-                                                      }
-                                                    },
-                                                    "typ": {
-                                                      "column_types": [
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": true
-                                                        },
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": true
-                                                        }
-                                                      ],
-                                                      "keys": []
-                                                    },
-                                                    "access_strategy": "UnknownOrLocal"
-                                                  }
-                                                }
-                                              ],
-                                              "equivalences": [],
-                                              "implementation": "Unimplemented"
-                                            }
-                                          },
-                                          "group_key": [
-                                            {
-                                              "Column": 0
-                                            }
-                                          ],
-                                          "aggregates": [
-                                            {
-                                              "func": "MaxInt32",
-                                              "expr": {
-                                                "CallBinary": {
-                                                  "func": "MulInt32",
-                                                  "expr1": {
-                                                    "Column": 0
-                                                  },
-                                                  "expr2": {
-                                                    "Column": 1
-                                                  }
-                                                }
-                                              },
-                                              "distinct": false
-                                            }
-                                          ],
-                                          "monotonic": false,
-                                          "expected_group_size": null
-                                        }
-                                      },
-                                      "body": {
-                                        "Union": {
-                                          "base": {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 3
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": [
-                                                  [
-                                                    0
-                                                  ]
-                                                ]
-                                              },
-                                              "access_strategy": "UnknownOrLocal"
-                                            }
-                                          },
-                                          "inputs": [
-                                            {
-                                              "Join": {
-                                                "inputs": [
-                                                  {
-                                                    "Project": {
-                                                      "input": {
-                                                        "Join": {
-                                                          "inputs": [
-                                                            {
-                                                              "Union": {
-                                                                "base": {
-                                                                  "Negate": {
-                                                                    "input": {
-                                                                      "Reduce": {
-                                                                        "input": {
-                                                                          "Get": {
-                                                                            "id": {
-                                                                              "Local": 3
-                                                                            },
-                                                                            "typ": {
-                                                                              "column_types": [
-                                                                                {
-                                                                                  "scalar_type": "Int32",
-                                                                                  "nullable": true
-                                                                                },
-                                                                                {
-                                                                                  "scalar_type": "Int32",
-                                                                                  "nullable": true
-                                                                                }
-                                                                              ],
-                                                                              "keys": [
-                                                                                [
-                                                                                  0
-                                                                                ]
-                                                                              ]
-                                                                            },
-                                                                            "access_strategy": "UnknownOrLocal"
-                                                                          }
-                                                                        },
-                                                                        "group_key": [
-                                                                          {
-                                                                            "Column": 0
-                                                                          }
-                                                                        ],
-                                                                        "aggregates": [],
-                                                                        "monotonic": false,
-                                                                        "expected_group_size": null
-                                                                      }
-                                                                    }
-                                                                  }
-                                                                },
-                                                                "inputs": [
-                                                                  {
-                                                                    "Reduce": {
-                                                                      "input": {
-                                                                        "Get": {
-                                                                          "id": {
-                                                                            "Local": 2
-                                                                          },
-                                                                          "typ": {
-                                                                            "column_types": [
-                                                                              {
-                                                                                "scalar_type": "Int32",
-                                                                                "nullable": true
-                                                                              }
-                                                                            ],
-                                                                            "keys": [
-                                                                              [
-                                                                                0
-                                                                              ]
-                                                                            ]
-                                                                          },
-                                                                          "access_strategy": "UnknownOrLocal"
-                                                                        }
-                                                                      },
-                                                                      "group_key": [
-                                                                        {
-                                                                          "Column": 0
-                                                                        }
-                                                                      ],
-                                                                      "aggregates": [],
-                                                                      "monotonic": false,
-                                                                      "expected_group_size": null
-                                                                    }
-                                                                  }
-                                                                ]
-                                                              }
-                                                            },
-                                                            {
-                                                              "Get": {
-                                                                "id": {
-                                                                  "Local": 2
-                                                                },
-                                                                "typ": {
-                                                                  "column_types": [
-                                                                    {
-                                                                      "scalar_type": "Int32",
-                                                                      "nullable": true
-                                                                    }
-                                                                  ],
-                                                                  "keys": [
-                                                                    [
-                                                                      0
-                                                                    ]
-                                                                  ]
-                                                                },
-                                                                "access_strategy": "UnknownOrLocal"
-                                                              }
-                                                            }
-                                                          ],
-                                                          "equivalences": [
-                                                            [
-                                                              {
-                                                                "Column": 0
-                                                              },
-                                                              {
-                                                                "Column": 1
-                                                              }
-                                                            ]
-                                                          ],
-                                                          "implementation": "Unimplemented"
-                                                        }
-                                                      },
-                                                      "outputs": [
-                                                        0
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "Constant": {
-                                                      "rows": {
-                                                        "Ok": [
-                                                          [
-                                                            {
-                                                              "data": [
-                                                                0
-                                                              ]
-                                                            },
-                                                            1
-                                                          ]
-                                                        ]
-                                                      },
-                                                      "typ": {
-                                                        "column_types": [
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": true
-                                                          }
-                                                        ],
-                                                        "keys": []
-                                                      }
-                                                    }
-                                                  }
-                                                ],
-                                                "equivalences": [],
-                                                "implementation": "Unimplemented"
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "body": {
-                                    "Filter": {
-                                      "input": {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 4
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          },
-                                          "access_strategy": "UnknownOrLocal"
-                                        }
-                                      },
-                                      "predicates": [
-                                        {
-                                          "CallBinary": {
-                                            "func": "NotEq",
-                                            "expr1": {
-                                              "Column": 1
-                                            },
-                                            "expr2": {
-                                              "Column": 0
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  }
-                                }
-                              }
-                            ],
-                            "equivalences": [
-                              [
-                                {
-                                  "Column": 0
-                                },
-                                {
-                                  "Column": 2
-                                }
-                              ]
-                            ],
-                            "implementation": "Unimplemented"
-                          }
-                        },
-                        "outputs": [
-                          0,
-                          1,
-                          3
-                        ]
-                      }
-                    }
-                  }
-                },
-                "predicates": [
-                  {
-                    "Literal": [
-                      {
-                        "Ok": {
-                          "data": [
-                            2
-                          ]
-                        }
-                      },
-                      {
-                        "scalar_type": "Bool",
-                        "nullable": false
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "body": {
-          "Filter": {
-            "input": {
-              "Let": {
-                "id": 6,
-                "value": {
-                  "Reduce": {
-                    "input": {
-                      "Get": {
-                        "id": {
-                          "Local": 5
-                        },
-                        "typ": {
-                          "column_types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": false
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": false
-                            }
-                          ],
-                          "keys": []
-                        },
-                        "access_strategy": "UnknownOrLocal"
-                      }
-                    },
-                    "group_key": [
-                      {
-                        "Column": 0
-                      }
-                    ],
-                    "aggregates": [],
-                    "monotonic": false,
-                    "expected_group_size": null
-                  }
-                },
-                "body": {
-                  "Project": {
-                    "input": {
-                      "Join": {
-                        "inputs": [
-                          {
-                            "Get": {
-                              "id": {
-                                "Local": 5
-                              },
-                              "typ": {
-                                "column_types": [
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": false
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": false
-                                  }
-                                ],
-                                "keys": []
-                              },
-                              "access_strategy": "UnknownOrLocal"
-                            }
-                          },
-                          {
-                            "Let": {
-                              "id": 8,
-                              "value": {
-                                "Let": {
-                                  "id": 7,
-                                  "value": {
-                                    "Reduce": {
-                                      "input": {
-                                        "Join": {
-                                          "inputs": [
-                                            {
-                                              "Get": {
-                                                "id": {
-                                                  "Local": 6
-                                                },
-                                                "typ": {
-                                                  "column_types": [
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": false
-                                                    }
-                                                  ],
-                                                  "keys": [
-                                                    [
-                                                      0
-                                                    ]
-                                                  ]
-                                                },
-                                                "access_strategy": "UnknownOrLocal"
-                                              }
-                                            },
-                                            {
-                                              "Get": {
-                                                "id": {
-                                                  "Global": {
-                                                    "User": 1
-                                                  }
-                                                },
-                                                "typ": {
-                                                  "column_types": [
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": true
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": true
-                                                    }
-                                                  ],
-                                                  "keys": []
-                                                },
-                                                "access_strategy": "UnknownOrLocal"
-                                              }
-                                            }
-                                          ],
-                                          "equivalences": [],
-                                          "implementation": "Unimplemented"
-                                        }
-                                      },
-                                      "group_key": [
-                                        {
-                                          "Column": 0
-                                        }
-                                      ],
-                                      "aggregates": [
-                                        {
-                                          "func": "MaxInt32",
-                                          "expr": {
-                                            "CallBinary": {
-                                              "func": "MulInt32",
-                                              "expr1": {
-                                                "Column": 0
-                                              },
-                                              "expr2": {
-                                                "Column": 1
-                                              }
-                                            }
-                                          },
-                                          "distinct": false
-                                        }
-                                      ],
-                                      "monotonic": false,
-                                      "expected_group_size": null
-                                    }
-                                  },
-                                  "body": {
-                                    "Union": {
-                                      "base": {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 7
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": false
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": [
-                                              [
-                                                0
-                                              ]
-                                            ]
-                                          },
-                                          "access_strategy": "UnknownOrLocal"
-                                        }
-                                      },
-                                      "inputs": [
-                                        {
-                                          "Join": {
-                                            "inputs": [
-                                              {
-                                                "Project": {
-                                                  "input": {
-                                                    "Join": {
-                                                      "inputs": [
-                                                        {
-                                                          "Union": {
-                                                            "base": {
-                                                              "Negate": {
-                                                                "input": {
-                                                                  "Reduce": {
-                                                                    "input": {
-                                                                      "Get": {
-                                                                        "id": {
-                                                                          "Local": 7
-                                                                        },
-                                                                        "typ": {
-                                                                          "column_types": [
-                                                                            {
-                                                                              "scalar_type": "Int32",
-                                                                              "nullable": false
-                                                                            },
-                                                                            {
-                                                                              "scalar_type": "Int32",
-                                                                              "nullable": true
-                                                                            }
-                                                                          ],
-                                                                          "keys": [
-                                                                            [
-                                                                              0
-                                                                            ]
-                                                                          ]
-                                                                        },
-                                                                        "access_strategy": "UnknownOrLocal"
-                                                                      }
-                                                                    },
-                                                                    "group_key": [
-                                                                      {
-                                                                        "Column": 0
-                                                                      }
-                                                                    ],
-                                                                    "aggregates": [],
-                                                                    "monotonic": false,
-                                                                    "expected_group_size": null
-                                                                  }
-                                                                }
-                                                              }
-                                                            },
-                                                            "inputs": [
-                                                              {
-                                                                "Reduce": {
-                                                                  "input": {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Local": 6
-                                                                      },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": false
-                                                                          }
-                                                                        ],
-                                                                        "keys": [
-                                                                          [
-                                                                            0
-                                                                          ]
-                                                                        ]
-                                                                      },
-                                                                      "access_strategy": "UnknownOrLocal"
-                                                                    }
-                                                                  },
-                                                                  "group_key": [
-                                                                    {
-                                                                      "Column": 0
-                                                                    }
-                                                                  ],
-                                                                  "aggregates": [],
-                                                                  "monotonic": false,
-                                                                  "expected_group_size": null
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        },
-                                                        {
-                                                          "Get": {
-                                                            "id": {
-                                                              "Local": 6
-                                                            },
-                                                            "typ": {
-                                                              "column_types": [
-                                                                {
-                                                                  "scalar_type": "Int32",
-                                                                  "nullable": false
-                                                                }
-                                                              ],
-                                                              "keys": [
-                                                                [
-                                                                  0
-                                                                ]
-                                                              ]
-                                                            },
-                                                            "access_strategy": "UnknownOrLocal"
-                                                          }
-                                                        }
-                                                      ],
-                                                      "equivalences": [
-                                                        [
-                                                          {
-                                                            "Column": 0
-                                                          },
-                                                          {
-                                                            "Column": 1
-                                                          }
-                                                        ]
-                                                      ],
-                                                      "implementation": "Unimplemented"
-                                                    }
-                                                  },
-                                                  "outputs": [
-                                                    0
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "Constant": {
-                                                  "rows": {
-                                                    "Ok": [
-                                                      [
-                                                        {
-                                                          "data": [
-                                                            0
-                                                          ]
-                                                        },
-                                                        1
-                                                      ]
-                                                    ]
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      }
-                                                    ],
-                                                    "keys": []
-                                                  }
-                                                }
-                                              }
-                                            ],
-                                            "equivalences": [],
-                                            "implementation": "Unimplemented"
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  }
-                                }
-                              },
-                              "body": {
-                                "Filter": {
-                                  "input": {
-                                    "Get": {
-                                      "id": {
-                                        "Local": 8
-                                      },
-                                      "typ": {
-                                        "column_types": [
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": false
-                                          },
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          }
-                                        ],
-                                        "keys": []
-                                      },
-                                      "access_strategy": "UnknownOrLocal"
-                                    }
-                                  },
-                                  "predicates": [
-                                    {
-                                      "CallVariadic": {
-                                        "func": "Or",
-                                        "exprs": [
-                                          {
-                                            "CallBinary": {
-                                              "func": "NotEq",
-                                              "expr1": {
-                                                "Column": 1
-                                              },
-                                              "expr2": {
-                                                "Column": 0
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "CallVariadic": {
-                                              "func": "And",
-                                              "exprs": [
-                                                {
-                                                  "CallUnary": {
-                                                    "func": {
-                                                      "Not": null
-                                                    },
-                                                    "expr": {
-                                                      "CallUnary": {
-                                                        "func": {
-                                                          "IsNull": null
-                                                        },
-                                                        "expr": {
-                                                          "Column": 1
-                                                        }
-                                                      }
-                                                    }
-                                                  }
-                                                },
-                                                {
-                                                  "CallUnary": {
-                                                    "func": {
-                                                      "IsNull": null
-                                                    },
-                                                    "expr": {
-                                                      "Column": 0
-                                                    }
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            }
-                          }
-                        ],
-                        "equivalences": [
-                          [
-                            {
-                              "Column": 0
-                            },
-                            {
-                              "Column": 3
-                            }
-                          ]
-                        ],
-                        "implementation": "Unimplemented"
-                      }
-                    },
-                    "outputs": [
-                      0,
-                      1,
-                      2,
-                      4
-                    ]
-                  }
-                }
-              }
-            },
-            "predicates": [
-              {
-                "Literal": [
-                  {
-                    "Ok": {
-                      "data": [
-                        2
-                      ]
-                    }
-                  },
-                  {
-                    "scalar_type": "Bool",
-                    "nullable": false
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test multiple CTEs: a case where we cannot pull the let statement up
-# through the join because the local l0 is correlated against the lhs of
-# the enclosing join.
-query T multiline
-EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
-SELECT
-  *
-FROM
-  (
-    SELECT * FROM t
-  ) as r1
-  CROSS JOIN LATERAL (
-    WITH r4 as (
-      SELECT MAX(r1.a * t.a) AS m FROM t
-    )
-    SELECT *
-    FROM
-      r4
-      CROSS JOIN LATERAL (
-        WITH r2 as (
-          SELECT MAX(r1.a * t.a) AS m FROM t
-        )
-        SELECT * FROM r2 WHERE r1.a = r4.m AND r2.m > 5
-      ) as r3
-    WHERE a != r1.a
-  ) as r5;
-----
-{
-  "Let": {
-    "id": 0,
-    "value": {
-      "Constant": {
-        "rows": {
-          "Ok": [
-            [
-              {
-                "data": []
-              },
-              1
-            ]
-          ]
-        },
-        "typ": {
-          "column_types": [],
-          "keys": []
-        }
-      }
-    },
-    "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  },
-                  "access_strategy": "UnknownOrLocal"
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ],
-                    "keys": []
-                  },
-                  "access_strategy": "UnknownOrLocal"
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Filter": {
-            "input": {
               "Let": {
                 "id": 2,
                 "value": {
@@ -7949,517 +6821,32 @@ FROM
                               "body": {
                                 "Filter": {
                                   "input": {
-                                    "Let": {
-                                      "id": 5,
-                                      "value": {
-                                        "Reduce": {
-                                          "input": {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 4
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              },
-                                              "access_strategy": "UnknownOrLocal"
-                                            }
-                                          },
-                                          "group_key": [
-                                            {
-                                              "Column": 1
-                                            },
-                                            {
-                                              "Column": 0
-                                            }
-                                          ],
-                                          "aggregates": [],
-                                          "monotonic": false,
-                                          "expected_group_size": null
-                                        }
+                                    "Get": {
+                                      "id": {
+                                        "Local": 4
                                       },
-                                      "body": {
-                                        "Project": {
-                                          "input": {
-                                            "Join": {
-                                              "inputs": [
-                                                {
-                                                  "Get": {
-                                                    "id": {
-                                                      "Local": 4
-                                                    },
-                                                    "typ": {
-                                                      "column_types": [
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": true
-                                                        },
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": true
-                                                        }
-                                                      ],
-                                                      "keys": []
-                                                    },
-                                                    "access_strategy": "UnknownOrLocal"
-                                                  }
-                                                },
-                                                {
-                                                  "Let": {
-                                                    "id": 7,
-                                                    "value": {
-                                                      "Let": {
-                                                        "id": 6,
-                                                        "value": {
-                                                          "Reduce": {
-                                                            "input": {
-                                                              "Join": {
-                                                                "inputs": [
-                                                                  {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Local": 5
-                                                                      },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          },
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          }
-                                                                        ],
-                                                                        "keys": [
-                                                                          [
-                                                                            0,
-                                                                            1
-                                                                          ]
-                                                                        ]
-                                                                      },
-                                                                      "access_strategy": "UnknownOrLocal"
-                                                                    }
-                                                                  },
-                                                                  {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Global": {
-                                                                          "User": 1
-                                                                        }
-                                                                      },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          },
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          }
-                                                                        ],
-                                                                        "keys": []
-                                                                      },
-                                                                      "access_strategy": "UnknownOrLocal"
-                                                                    }
-                                                                  }
-                                                                ],
-                                                                "equivalences": [],
-                                                                "implementation": "Unimplemented"
-                                                              }
-                                                            },
-                                                            "group_key": [
-                                                              {
-                                                                "Column": 0
-                                                              },
-                                                              {
-                                                                "Column": 1
-                                                              }
-                                                            ],
-                                                            "aggregates": [
-                                                              {
-                                                                "func": "MaxInt32",
-                                                                "expr": {
-                                                                  "CallBinary": {
-                                                                    "func": "MulInt32",
-                                                                    "expr1": {
-                                                                      "Column": 1
-                                                                    },
-                                                                    "expr2": {
-                                                                      "Column": 2
-                                                                    }
-                                                                  }
-                                                                },
-                                                                "distinct": false
-                                                              }
-                                                            ],
-                                                            "monotonic": false,
-                                                            "expected_group_size": null
-                                                          }
-                                                        },
-                                                        "body": {
-                                                          "Union": {
-                                                            "base": {
-                                                              "Get": {
-                                                                "id": {
-                                                                  "Local": 6
-                                                                },
-                                                                "typ": {
-                                                                  "column_types": [
-                                                                    {
-                                                                      "scalar_type": "Int32",
-                                                                      "nullable": true
-                                                                    },
-                                                                    {
-                                                                      "scalar_type": "Int32",
-                                                                      "nullable": true
-                                                                    },
-                                                                    {
-                                                                      "scalar_type": "Int32",
-                                                                      "nullable": true
-                                                                    }
-                                                                  ],
-                                                                  "keys": [
-                                                                    [
-                                                                      0,
-                                                                      1
-                                                                    ]
-                                                                  ]
-                                                                },
-                                                                "access_strategy": "UnknownOrLocal"
-                                                              }
-                                                            },
-                                                            "inputs": [
-                                                              {
-                                                                "Join": {
-                                                                  "inputs": [
-                                                                    {
-                                                                      "Project": {
-                                                                        "input": {
-                                                                          "Join": {
-                                                                            "inputs": [
-                                                                              {
-                                                                                "Union": {
-                                                                                  "base": {
-                                                                                    "Negate": {
-                                                                                      "input": {
-                                                                                        "Reduce": {
-                                                                                          "input": {
-                                                                                            "Get": {
-                                                                                              "id": {
-                                                                                                "Local": 6
-                                                                                              },
-                                                                                              "typ": {
-                                                                                                "column_types": [
-                                                                                                  {
-                                                                                                    "scalar_type": "Int32",
-                                                                                                    "nullable": true
-                                                                                                  },
-                                                                                                  {
-                                                                                                    "scalar_type": "Int32",
-                                                                                                    "nullable": true
-                                                                                                  },
-                                                                                                  {
-                                                                                                    "scalar_type": "Int32",
-                                                                                                    "nullable": true
-                                                                                                  }
-                                                                                                ],
-                                                                                                "keys": [
-                                                                                                  [
-                                                                                                    0,
-                                                                                                    1
-                                                                                                  ]
-                                                                                                ]
-                                                                                              },
-                                                                                              "access_strategy": "UnknownOrLocal"
-                                                                                            }
-                                                                                          },
-                                                                                          "group_key": [
-                                                                                            {
-                                                                                              "Column": 0
-                                                                                            },
-                                                                                            {
-                                                                                              "Column": 1
-                                                                                            }
-                                                                                          ],
-                                                                                          "aggregates": [],
-                                                                                          "monotonic": false,
-                                                                                          "expected_group_size": null
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  },
-                                                                                  "inputs": [
-                                                                                    {
-                                                                                      "Reduce": {
-                                                                                        "input": {
-                                                                                          "Get": {
-                                                                                            "id": {
-                                                                                              "Local": 5
-                                                                                            },
-                                                                                            "typ": {
-                                                                                              "column_types": [
-                                                                                                {
-                                                                                                  "scalar_type": "Int32",
-                                                                                                  "nullable": true
-                                                                                                },
-                                                                                                {
-                                                                                                  "scalar_type": "Int32",
-                                                                                                  "nullable": true
-                                                                                                }
-                                                                                              ],
-                                                                                              "keys": [
-                                                                                                [
-                                                                                                  0,
-                                                                                                  1
-                                                                                                ]
-                                                                                              ]
-                                                                                            },
-                                                                                            "access_strategy": "UnknownOrLocal"
-                                                                                          }
-                                                                                        },
-                                                                                        "group_key": [
-                                                                                          {
-                                                                                            "Column": 0
-                                                                                          },
-                                                                                          {
-                                                                                            "Column": 1
-                                                                                          }
-                                                                                        ],
-                                                                                        "aggregates": [],
-                                                                                        "monotonic": false,
-                                                                                        "expected_group_size": null
-                                                                                      }
-                                                                                    }
-                                                                                  ]
-                                                                                }
-                                                                              },
-                                                                              {
-                                                                                "Get": {
-                                                                                  "id": {
-                                                                                    "Local": 5
-                                                                                  },
-                                                                                  "typ": {
-                                                                                    "column_types": [
-                                                                                      {
-                                                                                        "scalar_type": "Int32",
-                                                                                        "nullable": true
-                                                                                      },
-                                                                                      {
-                                                                                        "scalar_type": "Int32",
-                                                                                        "nullable": true
-                                                                                      }
-                                                                                    ],
-                                                                                    "keys": [
-                                                                                      [
-                                                                                        0,
-                                                                                        1
-                                                                                      ]
-                                                                                    ]
-                                                                                  },
-                                                                                  "access_strategy": "UnknownOrLocal"
-                                                                                }
-                                                                              }
-                                                                            ],
-                                                                            "equivalences": [
-                                                                              [
-                                                                                {
-                                                                                  "Column": 0
-                                                                                },
-                                                                                {
-                                                                                  "Column": 2
-                                                                                }
-                                                                              ],
-                                                                              [
-                                                                                {
-                                                                                  "Column": 1
-                                                                                },
-                                                                                {
-                                                                                  "Column": 3
-                                                                                }
-                                                                              ]
-                                                                            ],
-                                                                            "implementation": "Unimplemented"
-                                                                          }
-                                                                        },
-                                                                        "outputs": [
-                                                                          0,
-                                                                          1
-                                                                        ]
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "Constant": {
-                                                                        "rows": {
-                                                                          "Ok": [
-                                                                            [
-                                                                              {
-                                                                                "data": [
-                                                                                  0
-                                                                                ]
-                                                                              },
-                                                                              1
-                                                                            ]
-                                                                          ]
-                                                                        },
-                                                                        "typ": {
-                                                                          "column_types": [
-                                                                            {
-                                                                              "scalar_type": "Int32",
-                                                                              "nullable": true
-                                                                            }
-                                                                          ],
-                                                                          "keys": []
-                                                                        }
-                                                                      }
-                                                                    }
-                                                                  ],
-                                                                  "equivalences": [],
-                                                                  "implementation": "Unimplemented"
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        }
-                                                      }
-                                                    },
-                                                    "body": {
-                                                      "Filter": {
-                                                        "input": {
-                                                          "Get": {
-                                                            "id": {
-                                                              "Local": 7
-                                                            },
-                                                            "typ": {
-                                                              "column_types": [
-                                                                {
-                                                                  "scalar_type": "Int32",
-                                                                  "nullable": true
-                                                                },
-                                                                {
-                                                                  "scalar_type": "Int32",
-                                                                  "nullable": true
-                                                                },
-                                                                {
-                                                                  "scalar_type": "Int32",
-                                                                  "nullable": true
-                                                                }
-                                                              ],
-                                                              "keys": []
-                                                            },
-                                                            "access_strategy": "UnknownOrLocal"
-                                                          }
-                                                        },
-                                                        "predicates": [
-                                                          {
-                                                            "CallVariadic": {
-                                                              "func": "And",
-                                                              "exprs": [
-                                                                {
-                                                                  "CallBinary": {
-                                                                    "func": "Eq",
-                                                                    "expr1": {
-                                                                      "Column": 1
-                                                                    },
-                                                                    "expr2": {
-                                                                      "Column": 0
-                                                                    }
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "CallBinary": {
-                                                                    "func": "Gt",
-                                                                    "expr1": {
-                                                                      "Column": 2
-                                                                    },
-                                                                    "expr2": {
-                                                                      "Literal": [
-                                                                        {
-                                                                          "Ok": {
-                                                                            "data": [
-                                                                              42,
-                                                                              5
-                                                                            ]
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "scalar_type": "Int32",
-                                                                          "nullable": false
-                                                                        }
-                                                                      ]
-                                                                    }
-                                                                  }
-                                                                }
-                                                              ]
-                                                            }
-                                                          }
-                                                        ]
-                                                      }
-                                                    }
-                                                  }
-                                                }
-                                              ],
-                                              "equivalences": [
-                                                [
-                                                  {
-                                                    "Column": 1
-                                                  },
-                                                  {
-                                                    "Column": 2
-                                                  }
-                                                ],
-                                                [
-                                                  {
-                                                    "Column": 0
-                                                  },
-                                                  {
-                                                    "Column": 3
-                                                  }
-                                                ]
-                                              ],
-                                              "implementation": "Unimplemented"
-                                            }
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
                                           },
-                                          "outputs": [
-                                            0,
-                                            1,
-                                            4
-                                          ]
-                                        }
-                                      }
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      },
+                                      "access_strategy": "UnknownOrLocal"
                                     }
                                   },
                                   "predicates": [
                                     {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              2
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "Bool",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    },
-                                    {
                                       "CallBinary": {
                                         "func": "NotEq",
                                         "expr1": {
-                                          "Column": 0
+                                          "Column": 1
                                         },
                                         "expr2": {
                                           "Column": 0
@@ -8488,30 +6875,1439 @@ FROM
                     "outputs": [
                       0,
                       1,
-                      3,
-                      4
+                      3
                     ]
                   }
                 }
               }
-            },
-            "predicates": [
-              {
-                "Literal": [
-                  {
-                    "Ok": {
-                      "data": [
-                        2
-                      ]
-                    }
-                  },
-                  {
-                    "scalar_type": "Bool",
-                    "nullable": false
+            }
+          }
+        },
+        "body": {
+          "Let": {
+            "id": 6,
+            "value": {
+              "Reduce": {
+                "input": {
+                  "Get": {
+                    "id": {
+                      "Local": 5
+                    },
+                    "typ": {
+                      "column_types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        }
+                      ],
+                      "keys": []
+                    },
+                    "access_strategy": "UnknownOrLocal"
                   }
+                },
+                "group_key": [
+                  {
+                    "Column": 0
+                  }
+                ],
+                "aggregates": [],
+                "monotonic": false,
+                "expected_group_size": null
+              }
+            },
+            "body": {
+              "Project": {
+                "input": {
+                  "Join": {
+                    "inputs": [
+                      {
+                        "Get": {
+                          "id": {
+                            "Local": 5
+                          },
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": false
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": false
+                              }
+                            ],
+                            "keys": []
+                          },
+                          "access_strategy": "UnknownOrLocal"
+                        }
+                      },
+                      {
+                        "Let": {
+                          "id": 8,
+                          "value": {
+                            "Let": {
+                              "id": 7,
+                              "value": {
+                                "Reduce": {
+                                  "input": {
+                                    "Join": {
+                                      "inputs": [
+                                        {
+                                          "Get": {
+                                            "id": {
+                                              "Local": 6
+                                            },
+                                            "typ": {
+                                              "column_types": [
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": false
+                                                }
+                                              ],
+                                              "keys": [
+                                                [
+                                                  0
+                                                ]
+                                              ]
+                                            },
+                                            "access_strategy": "UnknownOrLocal"
+                                          }
+                                        },
+                                        {
+                                          "Get": {
+                                            "id": {
+                                              "Global": {
+                                                "User": 1
+                                              }
+                                            },
+                                            "typ": {
+                                              "column_types": [
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                },
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                }
+                                              ],
+                                              "keys": []
+                                            },
+                                            "access_strategy": "UnknownOrLocal"
+                                          }
+                                        }
+                                      ],
+                                      "equivalences": [],
+                                      "implementation": "Unimplemented"
+                                    }
+                                  },
+                                  "group_key": [
+                                    {
+                                      "Column": 0
+                                    }
+                                  ],
+                                  "aggregates": [
+                                    {
+                                      "func": "MaxInt32",
+                                      "expr": {
+                                        "CallBinary": {
+                                          "func": "MulInt32",
+                                          "expr1": {
+                                            "Column": 0
+                                          },
+                                          "expr2": {
+                                            "Column": 1
+                                          }
+                                        }
+                                      },
+                                      "distinct": false
+                                    }
+                                  ],
+                                  "monotonic": false,
+                                  "expected_group_size": null
+                                }
+                              },
+                              "body": {
+                                "Union": {
+                                  "base": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 7
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": [
+                                          [
+                                            0
+                                          ]
+                                        ]
+                                      },
+                                      "access_strategy": "UnknownOrLocal"
+                                    }
+                                  },
+                                  "inputs": [
+                                    {
+                                      "Join": {
+                                        "inputs": [
+                                          {
+                                            "Project": {
+                                              "input": {
+                                                "Join": {
+                                                  "inputs": [
+                                                    {
+                                                      "Union": {
+                                                        "base": {
+                                                          "Negate": {
+                                                            "input": {
+                                                              "Reduce": {
+                                                                "input": {
+                                                                  "Get": {
+                                                                    "id": {
+                                                                      "Local": 7
+                                                                    },
+                                                                    "typ": {
+                                                                      "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": false
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        }
+                                                                      ],
+                                                                      "keys": [
+                                                                        [
+                                                                          0
+                                                                        ]
+                                                                      ]
+                                                                    },
+                                                                    "access_strategy": "UnknownOrLocal"
+                                                                  }
+                                                                },
+                                                                "group_key": [
+                                                                  {
+                                                                    "Column": 0
+                                                                  }
+                                                                ],
+                                                                "aggregates": [],
+                                                                "monotonic": false,
+                                                                "expected_group_size": null
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "inputs": [
+                                                          {
+                                                            "Reduce": {
+                                                              "input": {
+                                                                "Get": {
+                                                                  "id": {
+                                                                    "Local": 6
+                                                                  },
+                                                                  "typ": {
+                                                                    "column_types": [
+                                                                      {
+                                                                        "scalar_type": "Int32",
+                                                                        "nullable": false
+                                                                      }
+                                                                    ],
+                                                                    "keys": [
+                                                                      [
+                                                                        0
+                                                                      ]
+                                                                    ]
+                                                                  },
+                                                                  "access_strategy": "UnknownOrLocal"
+                                                                }
+                                                              },
+                                                              "group_key": [
+                                                                {
+                                                                  "Column": 0
+                                                                }
+                                                              ],
+                                                              "aggregates": [],
+                                                              "monotonic": false,
+                                                              "expected_group_size": null
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    {
+                                                      "Get": {
+                                                        "id": {
+                                                          "Local": 6
+                                                        },
+                                                        "typ": {
+                                                          "column_types": [
+                                                            {
+                                                              "scalar_type": "Int32",
+                                                              "nullable": false
+                                                            }
+                                                          ],
+                                                          "keys": [
+                                                            [
+                                                              0
+                                                            ]
+                                                          ]
+                                                        },
+                                                        "access_strategy": "UnknownOrLocal"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "equivalences": [
+                                                    [
+                                                      {
+                                                        "Column": 0
+                                                      },
+                                                      {
+                                                        "Column": 1
+                                                      }
+                                                    ]
+                                                  ],
+                                                  "implementation": "Unimplemented"
+                                                }
+                                              },
+                                              "outputs": [
+                                                0
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "Constant": {
+                                              "rows": {
+                                                "Ok": [
+                                                  [
+                                                    {
+                                                      "data": [
+                                                        0
+                                                      ]
+                                                    },
+                                                    1
+                                                  ]
+                                                ]
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": []
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "equivalences": [],
+                                        "implementation": "Unimplemented"
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "body": {
+                            "Filter": {
+                              "input": {
+                                "Get": {
+                                  "id": {
+                                    "Local": 8
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": false
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  },
+                                  "access_strategy": "UnknownOrLocal"
+                                }
+                              },
+                              "predicates": [
+                                {
+                                  "CallVariadic": {
+                                    "func": "Or",
+                                    "exprs": [
+                                      {
+                                        "CallBinary": {
+                                          "func": "NotEq",
+                                          "expr1": {
+                                            "Column": 1
+                                          },
+                                          "expr2": {
+                                            "Column": 0
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "CallVariadic": {
+                                          "func": "And",
+                                          "exprs": [
+                                            {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "Not": null
+                                                },
+                                                "expr": {
+                                                  "CallUnary": {
+                                                    "func": {
+                                                      "IsNull": null
+                                                    },
+                                                    "expr": {
+                                                      "Column": 1
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "IsNull": null
+                                                },
+                                                "expr": {
+                                                  "Column": 0
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "equivalences": [
+                      [
+                        {
+                          "Column": 0
+                        },
+                        {
+                          "Column": 3
+                        }
+                      ]
+                    ],
+                    "implementation": "Unimplemented"
+                  }
+                },
+                "outputs": [
+                  0,
+                  1,
+                  2,
+                  4
                 ]
               }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+EOF
+
+# Test multiple CTEs: a case where we cannot pull the let statement up
+# through the join because the local l0 is correlated against the lhs of
+# the enclosing join.
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
+SELECT
+  *
+FROM
+  (
+    SELECT * FROM t
+  ) as r1
+  CROSS JOIN LATERAL (
+    WITH r4 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT *
+    FROM
+      r4
+      CROSS JOIN LATERAL (
+        WITH r2 as (
+          SELECT MAX(r1.a * t.a) AS m FROM t
+        )
+        SELECT * FROM r2 WHERE r1.a = r4.m AND r2.m > 5
+      ) as r3
+    WHERE a != r1.a
+  ) as r5;
+----
+{
+  "Let": {
+    "id": 0,
+    "value": {
+      "Constant": {
+        "rows": {
+          "Ok": [
+            [
+              {
+                "data": []
+              },
+              1
             ]
+          ]
+        },
+        "typ": {
+          "column_types": [],
+          "keys": []
+        }
+      }
+    },
+    "body": {
+      "Let": {
+        "id": 1,
+        "value": {
+          "Join": {
+            "inputs": [
+              {
+                "Get": {
+                  "id": {
+                    "Local": 0
+                  },
+                  "typ": {
+                    "column_types": [],
+                    "keys": [
+                      []
+                    ]
+                  },
+                  "access_strategy": "UnknownOrLocal"
+                }
+              },
+              {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
+                  },
+                  "typ": {
+                    "column_types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ],
+                    "keys": []
+                  },
+                  "access_strategy": "UnknownOrLocal"
+                }
+              }
+            ],
+            "equivalences": [],
+            "implementation": "Unimplemented"
+          }
+        },
+        "body": {
+          "Let": {
+            "id": 2,
+            "value": {
+              "Reduce": {
+                "input": {
+                  "Get": {
+                    "id": {
+                      "Local": 1
+                    },
+                    "typ": {
+                      "column_types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        }
+                      ],
+                      "keys": []
+                    },
+                    "access_strategy": "UnknownOrLocal"
+                  }
+                },
+                "group_key": [
+                  {
+                    "Column": 0
+                  }
+                ],
+                "aggregates": [],
+                "monotonic": false,
+                "expected_group_size": null
+              }
+            },
+            "body": {
+              "Project": {
+                "input": {
+                  "Join": {
+                    "inputs": [
+                      {
+                        "Get": {
+                          "id": {
+                            "Local": 1
+                          },
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ],
+                            "keys": []
+                          },
+                          "access_strategy": "UnknownOrLocal"
+                        }
+                      },
+                      {
+                        "Let": {
+                          "id": 4,
+                          "value": {
+                            "Let": {
+                              "id": 3,
+                              "value": {
+                                "Reduce": {
+                                  "input": {
+                                    "Join": {
+                                      "inputs": [
+                                        {
+                                          "Get": {
+                                            "id": {
+                                              "Local": 2
+                                            },
+                                            "typ": {
+                                              "column_types": [
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                }
+                                              ],
+                                              "keys": [
+                                                [
+                                                  0
+                                                ]
+                                              ]
+                                            },
+                                            "access_strategy": "UnknownOrLocal"
+                                          }
+                                        },
+                                        {
+                                          "Get": {
+                                            "id": {
+                                              "Global": {
+                                                "User": 1
+                                              }
+                                            },
+                                            "typ": {
+                                              "column_types": [
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                },
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                }
+                                              ],
+                                              "keys": []
+                                            },
+                                            "access_strategy": "UnknownOrLocal"
+                                          }
+                                        }
+                                      ],
+                                      "equivalences": [],
+                                      "implementation": "Unimplemented"
+                                    }
+                                  },
+                                  "group_key": [
+                                    {
+                                      "Column": 0
+                                    }
+                                  ],
+                                  "aggregates": [
+                                    {
+                                      "func": "MaxInt32",
+                                      "expr": {
+                                        "CallBinary": {
+                                          "func": "MulInt32",
+                                          "expr1": {
+                                            "Column": 0
+                                          },
+                                          "expr2": {
+                                            "Column": 1
+                                          }
+                                        }
+                                      },
+                                      "distinct": false
+                                    }
+                                  ],
+                                  "monotonic": false,
+                                  "expected_group_size": null
+                                }
+                              },
+                              "body": {
+                                "Union": {
+                                  "base": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 3
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": [
+                                          [
+                                            0
+                                          ]
+                                        ]
+                                      },
+                                      "access_strategy": "UnknownOrLocal"
+                                    }
+                                  },
+                                  "inputs": [
+                                    {
+                                      "Join": {
+                                        "inputs": [
+                                          {
+                                            "Project": {
+                                              "input": {
+                                                "Join": {
+                                                  "inputs": [
+                                                    {
+                                                      "Union": {
+                                                        "base": {
+                                                          "Negate": {
+                                                            "input": {
+                                                              "Reduce": {
+                                                                "input": {
+                                                                  "Get": {
+                                                                    "id": {
+                                                                      "Local": 3
+                                                                    },
+                                                                    "typ": {
+                                                                      "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        }
+                                                                      ],
+                                                                      "keys": [
+                                                                        [
+                                                                          0
+                                                                        ]
+                                                                      ]
+                                                                    },
+                                                                    "access_strategy": "UnknownOrLocal"
+                                                                  }
+                                                                },
+                                                                "group_key": [
+                                                                  {
+                                                                    "Column": 0
+                                                                  }
+                                                                ],
+                                                                "aggregates": [],
+                                                                "monotonic": false,
+                                                                "expected_group_size": null
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "inputs": [
+                                                          {
+                                                            "Reduce": {
+                                                              "input": {
+                                                                "Get": {
+                                                                  "id": {
+                                                                    "Local": 2
+                                                                  },
+                                                                  "typ": {
+                                                                    "column_types": [
+                                                                      {
+                                                                        "scalar_type": "Int32",
+                                                                        "nullable": true
+                                                                      }
+                                                                    ],
+                                                                    "keys": [
+                                                                      [
+                                                                        0
+                                                                      ]
+                                                                    ]
+                                                                  },
+                                                                  "access_strategy": "UnknownOrLocal"
+                                                                }
+                                                              },
+                                                              "group_key": [
+                                                                {
+                                                                  "Column": 0
+                                                                }
+                                                              ],
+                                                              "aggregates": [],
+                                                              "monotonic": false,
+                                                              "expected_group_size": null
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    {
+                                                      "Get": {
+                                                        "id": {
+                                                          "Local": 2
+                                                        },
+                                                        "typ": {
+                                                          "column_types": [
+                                                            {
+                                                              "scalar_type": "Int32",
+                                                              "nullable": true
+                                                            }
+                                                          ],
+                                                          "keys": [
+                                                            [
+                                                              0
+                                                            ]
+                                                          ]
+                                                        },
+                                                        "access_strategy": "UnknownOrLocal"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "equivalences": [
+                                                    [
+                                                      {
+                                                        "Column": 0
+                                                      },
+                                                      {
+                                                        "Column": 1
+                                                      }
+                                                    ]
+                                                  ],
+                                                  "implementation": "Unimplemented"
+                                                }
+                                              },
+                                              "outputs": [
+                                                0
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "Constant": {
+                                              "rows": {
+                                                "Ok": [
+                                                  [
+                                                    {
+                                                      "data": [
+                                                        0
+                                                      ]
+                                                    },
+                                                    1
+                                                  ]
+                                                ]
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": []
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "equivalences": [],
+                                        "implementation": "Unimplemented"
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "body": {
+                            "Filter": {
+                              "input": {
+                                "Let": {
+                                  "id": 5,
+                                  "value": {
+                                    "Reduce": {
+                                      "input": {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 4
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          },
+                                          "access_strategy": "UnknownOrLocal"
+                                        }
+                                      },
+                                      "group_key": [
+                                        {
+                                          "Column": 1
+                                        },
+                                        {
+                                          "Column": 0
+                                        }
+                                      ],
+                                      "aggregates": [],
+                                      "monotonic": false,
+                                      "expected_group_size": null
+                                    }
+                                  },
+                                  "body": {
+                                    "Project": {
+                                      "input": {
+                                        "Join": {
+                                          "inputs": [
+                                            {
+                                              "Get": {
+                                                "id": {
+                                                  "Local": 4
+                                                },
+                                                "typ": {
+                                                  "column_types": [
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": true
+                                                    },
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": true
+                                                    }
+                                                  ],
+                                                  "keys": []
+                                                },
+                                                "access_strategy": "UnknownOrLocal"
+                                              }
+                                            },
+                                            {
+                                              "Let": {
+                                                "id": 7,
+                                                "value": {
+                                                  "Let": {
+                                                    "id": 6,
+                                                    "value": {
+                                                      "Reduce": {
+                                                        "input": {
+                                                          "Join": {
+                                                            "inputs": [
+                                                              {
+                                                                "Get": {
+                                                                  "id": {
+                                                                    "Local": 5
+                                                                  },
+                                                                  "typ": {
+                                                                    "column_types": [
+                                                                      {
+                                                                        "scalar_type": "Int32",
+                                                                        "nullable": true
+                                                                      },
+                                                                      {
+                                                                        "scalar_type": "Int32",
+                                                                        "nullable": true
+                                                                      }
+                                                                    ],
+                                                                    "keys": [
+                                                                      [
+                                                                        0,
+                                                                        1
+                                                                      ]
+                                                                    ]
+                                                                  },
+                                                                  "access_strategy": "UnknownOrLocal"
+                                                                }
+                                                              },
+                                                              {
+                                                                "Get": {
+                                                                  "id": {
+                                                                    "Global": {
+                                                                      "User": 1
+                                                                    }
+                                                                  },
+                                                                  "typ": {
+                                                                    "column_types": [
+                                                                      {
+                                                                        "scalar_type": "Int32",
+                                                                        "nullable": true
+                                                                      },
+                                                                      {
+                                                                        "scalar_type": "Int32",
+                                                                        "nullable": true
+                                                                      }
+                                                                    ],
+                                                                    "keys": []
+                                                                  },
+                                                                  "access_strategy": "UnknownOrLocal"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "equivalences": [],
+                                                            "implementation": "Unimplemented"
+                                                          }
+                                                        },
+                                                        "group_key": [
+                                                          {
+                                                            "Column": 0
+                                                          },
+                                                          {
+                                                            "Column": 1
+                                                          }
+                                                        ],
+                                                        "aggregates": [
+                                                          {
+                                                            "func": "MaxInt32",
+                                                            "expr": {
+                                                              "CallBinary": {
+                                                                "func": "MulInt32",
+                                                                "expr1": {
+                                                                  "Column": 1
+                                                                },
+                                                                "expr2": {
+                                                                  "Column": 2
+                                                                }
+                                                              }
+                                                            },
+                                                            "distinct": false
+                                                          }
+                                                        ],
+                                                        "monotonic": false,
+                                                        "expected_group_size": null
+                                                      }
+                                                    },
+                                                    "body": {
+                                                      "Union": {
+                                                        "base": {
+                                                          "Get": {
+                                                            "id": {
+                                                              "Local": 6
+                                                            },
+                                                            "typ": {
+                                                              "column_types": [
+                                                                {
+                                                                  "scalar_type": "Int32",
+                                                                  "nullable": true
+                                                                },
+                                                                {
+                                                                  "scalar_type": "Int32",
+                                                                  "nullable": true
+                                                                },
+                                                                {
+                                                                  "scalar_type": "Int32",
+                                                                  "nullable": true
+                                                                }
+                                                              ],
+                                                              "keys": [
+                                                                [
+                                                                  0,
+                                                                  1
+                                                                ]
+                                                              ]
+                                                            },
+                                                            "access_strategy": "UnknownOrLocal"
+                                                          }
+                                                        },
+                                                        "inputs": [
+                                                          {
+                                                            "Join": {
+                                                              "inputs": [
+                                                                {
+                                                                  "Project": {
+                                                                    "input": {
+                                                                      "Join": {
+                                                                        "inputs": [
+                                                                          {
+                                                                            "Union": {
+                                                                              "base": {
+                                                                                "Negate": {
+                                                                                  "input": {
+                                                                                    "Reduce": {
+                                                                                      "input": {
+                                                                                        "Get": {
+                                                                                          "id": {
+                                                                                            "Local": 6
+                                                                                          },
+                                                                                          "typ": {
+                                                                                            "column_types": [
+                                                                                              {
+                                                                                                "scalar_type": "Int32",
+                                                                                                "nullable": true
+                                                                                              },
+                                                                                              {
+                                                                                                "scalar_type": "Int32",
+                                                                                                "nullable": true
+                                                                                              },
+                                                                                              {
+                                                                                                "scalar_type": "Int32",
+                                                                                                "nullable": true
+                                                                                              }
+                                                                                            ],
+                                                                                            "keys": [
+                                                                                              [
+                                                                                                0,
+                                                                                                1
+                                                                                              ]
+                                                                                            ]
+                                                                                          },
+                                                                                          "access_strategy": "UnknownOrLocal"
+                                                                                        }
+                                                                                      },
+                                                                                      "group_key": [
+                                                                                        {
+                                                                                          "Column": 0
+                                                                                        },
+                                                                                        {
+                                                                                          "Column": 1
+                                                                                        }
+                                                                                      ],
+                                                                                      "aggregates": [],
+                                                                                      "monotonic": false,
+                                                                                      "expected_group_size": null
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "inputs": [
+                                                                                {
+                                                                                  "Reduce": {
+                                                                                    "input": {
+                                                                                      "Get": {
+                                                                                        "id": {
+                                                                                          "Local": 5
+                                                                                        },
+                                                                                        "typ": {
+                                                                                          "column_types": [
+                                                                                            {
+                                                                                              "scalar_type": "Int32",
+                                                                                              "nullable": true
+                                                                                            },
+                                                                                            {
+                                                                                              "scalar_type": "Int32",
+                                                                                              "nullable": true
+                                                                                            }
+                                                                                          ],
+                                                                                          "keys": [
+                                                                                            [
+                                                                                              0,
+                                                                                              1
+                                                                                            ]
+                                                                                          ]
+                                                                                        },
+                                                                                        "access_strategy": "UnknownOrLocal"
+                                                                                      }
+                                                                                    },
+                                                                                    "group_key": [
+                                                                                      {
+                                                                                        "Column": 0
+                                                                                      },
+                                                                                      {
+                                                                                        "Column": 1
+                                                                                      }
+                                                                                    ],
+                                                                                    "aggregates": [],
+                                                                                    "monotonic": false,
+                                                                                    "expected_group_size": null
+                                                                                  }
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "Get": {
+                                                                              "id": {
+                                                                                "Local": 5
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  },
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  }
+                                                                                ],
+                                                                                "keys": [
+                                                                                  [
+                                                                                    0,
+                                                                                    1
+                                                                                  ]
+                                                                                ]
+                                                                              },
+                                                                              "access_strategy": "UnknownOrLocal"
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "equivalences": [
+                                                                          [
+                                                                            {
+                                                                              "Column": 0
+                                                                            },
+                                                                            {
+                                                                              "Column": 2
+                                                                            }
+                                                                          ],
+                                                                          [
+                                                                            {
+                                                                              "Column": 1
+                                                                            },
+                                                                            {
+                                                                              "Column": 3
+                                                                            }
+                                                                          ]
+                                                                        ],
+                                                                        "implementation": "Unimplemented"
+                                                                      }
+                                                                    },
+                                                                    "outputs": [
+                                                                      0,
+                                                                      1
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "Constant": {
+                                                                    "rows": {
+                                                                      "Ok": [
+                                                                        [
+                                                                          {
+                                                                            "data": [
+                                                                              0
+                                                                            ]
+                                                                          },
+                                                                          1
+                                                                        ]
+                                                                      ]
+                                                                    },
+                                                                    "typ": {
+                                                                      "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        }
+                                                                      ],
+                                                                      "keys": []
+                                                                    }
+                                                                  }
+                                                                }
+                                                              ],
+                                                              "equivalences": [],
+                                                              "implementation": "Unimplemented"
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "body": {
+                                                  "Filter": {
+                                                    "input": {
+                                                      "Get": {
+                                                        "id": {
+                                                          "Local": 7
+                                                        },
+                                                        "typ": {
+                                                          "column_types": [
+                                                            {
+                                                              "scalar_type": "Int32",
+                                                              "nullable": true
+                                                            },
+                                                            {
+                                                              "scalar_type": "Int32",
+                                                              "nullable": true
+                                                            },
+                                                            {
+                                                              "scalar_type": "Int32",
+                                                              "nullable": true
+                                                            }
+                                                          ],
+                                                          "keys": []
+                                                        },
+                                                        "access_strategy": "UnknownOrLocal"
+                                                      }
+                                                    },
+                                                    "predicates": [
+                                                      {
+                                                        "CallVariadic": {
+                                                          "func": "And",
+                                                          "exprs": [
+                                                            {
+                                                              "CallBinary": {
+                                                                "func": "Eq",
+                                                                "expr1": {
+                                                                  "Column": 1
+                                                                },
+                                                                "expr2": {
+                                                                  "Column": 0
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "CallBinary": {
+                                                                "func": "Gt",
+                                                                "expr1": {
+                                                                  "Column": 2
+                                                                },
+                                                                "expr2": {
+                                                                  "Literal": [
+                                                                    {
+                                                                      "Ok": {
+                                                                        "data": [
+                                                                          42,
+                                                                          5
+                                                                        ]
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "equivalences": [
+                                            [
+                                              {
+                                                "Column": 1
+                                              },
+                                              {
+                                                "Column": 2
+                                              }
+                                            ],
+                                            [
+                                              {
+                                                "Column": 0
+                                              },
+                                              {
+                                                "Column": 3
+                                              }
+                                            ]
+                                          ],
+                                          "implementation": "Unimplemented"
+                                        }
+                                      },
+                                      "outputs": [
+                                        0,
+                                        1,
+                                        4
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "predicates": [
+                                {
+                                  "CallBinary": {
+                                    "func": "NotEq",
+                                    "expr1": {
+                                      "Column": 0
+                                    },
+                                    "expr2": {
+                                      "Column": 0
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "equivalences": [
+                      [
+                        {
+                          "Column": 0
+                        },
+                        {
+                          "Column": 2
+                        }
+                      ]
+                    ],
+                    "implementation": "Unimplemented"
+                  }
+                },
+                "outputs": [
+                  0,
+                  1,
+                  3,
+                  4
+                ]
+              }
+            }
           }
         }
       }

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -99,12 +99,11 @@ EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT generate_series(a, b) from t
 ----
 Project (#2)
-  Filter true
-    FlatMap generate_series(#0, #1, 1)
-      CrossJoin
-        Constant
-          - ()
-        Get materialize.public.t
+  FlatMap generate_series(#0, #1, 1)
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
 
 Target cluster: quickstart
 
@@ -408,17 +407,16 @@ EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1, t as t2
 ----
 Project (#0, #2)
-  Filter true
-    Project (#0..=#3)
+  Project (#0..=#3)
+    CrossJoin
       CrossJoin
-        CrossJoin
-          Constant
-            - ()
-          Get materialize.public.t
-        CrossJoin
-          Constant
-            - ()
-          Get materialize.public.t
+        Constant
+          - ()
+        Get materialize.public.t
+      CrossJoin
+        Constant
+          - ()
+        Get materialize.public.t
 
 Target cluster: quickstart
 
@@ -430,17 +428,16 @@ EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1 INNER JOIN t as t2 ON true
 ----
 Project (#0, #2)
-  Filter true
-    Project (#0..=#3)
+  Project (#0..=#3)
+    CrossJoin
       CrossJoin
-        CrossJoin
-          Constant
-            - ()
-          Get materialize.public.t
-        CrossJoin
-          Constant
-            - ()
-          Get materialize.public.t
+        Constant
+          - ()
+        Get materialize.public.t
+      CrossJoin
+        Constant
+          - ()
+        Get materialize.public.t
 
 Target cluster: quickstart
 
@@ -458,24 +455,22 @@ WHERE t1.b = t2.b AND t2.b = t3.b
 ----
 Project (#0, #2)
   Filter ((#1 = #3) AND (#3 = #5))
-    Filter true
-      Project (#0..=#5)
-        CrossJoin
-          Filter true
-            Project (#0..=#3)
-              CrossJoin
-                CrossJoin
-                  Constant
-                    - ()
-                  Get materialize.public.t
-                CrossJoin
-                  Constant
-                    - ()
-                  Get materialize.public.t
+    Project (#0..=#5)
+      CrossJoin
+        Project (#0..=#3)
           CrossJoin
-            Constant
-              - ()
-            Get materialize.public.t
+            CrossJoin
+              Constant
+                - ()
+              Get materialize.public.t
+            CrossJoin
+              Constant
+                - ()
+              Get materialize.public.t
+        CrossJoin
+          Constant
+            - ()
+          Get materialize.public.t
 
 Target cluster: quickstart
 
@@ -589,11 +584,10 @@ Return
   Project (#2)
     Project (#0..=#2)
       Map ((#0 + #1))
-        Filter true
-          Project (#0, #1)
-            CrossJoin
-              Get l0
-              Get l0
+        Project (#0, #1)
+          CrossJoin
+            Get l0
+            Get l0
 With
   cte l0 =
     Project (#2)
@@ -631,25 +625,24 @@ FROM
   ) as r5;
 ----
 Return
-  Filter true
-    Project (#0..=#2, #4)
-      Join on=(#0 = #3)
-        Get l3
-        Filter ((#1 != #0) OR ((#1) IS NOT NULL AND (#0) IS NULL))
-          Union
-            Get l5
-            CrossJoin
-              Project (#0)
-                Join on=(#0 = #1)
-                  Union
-                    Negate
-                      Distinct project=[#0]
-                        Get l5
+  Project (#0..=#2, #4)
+    Join on=(#0 = #3)
+      Get l3
+      Filter ((#1 != #0) OR ((#1) IS NOT NULL AND (#0) IS NULL))
+        Union
+          Get l5
+          CrossJoin
+            Project (#0)
+              Join on=(#0 = #1)
+                Union
+                  Negate
                     Distinct project=[#0]
-                      Get l4
-                  Get l4
-              Constant
-                - (null)
+                      Get l5
+                  Distinct project=[#0]
+                    Get l4
+                Get l4
+            Constant
+              - (null)
 With
   cte l5 =
     Reduce group_by=[#0] aggregates=[max((#0 * #1))]
@@ -660,25 +653,24 @@ With
     Distinct project=[#0]
       Get l3
   cte l3 =
-    Filter true
-      Project (#0, #1, #3)
-        Join on=(#0 = #2)
-          Get l0
-          Filter (#1 != #0)
-            Union
-              Get l2
-              CrossJoin
-                Project (#0)
-                  Join on=(#0 = #1)
-                    Union
-                      Negate
-                        Distinct project=[#0]
-                          Get l2
+    Project (#0, #1, #3)
+      Join on=(#0 = #2)
+        Get l0
+        Filter (#1 != #0)
+          Union
+            Get l2
+            CrossJoin
+              Project (#0)
+                Join on=(#0 = #1)
+                  Union
+                    Negate
                       Distinct project=[#0]
-                        Get l1
-                    Get l1
-                Constant
-                  - (null)
+                        Get l2
+                    Distinct project=[#0]
+                      Get l1
+                  Get l1
+              Constant
+                - (null)
   cte l2 =
     Reduce group_by=[#0] aggregates=[max((#0 * #1))]
       CrossJoin
@@ -725,29 +717,28 @@ FROM
   ) as r5;
 ----
 Return
-  Filter true
-    Project (#0, #1, #3, #4)
-      Join on=(#0 = #2)
-        Get l0
-        Filter true AND (#0 != #0)
-          Project (#0, #1, #4)
-            Join on=(#1 = #2 AND #0 = #3)
-              Get l3
-              Filter ((#1 = #0) AND (#2 > 5))
-                Union
-                  Get l5
-                  CrossJoin
-                    Project (#0, #1)
-                      Join on=(#0 = #2 AND #1 = #3)
-                        Union
-                          Negate
-                            Distinct project=[#0, #1]
-                              Get l5
+  Project (#0, #1, #3, #4)
+    Join on=(#0 = #2)
+      Get l0
+      Filter (#0 != #0)
+        Project (#0, #1, #4)
+          Join on=(#1 = #2 AND #0 = #3)
+            Get l3
+            Filter ((#1 = #0) AND (#2 > 5))
+              Union
+                Get l5
+                CrossJoin
+                  Project (#0, #1)
+                    Join on=(#0 = #2 AND #1 = #3)
+                      Union
+                        Negate
                           Distinct project=[#0, #1]
-                            Get l4
-                        Get l4
-                    Constant
-                      - (null)
+                            Get l5
+                        Distinct project=[#0, #1]
+                          Get l4
+                      Get l4
+                  Constant
+                    - (null)
 With
   cte l5 =
     Reduce group_by=[#0, #1] aggregates=[max((#1 * #2))]

--- a/test/sqllogictest/github-17616.slt
+++ b/test/sqllogictest/github-17616.slt
@@ -49,30 +49,29 @@ FROM
 ----
 Return // { arity: 3 }
   Project (#3..=#5) // { arity: 3 }
-    Filter true // { arity: 6 }
-      Project (#0..=#2, #4..=#6) // { arity: 6 }
-        Join on=(#1 = #3) // { arity: 7 }
-          Get l0 // { arity: 3 }
-          Project (#0, #3..=#5) // { arity: 4 }
-            Map ((#3 * 2)) // { arity: 6 }
-              Project (#0..=#2, #7, #8) // { arity: 5 }
-                Map ((#0 * #1), #6) // { arity: 9 }
-                  Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) // { arity: 7 }
-                    Get l1 // { arity: 3 }
-                    Union // { arity: 4 }
-                      Get l4 // { arity: 4 }
-                      CrossJoin // { arity: 4 }
-                        Project (#0..=#2) // { arity: 3 }
-                          Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) // { arity: 6 }
-                            Union // { arity: 3 }
-                              Negate // { arity: 3 }
-                                Distinct project=[#0..=#2] // { arity: 3 }
-                                  Get l4 // { arity: 4 }
+    Project (#0..=#2, #4..=#6) // { arity: 6 }
+      Join on=(#1 = #3) // { arity: 7 }
+        Get l0 // { arity: 3 }
+        Project (#0, #3..=#5) // { arity: 4 }
+          Map ((#3 * 2)) // { arity: 6 }
+            Project (#0..=#2, #7, #8) // { arity: 5 }
+              Map ((#0 * #1), #6) // { arity: 9 }
+                Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) // { arity: 7 }
+                  Get l1 // { arity: 3 }
+                  Union // { arity: 4 }
+                    Get l4 // { arity: 4 }
+                    CrossJoin // { arity: 4 }
+                      Project (#0..=#2) // { arity: 3 }
+                        Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) // { arity: 6 }
+                          Union // { arity: 3 }
+                            Negate // { arity: 3 }
                               Distinct project=[#0..=#2] // { arity: 3 }
-                                Get l2 // { arity: 3 }
-                            Get l2 // { arity: 3 }
-                        Constant // { arity: 1 }
-                          - (null)
+                                Get l4 // { arity: 4 }
+                            Distinct project=[#0..=#2] // { arity: 3 }
+                              Get l2 // { arity: 3 }
+                          Get l2 // { arity: 3 }
+                      Constant // { arity: 1 }
+                        - (null)
 With
   cte l4 =
     Union // { arity: 4 }

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -215,25 +215,24 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 );
 ----
 Return // { arity: 6 }
-  Filter true // { arity: 6 }
-    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
-      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
-        Get l0 // { arity: 2 }
-        Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
-          Union // { arity: 17 }
-            Get l3 // { arity: 17 }
-            CrossJoin // { arity: 17 }
-              Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
-                Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
-                  Union // { arity: 11 }
-                    Negate // { arity: 11 }
-                      Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
-                        Get l3 // { arity: 17 }
+  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+    Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
+      Get l0 // { arity: 2 }
+      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+        Union // { arity: 17 }
+          Get l3 // { arity: 17 }
+          CrossJoin // { arity: 17 }
+            Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
+              Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
+                Union // { arity: 11 }
+                  Negate // { arity: 11 }
                     Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
-                      Get l2 // { arity: 11 }
-                  Get l2 // { arity: 11 }
-              Constant // { arity: 6 }
-                - (null, null, null, null, null, null)
+                      Get l3 // { arity: 17 }
+                  Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
+                    Get l2 // { arity: 11 }
+                Get l2 // { arity: 11 }
+            Constant // { arity: 6 }
+              - (null, null, null, null, null, null)
 With
   cte l3 =
     Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
@@ -276,25 +275,24 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 );
 ----
 Return // { arity: 6 }
-  Filter true // { arity: 6 }
-    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
-      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
-        Get l0 // { arity: 2 }
-        Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
-          Union // { arity: 17 }
-            Map (null, null, null, null, null, null) // { arity: 17 }
-              Union // { arity: 11 }
-                Negate // { arity: 11 }
-                  Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
-                    Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                      Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
-                        Get l2 // { arity: 11 }
-                      Distinct project=[#0{x}..=#2] // { arity: 3 }
-                        Project (#17..=#19) // { arity: 3 }
-                          Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
-                            Get l3 // { arity: 17 }
-                Get l2 // { arity: 11 }
-            Get l3 // { arity: 17 }
+  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+    Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
+      Get l0 // { arity: 2 }
+      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+        Union // { arity: 17 }
+          Map (null, null, null, null, null, null) // { arity: 17 }
+            Union // { arity: 11 }
+              Negate // { arity: 11 }
+                Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
+                  Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
+                    Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
+                      Get l2 // { arity: 11 }
+                    Distinct project=[#0{x}..=#2] // { arity: 3 }
+                      Project (#17..=#19) // { arity: 3 }
+                        Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
+                          Get l3 // { arity: 17 }
+              Get l2 // { arity: 11 }
+          Get l3 // { arity: 17 }
 With
   cte l3 =
     Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
@@ -337,26 +335,25 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 );
 ----
 Return // { arity: 6 }
-  Filter true // { arity: 6 }
-    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
-      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
-        Get l0 // { arity: 2 }
-        Project (#0{x}, #1{y}, #8, #12, #9, #3{facts_d01}) // { arity: 6 }
-          Union // { arity: 17 }
-            Project (#0{x}, #1{y}, #11{dim03_k01}..=#16{facts_d05}, #2..=#10{dim02_k01}) // { arity: 17 }
-              Map (null, null, null, null, null, null) // { arity: 17 }
-                Union // { arity: 11 }
-                  Negate // { arity: 11 }
-                    Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
-                      Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                        Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
-                          Get l2 // { arity: 11 }
-                        Distinct project=[#0{x}..=#2] // { arity: 3 }
-                          Project (#17..=#19) // { arity: 3 }
-                            Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
-                              Get l3 // { arity: 17 }
-                  Get l2 // { arity: 11 }
-            Get l3 // { arity: 17 }
+  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+    Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
+      Get l0 // { arity: 2 }
+      Project (#0{x}, #1{y}, #8, #12, #9, #3{facts_d01}) // { arity: 6 }
+        Union // { arity: 17 }
+          Project (#0{x}, #1{y}, #11{dim03_k01}..=#16{facts_d05}, #2..=#10{dim02_k01}) // { arity: 17 }
+            Map (null, null, null, null, null, null) // { arity: 17 }
+              Union // { arity: 11 }
+                Negate // { arity: 11 }
+                  Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
+                    Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
+                      Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL // { arity: 11 }
+                        Get l2 // { arity: 11 }
+                      Distinct project=[#0{x}..=#2] // { arity: 3 }
+                        Project (#17..=#19) // { arity: 3 }
+                          Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
+                            Get l3 // { arity: 17 }
+                Get l2 // { arity: 11 }
+          Get l3 // { arity: 17 }
 With
   cte l3 =
     Filter ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
@@ -403,25 +400,24 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 );
 ----
 Return // { arity: 6 }
-  Filter true // { arity: 6 }
-    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
-      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
-        Get l0 // { arity: 2 }
-        Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
-          Union // { arity: 17 }
-            Get l3 // { arity: 17 }
-            CrossJoin // { arity: 17 }
-              Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
-                Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
-                  Union // { arity: 11 }
-                    Negate // { arity: 11 }
-                      Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
-                        Get l3 // { arity: 17 }
+  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+    Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
+      Get l0 // { arity: 2 }
+      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+        Union // { arity: 17 }
+          Get l3 // { arity: 17 }
+          CrossJoin // { arity: 17 }
+            Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
+              Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
+                Union // { arity: 11 }
+                  Negate // { arity: 11 }
                     Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
-                      Get l2 // { arity: 11 }
-                  Get l2 // { arity: 11 }
-              Constant // { arity: 6 }
-                - (null, null, null, null, null, null)
+                      Get l3 // { arity: 17 }
+                  Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
+                    Get l2 // { arity: 11 }
+                Get l2 // { arity: 11 }
+            Constant // { arity: 6 }
+              - (null, null, null, null, null, null)
 With
   cte l3 =
     Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND (#13{dim01_d02} = 24)) // { arity: 17 }
@@ -468,25 +464,24 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 );
 ----
 Return // { arity: 6 }
-  Filter true // { arity: 6 }
-    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
-      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
-        Get l0 // { arity: 2 }
-        Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
-          Union // { arity: 17 }
-            Map (null, null, null, null, null, null) // { arity: 17 }
-              Union // { arity: 11 }
-                Negate // { arity: 11 }
-                  Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
-                    Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                      Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
-                        Get l2 // { arity: 11 }
-                      Distinct project=[#0{x}..=#2] // { arity: 3 }
-                        Project (#17..=#19) // { arity: 3 }
-                          Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
-                            Get l3 // { arity: 17 }
-                Get l2 // { arity: 11 }
-            Get l3 // { arity: 17 }
+  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+    Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
+      Get l0 // { arity: 2 }
+      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+        Union // { arity: 17 }
+          Map (null, null, null, null, null, null) // { arity: 17 }
+            Union // { arity: 11 }
+              Negate // { arity: 11 }
+                Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
+                  Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
+                    Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
+                      Get l2 // { arity: 11 }
+                    Distinct project=[#0{x}..=#2] // { arity: 3 }
+                      Project (#17..=#19) // { arity: 3 }
+                        Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
+                          Get l3 // { arity: 17 }
+              Get l2 // { arity: 11 }
+          Get l3 // { arity: 17 }
 With
   cte l3 =
     Filter (#7{facts_d02} = 42) AND (#13{dim01_d02} = 24) AND ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
@@ -533,26 +528,25 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 );
 ----
 Return // { arity: 6 }
-  Filter true // { arity: 6 }
-    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
-      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
-        Get l0 // { arity: 2 }
-        Project (#0{x}, #1{y}, #8, #12, #9, #3{facts_d01}) // { arity: 6 }
-          Union // { arity: 17 }
-            Project (#0{x}, #1{y}, #11{dim03_k01}..=#16{facts_d05}, #2..=#10{dim02_k01}) // { arity: 17 }
-              Map (null, null, null, null, null, null) // { arity: 17 }
-                Union // { arity: 11 }
-                  Negate // { arity: 11 }
-                    Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
-                      Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
-                        Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
-                          Get l2 // { arity: 11 }
-                        Distinct project=[#0{x}..=#2] // { arity: 3 }
-                          Project (#17..=#19) // { arity: 3 }
-                            Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
-                              Get l3 // { arity: 17 }
-                  Get l2 // { arity: 11 }
-            Get l3 // { arity: 17 }
+  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+    Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
+      Get l0 // { arity: 2 }
+      Project (#0{x}, #1{y}, #8, #12, #9, #3{facts_d01}) // { arity: 6 }
+        Union // { arity: 17 }
+          Project (#0{x}, #1{y}, #11{dim03_k01}..=#16{facts_d05}, #2..=#10{dim02_k01}) // { arity: 17 }
+            Map (null, null, null, null, null, null) // { arity: 17 }
+              Union // { arity: 11 }
+                Negate // { arity: 11 }
+                  Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
+                    Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
+                      Filter ((#3{dim01_k01} + #0{x})) IS NOT NULL AND (#7{facts_d02} = 42) // { arity: 11 }
+                        Get l2 // { arity: 11 }
+                      Distinct project=[#0{x}..=#2] // { arity: 3 }
+                        Project (#17..=#19) // { arity: 3 }
+                          Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
+                            Get l3 // { arity: 17 }
+                Get l2 // { arity: 11 }
+          Get l3 // { arity: 17 }
 With
   cte l3 =
     Filter (#4{dim01_d02} = 24) AND (#13{facts_d02} = 42) AND ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
@@ -598,32 +592,31 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 );
 ----
 Return // { arity: 6 }
-  Filter true // { arity: 6 }
-    Project (#0{x}, #1{y}, #4{dim02_d02}..=#7) // { arity: 6 }
-      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
-        Get l0 // { arity: 2 }
-        Project (#0{x}..=#2{dim01_k01}, #2{dim01_k01}, #10, #10) // { arity: 6 }
-          Union // { arity: 14 }
-            Project (#0{x}, #1{y}, #8{dim02_k01}..=#13{dim02_d05}, #2..=#7) // { arity: 14 }
-              Map (null, null, null, null, null, null) // { arity: 14 }
-                Union // { arity: 8 }
-                  Negate // { arity: 8 }
-                    Project (#0{x}..=#7{dim02_d05}) // { arity: 8 }
-                      Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim02_k01}, #1{y}) = #10) // { arity: 11 }
-                        Filter (coalesce(#2{dim02_k01}, #1{y})) IS NOT NULL AND (#5{dim02_d03} < 24) // { arity: 8 }
-                          Get l3 // { arity: 8 }
-                        Get l5 // { arity: 3 }
-                  Get l3 // { arity: 8 }
+  Project (#0{x}, #1{y}, #4{dim02_d02}..=#7) // { arity: 6 }
+    Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
+      Get l0 // { arity: 2 }
+      Project (#0{x}..=#2{dim01_k01}, #2{dim01_k01}, #10, #10) // { arity: 6 }
+        Union // { arity: 14 }
+          Project (#0{x}, #1{y}, #8{dim02_k01}..=#13{dim02_d05}, #2..=#7) // { arity: 14 }
             Map (null, null, null, null, null, null) // { arity: 14 }
               Union // { arity: 8 }
                 Negate // { arity: 8 }
-                  Project (#0{x}..=#7{dim01_d05}) // { arity: 8 }
-                    Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim01_k01}, #0{x}) = #10) // { arity: 11 }
-                      Filter (coalesce(#2{dim01_k01}, #0{x})) IS NOT NULL AND (#5{dim01_d03} > 42) // { arity: 8 }
-                        Get l2 // { arity: 8 }
+                  Project (#0{x}..=#7{dim02_d05}) // { arity: 8 }
+                    Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim02_k01}, #1{y}) = #10) // { arity: 11 }
+                      Filter (coalesce(#2{dim02_k01}, #1{y})) IS NOT NULL AND (#5{dim02_d03} < 24) // { arity: 8 }
+                        Get l3 // { arity: 8 }
                       Get l5 // { arity: 3 }
-                Get l2 // { arity: 8 }
-            Get l4 // { arity: 14 }
+                Get l3 // { arity: 8 }
+          Map (null, null, null, null, null, null) // { arity: 14 }
+            Union // { arity: 8 }
+              Negate // { arity: 8 }
+                Project (#0{x}..=#7{dim01_d05}) // { arity: 8 }
+                  Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim01_k01}, #0{x}) = #10) // { arity: 11 }
+                    Filter (coalesce(#2{dim01_k01}, #0{x})) IS NOT NULL AND (#5{dim01_d03} > 42) // { arity: 8 }
+                      Get l2 // { arity: 8 }
+                    Get l5 // { arity: 3 }
+              Get l2 // { arity: 8 }
+          Get l4 // { arity: 14 }
 With
   cte l5 =
     Distinct project=[#0{x}..=#2] // { arity: 3 }
@@ -677,25 +670,24 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 );
 ----
 Return // { arity: 6 }
-  Filter true // { arity: 6 }
-    Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
-      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
-        Get l0 // { arity: 2 }
-        Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
-          Union // { arity: 17 }
-            Get l8 // { arity: 17 }
-            CrossJoin // { arity: 17 }
-              Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
-                Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
-                  Union // { arity: 11 }
-                    Negate // { arity: 11 }
-                      Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
-                        Get l8 // { arity: 17 }
+  Project (#0{x}, #1{y}, #4{dim01_k01}..=#7) // { arity: 6 }
+    Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
+      Get l0 // { arity: 2 }
+      Project (#0{x}..=#2{facts_k01}, #6, #3{facts_d01}, #12) // { arity: 6 }
+        Union // { arity: 17 }
+          Get l8 // { arity: 17 }
+          CrossJoin // { arity: 17 }
+            Project (#0{x}..=#10{facts_d05}) // { arity: 11 }
+              Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
+                Union // { arity: 11 }
+                  Negate // { arity: 11 }
                     Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
-                      Get l2 // { arity: 11 }
-                  Get l2 // { arity: 11 }
-              Constant // { arity: 6 }
-                - (null, null, null, null, null, null)
+                      Get l8 // { arity: 17 }
+                  Distinct project=[#0{x}..=#10{facts_d05}] // { arity: 11 }
+                    Get l2 // { arity: 11 }
+                Get l2 // { arity: 11 }
+            Constant // { arity: 6 }
+              - (null, null, null, null, null, null)
 With
   cte l8 =
     Project (#0{x}..=#16{dim01_d05}) // { arity: 17 }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -242,11 +242,10 @@ With
     Distinct project=[#0] // { arity: 1 }
       Get l0 // { arity: 2 }
   cte l0 =
-    Filter true // { arity: 2 }
-      CrossJoin // { arity: 2 }
-        Constant // { arity: 0 }
-          - ()
-        Get materialize.public.t1 // { arity: 2 }
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.t1 // { arity: 2 }
 
 Target cluster: quickstart
 
@@ -337,21 +336,20 @@ query T multiline
 EXPLAIN DECORRELATED PLAN WITH(arity) FOR SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER() FROM t1 WHERE t1.f2 = t2.f2) AS foo;
 ----
 Return // { arity: 5 }
-  Filter true // { arity: 5 }
-    Project (#0, #1, #3..=#5) // { arity: 5 }
-      Join on=(#1 = #2) // { arity: 6 }
-        Get l0 // { arity: 2 }
-        Project (#0..=#2, #4) // { arity: 4 }
-          Map (#3) // { arity: 5 }
-            Project (#3..=#6) // { arity: 4 }
-              Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[2](record_get[1](#2)), record_get[0](#2)) // { arity: 7 }
-                FlatMap unnest_list(#1) // { arity: 3 }
-                  Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 2 }
-                    Filter (#2 = #0) // { arity: 3 }
-                      CrossJoin // { arity: 3 }
-                        Distinct project=[#1] // { arity: 1 }
-                          Get l0 // { arity: 2 }
-                        Get materialize.public.t1 // { arity: 2 }
+  Project (#0, #1, #3..=#5) // { arity: 5 }
+    Join on=(#1 = #2) // { arity: 6 }
+      Get l0 // { arity: 2 }
+      Project (#0..=#2, #4) // { arity: 4 }
+        Map (#3) // { arity: 5 }
+          Project (#3..=#6) // { arity: 4 }
+            Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[2](record_get[1](#2)), record_get[0](#2)) // { arity: 7 }
+              FlatMap unnest_list(#1) // { arity: 3 }
+                Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 2 }
+                  Filter (#2 = #0) // { arity: 3 }
+                    CrossJoin // { arity: 3 }
+                      Distinct project=[#1] // { arity: 1 }
+                        Get l0 // { arity: 2 }
+                      Get materialize.public.t1 // { arity: 2 }
 With
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -367,21 +365,20 @@ query T multiline
 EXPLAIN DECORRELATED PLAN WITH(arity) FOR SELECT * FROM t2, LATERAL(SELECT t1.*, ROW_NUMBER() OVER(PARTITION BY f1) FROM t1 WHERE t1.f2 = t2.f2) AS foo;
 ----
 Return // { arity: 5 }
-  Filter true // { arity: 5 }
-    Project (#0, #1, #3..=#5) // { arity: 5 }
-      Join on=(#1 = #2) // { arity: 6 }
-        Get l0 // { arity: 2 }
-        Project (#0..=#2, #4) // { arity: 4 }
-          Map (#3) // { arity: 5 }
-            Project (#4..=#7) // { arity: 4 }
-              Map (record_get[0](record_get[1](#3)), record_get[1](record_get[1](#3)), record_get[2](record_get[1](#3)), record_get[0](#3)) // { arity: 8 }
-                FlatMap unnest_list(#2) // { arity: 4 }
-                  Reduce group_by=[#0, #1] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 3 }
-                    Filter (#2 = #0) // { arity: 3 }
-                      CrossJoin // { arity: 3 }
-                        Distinct project=[#1] // { arity: 1 }
-                          Get l0 // { arity: 2 }
-                        Get materialize.public.t1 // { arity: 2 }
+  Project (#0, #1, #3..=#5) // { arity: 5 }
+    Join on=(#1 = #2) // { arity: 6 }
+      Get l0 // { arity: 2 }
+      Project (#0..=#2, #4) // { arity: 4 }
+        Map (#3) // { arity: 5 }
+          Project (#4..=#7) // { arity: 4 }
+            Map (record_get[0](record_get[1](#3)), record_get[1](record_get[1](#3)), record_get[2](record_get[1](#3)), record_get[0](#3)) // { arity: 8 }
+              FlatMap unnest_list(#2) // { arity: 4 }
+                Reduce group_by=[#0, #1] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 3 }
+                  Filter (#2 = #0) // { arity: 3 }
+                    CrossJoin // { arity: 3 }
+                      Distinct project=[#1] // { arity: 1 }
+                        Get l0 // { arity: 2 }
+                      Get materialize.public.t1 // { arity: 2 }
 With
   cte l0 =
     CrossJoin // { arity: 2 }


### PR DESCRIPTION
Some MIR constructors could have been smarter, and in the absence of this smartness they produced somewhat noisy plans.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
