### PR TITLE
sql: error on invalid use of regexp_extract

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3809,7 +3809,10 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                     .map(|cg| {
                         cg.name.clone().unwrap_or_else(|| format!("column{}", cg.index)).into()
                     })
-                    .collect();
+                    .collect::<Vec<_>>();
+                if column_names.is_empty(){
+                    sql_bail!("regexp_extract must specify at least one capture group");
+                }
                 Ok(TableFuncPlan {
                     expr: HirRelationExpr::CallTable {
                         func: TableFunc::RegexpExtract(regex),

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1472,3 +1472,7 @@ SELECT generate_series FROM generate_series(1, 3) OVER (ORDER BY generate_series
 
 query error Expected right parenthesis, found number "1"
 SELECT generate_series FROM generate_series(DISTINCT 1, 3);
+
+# Regression for https://github.com/MaterializeInc/materialize/issues/20533
+query error db error: ERROR: regexp_extract must specify at least one capture group
+select regexp_extract('aaa', 'a')


### PR DESCRIPTION
regexp_extract produces one column per capture group. If there are no capture groups, error.

Fixes #23805
Fixes #20533

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a