### PR TITLE
Replace recursive `typ()` call with already available key information

### DIFF
--- a/src/expr/src/relation.rs
+++ b/src/expr/src/relation.rs
@@ -920,13 +920,18 @@ impl MirRelationExpr {
                                         {
                                             if first_id == second_id {
                                                 result.extend(
-                                                    inputs[0].typ().keys.drain(..).filter(|key| {
-                                                        key.iter().all(|c| {
-                                                            outputs.get(*c) == Some(c)
-                                                                && base_projection.get(*c)
-                                                                    == Some(c)
+                                                    input_keys
+                                                        .next()
+                                                        .unwrap()
+                                                        .iter()
+                                                        .filter(|key| {
+                                                            key.iter().all(|c| {
+                                                                outputs.get(*c) == Some(c)
+                                                                    && base_projection.get(*c)
+                                                                        == Some(c)
+                                                            })
                                                         })
-                                                    }),
+                                                        .cloned(),
                                                 );
                                             }
                                         }


### PR DESCRIPTION
Our `expr.typ()` method performs a recursive traversal of the expression, doing among other things key determination. However, in determining the key for a `Union` AST node, it again calls `typ()`, resulting in a potentially exponential running time if we have lots of unions.

This PR removes the call to `typ()`, which only required information about the unique keys, and uses instead the unique key information that is supplied to the function. Likely this was a missed case when we pivoted from using `typ()` everywhere to trying to be better and only do one linear pass through expressions.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
