### PR TITLE
ci: Notify QA about infra failures

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -204,15 +204,17 @@ def _upload_shard_info_metadata(items: list[str]) -> None:
 
 
 def add_failure_for_qa_team(failure: str) -> None:
-    pipeline = {"notify": [{"email": "dennis.felsing@materialize.com"}]}
     step_key = get_var(BuildkiteEnvVar.BUILDKITE_STEP_KEY)
-
-    add_annotation_raw(
-        style="error",
-        markdown=f"Relevant for #team-testing: {step_key}\n```\n{failure}\n```",
-    )
-    # TODO(def-) once we have integration switch to Slack: https://materializeinc.slack.com/archives/C01KV5PEZ9R/p1721756599344869
-    # pipeline = {"notify": [{"slack": {"channels": ["#team-testing-bots"], "message": f"{step_key}: {failure}"}}]}
+    pipeline = {
+        "notify": [
+            {
+                "slack": {
+                    "channels": ["#team-testing-bots"],
+                    "message": f"{step_key}: {failure}",
+                }
+            }
+        ]
+    }
     spawn.runv(
         ["buildkite-agent", "pipeline", "upload"], stdin=yaml.dump(pipeline).encode()
     )

--- a/misc/python/materialize/output_consistency/output_consistency_test.py
+++ b/misc/python/materialize/output_consistency/output_consistency_test.py
@@ -278,7 +278,7 @@ def upload_output_consistency_results_to_test_analytics(
         print("Uploaded results.")
     except Exception as e:
         # An error during an upload must never cause the build to fail
-        print(f"Uploading results failed! {e}")
+        buildkite.add_failure_for_qa_team(f"Uploading results failed! {e}")
 
 
 def connect(host: str, port: int, user: str, password: str | None = None) -> Connection:

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -729,4 +729,4 @@ def upload_results_to_test_analytics(
         print("Uploaded results.")
     except Exception as e:
         # An error during an upload must never cause the build to fail
-        print(f"Uploading results failed! {e}")
+        buildkite.add_failure_for_qa_team(f"Uploading results failed! {e}")

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -601,7 +601,7 @@ def upload_results_to_test_analytics(
         print("Uploaded results.")
     except Exception as e:
         # An error during an upload must never cause the build to fail
-        print(f"Uploading results failed! {e}")
+        buildkite.add_failure_for_qa_team(f"Uploading results failed! {e}")
 
 
 def _get_head_target_endpoint(endpoints: list[Endpoint]) -> Endpoint | None:


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
