### PR TITLE
sql-pretty: CREATE SOURCE merge skew fix

### DIFF
--- a/src/sql-pretty/src/doc.rs
+++ b/src/sql-pretty/src/doc.rs
@@ -70,8 +70,8 @@ pub(crate) fn doc_create_source<T: AstInfo>(v: &CreateSourceStatement<T>) -> RcD
     if let Some(envelope) = &v.envelope {
         docs.push(nest_title("ENVELOPE", doc_display_pass(envelope)));
     }
-    if let Some(subsources) = &v.referenced_subsources {
-        docs.push(doc_referenced_subsources(subsources));
+    if let Some(references) = &v.external_references {
+        docs.push(doc_external_references(references));
     }
     if let Some(progress) = &v.progress_subsource {
         docs.push(nest_title("EXPOSE PROGRESS AS", doc_display_pass(progress)));
@@ -86,19 +86,19 @@ pub(crate) fn doc_create_source<T: AstInfo>(v: &CreateSourceStatement<T>) -> RcD
     RcDoc::intersperse(docs, Doc::line()).group()
 }
 
-fn doc_referenced_subsources(v: &ReferencedSubsources) -> RcDoc {
+fn doc_external_references(v: &ExternalReferences) -> RcDoc {
     match v {
-        ReferencedSubsources::SubsetTables(subsources) => bracket(
+        ExternalReferences::SubsetTables(subsources) => bracket(
             "FOR TABLES (",
             comma_separate(doc_display_pass, subsources),
             ")",
         ),
-        ReferencedSubsources::SubsetSchemas(schemas) => bracket(
+        ExternalReferences::SubsetSchemas(schemas) => bracket(
             "FOR SCHEMAS (",
             comma_separate(doc_display_pass, schemas),
             ")",
         ),
-        ReferencedSubsources::All => RcDoc::text("FOR ALL TABLES"),
+        ExternalReferences::All => RcDoc::text("FOR ALL TABLES"),
     }
 }
 


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a