### PR TITLE
storage: don't artificially forward table upper to register_ts

### DIFF
--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1556,7 +1556,7 @@ where
                 None => data_shard_since,
             };
 
-            let mut collection_state = CollectionState::new(
+            let collection_state = CollectionState::new(
                 description,
                 initial_since,
                 write_frontier.clone(),
@@ -1601,18 +1601,6 @@ where
                     self_collections.insert(id, collection_state);
                 }
                 DataSource::Other(DataSourceOther::TableWrites) => {
-                    let register_ts = register_ts
-                        .as_ref()
-                        .expect("caller should have provided a register_ts when creating a table");
-                    // This register call advances the logical upper of the
-                    // table. The register call eventually circles that info
-                    // back to us, but some tests fail if we don't synchronously
-                    // update it in create_collections, so just do that now.
-                    let advance_to = mz_persist_types::StepForward::step_forward(register_ts);
-
-                    if collection_state.write_frontier.less_than(&advance_to) {
-                        collection_state.write_frontier = Antichain::from_elem(advance_to.clone());
-                    }
                     self_collections.insert(id, collection_state);
                 }
                 DataSource::Progress | DataSource::Other(DataSourceOther::Compute) => {


### PR DESCRIPTION
Work towards zero-downtime upgrades: #27406

This was a hack for tests that is (apparently) not needed anymore, plus it interferes with read-only mode, where we never write to table and therefore tables never become readable at their artificially advanced upper.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
