### PR TITLE
Reduce `Join::equivalences` in EQProp

### DIFF
--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -284,21 +284,8 @@ impl EquivalencePropagation {
                 // Certain equivalences are ensured by each of the inputs.
                 // Other equivalences are imposed by parents of the expression.
                 // We must not weaken the properties provided by the expression to its parents,
-                // meaning we can optimize `equivalences` with respect to input guararentees,
+                // meaning we can optimize `equivalences` with respect to input guarantees,
                 // but not with respect to `outer_equivalences`.
-
-                let mut join_equivalences = EquivalenceClasses::default();
-                join_equivalences
-                    .classes
-                    .extend(equivalences.iter().cloned());
-
-                // // Optionally, introduce `outer_equivalences` into `equivalences`.
-                // // This is not required, but it could be very helpful. To be seen.
-                // join_equivalences
-                //     .classes
-                //     .extend(outer_equivalences.classes.clone());
-
-                join_equivalences.minimize(expr_type);
 
                 // Each child can be presented with the integration of `join_equivalences`, `outer_equivalences`,
                 // and each input equivalence *other than* their own, projected onto the input's columns.
@@ -322,10 +309,38 @@ impl EquivalencePropagation {
                     if let Some(mut equivalences) = equivalences {
                         let permutation = (columns..(columns + child_arity)).collect::<Vec<_>>();
                         equivalences.permute(&permutation);
+                        equivalences.minimize(expr_type);
                         input_equivalences.push(equivalences);
                     }
                     columns += child_arity;
                 }
+
+                // Form the equivalences we will use to replace `equivalences`.
+                let mut join_equivalences = EquivalenceClasses::default();
+                join_equivalences
+                    .classes
+                    .extend(equivalences.iter().cloned());
+                // // Optionally, introduce `outer_equivalences` into `equivalences`.
+                // // This is not required, but it could be very helpful. To be seen.
+                // join_equivalences
+                //     .classes
+                //     .extend(outer_equivalences.classes.clone());
+
+                // Reduce join equivalences by the input equivalences.
+                for input_equivs in input_equivalences.iter() {
+                    for class in join_equivalences.classes.iter_mut() {
+                        for expr in class.iter_mut() {
+                            // Semijoin elimination currently fails if you do more advanced simplification than
+                            // literal substitution.
+                            let old = expr.clone();
+                            input_equivs.reduce_expr(expr);
+                            if !expr.is_literal() {
+                                expr.clone_from(&old);
+                            }
+                        }
+                    }
+                }
+                join_equivalences.minimize(expr_type);
 
                 // Revisit each child, determining the information to present to it, and recurring.
                 let mut columns = 0;


### PR DESCRIPTION
The `EquivalencePropagation` transform was pushing down predicates through `Join`, but was not applying expression simplification to expressions in `Join::equivalences` as it went. This meant that e.g. columns that were known to be constants weren't being substituted, and non-trivial but pointless equivalences (and the columns on which they depend) were retained.

This PR fixes this by reducing expressions in `equivalences` by the implied input equivalences (permuted to point their column references at the right things). It continues to minimize these equivalences (i.e. reduce them relative to themselves), but that might have a different effect with more information introduced into them.

### Motivation

This missing behavior prevents the removal of `ColumnKnowledge`, as that transform performs this reduction.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
