### PR TITLE
dev docs: Mention system parameters for testdrive

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -107,6 +107,20 @@ In the second terminal, run testdrive:
 $ cargo run --bin testdrive --release -- test/testdrive/TESTFILE.td
 ```
 
+Note that mzcompose has a different default of system parameters in order to
+test more risky features of Materialize, see `DEFAULT_SYSTEM_PARAMETERS` in
+[https://github.com/MaterializeInc/materialize/blob/main/misc/python/materialize/mzcompose/__init__.py](mzcompose/__init__.py).
+On the command line specific system parameters can be set using the
+`MZSYSTEM_PARAMETER_DEFAULT` environment variable (`;`-separated).
+Alternatively `MZ_ALL_FEATURES=1` enables all available Materialize features.
+For example to run the `mz-arrangement-sharing.td` locally with a Debug build
+for fast turnaround times:
+
+```shell
+$ MZ_ALL_FEATURES=1 bin/environmentd
+$ cargo run --bin testdrive -- test/testdrive/mz-arrangement-sharing.td
+```
+
 Many testdrive tests require Zookeeper, Kafka, and
 the Confluent Schema Registry. See the [unit tests docs for starting them](guide-testing.md#unitintegration-tests).
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
