### PR TITLE
docs: indexes and mat views - monotonicity behavior diffs

### DIFF
--- a/doc/user/content/concepts/indexes.md
+++ b/doc/user/content/concepts/indexes.md
@@ -17,23 +17,40 @@ In Materialize, indexes represent query results stored in memory within a
 [sources](/concepts/sources/), [views](/concepts/views/#views), or [materialized
 views](/concepts/views/#materialized-views).
 
-Indexes can [optimize query performance](/transform-data/optimization).
-For example, indexes in Materialize can:
 
-- Provide faster sequential access.
+Indexes can help [optimize query performance](/transform-data/optimization/),
+such as:
 
-- Provide fast random access for lookup queries (i.e., selecting individual keys).
+- Provide faster sequential access than unindexed data.
 
-Additionally, because indexes in Materialize are maintained in memory, indexing
-views and materialized views can provide further performance improvements.
+- Provide fast random access for lookup queries (i.e., selecting individual
+  keys).
+
+
+{{< tip >}}
+
+In Materialize, you do not need to always create indexes to help optimize
+computations. For queries that have no supporting indexes, Materialize uses the
+same mechanics used by indexes to optimize computations.
+
+Specific instances where indexes can be useful to improve performance include:
+
+- When used in ad-hoc queries.
+
+- When used by multiple queries within the same cluster.
+
+- When used to enable delta joins.
+
+For more information, see [Optimization](/transform-data/optimization).
+
+{{</ tip >}}
 
 ## Indexes and views
 
 In Materialize, indexes on a [view](/concepts/views/#views) **maintain and
 incrementally update** view results in memory within a
 [cluster](/concepts/clusters/). The in-memory up-to-date results are accessible
-to queries within the cluster, even for queries that do not use the index
-key(s).
+to queries within the cluster.
 
 ## Indexes and materialized views
 
@@ -41,13 +58,29 @@ In Materialize, indexing a
 [materialized view](/concepts/views/#materialized-views) maintains results in memory within the [cluster](/concepts/clusters/). Because
 materialized views maintain the up-to-date results in durable storage, indexes
 on materialized views serve up-to-date results without themselves performing the
-incremental computation. The in-memory results are accessible to queries within
-the cluster, even for queries that do not use the index key(s).
+incremental computation. However, unlike the materialized view, indexes are
+local to the cluster.
+
+```mzsql
+CREATE INDEX idx_on_my_view ON my_view_name(...) ;
+```
 
 ## Indexes and clusters
 
 Indexes are local to a cluster. Queries in a different cluster cannot use the
 indexes in another cluster.
+
+For example, to create an index in the current cluster:
+
+```mzsql
+CREATE INDEX idx_on_my_view ON my_view_name(...) ;
+```
+
+You can also explicitly specify the cluster:
+
+```mzsql
+CREATE INDEX idx_on_my_view IN CLUSTER active_cluster ON my_view (...);
+```
 
 ## Related pages
 

--- a/doc/user/content/concepts/indexes.md
+++ b/doc/user/content/concepts/indexes.md
@@ -13,7 +13,7 @@ aliases:
 ## Overview
 
 In Materialize, indexes represent query results stored in memory within a
-[cluster](/concepts/clusters/).  You can create indexes on
+[cluster](/concepts/clusters/). You can create indexes on
 [sources](/concepts/sources/), [views](/concepts/views/#views), or [materialized
 views](/concepts/views/#materialized-views).
 
@@ -22,7 +22,7 @@ For example, indexes in Materialize can:
 
 - Provide faster sequential access.
 
-- Provide fast random access for queries selecting individual keys.
+- Provide fast random access for lookup queries (i.e., selecting individual keys).
 
 Additionally, because indexes in Materialize are maintained in memory, indexing
 views and materialized views can provide further performance improvements.
@@ -30,7 +30,7 @@ views and materialized views can provide further performance improvements.
 ## Indexes and views
 
 In Materialize, indexes on a [view](/concepts/views/#views) **maintain and
-incrementally update** view results in memory within the
+incrementally update** view results in memory within a
 [cluster](/concepts/clusters/). The in-memory up-to-date results are accessible
 to queries within the cluster, even for queries that do not use the index
 key(s).

--- a/doc/user/content/concepts/indexes.md
+++ b/doc/user/content/concepts/indexes.md
@@ -12,22 +12,28 @@ aliases:
 
 ## Overview
 
-Indexes can [optimize query performance](/transform-data/optimization).  In
-addition, because indexes in Materialize are maintained in memory, indexing a
-view (non-materialized and materialized) may provide further performance
-improvements.
+In Materialize, indexes represent query results stored in memory within a
+[cluster](/concepts/clusters/).  You can create indexes on
+[sources](/concepts/sources/), [views](/concepts/views/#views), or [materialized
+views](/concepts/views/#materialized-views).
+
+Indexes can [optimize query performance](/transform-data/optimization).
+For example, indexes in Materialize can:
+
+- Provide faster sequential access.
+
+- Provide fast random access for queries selecting individual keys.
+
+Additionally, because indexes in Materialize are maintained in memory, indexing
+views and materialized views can provide further performance improvements.
 
 ## Indexes and views
 
-In Materialize, indexing a [non-materialized
-view](/concepts/views/#non-materialized-views) causes view results to be
-**maintained and incrementally updated in memory** within the
+In Materialize, indexes on a [view](/concepts/views/#views) **maintain and
+incrementally update** view results in memory within the
 [cluster](/concepts/clusters/). The in-memory up-to-date results are accessible
 to queries within the cluster, even for queries that do not use the index
 key(s).
-
-Indexes preserve monotonicity information.  As such, for indexed
-non-materialized views, results can be monotonic.
 
 ## Indexes and materialized views
 
@@ -38,9 +44,6 @@ on materialized views serve up-to-date results without themselves performing the
 incremental computation. The in-memory results are accessible to queries within
 the cluster, even for queries that do not use the index key(s).
 
-Although indexes preserve monotonicity information, materialized views do
-**not**. As such, for (indexed or non-indexed) materialized views, results are not monotonic.
-
 ## Indexes and clusters
 
 Indexes are local to a cluster. Queries in a different cluster cannot use the
@@ -48,5 +51,10 @@ indexes in another cluster.
 
 ## Related pages
 
+- [Optimization](/transform-data/optimization)
 - [Views](/concepts/views)
 - [`CREATE INDEX`](/sql/create-index)
+
+<style>
+red { color: Red; font-weight: 500; }
+</style>

--- a/doc/user/content/concepts/indexes.md
+++ b/doc/user/content/concepts/indexes.md
@@ -26,6 +26,9 @@ view](/concepts/views/#non-materialized-views) causes view results to be
 to queries within the cluster, even for queries that do not use the index
 key(s).
 
+Indexes preserve monotonicity information.  As such, for indexed
+non-materialized views, results can be monotonic.
+
 ## Indexes and materialized views
 
 In Materialize, indexing a
@@ -34,6 +37,9 @@ materialized views maintain the up-to-date results in durable storage, indexes
 on materialized views serve up-to-date results without themselves performing the
 incremental computation. The in-memory results are accessible to queries within
 the cluster, even for queries that do not use the index key(s).
+
+Although indexes preserve monotonicity information, materialized views do
+**not**. As such, for (indexed or non-indexed) materialized views, results are not monotonic.
 
 ## Indexes and clusters
 

--- a/doc/user/content/concepts/views.md
+++ b/doc/user/content/concepts/views.md
@@ -51,7 +51,12 @@ that [cluster](/concepts/clusters/). The in-memory up-to-date results are
 accessible to queries within the cluster, even for queries that do not use the
 index key(s).
 
-Indexes are local to a cluster.
+#### Considerations for indexed non-materialized views
+
+- Indexes are local to a cluster.
+
+- Indexes preserve monotonicity information. As such, for indexed
+  non-materialized views, results can be monotonic.
 
 See also:
 
@@ -95,6 +100,13 @@ computation. The in-memory up-to-date results are accessible to queries within
 the cluster, even for queries that do not use the index key(s).
 
 Indexes are local to a cluster.
+
+#### Considerations for indexed materialized views
+
+- Indexes are local to a cluster.
+
+- Materialized views do **not** preserve monotonicity information. As such, for
+  (indexed or non-indexed) materialized views, results are not monotonic.
 
 See also:
 

--- a/doc/user/content/concepts/views.md
+++ b/doc/user/content/concepts/views.md
@@ -17,7 +17,7 @@ a shorthand for the underlying query.
 
 Type |
 -----|------------
-[**Views**](#views) | Results are **not** persisted in durable storage. These views can be indexed to maintain and incrementally update results in memory.
+[**Views**](#views) | Results are **not** persisted in durable storage. Views can be indexed to maintain and incrementally update results in memory within a cluster.
 [**Materialized views**](#materialized-views) | Results **are** persisted and incrementally updated in durable storage. Materialized views can be indexed to maintain the results in memory.
 
 All views in Materialize are built by reading data from
@@ -26,9 +26,12 @@ All views in Materialize are built by reading data from
 ## Views
 
 A view saves a query under a name to provide a shorthand for referencing the
-query. Views can be referenced across [clusters](/concepts/clusters/).
+query. Views are not associated with a cluster, and can be referenced across
+[clusters](/concepts/clusters/).
 
-During view creation, the underlying query is not executed , and the view
+During view creation, the underlying query is not executed, so results are not
+persisted. This means that view results will be recomputed from scratch each
+time the view is accessed.
 results are not persisted in durable storage.
 
 ```mzsql
@@ -36,9 +39,9 @@ CREATE VIEW my_view_name AS
   SELECT ... FROM ...  ;
 ```
 
-<red>However</red>, in Materialize, you can [index](/concepts/indexes/) a view
-to **maintain and incrementally update** view results in memory within a
-cluster.
+<red>However</red>, in Materialize, you can create an [index](/concepts/indexes/)
+on a view to **maintain and incrementally update** its results in memory within
+a cluster.
 
 ```mzsql
 CREATE INDEX idx_on_my_view ON my_view_name(...) ;
@@ -103,7 +106,7 @@ CREATE INDEX idx_on_my_view ON my_mat_view_name(...) ;
 
 Because materialized views maintain the up-to-date results in durable storage,
 indexes on materialized views serve up-to-date results without themselves
-performing the incremental computation. The in-memory up-to-date results are
+performing the incremental computation. The in-memory, up-to-date results are
 accessible to queries within the cluster, even for queries that do not use the
 index key(s).
 

--- a/doc/user/content/concepts/views.md
+++ b/doc/user/content/concepts/views.md
@@ -64,7 +64,7 @@ CREATE INDEX idx_on_my_view ON my_view_name(...) ;
 ```
 
 Indexes on views both **maintain and incrementally update view results in
-memory** within that [cluster](/concepts/clusters/). The in-memory up-to-date
+memory** within that [cluster](/concepts/clusters/). The in-memory, up-to-date
 results are accessible to queries within the cluster, even for queries that do
 not use the index key(s).
 

--- a/doc/user/content/concepts/views.md
+++ b/doc/user/content/concepts/views.md
@@ -26,29 +26,29 @@ All views in Materialize are built by reading data from
 ## Views
 
 A view saves a query under a name to provide a shorthand for referencing the
-query. Views are not associated with a cluster, and can be referenced across
-[clusters](/concepts/clusters/).
+query. Views are not associated with a [cluster](/concepts/clusters/), and can
+be referenced across clusters.
 
 During view creation, the underlying query is not executed, so results are not
 persisted. This means that view results will be recomputed from scratch each
 time the view is accessed.
-results are not persisted in durable storage.
 
 ```mzsql
 CREATE VIEW my_view_name AS
   SELECT ... FROM ...  ;
 ```
 
-<red>However</red>, in Materialize, you can create an [index](/concepts/indexes/)
-on a view to **maintain and incrementally update** its results in memory within
-a cluster.
+However, in Materialize, you can create an [index](/concepts/indexes/) on a view
+to **maintain and incrementally update** its results in memory within a cluster.
+
 
 ```mzsql
 CREATE INDEX idx_on_my_view ON my_view_name(...) ;
 ```
 
-Queries within that cluster can use the index to access view results from
-memory.  See [Indexes and views](#indexes-and-views) for more information.
+Once indexed, queries within that cluster can use the index to access view
+results from memory.  See [Indexes and views](#indexes-and-views) for more
+information.
 
 See also:
 
@@ -59,14 +59,21 @@ See also:
 
 In Materialize, views can be [indexed](/concepts/indexes/).
 
+For example, to create an index in the current cluster:
+
 ```mzsql
 CREATE INDEX idx_on_my_view ON my_view_name(...) ;
 ```
 
+You can also explicitly specify the cluster:
+
+```mzsql
+CREATE INDEX idx_on_my_view IN CLUSTER active_cluster ON my_view (...);
+```
+
 Indexes on views both **maintain and incrementally update view results in
 memory** within that [cluster](/concepts/clusters/). The in-memory, up-to-date
-results are accessible to queries within the cluster, even for queries that do
-not use the index key(s).
+results are accessible to queries within the cluster.
 
 See also:
 
@@ -77,18 +84,19 @@ See also:
 ## Materialized views
 
 In Materialize, a materialized view is a view whose underlying query is executed
-during the view creation, and the view results are both **persisted and
-incrementally updated** in durable storage. Materialized views can be referenced across [clusters](/concepts/clusters/).
+during the view creation, and the view results are persisted **and
+incrementally updated** in durable storage.
 
 ```mzsql
 CREATE MATERIALIZED VIEW my_mat_view_name AS
   SELECT ... FROM ...  ;
 ```
 
-You can index a materialized view to maintain the results in memory
-within the cluster. This enables queries within the cluster to use the index to
-access view results from memory.
+Materialized views can be referenced across [clusters](/concepts/clusters/).
 
+You can also index a materialized view to maintain the results in memory within
+the cluster. This enables queries within the cluster to use the index to access
+view results from memory.
 
 See also:
 
@@ -106,9 +114,8 @@ CREATE INDEX idx_on_my_view ON my_mat_view_name(...) ;
 
 Because materialized views maintain the up-to-date results in durable storage,
 indexes on materialized views serve up-to-date results without themselves
-performing the incremental computation. The in-memory, up-to-date results are
-accessible to queries within the cluster, even for queries that do not use the
-index key(s).
+performing the incremental computation. However, unlike materialized views that
+are accessible across clusters, indexes are accessible only within the cluster.
 
 See also:
 
@@ -129,7 +136,6 @@ See also:
 
 - Materialized views are not monotonic; that is, materialized views cannot be
   recognized as append-only.
-
 
 <style>
 red { color: Red; font-weight: 500; }

--- a/doc/user/content/get-started/_index.md
+++ b/doc/user/content/get-started/_index.md
@@ -47,8 +47,7 @@ In Materialize, you don't have to make such compromises. Materialize supports
 incrementally updated view results that are **always fresh** (even when using
 complex SQL statements, like multi-way joins with aggregations) for *both*:
 
-- [Non-materialized views **with an
-index**](/concepts/views/#indexes-and-non-materialized-views) and
+- [Views **with an index**](/concepts/views/#indexes-and-views) and
 
 - [Materialized views](/concepts/views/#materialized-views).
 

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -104,7 +104,7 @@ with.
   available**. To identify potential auction flippers, you need to keep track
   of the winning bids for each completed auction.
 
-1. Create a [**view**](/concepts/views/#non-materialized-views) that
+1. Create a [**view**](/concepts/views/#views) that
 joins data from `auctions` and `bids` to get the bid with the highest `amount`
 for each auction at its `end_time`.
 

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -100,6 +100,15 @@ cause Materialize to install a dataflow to determine and maintain the results of
 the view. This dataflow may have a memory footprint itself, in addition to that
 of the index.
 
+### Monotonicity
+
+Indexes preserve monotonicity information whereas [materialized
+views](/concepts/views/#materialized-views) do not.  As such:
+
+- For indexed non-materialized views, results can be monotonic.
+
+- For materialized views (indexed or non-indexed), results are not monotonic.
+
 ## Examples
 
 ### Optimizing joins with indexes

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -100,15 +100,6 @@ cause Materialize to install a dataflow to determine and maintain the results of
 the view. This dataflow may have a memory footprint itself, in addition to that
 of the index.
 
-### Monotonicity
-
-Indexes preserve monotonicity information whereas [materialized
-views](/concepts/views/#materialized-views) do not.  As such:
-
-- For indexed non-materialized views, results can be monotonic.
-
-- For materialized views (indexed or non-indexed), results are not monotonic.
-
 ## Examples
 
 ### Optimizing joins with indexes

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -9,12 +9,10 @@ menu:
 
 {{< note >}}
 
-In Materialize, [indexes on non-materialized
-views](/concepts/views/#non-materialized-views) **maintain and incrementally
-update view results in memory** for the cluster where you create the index.  For
-more information, see [Non-materialized
-views](/concepts/views/#non-materialized-views) and [`CREATE
-VIEW`](/sql/create-view).
+As an alternative to materialized views, [indexes on
+views](/concepts/views/#views) **maintain and incrementally update view results
+in memory** for the cluster where you create the index.  For more information,
+see [Views](/concepts/views/#views) and [`CREATE VIEW`](/sql/create-view).
 
 {{</ note >}}
 
@@ -25,8 +23,6 @@ A materialized view specifies a [cluster](/concepts/clusters/) that
 is tasked with keeping its results up-to-date, but **can be referenced in
 any cluster**. This allows you to effectively decouple the computational
 resources used for view maintenance from the resources used for query serving.
-
-
 
 ## Syntax
 
@@ -65,7 +61,7 @@ view. It's a good idea to create a materialized view if:
 * The final consumer of the view is a sink or a [`SUBSCRIBE`](../subscribe) operation.
 
 On the other hand, if you only need to access a view from a single cluster, you
-should consider creating a [non-materialized view](../create-view) and building
+should consider creating a [view](../create-view) and building
 an index on it instead. The index will incrementally maintain the results of
 the view updated in memory within that cluster, allowing you to avoid the costs
 and latency overhead of materialization.
@@ -91,10 +87,6 @@ indexes in each cluster you are referencing the materialized view in.
 this exists+add detail about using indexes to optimize materialized view
 stacking."
 
-### Monotonicity
-
-Although [indexes](/concepts/indexes) preserve monotonicity information,  [Materialized
-views](/concepts/views/#materialized-views) do not. That is, for materialized views (indexed or non-indexed), results are not monotonic.
 
 ### Non-null assertions
 
@@ -397,6 +389,11 @@ The privileges required to execute this statement are:
 - `CREATE` privileges on the containing cluster.
 - `USAGE` privileges on all types used in the materialized view definition.
 - `USAGE` privileges on the schemas that all types in the statement are contained in.
+
+## Additional Information
+
+- Materialized views are not monotonic; that is, materialized views cannot be
+  recognized as append-only.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -8,10 +8,14 @@ menu:
 ---
 
 {{< note >}}
-As an alternative to materialized views, [indexes on views](/concepts/views/#views)
-**maintain and incrementally update view results in memory** for the cluster
-where you create the index.  For more information, see [Views](/concepts/views/#views)
-and [`CREATE VIEW`](/sql/create-view).
+
+Depending on your use case, instead of a materialized view, you might prefer to
+[create a view and index it](/concepts/views/#views). In Materialize, [indexes
+on views](/concepts/indexes/) **maintain and incrementally update view results
+in memory** for the cluster where you create the index.  For more information on
+views and indexes, see [Views](/concepts/views/#views) and [`CREATE
+VIEW`](/sql/create-view).
+
 {{</ note >}}
 
 `CREATE MATERIALIZED VIEW` defines a view that is persisted in durable storage and

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -8,12 +8,10 @@ menu:
 ---
 
 {{< note >}}
-
-As an alternative to materialized views, [indexes on
-views](/concepts/views/#views) **maintain and incrementally update view results
-in memory** for the cluster where you create the index.  For more information,
-see [Views](/concepts/views/#views) and [`CREATE VIEW`](/sql/create-view).
-
+As an alternative to materialized views, [indexes on views](/concepts/views/#views)
+**maintain and incrementally update view results in memory** for the cluster
+where you create the index.  For more information, see [Views](/concepts/views/#views)
+and [`CREATE VIEW`](/sql/create-view).
 {{</ note >}}
 
 `CREATE MATERIALIZED VIEW` defines a view that is persisted in durable storage and
@@ -390,7 +388,7 @@ The privileges required to execute this statement are:
 - `USAGE` privileges on all types used in the materialized view definition.
 - `USAGE` privileges on the schemas that all types in the statement are contained in.
 
-## Additional Information
+## Additional information
 
 - Materialized views are not monotonic; that is, materialized views cannot be
   recognized as append-only.

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -7,6 +7,17 @@ menu:
     parent: 'commands'
 ---
 
+{{< note >}}
+
+In Materialize, [indexes on non-materialized
+views](/concepts/views/#non-materialized-views) **maintain and incrementally
+update view results in memory** for the cluster where you create the index.  For
+more information, see [Non-materialized
+views](/concepts/views/#non-materialized-views) and [`CREATE
+VIEW`](/sql/create-view).
+
+{{</ note >}}
+
 `CREATE MATERIALIZED VIEW` defines a view that is persisted in durable storage and
 incrementally updated as new data arrives.
 
@@ -14,6 +25,8 @@ A materialized view specifies a [cluster](/concepts/clusters/) that
 is tasked with keeping its results up-to-date, but **can be referenced in
 any cluster**. This allows you to effectively decouple the computational
 resources used for view maintenance from the resources used for query serving.
+
+
 
 ## Syntax
 

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -78,6 +78,11 @@ indexes in each cluster you are referencing the materialized view in.
 this exists+add detail about using indexes to optimize materialized view
 stacking."
 
+### Monotonicity
+
+Although [indexes](/concepts/indexes) preserve monotonicity information,  [Materialized
+views](/concepts/views/#materialized-views) do not. That is, for materialized views (indexed or non-indexed), results are not monotonic.
+
 ### Non-null assertions
 
 Because materialized views may be created on arbitrary queries, it may not in

--- a/doc/user/content/sql/create-view.md
+++ b/doc/user/content/sql/create-view.md
@@ -16,6 +16,9 @@ The results of a view can be incrementally maintained **in memory** within a
 This allows you to serve queries without the overhead of
 materializing the view.
 
+Because indexes preserve monotonicity information, results can be monotonic for
+indexed non-materialized views.
+
 ## Syntax
 
 {{< diagram "create-view.svg" >}}

--- a/doc/user/content/sql/create-view.md
+++ b/doc/user/content/sql/create-view.md
@@ -41,7 +41,7 @@ automatically dropped at the end of the SQL session and are not visible to other
 connections. They are always created in the special `mz_temp` schema.
 
 Temporary views may depend upon other temporary database objects, but non-temporary
-views may not depend on temporary objects
+views may not depend on temporary objects.
 
 ## Examples
 
@@ -69,7 +69,7 @@ The privileges required to execute this statement are:
 - `USAGE` privileges on all types used in the view definition.
 - `USAGE` privileges on the schemas that all types in the statement are contained in.
 
-## Additional Information
+## Additional information
 
 - Views can be monotonic; that is, views can be recognized as append-only.
 

--- a/doc/user/content/sql/create-view.md
+++ b/doc/user/content/sql/create-view.md
@@ -1,6 +1,6 @@
 ---
 title: "CREATE VIEW"
-description: "`CREATE VIEW` defines a non-materialized view, which provides an alias for the embedded `SELECT` statement."
+description: "`CREATE VIEW` defines view, which provides an alias for the embedded `SELECT` statement."
 menu:
   # This should also have a "non-content entry" under Reference, which is
   # configured in doc/user/config.toml
@@ -8,16 +8,13 @@ menu:
     parent: 'commands'
 ---
 
-`CREATE VIEW` defines a non-materialized view, which simply provides an alias
+`CREATE VIEW` defines a view, which simply provides an alias
 for the embedded `SELECT` statement.
 
 The results of a view can be incrementally maintained **in memory** within a
 [cluster](/concepts/clusters/) by creating an [index](../create-index).
 This allows you to serve queries without the overhead of
 materializing the view.
-
-Because indexes preserve monotonicity information, results can be monotonic for
-indexed non-materialized views.
 
 ## Syntax
 
@@ -44,7 +41,7 @@ automatically dropped at the end of the SQL session and are not visible to other
 connections. They are always created in the special `mz_temp` schema.
 
 Temporary views may depend upon other temporary database objects, but non-temporary
-views may not depend on temporary objects.
+views may not depend on temporary objects
 
 ## Examples
 
@@ -71,6 +68,10 @@ The privileges required to execute this statement are:
 - `CREATE` privileges on the containing schema.
 - `USAGE` privileges on all types used in the view definition.
 - `USAGE` privileges on the schemas that all types in the statement are contained in.
+
+## Additional Information
+
+- Views can be monotonic; that is, views can be recognized as append-only.
 
 ## Related pages
 


### PR DESCRIPTION
Added behavior w.r.t. preserving monotonicity (indexes) and not (materialized views).
- Added a second patch to raise awareness of indexing a non-mat view to the create mat view page.   (generally don't mix separate changes like this, but since small).
