### PR TITLE
feature-flag consistency test

### DIFF
--- a/bin/feature-flag-consistency-test
+++ b/bin/feature-flag-consistency-test
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
@@ -6,16 +8,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+#
+# feature-flag-consistency-test - Test the output consistency of different feature flags
 
-from enum import Enum
-
-
-class EvaluationScenario(Enum):
-    OUTPUT_CONSISTENCY = 1
-    """Data-flow rendering vs. constant folding"""
-    POSTGRES_CONSISTENCY = 2
-    """Materialize vs. Postgres"""
-    VERSION_CONSISTENCY = 3
-    """Two different versions of mz"""
-    FEATURE_FLAG_CONSISTENCY = 4
-    """Different feature flag configuration in mz"""
+exec "$(dirname "$0")"/pyactivate -m materialize.feature_flag_consistency.feature_flag_consistency_test "$@"

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1100,6 +1100,17 @@ steps:
               composition: version-consistency
               args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200", "--evaluation-strategy=constant_folding", "--other-tag=common-ancestor"]
 
+      - id: output-consistency-feature-flags-dfr
+        label: "Output consistency (feature-flags for DFR)"
+        depends_on: build-aarch64
+        timeout_in_minutes: 58
+        agents:
+          queue: linux-aarch64-small
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: feature-flag-consistency
+              args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200", "--evaluation-strategy=dataflow_rendering"]
+
 
   - group: SQLsmith
     key: sqlsmith-group

--- a/misc/python/materialize/feature_flag_consistency/execution/multi_config_executors.py
+++ b/misc/python/materialize/feature_flag_consistency/execution/multi_config_executors.py
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from materialize.feature_flag_consistency.feature_flag.feature_flag import (
+    FeatureFlagSystemConfigurationPair,
+)
+from materialize.output_consistency.execution.multi_mz_executors import (
+    MultiMzSqlExecutors,
+)
+from materialize.output_consistency.execution.sql_executor import SqlExecutor
+
+
+class MultiConfigSqlExecutors(MultiMzSqlExecutors):
+
+    def __init__(
+        self,
+        executor1: SqlExecutor,
+        executor2: SqlExecutor,
+        flag_configuration_pair: FeatureFlagSystemConfigurationPair,
+    ):
+        super().__init__(executor1, executor2)
+        self.flag_configuration_pair = flag_configuration_pair
+
+    def get_database_infos(self) -> str:
+        config1_info = str(self.flag_configuration_pair.config1.to_system_params())
+        config2_info = str(self.flag_configuration_pair.config2.to_system_params())
+        return (
+            f"Using {self.executor.name} in version '{self.executor.query_version()}' with config '{config1_info}'. "
+            f"Using {self.executor2.name} in version '{self.executor2.query_version()}' with config '{config2_info}'. "
+        )

--- a/misc/python/materialize/feature_flag_consistency/feature_flag/feature_flag.py
+++ b/misc/python/materialize/feature_flag_consistency/feature_flag/feature_flag.py
@@ -1,0 +1,70 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from dataclasses import dataclass
+
+# These values must be in lowercase
+FEATURE_FLAG_TRUE_VALUE = "true"
+FEATURE_FLAG_FALSE_VALUE = "false"
+
+
+@dataclass
+class FeatureFlagValue:
+    name: str
+    value: str
+
+
+@dataclass
+class FeatureFlagSystemConfiguration:
+    name: str
+    shortcut: str
+    flags: list[FeatureFlagValue]
+
+    def to_system_params(self) -> dict[str, str]:
+        return {flag.name: flag.value for flag in self.flags}
+
+    def verify_is_applied(self) -> None:
+        # TODO
+        raise NotImplementedError
+
+
+@dataclass
+class FeatureFlagSystemConfigurationPair:
+    name: str
+    config1: FeatureFlagSystemConfiguration
+    config2: FeatureFlagSystemConfiguration
+
+    def __post_init__(self):
+        assert (
+            self.config1.name != self.config2.name
+        ), "Feature flag configurations must have different names"
+        assert (
+            self.config1.shortcut != self.config2.shortcut
+        ), "Feature flag configurations must have different shortcuts"
+
+    def get_configs(self) -> list[FeatureFlagSystemConfiguration]:
+        return [self.config1, self.config2]
+
+
+def create_boolean_feature_flag_configuration_pair(
+    flag_name: str, shortcut: str
+) -> FeatureFlagSystemConfigurationPair:
+    return FeatureFlagSystemConfigurationPair(
+        name=flag_name,
+        config1=FeatureFlagSystemConfiguration(
+            name="default",
+            shortcut="default",
+            flags=[FeatureFlagValue(flag_name, FEATURE_FLAG_TRUE_VALUE)],
+        ),
+        config2=FeatureFlagSystemConfiguration(
+            name=f"w/ {flag_name}",
+            shortcut=shortcut,
+            flags=[FeatureFlagValue(flag_name, FEATURE_FLAG_FALSE_VALUE)],
+        ),
+    )

--- a/misc/python/materialize/feature_flag_consistency/feature_flag/feature_flag.py
+++ b/misc/python/materialize/feature_flag_consistency/feature_flag/feature_flag.py
@@ -29,10 +29,6 @@ class FeatureFlagSystemConfiguration:
     def to_system_params(self) -> dict[str, str]:
         return {flag.name: flag.value for flag in self.flags}
 
-    def verify_is_applied(self) -> None:
-        # TODO
-        raise NotImplementedError
-
 
 @dataclass
 class FeatureFlagSystemConfigurationPair:

--- a/misc/python/materialize/feature_flag_consistency/feature_flag_consistency_test.py
+++ b/misc/python/materialize/feature_flag_consistency/feature_flag_consistency_test.py
@@ -157,8 +157,6 @@ def main() -> int:
         description="Test the consistency of different feature flag configurations",
     )
 
-    parser.add_argument("--configuration", type=str, mandatory=True)
-
     parser.add_argument("--mz-host", default="localhost", type=str)
     parser.add_argument("--mz-port", default=6875, type=int)
     parser.add_argument("--mz-system-port", default=6877, type=int)
@@ -179,7 +177,24 @@ def main() -> int:
     )
 
     args = test.parse_output_consistency_input_args(parser)
-    test.set_configuration_pair_by_name(args.configuration)
+    test.flag_configuration_pair = FeatureFlagSystemConfigurationPair(
+        name="as_started",
+        config1=FeatureFlagSystemConfiguration(
+            name=f"as mz_1 running on {args.mz_port}",
+            shortcut="as_mz_1",
+            flags=[FeatureFlagValue("as_started", "mz-1")],
+        ),
+        config2=FeatureFlagSystemConfiguration(
+            name=f"as mz_2 running on {args.mz_port_2}",
+            shortcut="as_mz_2",
+            flags=[FeatureFlagValue("as_started", "mz-2")],
+        ),
+    )
+
+    print(
+        "When running outside of mzcompose, make sure that the instances are started with the desired feature flags!"
+    )
+    time.sleep(5)
 
     try:
         mz_db_user = "materialize"

--- a/misc/python/materialize/feature_flag_consistency/feature_flag_consistency_test.py
+++ b/misc/python/materialize/feature_flag_consistency/feature_flag_consistency_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 import argparse
+import time
 
 from pg8000 import Connection
 from pg8000.exceptions import InterfaceError
@@ -15,7 +16,9 @@ from materialize.feature_flag_consistency.execution.multi_config_executors impor
     MultiConfigSqlExecutors,
 )
 from materialize.feature_flag_consistency.feature_flag.feature_flag import (
+    FeatureFlagSystemConfiguration,
     FeatureFlagSystemConfigurationPair,
+    FeatureFlagValue,
 )
 from materialize.feature_flag_consistency.ignore_filter.feature_flag_consistency_ignore_filter import (
     FeatureFlagConsistencyIgnoreFilter,
@@ -57,17 +60,6 @@ class FeatureFlagConsistencyTest(OutputConsistencyTest):
         self.flag_configuration_pair: FeatureFlagSystemConfigurationPair | None = None
         self.mz2_connection: Connection | None = None
         self.mz2_system_connection: Connection | None = None
-
-    def shall_run(self, sql_executors: SqlExecutors) -> bool:
-        assert self.flag_configuration_pair is not None
-
-        try:
-            self.flag_configuration_pair.config1.verify_is_applied()
-            self.flag_configuration_pair.config2.verify_is_applied()
-            return True
-        except Exception as e:
-            print(e)
-            return False
 
     def get_scenario(self) -> EvaluationScenario:
         return EvaluationScenario.FEATURE_FLAG_CONSISTENCY

--- a/misc/python/materialize/feature_flag_consistency/feature_flag_consistency_test.py
+++ b/misc/python/materialize/feature_flag_consistency/feature_flag_consistency_test.py
@@ -1,0 +1,211 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+import argparse
+
+from pg8000 import Connection
+from pg8000.exceptions import InterfaceError
+
+from materialize.feature_flag_consistency.execution.multi_config_executors import (
+    MultiConfigSqlExecutors,
+)
+from materialize.feature_flag_consistency.feature_flag.feature_flag import (
+    FeatureFlagSystemConfigurationPair,
+)
+from materialize.feature_flag_consistency.ignore_filter.feature_flag_consistency_ignore_filter import (
+    FeatureFlagConsistencyIgnoreFilter,
+)
+from materialize.feature_flag_consistency.input_data.feature_flag_configurations import (
+    FEATURE_FLAG_CONFIGURATION_PAIRS,
+)
+from materialize.output_consistency.common.configuration import (
+    ConsistencyTestConfiguration,
+)
+from materialize.output_consistency.execution.evaluation_strategy import (
+    EVALUATION_STRATEGY_NAME_DFR,
+    INTERNAL_EVALUATION_STRATEGY_NAMES,
+    EvaluationStrategy,
+    create_internal_evaluation_strategy_twice,
+)
+from materialize.output_consistency.execution.query_output_mode import (
+    QUERY_OUTPUT_MODE_CHOICES,
+    QueryOutputMode,
+)
+from materialize.output_consistency.execution.sql_executors import SqlExecutors
+from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter import (
+    GenericInconsistencyIgnoreFilter,
+)
+from materialize.output_consistency.input_data.scenarios.evaluation_scenario import (
+    EvaluationScenario,
+)
+from materialize.output_consistency.output.output_printer import OutputPrinter
+from materialize.output_consistency.output_consistency_test import (
+    OutputConsistencyTest,
+    connect,
+)
+
+
+class FeatureFlagConsistencyTest(OutputConsistencyTest):
+
+    def __init__(self) -> None:
+        self.evaluation_strategy_name: str | None = None
+        self.flag_configuration_pair: FeatureFlagSystemConfigurationPair | None = None
+        self.mz2_connection: Connection | None = None
+        self.mz2_system_connection: Connection | None = None
+
+    def shall_run(self, sql_executors: SqlExecutors) -> bool:
+        assert self.flag_configuration_pair is not None
+
+        try:
+            self.flag_configuration_pair.config1.verify_is_applied()
+            self.flag_configuration_pair.config2.verify_is_applied()
+            return True
+        except Exception as e:
+            print(e)
+            return False
+
+    def get_scenario(self) -> EvaluationScenario:
+        return EvaluationScenario.FEATURE_FLAG_CONSISTENCY
+
+    def create_evaluation_strategies(
+        self, sql_executors: SqlExecutors
+    ) -> list[EvaluationStrategy]:
+        assert (
+            self.evaluation_strategy_name is not None
+        ), "Evaluation strategy name is not initialized"
+        assert (
+            self.flag_configuration_pair is not None
+        ), "Configuration is not initialized"
+
+        strategies = create_internal_evaluation_strategy_twice(
+            self.evaluation_strategy_name
+        )
+
+        for strategy, flag_config in zip(
+            strategies, self.flag_configuration_pair.get_configs()
+        ):
+            strategy.name = f"{strategy.name} {flag_config.name}"
+
+            strategy.object_name_base = (
+                f"{strategy.object_name_base}_{flag_config.shortcut}"
+            )
+            strategy.simple_db_object_name = (
+                f"{strategy.simple_db_object_name}_{flag_config.shortcut}"
+            )
+            strategy.additional_setup_info = f"Config: {flag_config.to_system_params()}"
+
+        return strategies
+
+    def find_configuration_pair_by_name(
+        self, name: str
+    ) -> FeatureFlagSystemConfigurationPair:
+        if name not in FEATURE_FLAG_CONFIGURATION_PAIRS.keys():
+            raise RuntimeError(
+                f"Feature flag configuration with name '{name}' not found. Available configuration names: {list(FEATURE_FLAG_CONFIGURATION_PAIRS.keys())}"
+            )
+
+        return FEATURE_FLAG_CONFIGURATION_PAIRS[name]
+
+    def set_configuration_pair_by_name(self, name: str) -> None:
+        self.flag_configuration_pair = self.find_configuration_pair_by_name(name)
+
+    def create_inconsistency_ignore_filter(self) -> GenericInconsistencyIgnoreFilter:
+        assert self.flag_configuration_pair is not None
+        return FeatureFlagConsistencyIgnoreFilter(self.flag_configuration_pair)
+
+    def create_sql_executors(
+        self,
+        config: ConsistencyTestConfiguration,
+        default_connection: Connection,
+        mz_system_connection: Connection,
+        output_printer: OutputPrinter,
+    ) -> SqlExecutors:
+        assert (
+            self.flag_configuration_pair is not None
+        ), "Flag configuration is not initialized"
+        assert self.mz2_connection is not None, "Second connection is not initialized"
+        assert (
+            self.mz2_system_connection is not None
+        ), "Second system connection is not initialized"
+
+        mz1_sql_executor = self.create_sql_executor(
+            config, default_connection, mz_system_connection, output_printer, "mz1"
+        )
+        mz2_sql_executor = self.create_sql_executor(
+            config,
+            self.mz2_connection,
+            self.mz2_system_connection,
+            output_printer,
+            "mz2",
+        )
+
+        return MultiConfigSqlExecutors(
+            mz1_sql_executor, mz2_sql_executor, self.flag_configuration_pair
+        )
+
+
+def main() -> int:
+    test = FeatureFlagConsistencyTest()
+    parser = argparse.ArgumentParser(
+        prog="feature-flag-consistency-test",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Test the consistency of different feature flag configurations",
+    )
+
+    parser.add_argument("--configuration", type=str, mandatory=True)
+
+    parser.add_argument("--mz-host", default="localhost", type=str)
+    parser.add_argument("--mz-port", default=6875, type=int)
+    parser.add_argument("--mz-system-port", default=6877, type=int)
+    parser.add_argument("--mz-host-2", default="localhost", type=str)
+    parser.add_argument("--mz-port-2", default=6975, type=int)
+    parser.add_argument("--mz-system-port-2", default=6977, type=int)
+    parser.add_argument(
+        "--evaluation-strategy",
+        default=EVALUATION_STRATEGY_NAME_DFR,
+        type=str,
+        choices=INTERNAL_EVALUATION_STRATEGY_NAMES,
+    )
+    parser.add_argument(
+        "--query-output-mode",
+        type=lambda mode: QueryOutputMode[mode.upper()],
+        choices=QUERY_OUTPUT_MODE_CHOICES,
+        default=QueryOutputMode.SELECT,
+    )
+
+    args = test.parse_output_consistency_input_args(parser)
+    test.set_configuration_pair_by_name(args.configuration)
+
+    try:
+        mz_db_user = "materialize"
+        my_system_user = "mz_system"
+        mz_connection = connect(args.mz_host, args.mz_port, mz_db_user)
+        mz_system_connection = connect(
+            args.mz_host, args.mz_system_port, my_system_user
+        )
+
+        test.mz2_connection = connect(args.mz_host_2, args.mz_port_2, mz_db_user)
+        test.mz2_system_connection = connect(
+            args.mz_host_2, args.mz_system_port_2, my_system_user
+        )
+
+        test.evaluation_strategy_name = args.evaluation_strategy
+    except InterfaceError:
+        return 1
+
+    result = test.run_output_consistency_tests(
+        mz_connection,
+        mz_system_connection,
+        args,
+        query_output_mode=args.query_output_mode,
+    )
+    return 0 if result.all_passed() else 1
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/misc/python/materialize/feature_flag_consistency/ignore_filter/feature_flag_consistency_ignore_filter.py
+++ b/misc/python/materialize/feature_flag_consistency/ignore_filter/feature_flag_consistency_ignore_filter.py
@@ -1,0 +1,53 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.feature_flag_consistency.feature_flag.feature_flag import (
+    FeatureFlagSystemConfiguration,
+    FeatureFlagSystemConfigurationPair,
+)
+from materialize.output_consistency.execution.evaluation_strategy import (
+    EvaluationStrategy,
+    is_other_db_evaluation_strategy,
+)
+from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter import (
+    GenericInconsistencyIgnoreFilter,
+    PostExecutionInconsistencyIgnoreFilterBase,
+    PreExecutionInconsistencyIgnoreFilterBase,
+)
+
+
+class FeatureFlagConsistencyIgnoreFilter(GenericInconsistencyIgnoreFilter):
+    def __init__(self, configuration_pair: FeatureFlagSystemConfigurationPair):
+        super().__init__(
+            FeatureFlagPreExecutionInconsistencyIgnoreFilter(configuration_pair),
+            FeatureFlagPostExecutionInconsistencyIgnoreFilter(configuration_pair),
+        )
+
+
+class FeatureFlagPreExecutionInconsistencyIgnoreFilter(
+    PreExecutionInconsistencyIgnoreFilterBase
+):
+    def __init__(self, configuration_pair: FeatureFlagSystemConfigurationPair):
+        self.configuration_pair = configuration_pair
+
+
+class FeatureFlagPostExecutionInconsistencyIgnoreFilter(
+    PostExecutionInconsistencyIgnoreFilterBase
+):
+    def __init__(self, configuration_pair: FeatureFlagSystemConfigurationPair):
+        self.configuration_pair = configuration_pair
+
+
+def get_flag_configuration(
+    configuration_pair: FeatureFlagSystemConfigurationPair, strategy: EvaluationStrategy
+) -> FeatureFlagSystemConfiguration:
+    if is_other_db_evaluation_strategy(strategy.identifier):
+        return configuration_pair.config2
+    else:
+        return configuration_pair.config1

--- a/misc/python/materialize/feature_flag_consistency/input_data/feature_flag_configurations.py
+++ b/misc/python/materialize/feature_flag_consistency/input_data/feature_flag_configurations.py
@@ -7,15 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from enum import Enum
+
+from materialize.feature_flag_consistency.feature_flag.feature_flag import (
+    FeatureFlagSystemConfigurationPair,
+)
+
+FEATURE_FLAG_CONFIGURATION_PAIRS = dict()
 
 
-class EvaluationScenario(Enum):
-    OUTPUT_CONSISTENCY = 1
-    """Data-flow rendering vs. constant folding"""
-    POSTGRES_CONSISTENCY = 2
-    """Materialize vs. Postgres"""
-    VERSION_CONSISTENCY = 3
-    """Two different versions of mz"""
-    FEATURE_FLAG_CONSISTENCY = 4
-    """Different feature flag configuration in mz"""
+def append_config(config_pair: FeatureFlagSystemConfigurationPair) -> None:
+    FEATURE_FLAG_CONFIGURATION_PAIRS[config_pair.name] = config_pair

--- a/misc/python/materialize/feature_flag_consistency/input_data/feature_flag_configurations.py
+++ b/misc/python/materialize/feature_flag_consistency/input_data/feature_flag_configurations.py
@@ -10,6 +10,7 @@
 
 from materialize.feature_flag_consistency.feature_flag.feature_flag import (
     FeatureFlagSystemConfigurationPair,
+    create_boolean_feature_flag_configuration_pair,
 )
 
 FEATURE_FLAG_CONFIGURATION_PAIRS = dict()
@@ -17,3 +18,26 @@ FEATURE_FLAG_CONFIGURATION_PAIRS = dict()
 
 def append_config(config_pair: FeatureFlagSystemConfigurationPair) -> None:
     FEATURE_FLAG_CONFIGURATION_PAIRS[config_pair.name] = config_pair
+
+
+# Test enable_equivalence_propagation enabled.
+# Assessment: "definitely good to include because it enables a super-complicated transform that does many things"
+append_config(
+    create_boolean_feature_flag_configuration_pair(
+        "enable_equivalence_propagation", "equiv_prop"
+    )
+)
+
+# Test enable_letrec_fixpoint_analysis enabled.
+# Assessment: "only affects queries with WMR, in theory. But the code around it is complex, and there is a non-0 chance that even non-WMR code is affected if there is a bug in it"
+append_config(
+    create_boolean_feature_flag_configuration_pair(
+        "enable_letrec_fixpoint_analysis", "fp_analysis"
+    )
+)
+
+# TODO: #19825 (output consistency: support joins): configure
+# * enable_outer_join_null_filter
+# * enable_variadic_left_join_lowering
+# * enable_eager_delta_joins
+# * enable_variadic_left_join_lowering && enable_eager_delta_joins

--- a/test/feature-flag-consistency/README.md
+++ b/test/feature-flag-consistency/README.md
@@ -1,0 +1,28 @@
+# Feature Flag consistency tests
+
+## Overview
+
+**These tests aim to ensure that a different feature flag configuration produces the same results.**
+
+## Getting started
+
+To launch the tests using mzcompose, run
+```
+bin/mzcompose --find feature-flag-consistency down -v && bin/mzcompose --find feature-flag-consistency run default
+```
+To start the tests from a shell, use
+```
+bin/feature-flag-consistency --max-runtime-in-sec 60
+```
+
+## Test explain plans
+
+This can be done using the `--output-query-mode` parameter. Refer to the version-consistency test for more details.
+
+## Query generation
+
+Queries are generated using the output consistency test framework, which is also used to ensure consistency between
+data-flow rendering and constant folding evaluations. See [this README](../output-consistency/README.md) for more
+details on query generation.
+
+To ignore known inconsistencies, extend the `FeatureFlagConsistencyIgnoreFilter`.

--- a/test/feature-flag-consistency/mzcompose
+++ b/test/feature-flag-consistency/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/feature-flag-consistency/mzcompose.py
+++ b/test/feature-flag-consistency/mzcompose.py
@@ -1,0 +1,151 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.feature_flag_consistency.feature_flag_consistency_test import (
+    FeatureFlagConsistencyTest,
+)
+from materialize.feature_flag_consistency.input_data.feature_flag_configurations import (
+    FEATURE_FLAG_CONFIGURATION_PAIRS,
+)
+from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services.cockroach import Cockroach
+from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mz import Mz
+from materialize.mzcompose.services.postgres import Postgres
+from materialize.mzcompose.test_result import FailedTestExecutionError
+from materialize.output_consistency.execution.evaluation_strategy import (
+    EVALUATION_STRATEGY_NAME_DFR,
+    INTERNAL_EVALUATION_STRATEGY_NAMES,
+)
+from materialize.output_consistency.execution.query_output_mode import (
+    QUERY_OUTPUT_MODE_CHOICES,
+    QueryOutputMode,
+)
+from materialize.output_consistency.output_consistency_test import (
+    upload_output_consistency_results_to_test_analytics,
+)
+
+SERVICES = [
+    Cockroach(setup_materialize=True),
+    Postgres(),
+    Materialized(name="mz_this"),  # Overridden below
+    Materialized(name="mz_other"),  # Overridden below
+    Mz(app_password=""),
+]
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """
+    Test the consistency with another mz version.
+    """
+
+    c.down(destroy_volumes=True)
+
+    test = FeatureFlagConsistencyTest()
+
+    parser.add_argument("--configuration", action="append", default=[], type=str)
+
+    parser.add_argument(
+        "--evaluation-strategy",
+        default=EVALUATION_STRATEGY_NAME_DFR,
+        type=str,
+        choices=INTERNAL_EVALUATION_STRATEGY_NAMES,
+    )
+
+    parser.add_argument(
+        "--other-tag",
+        type=str,
+        default="common-ancestor",
+    )
+
+    parser.add_argument(
+        "--query-output-mode",
+        type=lambda mode: QueryOutputMode[mode.upper()],
+        choices=QUERY_OUTPUT_MODE_CHOICES,
+        default=QueryOutputMode.SELECT,
+    )
+
+    args = test.parse_output_consistency_input_args(parser)
+
+    port_mz_default_internal, port_mz_system_internal = 6875, 6877
+    port_mz_default_this, port_mz_system_this = 6875, 6877
+    port_mz_default_other, port_mz_system_other = 16875, 16877
+
+    configurations = args.configuration
+
+    if len(configurations) == 0:
+        configurations = FEATURE_FLAG_CONFIGURATION_PAIRS.keys()
+
+    runtime_per_config_in_sec = args.max_runtime_in_sec / len(configurations)
+
+    test_summaries = []
+
+    for configuration in configurations:
+        test.set_configuration_pair_by_name(configuration)
+        assert test.flag_configuration_pair is not None
+        print(f"Running flag configuration: {test.flag_configuration_pair.name}")
+
+        with c.override(
+            Materialized(
+                name="mz_this",
+                ports=[
+                    f"{port_mz_default_this}:{port_mz_default_internal}",
+                    f"{port_mz_system_this}:{port_mz_system_internal}",
+                ],
+                additional_system_parameter_defaults=test.flag_configuration_pair.config1.to_system_params(),
+                use_default_volumes=False,
+            ),
+            Materialized(
+                name="mz_other",
+                ports=[
+                    f"{port_mz_default_other}:{port_mz_default_internal}",
+                    f"{port_mz_system_other}:{port_mz_system_internal}",
+                ],
+                additional_system_parameter_defaults=test.flag_configuration_pair.config2.to_system_params(),
+                use_default_volumes=False,
+            ),
+        ):
+            c.up("mz_this", "mz_other")
+
+            default_connection = c.sql_connection(
+                service="mz_this", port=port_mz_default_internal
+            )
+            mz_system_connection = c.sql_connection(
+                service="mz_this", port=port_mz_system_internal, user="mz_system"
+            )
+            test.mz2_connection = c.sql_connection(
+                service="mz_other", port=port_mz_default_internal
+            )
+            test.mz2_system_connection = c.sql_connection(
+                service="mz_other", port=port_mz_system_internal, user="mz_system"
+            )
+
+            test.evaluation_strategy_name = args.evaluation_strategy
+
+            test_summary = test.run_output_consistency_tests(
+                default_connection,
+                mz_system_connection,
+                args,
+                query_output_mode=args.query_output_mode,
+                override_max_runtime_in_sec=runtime_per_config_in_sec,
+            )
+
+            test_summaries.append(test_summary)
+
+        assert len(test_summaries) > 0
+
+        merged_summary = test_summaries[0]
+
+        for test_summary in test_summaries[1:]:
+            merged_summary.merge(test_summary)
+
+        upload_output_consistency_results_to_test_analytics(c, merged_summary)
+
+        if not merged_summary.all_passed():
+            raise FailedTestExecutionError(errors=merged_summary.failures)


### PR DESCRIPTION
### Commits
This is based on https://github.com/MaterializeInc/materialize/pull/28752.

9dd936d872 feature-flag consistency: add test
d987e96981 feature-flag consistency: specify flag configurations
5e954cc432 feature-flag consistency: add mzcompose
40c107dc72 feature-flag consistency: use mz as started when running outside mzcompose
cbf465776c feature-flag consistency: remove feature flag configuration check
6122c0bdba feature-flag consistency: add README
4874ff9f82 ci: add feature-flag consistency test to nightly

### Nightly
https://buildkite.com/materialize/nightly/builds?branch=nrainer-materialize%3Aoutput-consistency%2Ffeature-flags

### Follow-up
Once joins are supported by the test framework (https://github.com/MaterializeInc/materialize/issues/19825), configure
* `enable_outer_join_null_filter`
* `enable_variadic_left_join_lowering`
* `enable_eager_delta_joins`
* `enable_variadic_left_join_lowering` && `enable_eager_delta_joins`