### PR TITLE
SLT: In no-fail mode don't add failures to junit.xml

### DIFF
--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -233,7 +233,7 @@ async fn main() -> ExitCode {
                                 );
                             }
                             if let Some((_, junit_suite)) = &mut junit {
-                                let mut test_case = if o.any_failed() {
+                                let mut test_case = if o.any_failed() && !args.no_fail {
                                     let mut result = junit_report::TestCase::failure(
                                         &entry.path().to_string_lossy(),
                                         start_time.elapsed(),

--- a/test/sqllogictest/rbac_views.slt
+++ b/test/sqllogictest/rbac_views.slt
@@ -526,6 +526,64 @@ materialize  NULL         NULL  table       r1      INSERT
 materialize  NULL         NULL  table       r1      SELECT
 PUBLIC       NULL         NULL  type        PUBLIC  USAGE
 
+# Prepration to be able to drop roles
+statement ok
+REVOKE r2 FROM r1
+
+statement ok
+REVOKE r3 FROM r2
+
+statement ok
+REVOKE r5 FROM r4
+
+simple conn=mz_system,user=mz_system
+REVOKE ALL ON SYSTEM FROM r1;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE ALL ON SYSTEM FROM r2;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE ALL ON SYSTEM FROM r4;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE CREATECLUSTER ON SYSTEM FROM PUBLIC;
+----
+COMPLETE 0
+
+statement ok
+DROP CLUSTER c CASCADE;
+
+statement ok
+DROP DATABASE d CASCADE;
+
+statement ok
+DROP SCHEMA S CASCADE;
+
+statement ok
+DROP TABLE T CASCADE;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE materialize REVOKE ALL ON TABLES FROM r1
+
+simple conn=mz_system,user=mz_system
+ALTER DEFAULT PRIVILEGES FOR ROLE PUBLIC REVOKE ALL ON SCHEMAS FROM r4
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER DEFAULT PRIVILEGES FOR ROLE r5 REVOKE ALL ON DATABASES FROM PUBLIC
+----
+COMPLETE 0
+
+statement ok
+DROP ROLE r1, r2, r3, r4, r5
+
 # Disable rbac checks.
 
 simple conn=mz_system,user=mz_system

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -957,9 +957,6 @@ WHERE credits_per_hour > credits_per_hour;
 # Regression test for https://github.com/MaterializeInc/materialize/issues/20199
 
 statement ok
-DROP ROLE IF EXISTS r2 CASCADE;
-
-statement ok
 CREATE ROLE r2;
 
 statement ok
@@ -1008,6 +1005,9 @@ Source materialize.public.t
 Target cluster: quickstart
 
 EOF
+
+statement ok
+DROP ROLE r2;
 
 # Regression test for https://github.com/MaterializeInc/materialize/issues/22257
 # The transitive closure computation in `inline_if_not_too_big` has to do more than one step here. For this, later map

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -957,6 +957,9 @@ WHERE credits_per_hour > credits_per_hour;
 # Regression test for https://github.com/MaterializeInc/materialize/issues/20199
 
 statement ok
+DROP ROLE IF EXISTS r2 CASCADE;
+
+statement ok
 CREATE ROLE r2;
 
 statement ok


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/slt/builds/5987

Fallout from https://github.com/MaterializeInc/materialize/pull/28346

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
