### PR TITLE
security: fix security pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7128,9 +7128,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -7169,9 +7169,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9746,9 +9746,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-openssl"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
+checksum = "6ffab79df67727f6acf57f1ff743091873c24c579b1e2ce4d8f53e47ded4d63d"
 dependencies = [
  "futures-util",
  "openssl",

--- a/deny.toml
+++ b/deny.toml
@@ -232,8 +232,6 @@ ignore = [
     "RUSTSEC-2021-0145",
     # Consider `encoding_rs` instead of `encoding` (unmaintained)
     "RUSTSEC-2021-0153",
-    # Upgrading openssl will increase the shared library we depend on
-    "RUSTSEC-2023-0072",
 ]
 
 # Must be manually kept in sync with about.toml.

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -826,8 +826,16 @@ criteria = "safe-to-deploy"
 version = "0.15.5"
 criteria = "safe-to-deploy"
 
+[[exemptions.openssl]]
+version = "0.10.66"
+criteria = "safe-to-deploy"
+
 [[exemptions.openssl-probe]]
 version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl-sys]]
+version = "0.9.103"
 criteria = "safe-to-deploy"
 
 [[exemptions.option-ext]]
@@ -1379,7 +1387,7 @@ version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-openssl]]
-version = "0.6.3"
+version = "0.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-pipe]]

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -79,7 +79,7 @@ num = { version = "0.4.1" }
 num-bigint = { version = "0.4.3" }
 num-integer = { version = "0.1.46", features = ["i128"] }
 num-traits = { version = "0.2.15", features = ["i128", "libm"] }
-openssl = { version = "0.10.64", features = ["vendored"] }
+openssl = { version = "0.10.66", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
@@ -203,7 +203,7 @@ num = { version = "0.4.1" }
 num-bigint = { version = "0.4.3" }
 num-integer = { version = "0.1.46", features = ["i128"] }
 num-traits = { version = "0.2.15", features = ["i128", "libm"] }
-openssl = { version = "0.10.64", features = ["vendored"] }
+openssl = { version = "0.10.66", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
@@ -266,7 +266,7 @@ zstd-sys = { version = "2.0.9", features = ["std"] }
 bitflags = { version = "2.4.1", default-features = false, features = ["std"] }
 camino = { version = "1.1.7", default-features = false, features = ["serde1"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
-openssl-sys = { version = "0.9.102", default-features = false, features = ["vendored"] }
+openssl-sys = { version = "0.9.103", default-features = false, features = ["vendored"] }
 pathdiff = { version = "0.2.1", default-features = false, features = ["camino"] }
 ring = { version = "0.17.7", features = ["std"] }
 
@@ -274,7 +274,7 @@ ring = { version = "0.17.7", features = ["std"] }
 bitflags = { version = "2.4.1", default-features = false, features = ["std"] }
 camino = { version = "1.1.7", default-features = false, features = ["serde1"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
-openssl-sys = { version = "0.9.102", default-features = false, features = ["vendored"] }
+openssl-sys = { version = "0.9.103", default-features = false, features = ["vendored"] }
 pathdiff = { version = "0.2.1", default-features = false, features = ["camino"] }
 ring = { version = "0.17.7", features = ["std"] }
 


### PR DESCRIPTION
### Issues

https://buildkite.com/materialize/security/builds/1261

#### 1)
```
ID: RUSTSEC-2024-0357
Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0357
Previously, `MemBio::get_buf` called `slice::from_raw_parts` with a null-pointer, which violates the functions invariants, leading to undefined behavior. In debug builds this would produce an assertion failure. This is now fixed.
Announcement: https://github.com/sfackler/rust-openssl/pull/2266
Solution: Upgrade to >=0.10.66 (try `cargo update -p openssl`)
```

* `cargo update -p openssl` doesn't do anything (as of now)
* updated `tokio-openssl` but this did not fix the issue

#### 2)
```
warning[advisory-not-detected]: advisory was not encountered
    ┌─ /var/lib/buildkite-agent/builds/buildkite-aarch64-b9f4a11-i-0aebb6f13f5cf4383-1/materialize/security/deny.toml:236:6
    │
236 │     "RUSTSEC-2023-0072",
    │      ^^^^^^^^^^^^^^^^^ no crate matched advisory criteria
```

=> solved by removing the entry ✅ 

### Security pipeline
https://buildkite.com/materialize/security/builds?branch=nrainer-materialize%3Asecurity%2Fno-create-matched