### PR TITLE
bazel: Fix build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -437,7 +437,6 @@ crates_repository(
         "//:src/pgwire/Cargo.toml",
         "//:src/postgres-client/Cargo.toml",
         "//:src/postgres-util/Cargo.toml",
-        "//:src/proc/Cargo.toml",
         "//:src/prof-http/Cargo.toml",
         "//:src/prof/Cargo.toml",
         "//:src/proto/Cargo.toml",


### PR DESCRIPTION
The `proc` crate was recently deleted but Bazel was trying to find it.

### Motivation

Fix nightly

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
