### PR TITLE
Do not descend into LetRec::values with outer equivalences

### DIFF
--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -181,8 +181,13 @@ impl EquivalencePropagation {
                 }
             }
             MirRelationExpr::LetRec { .. } => {
-                for (child, derived) in expr.children_mut().rev().zip(derived.children_rev()) {
-                    self.apply(child, derived, outer_equivalences.clone(), get_equivalences);
+                let mut child_iter = expr.children_mut().rev().zip(derived.children_rev());
+                // Continue in `body` with the outer equivalences.
+                let (body, view) = child_iter.next().unwrap();
+                self.apply(body, view, outer_equivalences, get_equivalences);
+                // Continue recursively, but without the outer equivalences supplied to `body`.
+                for (child, view) in child_iter {
+                    self.apply(child, view, EquivalenceClasses::default(), get_equivalences);
                 }
             }
             MirRelationExpr::Project { input, outputs } => {


### PR DESCRIPTION
The action of `EquivalencePropagation` on `LetRec` seems to be wrong, descending into `values` (which is fine) presenting the `outer_equivalences` that will be applied to the `LetRec` (which is not fine). These outer equivalences apply to the `LetRec`, and can only be propagated to the `body` of the `LetRec`. For example, if `#1 > 3` is a thing that must be true of the `LetRec`, it must be true of `body` but needn't be true of any binding, because .. they have totally unrelated columns.

A more advanced analysis could present more information about what equivalences will be applied, but it seems like it would need to be a top-down analogue of the bottom-up `Analysis`. I.e. it would need to iterate around `LetRec` until fixed point reached, all that stuff. Not in the cards at the moment, so just need to fix the current transform.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
