### PR TITLE
output consistency: add table functions

### DIFF
--- a/misc/python/materialize/output_consistency/expression/expression_with_args.py
+++ b/misc/python/materialize/output_consistency/expression/expression_with_args.py
@@ -171,6 +171,9 @@ class ExpressionWithArgs(Expression):
 
         return False
 
+    def operation_to_pattern(self) -> str:
+        return self.operation.to_pattern(self.count_args())
+
 
 def _determine_storage_layout(args: list[Expression]) -> ValueStorageLayout:
     mutual_storage_layout: ValueStorageLayout | None = None

--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -16,6 +16,9 @@ from materialize.output_consistency.expression.expression import (
     Expression,
     LeafExpression,
 )
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
 from materialize.output_consistency.expression.expression_with_args import (
     ExpressionWithArgs,
 )
@@ -174,6 +177,25 @@ def is_known_to_involve_exact_data_types(
 def is_operation_tagged(expression: Expression, tag: str) -> bool:
     if isinstance(expression, ExpressionWithArgs):
         return expression.operation.is_tagged(tag)
+
+    return False
+
+
+def argument_has_any_characteristic(
+    expression: Expression,
+    arg_index: int,
+    characteristics: set[ExpressionCharacteristics],
+) -> bool:
+    if isinstance(expression, ExpressionWithArgs):
+        assert arg_index < len(
+            expression.operation.params
+        ), f"Invalid argument index for {expression.operation_to_pattern()}"
+        param = expression.operation.params[arg_index]
+        if param.optional and len(expression.args) <= arg_index:
+            return False
+
+        argument = expression.args[arg_index]
+        return argument.has_any_characteristic(characteristics)
 
     return False
 

--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -244,3 +244,9 @@ def is_known_to_return_non_integer_number(expression: Expression):
         return return_type_spec.always_floating_type
 
     return False
+
+
+def is_table_function(expression: Expression) -> bool:
+    if isinstance(expression, ExpressionWithArgs):
+        return expression.operation.is_table_function
+    return False

--- a/misc/python/materialize/output_consistency/input_data/operations/all_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/all_operations_provider.py
@@ -60,6 +60,9 @@ from materialize.output_consistency.input_data.operations.set_operations_provide
 from materialize.output_consistency.input_data.operations.string_operations_provider import (
     STRING_OPERATION_TYPES,
 )
+from materialize.output_consistency.input_data.operations.table_operations_provider import (
+    TABLE_OPERATION_TYPES,
+)
 from materialize.output_consistency.input_data.operations.trigonometric_operations_provider import (
     TRIGONOMETRIC_OPERATION_TYPES,
 )
@@ -88,6 +91,7 @@ ALL_OPERATION_TYPES: list[DbOperationOrFunction] = list(
         RANGE_OPERATION_TYPES,
         UUID_OPERATION_TYPES,
         RECORD_OPERATION_TYPES,
+        TABLE_OPERATION_TYPES,
         PG_OPERATIONS,
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/list_operations_provider.py
@@ -15,8 +15,8 @@ from materialize.output_consistency.input_data.params.collection_operation_param
     ElementOfOtherCollectionOperationParam,
 )
 from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
+    COLLECTION_INDEX_OPTIONAL_PARAM,
     COLLECTION_INDEX_PARAM,
-    COLLECTION_INDEX_PARAM_OPT,
 )
 from materialize.output_consistency.input_data.params.list_operation_param import (
     ListLikeOtherListOperationParam,
@@ -125,7 +125,11 @@ LIST_OPERATION_TYPES.append(
 LIST_OPERATION_TYPES.append(
     DbOperation(
         "$[$:$]",
-        [ListOperationParam(), COLLECTION_INDEX_PARAM_OPT, COLLECTION_INDEX_PARAM_OPT],
+        [
+            ListOperationParam(),
+            COLLECTION_INDEX_OPTIONAL_PARAM,
+            COLLECTION_INDEX_OPTIONAL_PARAM,
+        ],
         ListReturnTypeSpec(),
         comment="slice list",
     )

--- a/misc/python/materialize/output_consistency/input_data/operations/string_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/string_operations_provider.py
@@ -19,7 +19,7 @@ from materialize.output_consistency.input_data.params.boolean_operation_param im
 )
 from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
     LIKE_PARAM,
-    REGEX_FLAG_PARAM,
+    REGEX_FLAG_OPTIONAL_PARAM,
     REGEX_PARAM,
     REPETITIONS_PARAM,
     STRING_TRIM_SPEC_PARAM,
@@ -289,7 +289,7 @@ STRING_OPERATION_TYPES.append(
 STRING_OPERATION_TYPES.append(
     DbFunction(
         "regexp_match",
-        [StringOperationParam(), REGEX_PARAM, REGEX_FLAG_PARAM],
+        [StringOperationParam(), REGEX_PARAM, REGEX_FLAG_OPTIONAL_PARAM],
         ArrayReturnTypeSpec(array_value_type_category=DataTypeCategory.STRING),
         tags={TAG_REGEX},
     )
@@ -297,7 +297,12 @@ STRING_OPERATION_TYPES.append(
 
 REGEXP_REPLACE = DbFunction(
     "regexp_replace",
-    [StringOperationParam(), REGEX_PARAM, StringOperationParam(), REGEX_FLAG_PARAM],
+    [
+        StringOperationParam(),
+        REGEX_PARAM,
+        StringOperationParam(),
+        REGEX_FLAG_OPTIONAL_PARAM,
+    ],
     StringReturnTypeSpec(),
     tags={TAG_REGEX},
 )
@@ -306,7 +311,7 @@ STRING_OPERATION_TYPES.append(REGEXP_REPLACE)
 STRING_OPERATION_TYPES.append(
     DbFunction(
         "regexp_split_to_array",
-        [StringOperationParam(), REGEX_PARAM, REGEX_FLAG_PARAM],
+        [StringOperationParam(), REGEX_PARAM, REGEX_FLAG_OPTIONAL_PARAM],
         ArrayReturnTypeSpec(array_value_type_category=DataTypeCategory.ARRAY),
         tags={TAG_REGEX},
     )

--- a/misc/python/materialize/output_consistency/input_data/operations/table_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/table_operations_provider.py
@@ -110,6 +110,8 @@ TABLE_OPERATION_TYPES.append(
         DateTimeReturnTypeSpec(TIMESTAMP_TYPE_IDENTIFIER),
         is_table_function=True,
         relevance=OperationRelevance.LOW,
+        # this is likely to take down mz with aggressive values
+        is_enabled=False,
     ),
 )
 

--- a/misc/python/materialize/output_consistency/input_data/operations/table_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/table_operations_provider.py
@@ -17,7 +17,7 @@ from materialize.output_consistency.input_data.params.date_time_operation_param 
     TimeIntervalOperationParam,
 )
 from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
-    REGEX_FLAG_PARAM,
+    REGEX_FLAG_OPTIONAL_PARAM,
     REGEX_PARAM,
     REGEX_PARAM_WITH_GROUP,
 )
@@ -142,7 +142,7 @@ TABLE_OPERATION_TYPES.append(
 TABLE_OPERATION_TYPES.append(
     DbFunction(
         "regexp_split_to_table",
-        [StringOperationParam(), REGEX_PARAM, REGEX_FLAG_PARAM],
+        [StringOperationParam(), REGEX_PARAM, REGEX_FLAG_OPTIONAL_PARAM],
         StringReturnTypeSpec(),
         is_table_function=True,
     ),

--- a/misc/python/materialize/output_consistency/input_data/operations/table_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/table_operations_provider.py
@@ -1,0 +1,182 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.input_data.params.array_operation_param import (
+    ArrayOperationParam,
+)
+from materialize.output_consistency.input_data.params.date_time_operation_param import (
+    DateTimeOperationParam,
+    TimeIntervalOperationParam,
+)
+from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
+    REGEX_FLAG_PARAM,
+    REGEX_PARAM,
+    REGEX_PARAM_WITH_GROUP,
+)
+from materialize.output_consistency.input_data.params.list_operation_param import (
+    ListOperationParam,
+)
+from materialize.output_consistency.input_data.params.map_operation_param import (
+    MapOperationParam,
+)
+from materialize.output_consistency.input_data.params.number_operation_param import (
+    NumericOperationParam,
+)
+from materialize.output_consistency.input_data.params.string_operation_param import (
+    StringOperationParam,
+)
+from materialize.output_consistency.input_data.return_specs.collection_entry_return_spec import (
+    CollectionEntryReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.date_time_return_spec import (
+    DateTimeReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.number_return_spec import (
+    NumericReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.record_return_spec import (
+    RecordReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.return_specs.string_return_spec import (
+    StringReturnTypeSpec,
+)
+from materialize.output_consistency.input_data.types.date_time_types_provider import (
+    TIMESTAMP_TYPE_IDENTIFIER,
+)
+from materialize.output_consistency.operation.operation import (
+    DbFunction,
+    DbFunctionWithCustomPattern,
+    DbOperationOrFunction,
+    OperationRelevance,
+)
+
+TABLE_OPERATION_TYPES: list[DbOperationOrFunction] = []
+
+TABLE_OPERATION_TYPES.append(
+    DbFunctionWithCustomPattern(
+        "generate_series",
+        {2: "generate_series($, min($, 30))", 3: "generate_series($, min($, 30), $)"},
+        [
+            NumericOperationParam(
+                only_int_type=True,
+                incompatibilities={
+                    ExpressionCharacteristics.MAX_VALUE,
+                    ExpressionCharacteristics.LARGE_VALUE,
+                },
+            ),
+            NumericOperationParam(
+                only_int_type=True,
+                incompatibilities={
+                    ExpressionCharacteristics.MAX_VALUE,
+                    ExpressionCharacteristics.LARGE_VALUE,
+                },
+            ),
+            NumericOperationParam(
+                only_int_type=True,
+                incompatibilities={
+                    ExpressionCharacteristics.MAX_VALUE,
+                    ExpressionCharacteristics.LARGE_VALUE,
+                },
+            ),
+        ],
+        NumericReturnTypeSpec(only_integer=True),
+        is_table_function=True,
+        relevance=OperationRelevance.LOW,
+    ),
+)
+
+TABLE_OPERATION_TYPES.append(
+    DbFunction(
+        "generate_series",
+        [
+            DateTimeOperationParam(
+                incompatibilities={ExpressionCharacteristics.MAX_VALUE}
+            ),
+            DateTimeOperationParam(
+                incompatibilities={ExpressionCharacteristics.MAX_VALUE}
+            ),
+            TimeIntervalOperationParam(
+                incompatibilities={ExpressionCharacteristics.MAX_VALUE}
+            ),
+        ],
+        DateTimeReturnTypeSpec(TIMESTAMP_TYPE_IDENTIFIER),
+        is_table_function=True,
+        relevance=OperationRelevance.LOW,
+    ),
+)
+
+
+TABLE_OPERATION_TYPES.append(
+    DbFunction(
+        "generate_subscripts",
+        [
+            ArrayOperationParam(),
+            NumericOperationParam(only_int_type=True),
+        ],
+        NumericReturnTypeSpec(only_integer=True),
+        is_table_function=True,
+        comment="Returns indices of the specified array dimension",
+    ),
+)
+
+TABLE_OPERATION_TYPES.append(
+    DbFunction(
+        "regexp_extract",
+        [
+            REGEX_PARAM_WITH_GROUP,
+            StringOperationParam(),
+        ],
+        StringReturnTypeSpec(),
+        is_table_function=True,
+    ),
+)
+
+TABLE_OPERATION_TYPES.append(
+    DbFunction(
+        "regexp_split_to_table",
+        [StringOperationParam(), REGEX_PARAM, REGEX_FLAG_PARAM],
+        StringReturnTypeSpec(),
+        is_table_function=True,
+    ),
+)
+
+TABLE_OPERATION_TYPES.append(
+    DbFunction(
+        "unnest",
+        [
+            ArrayOperationParam(),
+        ],
+        CollectionEntryReturnTypeSpec(param_index_to_take_type=0),
+        is_table_function=True,
+    ),
+)
+
+TABLE_OPERATION_TYPES.append(
+    DbFunction(
+        "unnest",
+        [
+            ListOperationParam(),
+        ],
+        CollectionEntryReturnTypeSpec(param_index_to_take_type=0),
+        is_table_function=True,
+    ),
+)
+
+TABLE_OPERATION_TYPES.append(
+    DbFunction(
+        "unnest",
+        [
+            MapOperationParam(),
+        ],
+        RecordReturnTypeSpec(),
+        is_table_function=True,
+    ),
+)

--- a/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
+++ b/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
@@ -63,7 +63,7 @@ REGEX_PARAM_WITH_GROUP = EnumConstantOperationParam(
     ["(.)", "(.*)", "(A+)", "([ab])"], add_quotes=True, invalid_value="ab("
 )
 
-REGEX_FLAG_PARAM = EnumConstantOperationParam(
+REGEX_FLAG_OPTIONAL_PARAM = EnumConstantOperationParam(
     ["i", "g", "n"], add_quotes=True, optional=True
 )
 
@@ -119,7 +119,7 @@ COLLECTION_INDEX_PARAM = EnumConstantOperationParam(
     ["0", "1", "2", "8"], add_quotes=False, add_invalid_value=False
 )
 
-COLLECTION_INDEX_PARAM_OPT = EnumConstantOperationParam(
+COLLECTION_INDEX_OPTIONAL_PARAM = EnumConstantOperationParam(
     ["0", "1", "2", "8"], add_quotes=False, add_invalid_value=False, optional=True
 )
 

--- a/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
+++ b/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
@@ -59,6 +59,10 @@ REGEX_PARAM = EnumConstantOperationParam(
     [".*", "A+", "[ab]"], add_quotes=True, invalid_value="ab("
 )
 
+REGEX_PARAM_WITH_GROUP = EnumConstantOperationParam(
+    ["(.)", "(.*)", "(A+)", "([ab])"], add_quotes=True, invalid_value="ab("
+)
+
 REGEX_FLAG_PARAM = EnumConstantOperationParam(
     ["i", "g", "n"], add_quotes=True, optional=True
 )
@@ -125,7 +129,7 @@ ARRAY_DIMENSION_PARAM = EnumConstantOperationParam(
 
 RECORD_FIELD_PARAM = EnumConstantOperationParam(
     # do not use "*" because it will mess up the column mapping between query and result
-    ["f1", "f2", "f3", "f4"],
+    ["f1", "f2", "f3", "f4", "key", "value"],
     add_quotes=False,
     add_invalid_value=True,
 )

--- a/misc/python/materialize/output_consistency/operation/operation.py
+++ b/misc/python/materialize/output_consistency/operation/operation.py
@@ -43,6 +43,7 @@ class DbOperationOrFunction:
         return_type_spec: ReturnTypeSpec,
         args_validators: set[OperationArgsValidator] | None = None,
         is_aggregation: bool = False,
+        is_table_function: bool = False,
         relevance: OperationRelevance = OperationRelevance.DEFAULT,
         comment: str | None = None,
         is_enabled: bool = True,
@@ -63,6 +64,7 @@ class DbOperationOrFunction:
         self.return_type_spec = return_type_spec
         self.args_validators: set[OperationArgsValidator] = args_validators
         self.is_aggregation = is_aggregation
+        self.is_table_function = is_table_function
         self.relevance = relevance
         self.comment = comment
         self.is_enabled = is_enabled
@@ -198,6 +200,7 @@ class DbFunction(DbOperationOrFunction):
         return_type_spec: ReturnTypeSpec,
         args_validators: set[OperationArgsValidator] | None = None,
         is_aggregation: bool = False,
+        is_table_function: bool = False,
         relevance: OperationRelevance = OperationRelevance.DEFAULT,
         comment: str | None = None,
         is_enabled: bool = True,
@@ -214,6 +217,7 @@ class DbFunction(DbOperationOrFunction):
             return_type_spec=return_type_spec,
             args_validators=args_validators,
             is_aggregation=is_aggregation,
+            is_table_function=is_table_function,
             relevance=relevance,
             comment=comment,
             is_enabled=is_enabled,
@@ -262,6 +266,7 @@ class DbFunctionWithCustomPattern(DbFunction):
         return_type_spec: ReturnTypeSpec,
         args_validators: set[OperationArgsValidator] | None = None,
         is_aggregation: bool = False,
+        is_table_function: bool = False,
         relevance: OperationRelevance = OperationRelevance.DEFAULT,
         comment: str | None = None,
         is_enabled: bool = True,
@@ -273,6 +278,7 @@ class DbFunctionWithCustomPattern(DbFunction):
             return_type_spec,
             args_validators=args_validators,
             is_aggregation=is_aggregation,
+            is_table_function=is_table_function,
             relevance=relevance,
             comment=comment,
             is_enabled=is_enabled,

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -347,8 +347,8 @@ class ResultComparator:
             column_values2.append(result2.result_rows[row_index][col_index])
 
         if self.ignore_row_order(expression):
-            column_values1 = sorted(column_values1)
-            column_values2 = sorted(column_values2)
+            column_values1 = self._sort_column_values(column_values1)
+            column_values2 = self._sort_column_values(column_values2)
 
         for row_index in range(0, row_length):
             result_value1 = column_values1[row_index]
@@ -521,3 +521,10 @@ class ResultComparator:
             return query_execution.query_template.select_expressions[0]
 
         return None
+
+    def _sort_column_values(self, column_values: list[Any]) -> list[Any]:
+        # needed because, for example, None values have no order
+        def sort_key(value: Any) -> Any:
+            return str(value)
+
+        return sorted(column_values, key=sort_key)

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -338,10 +338,21 @@ class ResultComparator:
         # both results are known to be not empty and have the same number of rows
         row_length = len(result1.result_rows)
 
+        column_values1 = []
+        column_values2 = []
+        expression = query_execution.query_template.select_expressions[col_index]
+
         for row_index in range(0, row_length):
-            result_value1 = result1.result_rows[row_index][col_index]
-            result_value2 = result2.result_rows[row_index][col_index]
-            expression = query_execution.query_template.select_expressions[col_index]
+            column_values1.append(result1.result_rows[row_index][col_index])
+            column_values2.append(result2.result_rows[row_index][col_index])
+
+        if self.ignore_row_order(expression):
+            column_values1 = sorted(column_values1)
+            column_values2 = sorted(column_values2)
+
+        for row_index in range(0, row_length):
+            result_value1 = column_values1[row_index]
+            result_value2 = column_values2[row_index]
 
             if not self.is_value_equal(result_value1, result_value2, expression):
                 error_type = ValidationErrorType.CONTENT_MISMATCH
@@ -496,6 +507,9 @@ class ResultComparator:
                 return False
 
         return True
+
+    def ignore_row_order(self, expression: Expression) -> bool:
+        return False
 
     def ignore_order_when_comparing_collection(self, expression: Expression) -> bool:
         return False

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from materialize.output_consistency.expression.expression import Expression
 from materialize.output_consistency.ignore_filter.expression_matchers import (
+    is_table_function,
     matches_fun_by_name,
 )
 from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter import (
@@ -171,6 +172,16 @@ class PostgresResultComparator(ResultComparator):
             return value
 
         return match.group(1) + " " + match.group(2)
+
+    def ignore_row_order(self, expression: Expression) -> bool:
+        if expression.matches(
+            is_table_function,
+            True,
+        ):
+            # inconsistent sort order
+            return True
+
+        return False
 
     def ignore_order_when_comparing_collection(self, expression: Expression) -> bool:
         if expression.matches(

--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -18,8 +18,8 @@ from materialize.output_consistency.ignore_filter.expression_matchers import (
     is_operation_tagged,
     matches_fun_by_any_name,
     matches_fun_by_name,
+    matches_op_by_any_pattern,
     matches_op_by_pattern,
-    matches_x_or_y,
 )
 from materialize.output_consistency.ignore_filter.ignore_verdict import (
     YesIgnore,
@@ -125,15 +125,11 @@ class VersionPreExecutionInconsistencyIgnoreFilter(
             self.lower_version < MZ_VERSION_0_93_0 <= self.higher_version
             and expression.matches(
                 partial(
-                    matches_x_or_y,
-                    x=partial(
-                        matches_op_by_pattern,
-                        pattern="$ ILIKE $",
-                    ),
-                    y=partial(
-                        matches_op_by_pattern,
-                        pattern="$ NOT ILIKE $",
-                    ),
+                    matches_op_by_any_pattern,
+                    patterns={
+                        "$ ILIKE $",
+                        "$ NOT ILIKE $",
+                    },
                 ),
                 True,
             )


### PR DESCRIPTION
### Commits
7175982905 output consistency: mark table functions
5b5ad6936d output consistency: add table functions
13a2585ca1 output consistency: rename enum constant params
439d3ce867 output consistency: allow ignoring row order
6038acac09 output consistency: fix column sorting
f23e701481 output consistency: disable generate_series on date-time parameters
56617732f1 output consistency: expression matcher: add matcher argument_has_any_characteristic
a474b1212b version consistency: simplify ignore
b7edb0d2f5 postgres consistency: add ignore entries
1611254017 postgres consistency: ignore row order when table functions are involved
4f364dd955 postgres consistency: add ignore entry when sort order cannot be guaranteed

### Issues
* https://github.com/MaterializeInc/materialize/issues/28806
* https://github.com/MaterializeInc/materialize/issues/28393
* https://github.com/MaterializeInc/materialize/issues/28871
* https://github.com/MaterializeInc/materialize/issues/28390

### Nightly
https://buildkite.com/materialize/nightly/builds?branch=nrainer-materialize%3Aoutput-consistency%2Ftable-functions