### PR TITLE
Bail out of optimistic analysis if assumptions not upheld

### DIFF
--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -465,6 +465,16 @@ pub mod common {
                 let value = self.derive(exprs[upper - 1], upper - 1, depends);
                 Ok(lattice.meet_assign(&mut self.results[upper - 1], value))
             } else {
+                if exprs[upper - 1].is_recursive() {
+                    // We should not be here if `expr` is still recursive.
+                    // Should that happen, note an error and return an error,
+                    // diverting us to the pessimistic case.
+                    mz_ore::soft_assert_or_log!(
+                        !exprs[upper - 1].is_recursive(),
+                        "Analysis of non-let-normal expression"
+                    );
+                    return Err(());
+                }
                 // If not a `LetRec`, we still want to revisit results and update them with meet.
                 let mut changed = false;
                 for index in lower..upper {


### PR DESCRIPTION
The `Analysis` framework assumed that it would be called on let-normalized expressions, but this doesn't have to be the case. Add a defensive check to make sure that if it is called on unnormalized expressions it bails out and enters the pessimistic case instead (while logging an error so we can track this down).

Future work: figure out how to route around the problem, and perform the optimistic analysis on non-normalized expressions.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
