### PR TITLE
tests: Reduce number of proptest cases for `all_datums_produce_valid_stats`

### DIFF
--- a/src/storage-types/src/stats.rs
+++ b/src/storage-types/src/stats.rs
@@ -421,11 +421,15 @@ mod tests {
             prop::collection::vec(arb_datum_for_column(&ty), 0..128)
                 .prop_map(move |datums| (ty.clone(), datums))
         });
-        proptest!(|((ty, datums) in datums)| {
-            // The proptest! macro interferes with rustfmt.
-            let datums: Vec<_> = datums.iter().map(Datum::from).collect();
-            prop_assert_eq!(validate_stats(&ty, &datums[..]), Ok(()));
-        })
+
+        proptest!(
+            ProptestConfig::with_cases(80),
+            |((ty, datums) in datums)| {
+                // The proptest! macro interferes with rustfmt.
+                let datums: Vec<_> = datums.iter().map(Datum::from).collect();
+                prop_assert_eq!(validate_stats(&ty, &datums[..]), Ok(()));
+            }
+        )
     }
 
     #[mz_ore::test]


### PR DESCRIPTION
Reduces the number of test cases for `all_datums_produce_valid_stats` from the default of 256 to 80. The aim here is to prevent timeouts.

### Motivation

Non-flaky tests

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
