### PR TITLE
storage: connect to all replicas

### DIFF
--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -36,6 +36,13 @@ pub struct ClusterStartupEpoch {
     replica: u64,
 }
 
+impl ClusterStartupEpoch {
+    /// Increases the replica incarnation counter.
+    pub fn bump_replica(&mut self) {
+        self.replica += 1;
+    }
+}
+
 impl RustType<ProtoClusterStartupEpoch> for ClusterStartupEpoch {
     fn into_proto(&self) -> ProtoClusterStartupEpoch {
         let Self { envd, replica } = self;

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -114,6 +114,20 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     RunSinks(Vec<RunSinkCommand<T>>),
 }
 
+impl<T> StorageCommand<T> {
+    /// Returns whether this command instructs the installation of storage objects.
+    pub fn installs_objects(&self) -> bool {
+        use StorageCommand::*;
+        match self {
+            CreateTimely { .. }
+            | InitializationComplete
+            | UpdateConfiguration(_)
+            | AllowCompaction(_) => false,
+            RunIngestions(_) | RunSinks(_) => true,
+        }
+    }
+}
+
 /// A command that starts ingesting the given ingestion description
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RunIngestionCommand {

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -38,7 +38,7 @@ use timely::PartialOrder;
 use tonic::{Request, Status as TonicStatus, Streaming};
 
 use crate::client::proto_storage_server::ProtoStorage;
-use crate::metrics::RehydratingStorageClientMetrics;
+use crate::metrics::ReplicaMetrics;
 use crate::statistics::{SinkStatisticsUpdate, SourceStatisticsUpdate};
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage_client.client.rs"));
@@ -68,7 +68,7 @@ pub enum StorageProtoServiceTypes {}
 impl ProtoServiceTypes for StorageProtoServiceTypes {
     type PC = ProtoStorageCommand;
     type PR = ProtoStorageResponse;
-    type STATS = RehydratingStorageClientMetrics;
+    type STATS = ReplicaMetrics;
     const URL: &'static str = "/mz_storage_client.client.ProtoStorage/CommandResponseStream";
 }
 

--- a/src/storage-client/src/metrics.rs
+++ b/src/storage-client/src/metrics.rs
@@ -90,6 +90,7 @@ impl StorageControllerMetrics {
     }
 }
 
+#[derive(Debug)]
 pub struct InstanceMetrics {
     instance_id: StorageInstanceId,
     metrics: StorageControllerMetrics,

--- a/src/storage-client/src/metrics.rs
+++ b/src/storage-client/src/metrics.rs
@@ -11,6 +11,7 @@
 
 use std::sync::Arc;
 
+use mz_cluster_client::ReplicaId;
 use mz_ore::cast::{CastFrom, TryCastFrom};
 use mz_ore::metric;
 use mz_ore::metrics::{
@@ -42,13 +43,13 @@ impl StorageControllerMetrics {
             messages_sent_bytes: metrics_registry.register(metric!(
                 name: "mz_storage_messages_sent_bytes",
                 help: "size of storage messages sent",
-                var_labels: ["instance"],
+                var_labels: ["instance_id", "replica_id"],
                 buckets: HISTOGRAM_BYTE_BUCKETS.to_vec()
             )),
             messages_received_bytes: metrics_registry.register(metric!(
                 name: "mz_storage_messages_received_bytes",
                 help: "size of storage messages received",
-                var_labels: ["instance"],
+                var_labels: ["instance_id", "replica_id"],
                 buckets: HISTOGRAM_BYTE_BUCKETS.to_vec()
             )),
             startup_prepared_statements_kept: metrics_registry.register(metric!(
@@ -76,17 +77,10 @@ impl StorageControllerMetrics {
             .get_delete_on_drop_metric(vec![id.to_string()])
     }
 
-    pub fn for_instance(&self, id: StorageInstanceId) -> RehydratingStorageClientMetrics {
-        let labels = vec![id.to_string()];
-        RehydratingStorageClientMetrics {
-            inner: Arc::new(RehydratingStorageClientMetricsInner {
-                messages_sent_bytes: self
-                    .messages_sent_bytes
-                    .get_delete_on_drop_metric(labels.clone()),
-                messages_received_bytes: self
-                    .messages_received_bytes
-                    .get_delete_on_drop_metric(labels),
-            }),
+    pub fn for_instance(&self, id: StorageInstanceId) -> InstanceMetrics {
+        InstanceMetrics {
+            instance_id: id,
+            metrics: self.clone(),
         }
     }
 
@@ -96,20 +90,61 @@ impl StorageControllerMetrics {
     }
 }
 
+pub struct InstanceMetrics {
+    instance_id: StorageInstanceId,
+    metrics: StorageControllerMetrics,
+}
+
+impl InstanceMetrics {
+    pub fn for_replica(&self, id: ReplicaId) -> ReplicaMetrics {
+        let labels = vec![self.instance_id.to_string(), id.to_string()];
+        ReplicaMetrics {
+            inner: Arc::new(ReplicaMetricsInner {
+                messages_sent_bytes: self
+                    .metrics
+                    .messages_sent_bytes
+                    .get_delete_on_drop_metric(labels.clone()),
+                messages_received_bytes: self
+                    .metrics
+                    .messages_received_bytes
+                    .get_delete_on_drop_metric(labels),
+            }),
+        }
+    }
+
+    pub fn for_history(&self) -> HistoryMetrics {
+        let command_gauge = |name: &str| {
+            let labels = vec![self.instance_id.to_string(), name.to_string()];
+            self.metrics
+                .history_command_count
+                .get_delete_on_drop_metric(labels)
+        };
+
+        HistoryMetrics {
+            create_timely_count: command_gauge("create_timely"),
+            run_ingestions_count: command_gauge("run_ingestions"),
+            run_sinks_count: command_gauge("run_sinks"),
+            allow_compaction_count: command_gauge("allow_compaction"),
+            initialization_complete_count: command_gauge("initialization_complete"),
+            update_configuration_count: command_gauge("update_configuration"),
+        }
+    }
+}
+
 #[derive(Debug)]
-struct RehydratingStorageClientMetricsInner {
+struct ReplicaMetricsInner {
     messages_sent_bytes: DeleteOnDropHistogram<'static, Vec<String>>,
     messages_received_bytes: DeleteOnDropHistogram<'static, Vec<String>>,
 }
 
 /// Per-instance metrics
 #[derive(Debug, Clone)]
-pub struct RehydratingStorageClientMetrics {
-    inner: Arc<RehydratingStorageClientMetricsInner>,
+pub struct ReplicaMetrics {
+    inner: Arc<ReplicaMetricsInner>,
 }
 
-/// Make ReplicaConnectionMetric pluggable into the gRPC connection.
-impl StatsCollector<ProtoStorageCommand, ProtoStorageResponse> for RehydratingStorageClientMetrics {
+/// Make [`ReplicaMetrics`] pluggable into the gRPC connection.
+impl StatsCollector<ProtoStorageCommand, ProtoStorageResponse> for ReplicaMetrics {
     fn send_event(&self, _item: &ProtoStorageCommand, size: usize) {
         match f64::try_cast_from(u64::cast_from(size)) {
             Some(x) => self.inner.messages_sent_bytes.observe(x),

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -1,0 +1,468 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A reducible history of storage commands.
+
+use std::collections::BTreeMap;
+
+use mz_storage_client::client::StorageCommand;
+use mz_storage_types::parameters::StorageParameters;
+
+/// A history of storage commands.
+#[derive(Debug)]
+pub(crate) struct CommandHistory<T> {
+    /// The number of commands at the last time we compacted the history.
+    reduced_count: usize,
+    /// The sequence of commands that should be applied.
+    ///
+    /// This list may not be "compact" in that there can be commands that could be optimized or
+    /// removed given the context of other commands, for example compaction commands that can be
+    /// unified, or run commands that can be dropped due to allowed compaction.
+    commands: Vec<StorageCommand<T>>,
+}
+
+impl<T: std::fmt::Debug> CommandHistory<T> {
+    /// Constructs a new command history.
+    pub fn new() -> Self {
+        Self {
+            reduced_count: 0,
+            commands: Vec::new(),
+        }
+    }
+
+    /// Returns an iterator over the contained storage commands.
+    pub fn iter(&self) -> impl Iterator<Item = &StorageCommand<T>> {
+        self.commands.iter()
+    }
+
+    /// Adds a command to the history.
+    ///
+    /// This action will reduce the history every time it doubles.
+    pub fn push(&mut self, command: StorageCommand<T>) {
+        self.commands.push(command);
+
+        if self.commands.len() > 2 * self.reduced_count {
+            self.reduce();
+        }
+    }
+
+    /// Reduces the command history to a minimal form.
+    pub fn reduce(&mut self) {
+        use StorageCommand::*;
+
+        let mut create_timely_command = None;
+        let mut initialization_complete = false;
+        let mut final_compactions = BTreeMap::new();
+
+        // Collect the final definitions of ingestions and sinks.
+        // The same object ID can occur in multiple run commands when an object was altered. In
+        // this scenario, we only want to send the most recent definition of the object.
+        let mut final_ingestions = BTreeMap::new();
+        let mut final_sinks = BTreeMap::new();
+
+        // Collect only the final configuration.
+        // Note that this means the final configuration is applied to all objects installed on the
+        // new replica during initialization, even when the same objects where installed with an
+        // older config on existing replicas. This is only correct as long as config parameters
+        // don't affect the output of storage objects, as that would make different replicas write
+        // different data, which is likely to produce inconsistencies.
+        let mut final_configuration = StorageParameters::default();
+
+        for command in self.commands.drain(..) {
+            match command {
+                cmd @ CreateTimely { .. } => create_timely_command = Some(cmd),
+                InitializationComplete => initialization_complete = true,
+                UpdateConfiguration(params) => final_configuration.update(params),
+                RunIngestions(cmds) => {
+                    final_ingestions.extend(cmds.into_iter().map(|c| (c.id, c)));
+                }
+                RunSinks(cmds) => {
+                    final_sinks.extend(cmds.into_iter().map(|c| (c.id, c)));
+                }
+                AllowCompaction(updates) => final_compactions.extend(updates),
+            }
+        }
+
+        let mut run_ingestions = Vec::new();
+        let mut run_sinks = Vec::new();
+        let mut allow_compaction = Vec::new();
+
+        // Discard ingestions that have been dropped, keep the rest.
+        for ingestion in final_ingestions.into_values() {
+            if let Some(frontier) = final_compactions.get(&ingestion.id) {
+                if frontier.is_empty() {
+                    continue;
+                }
+            }
+
+            let compactions = ingestion
+                .description
+                .subsource_ids()
+                .filter_map(|id| final_compactions.remove(&id).map(|f| (id, f)));
+            allow_compaction.extend(compactions);
+
+            run_ingestions.push(ingestion);
+        }
+
+        // Discard sinks that have been dropped, advance the as-of of the rest.
+        for mut sink in final_sinks.into_values() {
+            if let Some(frontier) = final_compactions.remove(&sink.id) {
+                if frontier.is_empty() {
+                    continue;
+                }
+                sink.description.as_of = frontier;
+            }
+
+            run_sinks.push(sink);
+        }
+
+        // Reconstitute the commands as a compact history.
+        if let Some(create_timely_command) = create_timely_command {
+            self.commands.push(create_timely_command);
+        }
+        if !final_configuration.all_unset() {
+            self.commands
+                .push(StorageCommand::UpdateConfiguration(final_configuration));
+        }
+        if !run_ingestions.is_empty() {
+            self.commands
+                .push(StorageCommand::RunIngestions(run_ingestions));
+        }
+        if !run_sinks.is_empty() {
+            self.commands.push(StorageCommand::RunSinks(run_sinks));
+        }
+        if !allow_compaction.is_empty() {
+            let updates = allow_compaction.into_iter().collect();
+            self.commands.push(StorageCommand::AllowCompaction(updates));
+        }
+        if initialization_complete {
+            self.commands.push(StorageCommand::InitializationComplete);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mz_ore::metrics::MetricsRegistry;
+    use mz_persist_types::PersistLocation;
+    use mz_repr::{GlobalId, RelationDesc, RelationType};
+    use mz_storage_client::client::{RunIngestionCommand, RunSinkCommand};
+    use mz_storage_client::metrics::StorageControllerMetrics;
+    use mz_storage_types::connections::inline::InlinedConnection;
+    use mz_storage_types::connections::{KafkaConnection, Tunnel};
+    use mz_storage_types::controller::CollectionMetadata;
+    use mz_storage_types::instances::StorageInstanceId;
+    use mz_storage_types::sinks::{
+        KafkaIdStyle, KafkaSinkCompressionType, KafkaSinkConnection, KafkaSinkFormat,
+        KafkaSinkFormatType, MetadataFilled, SinkEnvelope, StorageSinkConnection, StorageSinkDesc,
+    };
+    use mz_storage_types::sources::load_generator::LoadGenerator;
+    use mz_storage_types::sources::{
+        GenericSourceConnection, IngestionDescription, LoadGeneratorSourceConnection, SourceDesc,
+        SourceEnvelope, SourceExport,
+    };
+    use timely::progress::Antichain;
+
+    use super::*;
+
+    fn history() -> CommandHistory<u64> {
+        let registry = MetricsRegistry::new();
+        let metrics = StorageControllerMetrics::new(registry)
+            .for_instance(StorageInstanceId::System(0))
+            .for_history();
+
+        CommandHistory::new(metrics)
+    }
+
+    fn ingestion_description<S: Into<Vec<u64>>>(
+        ingestion_id: u64,
+        subsource_ids: S,
+        remap_collection_id: u64,
+    ) -> IngestionDescription<CollectionMetadata, InlinedConnection> {
+        let export_ids = [ingestion_id, remap_collection_id]
+            .into_iter()
+            .chain(subsource_ids.into());
+        let source_exports = export_ids
+            .map(|id| {
+                let export = SourceExport {
+                    ingestion_output: Default::default(),
+                    storage_metadata: CollectionMetadata {
+                        persist_location: PersistLocation {
+                            blob_uri: Default::default(),
+                            consensus_uri: Default::default(),
+                        },
+                        remap_shard: Default::default(),
+                        data_shard: Default::default(),
+                        status_shard: Default::default(),
+                        relation_desc: RelationDesc::new(
+                            RelationType {
+                                column_types: Default::default(),
+                                keys: Default::default(),
+                            },
+                            Vec::<String>::new(),
+                        ),
+                        txns_shard: Default::default(),
+                    },
+                };
+                (GlobalId::User(id), export)
+            })
+            .collect();
+
+        IngestionDescription {
+            desc: SourceDesc {
+                connection: GenericSourceConnection::LoadGenerator(LoadGeneratorSourceConnection {
+                    load_generator: LoadGenerator::Auction,
+                    tick_micros: Default::default(),
+                    as_of: Default::default(),
+                    up_to: Default::default(),
+                }),
+                encoding: Default::default(),
+                envelope: SourceEnvelope::CdcV2,
+                timestamp_interval: Default::default(),
+            },
+            ingestion_metadata: CollectionMetadata {
+                persist_location: PersistLocation {
+                    blob_uri: Default::default(),
+                    consensus_uri: Default::default(),
+                },
+                remap_shard: Default::default(),
+                data_shard: Default::default(),
+                status_shard: Default::default(),
+                relation_desc: RelationDesc::new(
+                    RelationType {
+                        column_types: Default::default(),
+                        keys: Default::default(),
+                    },
+                    Vec::<String>::new(),
+                ),
+                txns_shard: Default::default(),
+            },
+            source_exports,
+            instance_id: StorageInstanceId::System(0),
+            remap_collection_id: GlobalId::User(remap_collection_id),
+        }
+    }
+
+    fn sink_description() -> StorageSinkDesc<MetadataFilled, u64> {
+        StorageSinkDesc {
+            from: GlobalId::System(1),
+            from_desc: RelationDesc::new(
+                RelationType {
+                    column_types: Default::default(),
+                    keys: Default::default(),
+                },
+                Vec::<String>::new(),
+            ),
+            connection: StorageSinkConnection::Kafka(KafkaSinkConnection {
+                connection_id: GlobalId::System(2),
+                connection: KafkaConnection {
+                    brokers: Default::default(),
+                    default_tunnel: Tunnel::Direct,
+                    progress_topic: Default::default(),
+                    progress_topic_options: Default::default(),
+                    options: Default::default(),
+                    tls: Default::default(),
+                    sasl: Default::default(),
+                },
+                format: KafkaSinkFormat {
+                    key_format: Default::default(),
+                    value_format: KafkaSinkFormatType::Text,
+                },
+                relation_key_indices: Default::default(),
+                key_desc_and_indices: Default::default(),
+                headers_index: Default::default(),
+                value_desc: RelationDesc::new(
+                    RelationType {
+                        column_types: Default::default(),
+                        keys: Default::default(),
+                    },
+                    Vec::<String>::new(),
+                ),
+                topic: Default::default(),
+                topic_options: Default::default(),
+                compression_type: KafkaSinkCompressionType::None,
+                progress_group_id: KafkaIdStyle::Legacy,
+                transactional_id: KafkaIdStyle::Legacy,
+            }),
+            with_snapshot: Default::default(),
+            version: Default::default(),
+            envelope: SinkEnvelope::Upsert,
+            as_of: Antichain::from_elem(0),
+            status_id: Default::default(),
+            from_storage_metadata: CollectionMetadata {
+                persist_location: PersistLocation {
+                    blob_uri: Default::default(),
+                    consensus_uri: Default::default(),
+                },
+                remap_shard: Default::default(),
+                data_shard: Default::default(),
+                status_shard: Default::default(),
+                relation_desc: RelationDesc::new(
+                    RelationType {
+                        column_types: Default::default(),
+                        keys: Default::default(),
+                    },
+                    Vec::<String>::new(),
+                ),
+                txns_shard: Default::default(),
+            },
+        }
+    }
+
+    #[mz_ore::test]
+    fn reduce_drops_dropped_ingestion() {
+        let mut history = history();
+
+        let commands = [
+            StorageCommand::RunIngestions(vec![RunIngestionCommand {
+                id: GlobalId::User(1),
+                description: ingestion_description(1, [2], 3),
+            }]),
+            StorageCommand::AllowCompaction(vec![
+                (GlobalId::User(1), Antichain::new()),
+                (GlobalId::User(2), Antichain::new()),
+                (GlobalId::User(3), Antichain::new()),
+            ]),
+        ];
+
+        for cmd in commands {
+            history.push(cmd);
+        }
+
+        history.reduce();
+
+        let commands_after: Vec<_> = history.iter().collect();
+        assert!(commands_after.is_empty(), "{:?}", commands_after);
+    }
+
+    #[mz_ore::test]
+    fn reduce_keeps_compacted_ingestion() {
+        let mut history = history();
+
+        let commands = [
+            StorageCommand::RunIngestions(vec![RunIngestionCommand {
+                id: GlobalId::User(1),
+                description: ingestion_description(1, [2], 3),
+            }]),
+            StorageCommand::AllowCompaction(vec![
+                (GlobalId::User(1), Antichain::from_elem(1)),
+                (GlobalId::User(2), Antichain::from_elem(2)),
+                (GlobalId::User(3), Antichain::from_elem(3)),
+            ]),
+        ];
+
+        for cmd in commands.clone() {
+            history.push(cmd);
+        }
+
+        history.reduce();
+
+        let commands_after: Vec<_> = history.iter().cloned().collect();
+        assert_eq!(commands_after, commands);
+    }
+
+    #[mz_ore::test]
+    fn reduce_keeps_partially_dropped_ingestion() {
+        let mut history = history();
+
+        let commands = [
+            StorageCommand::RunIngestions(vec![RunIngestionCommand {
+                id: GlobalId::User(1),
+                description: ingestion_description(1, [2], 3),
+            }]),
+            StorageCommand::AllowCompaction(vec![(GlobalId::User(2), Antichain::new())]),
+        ];
+
+        for cmd in commands.clone() {
+            history.push(cmd);
+        }
+
+        history.reduce();
+
+        let commands_after: Vec<_> = history.iter().cloned().collect();
+        assert_eq!(commands_after, commands);
+    }
+
+    #[mz_ore::test]
+    fn reduce_drops_dropped_sink() {
+        let mut history = history();
+
+        let commands = [
+            StorageCommand::RunSinks(vec![RunSinkCommand {
+                id: GlobalId::User(1),
+                description: sink_description(),
+            }]),
+            StorageCommand::AllowCompaction(vec![(GlobalId::User(1), Antichain::new())]),
+        ];
+
+        for cmd in commands {
+            history.push(cmd);
+        }
+
+        history.reduce();
+
+        let commands_after: Vec<_> = history.iter().collect();
+        assert!(commands_after.is_empty(), "{:?}", commands_after);
+    }
+
+    #[mz_ore::test]
+    fn reduce_keeps_compacted_sink() {
+        let mut history = history();
+
+        let sink_desc = sink_description();
+        let commands = [
+            StorageCommand::RunSinks(vec![RunSinkCommand {
+                id: GlobalId::User(1),
+                description: sink_desc.clone(),
+            }]),
+            StorageCommand::AllowCompaction(vec![(GlobalId::User(1), Antichain::from_elem(42))]),
+        ];
+
+        for cmd in commands {
+            history.push(cmd);
+        }
+
+        history.reduce();
+
+        let commands_after: Vec<_> = history.iter().cloned().collect();
+
+        let expected_sink_desc = StorageSinkDesc {
+            as_of: Antichain::from_elem(42),
+            ..sink_desc
+        };
+        let expected_commands = [StorageCommand::RunSinks(vec![RunSinkCommand {
+            id: GlobalId::User(1),
+            description: expected_sink_desc,
+        }])];
+
+        assert_eq!(commands_after, expected_commands);
+    }
+
+    #[mz_ore::test]
+    fn reduce_drops_stray_compactions() {
+        let mut history = history();
+
+        let commands = [
+            StorageCommand::AllowCompaction(vec![(GlobalId::User(1), Antichain::new())]),
+            StorageCommand::AllowCompaction(vec![
+                (GlobalId::User(2), Antichain::from_elem(1)),
+                (GlobalId::User(2), Antichain::from_elem(2)),
+            ]),
+        ];
+
+        for cmd in commands {
+            history.push(cmd);
+        }
+
+        history.reduce();
+
+        let commands_after: Vec<_> = history.iter().collect();
+        assert!(commands_after.is_empty(), "{:?}", commands_after);
+    }
+}

--- a/src/storage-controller/src/instance.rs
+++ b/src/storage-controller/src/instance.rs
@@ -1,0 +1,420 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A controller for a storage instance.
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::num::NonZeroI64;
+use std::task::Poll;
+use std::time::Duration;
+
+use anyhow::bail;
+use differential_dataflow::lattice::Lattice;
+use futures::stream::{FuturesUnordered, StreamExt};
+use mz_build_info::BuildInfo;
+use mz_cluster_client::client::{ClusterReplicaLocation, ClusterStartupEpoch, TimelyConfig};
+use mz_cluster_client::ReplicaId;
+use mz_ore::retry::{Retry, RetryState};
+use mz_ore::task::AbortOnDropHandle;
+use mz_service::client::{GenericClient, Partitioned};
+use mz_service::params::GrpcClientParameters;
+use mz_storage_client::client::{
+    StorageClient, StorageCommand, StorageGrpcClient, StorageResponse,
+};
+use mz_storage_client::metrics::{InstanceMetrics, ReplicaMetrics};
+use timely::progress::Timestamp;
+use tokio::select;
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+use crate::history::CommandHistory;
+
+/// A controller for a storage instance.
+///
+/// Encapsulates communication with replicas in this instance, and their rehydration.
+///
+/// Note that storage objects (sources and sinks) don't currently support replication (#17418).
+/// An instance can have muliple replicas connected, but only if it has no storage objects
+/// installed. Attempting to install storage objects on multi-replica instances, or attempting to
+/// add more than one replica to instances that have storage objects installed, is illegal and will
+/// lead to panics.
+#[derive(Debug)]
+pub(crate) struct Instance<T> {
+    /// The replicas connected to this storage instance.
+    replicas: BTreeMap<ReplicaId, Replica<T>>,
+    /// The command history, used to replay past commands when introducing new replicas or
+    /// reconnecting to existing replicas.
+    history: CommandHistory<T>,
+    /// The current cluster startup epoch.
+    ///
+    /// The `replica` value of the epoch is increased every time a replica is (re)connected,
+    /// allowing the distinction of different replica incarnations.
+    epoch: ClusterStartupEpoch,
+    /// Metrics tracked for this storage instance.
+    metrics: InstanceMetrics,
+}
+
+impl<T> Instance<T>
+where
+    T: Timestamp + Lattice,
+    StorageGrpcClient: StorageClient<T>,
+{
+    /// Creates a new [`Instance`].
+    pub fn new(envd_epoch: NonZeroI64, metrics: InstanceMetrics) -> Self {
+        let history = CommandHistory::new(metrics.for_history());
+        let epoch = ClusterStartupEpoch::new(envd_epoch, 0);
+
+        let mut instance = Self {
+            replicas: Default::default(),
+            history,
+            epoch,
+            metrics,
+        };
+
+        instance.send(StorageCommand::CreateTimely {
+            config: TimelyConfig::default(),
+            epoch,
+        });
+
+        instance
+    }
+
+    /// Returns the IDs of all replicas connected to this storage instance.
+    pub fn replica_ids(&self) -> impl Iterator<Item = ReplicaId> + '_ {
+        self.replicas.keys().copied()
+    }
+
+    /// Adds a new replica to this storage instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this storage instance has storage objects installed and already has a replica
+    /// connected.
+    pub fn add_replica(&mut self, id: ReplicaId, config: ReplicaConfig) {
+        // Reduce the history to limit the amount of commands sent to the new replica, and to
+        // enable the `objects_installed` assert below.
+        self.history.reduce();
+
+        let objects_installed = self.history.iter().any(|cmd| cmd.installs_objects());
+        assert!(
+            !objects_installed || self.replicas.is_empty(),
+            "replication not supported for storage objects",
+        );
+
+        self.epoch.bump_replica();
+        let metrics = self.metrics.for_replica(id);
+        let mut replica = Replica::new(id, config, self.epoch, metrics);
+
+        // Replay the commands at the new replica.
+        for command in self.history.iter() {
+            replica.send(command.clone());
+        }
+
+        self.replicas.insert(id, replica);
+    }
+
+    /// Removes the identified replica from this storage instance.
+    pub fn drop_replica(&mut self, id: ReplicaId) {
+        self.replicas.remove(&id);
+    }
+
+    /// Rehydrates any failed replicas of this storage instance.
+    pub fn rehydrate_failed_replicas(&mut self) {
+        let replicas = self.replicas.iter();
+        let failed_replicas: Vec<_> = replicas
+            .filter_map(|(id, replica)| replica.failed.then_some(*id))
+            .collect();
+
+        for id in failed_replicas {
+            let replica = self.replicas.remove(&id).expect("must exist");
+            self.add_replica(id, replica.config);
+        }
+    }
+
+    /// Sends a command to this storage instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the storage instance has multiple replicas connected and the given command
+    /// instructs the installation of storage objects.
+    pub fn send(&mut self, command: StorageCommand<T>) {
+        assert!(
+            !command.installs_objects() || self.replicas.len() <= 1,
+            "replication not supported for storage objects"
+        );
+
+        // Record the command so that new replicas can be brought up to speed.
+        self.history.push(command.clone());
+
+        // Clone the command for each active replica.
+        for replica in self.replicas.values_mut() {
+            replica.send(command.clone());
+        }
+    }
+
+    /// Receives the next response from this storage instance.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
+    /// statement and some other branch completes first, it is guaranteed that no response was
+    /// received from this storage instance.
+    ///
+    /// The implementation intentionally avoids the `async`/`await` syntax to facilitate reasoning
+    /// about its cancel safety.
+    pub fn recv(&mut self) -> impl Future<Output = Option<StorageResponse<T>>> + '_ {
+        std::future::poll_fn(|cx| {
+            let receives = self.replicas.values_mut().map(|r| r.recv());
+            let mut futs: FuturesUnordered<_> = receives.collect();
+
+            // `futs` is a cancel safe stream: It only awaits `Replica::recv`, which is documented as
+            // cancel safe. Thus dropping `futs` while awaiting its next element is guaranteed to never
+            // drop a replica response.
+            match std::task::ready!(futs.poll_next_unpin(cx)) {
+                Some(resp) => Poll::Ready(resp),
+                None => {
+                    // There are no live replicas left.
+                    // Remain pending to communicate that no response is ready.
+                    Poll::Pending
+                }
+            }
+        })
+    }
+}
+
+/// Replica-specific configuration.
+#[derive(Clone, Debug)]
+pub(super) struct ReplicaConfig {
+    pub build_info: &'static BuildInfo,
+    pub location: ClusterReplicaLocation,
+    pub grpc_client: GrpcClientParameters,
+}
+
+/// State maintained about individual replicas.
+#[derive(Debug)]
+pub struct Replica<T> {
+    /// Replica configuration.
+    config: ReplicaConfig,
+    /// Whether the replica has failed and requires rehydration.
+    failed: bool,
+
+    /// A sender for commands for the replica.
+    ///
+    /// If sending to this channel fails, the replica has failed and requires
+    /// rehydration.
+    command_tx: mpsc::UnboundedSender<StorageCommand<T>>,
+    /// A receiver for responses from the replica.
+    ///
+    /// If receiving from the channel returns `None`, the replica has failed
+    /// and requires rehydration.
+    response_rx: mpsc::UnboundedReceiver<StorageResponse<T>>,
+    /// A handle to the task that aborts it when the replica is dropped.
+    _task: AbortOnDropHandle<()>,
+}
+
+impl<T> Replica<T>
+where
+    T: Timestamp + Lattice,
+    StorageGrpcClient: StorageClient<T>,
+{
+    /// Creates a new [`Replica`].
+    fn new(
+        id: ReplicaId,
+        config: ReplicaConfig,
+        epoch: ClusterStartupEpoch,
+        metrics: ReplicaMetrics,
+    ) -> Self {
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let (response_tx, response_rx) = mpsc::unbounded_channel();
+
+        let task = mz_ore::task::spawn(
+            || "storage-replica-{id}",
+            ReplicaTask {
+                replica_id: id,
+                config: config.clone(),
+                epoch,
+                metrics: metrics.clone(),
+                command_rx,
+                response_tx,
+            }
+            .run(),
+        );
+
+        Self {
+            config,
+            failed: false,
+            command_tx,
+            response_rx,
+            _task: task.abort_on_drop(),
+        }
+    }
+
+    /// Sends a command to the replica.
+    fn send(&mut self, command: StorageCommand<T>) {
+        if self.command_tx.send(command).is_err() {
+            self.failed = true;
+        }
+    }
+
+    /// Receives the next response from the replica and returns it, or `None` if the replica has
+    /// disconnected.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
+    /// statement and some other branch completes first, it is guaranteed that no response was
+    /// received from this replica.
+    ///
+    /// The implementation intentionally avoids the `async`/`await` syntax to facilitate reasoning
+    /// about its cancel safety.
+    fn recv(&mut self) -> impl Future<Output = Option<StorageResponse<T>>> + '_ {
+        std::future::poll_fn(|cx| {
+            // `tokio::sync::mpsc::UnboundedReceiver::recv` is documented as cancel safe.
+            let resp = std::task::ready!(self.response_rx.poll_recv(cx));
+            if resp.is_none() {
+                self.failed = true;
+            }
+            Poll::Ready(resp)
+        })
+    }
+}
+
+type ReplicaClient<T> = Partitioned<StorageGrpcClient, StorageCommand<T>, StorageResponse<T>>;
+
+/// A task handling communication with a replica.
+struct ReplicaTask<T> {
+    /// The ID of the replica.
+    replica_id: ReplicaId,
+    /// Replica configuration.
+    config: ReplicaConfig,
+    /// The epoch identifying this incarnation of the replica.
+    epoch: ClusterStartupEpoch,
+    /// Replica metrics.
+    metrics: ReplicaMetrics,
+    /// A channel upon which commands intended for the replica are delivered.
+    command_rx: mpsc::UnboundedReceiver<StorageCommand<T>>,
+    /// A channel upon which responses from the replica are delivered.
+    response_tx: mpsc::UnboundedSender<StorageResponse<T>>,
+}
+
+impl<T> ReplicaTask<T>
+where
+    T: Timestamp + Lattice,
+    StorageGrpcClient: StorageClient<T>,
+{
+    /// Runs the replica task.
+    async fn run(self) {
+        let replica_id = self.replica_id;
+        info!(%replica_id, "starting replica task");
+
+        let client = self.connect().await;
+        match self.run_message_loop(client).await {
+            Ok(()) => info!(%replica_id, "stopped replica task"),
+            Err(error) => warn!(%replica_id, %error, "replica task failed"),
+        }
+    }
+
+    /// Connects to the replica.
+    ///
+    /// The connection is retried forever (with backoff) and this method returns only after
+    /// a connection was successfully established.
+    async fn connect(&self) -> ReplicaClient<T> {
+        let try_connect = |retry: RetryState| {
+            let addrs = &self.config.location.ctl_addrs;
+            let dests = addrs
+                .iter()
+                .map(|addr| (addr.clone(), self.metrics.clone()))
+                .collect();
+            let version = self.config.build_info.semver_version();
+            let client_params = &self.config.grpc_client;
+
+            async move {
+                StorageGrpcClient::connect_partitioned(dests, version, client_params)
+                    .await
+                    .inspect_err(|error| {
+                        let next_backoff = retry.next_backoff.unwrap();
+                        if retry.i >= mz_service::retry::INFO_MIN_RETRIES {
+                            info!(
+                                replica_id = %self.replica_id, ?next_backoff,
+                                "error connecting to replica: {error:#}",
+                            );
+                        } else {
+                            debug!(
+                                replica_id = %self.replica_id, ?next_backoff,
+                                "error connecting to replica: {error:#}",
+                            );
+                        }
+                    })
+            }
+        };
+
+        Retry::default()
+            .clamp_backoff(Duration::from_secs(1))
+            .retry_async(try_connect)
+            .await
+            .expect("retries forever")
+    }
+
+    /// Runs the message loop.
+    ///
+    /// Returns (with an `Err`) if it encounters an error condition (e.g. the replica disconnects).
+    /// If no error condition is encountered, the task runs until the controller disconnects from
+    /// the command channel, or the task is dropped.
+    async fn run_message_loop(mut self, mut client: ReplicaClient<T>) -> Result<(), anyhow::Error> {
+        loop {
+            select! {
+                // Command from controller to forward to replica.
+                // `tokio::sync::mpsc::UnboundedReceiver::recv` is documented as cancel safe.
+                command = self.command_rx.recv() => {
+                    let Some(mut command) = command else {
+                        // Controller is no longer interested in this replica. Shut down.
+                        break;
+                    };
+
+                    self.specialize_command(&mut command);
+                    client.send(command).await?;
+                },
+                // Response from replica to forward to controller.
+                // `GenericClient::recv` implementations are required to be cancel safe.
+                response = client.recv() => {
+                    let Some(response) = response? else {
+                        bail!("replica unexpectedly gracefully terminated connection");
+                    };
+
+                    if self.response_tx.send(response).is_err() {
+                        // Controller is no longer interested in this replica. Shut down.
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Specialize a command for the given replica configuration.
+    ///
+    /// Most [`StorageCommand`]s are independent of the target replica, but some contain
+    /// replica-specific fields that must be adjusted before sending.
+    fn specialize_command(&self, command: &mut StorageCommand<T>) {
+        if let StorageCommand::CreateTimely { config, epoch } = command {
+            *config = TimelyConfig {
+                workers: self.config.location.workers,
+                // Overridden by the storage `PartitionedState` implementation.
+                process: 0,
+                addresses: self.config.location.dataflow_addrs.clone(),
+                // This value is not currently used by storage, so we just choose
+                // some identifiable value.
+                arrangement_exert_proportionality: 1337,
+            };
+            *epoch = self.epoch;
+        }
+    }
+}

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -91,6 +91,7 @@ use crate::rehydration::RehydratingStorageClient;
 use crate::statistics::StatsState;
 mod collection_mgmt;
 mod collection_status;
+mod history;
 mod persist_handles;
 mod rehydration;
 mod rtr;

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -89,9 +89,11 @@ use tracing::{debug, info, warn};
 
 use crate::rehydration::RehydratingStorageClient;
 use crate::statistics::StatsState;
+
 mod collection_mgmt;
 mod collection_status;
 mod history;
+mod instance;
 mod persist_handles;
 mod rehydration;
 mod rtr;

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -283,6 +283,11 @@ impl StorageParameters {
             user_storage_managed_collections_batch_duration;
         self.dyncfg_updates.extend(dyncfg_updates);
     }
+
+    /// Return whether all parameters are unset.
+    pub fn all_unset(&self) -> bool {
+        *self == Self::default()
+    }
 }
 
 impl RustType<ProtoStorageParameters> for StorageParameters {

--- a/test/sqllogictest/github-28166.slt
+++ b/test/sqllogictest/github-28166.slt
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for #28166.
+
+statement ok
+CREATE CLUSTER test REPLICAS(
+    r1 (SIZE '1'),
+    r2 (SIZE '1')
+)
+
+statement ok
+DROP CLUSTER REPLICA test.r1;
+
+statement ok
+CREATE SOURCE counter IN CLUSTER test FROM LOAD GENERATOR COUNTER
+
+query I
+SELECT min(counter) FROM counter
+----
+1
+
+statement ok
+DROP CLUSTER test CASCADE
+
+statement ok
+CREATE CLUSTER test REPLICAS(
+    r1 (SIZE '1'),
+    r2 (SIZE '1')
+)
+
+statement ok
+DROP CLUSTER REPLICA test.r2;
+
+statement ok
+CREATE SOURCE counter IN CLUSTER test FROM LOAD GENERATOR COUNTER
+
+query I
+SELECT min(counter) FROM counter
+----
+1


### PR DESCRIPTION
This PR makes the storage controller connect to all replicas in each instance, rather than just the one most recently added. This solves two bugs around replica connections (https://github.com/MaterializeInc/materialize/issues/28046, https://github.com/MaterializeInc/materialize/issues/28166), prepares the storage controller code for active replication support, and makes the two controllers function more similarly. Note that it is still not allowed to run sources or sinks on clusters that have more than one replica, and the new code asserts this.

The implementation is copied from/heavily inspired by the compute controller implementation. The storage controller now gets an `Instance` struct that manages communication with the replicas in a cluster. Each `Instance` keeps track of its received commands in a `CommandHistory`, to replay them when a new replica is connected, or a replica disconnects and needs to be rehydrated. There is a `ReplicaTask` for each live replica, managing communication with that replica asynchronously. In contrast to the compute controller, the storage controller still manages all its collections at a global level (within `Controller`) rather than at a per-instance level. This is something we'll probably want to unify in the future, but it's outside the scope of this PR.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/28046
Fixes https://github.com/MaterializeInc/materialize/issues/28166

   * This PR refactors existing code.

Partially unifies storage and compute controller implementations.
Works toward https://github.com/MaterializeInc/materialize/issues/17418.

### Tips for reviewer

I've tried to keep the individual commits as small and self-contained as possible, though the "add `Instance` type" one is unfortunately still pretty bulky.

Most of the time I've simply used the precedent we already have in the compute controller, regarding structure and naming of things. I think the result is okay, though there is certainly opportunity for improvement. I would prefer if we made these improvements outside the scope of this PR, so we can apply them to both controllers at the same time.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
