### PR TITLE
doc: DBeaver guide show system objects

### DIFF
--- a/doc/user/content/integrations/sql-clients.md
+++ b/doc/user/content/integrations/sql-clients.md
@@ -130,7 +130,7 @@ To show system objects in the database explorer:
 
 1. Right-click on the database connection in the **Database Navigator**.
 1. Click on **Edit Connection**.
-1. In the **Connection settings** tab, check click **General**.
+1. In the **Connection settings** tab, select **General**.
 1. Next to the **Navigator view**, click **Customize**.
 1. In the **Navigator settings** dialog, check **Show system objects**.
 1. Click **OK**.

--- a/doc/user/content/integrations/sql-clients.md
+++ b/doc/user/content/integrations/sql-clients.md
@@ -121,6 +121,20 @@ Alternatively, you can change the default value of the `cluster` configuration
 parameter for a specific user (i.e. role) using the [`ALTER
 ROLE...SET`](/sql/alter-role) command.
 
+#### Show system objects
+
+By default, DBeaver hides system objects in the database explorer. This
+includes tables, views, and other objects that start with `pg_` or `mz_`.
+
+To show system objects in the database explorer:
+
+1. Right-click on the database connection in the **Database Navigator**.
+1. Click on **Edit Connection**.
+1. In the **Connection settings** tab, check click **General**.
+1. Next to the **Navigator view**, click **Customize**.
+1. In the **Navigator settings** dialog, check **Show system objects**.
+1. Click **OK**.
+
 ### TablePlus
 
 {{< note >}}

--- a/doc/user/content/integrations/sql-clients.md
+++ b/doc/user/content/integrations/sql-clients.md
@@ -123,8 +123,9 @@ ROLE...SET`](/sql/alter-role) command.
 
 #### Show system objects
 
-By default, DBeaver hides system objects in the database explorer. This
-includes tables, views, and other objects that start with `pg_` or `mz_`.
+By default, DBeaver hides system catalog objects in the database explorer. This
+includes tables, views, and other objects in the `mz_catalog` and `mz_internal`
+schemas.
 
 To show system objects in the database explorer:
 

--- a/doc/user/content/integrations/sql-clients.md
+++ b/doc/user/content/integrations/sql-clients.md
@@ -132,7 +132,7 @@ To show system objects in the database explorer:
 1. Click on **Edit Connection**.
 1. In the **Connection settings** tab, select **General**.
 1. Next to the **Navigator view**, click **Customize**.
-1. In the **Navigator settings** dialog, check **Show system objects**.
+1. In the **Navigator settings** dialog, check the **Show system objects** checkbox.
 1. Click **OK**.
 
 ### TablePlus


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

By default, DBeaver hides system objects in the database explorer. This
includes tables, views, and other objects that start with `pg_` or `mz_`.

Adding instructions on how to show those.