### PR TITLE
mzcompose: Support CI_EXTRA_ARGS

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -203,15 +203,8 @@ case "$cmd" in
             --env AWS_DEFAULT_REGION
             --env AWS_SECRET_ACCESS_KEY
             --env AWS_SESSION_TOKEN
-            --env BUILDKITE_CI_API_KEY
             --env CANARY_LOADTEST_APP_PASSWORD
             --env CANARY_LOADTEST_PASSWORD
-            --env CI
-            --env CI_SANITIZER
-            --env CI_COVERAGE_ENABLED
-            --env CI_FINAL_PREFLIGHT_CHECK_VERSION
-            --env CI_FINAL_PREFLIGHT_CHECK_ROLLBACK
-            --env CI_TEST_SELECTION
             --env CLOUDTEST_CLUSTER_DEFINITION_FILE
             --env COMMON_ANCESTOR_OVERRIDE
             --env CONFLUENT_CLOUD_DEVEX_KAFKA_PASSWORD
@@ -230,7 +223,6 @@ case "$cmd" in
             --env PRODUCTION_SANDBOX_APP_PASSWORD
             --env PYPI_TOKEN
             --env MZ_DEV_BUILD_SHA
-            --env BUILDKITE_SENTRY_DSN
             # For Miri with nightly Rust
             --env ZOOKEEPER_ADDR
             --env KAFKA_ADDRS
@@ -239,7 +231,6 @@ case "$cmd" in
             --env COCKROACH_URL
             # For ci-closed-issues-detect
             --env GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN
-            --env GITHUB_TOKEN
         )
 
         if [[ $detach_container == "true" ]]; then
@@ -250,7 +241,7 @@ case "$cmd" in
             args+=("--name=$container_name_param")
         fi
 
-        for env in $(printenv | grep -E '^(BUILDKITE|MZCOMPOSE)' | sed 's/=.*//'); do
+        for env in $(printenv | grep -E '^(BUILDKITE|MZCOMPOSE|CI)' | sed 's/=.*//'); do
             args+=(--env "$env")
         done
         if [[ -t 1 ]]; then

--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -86,4 +86,5 @@ sudo journalctl --merge --since "$(cat step_start_timestamp)" > journalctl-merge
 mapfile -t artifacts < <(printf "run.log\nkubectl-get-logs.log\nkubectl-get-logs-previous.log\nkubectl-get-events.log\nkubectl-get-all.log\nkubectl-describe-all.log\nkubectl-pods-with-nodes.log\nkubectl-get-events-kube-system.log\nkubectl-get-all-kube-system.log\nkubectl-describe-all-kube-system.log\njournalctl-merge.log\nkail-output.log\n"; find . -name 'junit_*.xml')
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 buildkite-agent artifact upload "$artifacts_str"
+unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}"

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -73,6 +73,7 @@ bin/ci-builder run stable zstd --rm parallel-workload-queries.log || true
 mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nnetstat-ant.log\nnetstat-panelot.log\nps-aux.log\ndocker-ps-a.log\ndocker-inspect.log\n"; find . -name 'junit_*.xml')
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 buildkite-agent artifact upload "$artifacts_str"
+unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}"
 
 if [ ! -s services.log ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Long single-node Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of txn-wal" ] && [ "$BUILDKITE_LABEL" != "Mz E2E Test" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version for DFR)" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version for CTF)" ] && [ "$BUILDKITE_LABEL" != "QA Canary Environment Base Load" ]; then

--- a/doc/developer/feature-benchmark.md
+++ b/doc/developer/feature-benchmark.md
@@ -60,8 +60,8 @@ interference of any defaults that may be in effect and that can change over time
 ## Running manually in Buildkite
 
 Go to [Trigger CI](https://trigger-ci.dev.materialize.com/) and enter your pull request, select Feature Benchmark to only run that test.
-If you want to run a specific senario only, enter a Feature Benchmark Scenario.
-For example, to run all scenarios that are subclasses of `Kafka`, use `MZCOMPOSE_SCENARIO=Kafka`.
+If you want to run a specific senario only, enter a Feature Benchmark Scenario in the extra args.
+For example, to run all scenarios that are subclasses of `Kafka`, use `--scenario=Kafka`.
 
 # Output
 

--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -211,21 +211,15 @@ def shard_list(items: list[T], to_identifier: Callable[[T], str]) -> list[T]:
     if parallelism_count == 1:
         return items
 
-    if is_in_buildkite():
-        _upload_shard_info_metadata(
-            [
-                to_identifier(item)
-                for item in items
-                if _accepted_by_shard(
-                    to_identifier(item), parallelism_index, parallelism_count
-                )
-            ]
-        )
-    return [
+    accepted_items = [
         item
         for item in items
         if _accepted_by_shard(to_identifier(item), parallelism_index, parallelism_count)
     ]
+
+    if is_in_buildkite() and accepted_items:
+        _upload_shard_info_metadata(list(map(to_identifier, accepted_items)))
+    return accepted_items
 
 
 def _validate_parallelism_configuration() -> None:

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -631,7 +631,7 @@ To see the available workflows, run:
                 buildkite_step_key = os.getenv("BUILDKITE_STEP_KEY")
                 extra_args = (
                     shlex.split(ci_extra_args[buildkite_step_key])
-                    if buildkite_step_key
+                    if buildkite_step_key and buildkite_step_key in ci_extra_args
                     else []
                 )
                 composition.workflow(

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -24,7 +24,9 @@ from __future__ import annotations
 
 import argparse
 import inspect
+import json
 import os
+import shlex
 import subprocess
 import sys
 import webbrowser
@@ -625,7 +627,16 @@ To see the available workflows, run:
             # test analytics, even if the workflow doesn't define more granular
             # test cases.
             with composition.test_case(f"workflow-{args.workflow}"):
-                composition.workflow(args.workflow, *args.unknown_subargs[1:])
+                ci_extra_args = json.loads(os.getenv("CI_EXTRA_ARGS", "{}"))
+                buildkite_step_key = os.getenv("BUILDKITE_STEP_KEY")
+                extra_args = (
+                    shlex.split(ci_extra_args[buildkite_step_key])
+                    if buildkite_step_key
+                    else []
+                )
+                composition.workflow(
+                    args.workflow, *args.unknown_subargs[1:], *extra_args
+                )
 
             if self.shall_generate_junit_report(args.find):
                 junit_suite = self.generate_junit_suite(composition)

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -394,7 +394,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--scenario",
         metavar="SCENARIO",
         type=str,
-        default=os.getenv("MZCOMPOSE_SCENARIO", default="Scenario"),
+        default="Scenario",
         help="Scenario or scenario family to benchmark. See scenarios.py for available scenarios.",
     )
 

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -480,7 +480,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         selected_scenarios, lambda scenario_cls: scenario_cls.__name__
     )
 
-    if len(scenarios_scheduled_to_run) == 0 and buildkite.is_in_buildkite():
+    if (
+        len(scenarios_scheduled_to_run) == 0
+        and buildkite.is_in_buildkite()
+        and not os.getenv("CI_EXTRA_ARGS")
+    ):
         raise FailedTestExecutionError(
             error_summary="No scenarios were selected", errors=[]
         )


### PR DESCRIPTION
Tested locally with `CI_EXTRA_ARGS='{"feature-benchmark": "--scenario=Foasdb"}' BUILDKITE_STEP_KEY=feature-benchmark bin/mzcompose --find feature-benchmark run default`
Looks like this in trigger-ci: 
![Screenshot 2024-07-18 at 01 02 26](https://github.com/user-attachments/assets/87e14d03-59da-4701-8527-00edcd7d7ad2)
Code: https://github.com/MaterializeInc/trigger-ci/commit/eb9c9f686a1bddd8a56f3575f9fdb2eb5dc3ab09 (not live yet)

Proof that this works: https://buildkite.com/materialize/nightly/builds/8639
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
