### PR TITLE
ci: Reduce agent sizes, using the new medium size

### DIFF
--- a/ci/deploy/pipeline.template.yml
+++ b/ci/deploy/pipeline.template.yml
@@ -12,14 +12,14 @@ steps:
     branches: main
     timeout_in_minutes: 30
     agents:
-      queue: builder-linux-x86_64
+      queue: linux-x86_64-small
     concurrency: 1
     concurrency_group: deploy/devsite
 
   - command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.docker
     timeout_in_minutes: 30
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
     concurrency: 1
     concurrency_group: deploy/linux
 
@@ -28,14 +28,14 @@ steps:
     concurrency: 1
     concurrency_group: deploy/pypi
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.npm
     timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy/npm
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
 
   - label: ":bulb: Full SQL Logic Tests"
     trigger: slt

--- a/ci/deploy_mz/pipeline.template.yml
+++ b/ci/deploy_mz/pipeline.template.yml
@@ -17,7 +17,7 @@ steps:
     command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz.linux
     timeout_in_minutes: 30
     agents:
-      queue: builder-linux-x86_64
+      queue: linux-x86_64-small
     concurrency: 1
     concurrency_group: deploy-mz/linux/x86_64
 
@@ -25,7 +25,7 @@ steps:
     command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz.linux
     timeout_in_minutes: 30
     agents:
-      queue: builder-linux-aarch64
+      queue: linux-aarch64-small
     concurrency: 1
     concurrency_group: deploy-mz/linux/aarch64
 
@@ -35,7 +35,7 @@ steps:
       - linux-x86_64
       - linux-aarch64
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small
     concurrency: 1
     concurrency_group: deploy-mz/docker
 

--- a/ci/deploy_mz_lsp_server/pipeline.template.yml
+++ b/ci/deploy_mz_lsp_server/pipeline.template.yml
@@ -20,7 +20,7 @@ steps:
     command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz_lsp_server.linux
     timeout_in_minutes: 30
     agents:
-      queue: builder-linux-x86_64
+      queue: linux-x86_64-small
     concurrency: 1
     concurrency_group: deploy-mz-lsp-server/linux/x86_64
     retry:
@@ -31,7 +31,7 @@ steps:
     command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz_lsp_server.linux
     timeout_in_minutes: 30
     agents:
-      queue: builder-linux-aarch64
+      queue: linux-aarch64-small
     concurrency: 1
     concurrency_group: deploy-mz-lsp-server/linux/aarch64
     retry:

--- a/ci/deploy_website/pipeline.template.yml
+++ b/ci/deploy_website/pipeline.template.yml
@@ -12,6 +12,6 @@ steps:
     branches: main
     timeout_in_minutes: 30
     agents:
-      queue: builder-linux-x86_64
+      queue: linux-x86_64-small
     concurrency: 1
     concurrency_group: deploy/website

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -65,7 +65,7 @@ steps:
         timeout_in_minutes: 720
         parallelism: 8
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: feature-benchmark
@@ -122,7 +122,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: scalability
@@ -220,7 +220,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
           - ./ci/plugins/mzcompose:
@@ -244,7 +244,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
           - ./ci/plugins/mzcompose:
@@ -256,7 +256,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
           - ./ci/plugins/mzcompose:
@@ -273,7 +273,7 @@ steps:
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
           - ./ci/plugins/cloudtest:
@@ -300,7 +300,7 @@ steps:
         label: "Product limits"
         depends_on: build-aarch64
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: limits
@@ -313,7 +313,7 @@ steps:
         agents:
           # A larger instance is needed due to the
           # many containers that are being created
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: limits
@@ -512,10 +512,10 @@ steps:
       - id: checks-restart-cockroach
         label: "Checks + restart Cockroach"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -524,9 +524,9 @@ steps:
       - id: checks-restart-entire-mz
         label: "Checks + restart of the entire Mz"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -535,9 +535,9 @@ steps:
       - id: checks-backup-restore-before-manipulate
         label: "Checks backup + restore between the two manipulate()"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -546,9 +546,9 @@ steps:
       - id: checks-backup-restore-after-manipulate
         label: "Checks backup + restore after manipulate()"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -557,9 +557,9 @@ steps:
       - id: checks-backup-multi
         label: "Checks + multiple backups/restores"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -568,9 +568,9 @@ steps:
       - id: checks-backup-rollback
         label: "Checks + backup + rollback to previous"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -580,9 +580,9 @@ steps:
         label: "Checks parallel + DROP/CREATE replica"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -592,9 +592,9 @@ steps:
         label: "Checks parallel + restart compute clusterd"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -604,9 +604,9 @@ steps:
         label: "Checks parallel + restart of the entire Mz"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -616,9 +616,9 @@ steps:
         label: "Checks parallel + restart of environmentd & storage clusterd"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -628,9 +628,9 @@ steps:
         label: "Checks parallel + kill storage clusterd"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -640,9 +640,9 @@ steps:
         label: "Checks parallel + restart Redpanda & Debezium"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -651,9 +651,9 @@ steps:
       - id: checks-upgrade-entire-mz
         label: "Checks upgrade, whole-Mz restart"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -662,9 +662,9 @@ steps:
       - id: checks-preflight-check-continue
         label: "Checks preflight-check and continue upgrade"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -673,9 +673,9 @@ steps:
       - id: checks-preflight-check-rollback
         label: "Checks preflight-check and roll back upgrade"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -684,9 +684,9 @@ steps:
       - id: checks-upgrade-entire-mz-two-versions
         label: "Checks upgrade across two versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -697,7 +697,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -706,9 +706,9 @@ steps:
       - id: checks-upgrade-clusterd-compute-first
         label: "Platform checks upgrade, restarting compute clusterd first"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -717,9 +717,9 @@ steps:
       - id: checks-upgrade-clusterd-compute-last
         label: "Platform checks upgrade, restarting compute clusterd last"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -728,9 +728,9 @@ steps:
       - id: checks-kill-clusterd-storage
         label: "Checks + kill storage clusterd"
         depends_on: build-aarch64
-        timeout_in_minutes: 45
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -739,9 +739,9 @@ steps:
       - id: checks-restart-source-postgres
         label: "Checks + restart source Postgres"
         depends_on: build-aarch64
-        timeout_in_minutes: 45
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -750,9 +750,9 @@ steps:
       - id: checks-restart-clusterd-compute
         label: "Checks + restart clusterd compute"
         depends_on: build-aarch64
-        timeout_in_minutes: 45
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -761,10 +761,10 @@ steps:
       - id: checks-drop-create-default-replica
         label: "Checks + DROP/CREATE replica"
         depends_on: build-aarch64
-        timeout_in_minutes: 45
+        timeout_in_minutes: 90
         agents:
           # Seems to require more memory on aarch64
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -773,9 +773,9 @@ steps:
       - id: checks-toggle-persist-batch-columnar-format
         label: "Checks toggling persist batch columnar format"
         depends_on: build-aarch64
-        timeout_in_minutes: 45
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -784,9 +784,9 @@ steps:
       - id: checks-0dt-restart-entire-mz
         label: "Checks 0dt restart of the entire Mz"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -795,9 +795,9 @@ steps:
       - id: checks-0dt-upgrade-entire-mz
         label: "Checks 0dt upgrade, whole-Mz restart"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -806,9 +806,9 @@ steps:
       - id: checks-0dt-upgrade-entire-mz-two-versions
         label: "Checks 0dt upgrade across two versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -819,7 +819,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 90
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -828,11 +828,11 @@ steps:
       - id: cloudtest-upgrade
         label: "Platform checks upgrade in Cloudtest/K8s"
         depends_on: build-aarch64
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/scratch-aws-access: ~
           - ./ci/plugins/cloudtest:
@@ -850,6 +850,8 @@ steps:
         retry:
           automatic:
             - exit_status: 1
+              limit: 2
+            - exit_status: 255
               limit: 2
         agents:
           queue: linux-aarch64
@@ -873,8 +875,9 @@ steps:
         retry:
           automatic:
             - exit_status: 1
-              limit:
-                1
+              limit: 2
+            - exit_status: 255
+              limit: 2
         agents:
           queue: linux-aarch64
         inputs:
@@ -897,7 +900,9 @@ steps:
         retry:
           automatic:
             - exit_status: 1
-              limit: 1
+              limit: 2
+            - exit_status: 255
+              limit: 2
         agents:
           queue: linux-aarch64
         inputs:
@@ -920,7 +925,9 @@ steps:
         retry:
           automatic:
             - exit_status: 1
-              limit: 1
+              limit: 2
+            - exit_status: 255
+              limit: 2
         agents:
           queue: linux-aarch64
         inputs:
@@ -1355,7 +1362,7 @@ steps:
         timeout_in_minutes: 60
         agents:
           # Sporadic OoM otherwise
-          queue: linux-aarch64-large
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1512,7 +1519,7 @@ steps:
             composition: copy-to-s3
             run: nightly
       agents:
-        queue: linux-aarch64-large
+        queue: linux-aarch64-medium
 
     - id: copy-to-s3-2-replicas
       label: "Copy To S3 (2 replicas)"
@@ -1524,7 +1531,7 @@ steps:
             run: nightly
             args: [--default-size=2]
       agents:
-        queue: linux-aarch64-large
+        queue: linux-aarch64-medium
 
   - group: "Language tests"
     key: language-tests

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -43,7 +43,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: builder-linux-aarch64
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -56,7 +56,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-large
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -67,7 +67,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: builder-linux-aarch64
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -78,7 +78,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: builder-linux-aarch64
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -89,7 +89,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-large
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -101,7 +101,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-large
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -112,7 +112,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-large
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -135,7 +135,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: builder-linux-aarch64
+        queue: linux-aarch64-medium
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -147,7 +147,7 @@ steps:
     timeout_in_minutes: 2880
     parallelism: 8
     agents:
-      queue: linux-aarch64-large
+      queue: linux-aarch64-medium
     plugins:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -807,7 +807,7 @@ steps:
     inputs: ["*"]
     priority: 1
     agents:
-      queue: linux-aarch64-large
+      queue: linux-aarch64-medium
     coverage: only
 
   - wait: ~

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from materialize import MZ_ROOT
 
-FEATURE_BENCHMARK_FRAMEWORK_VERSION = "1.0.0"
+FEATURE_BENCHMARK_FRAMEWORK_VERSION = "1.1.0"
 FEATURE_BENCHMARK_FRAMEWORK_HASH_FILE = Path(__file__).relative_to(MZ_ROOT)
 
 FEATURE_BENCHMARK_FRAMEWORK_DIR = Path(__file__).resolve().parent

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1586,6 +1586,8 @@ class CreateWebhookSourceAction(Action):
             webhook_source_id = exe.db.webhook_source_id
             exe.db.webhook_source_id += 1
             potential_clusters = [c for c in exe.db.clusters if len(c.replicas) == 1]
+            if not potential_clusters:
+                return False
             cluster = self.rng.choice(potential_clusters)
             schema = self.rng.choice(exe.db.schemas)
         with schema.lock, cluster.lock:
@@ -1638,6 +1640,8 @@ class CreateKafkaSourceAction(Action):
             source_id = exe.db.kafka_source_id
             exe.db.kafka_source_id += 1
             potential_clusters = [c for c in exe.db.clusters if len(c.replicas) == 1]
+            if not potential_clusters:
+                return False
             cluster = self.rng.choice(potential_clusters)
             schema = self.rng.choice(exe.db.schemas)
         with schema.lock, cluster.lock:
@@ -1705,6 +1709,8 @@ class CreateMySqlSourceAction(Action):
             source_id = exe.db.mysql_source_id
             exe.db.mysql_source_id += 1
             potential_clusters = [c for c in exe.db.clusters if len(c.replicas) == 1]
+            if not potential_clusters:
+                return False
             schema = self.rng.choice(exe.db.schemas)
             cluster = self.rng.choice(potential_clusters)
         with schema.lock, cluster.lock:
@@ -1772,6 +1778,8 @@ class CreatePostgresSourceAction(Action):
             source_id = exe.db.postgres_source_id
             exe.db.postgres_source_id += 1
             potential_clusters = [c for c in exe.db.clusters if len(c.replicas) == 1]
+            if not potential_clusters:
+                return False
             schema = self.rng.choice(exe.db.schemas)
             cluster = self.rng.choice(potential_clusters)
         with schema.lock, cluster.lock:
@@ -1834,6 +1842,8 @@ class CreateKafkaSinkAction(Action):
             sink_id = exe.db.kafka_sink_id
             exe.db.kafka_sink_id += 1
             potential_clusters = [c for c in exe.db.clusters if len(c.replicas) == 1]
+            if not potential_clusters:
+                return False
             cluster = self.rng.choice(potential_clusters)
             schema = self.rng.choice(exe.db.schemas)
         with schema.lock, cluster.lock:

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -355,7 +355,7 @@ def run(
             if thread.is_alive():
                 print(f"{thread.name} still running: {worker.exe.last_log}")
         print("Threads have not stopped within 5 minutes, exiting hard")
-        print_stats(num_queries, workers)
+        print_stats(num_queries, workers, num_threads)
         if scenario == Scenario.Rename:
             # TODO(def-): Switch to failing exit code when #28182 is fixed
             os._exit(0)
@@ -388,11 +388,13 @@ def run(
         else:
             raise ValueError("Sessions did not clean up within 30s of threads stopping")
     conn.close()
-    print_stats(num_queries, workers)
+    print_stats(num_queries, workers, num_threads)
 
 
 def print_stats(
-    num_queries: defaultdict[ActionList, Counter[type[Action]]], workers: list[Worker]
+    num_queries: defaultdict[ActionList, Counter[type[Action]]],
+    workers: list[Worker],
+    num_threads: int,
 ) -> None:
     ignored_errors: defaultdict[str, Counter[type[Action]]] = defaultdict(Counter)
     num_failures = 0
@@ -422,7 +424,7 @@ def print_stats(
             for action_class, count in counter.items()
         )
         print(f"  {error}: {text}")
-    assert failed < 50
+    assert failed < 50 if num_threads < 50 else failed < 75
 
 
 def parse_common_args(parser: argparse.ArgumentParser) -> None:

--- a/misc/python/materialize/scalability/scalability_versioning.py
+++ b/misc/python/materialize/scalability/scalability_versioning.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from materialize import MZ_ROOT
 
-SCALABILITY_FRAMEWORK_VERSION = "1.0.0"
+SCALABILITY_FRAMEWORK_VERSION = "1.1.0"
 SCALABILITY_FRAMEWORK_HASH_FILE = Path(__file__).relative_to(MZ_ROOT)
 
 SCALABILITY_FRAMEWORK_DIR = Path(__file__).resolve().parent


### PR DESCRIPTION
Also don't use builder-* agents just because something is built in the deploy steps!

So far so green:
https://buildkite.com/materialize/test/builds/86215
https://buildkite.com/materialize/nightly/builds/8645
https://buildkite.com/materialize/release-qualification/builds/552
I'll wait for results from RQ before submitting, shouldn't be any worse than our current state hopefully.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
