### PR TITLE
sql-pretty: Improve sql-pretty-wasm types

### DIFF
--- a/misc/wasm/Cargo.lock
+++ b/misc/wasm/Cargo.lock
@@ -67,6 +67,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,9 +167,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ctor",
+ "derivative",
  "either",
- "mz-ore-instrument-macro",
- "mz-test-macro",
+ "mz-ore-proc",
  "num",
  "once_cell",
  "paste",
@@ -169,8 +180,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "mz-ore-instrument-macro"
-version = "0.0.0"
+name = "mz-ore-proc"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "mz-sql-lexer"
@@ -206,6 +222,7 @@ dependencies = [
  "mz-walkabout",
  "phf",
  "serde",
+ "smallvec",
  "thiserror",
  "tracing",
  "uncased",
@@ -227,15 +244,6 @@ dependencies = [
  "lol_alloc",
  "mz-sql-pretty",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "mz-test-macro"
-version = "0.1.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -556,6 +564,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "spin"

--- a/misc/wasm/src/sql-pretty-wasm/src/lib.rs
+++ b/misc/wasm/src/sql-pretty-wasm/src/lib.rs
@@ -23,32 +23,23 @@ use wasm_bindgen::prelude::*;
 static ALLOCATOR: LockedAllocator<FreeListAllocator> =
     LockedAllocator::new(FreeListAllocator::new());
 
-#[wasm_bindgen(typescript_custom_section)]
-const PRETTY_STR_TS_DEF: &str = r#"export function pretty_str(query: string): string;"#;
-
-#[wasm_bindgen(typescript_custom_section)]
-const PRETTY_STRS_TS_DEF: &str = r#"export function pretty_str(queries: string): string[];"#;
-
 /// Pretty prints one SQL query.
 ///
 /// Returns the pretty-printed query at the specified maximum target width. Returns an error if the
 /// SQL query is not parseable.
-#[wasm_bindgen(js_name = prettyStr, skip_typescript)]
-pub fn pretty_str(query: &str, width: usize) -> Result<JsValue, JsError> {
-    mz_sql_pretty::pretty_str(query, width)
-        .map_err(|e| JsError::new(&e.to_string()))
-        .map(|s| JsValue::from(s))
+#[wasm_bindgen(js_name = prettyStr)]
+pub fn pretty_str(query: &str, width: usize) -> Result<String, JsError> {
+    mz_sql_pretty::pretty_str(query, width).map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Pretty prints many SQL queries.
 ///
 /// Returns the list of pretty-printed queries at the specified maximum target width. Returns an
 /// error if any SQL query is not parseable.
-#[wasm_bindgen(js_name = prettyStrs, skip_typescript)]
-pub fn pretty_strs(queries: &str, width: usize) -> Result<Vec<JsValue>, JsError> {
+#[wasm_bindgen(js_name = prettyStrs)]
+pub fn pretty_strs(queries: &str, width: usize) -> Result<Vec<String>, JsError> {
     Ok(mz_sql_pretty::pretty_strs(queries, width)
         .map_err(|e| JsError::new(&e.to_string()))?
         .into_iter()
-        .map(|s| JsValue::from(s))
         .collect())
 }


### PR DESCRIPTION
The existing sql-pretty wasm signatures didn't match the build output. I also moved to automatically generating the typescript signature, rather than overriding it manually.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - NA
