### PR TITLE
test-analytics: Add tables and view for ci-failures, Store known issues

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -40,6 +40,7 @@ from materialize.buildkite_insights.util.build_step_utils import (
 )
 from materialize.cli.mzcompose import JUNIT_ERROR_DETAILS_SEPARATOR
 from materialize.github import (
+    KnownGitHubIssue,
     for_github_re,
     get_known_issues_from_github,
 )
@@ -607,6 +608,8 @@ def annotate_logged_errors(
 
         store_annotation_in_test_analytics(test_analytics, annotation)
 
+    store_known_issues_in_test_analytics(test_analytics, known_issues)
+
     return len(unknown_errors)
 
 
@@ -864,6 +867,13 @@ def format_message_as_code_block(
 
     # Don't have too huge output, so truncate
     return f"```\n{sanitize_text(error_message, max_length)}\n```"
+
+
+def store_known_issues_in_test_analytics(
+    test_analytics: TestAnalyticsDb, known_issues: list[KnownGitHubIssue]
+) -> None:
+    for issue in known_issues:
+        test_analytics.known_issues.add_issue(issue)
 
 
 def store_annotation_in_test_analytics(

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -873,7 +873,7 @@ def store_known_issues_in_test_analytics(
     test_analytics: TestAnalyticsDb, known_issues: list[KnownGitHubIssue]
 ) -> None:
     for issue in known_issues:
-        test_analytics.known_issues.add_issue(issue)
+        test_analytics.known_issues.add_or_update_issue(issue)
 
 
 def store_annotation_in_test_analytics(

--- a/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
+++ b/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
@@ -135,7 +135,7 @@ class DatabaseConnector:
 
         last_executed_sql = self.update_statements[0]
 
-        print("~~~ Updates to test analytics database")
+        print("--- Updates to test analytics database")
 
         try:
             if self._use_transaction:

--- a/misc/python/materialize/test_analytics/data/known_issues/known_issues_storage.py
+++ b/misc/python/materialize/test_analytics/data/known_issues/known_issues_storage.py
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.github import KnownGitHubIssue
+from materialize.test_analytics.data.base_data_storage import BaseDataStorage
+from materialize.test_analytics.util import mz_sql_util
+
+
+class KnownIssuesStorage(BaseDataStorage):
+    def add_issue(
+        self,
+        issue: KnownGitHubIssue,
+    ) -> None:
+        issue_str = f"{issue.info['repository']['name']}/{issue.info['number']}"
+        sql_statements = [
+            f"""
+            UPDATE issues
+            SET title = {mz_sql_util.as_sanitized_literal(issue.info["title"])},
+                ci_regexp = {mz_sql_util.as_sanitized_literal(issue.regex.pattern)}
+            WHERE issue = {mz_sql_util.as_sanitized_literal(issue_str)}
+            ;
+            """,
+            f"""
+            INSERT INTO issues (issue, title, ci_regexp)
+                SELECT {mz_sql_util.as_sanitized_literal(issue_str)},
+                       {mz_sql_util.as_sanitized_literal(issue.info["title"])},
+                       {mz_sql_util.as_sanitized_literal(issue.regex.pattern)}
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM issues WHERE issue = {mz_sql_util.as_sanitized_literal(issue_str)}
+                )
+            ;
+            """,
+        ]
+
+        self.database_connector.add_update_statements(sql_statements)

--- a/misc/python/materialize/test_analytics/data/known_issues/known_issues_storage.py
+++ b/misc/python/materialize/test_analytics/data/known_issues/known_issues_storage.py
@@ -13,7 +13,7 @@ from materialize.test_analytics.util import mz_sql_util
 
 
 class KnownIssuesStorage(BaseDataStorage):
-    def add_issue(
+    def add_or_update_issue(
         self,
         issue: KnownGitHubIssue,
     ) -> None:
@@ -22,21 +22,21 @@ class KnownIssuesStorage(BaseDataStorage):
         )
         sql_statements = [
             f"""
-            UPDATE issues
+            UPDATE issue
             SET title = {mz_sql_util.as_sanitized_literal(issue.info["title"])},
                 ci_regexp = {mz_sql_util.as_sanitized_literal(issue.regex.pattern.decode("utf-8"))},
                 state = {mz_sql_util.as_sanitized_literal(issue.info["state"])}
-            WHERE issue = {mz_sql_util.as_sanitized_literal(issue_str)}
+            WHERE issue_id = {mz_sql_util.as_sanitized_literal(issue_str)}
             ;
             """,
             f"""
-            INSERT INTO issues (issue, title, ci_regexp, state)
+            INSERT INTO issue (issue_id, title, ci_regexp, state)
                 SELECT {mz_sql_util.as_sanitized_literal(issue_str)},
                        {mz_sql_util.as_sanitized_literal(issue.info["title"])},
-                       {mz_sql_util.as_sanitized_literal(issue.regex.pattern)},
+                       {mz_sql_util.as_sanitized_literal(issue.regex.pattern.decode("utf-8"))},
                        {mz_sql_util.as_sanitized_literal(issue.info["state"])}
                 WHERE NOT EXISTS (
-                    SELECT 1 FROM issues WHERE issue = {mz_sql_util.as_sanitized_literal(issue_str)}
+                    SELECT 1 FROM issue WHERE issue_id = {mz_sql_util.as_sanitized_literal(issue_str)}
                 )
             ;
             """,

--- a/misc/python/materialize/test_analytics/setup/tables/40-issues.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/40-issues.sql
@@ -7,4 +7,4 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-CREATE TABLE issues (issue TEXT NOT NULL, title TEXT NOT NULL, ci_regexp TEXT, state TEXT);
+CREATE TABLE issue (issue_id TEXT NOT NULL, title TEXT NOT NULL, ci_regexp TEXT NOT NULL, state TEXT NOT NULL);

--- a/misc/python/materialize/test_analytics/setup/tables/40-issues.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/40-issues.sql
@@ -7,4 +7,4 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-CREATE TABLE issues (issue TEXT NOT NULL, title TEXT NOT NULL, ci_regexp TEXT);
+CREATE TABLE issues (issue TEXT NOT NULL, title TEXT NOT NULL, ci_regexp TEXT, state TEXT);

--- a/misc/python/materialize/test_analytics/setup/tables/40-issues.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/40-issues.sql
@@ -1,0 +1,10 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+CREATE TABLE issues (issue TEXT NOT NULL, title TEXT NOT NULL, ci_regexp TEXT);

--- a/misc/python/materialize/test_analytics/setup/views/01-build.sql
+++ b/misc/python/materialize/test_analytics/setup/views/01-build.sql
@@ -14,6 +14,7 @@
 -- limitations under the License.
 
 CREATE OR REPLACE VIEW v_count_builds_per_week AS
+IN CLUSTER test_analytics AS
 SELECT
     EXTRACT(YEAR FROM date) AS year,
     EXTRACT(WEEK FROM date) AS week,

--- a/misc/python/materialize/test_analytics/setup/views/100-data-integrity.sql
+++ b/misc/python/materialize/test_analytics/setup/views/100-data-integrity.sql
@@ -74,4 +74,9 @@ CREATE OR REPLACE VIEW v_data_integrity (table_name, own_item_key, referenced_it
     SELECT 'config', 'config', NULL, 'more than one config entry exists'
     FROM config
     HAVING count(*) > 1
+    UNION
+    SELECT 'issue', issue_id, NULL, 'more than one issue entry exists'
+    FROM issue
+    GROUP BY issue_id
+    HAVING count(*) > 1
 ;

--- a/misc/python/materialize/test_analytics/setup/views/30-ci-failures.sql
+++ b/misc/python/materialize/test_analytics/setup/views/30-ci-failures.sql
@@ -1,0 +1,45 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+CREATE OR REPLACE MATERIALIZED VIEW mv_ci_failures AS
+    SELECT
+        pipeline || '#' || build_number AS build,
+        test_suite,
+        CASE WHEN error_type = 'KNOWN_ISSUE' THEN issue ELSE error_type END AS issue,
+        string_agg(content, '\n') AS content,
+        branch,
+        build_date,
+        mz_version,
+        commit_hash,
+        build_step_key,
+        test_retry_count,
+        occurrence_count,
+        build_id,
+        build_job_id
+    FROM v_build_annotation_error
+    GROUP BY
+        pipeline,
+        build_number,
+        test_suite,
+        error_type,
+        issue,
+        branch,
+        build_date,
+        mz_version,
+        commit_hash,
+        build_step_key,
+        test_retry_count,
+        occurrence_count,
+        build_id,
+        build_job_id
+;
+
+CREATE INDEX IN CLUSTER test_analytics ON mv_ci_failures (branch, build_date, issue);
+
+GRANT SELECT ON mv_ci_failures TO "ci-failures";

--- a/misc/python/materialize/test_analytics/setup/views/30-ci-failures.sql
+++ b/misc/python/materialize/test_analytics/setup/views/30-ci-failures.sql
@@ -8,10 +8,13 @@
 -- by the Apache License, Version 2.0.
 
 CREATE OR REPLACE MATERIALIZED VIEW mv_ci_failures AS
+IN CLUSTER test_analytics AS
     SELECT
-        pipeline || '#' || build_number AS build,
+        pipeline || '#' || build_number AS build_identifier,
         test_suite,
-        CASE WHEN error_type = 'KNOWN_ISSUE' THEN issue ELSE error_type END AS issue,
+        CASE WHEN error_type = 'KNOWN_ISSUE' THEN issue || ' (KNOWN ISSUE)' ELSE
+          CASE WHEN error_type = 'POTENTIAL_REGRESSION' THEN issue || ' (POTENTIAL REGRESSION)' ELSE
+          REPLACE(error_type, '_', ' ') END END AS issue,
         string_agg(content, '\n') AS content,
         branch,
         build_date,

--- a/misc/python/materialize/test_analytics/setup/views/31-ci-issues.sql
+++ b/misc/python/materialize/test_analytics/setup/views/31-ci-issues.sql
@@ -9,7 +9,7 @@
 
 CREATE OR REPLACE MATERIALIZED VIEW mv_ci_issues
 IN CLUSTER test_analytics AS
-    SELECT a.*, title, ci_regexp
+    SELECT a.*, title, ci_regexp, state
     FROM (
         SELECT
             issue,

--- a/misc/python/materialize/test_analytics/setup/views/31-ci-issues.sql
+++ b/misc/python/materialize/test_analytics/setup/views/31-ci-issues.sql
@@ -21,7 +21,7 @@ IN CLUSTER test_analytics AS
         GROUP BY issue
     )
     AS a
-    JOIN issues AS i ON a.issue = i.issue
+    JOIN issue AS i ON a.issue = i.issue_id
 ;
 
 GRANT SELECT ON mv_ci_issues TO "ci-failures";

--- a/misc/python/materialize/test_analytics/setup/views/31-ci-issues.sql
+++ b/misc/python/materialize/test_analytics/setup/views/31-ci-issues.sql
@@ -1,0 +1,27 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+CREATE OR REPLACE MATERIALIZED VIEW mv_ci_issues
+IN CLUSTER test_analytics AS
+    SELECT a.*, title, ci_regexp
+    FROM (
+        SELECT
+            issue,
+            count(*) AS occurrences,
+            min(build_date) AS first_occurrence,
+            max(build_date) AS last_occurrence
+        FROM v_build_annotation_error
+        WHERE issue IS NOT NULL
+        GROUP BY issue
+    )
+    AS a
+    JOIN issues AS i ON a.issue = i.issue
+;
+
+GRANT SELECT ON mv_ci_issues TO "ci-failures";

--- a/misc/python/materialize/test_analytics/test_analytics_db.py
+++ b/misc/python/materialize/test_analytics/test_analytics_db.py
@@ -22,6 +22,9 @@ from materialize.test_analytics.data.build_annotation.build_annotation_storage i
 from materialize.test_analytics.data.feature_benchmark.feature_benchmark_result_storage import (
     FeatureBenchmarkResultStorage,
 )
+from materialize.test_analytics.data.known_issues.known_issues_storage import (
+    KnownIssuesStorage,
+)
 from materialize.test_analytics.data.output_consistency.output_consistency_stats_storage import (
     OutputConsistencyStatsStorage,
 )
@@ -51,6 +54,7 @@ class TestAnalyticsDb:
         self.build_annotations = BuildAnnotationStorage(self.database_connector)
         self.build_history = BuildHistoryAnalysis(self.database_connector)
         self.output_consistency = OutputConsistencyStatsStorage(self.database_connector)
+        self.known_issues = KnownIssuesStorage(self.database_connector)
 
     def submit_updates(self) -> None:
         """

--- a/misc/python/materialize/test_analytics/util/mz_sql_util.py
+++ b/misc/python/materialize/test_analytics/util/mz_sql_util.py
@@ -7,9 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-
-def sanitize_text_value(value: str) -> str:
-    return value.replace("'", "\\'")
+from pg8000.native import literal
 
 
 def as_sanitized_literal(value: str | None, sanitize_value: bool = True) -> str:
@@ -17,6 +15,6 @@ def as_sanitized_literal(value: str | None, sanitize_value: bool = True) -> str:
         return "NULL"
 
     if sanitize_value:
-        value = sanitize_text_value(value)
+        return literal(value)
 
-    return f"E'{value}'"
+    return f"'{value}'"

--- a/test/sqlancer/mzcompose.py
+++ b/test/sqlancer/mzcompose.py
@@ -61,7 +61,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     seed = args.seed or random.randint(0, 2**31)
 
-    print("~~~ Run in progress")
+    print("--- Run in progress")
     result = c.run(
         "sqlancer",
         "--random-seed",


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
