### PR TITLE
test/bounded-memory: use the correct cluster

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -79,10 +79,8 @@ class PgCdcScenario(Scenario):
     )
     MZ_SETUP = dedent(
         """
-        > DROP CLUSTER IF EXISTS single_replica_cluster;
-        > CREATE CLUSTER single_replica_cluster SIZE '${arg.default-storage-size}';
         > CREATE SOURCE mz_source
-          IN CLUSTER single_replica_cluster
+          IN CLUSTER clusterd
           FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
           FOR ALL TABLES;
 
@@ -124,10 +122,8 @@ class MySqlCdcScenario(Scenario):
     )
     MZ_SETUP = dedent(
         """
-        > DROP CLUSTER IF EXISTS single_replica_cluster;
-        > CREATE CLUSTER single_replica_cluster SIZE '${arg.default-storage-size}';
         > CREATE SOURCE mz_source
-          IN CLUSTER single_replica_cluster
+          IN CLUSTER clusterd
           FROM MYSQL CONNECTION mysql_conn
           FOR ALL TABLES;
 
@@ -171,10 +167,8 @@ class KafkaScenario(Scenario):
 
     SOURCE = dedent(
         """
-        > DROP CLUSTER IF EXISTS single_replica_cluster;
-        > CREATE CLUSTER single_replica_cluster SIZE '${arg.default-storage-size}';
         > CREATE SOURCE s1
-          IN CLUSTER single_replica_cluster
+          IN CLUSTER clusterd
           FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic1-${testdrive.seed}')
           FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
           ENVELOPE UPSERT;
@@ -732,10 +726,8 @@ SCENARIOS = [
         + KafkaScenario.END_MARKER
         + dedent(
             """
-            > DROP CLUSTER IF EXISTS single_replica_cluster;
-            > CREATE CLUSTER single_replica_cluster SIZE '${arg.default-storage-size}';
             > CREATE SOURCE s1
-              IN CLUSTER single_replica_cluster
+              IN CLUSTER clusterd
               FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic1-${testdrive.seed}')
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
               ENVELOPE UPSERT;


### PR DESCRIPTION
This fixes a regression introduced by a previous commit[1] which caused workloads to be scheduled on a cluster that is not actually memory constrained.

[1] https://github.com/MaterializeInc/materialize/commit/c6f2bc50#diff-aaf1582f6a06e65692e924ba44caee78cb45758df8b247084b50267710593181

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
