### PR TITLE
persist: Add structured data to inline writes

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -333,7 +333,7 @@ pub struct BatchBuilderConfig {
     pub(crate) batch_delete_enabled: bool,
     pub(crate) batch_builder_max_outstanding_parts: usize,
     pub(crate) batch_columnar_format: BatchColumnarFormat,
-    pub(crate) batch_columnar_stats_only_override: bool,
+    pub(crate) batch_write_columnar_data: bool,
     pub(crate) batch_record_part_format: bool,
     pub(crate) inline_writes_single_max_bytes: usize,
     pub(crate) stats_collection_enabled: bool,
@@ -398,6 +398,12 @@ impl BatchBuilderConfig {
     /// Initialize a batch builder config based on a snapshot of the Persist config.
     pub fn new(value: &PersistConfig, _writer_id: &WriterId) -> Self {
         let writer_key = WriterKey::for_version(&value.build_version);
+
+        let batch_columnar_format =
+            BatchColumnarFormat::from_str(&BATCH_COLUMNAR_FORMAT.get(value));
+        let batch_write_columnar_data =
+            batch_columnar_format.is_structured() && !BATCH_COLUMNAR_STATS_ONLY_OVERRIDE.get(value);
+
         BatchBuilderConfig {
             writer_key,
             blob_target_size: BLOB_TARGET_SIZE.get(value),
@@ -405,8 +411,8 @@ impl BatchBuilderConfig {
             batch_builder_max_outstanding_parts: value
                 .dynamic
                 .batch_builder_max_outstanding_parts(),
-            batch_columnar_format: BatchColumnarFormat::from_str(&BATCH_COLUMNAR_FORMAT.get(value)),
-            batch_columnar_stats_only_override: BATCH_COLUMNAR_STATS_ONLY_OVERRIDE.get(value),
+            batch_columnar_format,
+            batch_write_columnar_data,
             batch_record_part_format: BATCH_RECORD_PART_FORMAT.get(value),
             inline_writes_single_max_bytes: INLINE_WRITES_SINGLE_MAX_BYTES.get(value),
             stats_collection_enabled: STATS_COLLECTION_ENABLED.get(value),
@@ -896,12 +902,9 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         let index = u64::cast_from(self.finished_parts.len() + self.writing_parts.len());
         let ts_rewrite = None;
 
-        let should_columnar_encode = self.cfg.batch_columnar_format.is_structured()
-            && !self.cfg.batch_columnar_stats_only_override;
-
         // If we're going to encode structured data then halve our limit since we're storing
         // it twice, once as binary encoded and once as structured.
-        let inline_threshold = if should_columnar_encode {
+        let inline_threshold = if self.cfg.batch_write_columnar_data {
             self.cfg.inline_writes_single_max_bytes.saturating_div(2)
         } else {
             self.cfg.inline_writes_single_max_bytes
@@ -918,7 +921,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
                 async move {
                     // Wrap our updates just so the types match.
                     let updates = BlobTraceUpdates::Row(updates);
-                    let structured_ext = if should_columnar_encode {
+                    let structured_ext = if cfg.batch_write_columnar_data {
                         let result = metrics.columnar.arrow().measure_part_build(|| {
                             encode_updates(&schemas, &updates, &cfg.batch_columnar_format)
                         });
@@ -1038,7 +1041,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
                         // override is not set.
                         if let BlobTraceUpdates::Row(record) = &updates.updates {
                             if let Some(record_ext) = extended_cols {
-                                if !cfg.batch_columnar_stats_only_override {
+                                if cfg.batch_write_columnar_data {
                                     updates.updates =
                                         BlobTraceUpdates::Both(record.clone(), record_ext);
                                 }

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -926,12 +926,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
                             encode_updates(&schemas, &updates, &cfg.batch_columnar_format)
                         });
                         match result {
-                            Ok(((key_col, val_col), _stats)) => {
-                                Some(ColumnarRecordsStructuredExt {
-                                    key: key_col,
-                                    val: val_col,
-                                })
-                            }
+                            Ok((struct_ext, _stats)) => struct_ext,
                             Err(err) => {
                                 tracing::error!(?err, "failed to encode in columnar format!");
                                 None

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1423,11 +1423,16 @@ impl ProtoInlineBatchPart {
         let updates = proto
             .updates
             .ok_or_else(|| TryFromProtoError::missing_field("ProtoInlineBatchPart::updates"))?;
-        let updates = ColumnarRecords::from_proto(lgbytes, updates)?;
+        let (updates, ext) = ColumnarRecords::from_proto(lgbytes, updates)?;
+        let updates = match ext {
+            None => BlobTraceUpdates::Row(updates),
+            Some(ext) => BlobTraceUpdates::Both(updates, ext),
+        };
+
         Ok(BlobTraceBatchPart {
             desc: proto.desc.into_rust_if_some("ProtoInlineBatchPart::desc")?,
             index: proto.index.into_rust()?,
-            updates: BlobTraceUpdates::Row(updates),
+            updates,
         })
     }
 }

--- a/src/persist-client/src/project.rs
+++ b/src/persist-client/src/project.rs
@@ -149,7 +149,7 @@ impl ProjectionPushdown {
 
         let mut faked_data = ColumnarRecordsBuilder::default();
         assert!(faked_data.push(((key_bytes, val_bytes), T::encode(as_of), diffs_sum)));
-        let updates = faked_data.finish(&metrics.columnar).into_proto();
+        let updates = faked_data.finish(&metrics.columnar).into_proto(None);
         let faked_data = LazyInlineBatchPart::from(&ProtoInlineBatchPart {
             desc: Some(desc.into_proto()),
             index: 0,

--- a/src/persist/BUILD.bazel
+++ b/src/persist/BUILD.bazel
@@ -90,7 +90,10 @@ rust_doc_test(
 
 filegroup(
 	name = "all_protos",
-	srcs = ["src/persist.proto"],
+	srcs = [
+		"src/persist.proto",
+		"//src/persist-types:all_protos",
+	],
 )
 
 cargo_build_script(

--- a/src/persist/build.rs
+++ b/src/persist/build.rs
@@ -19,6 +19,7 @@ fn main() {
             "#[derive(serde::Serialize)]",
         )
         .bytes([".mz_persist.gen.persist.ProtoColumnarRecords"])
+        .extern_path(".mz_persist_types.arrow", "::mz_persist_types::arrow")
         .compile_protos(&["persist/src/persist.proto"], &[".."])
         .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/persist/build.rs
+++ b/src/persist/build.rs
@@ -11,6 +11,7 @@ use std::env;
 
 fn main() {
     env::set_var("PROTOC", mz_build_tools::protoc());
+    env::set_var("PROTOC_INCLUDE", mz_build_tools::protoc_include());
 
     prost_build::Config::new()
         .btree_map(["."])

--- a/src/persist/src/persist.proto
+++ b/src/persist/src/persist.proto
@@ -18,6 +18,8 @@ syntax = "proto3";
 
 package mz_persist.gen.persist;
 
+import "persist-types/src/arrow.proto";
+
 message ProtoU64Antichain {
     repeated uint64 elements = 1;
 }
@@ -93,4 +95,7 @@ message ProtoColumnarRecords {
     bytes val_data = 5;
     repeated int64 timestamps = 6;
     repeated int64 diffs = 7;
+
+    mz_persist_types.arrow.ProtoArrayData key_structured = 8;
+    mz_persist_types.arrow.ProtoArrayData val_structured = 9;
 }

--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -1687,9 +1687,13 @@ mod tests {
             let bytes = proto.encode_to_vec();
             let proto = mz_persist_types::arrow::ProtoArrayData::decode(&bytes[..]).unwrap();
             let array_data: ArrayData = proto.into_rust().unwrap();
-            let col_rnd = StructArray::from(array_data);
 
+            let col_rnd = StructArray::from(array_data.clone());
             assert_eq!(col, col_rnd);
+
+            let col_dyn = arrow::array::make_array(array_data);
+            let col_dyn = col_dyn.as_any().downcast_ref::<StructArray>().unwrap();
+            assert_eq!(&col, col_dyn);
         }
 
         let decoder = <RelationDesc as Schema2<Row>>::decoder(desc, col.clone()).unwrap();

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1973,9 +1973,13 @@ mod tests {
             let bytes = proto.encode_to_vec();
             let proto = mz_persist_types::arrow::ProtoArrayData::decode(&bytes[..]).unwrap();
             let array_data: ArrayData = proto.into_rust().unwrap();
-            let col_rnd = StructArray::from(array_data);
 
+            let col_rnd = StructArray::from(array_data.clone());
             assert_eq!(col, col_rnd);
+
+            let col_dyn = arrow::array::make_array(array_data);
+            let col_dyn = col_dyn.as_any().downcast_ref::<StructArray>().unwrap();
+            assert_eq!(&col, col_dyn);
         }
 
         // Encode to Parquet.


### PR DESCRIPTION
This PR adds the new `ProtoArrayData` type from https://github.com/MaterializeInc/materialize/pull/28354 to `ProtoColumnarRecords` so we can include structured data in inline batch parts.

I really need to figure out the story for estimating the encoded size of arrow data, with `ProtoArrayData` it should be fairly straight forward. For now if structured data is enabled we halve the threshold for inline parts as an estimate.

### Motivation

Technically completes the implementation for https://github.com/MaterializeInc/materialize/issues/24830

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
