### PR TITLE
parallel-workload: Also allow stuck threads in DDL complexity

### DIFF
--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -359,7 +359,7 @@ def run(
         if scenario == Scenario.Rename:
             # TODO(def-): Switch to failing exit code when #28182 is fixed
             os._exit(0)
-        if complexity == Complexity.DDLOnly:
+        if complexity in (Complexity.DDLOnly, Complexity.DDL):
             # TODO(def-): Switch to failing exit code when #28400 is fixed
             os._exit(0)
         if num_threads >= 50:


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
