### PR TITLE
DNM: Follow each ColumnKnowledge with EQProp

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -595,6 +595,7 @@ impl Optimizer {
                     // less well than the previous transform. Eliminate
                     // redundancy between the two transforms.
                     Box::new(column_knowledge::ColumnKnowledge::default()),
+                    Box::new(equivalence_propagation::EquivalencePropagation::default()),
                     // Lifts the information `col1 = col2`
                     Box::new(demand::Demand::default()),
                     Box::new(FuseAndCollapse::default()),
@@ -678,6 +679,7 @@ impl Optimizer {
                 limit: 100,
                 transforms: vec![
                     Box::new(column_knowledge::ColumnKnowledge::default()),
+                    Box::new(equivalence_propagation::EquivalencePropagation::default()),
                     Box::new(fold_constants::FoldConstants {
                         limit: Some(FOLD_CONSTANTS_LIMIT),
                     }),

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -631,19 +631,11 @@ WITH MUTUALLY RECURSIVE
 SELECT f1, f2, f1 + f2 FROM c0;
 ----
 Explained Query:
-  Return // { arity: 3, types: "(integer, integer, integer)" }
-    Map (8) // { arity: 3, types: "(integer, integer, integer)" }
-      Get l0 // { arity: 2, types: "(integer, integer)" }
-  With Mutually Recursive
-    cte l0 =
-      Map (3, 5) // { arity: 2, types: "(integer, integer)" }
-        Distinct project=[] // { arity: 0, types: "()" }
-          Union // { arity: 0, types: "()" }
-            Project () // { arity: 0, types: "()" }
-              Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
-                ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
-            Project () // { arity: 0, types: "()" }
-              Get l0 // { arity: 2, types: "(integer, integer)" }
+  Map (3, 5, 8) // { arity: 3, types: "(integer, integer, integer)" }
+    Distinct project=[] // { arity: 0, types: "()" }
+      Project () // { arity: 0, types: "()" }
+        Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
+          ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
 
 Source materialize.public.t1
   filter=((#0 = 3) AND (#1 = 5))
@@ -672,19 +664,11 @@ WITH MUTUALLY RECURSIVE (RECURSION LIMIT 1)
 SELECT f1, f2, f1 + f2 FROM c0;
 ----
 Explained Query:
-  Return // { arity: 3, types: "(integer, integer, integer)" }
-    Map (8) // { arity: 3, types: "(integer, integer, integer)" }
-      Get l0 // { arity: 2, types: "(integer, integer)" }
-  With Mutually Recursive [recursion_limit=1]
-    cte l0 =
-      Map (3, 5) // { arity: 2, types: "(integer, integer)" }
-        Distinct project=[] // { arity: 0, types: "()" }
-          Union // { arity: 0, types: "()" }
-            Project () // { arity: 0, types: "()" }
-              Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
-                ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
-            Project () // { arity: 0, types: "()" }
-              Get l0 // { arity: 2, types: "(integer, integer)" }
+  Map (3, 5, 8) // { arity: 3, types: "(integer, integer, integer)" }
+    Distinct project=[] // { arity: 0, types: "()" }
+      Project () // { arity: 0, types: "()" }
+        Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
+          ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
 
 Source materialize.public.t1
   filter=((#0 = 3) AND (#1 = 5))
@@ -707,16 +691,10 @@ WITH MUTUALLY RECURSIVE
 SELECT f1, f2, f1 IS NOT NULL, f2 IS NULL FROM c0;
 ----
 Explained Query:
-  Return // { arity: 4, types: "(integer, integer, boolean, boolean)" }
-    Map (true, false) // { arity: 4, types: "(integer, integer, boolean, boolean)" }
-      Get l0 // { arity: 2, types: "(integer, integer)" }
-  With Mutually Recursive
-    cte l0 =
-      Distinct project=[#0, #1] // { arity: 2, types: "(integer, integer)" }
-        Union // { arity: 2, types: "(integer, integer)" }
-          Filter (#1) IS NOT NULL // { arity: 2, types: "(integer, integer)" }
-            ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
-          Get l0 // { arity: 2, types: "(integer, integer)" }
+  Map (true, false) // { arity: 4, types: "(integer, integer, boolean, boolean)" }
+    Distinct project=[#0, #1] // { arity: 2, types: "(integer, integer)" }
+      Filter (#1) IS NOT NULL // { arity: 2, types: "(integer, integer)" }
+        ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
 
 Source materialize.public.t1
   filter=((#1) IS NOT NULL)


### PR DESCRIPTION
Smoke test for introducing EQProp where ColumnKnowledge exists. This does some weird things to `column_knowledge.slt`, and want to see how widespread it is.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
