### PR TITLE
docs: Add demo link to ingest pages

### DIFF
--- a/doc/user/assets/sass/_base.scss
+++ b/doc/user/assets/sass/_base.scss
@@ -103,6 +103,12 @@ body.dark {
     --note-border: #b9a61545;
     --note-after: #fbe2d9;
     --note-gutter: #ffe600;
+
+    --tip: #3f3b4291;
+    --tip-border: #983fb1;
+    --tip-after: #761c91;
+    --tip-gutter: #b115b9;
+
     // NOTE(benesch): please ensure these colors stay blueish. Public preview
     // requires a mild amount of caution. Importantly, green is not the right
     // color, as that implies encouragement rather than caution.
@@ -141,6 +147,12 @@ body.light {
     --note-border: #b9a61545;
     --note-after: #fbe2d9;
     --note-gutter: #7b7b29;
+
+    --tip: #f4e3fd91;
+    --tip-border: #983fb1;
+    --tip-after: #761c91;
+    --tip-gutter: #b115b9;
+
     // NOTE(benesch): please ensure these colors stay blueish. Public preview
     // requires a mild amount of caution. Importantly, green is not the right
     // color, as that implies encouragement rather than caution.
@@ -232,6 +244,7 @@ nav {
 
 p > a,
 .note > a,
+.tip > a,
 .link-with-code {
     color: var(--link);
 

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -142,7 +142,8 @@ p+p {
 
     pre,
     .warning,
-    .note {
+    .note,
+	.tip {
         font-size: 1.5rem;
         font-weight: 300;
     }
@@ -502,6 +503,34 @@ p+p {
         }
     }
 
+    .tip {
+        background: var(--tip);
+        border: 1px solid var(--tip-border);
+
+        a {
+            &:hover,
+            &:focus {
+                color: var(--sub) !important;
+            }
+
+            code {
+                &:hover,
+                &:focus {
+                    color: var(--sub) !important;
+                }
+            }
+        }
+
+        &::after {
+            border-color: var(--bg) var(--bg) var(--tip-after) var(--tip-after);
+            background: var(--tip-after);
+        }
+
+        .gutter {
+            color: var(--tip-gutter);
+        }
+    }
+
     .public-preview {
         background: var(--public-preview);
         border: 1px solid var(--public-preview-border);
@@ -519,6 +548,7 @@ p+p {
 
     .warning,
     .note,
+    .tip,
     .private-preview,
     .public-preview {
         box-sizing: border-box;
@@ -1122,6 +1152,17 @@ body.dark .content {
         &::after {
             border-color: --var(--note-border);
             background: var(--note);
+        }
+    }
+
+    .tip {
+        a {
+            color: var(--link);
+        }
+
+        &::after {
+            border-color: --var(--tip-border);
+            background: var(--tip);
         }
     }
 

--- a/doc/user/content/free-trial-faqs.md
+++ b/doc/user/content/free-trial-faqs.md
@@ -11,6 +11,10 @@ When you [sign up for Materialize](https://materialize.com/register/), you get a
 free trial account so you can explore the product and start building! This page
 answers some frequently asked questions about free trials.
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## What are the limits of a free trial?
 
 In Materialize, [clusters](/concepts/clusters/) are the pools of
@@ -36,7 +40,7 @@ is under the rate limit of 4 credits per hour.
 
 7 days.
 
-If you need additional time, please [chat with our team](http://materialize.com/convert-account/).
+If you need additional time, please [chat with our team](http://materialize.com/convert-account/?utm_campaign=General&utm_source=documentation).
 Otherwise, Materialize will delete your resources and data at the end of the
 trial period.
 
@@ -73,7 +77,7 @@ Error: creating cluster replica would violate max_credit_consumption_rate limit 
 Hint: Drop an existing cluster replica or contact support to request a limit increase.
 ```
 
-If you need additional resources during your trial, [chat with our team](http://materialize.com/convert-account/).
+If you need additional resources during your trial, [chat with our team](http://materialize.com/convert-account/?utm_campaign=General&utm_source=documentation).
 
 ## How do I get help during my trial?
 

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -306,6 +306,10 @@ DROP TABLE fraud_accounts;
 
 ## What's next?
 
+{{< note >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /note >}}
+
 [//]: # "TODO(morsapaes) Extend to suggest third party tools. dbt, Census and Metabase could all fit here to do interesting things as a follow-up."
 
 To get started ingesting your own data from an external system like Kafka, MySQL

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -306,13 +306,13 @@ DROP TABLE fraud_accounts;
 
 ## What's next?
 
-{{< note >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
-{{< /note >}}
-
 [//]: # "TODO(morsapaes) Extend to suggest third party tools. dbt, Census and Metabase could all fit here to do interesting things as a follow-up."
 
 To get started ingesting your own data from an external system like Kafka, MySQL
 or PostgreSQL, check the documentation for [sources](/sql/create-source/), and
 navigate to **Data** > **Sources** > **New source** in the [Materialize Console](https://console.materialize.com/)
 to create your first source.
+
+For help getting started with your data or other questions about Materialize,
+you can schedule a [free guided
+trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).

--- a/doc/user/content/ingest-data/amazon-eventbridge.md
+++ b/doc/user/content/ingest-data/amazon-eventbridge.md
@@ -12,6 +12,10 @@ aliases:
 This guide walks through the steps to ingest data from [Amazon EventBridge](https://aws.amazon.com/eventbridge/)
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 Ensure that you have:

--- a/doc/user/content/ingest-data/amazon-eventbridge.md
+++ b/doc/user/content/ingest-data/amazon-eventbridge.md
@@ -13,7 +13,7 @@ This guide walks through the steps to ingest data from [Amazon EventBridge](http
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/ingest-data/amazon-msk.md
+++ b/doc/user/content/ingest-data/amazon-msk.md
@@ -17,7 +17,7 @@ with the Postgres ones. We should include spill to disk in the guidance then."
 This guide goes through the required steps to connect Materialize to an Amazon MSK cluster.
 
 {{< tip >}}
-For help getting started with your own data, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/ingest-data/amazon-msk.md
+++ b/doc/user/content/ingest-data/amazon-msk.md
@@ -17,7 +17,7 @@ with the Postgres ones. We should include spill to disk in the guidance then."
 This guide goes through the required steps to connect Materialize to an Amazon MSK cluster.
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+For help getting started with your own data, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/ingest-data/amazon-msk.md
+++ b/doc/user/content/ingest-data/amazon-msk.md
@@ -16,6 +16,10 @@ with the Postgres ones. We should include spill to disk in the guidance then."
 
 This guide goes through the required steps to connect Materialize to an Amazon MSK cluster.
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 Before you begin, you must have:

--- a/doc/user/content/ingest-data/cdc-sql-server.md
+++ b/doc/user/content/ingest-data/cdc-sql-server.md
@@ -18,6 +18,10 @@ Server database to downstream consumers. In this guide, we’ll cover how to use
 Materialize to create and efficiently maintain real-time materialized views on
 top of CDC data.
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Kafka + Debezium
 
 Use [Debezium](https://debezium.io/) and the [Kafka source](/sql/create-source/kafka/#using-debezium)

--- a/doc/user/content/ingest-data/cdc-sql-server.md
+++ b/doc/user/content/ingest-data/cdc-sql-server.md
@@ -19,7 +19,7 @@ Materialize to create and efficiently maintain real-time materialized views on
 top of CDC data.
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Kafka + Debezium

--- a/doc/user/content/ingest-data/confluent-cloud.md
+++ b/doc/user/content/ingest-data/confluent-cloud.md
@@ -17,7 +17,7 @@ This guide goes through the required steps to connect Materialize to a Confluent
 Cloud Kafka cluster.
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 If you already have a Confluent Cloud Kafka cluster, you can skip step 1 and

--- a/doc/user/content/ingest-data/confluent-cloud.md
+++ b/doc/user/content/ingest-data/confluent-cloud.md
@@ -16,6 +16,10 @@ with the Postgres ones. We should include spill to disk in the guidance then."
 This guide goes through the required steps to connect Materialize to a Confluent
 Cloud Kafka cluster.
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 If you already have a Confluent Cloud Kafka cluster, you can skip step 1 and
 directly move on to [Create an API Key](#create-an-api-key). You can also skip
 step 3 if you already have a Confluent Cloud Kafka cluster up and running, and

--- a/doc/user/content/ingest-data/hubspot.md
+++ b/doc/user/content/ingest-data/hubspot.md
@@ -11,7 +11,7 @@ This guide walks through the steps to ingest data from [HubSpot](https://www.hub
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ### Before you begin

--- a/doc/user/content/ingest-data/hubspot.md
+++ b/doc/user/content/ingest-data/hubspot.md
@@ -10,6 +10,10 @@ menu:
 This guide walks through the steps to ingest data from [HubSpot](https://www.hubspot.com/)
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ### Before you begin
 
 Ensure that you have:

--- a/doc/user/content/ingest-data/kafka-self-hosted.md
+++ b/doc/user/content/ingest-data/kafka-self-hosted.md
@@ -17,6 +17,10 @@ with the Postgres ones. We should include spill to disk in the guidance then."
 This guide goes through the required steps to connect Materialize to a
 self-hosted Kafka cluster.
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 Before you begin, you must have:

--- a/doc/user/content/ingest-data/kafka-self-hosted.md
+++ b/doc/user/content/ingest-data/kafka-self-hosted.md
@@ -18,7 +18,7 @@ This guide goes through the required steps to connect Materialize to a
 self-hosted Kafka cluster.
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/ingest-data/mysql/amazon-aurora.md
+++ b/doc/user/content/ingest-data/mysql/amazon-aurora.md
@@ -13,6 +13,10 @@ menu:
 This page shows you how to stream data from [Amazon Aurora MySQL](https://aws.amazon.com/rds/aurora/)
 to Materialize using the [MySQL source](/sql/create-source/mysql/).
 
+{{< tip >}}
+{{< guided-tour-blurb-for-ingest-data >}}
+{{< /tip >}}
+
 ## Before you begin
 
 {{% mysql-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/mysql/amazon-rds.md
+++ b/doc/user/content/ingest-data/mysql/amazon-rds.md
@@ -13,6 +13,10 @@ menu:
 This page shows you how to stream data from [Amazon RDS for MySQL](https://aws.amazon.com/rds/mysql/)
 to Materialize using the [MySQL source](/sql/create-source/mysql).
 
+{{< tip >}}
+{{< guided-tour-blurb-for-ingest-data >}}
+{{< /tip >}}
+
 ## Before you begin
 
 {{% mysql-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/mysql/azure-db.md
+++ b/doc/user/content/ingest-data/mysql/azure-db.md
@@ -13,6 +13,10 @@ menu:
 This page shows you how to stream data from [Azure DB for MySQL](https://azure.microsoft.com/en-us/products/MySQL)
 to Materialize using the [MySQL source](/sql/create-source/mysql/).
 
+{{< tip >}}
+{{< guided-tour-blurb-for-ingest-data >}}
+{{< /tip >}}
+
 ## Before you begin
 
 {{% mysql-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/mysql/debezium.md
+++ b/doc/user/content/ingest-data/mysql/debezium.md
@@ -18,6 +18,10 @@ database to downstream consumers based on its binary log (`binlog`). In this
 guide, we'll cover how to use Materialize to create and efficiently maintain
 real-time materialized views on top of CDC data.
 
+{{< tip >}}
+{{< guided-tour-blurb-for-ingest-data >}}
+{{< /tip >}}
+
 ## Kafka + Debezium
 
 You can use [Debezium](https://debezium.io/) and the [Kafka source](/sql/create-source/kafka/#using-debezium)

--- a/doc/user/content/ingest-data/mysql/google-cloud-sql.md
+++ b/doc/user/content/ingest-data/mysql/google-cloud-sql.md
@@ -13,6 +13,10 @@ menu:
 This page shows you how to stream data from [Google Cloud SQL for MySQL](https://cloud.google.com/sql/MySQL)
 to Materialize using the[MySQL source](/sql/create-source/mysql/).
 
+{{< tip >}}
+{{< guided-tour-blurb-for-ingest-data >}}
+{{< /tip >}}
+
 ## Before you begin
 
 {{% mysql-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/mysql/self-hosted.md
+++ b/doc/user/content/ingest-data/mysql/self-hosted.md
@@ -13,6 +13,10 @@ menu:
 This page shows you how to stream data from a self-hosted MySQL database to
 Materialize using the [MySQL source](/sql/create-source/mysql/).
 
+{{< tip >}}
+{{< guided-tour-blurb-for-ingest-data >}}
+{{< /tip >}}
+
 ## Before you begin
 
 {{% mysql-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/postgres/alloydb.md
+++ b/doc/user/content/ingest-data/postgres/alloydb.md
@@ -14,7 +14,7 @@ This page shows you how to stream data from [AlloyDB for PostgreSQL](https://clo
 to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/ingest-data/postgres/alloydb.md
+++ b/doc/user/content/ingest-data/postgres/alloydb.md
@@ -13,6 +13,10 @@ menu:
 This page shows you how to stream data from [AlloyDB for PostgreSQL](https://cloud.google.com/alloydb)
 to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 {{% postgres-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/postgres/amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres/amazon-aurora.md
@@ -13,6 +13,10 @@ menu:
 This page shows you how to stream data from [Amazon Aurora for PostgreSQL](https://aws.amazon.com/rds/aurora/)
 to Materialize using the[PostgreSQL source](/sql/create-source/postgres/).
 
+{{< note >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /note >}}
+
 ## Before you begin
 
 {{% postgres-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/postgres/amazon-aurora.md
+++ b/doc/user/content/ingest-data/postgres/amazon-aurora.md
@@ -13,9 +13,9 @@ menu:
 This page shows you how to stream data from [Amazon Aurora for PostgreSQL](https://aws.amazon.com/rds/aurora/)
 to Materialize using the[PostgreSQL source](/sql/create-source/postgres/).
 
-{{< note >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
-{{< /note >}}
+{{< tip >}}
+{{< guided-tour-blurb-for-ingest-data >}}
+{{< /tip >}}
 
 ## Before you begin
 

--- a/doc/user/content/ingest-data/postgres/amazon-rds.md
+++ b/doc/user/content/ingest-data/postgres/amazon-rds.md
@@ -16,6 +16,10 @@ menu:
 This page shows you how to stream data from [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/)
 to Materialize using the[PostgreSQL source](/sql/create-source/postgres/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 {{% postgres-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/postgres/amazon-rds.md
+++ b/doc/user/content/ingest-data/postgres/amazon-rds.md
@@ -17,7 +17,7 @@ This page shows you how to stream data from [Amazon RDS for PostgreSQL](https://
 to Materialize using the[PostgreSQL source](/sql/create-source/postgres/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/ingest-data/postgres/azure-db.md
+++ b/doc/user/content/ingest-data/postgres/azure-db.md
@@ -14,7 +14,7 @@ This page shows you how to stream data from [Azure DB for PostgreSQL](https://az
 to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/ingest-data/postgres/azure-db.md
+++ b/doc/user/content/ingest-data/postgres/azure-db.md
@@ -13,6 +13,10 @@ menu:
 This page shows you how to stream data from [Azure DB for PostgreSQL](https://azure.microsoft.com/en-us/products/postgresql)
 to Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 {{% postgres-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/postgres/cloud-sql.md
+++ b/doc/user/content/ingest-data/postgres/cloud-sql.md
@@ -14,8 +14,9 @@ This page shows you how to stream data from [Google Cloud SQL for PostgreSQL](ht
 to Materialize using the[PostgreSQL source](/sql/create-source/postgres/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
+
 
 ## Before you begin
 

--- a/doc/user/content/ingest-data/postgres/cloud-sql.md
+++ b/doc/user/content/ingest-data/postgres/cloud-sql.md
@@ -13,6 +13,10 @@ menu:
 This page shows you how to stream data from [Google Cloud SQL for PostgreSQL](https://cloud.google.com/sql/postgresql)
 to Materialize using the[PostgreSQL source](/sql/create-source/postgres/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 {{% postgres-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/postgres/debezium.md
+++ b/doc/user/content/ingest-data/postgres/debezium.md
@@ -20,6 +20,10 @@ changes resulting from `INSERT`, `UPDATE` and `DELETE` operations in the
 upstream database and publishes them as events to Kafka using Kafka
 Connect-compatible connectors.
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## A. Configure database
 
 **Minimum requirements:** PostgreSQL 11+

--- a/doc/user/content/ingest-data/postgres/debezium.md
+++ b/doc/user/content/ingest-data/postgres/debezium.md
@@ -21,7 +21,7 @@ upstream database and publishes them as events to Kafka using Kafka
 Connect-compatible connectors.
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## A. Configure database

--- a/doc/user/content/ingest-data/postgres/self-hosted.md
+++ b/doc/user/content/ingest-data/postgres/self-hosted.md
@@ -13,6 +13,10 @@ menu:
 This page shows you how to stream data from a self-hosted PostgreSQL database to
 Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 {{% postgres-direct/before-you-begin %}}

--- a/doc/user/content/ingest-data/postgres/self-hosted.md
+++ b/doc/user/content/ingest-data/postgres/self-hosted.md
@@ -14,7 +14,7 @@ This page shows you how to stream data from a self-hosted PostgreSQL database to
 Materialize using the [PostgreSQL source](/sql/create-source/postgres/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/ingest-data/redpanda-cloud.md
+++ b/doc/user/content/ingest-data/redpanda-cloud.md
@@ -17,6 +17,10 @@ This guide goes through the required steps to connect Materialize to a Redpanda
 Cloud cluster. If you already have a Redpanda Cloud cluster up and running,
 skip straight to [Step 2](#step-2-create-a-user).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Step 1. Create a Redpanda Cloud cluster
 
 {{< note >}}

--- a/doc/user/content/ingest-data/redpanda-cloud.md
+++ b/doc/user/content/ingest-data/redpanda-cloud.md
@@ -18,7 +18,7 @@ Cloud cluster. If you already have a Redpanda Cloud cluster up and running,
 skip straight to [Step 2](#step-2-create-a-user).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Step 1. Create a Redpanda Cloud cluster

--- a/doc/user/content/ingest-data/redpanda.md
+++ b/doc/user/content/ingest-data/redpanda.md
@@ -15,7 +15,12 @@ menu:
 [//]: # "TODO(morsapaes) The Kafka guides need to be rewritten for consistency
 with the Postgres ones. We should include spill to disk in the guidance then."
 
-Because [Redpanda](https://vectorized.io/) is Kafka API-compatible, Materialize can process data from it in the same way it processes data from Kafka sources.
+Because [Redpanda](https://vectorized.io/) is Kafka API-compatible, Materialize
+can process data from it in the same way it processes data from Kafka sources.
+
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
 
 ## Configuration
 

--- a/doc/user/content/ingest-data/redpanda.md
+++ b/doc/user/content/ingest-data/redpanda.md
@@ -19,7 +19,7 @@ Because [Redpanda](https://vectorized.io/) is Kafka API-compatible, Materialize
 can process data from it in the same way it processes data from Kafka sources.
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Configuration

--- a/doc/user/content/ingest-data/rudderstack.md
+++ b/doc/user/content/ingest-data/rudderstack.md
@@ -11,7 +11,7 @@ This guide walks through the steps to ingest data from [RudderStack](https://rud
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/ingest-data/rudderstack.md
+++ b/doc/user/content/ingest-data/rudderstack.md
@@ -10,6 +10,10 @@ menu:
 This guide walks through the steps to ingest data from [RudderStack](https://rudderstack.com/)
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 Ensure that you have:

--- a/doc/user/content/ingest-data/segment.md
+++ b/doc/user/content/ingest-data/segment.md
@@ -12,6 +12,10 @@ aliases:
 This guide walks through the steps to ingest data from [Segment](https://segment.com/)
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ### Before you begin
 
 Ensure that you have:

--- a/doc/user/content/ingest-data/segment.md
+++ b/doc/user/content/ingest-data/segment.md
@@ -13,7 +13,7 @@ This guide walks through the steps to ingest data from [Segment](https://segment
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ### Before you begin

--- a/doc/user/content/ingest-data/snowcatcloud.md
+++ b/doc/user/content/ingest-data/snowcatcloud.md
@@ -11,7 +11,7 @@ This guide walks through the steps to ingest data from [SnowcatCloud](https://ww
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/ingest-data/snowcatcloud.md
+++ b/doc/user/content/ingest-data/snowcatcloud.md
@@ -10,6 +10,10 @@ menu:
 This guide walks through the steps to ingest data from [SnowcatCloud](https://www.snowcatcloud.com/)
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 Ensure that you have:

--- a/doc/user/content/ingest-data/stripe.md
+++ b/doc/user/content/ingest-data/stripe.md
@@ -13,7 +13,7 @@ This guide walks through the steps to ingest data from [Stripe](https://stripe.c
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ### Before you begin

--- a/doc/user/content/ingest-data/stripe.md
+++ b/doc/user/content/ingest-data/stripe.md
@@ -12,6 +12,10 @@ aliases:
 This guide walks through the steps to ingest data from [Stripe](https://stripe.com/)
 into Materialize using the [Webhook source](/sql/create-source/webhook/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ### Before you begin
 
 Ensure that you have a Stripe account.

--- a/doc/user/content/ingest-data/troubleshooting.md
+++ b/doc/user/content/ingest-data/troubleshooting.md
@@ -20,7 +20,7 @@ troubleshooting guidance for slow or unresponsive queries, check out the
 instead.
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Why isn't my source ingesting data?

--- a/doc/user/content/ingest-data/troubleshooting.md
+++ b/doc/user/content/ingest-data/troubleshooting.md
@@ -19,6 +19,10 @@ troubleshooting guidance for slow or unresponsive queries, check out the
 [`Transform data` troubleshooting](/transform-data/troubleshooting) guide
 instead.
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Why isn't my source ingesting data?
 
 First, check the status of your source in the Materialize console by navigating

--- a/doc/user/content/ingest-data/upstash-kafka.md
+++ b/doc/user/content/ingest-data/upstash-kafka.md
@@ -16,6 +16,10 @@ with the Postgres ones. We should include spill to disk in the guidance then."
 This guide goes through the required steps to connect Materialize to an Upstash
 Kafka cluster.
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 If you already have an Upstash Kafka cluster, you can skip steps 1 and 2 and
 directly move on to [Create a topic](#create-a-topic). You can also skip step 3
 if you already have an Upstash Kafka cluster up and running, and have created a

--- a/doc/user/content/ingest-data/upstash-kafka.md
+++ b/doc/user/content/ingest-data/upstash-kafka.md
@@ -17,7 +17,7 @@ This guide goes through the required steps to connect Materialize to an Upstash
 Kafka cluster.
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 If you already have an Upstash Kafka cluster, you can skip steps 1 and 2 and

--- a/doc/user/content/ingest-data/warpstream.md
+++ b/doc/user/content/ingest-data/warpstream.md
@@ -23,7 +23,7 @@ costs and no local disks management. This guide highlights its integration with
 Materialize using [Fly.io](https://fly.io/).
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 #### Before you begin

--- a/doc/user/content/ingest-data/warpstream.md
+++ b/doc/user/content/ingest-data/warpstream.md
@@ -22,6 +22,10 @@ Storage, Azure Blob Storage) and offers benefits such as no inter-AZ bandwidth
 costs and no local disks management. This guide highlights its integration with
 Materialize using [Fly.io](https://fly.io/).
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 #### Before you begin
 
 Ensure you have the following:

--- a/doc/user/content/ingest-data/webhook-quickstart.md
+++ b/doc/user/content/ingest-data/webhook-quickstart.md
@@ -13,6 +13,10 @@ Webhook sources let your applications push webhook events into Materialize. This
 quickstart uses an embedded **webhook event generator** that makes it easier for
 you to learn and prototype with no external dependencies.
 
+{{< tip >}}
+For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< /tip >}}
+
 ## Before you begin
 
 All you need is a Materialize account. If you already have one —

--- a/doc/user/content/ingest-data/webhook-quickstart.md
+++ b/doc/user/content/ingest-data/webhook-quickstart.md
@@ -14,7 +14,7 @@ quickstart uses an embedded **webhook event generator** that makes it easier for
 you to learn and prototype with no external dependencies.
 
 {{< tip >}}
-For help getting started with your data or other questions about Materialize, you can schedule a [free guided trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).
+{{< guided-tour-blurb-for-ingest-data >}}
 {{< /tip >}}
 
 ## Before you begin

--- a/doc/user/content/stylesheet.md
+++ b/doc/user/content/stylesheet.md
@@ -62,6 +62,13 @@ Diagrams from [rr.red-dove.com/ui](https://rr.red-dove.com/ui):
 This is a note.
 {{</ note >}}
 
+### `tip` shortcode
+
+{{< tip >}}
+This is a tip.
+{{</ tip >}}
+
+
 ### `warning` shortcode
 
 {{< warning >}}

--- a/doc/user/layouts/shortcodes/guided-tour-blurb-for-ingest-data.html
+++ b/doc/user/layouts/shortcodes/guided-tour-blurb-for-ingest-data.html
@@ -1,0 +1,2 @@
+For help getting started with your own data, you can schedule a [free guided
+trial](https://materialize.com/demo/?utm_campaign=General&utm_source=documentation).

--- a/doc/user/layouts/shortcodes/tip.html
+++ b/doc/user/layouts/shortcodes/tip.html
@@ -1,0 +1,4 @@
+<div class="tip">
+  <strong class="gutter">
+    💡 Tip: </strong> {{ .Inner | $.Page.RenderString }}
+</div>


### PR DESCRIPTION
- Added as a tip for users who might want a bit more guidance on the ingest data pages.
   - Skipped the MySQL pages since those already require users get in touch to turn on the preview features.  But, can add if we think having the tip on those pages could also help.
- Added CSS for tips (not sure what the process is on updating CSS).