### PR TITLE
storage/sources: Store per-export details on SourceExports rather than the top-level SourceConnection

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -509,6 +509,7 @@ impl CatalogState {
                         DataSourceDesc::IngestionExport {
                             ingestion_id,
                             external_reference: UnresolvedItemName(external_reference),
+                            details: _,
                         } => {
                             let ingestion_entry = self
                                 .get_entry(ingestion_id)

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -514,8 +514,8 @@ fn mysql_subsources_remove_unnecessary_db_name(
     let items = conn_catalog.get_items();
     let mysql_subsources_to_update: Vec<_> = items
         .into_iter()
-        .filter_map(|item| match item.subsource_details() {
-            Some((ingestion_id, external_reference)) => {
+        .filter_map(|item| match item.source_export_details() {
+            Some((ingestion_id, external_reference, _details)) => {
                 match conn_catalog
                     .state()
                     .get_entry(&ingestion_id)

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -839,9 +839,11 @@ impl CatalogState {
                     mz_sql::plan::DataSourceDesc::IngestionExport {
                         ingestion_id,
                         external_reference,
+                        details,
                     } => DataSourceDesc::IngestionExport {
                         ingestion_id,
                         external_reference,
+                        details,
                     },
                     mz_sql::plan::DataSourceDesc::Progress => DataSourceDesc::Progress,
                     mz_sql::plan::DataSourceDesc::Webhook {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2252,10 +2252,12 @@ impl Coordinator {
                 DataSourceDesc::IngestionExport {
                     ingestion_id,
                     external_reference,
+                    details,
                 } => (
                     DataSource::IngestionExport {
                         ingestion_id,
                         external_reference,
+                        details,
                     },
                     Some(source_status_collection_id),
                 ),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -30,16 +30,13 @@ use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::task::{self, spawn, JoinHandle};
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::vec::VecExt;
-use mz_proto::RustType;
 use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
 use mz_repr::explain::json::json_string;
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::role_id::RoleId;
 use mz_repr::{Datum, Diff, GlobalId, IntoRowIterator, Row, RowArena, RowIterator, Timestamp};
-use mz_sql::ast::{
-    CreateSubsourceStatement, Ident, MySqlConfigOptionName, UnresolvedItemName, Value,
-};
+use mz_sql::ast::{CreateSubsourceStatement, MySqlConfigOptionName, UnresolvedItemName};
 use mz_sql::catalog::{
     CatalogCluster, CatalogClusterReplica, CatalogDatabase, CatalogError,
     CatalogItem as SqlCatalogItem, CatalogItemType, CatalogRole, CatalogSchema, CatalogTypeDetails,
@@ -52,11 +49,6 @@ use mz_sql::names::{
 use mz_sql::plan::StatementContext;
 use mz_sql::pure::{generate_subsource_statements, PurifiedSourceExport};
 use mz_storage_types::sinks::StorageSinkDesc;
-use mz_storage_types::sources::mysql::{MySqlSourceDetails, ProtoMySqlSourceDetails};
-use mz_storage_types::sources::postgres::{
-    PostgresSourcePublicationDetails, ProtoPostgresSourcePublicationDetails,
-};
-use prost::Message as _;
 use timely::progress::Timestamp as TimelyTimestamp;
 // Import `plan` module, but only import select elements to avoid merge conflicts on use statements.
 use mz_adapter_types::connection::ConnectionId;
@@ -559,10 +551,12 @@ impl Coordinator {
                         DataSourceDesc::IngestionExport {
                             ingestion_id,
                             external_reference,
+                            details,
                         } => (
                             DataSource::IngestionExport {
                                 ingestion_id,
                                 external_reference,
+                                details,
                             },
                             source_status_collection_id,
                         ),
@@ -3538,7 +3532,6 @@ impl Coordinator {
                 let mz_sql::plan::AlterSourceAddSubsourceOptionExtracted {
                     text_columns: mut new_text_columns,
                     ignore_columns: mut new_ignore_columns,
-                    details: new_details,
                     ..
                 } = options.try_into()?;
 
@@ -3555,8 +3548,8 @@ impl Coordinator {
                     .filter_map(|subsource| {
                         catalog
                             .get_entry(subsource)
-                            .subsource_details()
-                            .map(|(_id, reference)| reference)
+                            .source_export_details()
+                            .map(|(_id, reference, _details)| reference)
                     })
                     .collect();
 
@@ -3565,116 +3558,21 @@ impl Coordinator {
                 let purification_err =
                     || AdapterError::internal(ALTER_SOURCE, "error in subsource purification");
 
+                // TODO(roshan): Remove all the statement option merging necessary here once we have
+                // removed support for implicitly created subsources from a top-level `CREATE SOURCE`
+                // statement.
                 match &mut create_source_stmt.connection {
                     CreateSourceConnection::Postgres {
                         options: curr_options,
                         ..
                     } => {
                         let mz_sql::plan::PgConfigOptionExtracted {
-                            details,
-                            mut text_columns,
-                            ..
+                            mut text_columns, ..
                         } = curr_options.clone().try_into()?;
 
-                        // Drop both details and text columns; we will add them back in
+                        // Drop text columns; we will add them back in
                         // as appropriate below.
-                        curr_options.retain(|o| {
-                            !matches!(
-                                o.name,
-                                PgConfigOptionName::Details | PgConfigOptionName::TextColumns
-                            )
-                        });
-
-                        let gen_details = |details: Option<String>| -> Result<
-                            PostgresSourcePublicationDetails,
-                            AdapterError,
-                        > {
-                            let details = details.as_ref().ok_or_else(|| {
-                                AdapterError::internal(
-                                    ALTER_SOURCE,
-                                    "Postgres source missing details",
-                                )
-                            })?;
-
-                            let details = hex::decode(details)
-                                .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?;
-                            let details = ProtoPostgresSourcePublicationDetails::decode(&*details)
-                                .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?;
-
-                            PostgresSourcePublicationDetails::from_proto(details)
-                                .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))
-                        };
-
-                        let mut curr_details = gen_details(details)?;
-                        let mut new_details = gen_details(new_details)?;
-
-                        // n.b. this does not check publication table names, so we must
-                        // do that separately.
-                        curr_details
-                            .alter_compatible(cur_entry.id(), &new_details)
-                            .map_err(StorageError::InvalidAlter)?;
-
-                        // Trim any unreferred-to tables.
-                        curr_details.tables.retain(|table| {
-                            let name = UnresolvedItemName(vec![
-                                // Unchecked is fine beause we have previously verified
-                                // that these are valid idents.
-                                Ident::new_unchecked(curr_details.database.clone()),
-                                Ident::new_unchecked(table.namespace.clone()),
-                                Ident::new_unchecked(table.name.clone()),
-                            ]);
-
-                            // Retain the definition of only those that are still referenced. This
-                            // lets us retain only the minimal set of publication details, which can
-                            // help avoid issues when generating PostgreSQL table casts.
-                            //
-                            // For example, if a table in the publication contains a column whose
-                            // cast requires using `TEXT COLUMNS` but the table is not an ingested
-                            // subsource. This poses an issue because `TEXT COLUMNS` requires that
-                            // the columns refer only to referenced subsources. The best solution to
-                            // this is to ensure that we simply don't try to generate the table cast
-                            // in the first place.
-                            curr_references.contains(&name)
-                        });
-
-                        mz_ore::soft_assert_eq_or_log!(
-                            curr_details.tables.len(),
-                            curr_references.len(),
-                            "PostgresSourcePublicationDetails must have entry for every reference"
-                        );
-
-                        let referenced_oids: BTreeSet<_> =
-                            curr_details.tables.iter().map(|t| t.oid).collect();
-
-                        // Ensure that new tables are distinct from the current tables. We check the names only because
-                        for table in new_details.tables.iter() {
-                            let name = UnresolvedItemName(vec![
-                                // Unchecked is fine beause we have previously verified
-                                // that these are valid idents.
-                                Ident::new_unchecked(curr_details.database.clone()),
-                                Ident::new_unchecked(table.namespace.clone()),
-                                Ident::new_unchecked(table.name.clone()),
-                            ]);
-
-                            // Check both the OIDs and the names of the references to protect against
-                            // hard-to-reason-about renames.
-                            if referenced_oids.contains(&table.oid)
-                                || curr_references.contains(&name)
-                            {
-                                Err(AdapterError::SubsourceAlreadyReferredTo { name })?;
-                            }
-                        }
-
-                        // Merge the current table definitions into new tables. Note
-                        // this changes the output indexes of the subsources.
-                        new_details.tables.extend(curr_details.tables);
-
-                        curr_options.push(PgConfigOption {
-                            name: PgConfigOptionName::Details,
-                            value: Some(WithOptionValue::Value(Value::String(hex::encode(
-                                new_details.into_proto().encode_to_vec(),
-                            )))),
-                        });
+                        curr_options.retain(|o| !matches!(o.name, PgConfigOptionName::TextColumns));
 
                         // Drop all text columns that are not currently referred to.
                         text_columns.retain(|column_qualified_reference| {
@@ -3710,115 +3608,19 @@ impl Coordinator {
                         ..
                     } => {
                         let mz_sql::plan::MySqlConfigOptionExtracted {
-                            details,
                             mut text_columns,
                             mut ignore_columns,
                             ..
                         } = curr_options.clone().try_into()?;
 
-                        // Drop both details and text columns; we will add them back in
+                        // Drop both ignore and text columns; we will add them back in
                         // as appropriate below.
                         curr_options.retain(|o| {
                             !matches!(
                                 o.name,
-                                MySqlConfigOptionName::Details
-                                    | MySqlConfigOptionName::TextColumns
+                                MySqlConfigOptionName::TextColumns
                                     | MySqlConfigOptionName::IgnoreColumns
                             )
-                        });
-
-                        let gen_details =
-                            |details: Option<String>| -> Result<MySqlSourceDetails, AdapterError> {
-                                let details = details.as_ref().ok_or_else(|| {
-                                    AdapterError::internal(
-                                        ALTER_SOURCE,
-                                        "MySQL source missing details",
-                                    )
-                                })?;
-
-                                let details = hex::decode(details)
-                                    .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?;
-                                let details = ProtoMySqlSourceDetails::decode(&*details)
-                                    .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?;
-
-                                let mut details = MySqlSourceDetails::from_proto(details)
-                                    .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?;
-
-                                // Expand the initial_gtid_set vec to be one entry per table if
-                                // it's currently in the form of one entry for the whole source.
-                                if details.initial_gtid_set.len() == 1 {
-                                    details.initial_gtid_set = vec![
-                                        details.initial_gtid_set[0]
-                                            .clone();
-                                        details.tables.len()
-                                    ];
-                                }
-                                Ok(details)
-                            };
-
-                        let mut curr_details = gen_details(details)?;
-                        let mut new_details = gen_details(new_details)?;
-
-                        // this doesn't check table names, so we must do that separately.
-                        curr_details
-                            .alter_compatible(cur_entry.id(), &new_details)
-                            .map_err(StorageError::InvalidAlter)?;
-
-                        // Trim any unreferred-to tables and their corresponding initial_gtid_sets.
-                        let mut to_remove = vec![];
-                        for (i, table) in curr_details.tables.iter().enumerate() {
-                            let name = UnresolvedItemName(vec![
-                                // Unchecked is fine beause we have previously verified
-                                // that these are valid idents.
-                                Ident::new_unchecked(table.schema_name.clone()),
-                                Ident::new_unchecked(table.name.clone()),
-                            ]);
-                            if !curr_references.contains(&name) {
-                                to_remove.push(i);
-                            }
-                        }
-                        for i in to_remove.into_iter().rev() {
-                            curr_details.tables.remove(i);
-                            curr_details.initial_gtid_set.remove(i);
-                        }
-
-                        mz_ore::soft_assert_eq_or_log!(
-                            curr_details.tables.len(),
-                            curr_references.len(),
-                            "MySqlSourceDetails must have entry for every reference"
-                        );
-
-                        // Ensure that new tables are distinct from the current tables.
-                        for table in new_details.tables.iter() {
-                            let name = UnresolvedItemName(vec![
-                                // Unchecked is fine beause we have previously verified
-                                // that these are valid idents.
-                                Ident::new_unchecked(table.schema_name.clone()),
-                                Ident::new_unchecked(table.name.clone()),
-                            ]);
-                            if curr_references.contains(&name) {
-                                Err(AdapterError::SubsourceAlreadyReferredTo { name })?;
-                            }
-                        }
-
-                        // Merge the current table definitions into new tables. Note
-                        // this changes the output indexes of the subsources.
-                        new_details.tables.extend(curr_details.tables);
-                        new_details
-                            .initial_gtid_set
-                            .extend(curr_details.initial_gtid_set);
-
-                        assert_eq!(
-                            new_details.tables.len(),
-                            new_details.initial_gtid_set.len(),
-                            "initial_gtid_set must have entry for every table after merging"
-                        );
-
-                        curr_options.push(MySqlConfigOption {
-                            name: MySqlConfigOptionName::Details,
-                            value: Some(WithOptionValue::Value(Value::String(hex::encode(
-                                new_details.into_proto().encode_to_vec(),
-                            )))),
                         });
 
                         // Drop all text / ignore columns that are not currently referred to.
@@ -3957,10 +3759,12 @@ impl Coordinator {
                         DataSourceDesc::IngestionExport {
                             ingestion_id,
                             external_reference,
+                            details,
                         } => (
                             DataSource::IngestionExport {
                                 ingestion_id,
                                 external_reference,
+                                details,
                             },
                             source_status_collection_id,
                         ),

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -169,6 +169,13 @@ impl<'a> Transaction<'a> {
         })
     }
 
+    pub fn get_item(&self, id: &GlobalId) -> Option<Item> {
+        let key = ItemKey { gid: *id };
+        self.items
+            .get(&key)
+            .map(|v| DurableType::from_key_value(key, v.clone()))
+    }
+
     pub fn get_items(&self) -> impl Iterator<Item = Item> {
         self.items
             .items()

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -1602,15 +1602,18 @@ impl CatalogEntry {
         matches!(self.item(), CatalogItem::Source(_))
     }
 
-    /// Reports whether this catalog entry is a subsource and, if it is, the
-    /// ingestion it is a subsource of, as well as the item it exports.
-    pub fn subsource_details(&self) -> Option<(GlobalId, &UnresolvedItemName)> {
+    /// Reports whether this catalog entry is a source export and, if it is, the
+    /// ingestion it is an export of of, as well as the item it exports.
+    pub fn source_export_details(
+        &self,
+    ) -> Option<(GlobalId, &UnresolvedItemName, &SourceExportDetails)> {
         match &self.item() {
             CatalogItem::Source(source) => match &source.data_source {
                 DataSourceDesc::IngestionExport {
                     ingestion_id,
                     external_reference,
-                } => Some((*ingestion_id, external_reference)),
+                    details,
+                } => Some((*ingestion_id, external_reference, details)),
                 _ => None,
             },
             _ => None,
@@ -2381,8 +2384,10 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
         self.used_by()
     }
 
-    fn subsource_details(&self) -> Option<(GlobalId, &UnresolvedItemName)> {
-        self.subsource_details()
+    fn source_export_details(
+        &self,
+    ) -> Option<(GlobalId, &UnresolvedItemName, &SourceExportDetails)> {
+        self.source_export_details()
     }
 
     fn is_progress_source(&self) -> bool {

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -52,7 +52,8 @@ use mz_storage_client::controller::IntrospectionType;
 use mz_storage_types::connections::inline::ReferencedConnection;
 use mz_storage_types::sinks::{SinkEnvelope, StorageSinkConnection};
 use mz_storage_types::sources::{
-    GenericSourceConnection, SourceConnection, SourceDesc, SourceEnvelope, Timeline,
+    GenericSourceConnection, SourceConnection, SourceDesc, SourceEnvelope, SourceExportDetails,
+    Timeline,
 };
 use once_cell::sync::Lazy;
 use serde::ser::SerializeSeq;
@@ -560,6 +561,7 @@ pub enum DataSourceDesc {
     IngestionExport {
         ingestion_id: GlobalId,
         external_reference: UnresolvedItemName,
+        details: SourceExportDetails,
     },
     /// Receives introspection data from an internal system
     Introspection(IntrospectionType),
@@ -630,6 +632,7 @@ impl Source {
                 mz_sql::plan::DataSourceDesc::IngestionExport {
                     ingestion_id,
                     external_reference,
+                    details,
                 } => {
                     assert!(
                         plan.in_cluster.is_none(),
@@ -638,6 +641,7 @@ impl Source {
                     DataSourceDesc::IngestionExport {
                         ingestion_id,
                         external_reference,
+                        details,
                     }
                 }
                 mz_sql::plan::DataSourceDesc::Webhook {

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1022,6 +1022,11 @@ pub enum PgConfigOptionName {
     /// The name of the publication to sync
     Publication,
     /// Columns whose types you want to unconditionally format as text
+    /// NOTE(roshan): This value is kept around to allow round-tripping a
+    /// `CREATE SOURCE` statement while we still allow creating implicit
+    /// subsources from `CREATE SOURCE`, but will be removed once
+    /// fully deprecating that feature and forcing users to use explicit
+    /// `CREATE TABLE .. FROM SOURCE` statements
     TextColumns,
 }
 
@@ -1066,8 +1071,18 @@ pub enum MySqlConfigOptionName {
     /// `mz_storage_types::sources::mysql::MySqlSourceDetails`
     Details,
     /// Columns whose types you want to unconditionally format as text
+    /// NOTE(roshan): This value is kept around to allow round-tripping a
+    /// `CREATE SOURCE` statement while we still allow creating implicit
+    /// subsources from `CREATE SOURCE`, but will be removed once
+    /// fully deprecating that feature and forcing users to use explicit
+    /// `CREATE TABLE .. FROM SOURCE` statements
     TextColumns,
     /// Columns you want to ignore
+    /// NOTE(roshan): This value is kept around to allow round-tripping a
+    /// `CREATE SOURCE` statement while we still allow creating implicit
+    /// subsources from `CREATE SOURCE`, but will be removed once
+    /// fully deprecating that feature and forcing users to use explicit
+    /// `CREATE TABLE .. FROM SOURCE` statements
     IgnoreColumns,
 }
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1096,18 +1096,24 @@ pub enum CreateSubsourceOptionName {
     Progress,
     // Tracks which item this subsource references in the primary source.
     ExternalReference,
+    /// Columns whose types you want to unconditionally format as text
+    TextColumns,
+    /// Columns you want to ignore when ingesting data
+    IgnoreColumns,
+    /// `DETAILS` for this subsource, hex-encoded protobuf type
+    /// [`mz_storage_types::sources::SourceExportStatementDetails`]
+    Details,
 }
 
 impl AstDisplay for CreateSubsourceOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        match self {
-            CreateSubsourceOptionName::Progress => {
-                f.write_str("PROGRESS");
-            }
-            CreateSubsourceOptionName::ExternalReference => {
-                f.write_str("EXTERNAL REFERENCE");
-            }
-        }
+        f.write_str(match self {
+            CreateSubsourceOptionName::Progress => "PROGRESS",
+            CreateSubsourceOptionName::ExternalReference => "EXTERNAL REFERENCE",
+            CreateSubsourceOptionName::TextColumns => "TEXT COLUMNS",
+            CreateSubsourceOptionName::IgnoreColumns => "IGNORE COLUMNS",
+            CreateSubsourceOptionName::Details => "DETAILS",
+        })
     }
 }
 
@@ -1119,9 +1125,11 @@ impl WithOptionName for CreateSubsourceOptionName {
     /// on the conservative side and return `true`.
     fn redact_value(&self) -> bool {
         match self {
-            CreateSubsourceOptionName::Progress | CreateSubsourceOptionName::ExternalReference => {
-                false
-            }
+            CreateSubsourceOptionName::Progress
+            | CreateSubsourceOptionName::ExternalReference
+            | CreateSubsourceOptionName::Details
+            | CreateSubsourceOptionName::TextColumns
+            | CreateSubsourceOptionName::IgnoreColumns => false,
         }
     }
 }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -32,7 +32,7 @@ use mz_repr::{ColumnName, GlobalId, RelationDesc};
 use mz_sql_parser::ast::{Expr, QualifiedReplica, UnresolvedItemName};
 use mz_storage_types::connections::inline::{ConnectionResolver, ReferencedConnection};
 use mz_storage_types::connections::{Connection, ConnectionContext};
-use mz_storage_types::sources::SourceDesc;
+use mz_storage_types::sources::{SourceDesc, SourceExportDetails};
 use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
 use regex::Regex;
@@ -613,9 +613,11 @@ pub trait CatalogItem {
     /// Returns the IDs of the catalog items that depend upon this catalog item.
     fn used_by(&self) -> &[GlobalId];
 
-    /// Reports whether this catalog entry is a subsource and, if it is, the
-    /// ingestion it is a subsource of, as well as the item it exports.
-    fn subsource_details(&self) -> Option<(GlobalId, &UnresolvedItemName)>;
+    /// Reports whether this catalog entry is a source export and, if it is, the
+    /// ingestion it is an export of, as well as the item it exports.
+    fn source_export_details(
+        &self,
+    ) -> Option<(GlobalId, &UnresolvedItemName, &SourceExportDetails)>;
 
     /// Reports whether this catalog item is a progress source.
     fn is_progress_source(&self) -> bool;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -51,7 +51,7 @@ use mz_sql_parser::ast::{
 };
 use mz_storage_types::connections::inline::ReferencedConnection;
 use mz_storage_types::sinks::{S3SinkFormat, SinkEnvelope, StorageSinkConnection};
-use mz_storage_types::sources::{SourceDesc, Timeline};
+use mz_storage_types::sources::{SourceDesc, SourceExportDetails, Timeline};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -1331,6 +1331,7 @@ pub enum DataSourceDesc {
     IngestionExport {
         ingestion_id: GlobalId,
         external_reference: UnresolvedItemName,
+        details: SourceExportDetails,
     },
     /// Receives data from the source's reclocking/remapping operations.
     Progress,

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -253,8 +253,8 @@ pub enum PlanError {
         expected_type: ObjectType,
     },
     /// MZ failed to generate cast for the data type.
-    PublicationContainsUningestableTypes {
-        publication: String,
+    TableContainsUningestableTypes {
+        name: String,
         type_: String,
         column: String,
     },
@@ -435,8 +435,8 @@ impl PlanError {
             | Self::InvalidRefreshEveryAlignedTo => {
                 Some("Calling `mz_now()` is allowed.".into())
             },
-            Self::PublicationContainsUningestableTypes { column,.. } => {
-                Some(format!("Remove the table from the publication or use TEXT COLUMNS ({column}, ..) to ingest this column as text"))
+            Self::TableContainsUningestableTypes { column,.. } => {
+                Some(format!("Remove the table or use TEXT COLUMNS ({column}, ..) to ingest this column as text"))
             }
             Self::RetainHistoryLow { .. } | Self::RetainHistoryRequired => {
                 Some("Use ALTER ... RESET (RETAIN HISTORY) to set the retain history to its default and lowest value.".into())
@@ -728,8 +728,8 @@ impl fmt::Display for PlanError {
                     expected_type.to_string().to_lowercase()
                 )
             }
-            Self::PublicationContainsUningestableTypes { publication, type_, column } => {
-                write!(f, "publication {publication} contains column {column} of type {type_} which Materialize cannot currently ingest")
+            Self::TableContainsUningestableTypes { name, type_, column } => {
+                write!(f, "table {name} contains column {column} of type {type_} which Materialize cannot currently ingest")
             },
             Self::RetainHistoryLow { limit } => {
                 write!(f, "RETAIN HISTORY cannot be set lower than {}ms", limit.as_millis())

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -27,13 +27,12 @@ use mz_interchange::avro::{AvroSchemaGenerator, DocTarget};
 use mz_ore::cast::{CastFrom, TryCastFrom};
 use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::num::NonNeg;
+use mz_ore::soft_panic_or_log;
 use mz_ore::str::StrExt;
 use mz_ore::vec::VecExt;
-use mz_ore::{assert_none, soft_panic_or_log};
 use mz_proto::RustType;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
-use mz_repr::adt::system::Oid;
 use mz_repr::optimize::OptimizerFeatureOverrides;
 use mz_repr::refresh_schedule::{RefreshEvery, RefreshSchedule};
 use mz_repr::role_id::RoleId;
@@ -98,11 +97,13 @@ use mz_storage_types::sources::mysql::{
     MySqlSourceConnection, MySqlSourceDetails, ProtoMySqlSourceDetails,
 };
 use mz_storage_types::sources::postgres::{
-    CastType, PostgresSourceConnection, PostgresSourcePublicationDetails,
+    PostgresSourceConnection, PostgresSourcePublicationDetails,
     ProtoPostgresSourcePublicationDetails,
 };
 use mz_storage_types::sources::{
-    GenericSourceConnection, SourceConnection, SourceDesc, SourceReferenceResolver, Timeline,
+    GenericSourceConnection, MySqlSourceExportDetails, PostgresSourceExportDetails,
+    ProtoSourceExportStatementDetails, SourceConnection, SourceDesc, SourceExportDetails,
+    SourceExportStatementDetails, Timeline,
 };
 use prost::Message;
 
@@ -119,12 +120,11 @@ use crate::names::{
 };
 use crate::normalize::{self, ident};
 use crate::plan::error::PlanError;
-use crate::plan::expr::ColumnRef;
 use crate::plan::query::{plan_expr, scalar_type_from_catalog, ExprContext, QueryLifetime};
 use crate::plan::scope::Scope;
 use crate::plan::statement::ddl::connection::{INALTERABLE_OPTIONS, MUTUALLY_EXCLUSIVE_SETS};
 use crate::plan::statement::{scl, StatementContext, StatementDesc};
-use crate::plan::typeconv::{plan_cast, CastContext};
+use crate::plan::typeconv::CastContext;
 use crate::plan::with_options::{OptionalDuration, TryFromValue};
 use crate::plan::{
     literal, plan_utils, query, transform_ast, AlterClusterPlan, AlterClusterRenamePlan,
@@ -138,7 +138,7 @@ use crate::plan::{
     CreateConnectionPlan, CreateDatabasePlan, CreateIndexPlan, CreateMaterializedViewPlan,
     CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan,
     CreateTablePlan, CreateTypePlan, CreateViewPlan, DataSourceDesc, DropObjectsPlan,
-    DropOwnedPlan, FullItemName, HirScalarExpr, Index, Ingestion, MaterializedView, Params, Plan,
+    DropOwnedPlan, FullItemName, Index, Ingestion, MaterializedView, Params, Plan,
     PlanClusterOption, PlanNotice, QueryContext, ReplicaConfig, Secret, Sink, Source, Table, Type,
     VariableValue, View, WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders,
 };
@@ -801,17 +801,13 @@ pub fn plan_create_source(
             options,
         } => {
             let connection_item = scx.get_item_by_resolved_name(connection)?;
-            let connection = match connection_item.connection()? {
-                Connection::Postgres(connection) => connection.clone(),
-                _ => sql_bail!(
-                    "{} is not a postgres connection",
-                    scx.catalog.resolve_full_name(connection_item.name())
-                ),
-            };
             let PgConfigOptionExtracted {
                 details,
                 publication,
-                text_columns,
+                // text columns are already part of the source-exports and are only included
+                // in these options for roundtripping of a `CREATE SOURCE` statement. This should
+                // be removed once we drop support for implicitly created subsources.
+                text_columns: _,
                 seen: _,
             } = options.clone().try_into()?;
 
@@ -825,199 +821,10 @@ pub fn plan_create_source(
             let publication_details = PostgresSourcePublicationDetails::from_proto(details)
                 .map_err(|e| sql_err!("{}", e))?;
 
-            let reference_resolver =
-                SourceReferenceResolver::new(&connection.database, &publication_details.tables)
-                    .expect("references validated during purification");
-
-            let mut text_cols: BTreeMap<Oid, BTreeSet<String>> = BTreeMap::new();
-
-            // Look up the referenced text_columns in the publication_catalog.
-            for name in text_columns {
-                let (col, qual) = name.0.split_last().expect("must have at least one element");
-
-                let idx = reference_resolver
-                    .resolve_idx(qual)
-                    .expect("known to exist from purification");
-
-                let table_desc = &publication_details.tables[idx];
-
-                assert!(
-                    table_desc
-                        .columns
-                        .iter()
-                        .find(|column| column.name == col.as_str())
-                        .is_some(),
-                    "validated column exists in table during purification"
-                );
-
-                text_cols
-                    .entry(Oid(table_desc.oid))
-                    .or_default()
-                    .insert(col.clone().into_string());
-            }
-
-            // Here we will generate the cast expressions required to convert the text encoded
-            // columns into the appropriate target types, creating a Vec<MirScalarExpr> per table.
-            // The postgres source reader will then eval each of those on the incoming rows based
-            // on the target table
-            let mut table_casts = BTreeMap::new();
-
-            for (i, table) in publication_details.tables.iter().enumerate() {
-                // First, construct an expression context where the expression is evaluated on an
-                // imaginary row which has the same number of columns as the upstream table but all
-                // of the types are text
-                let mut cast_scx = scx.clone();
-                cast_scx.param_types = Default::default();
-                let cast_qcx = QueryContext::root(&cast_scx, QueryLifetime::Source);
-                let mut column_types = vec![];
-                for column in table.columns.iter() {
-                    column_types.push(ColumnType {
-                        nullable: column.nullable,
-                        scalar_type: ScalarType::String,
-                    });
-                }
-
-                let cast_ecx = ExprContext {
-                    qcx: &cast_qcx,
-                    name: "plan_postgres_source_cast",
-                    scope: &Scope::empty(),
-                    relation_type: &RelationType {
-                        column_types,
-                        keys: vec![],
-                    },
-                    allow_aggregates: false,
-                    allow_subqueries: false,
-                    allow_parameters: false,
-                    allow_windows: false,
-                };
-
-                // Then, for each column we will generate a MirRelationExpr that extracts the nth
-                // column and casts it to the appropriate target type
-                let mut column_casts = vec![];
-                for (i, column) in table.columns.iter().enumerate() {
-                    let (cast_type, ty) = match text_cols.get(&Oid(table.oid)) {
-                        // Treat the column as text if it was referenced in
-                        // `TEXT COLUMNS`. This is the only place we need to
-                        // perform this logic; even if the type is unsupported,
-                        // we'll be able to ingest its values as text in
-                        // storage.
-                        Some(names) if names.contains(&column.name) => {
-                            (CastType::Text, mz_pgrepr::Type::Text)
-                        }
-                        _ => {
-                            match mz_pgrepr::Type::from_oid_and_typmod(
-                                column.type_oid,
-                                column.type_mod,
-                            ) {
-                                Ok(t) => (CastType::Natural, t),
-                                // If this reference survived purification, we
-                                // do not expect it to be from a table that the
-                                // user will consume., i.e. expect this table to
-                                // be filtered out of table casts.
-                                Err(_) => {
-                                    column_casts.push((
-                                        CastType::Natural,
-                                        HirScalarExpr::CallVariadic {
-                                            func: mz_expr::VariadicFunc::ErrorIfNull,
-                                            exprs: vec![
-                                                HirScalarExpr::literal_null(ScalarType::String),
-                                                HirScalarExpr::literal(
-                                                    mz_repr::Datum::from(
-                                                        format!(
-                                                            "Unsupported type with OID {}",
-                                                            column.type_oid
-                                                        )
-                                                        .as_str(),
-                                                    ),
-                                                    ScalarType::String,
-                                                ),
-                                            ],
-                                        }
-                                        .lower_uncorrelated()
-                                        .expect("no correlation"),
-                                    ));
-                                    continue;
-                                }
-                            }
-                        }
-                    };
-
-                    let data_type = scx.resolve_type(ty)?;
-                    let scalar_type = query::scalar_type_from_sql(scx, &data_type)?;
-
-                    let col_expr = HirScalarExpr::Column(ColumnRef {
-                        level: 0,
-                        column: i,
-                    });
-
-                    let cast_expr =
-                        plan_cast(&cast_ecx, CastContext::Explicit, col_expr, &scalar_type)?;
-
-                    let cast = if column.nullable {
-                        cast_expr
-                    } else {
-                        // We must enforce nullability constraint on cast
-                        // because PG replication stream does not propagate
-                        // constraint changes and we want to error subsource if
-                        // e.g. the constraint is dropped and we don't notice
-                        // it.
-                        HirScalarExpr::CallVariadic {
-                            func: mz_expr::VariadicFunc::ErrorIfNull,
-                            exprs: vec![
-                                cast_expr,
-                                HirScalarExpr::literal(
-                                    mz_repr::Datum::from(
-                                        format!(
-                                            "PG column {}.{}.{} contained NULL data, despite having NOT NULL constraint",
-                                            table.namespace.clone(),
-                                            table.name.clone(),
-                                            column.name.clone())
-                                            .as_str(),
-                                    ),
-                                    ScalarType::String,
-                                ),
-                            ],
-                        }
-                    };
-
-                    // We expect only reg* types to encounter this issue. Users
-                    // can ingest the data as text if they need to ingest it.
-                    // This is acceptable because we don't expect the OIDs from
-                    // an external PG source to be unilaterally usable in
-                    // resolving item names in MZ.
-                    let mir_cast = cast.lower_uncorrelated().map_err(|_e| {
-                        tracing::info!(
-                            "cannot ingest {:?} data from PG source because cast is correlated",
-                            scalar_type
-                        );
-
-                        let publication = match publication.clone() {
-                            Some(publication) => publication,
-                            None => return sql_err!("[internal error]: missing publication"),
-                        };
-
-                        PlanError::PublicationContainsUningestableTypes {
-                            publication,
-                            type_: scx.humanize_scalar_type(&scalar_type),
-                            column: UnresolvedItemName::qualified(&[
-                                Ident::new_unchecked(table.name.to_string()),
-                                Ident::new_unchecked(column.name.to_string()),
-                            ])
-                            .to_ast_string(),
-                        }
-                    })?;
-
-                    column_casts.push((cast_type, mir_cast));
-                }
-                let r = table_casts.insert(i + 1, column_casts);
-                assert_none!(r, "cannot have table defined multiple times");
-            }
-
             let connection =
                 GenericSourceConnection::<ReferencedConnection>::from(PostgresSourceConnection {
                     connection: connection_item.id(),
                     connection_id: connection_item.id(),
-                    table_casts,
                     publication: publication.expect("validated exists during purification"),
                     publication_details,
                 });
@@ -1038,8 +845,11 @@ pub fn plan_create_source(
             };
             let MySqlConfigOptionExtracted {
                 details,
-                text_columns,
-                ignore_columns,
+                // text/ignore columns are already part of the source-exports and are only included
+                // in these options for roundtripping of a `CREATE SOURCE` statement. This should
+                // be removed once we drop support for implicitly created subsources.
+                text_columns: _,
+                ignore_columns: _,
                 seen: _,
             } = options.clone().try_into()?;
 
@@ -1051,22 +861,11 @@ pub fn plan_create_source(
                 ProtoMySqlSourceDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
             let details = MySqlSourceDetails::from_proto(details).map_err(|e| sql_err!("{}", e))?;
 
-            let text_columns = text_columns
-                .into_iter()
-                .map(|name| name.try_into().map_err(|e| sql_err!("{}", e)))
-                .collect::<Result<Vec<_>, _>>()?;
-            let ignore_columns = ignore_columns
-                .into_iter()
-                .map(|name| name.try_into().map_err(|e| sql_err!("{}", e)))
-                .collect::<Result<Vec<_>, _>>()?;
-
             let connection =
                 GenericSourceConnection::<ReferencedConnection>::from(MySqlSourceConnection {
                     connection: connection_item.id(),
                     connection_id: connection_item.id(),
                     details,
-                    text_columns,
-                    ignore_columns,
                 });
 
             connection
@@ -1426,7 +1225,10 @@ pub fn plan_create_source(
 generate_extracted_config!(
     CreateSubsourceOption,
     (Progress, bool, Default(false)),
-    (ExternalReference, UnresolvedItemName)
+    (ExternalReference, UnresolvedItemName),
+    (TextColumns, Vec::<String>, Default(vec![])),
+    (IgnoreColumns, Vec::<String>, Default(vec![])),
+    (Details, String)
 );
 
 pub fn plan_create_subsource(
@@ -1445,7 +1247,10 @@ pub fn plan_create_subsource(
     let CreateSubsourceOptionExtracted {
         progress,
         external_reference,
-        ..
+        text_columns,
+        ignore_columns,
+        details,
+        seen: _,
     } = with_options.clone().try_into()?;
 
     // This invariant is enforced during purification; we are responsible for
@@ -1561,9 +1366,43 @@ pub fn plan_create_subsource(
         let ingestion_id = *source_reference.item_id();
         let external_reference = external_reference.unwrap();
 
+        // Decode the details option stored on the subsource statement, which contains information
+        // created during the purification process.
+        let details = details
+            .as_ref()
+            .ok_or_else(|| sql_err!("internal error: source-export subsource missing details"))?;
+        let details = hex::decode(details).map_err(|e| sql_err!("{}", e))?;
+        let details =
+            ProtoSourceExportStatementDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
+        let details =
+            SourceExportStatementDetails::from_proto(details).map_err(|e| sql_err!("{}", e))?;
+
+        let details = match details {
+            SourceExportStatementDetails::Postgres { table } => {
+                SourceExportDetails::Postgres(PostgresSourceExportDetails {
+                    table_cast: crate::pure::postgres::generate_table_cast(
+                        scx,
+                        &table,
+                        &text_columns,
+                    )?,
+                    table,
+                })
+            }
+            SourceExportStatementDetails::MySql {
+                table,
+                initial_gtid_set,
+            } => SourceExportDetails::MySql(MySqlSourceExportDetails {
+                table,
+                initial_gtid_set,
+                text_columns,
+                ignore_columns,
+            }),
+        };
+
         DataSourceDesc::IngestionExport {
             ingestion_id,
             external_reference,
+            details,
         }
     } else if progress {
         DataSourceDesc::Progress

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -42,15 +42,14 @@ use mz_sql_parser::ast::{
     CsrConfigOptionName, CsrConnection, CsrSeedAvro, CsrSeedProtobuf, CsrSeedProtobufSchema,
     DeferredItemName, DocOnIdentifier, DocOnSchema, Expr, Function, FunctionArgs, Ident,
     KafkaSourceConfigOption, KafkaSourceConfigOptionName, MaterializedViewOption,
-    MaterializedViewOptionName, MySqlConfigOption, MySqlConfigOptionName, PgConfigOption,
-    PgConfigOptionName, RawItemName, ReaderSchemaSelectionStrategy, RefreshAtOptionValue,
-    RefreshEveryOptionValue, RefreshOptionValue, SourceEnvelope, Statement, UnresolvedItemName,
+    MaterializedViewOptionName, MySqlConfigOptionName, PgConfigOption, PgConfigOptionName,
+    RawItemName, ReaderSchemaSelectionStrategy, RefreshAtOptionValue, RefreshEveryOptionValue,
+    RefreshOptionValue, SourceEnvelope, Statement, UnresolvedItemName,
 };
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::connections::Connection;
 use mz_storage_types::errors::ContextCreationError;
-use mz_storage_types::sources::mysql::MySqlSourceDetails;
 use mz_storage_types::sources::postgres::PostgresSourcePublicationDetails;
 use mz_storage_types::sources::{
     ExternalCatalogReference, GenericSourceConnection, SourceConnection, SourceReferenceResolver,
@@ -251,12 +250,12 @@ pub struct PurifiedSourceExport {
 pub enum PurifiedExportDetails {
     MySql {
         table: MySqlTableDesc,
+        text_columns: Option<BTreeSet<String>>,
+        ignore_columns: Option<BTreeSet<String>>,
+        initial_gtid_set: String,
     },
     Postgres {
         table: PostgresTableDesc,
-        // Text Columns are needed in Postgres to generate cast expressions
-        // when (re)-planning the primary source
-        // TODO: Refactor this when we move casts to the source exports themselves
         text_columns: Option<BTreeSet<String>>,
     },
     Kafka {},
@@ -779,7 +778,6 @@ async fn purify_create_source(
 
             let postgres::PurifiedSourceExports {
                 source_exports: subsources,
-                referenced_tables,
                 normalized_text_columns,
             } = postgres::purify_source_exports(
                 &client,
@@ -811,7 +809,6 @@ async fn purify_create_source(
             // Remove any old detail references
             options.retain(|PgConfigOption { name, .. }| name != &PgConfigOptionName::Details);
             let details = PostgresSourcePublicationDetails {
-                tables: referenced_tables,
                 slot: format!(
                     "materialize_{}",
                     Uuid::new_v4().to_string().replace('-', "")
@@ -897,15 +894,8 @@ async fn purify_create_source(
                 ))?;
             }
 
-            // Retrieve the current @gtid_executed value of the server to mark as the effective
-            // initial snapshot point such that we can ensure consistency if the initial source
-            // snapshot is broken up over multiple points in time.
-            let initial_gtid_set =
-                mz_mysql_util::query_sys_var(&mut conn, "global.gtid_executed").await?;
-
             let mysql::PurifiedSourceExports {
                 source_exports: subsources,
-                tables,
                 normalized_text_columns,
                 normalized_ignore_columns,
             } = mysql::purify_source_exports(
@@ -917,25 +907,6 @@ async fn purify_create_source(
             )
             .await?;
             requested_subsource_map.extend(subsources);
-
-            // Create/Update the details for the source to include the new tables
-            let details = MySqlSourceDetails {
-                tables,
-                // Since we're creating a new source, we can just use a single
-                // value in this vector which is assumed to be for all tables.
-                // If we ever alter this source, this will be expanded to have a
-                // distinct value for each table.
-                initial_gtid_set: vec![initial_gtid_set],
-            };
-            // Update options with the purified details
-            options
-                .retain(|MySqlConfigOption { name, .. }| name != &MySqlConfigOptionName::Details);
-            options.push(MySqlConfigOption {
-                name: MySqlConfigOptionName::Details,
-                value: Some(WithOptionValue::Value(Value::String(hex::encode(
-                    details.into_proto().encode_to_vec(),
-                )))),
-            });
 
             if let Some(text_cols_option) = options
                 .iter_mut()
@@ -1190,7 +1161,6 @@ async fn purify_alter_source(
 
             let postgres::PurifiedSourceExports {
                 source_exports: subsources,
-                referenced_tables,
                 normalized_text_columns,
             } = postgres::purify_source_exports(
                 &client,
@@ -1211,47 +1181,6 @@ async fn purify_alter_source(
             }
 
             requested_subsource_map.extend(subsources);
-
-            let timeline_id = match pg_source_connection.publication_details.timeline_id {
-                None => {
-                    // If we had not yet been able to fill in the source's timeline ID, fill it in now.
-                    let replication_client = config
-                        .connect_replication(
-                            &storage_configuration.connection_context.ssh_tunnel_manager,
-                        )
-                        .await?;
-                    let timeline_id =
-                        mz_postgres_util::get_timeline_id(&replication_client).await?;
-                    Some(timeline_id)
-                }
-                timeline_id => timeline_id,
-            };
-
-            // These new details need to be merged with the existing details and cannot
-            // simply overwrite the existing details. This suggests they should be their
-            // own options, but it's nice to be able to take the values to and from a
-            // hex-encoded string.
-            let new_details = PostgresSourcePublicationDetails {
-                // In this context, we only track the referenced tables; we will merge these with the tables
-                // referenced in the catalog.
-                //
-                // We MUST check for duplicate references when we rejoin the main coordinator thread! We do
-                // that later because the sources that are present might have changed while this
-                // purification occurs.
-                tables: referenced_tables,
-                timeline_id,
-                // This value is not allowed to be altered in the source.
-                slot: pg_source_connection.publication_details.slot,
-                // This value is not allowed to be altered in the source.
-                database: pg_source_connection.publication_details.database,
-            };
-
-            options.push(AlterSourceAddSubsourceOption {
-                name: mz_sql_parser::ast::AlterSourceAddSubsourceOptionName::Details,
-                value: Some(WithOptionValue::Value(Value::String(hex::encode(
-                    new_details.into_proto().encode_to_vec(),
-                )))),
-            });
         }
         GenericSourceConnection::MySql(mysql_source_connection) => {
             let mysql_connection = &mysql_source_connection.connection;
@@ -1274,7 +1203,6 @@ async fn purify_alter_source(
 
             let mysql::PurifiedSourceExports {
                 source_exports: subsources,
-                tables,
                 normalized_text_columns,
                 normalized_ignore_columns,
             } = mysql::purify_source_exports(
@@ -1286,35 +1214,6 @@ async fn purify_alter_source(
             )
             .await?;
             requested_subsource_map.extend(subsources);
-
-            // Retrieve the current @gtid_executed value of the server to mark as the effective
-            // initial snapshot point for these subsources.
-            let initial_gtid_set =
-                mz_mysql_util::query_sys_var(&mut conn, "global.gtid_executed").await?;
-
-            // These new details need to be merged with the existing details and cannot
-            // simply overwrite the existing details. This suggests they should be their
-            // own options, but it's nice to be able to take the values to and from a
-            // hex-encoded string.
-            let new_details = MySqlSourceDetails {
-                // In this context, we only track the referenced tables; we will merge these with the tables
-                // referenced in the catalog.
-                //
-                // We MUST check for duplicate references when we rejoin the main coordinator thread! We do
-                // that later because the sources that are present might have changed while this
-                // purification occurs.
-                tables,
-                // This value will be expanded and merged with the existing value during sequencing to
-                // match the final set of tables.
-                initial_gtid_set: vec![initial_gtid_set],
-            };
-
-            options.push(AlterSourceAddSubsourceOption {
-                name: mz_sql_parser::ast::AlterSourceAddSubsourceOptionName::Details,
-                value: Some(WithOptionValue::Value(Value::String(hex::encode(
-                    new_details.into_proto().encode_to_vec(),
-                )))),
-            });
 
             // Update options with the purified details
             if let Some(text_cols_option) = options

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -11,22 +11,30 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use mz_expr::MirScalarExpr;
 use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::Config;
+use mz_proto::RustType;
+use mz_repr::{ColumnType, RelationType, ScalarType};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
-    ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CreateSubsourceStatement, Ident,
-    WithOptionValue,
+    ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CreateSubsourceStatement,
+    ExternalReferences, Ident, UnresolvedItemName, Value, WithOptionValue,
 };
-use mz_sql_parser::ast::{ExternalReferences, UnresolvedItemName};
 use mz_storage_types::connections::PostgresConnection;
-use mz_storage_types::sources::SourceReferenceResolver;
+use mz_storage_types::sources::postgres::CastType;
+use mz_storage_types::sources::{SourceExportStatementDetails, SourceReferenceResolver};
+use prost::Message;
 use tokio_postgres::types::Oid;
 use tokio_postgres::Client;
 
 use crate::names::{Aug, ResolvedItemName};
 use crate::normalize;
-use crate::plan::{PlanError, StatementContext};
+use crate::plan::expr::ColumnRef;
+use crate::plan::typeconv::{plan_cast, CastContext};
+use crate::plan::{
+    ExprContext, HirScalarExpr, PlanError, QueryContext, QueryLifetime, Scope, StatementContext,
+};
 
 use super::error::PgSourcePurificationError;
 use super::{PartialItemName, PurifiedExportDetails, PurifiedSourceExport, RequestedSourceExport};
@@ -138,7 +146,7 @@ pub fn generate_create_subsource_statements(
     let mut subsources = Vec::with_capacity(requested_subsources.len());
 
     for (subsource_name, purified_export) in requested_subsources {
-        let (text_columns, table) = match &purified_export.details {
+        let (text_columns, table) = match purified_export.details {
             PurifiedExportDetails::Postgres {
                 text_columns,
                 table,
@@ -151,7 +159,7 @@ pub fn generate_create_subsource_statements(
         for c in table.columns.iter() {
             let name = Ident::new(c.name.clone())?;
 
-            let ty = match text_columns {
+            let ty = match &text_columns {
                 Some(names) if names.contains(&c.name) => mz_pgrepr::Type::Text,
                 _ => match mz_pgrepr::Type::from_oid_and_typmod(c.type_oid, c.type_mod) {
                     Ok(t) => t,
@@ -217,6 +225,35 @@ pub fn generate_create_subsource_statements(
             }
         }
 
+        let details = SourceExportStatementDetails::Postgres { table };
+
+        let mut with_options = vec![
+            CreateSubsourceOption {
+                name: CreateSubsourceOptionName::ExternalReference,
+                value: Some(WithOptionValue::UnresolvedItemName(
+                    purified_export.external_reference,
+                )),
+            },
+            CreateSubsourceOption {
+                name: CreateSubsourceOptionName::Details,
+                value: Some(WithOptionValue::Value(Value::String(hex::encode(
+                    details.into_proto().encode_to_vec(),
+                )))),
+            },
+        ];
+
+        if let Some(text_columns) = text_columns {
+            with_options.push(CreateSubsourceOption {
+                name: CreateSubsourceOptionName::TextColumns,
+                value: Some(WithOptionValue::Sequence(
+                    text_columns
+                        .iter()
+                        .map(|s| WithOptionValue::Value::<Aug>(Value::String(s.to_string())))
+                        .collect::<Vec<_>>(),
+                )),
+            });
+        }
+
         // Create the subsource statement
         let subsource = CreateSubsourceStatement {
             name: subsource_name,
@@ -234,12 +271,7 @@ pub fn generate_create_subsource_statements(
             // one without and now we're producing garbage data.
             constraints,
             if_not_exists: false,
-            with_options: vec![CreateSubsourceOption {
-                name: CreateSubsourceOptionName::ExternalReference,
-                value: Some(WithOptionValue::UnresolvedItemName(
-                    purified_export.external_reference,
-                )),
-            }],
+            with_options,
         };
         subsources.push(subsource);
     }
@@ -256,7 +288,13 @@ pub fn generate_create_subsource_statements(
 
 pub(super) struct PurifiedSourceExports {
     pub(super) source_exports: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
-    pub(super) referenced_tables: Vec<PostgresTableDesc>,
+    // NOTE(roshan): These are returned to allow round-tripping a
+    // `CREATE SOURCE` statement while we still allow creating implicit
+    // subsources from `CREATE SOURCE`, but will be removed once
+    // fully deprecating that feature and forcing users to use explicit
+    // `CREATE TABLE .. FROM SOURCE` statements.
+    // The text columns are already part of their appropriate
+    // `source_exports` above.
     pub(super) normalized_text_columns: Vec<WithOptionValue<Aug>>,
 }
 
@@ -429,9 +467,146 @@ pub(super) async fn purify_source_exports(
 
     Ok(PurifiedSourceExports {
         source_exports: requested_subsources,
-        referenced_tables: publication_tables,
         normalized_text_columns,
     })
+}
+
+pub(crate) fn generate_table_cast(
+    scx: &StatementContext,
+    table: &PostgresTableDesc,
+    text_columns: &Vec<String>,
+) -> Result<Vec<(CastType, MirScalarExpr)>, PlanError> {
+    // Generate the cast expressions required to convert the text encoded columns into
+    // the appropriate target types, creating a Vec<MirScalarExpr>
+    // The postgres source reader will then eval each of those on the incoming rows
+    // First, construct an expression context where the expression is evaluated on an
+    // imaginary row which has the same number of columns as the upstream table but all
+    // of the types are text
+    let mut cast_scx = scx.clone();
+    cast_scx.param_types = Default::default();
+    let cast_qcx = QueryContext::root(&cast_scx, QueryLifetime::Source);
+    let mut column_types = vec![];
+    for column in table.columns.iter() {
+        column_types.push(ColumnType {
+            nullable: column.nullable,
+            scalar_type: ScalarType::String,
+        });
+    }
+
+    let cast_ecx = ExprContext {
+        qcx: &cast_qcx,
+        name: "plan_postgres_source_cast",
+        scope: &Scope::empty(),
+        relation_type: &RelationType {
+            column_types,
+            keys: vec![],
+        },
+        allow_aggregates: false,
+        allow_subqueries: false,
+        allow_parameters: false,
+        allow_windows: false,
+    };
+
+    // Then, for each column we will generate a MirRelationExpr that extracts the nth
+    // column and casts it to the appropriate target type
+    let mut table_cast = vec![];
+    for (i, column) in table.columns.iter().enumerate() {
+        let (cast_type, ty) = if text_columns.contains(&column.name) {
+            // Treat the column as text if it was referenced in
+            // `TEXT COLUMNS`. This is the only place we need to
+            // perform this logic; even if the type is unsupported,
+            // we'll be able to ingest its values as text in
+            // storage.
+            (CastType::Text, mz_pgrepr::Type::Text)
+        } else {
+            match mz_pgrepr::Type::from_oid_and_typmod(column.type_oid, column.type_mod) {
+                Ok(t) => (CastType::Natural, t),
+                // If this reference survived purification, we
+                // do not expect it to be from a table that the
+                // user will consume., i.e. expect this table to
+                // be filtered out of table casts.
+                Err(_) => {
+                    table_cast.push((
+                        CastType::Natural,
+                        HirScalarExpr::CallVariadic {
+                            func: mz_expr::VariadicFunc::ErrorIfNull,
+                            exprs: vec![
+                                HirScalarExpr::literal_null(ScalarType::String),
+                                HirScalarExpr::literal(
+                                    mz_repr::Datum::from(
+                                        format!("Unsupported type with OID {}", column.type_oid)
+                                            .as_str(),
+                                    ),
+                                    ScalarType::String,
+                                ),
+                            ],
+                        }
+                        .lower_uncorrelated()
+                        .expect("no correlation"),
+                    ));
+                    continue;
+                }
+            }
+        };
+
+        let data_type = scx.resolve_type(ty)?;
+        let scalar_type = crate::plan::query::scalar_type_from_sql(scx, &data_type)?;
+
+        let col_expr = HirScalarExpr::Column(ColumnRef {
+            level: 0,
+            column: i,
+        });
+
+        let cast_expr = plan_cast(&cast_ecx, CastContext::Explicit, col_expr, &scalar_type)?;
+
+        let cast = if column.nullable {
+            cast_expr
+        } else {
+            // We must enforce nullability constraint on cast
+            // because PG replication stream does not propagate
+            // constraint changes and we want to error subsource if
+            // e.g. the constraint is dropped and we don't notice
+            // it.
+            HirScalarExpr::CallVariadic {
+                            func: mz_expr::VariadicFunc::ErrorIfNull,
+                            exprs: vec![
+                                cast_expr,
+                                HirScalarExpr::literal(
+                                    mz_repr::Datum::from(
+                                        format!(
+                                            "PG column {}.{}.{} contained NULL data, despite having NOT NULL constraint",
+                                            table.namespace.clone(),
+                                            table.name.clone(),
+                                            column.name.clone())
+                                            .as_str(),
+                                    ),
+                                    ScalarType::String,
+                                ),
+                            ],
+                        }
+        };
+
+        // We expect only reg* types to encounter this issue. Users
+        // can ingest the data as text if they need to ingest it.
+        // This is acceptable because we don't expect the OIDs from
+        // an external PG source to be unilaterally usable in
+        // resolving item names in MZ.
+        let mir_cast = cast.lower_uncorrelated().map_err(|_e| {
+            tracing::info!(
+                "cannot ingest {:?} data from PG source because cast is correlated",
+                scalar_type
+            );
+
+            PlanError::TableContainsUningestableTypes {
+                name: table.name.to_string(),
+                type_: scx.humanize_scalar_type(&scalar_type),
+                column: column.name.to_string(),
+            }
+        })?;
+
+        table_cast.push((cast_type, mir_cast));
+    }
+    Ok(table_cast)
 }
 
 mod privileges {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -45,7 +45,7 @@ use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sinks::{MetadataUnfilled, StorageSinkConnection, StorageSinkDesc};
 use mz_storage_types::sources::{
-    GenericSourceConnection, IngestionDescription, SourceData, SourceDesc,
+    GenericSourceConnection, IngestionDescription, SourceData, SourceDesc, SourceExportDetails,
 };
 use serde::{Deserialize, Serialize};
 use timely::progress::Timestamp as TimelyTimestamp;
@@ -108,6 +108,7 @@ pub enum DataSource {
         // be sufficiently genericized to support all multi-output sources we
         // support.
         external_reference: UnresolvedItemName,
+        details: SourceExportDetails,
     },
     /// Data comes from introspection sources, which the controller itself is
     /// responsible for generating.

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -47,7 +47,7 @@ use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sources::{
     ExportReference, GenericSourceConnection, IngestionDescription, SourceData, SourceDesc,
-    SourceExport,
+    SourceExport, SourceExportDetails,
 };
 use mz_txn_wal::metrics::Metrics as TxnMetrics;
 use mz_txn_wal::txn_read::{DataSnapshot, TxnsRead};
@@ -1492,6 +1492,7 @@ where
                     SourceExport {
                         ingestion_output: None,
                         storage_metadata: (),
+                        details: SourceExportDetails::None,
                     },
                 );
             }
@@ -1575,6 +1576,7 @@ where
                 DataSource::IngestionExport {
                     ingestion_id,
                     external_reference,
+                    details,
                 } => {
                     // Adjust the source to contain this export.
                     let source_collection = self_collections
@@ -1591,6 +1593,7 @@ where
                                     external_reference.clone(),
                                 )),
                                 storage_metadata: (),
+                                details: details.clone(),
                             },
                         ),
                         _ => unreachable!(

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -71,8 +71,8 @@ use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sinks::{StorageSinkConnection, StorageSinkDesc};
 use mz_storage_types::sources::{
-    ExportReference, GenericSourceConnection, IngestionDescription, SourceConnection, SourceData,
-    SourceDesc, SourceExport, SourceExportDetails,
+    ExportReference, GenericSourceConnection, IngestionDescription, SourceData, SourceDesc,
+    SourceExport, SourceExportDetails,
 };
 use mz_storage_types::AlterCompatible;
 use mz_txn_wal::metrics::Metrics as TxnMetrics;

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -70,6 +70,22 @@ message ProtoCompression {
     }
 }
 
+message ProtoSourceExportDetails {
+    oneof kind {
+        mz_storage_types.sources.kafka.ProtoKafkaSourceExportDetails kafka = 1;
+        mz_storage_types.sources.postgres.ProtoPostgresSourceExportDetails postgres = 2;
+        mz_storage_types.sources.mysql.ProtoMySqlSourceExportDetails mysql = 3;
+        mz_storage_types.sources.load_generator.ProtoLoadGeneratorSourceExportDetails loadgen = 4;
+    }
+}
+
+message ProtoSourceExportStatementDetails {
+    oneof kind {
+        mz_storage_types.sources.postgres.ProtoPostgresSourceExportStatementDetails postgres = 1;
+        mz_storage_types.sources.mysql.ProtoMySqlSourceExportStatementDetails mysql = 2;
+    }
+}
+
 message ProtoIngestionDescription {
     message ProtoSourceImport {
         mz_repr.global_id.ProtoGlobalId id = 1;
@@ -83,6 +99,7 @@ message ProtoIngestionDescription {
         // uint64 output_index = 2;
         mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 3;
         repeated string ingestion_output = 4;
+        ProtoSourceExportDetails details = 5;
     }
 
     reserved 1;

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -72,8 +72,8 @@ pub mod postgres;
 pub use crate::sources::envelope::SourceEnvelope;
 pub use crate::sources::kafka::KafkaSourceConnection;
 pub use crate::sources::load_generator::LoadGeneratorSourceConnection;
-pub use crate::sources::mysql::MySqlSourceConnection;
-pub use crate::sources::postgres::PostgresSourceConnection;
+pub use crate::sources::mysql::{MySqlSourceConnection, MySqlSourceExportDetails};
+pub use crate::sources::postgres::{PostgresSourceConnection, PostgresSourceExportDetails};
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage_types.sources.rs"));
 
@@ -109,10 +109,6 @@ impl From<UnresolvedItemName> for ExportReference {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Arbitrary)]
 pub struct IngestionDescription<S: 'static = (), C: ConnectionAccess = InlinedConnection> {
     /// The source description.
-    ///
-    /// # Warning
-    /// Any time this field changes, you _must_ recalculate the [`SourceExport`]
-    /// values in [`Self::source_exports`].
     pub desc: SourceDesc<C>,
     /// Additional storage controller metadata needed to ingest this source
     pub ingestion_metadata: S,
@@ -125,8 +121,6 @@ pub struct IngestionDescription<S: 'static = (), C: ConnectionAccess = InlinedCo
     ///
     ///   Re-rendering/executing the source after making these modifications
     ///   adds and drops the subsource, respectively.
-    /// - Any time the [`Self::desc`] field changes, you must recalculate the
-    ///   [`SourceExport`] values.
     /// - This field includes the primary source's ID, which might need to be
     ///   filtered out to understand which exports are ingestion export
     ///   subsources.
@@ -182,35 +176,30 @@ impl<S> IngestionDescription<S> {
 
 impl<S: Clone> IngestionDescription<S> {
     pub fn source_exports_with_output_indices(&self) -> BTreeMap<GlobalId, SourceExport<usize, S>> {
-        let reference_resolver = self.desc.connection.get_reference_resolver();
-
         let mut source_exports = BTreeMap::new();
 
         for (
-            id,
-            SourceExport {
-                ingestion_output,
-                storage_metadata,
-            },
-        ) in self.source_exports.iter()
+            idx,
+            (
+                id,
+                SourceExport {
+                    ingestion_output: _,
+                    storage_metadata,
+                    details,
+                },
+            ),
+        ) in self.source_exports.iter().enumerate()
         {
-            let ingestion_output = match ingestion_output {
-                Some(ingestion_output) => {
-                    reference_resolver
-                        .resolve_idx(&ingestion_output.0)
-                        .expect("must have all subsource references")
-                        // output indices are the native details idx + 1 to
-                        // account for the `None` value representing 0.
-                        + 1
-                }
-                None => 0,
-            };
+            // output indices are idx + 1 to
+            // account for the primary source output at 0
+            let ingestion_output = idx + 1;
 
             source_exports.insert(
                 *id,
                 SourceExport {
                     ingestion_output,
                     storage_metadata: storage_metadata.clone(),
+                    details: details.clone(),
                 },
             );
         }
@@ -255,6 +244,7 @@ impl<S: Debug + Eq + PartialEq + AlterCompatible> AlterCompatible for IngestionD
                                 SourceExport {
                                     ingestion_output: l_reference,
                                     storage_metadata: l_metadata,
+                                    details: l_details,
                                 },
                             ),
                             (
@@ -262,11 +252,13 @@ impl<S: Debug + Eq + PartialEq + AlterCompatible> AlterCompatible for IngestionD
                                 SourceExport {
                                     ingestion_output: r_reference,
                                     storage_metadata: r_metadata,
+                                    details: r_details,
                                 },
                             ),
                         ) => {
                             l_reference == r_reference
                                 && l_metadata.alter_compatible(id, r_metadata).is_ok()
+                                && l_details.alter_compatible(id, r_details).is_ok()
                         }
                         _ => true,
                     }),
@@ -322,6 +314,8 @@ pub struct SourceExport<O: proptest::prelude::Arbitrary, S = ()> {
     pub ingestion_output: O,
     /// The collection metadata needed to write the exported data
     pub storage_metadata: S,
+    /// Details necessary for the source to export data to this export's collection.
+    pub details: SourceExportDetails,
 }
 
 impl RustType<ProtoIngestionDescription> for IngestionDescription<CollectionMetadata> {
@@ -390,6 +384,7 @@ impl ProtoMapEntry<GlobalId, SourceExport<Option<ExportReference>, CollectionMet
                 .map(|i| i.clone().into_string())
                 .collect(),
             storage_metadata: Some(source_export.storage_metadata.into_proto()),
+            details: Some(source_export.details.into_proto()),
         }
     }
 
@@ -418,6 +413,9 @@ impl ProtoMapEntry<GlobalId, SourceExport<Option<ExportReference>, CollectionMet
                 storage_metadata: self
                     .storage_metadata
                     .into_rust_if_some("ProtoSourceExport::storage_metadata")?,
+                details: self
+                    .details
+                    .into_rust_if_some("ProtoSourceExport::details")?,
             },
         ))
     }
@@ -738,10 +736,6 @@ pub trait SourceConnection: Debug + Clone + PartialEq + AlterCompatible {
     /// Returns metadata columns that this connection *instance* will produce once rendered. The
     /// columns are returned in the order specified by the user.
     fn metadata_columns(&self) -> Vec<(&str, ColumnType)>;
-
-    /// Returns a [`SourceReferenceResolver`] for this source connection's source exports, keyed
-    /// by their external reference.
-    fn get_reference_resolver(&self) -> SourceReferenceResolver;
 }
 
 #[derive(Arbitrary, Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -1040,15 +1034,6 @@ impl<C: ConnectionAccess> SourceConnection for GenericSourceConnection<C> {
             Self::LoadGenerator(conn) => conn.metadata_columns(),
         }
     }
-
-    fn get_reference_resolver(&self) -> SourceReferenceResolver {
-        match self {
-            Self::Kafka(conn) => conn.get_reference_resolver(),
-            Self::Postgres(conn) => conn.get_reference_resolver(),
-            Self::MySql(conn) => conn.get_reference_resolver(),
-            Self::LoadGenerator(conn) => conn.get_reference_resolver(),
-        }
-    }
 }
 
 impl<C: ConnectionAccess> crate::AlterCompatible for GenericSourceConnection<C> {
@@ -1105,6 +1090,148 @@ impl RustType<ProtoSourceConnection> for GenericSourceConnection<InlinedConnecti
             Kind::Postgres(postgres) => GenericSourceConnection::Postgres(postgres.into_rust()?),
             Kind::Mysql(mysql) => GenericSourceConnection::MySql(mysql.into_rust()?),
             Kind::Loadgen(loadgen) => GenericSourceConnection::LoadGenerator(loadgen.into_rust()?),
+        })
+    }
+}
+
+/// Details necessary for each source export to allow the source implementations
+/// to export data to the export's collection.
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SourceExportDetails {
+    /// Used for the primary export of a source
+    None,
+    Kafka,
+    Postgres(PostgresSourceExportDetails),
+    MySql(MySqlSourceExportDetails),
+    LoadGenerator,
+}
+
+impl crate::AlterCompatible for SourceExportDetails {
+    fn alter_compatible(&self, id: GlobalId, other: &Self) -> Result<(), AlterError> {
+        if self == other {
+            return Ok(());
+        }
+        let r = match (self, other) {
+            (Self::None, Self::None) => Ok(()),
+            (Self::Kafka, Self::Kafka) => Ok(()),
+            (Self::Postgres(s), Self::Postgres(o)) => s.alter_compatible(id, o),
+            (Self::MySql(s), Self::MySql(o)) => s.alter_compatible(id, o),
+            (Self::LoadGenerator, Self::LoadGenerator) => Ok(()),
+            _ => Err(AlterError { id }),
+        };
+
+        if r.is_err() {
+            tracing::warn!(
+                "SourceExportDetails incompatible:\nself:\n{:#?}\n\nother\n{:#?}",
+                self,
+                other
+            );
+        }
+
+        r
+    }
+}
+
+impl RustType<ProtoSourceExportDetails> for SourceExportDetails {
+    fn into_proto(&self) -> ProtoSourceExportDetails {
+        use proto_source_export_details::Kind;
+        ProtoSourceExportDetails {
+            kind: match self {
+                SourceExportDetails::None => None,
+                SourceExportDetails::Kafka => {
+                    Some(Kind::Kafka(kafka::ProtoKafkaSourceExportDetails {}))
+                }
+                SourceExportDetails::Postgres(details) => {
+                    Some(Kind::Postgres(details.into_proto()))
+                }
+                SourceExportDetails::MySql(details) => Some(Kind::Mysql(details.into_proto())),
+                SourceExportDetails::LoadGenerator => Some(Kind::Loadgen(
+                    load_generator::ProtoLoadGeneratorSourceExportDetails {},
+                )),
+            },
+        }
+    }
+
+    fn from_proto(proto: ProtoSourceExportDetails) -> Result<Self, TryFromProtoError> {
+        use proto_source_export_details::Kind;
+        Ok(match proto.kind {
+            None => SourceExportDetails::None,
+            Some(Kind::Kafka(_)) => SourceExportDetails::Kafka,
+            Some(Kind::Postgres(details)) => SourceExportDetails::Postgres(details.into_rust()?),
+            Some(Kind::Mysql(details)) => SourceExportDetails::MySql(details.into_rust()?),
+            Some(Kind::Loadgen(_)) => SourceExportDetails::LoadGenerator,
+        })
+    }
+}
+
+/// Details necessary to store in the `Details` option of a source export
+/// statement (currently only `CREATE SUBSOURCE` statements), to generate the
+/// appropriate `SourceExportDetails` struct during planning.
+/// NOTE that this is serialized as proto to the catalog, so any changes here
+/// must be backwards compatible or will require a migration.
+/// We only support `CREATE SUBSOURCE` statements for Postgres and MySQL
+/// for now, so we only need to support those here.
+pub enum SourceExportStatementDetails {
+    Postgres {
+        table: mz_postgres_util::desc::PostgresTableDesc,
+    },
+    MySql {
+        table: mz_mysql_util::MySqlTableDesc,
+        initial_gtid_set: String,
+    },
+}
+
+impl RustType<ProtoSourceExportStatementDetails> for SourceExportStatementDetails {
+    fn into_proto(&self) -> ProtoSourceExportStatementDetails {
+        match self {
+            SourceExportStatementDetails::Postgres { table } => ProtoSourceExportStatementDetails {
+                kind: Some(proto_source_export_statement_details::Kind::Postgres(
+                    postgres::ProtoPostgresSourceExportStatementDetails {
+                        table: Some(table.into_proto()),
+                    },
+                )),
+            },
+            SourceExportStatementDetails::MySql {
+                table,
+                initial_gtid_set,
+            } => ProtoSourceExportStatementDetails {
+                kind: Some(proto_source_export_statement_details::Kind::Mysql(
+                    mysql::ProtoMySqlSourceExportStatementDetails {
+                        table: Some(table.into_proto()),
+                        initial_gtid_set: initial_gtid_set.clone(),
+                    },
+                )),
+            },
+        }
+    }
+
+    fn from_proto(proto: ProtoSourceExportStatementDetails) -> Result<Self, TryFromProtoError> {
+        use proto_source_export_statement_details::Kind;
+        Ok(match proto.kind {
+            Some(Kind::Postgres(details)) => SourceExportStatementDetails::Postgres {
+                table: mz_postgres_util::desc::PostgresTableDesc::from_proto(
+                    details.table.ok_or_else(|| {
+                        TryFromProtoError::missing_field(
+                            "ProtoPostgresSourceExportStatementDetails::table",
+                        )
+                    })?,
+                )?,
+            },
+            Some(Kind::Mysql(details)) => SourceExportStatementDetails::MySql {
+                table: mz_mysql_util::MySqlTableDesc::from_proto(details.table.ok_or_else(
+                    || {
+                        TryFromProtoError::missing_field(
+                            "ProtoMySqlSourceExportStatementDetails::table",
+                        )
+                    },
+                )?)?,
+                initial_gtid_set: details.initial_gtid_set,
+            },
+            None => {
+                return Err(TryFromProtoError::missing_field(
+                    "ProtoSourceExportStatementDetails::kind",
+                ))
+            }
         })
     }
 }

--- a/src/storage-types/src/sources/kafka.proto
+++ b/src/storage-types/src/sources/kafka.proto
@@ -47,3 +47,5 @@ message ProtoKafkaHeader {
     string key = 1;
     bool use_bytes = 2;
 }
+
+message ProtoKafkaSourceExportDetails {}

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -253,10 +253,6 @@ impl<C: ConnectionAccess> SourceConnection for KafkaSourceConnection<C> {
             })
             .collect()
     }
-
-    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
-        super::SourceReferenceResolver::default()
-    }
 }
 
 impl<C: ConnectionAccess> crate::AlterCompatible for KafkaSourceConnection<C> {

--- a/src/storage-types/src/sources/load_generator.proto
+++ b/src/storage-types/src/sources/load_generator.proto
@@ -53,3 +53,5 @@ message ProtoKeyValueLoadGenerator {
     uint64 seed = 8;
     optional string include_offset = 9;
 }
+
+message ProtoLoadGeneratorSourceExportDetails {}

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -122,17 +122,6 @@ impl SourceConnection for LoadGeneratorSourceConnection {
     fn metadata_columns(&self) -> Vec<(&str, ColumnType)> {
         vec![]
     }
-
-    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
-        let views: Vec<_> = self
-            .load_generator
-            .views()
-            .into_iter()
-            .map(|(name, _)| (self.load_generator.schema_name(), name))
-            .collect();
-        super::SourceReferenceResolver::new(LOAD_GENERATOR_DATABASE_NAME, &views)
-            .expect("already validated that SourceReferenceResolver elements are valid")
-    }
 }
 
 impl crate::AlterCompatible for LoadGeneratorSourceConnection {}

--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -16,6 +16,7 @@ import "mysql-util/src/desc.proto";
 package mz_storage_types.sources.mysql;
 
 message ProtoMySqlSourceConnection {
+    reserved 4, 5;
     mz_repr.global_id.ProtoGlobalId connection_id = 1;
     mz_storage_types.connections.ProtoMySqlConnection connection = 2;
     ProtoMySqlSourceDetails details = 3;

--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -15,27 +15,32 @@ import "mysql-util/src/desc.proto";
 
 package mz_storage_types.sources.mysql;
 
-message ProtoMySqlColumnRef {
-    string schema_name = 1;
-    string table_name = 2;
-    string column_name = 3;
-}
-
 message ProtoMySqlSourceConnection {
     mz_repr.global_id.ProtoGlobalId connection_id = 1;
     mz_storage_types.connections.ProtoMySqlConnection connection = 2;
     ProtoMySqlSourceDetails details = 3;
-
-    repeated ProtoMySqlColumnRef text_columns = 4;
-    repeated ProtoMySqlColumnRef ignore_columns = 5;
 }
 
 message ProtoMySqlSourceDetails {
-    repeated mz_mysql_util.ProtoMySqlTableDesc tables = 1;
+    // These fields marked 'deprecated_' are kept around to migrate old sources since
+    // this message is serialized as proto in the catalog.
+    repeated mz_mysql_util.ProtoMySqlTableDesc deprecated_tables = 1;
     // This was changed from a string to a repeated string in order to support
     // separate GTID sets for each table. If this field contains a single element,
     // or the `legacy_initial_gtid_set` field is populated, it
     // is the initial GTID set for all tables.
-    string legacy_initial_gtid_set = 2;
-    repeated string initial_gtid_set = 3;
+    string deprecated_legacy_initial_gtid_set = 2;
+    repeated string deprecated_initial_gtid_set = 3;
+}
+
+message ProtoMySqlSourceExportDetails {
+    mz_mysql_util.ProtoMySqlTableDesc table = 1;
+    string initial_gtid_set = 2;
+    repeated string text_columns = 3;
+    repeated string ignore_columns = 4;
+}
+
+message ProtoMySqlSourceExportStatementDetails {
+    mz_mysql_util.ProtoMySqlTableDesc table = 1;
+    string initial_gtid_set = 2;
 }

--- a/src/storage-types/src/sources/postgres.proto
+++ b/src/storage-types/src/sources/postgres.proto
@@ -17,32 +17,41 @@ import "expr/src/scalar.proto";
 
 package mz_storage_types.sources.postgres;
 
+message ProtoCastType {
+    oneof kind {
+        google.protobuf.Empty natural = 1;
+        google.protobuf.Empty text = 2;
+    }
+}
+
+message ProtoPostgresTableCast {
+    repeated mz_expr.scalar.ProtoMirScalarExpr column_casts = 1;
+    repeated ProtoCastType column_cast_types = 2;
+}
+
 message ProtoPostgresSourceConnection {
-    message ProtoCastType {
-        oneof kind {
-            google.protobuf.Empty natural = 1;
-            google.protobuf.Empty text = 2;
-        }
-    }
-
-    message ProtoPostgresTableCast {
-        repeated mz_expr.scalar.ProtoMirScalarExpr column_casts = 1;
-        repeated ProtoCastType column_cast_types = 2;
-    }
-
+    reserved 5, 7;
     mz_repr.global_id.ProtoGlobalId connection_id = 6;
     mz_storage_types.connections.ProtoPostgresConnection connection = 1;
     string publication = 2;
     ProtoPostgresSourcePublicationDetails details = 4;
-    repeated ProtoPostgresTableCast table_casts = 5;
-    // Describes the position in the source's publication that the table cast
-    // correlates to; meant to be iterated over in tandem with table_casts
-    repeated uint64 table_cast_pos = 7;
 }
 
 message ProtoPostgresSourcePublicationDetails {
-    repeated mz_postgres_util.desc.ProtoPostgresTableDesc tables = 1;
+    // This field is deprecated, but kept around to migrate old sources since this
+    // field is serialized as proto in the catalog.
+    repeated mz_postgres_util.desc.ProtoPostgresTableDesc deprecated_tables = 1;
+
     string slot = 2;
     optional uint64 timeline_id = 3;
     string database = 4;
+}
+
+message ProtoPostgresSourceExportDetails {
+    mz_postgres_util.desc.ProtoPostgresTableDesc table = 1;
+    ProtoPostgresTableCast table_cast = 2;
+}
+
+message ProtoPostgresSourceExportStatementDetails {
+    mz_postgres_util.desc.ProtoPostgresTableDesc table = 1;
 }

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -9,8 +9,6 @@
 
 //! Types related to postgres sources
 
-use std::collections::BTreeMap;
-
 use itertools::Itertools;
 use mz_expr::MirScalarExpr;
 use mz_postgres_util::desc::PostgresTableDesc;
@@ -38,12 +36,6 @@ include!(concat!(
 pub struct PostgresSourceConnection<C: ConnectionAccess = InlinedConnection> {
     pub connection_id: GlobalId,
     pub connection: C::Pg,
-    /// The cast expressions to convert the incoming string encoded rows to
-    /// their target types, keyed by their position in the source.
-    #[proptest(
-        strategy = "proptest::collection::btree_map(any::<usize>(), proptest::collection::vec((any::<CastType>(), any::<MirScalarExpr>()), 0..4), 0..4)"
-    )]
-    pub table_casts: BTreeMap<usize, Vec<(CastType, MirScalarExpr)>>,
     pub publication: String,
     pub publication_details: PostgresSourcePublicationDetails,
 }
@@ -55,7 +47,6 @@ impl<R: ConnectionResolver> IntoInlineConnection<PostgresSourceConnection, R>
         let PostgresSourceConnection {
             connection_id,
             connection,
-            table_casts,
             publication,
             publication_details,
         } = self;
@@ -63,7 +54,6 @@ impl<R: ConnectionResolver> IntoInlineConnection<PostgresSourceConnection, R>
         PostgresSourceConnection {
             connection_id,
             connection: r.resolve_connection(connection).unwrap_pg(),
-            table_casts,
             publication,
             publication_details,
         }
@@ -132,14 +122,6 @@ impl<C: ConnectionAccess> SourceConnection for PostgresSourceConnection<C> {
     fn metadata_columns(&self) -> Vec<(&str, ColumnType)> {
         vec![]
     }
-
-    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
-        super::SourceReferenceResolver::new(
-            &self.publication_details.database,
-            &self.publication_details.tables,
-        )
-        .expect("already validated that SourceReferenceResolver elements are valid")
-    }
 }
 
 impl<C: ConnectionAccess> AlterCompatible for PostgresSourceConnection<C> {
@@ -151,15 +133,6 @@ impl<C: ConnectionAccess> AlterCompatible for PostgresSourceConnection<C> {
         let PostgresSourceConnection {
             connection_id,
             connection,
-            // Table casts may change and we will not, in the long term, have a
-            // means of understanding which tables are actually being used by
-            // the source so it's unclear if these changes will be breaking or
-            // not. This suggests that we might not want to maintain this
-            // information here statically––we could, instead, derive these
-            // casts dynamically from the table's schema for the subsource, and
-            // then the subsource itself understands how to cast its data from
-            // the source.
-            table_casts: _,
             publication,
             publication_details,
         } = self;
@@ -203,10 +176,10 @@ pub enum CastType {
     Text,
 }
 
-impl RustType<proto_postgres_source_connection::ProtoCastType> for CastType {
-    fn into_proto(&self) -> proto_postgres_source_connection::ProtoCastType {
-        use proto_postgres_source_connection::proto_cast_type::Kind::*;
-        proto_postgres_source_connection::ProtoCastType {
+impl RustType<ProtoCastType> for CastType {
+    fn into_proto(&self) -> ProtoCastType {
+        use proto_cast_type::Kind::*;
+        ProtoCastType {
             kind: Some(match self {
                 CastType::Natural => Natural(()),
                 CastType::Text => Text(()),
@@ -214,10 +187,8 @@ impl RustType<proto_postgres_source_connection::ProtoCastType> for CastType {
         }
     }
 
-    fn from_proto(
-        proto: proto_postgres_source_connection::ProtoCastType,
-    ) -> Result<Self, TryFromProtoError> {
-        use proto_postgres_source_connection::proto_cast_type::Kind::*;
+    fn from_proto(proto: ProtoCastType) -> Result<Self, TryFromProtoError> {
+        use proto_cast_type::Kind::*;
         Ok(match proto.kind {
             Some(Natural(())) => CastType::Natural,
             Some(Text(())) => CastType::Text,
@@ -232,66 +203,15 @@ impl RustType<proto_postgres_source_connection::ProtoCastType> for CastType {
 
 impl RustType<ProtoPostgresSourceConnection> for PostgresSourceConnection {
     fn into_proto(&self) -> ProtoPostgresSourceConnection {
-        use proto_postgres_source_connection::ProtoPostgresTableCast;
-        let mut table_casts = Vec::with_capacity(self.table_casts.len());
-        let mut table_cast_pos = Vec::with_capacity(self.table_casts.len());
-        for (pos, table_cast_inner) in self.table_casts.iter() {
-            let mut column_casts = Vec::with_capacity(table_casts.len());
-            let mut column_cast_types = Vec::with_capacity(table_casts.len());
-
-            for (table_cast_col_type, table_cast_col) in table_cast_inner {
-                column_casts.push(table_cast_col.into_proto());
-                column_cast_types.push(table_cast_col_type.into_proto());
-            }
-
-            table_casts.push(ProtoPostgresTableCast {
-                column_casts,
-                column_cast_types,
-            });
-            table_cast_pos.push(mz_ore::cast::usize_to_u64(*pos));
-        }
-
         ProtoPostgresSourceConnection {
             connection: Some(self.connection.into_proto()),
             connection_id: Some(self.connection_id.into_proto()),
             publication: self.publication.clone(),
             details: Some(self.publication_details.into_proto()),
-            table_casts,
-            table_cast_pos,
         }
     }
 
     fn from_proto(proto: ProtoPostgresSourceConnection) -> Result<Self, TryFromProtoError> {
-        // If we get the wrong number of table cast positions, we have to just
-        // accept all of the table casts. This is somewhat harmless, as the
-        // worst thing that happens is that we generate unused snapshots from
-        // the upstream PG publication, and this will (hopefully) correct
-        // itself on the next version upgrade.
-        let table_cast_pos = if proto.table_casts.len() == proto.table_cast_pos.len() {
-            proto.table_cast_pos
-        } else {
-            (1..proto.table_casts.len() + 1)
-                .map(mz_ore::cast::usize_to_u64)
-                .collect()
-        };
-
-        let mut table_casts = BTreeMap::new();
-        for (pos, cast) in table_cast_pos
-            .into_iter()
-            .zip_eq(proto.table_casts.into_iter())
-        {
-            let mut column_casts = vec![];
-            for (cast, cast_type) in cast
-                .column_casts
-                .into_iter()
-                .zip_eq(cast.column_cast_types.into_iter())
-            {
-                column_casts.push((cast_type.into_rust()?, cast.into_rust()?));
-            }
-
-            table_casts.insert(mz_ore::cast::u64_to_usize(pos), column_casts);
-        }
-
         Ok(PostgresSourceConnection {
             connection: proto
                 .connection
@@ -303,15 +223,72 @@ impl RustType<ProtoPostgresSourceConnection> for PostgresSourceConnection {
             publication_details: proto
                 .details
                 .into_rust_if_some("ProtoPostgresSourceConnection::details")?,
-            table_casts,
+        })
+    }
+}
+
+/// The details of a source export from a postgres source.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
+pub struct PostgresSourceExportDetails {
+    /// The cast expressions to convert the incoming string encoded rows to
+    /// their target types
+    #[proptest(
+        strategy = "proptest::collection::vec((any::<CastType>(), any::<MirScalarExpr>()), 0..4)"
+    )]
+    pub table_cast: Vec<(CastType, MirScalarExpr)>,
+    pub table: PostgresTableDesc,
+}
+
+impl AlterCompatible for PostgresSourceExportDetails {
+    fn alter_compatible(&self, _id: GlobalId, _other: &Self) -> Result<(), AlterError> {
+        // compatibility checks are performed against the upstream table in the source
+        // render operators instead
+        Ok(())
+    }
+}
+
+impl RustType<ProtoPostgresSourceExportDetails> for PostgresSourceExportDetails {
+    fn into_proto(&self) -> ProtoPostgresSourceExportDetails {
+        let mut column_casts = Vec::with_capacity(self.table_cast.len());
+        let mut column_cast_types = Vec::with_capacity(self.table_cast.len());
+
+        for (table_cast_col_type, table_cast_col) in self.table_cast.iter() {
+            column_casts.push(table_cast_col.into_proto());
+            column_cast_types.push(table_cast_col_type.into_proto());
+        }
+
+        ProtoPostgresSourceExportDetails {
+            table: Some(self.table.into_proto()),
+            table_cast: Some(ProtoPostgresTableCast {
+                column_casts,
+                column_cast_types,
+            }),
+        }
+    }
+
+    fn from_proto(proto: ProtoPostgresSourceExportDetails) -> Result<Self, TryFromProtoError> {
+        let mut column_casts = vec![];
+        if let Some(table_cast) = proto.table_cast {
+            for (cast, cast_type) in table_cast
+                .column_casts
+                .into_iter()
+                .zip_eq(table_cast.column_cast_types.into_iter())
+            {
+                column_casts.push((cast_type.into_rust()?, cast.into_rust()?));
+            }
+        }
+
+        Ok(PostgresSourceExportDetails {
+            table: proto
+                .table
+                .into_rust_if_some("ProtoPostgresSourceExportDetails::table")?,
+            table_cast: column_casts,
         })
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct PostgresSourcePublicationDetails {
-    #[proptest(strategy = "proptest::collection::vec(any::<PostgresTableDesc>(), 0..4)")]
-    pub tables: Vec<PostgresTableDesc>,
     pub slot: String,
     /// The active timeline_id when this source was created
     /// The None value indicates an unknown timeline, to account for sources that existed
@@ -323,7 +300,7 @@ pub struct PostgresSourcePublicationDetails {
 impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicationDetails {
     fn into_proto(&self) -> ProtoPostgresSourcePublicationDetails {
         ProtoPostgresSourcePublicationDetails {
-            tables: self.tables.iter().map(|t| t.into_proto()).collect(),
+            deprecated_tables: vec![],
             slot: self.slot.clone(),
             timeline_id: self.timeline_id.clone(),
             database: self.database.clone(),
@@ -332,11 +309,6 @@ impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicati
 
     fn from_proto(proto: ProtoPostgresSourcePublicationDetails) -> Result<Self, TryFromProtoError> {
         Ok(PostgresSourcePublicationDetails {
-            tables: proto
-                .tables
-                .into_iter()
-                .map(PostgresTableDesc::from_proto)
-                .collect::<Result<_, _>>()?,
             slot: proto.slot,
             timeline_id: proto.timeline_id,
             database: proto.database,
@@ -347,7 +319,6 @@ impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicati
 impl AlterCompatible for PostgresSourcePublicationDetails {
     fn alter_compatible(&self, id: mz_repr::GlobalId, other: &Self) -> Result<(), AlterError> {
         let PostgresSourcePublicationDetails {
-            tables: _,
             slot,
             timeline_id,
             database,

--- a/src/storage/src/source/mysql/schemas.rs
+++ b/src/storage/src/source/mysql/schemas.rs
@@ -11,9 +11,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use mysql_async::prelude::Queryable;
 use mz_mysql_util::{schema_info, MySqlError, MySqlTableDesc, QualifiedTableRef, SchemaRequest};
-use mz_storage_types::sources::mysql::MySqlColumnRef;
 
-use super::{DefiniteError, MySqlTableName};
+use super::{DefiniteError, MySqlTableName, SubsourceInfo};
 
 /// Given a list of tables and their expected schemas, retrieve the current schema for each table
 /// and verify they are compatible with the expected schema.
@@ -21,15 +20,12 @@ use super::{DefiniteError, MySqlTableName};
 /// Returns a vec of tables that have incompatible schema changes.
 pub(super) async fn verify_schemas<'a, Q>(
     conn: &mut Q,
-    expected: &[(&'a MySqlTableName, &MySqlTableDesc)],
-    text_columns: &Vec<MySqlColumnRef>,
-    ignore_columns: &Vec<MySqlColumnRef>,
+    expected: &[(&'a MySqlTableName, &SubsourceInfo)],
 ) -> Result<Vec<(&'a MySqlTableName, DefiniteError)>, MySqlError>
 where
     Q: Queryable,
 {
-    let text_column_map = map_columns(text_columns);
-    let ignore_column_map = map_columns(ignore_columns);
+    let (text_column_map, ignore_column_map) = map_columns(&expected);
 
     // Get the current schema for each requested table from mysql
     let cur_schemas: BTreeMap<_, _> = schema_info(
@@ -55,8 +51,8 @@ where
 
     Ok(expected
         .into_iter()
-        .filter_map(|(table, desc)| {
-            if let Err(err) = verify_schema(table, desc, &cur_schemas) {
+        .filter_map(|(table, info)| {
+            if let Err(err) = verify_schema(table, &info.desc, &cur_schemas) {
                 Some((*table, err))
             } else {
                 None
@@ -83,17 +79,32 @@ fn verify_schema(
 }
 
 fn map_columns<'a>(
-    columns: &'a [MySqlColumnRef],
-) -> BTreeMap<QualifiedTableRef<'a>, BTreeSet<&'a str>> {
-    let mut column_map = BTreeMap::new();
-    for column in columns {
-        column_map
-            .entry(QualifiedTableRef {
-                schema_name: column.schema_name.as_str(),
-                table_name: column.table_name.as_str(),
-            })
-            .or_insert_with(BTreeSet::new)
-            .insert(column.column_name.as_str());
+    tables: &'a [(&'a MySqlTableName, &SubsourceInfo)],
+) -> (
+    BTreeMap<QualifiedTableRef<'a>, BTreeSet<&'a str>>,
+    BTreeMap<QualifiedTableRef<'a>, BTreeSet<&'a str>>,
+) {
+    let mut text_column_map = BTreeMap::new();
+    let mut ignore_column_map = BTreeMap::new();
+    for (table, info) in tables {
+        if !info.text_columns.is_empty() {
+            text_column_map.insert(
+                QualifiedTableRef {
+                    schema_name: &table.0,
+                    table_name: &table.1,
+                },
+                info.text_columns.iter().map(|s| s.as_str()).collect(),
+            );
+        }
+        if !info.ignore_columns.is_empty() {
+            ignore_column_map.insert(
+                QualifiedTableRef {
+                    schema_name: &table.0,
+                    table_name: &table.1,
+                },
+                info.ignore_columns.iter().map(|s| s.as_str()).collect(),
+            );
+        }
     }
-    column_map
+    (text_column_map, ignore_column_map)
 }

--- a/src/storage/src/source/mysql/schemas.rs
+++ b/src/storage/src/source/mysql/schemas.rs
@@ -25,7 +25,7 @@ pub(super) async fn verify_schemas<'a, Q>(
 where
     Q: Queryable,
 {
-    let (text_column_map, ignore_column_map) = map_columns(&expected);
+    let (text_column_map, ignore_column_map) = map_columns(expected);
 
     // Get the current schema for each requested table from mysql
     let cur_schemas: BTreeMap<_, _> = schema_info(


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.
Fixes https://github.com/MaterializeInc/materialize/issues/28451

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

currently in draft while I figure out what tests I've broken and implement the migration for existing sources

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
