### PR TITLE
tests: Move index-source-stuck to testdrive

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2959,26 +2959,6 @@ def workflow_test_incident_70(c: Composition) -> None:
             thread.join()
 
 
-def workflow_test_index_source_stuck(
-    c: Composition, parser: WorkflowArgumentParser
-) -> None:
-    """Inspired by incident 78, test that selecting an index of a materialized
-    view still works when the source is stuck, for example because it's busy or
-    it has no replicas."""
-    c.down(destroy_volumes=True)
-
-    with c.override(
-        Testdrive(),
-        Clusterd(name="clusterd1"),
-        Clusterd(name="clusterd2"),
-        Materialized(),
-    ):
-        c.up("materialized")
-        c.up("clusterd1")
-        c.up("clusterd2")
-        c.run_testdrive_files("index-source-stuck/run.td")
-
-
 def workflow_test_github_cloud_7998(
     c: Composition, parser: WorkflowArgumentParser
 ) -> None:

--- a/test/testdrive/index-source-stuck.td
+++ b/test/testdrive/index-source-stuck.td
@@ -7,29 +7,19 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Test INSERT INTO...SELECT. This must be a testdrive test to avoid symbiosis
-# in sqllogictest.
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unorchestrated_cluster_replicas = true;
-
 > DROP CLUSTER IF EXISTS cluster1 CASCADE;
 > DROP CLUSTER IF EXISTS cluster2 CASCADE;
-> CREATE CLUSTER cluster1 REPLICAS (replica1 (
-  STORAGECTL ADDRESSES ['clusterd1:2100'],
-  STORAGE ADDRESSES ['clusterd1:2103'],
-  COMPUTECTL ADDRESSES ['clusterd1:2101'],
-  COMPUTE ADDRESSES ['clusterd1:2102'],
-  WORKERS 1));
-> CREATE CLUSTER cluster2 REPLICAS (replica1 (
-  STORAGECTL ADDRESSES ['clusterd2:2100'],
-  STORAGE ADDRESSES ['clusterd2:2103'],
-  COMPUTECTL ADDRESSES ['clusterd2:2101'],
-  COMPUTE ADDRESSES ['clusterd2:2102'],
-  WORKERS 1));
+> CREATE CLUSTER cluster1 REPLICAS (replica1 (SIZE '1'));
+> CREATE CLUSTER cluster2 REPLICAS (replica1 (SIZE '1'));
 > CREATE SOURCE src IN CLUSTER cluster1 FROM LOAD GENERATOR counter;
 > CREATE MATERIALIZED VIEW mv IN CLUSTER cluster2 AS SELECT * FROM src;
 > SET cluster = cluster2;
+
+# Prevent us from getting stuck, see #28328
+> SELECT min(counter) FROM src
+1
+> SELECT min(counter) FROM mv
+1
 
 # Dropping the replica will make the load generator be out of date from now on
 > DROP CLUSTER REPLICA cluster1.replica1;
@@ -91,8 +81,10 @@ Target cluster: cluster2
 > SELECT min(counter) FROM mv;
 1
 
-# Should return instantly, even inside of a transaction
 # TODO(def-): Enable once incident 78 is fixed:
 # > BEGIN
 # > SELECT * FROM mv;
 # > COMMIT
+
+> DROP CLUSTER IF EXISTS cluster1 CASCADE;
+> DROP CLUSTER IF EXISTS cluster2 CASCADE;


### PR DESCRIPTION
and fix issue

Fixes: #28328

See https://materializeinc.slack.com/archives/C01LKF361MZ/p1721252573742609

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
