### PR TITLE
adapter: make Postgres TimestampOracle aware of read-only mode

### DIFF
--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -182,6 +182,7 @@ impl Coordinator {
             self.catalog().config().now.clone(),
             self.pg_timestamp_oracle_config.clone(),
             &mut self.global_timelines,
+            self.read_only_controllers,
         )
         .await
     }
@@ -195,6 +196,7 @@ impl Coordinator {
         now: NowFn,
         pg_oracle_config: Option<PostgresTimestampOracleConfig>,
         global_timelines: &'a mut BTreeMap<Timeline, TimelineState<Timestamp>>,
+        read_only: bool,
     ) -> &'a mut TimelineState<Timestamp> {
         if !global_timelines.contains_key(timeline) {
             info!(
@@ -227,6 +229,7 @@ impl Coordinator {
                     timeline.to_string(),
                     initially,
                     now_fn,
+                    read_only,
                 )
                 .await,
             );

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -467,6 +467,7 @@ impl Service for TransactorService {
                         "maelstrom".to_owned(),
                         mz_repr::Timestamp::minimum(),
                         NOW_ZERO.clone(),
+                        false, /* read-only */
                     )
                     .await,
                 )

--- a/src/timestamp-oracle/src/batching_oracle.rs
+++ b/src/timestamp-oracle/src/batching_oracle.rs
@@ -153,8 +153,13 @@ mod tests {
 
         crate::tests::timestamp_oracle_impl_test(|timeline, now_fn, initial_ts| {
             // We use the postgres oracle as the backing oracle.
-            let pg_oracle =
-                PostgresTimestampOracle::open(config.clone(), timeline, initial_ts, now_fn);
+            let pg_oracle = PostgresTimestampOracle::open(
+                config.clone(),
+                timeline,
+                initial_ts,
+                now_fn,
+                false, /* read-only */
+            );
 
             async {
                 let arced_pg_oracle: Arc<dyn TimestampOracle<Timestamp> + Send + Sync> =


### PR DESCRIPTION
Work towards zero-downtime upgrades: https://github.com/MaterializeInc/materialize/issues/27406

Before, we were doing some write_ts/apply_write calls when
bootstrapping. This is technically okay, because the timestamp oracle is
designed to be used from multiple processes. But for the time being we
don't want a read-only/upgrade environmentd to futz with the oracle.

We now panic when attempting to to write operations in read-only mode.
This will make it so we immediately notice when we accidentally
introduce calls that would cause writes.

We noticed this was problematic while working on https://github.com/MaterializeInc/materialize/pull/27997.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
