### PR TITLE
test: reduce test size and test cases for `all_source_data_roundtrips`

### DIFF
--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -2003,9 +2003,8 @@ mod tests {
             (500, Just(0..8)),
             (50, Just(8..32)),
             (10, Just(32..128)),
-            (5, Just(128..512)),
-            (3, Just(512..2048)),
-            (1, Just(2048..8192)),
+            (5, Just(128..256)),
+            (1, Just(256..1050)),
         ]);
 
         let strat = (any::<RelationDesc>(), num_rows).prop_flat_map(|(desc, num_rows)| {
@@ -2014,7 +2013,7 @@ mod tests {
         });
 
         proptest!(
-            ProptestConfig::with_cases(100),
+            ProptestConfig::with_cases(80),
             |((desc, source_datas) in strat)| {
                 roundtrip_source_data(desc, source_datas);
             }


### PR DESCRIPTION
Reduces the size of the generated state, and the number of test cases for `all_source_data_roundtrips` with the goal of preventing timeouts.

### Motivation

More stable tests.

Fixes https://github.com/MaterializeInc/materialize/issues/27916

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a