### PR TITLE
GitHub templates: add ids

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -27,6 +27,7 @@ body:
     validations:
       required: true
   - type: textarea
+    id: issue
     attributes:
       label: What is the issue?
       description: |

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -18,5 +18,6 @@ body:
       value: |
         Thanks for your interest in Materialize. Please be as detailed as possible in your feature request.
   - type: textarea
+    id: feature-request
     attributes:
       label: Feature request

--- a/.github/ISSUE_TEMPLATE/03-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/03-documentation.yml
@@ -16,9 +16,11 @@ body:
       value: |
         Thanks for your interest in helping us improve the Materialize documentation!
   - type: textarea
+    id: documentation-request
     attributes:
       label: Documentation request
   - type: textarea
+    id: affected-pages
     attributes:
       label: Affected Pages
       description: |
@@ -27,6 +29,7 @@ body:
     validations:
       required: false
   - type: textarea
+    id: related-work
     attributes:
       label: Related work
       description: |

--- a/.github/ISSUE_TEMPLATE/07-ci-flake.yml
+++ b/.github/ISSUE_TEMPLATE/07-ci-flake.yml
@@ -40,6 +40,7 @@ body:
     validations:
       required: true
   - type: textarea
+    id: additional-thoughts
     attributes:
       label: Additional thoughts
       description: |


### PR DESCRIPTION
Allows prefilling the texts in links using query parameters

To be used for https://github.com/MaterializeInc/materialize/issues/26727

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
