### PR TITLE
sql-pretty: CREATE SOURCE

### DIFF
--- a/src/sql-pretty/src/lib.rs
+++ b/src/sql-pretty/src/lib.rs
@@ -16,8 +16,8 @@ use pretty::RcDoc;
 use thiserror::Error;
 
 use crate::doc::{
-    doc_copy, doc_create_materialized_view, doc_create_view, doc_display, doc_insert,
-    doc_select_statement, doc_subscribe,
+    doc_copy, doc_create_materialized_view, doc_create_source, doc_create_view, doc_display,
+    doc_insert, doc_select_statement, doc_subscribe,
 };
 
 pub use crate::doc::doc_expr;
@@ -32,6 +32,7 @@ fn to_doc<T: AstInfo>(v: &Statement<T>) -> RcDoc {
         Statement::CreateMaterializedView(v) => doc_create_materialized_view(v),
         Statement::Copy(v) => doc_copy(v),
         Statement::Subscribe(v) => doc_subscribe(v),
+        Statement::CreateSource(v) => doc_create_source(v),
         _ => doc_display(v, "statement"),
     }
 }

--- a/test/sqllogictest/redacted.slt
+++ b/test/sqllogictest/redacted.slt
@@ -96,7 +96,10 @@ EOF
 query T multiline
 SELECT regexp_replace(pretty_sql(redacted_create_sql), 'u[0-9]+', 'uX', 'g') FROM mz_sources WHERE name = 's'
 ----
-CREATE SOURCE materialize.public.s IN CLUSTER [uX] FROM LOAD GENERATOR COUNTER EXPOSE PROGRESS AS [uX AS materialize.public.s_progress];
+CREATE SOURCE materialize.public.s
+IN CLUSTER [uX]
+FROM LOAD GENERATOR COUNTER
+EXPOSE PROGRESS AS [uX AS materialize.public.s_progress];
 EOF
 
 statement ok


### PR DESCRIPTION
Add pretty support for CREATE SOURCE.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a