### PR TITLE
persist: Assert number of datums matches number of column encoders

### DIFF
--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -1266,10 +1266,18 @@ impl ColumnEncoder<Row> for RowColumnarEncoder {
     type FinishedStats = OptionStats<StructStats>;
 
     fn append(&mut self, val: &Row) {
-        // `zip_eq` will panic if the number of Datums != number of encoders.
-        for (datum, encoder) in val.iter().zip_eq(self.encoders.iter_mut()) {
+        let mut num_datums = 0;
+        for (datum, encoder) in val.iter().zip(self.encoders.iter_mut()) {
             encoder.push(datum).expect("failed to push datum");
+            num_datums += 1;
         }
+        assert_eq!(
+            num_datums,
+            self.encoders.len(),
+            "try to encode {val:?}, but have {:?}",
+            self.encoders
+        );
+
         self.nullability.append(true);
     }
 

--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -406,7 +406,8 @@ impl DatumColumnEncoder {
                 Datum::List(records),
             ) => {
                 let mut count = 0;
-                for (datum, encoder) in records.into_iter().zip(fields.iter_mut()) {
+                // `zip_eq` will panic if the number of records != number of fields.
+                for (datum, encoder) in records.into_iter().zip_eq(fields.iter_mut()) {
                     count += 1;
                     encoder.push(datum);
                 }
@@ -1265,7 +1266,8 @@ impl ColumnEncoder<Row> for RowColumnarEncoder {
     type FinishedStats = OptionStats<StructStats>;
 
     fn append(&mut self, val: &Row) {
-        for (datum, encoder) in val.iter().zip(self.encoders.iter_mut()) {
+        // `zip_eq` will panic if the number of Datums != number of encoders.
+        for (datum, encoder) in val.iter().zip_eq(self.encoders.iter_mut()) {
             encoder.push(datum).expect("failed to push datum");
         }
         self.nullability.append(true);
@@ -1288,7 +1290,7 @@ impl ColumnEncoder<Row> for RowColumnarEncoder {
 
         let (arrays, fields, stats): (Vec<_>, Vec<_>, Vec<_>) = col_names
             .iter()
-            .zip(encoders.into_iter())
+            .zip_eq(encoders.into_iter())
             .map(|((col_idx, col_name), encoder)| {
                 let nullable = encoder.nullable;
                 let (array, stats) = encoder.finish();
@@ -1690,7 +1692,8 @@ mod tests {
             assert_eq!(og_row, &rnd_row);
 
             // Check for each Datum in each Row that we're within our stats bounds.
-            for (c_idx, (rnd_datum, ty)) in rnd_row.iter().zip(desc.typ().columns()).enumerate() {
+            for (c_idx, (rnd_datum, ty)) in rnd_row.iter().zip_eq(desc.typ().columns()).enumerate()
+            {
                 let (lower, upper) = stats[c_idx];
 
                 // Assert our stat bounds are correct.
@@ -1724,7 +1727,7 @@ mod tests {
 
         // Validate that the null counts in our stats matched the actual counts.
         for (col_idx, (stats_count, actual_count)) in
-            stat_nulls.iter().zip(actual_nulls.iter()).enumerate()
+            stat_nulls.iter().zip_eq(actual_nulls.iter()).enumerate()
         {
             assert_eq!(
                 stats_count, actual_count,

--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -1274,7 +1274,7 @@ impl ColumnEncoder<Row> for RowColumnarEncoder {
         assert_eq!(
             num_datums,
             self.encoders.len(),
-            "try to encode {val:?}, but have {:?}",
+            "tried to encode {val:?}, but only have {:?}",
             self.encoders
         );
 


### PR DESCRIPTION
This PR tightens up the assertions we make for the `RowColumnarEncoder`, asserting that the number of Datums in a Row matches the number of column encoders. FWIW this would have panicked before but when finishing the `RowColumnarEncoder`, not when encoding.

### Motivation

@danhhz encountered a case of the Row we're trying to encode had fewer Datums then our columnar encoders.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
