### PR TITLE
Enable overflow checks in release builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -134,6 +134,7 @@ build:debuginfo-none --@rules_rust//:extra_rustc_flag=-Cstrip=symbols
 build --linkopt="-fuse-ld=lld"
 build --@rules_rust//:extra_rustc_flag="-Clink-arg=-fuse-ld=lld"
 build --@rules_rust//:extra_rustc_flag="-Csymbol-mangling-version=v0"
+build --@rules_rust//:extra_rustc_flag="-Coverflow-checks=true"
 # We use 64 because it's enough to totally saturate a CI builder so our builds
 # are as fast as possible, and it's less than the default of 256 used with
 # Cargo when incremental compilation is enabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,6 +278,10 @@ lto = "off"
 debug = false
 incremental = true
 
+# Enable overflow checks in release builds to prevent silent data
+# corruption.
+overflow-checks = true
+
 # IMPORTANT: when patching a dependency, you should only depend on "main",
 # "master", or an upstream release branch (e.g., "v7.x"). Do *not* depend on a
 # feature/patch branch (e.g., "fix-thing" or "pr-1234"). Feature/patch branches


### PR DESCRIPTION
Overflow checks by default are disabled in release builds, introducing
different behavior from debug builds. In Materialize, silent overflows
can cause us to surface invalid data, for example when a value's diff
wraps around. Enabling this check will incur a run time cost to check
for overflow, but prevents silent data corruption.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
