### PR TITLE
adapter: reduce the chance of sink hydration FPs

### DIFF
--- a/test/testdrive/hydration-status.td
+++ b/test/testdrive/hydration-status.td
@@ -413,3 +413,67 @@ mv_wmr_stuck hydrated_test_4 false
 mv_wmr       hydrated_test_4 true
 mv_wmr_const hydrated_test_4 true
 mv_wmr_stuck hydrated_test_4 false
+
+> DROP MATERIALIZED VIEW mv_wmr
+> DROP MATERIALIZED VIEW mv_wmr_const
+> DROP MATERIALIZED VIEW mv_wmr_stuck
+
+# Test that incorrectly configured sinks do _not_ show as hydrated.
+
+> CREATE TABLE schema1 (a int)
+> CREATE TABLE schema2 (a text)
+
+> CREATE SINK snk_schema1
+  IN CLUSTER test
+  FROM schema1
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk_schema1-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+> SELECT s.name, h.hydrated
+  FROM mz_sinks s
+  JOIN mz_internal.mz_hydration_statuses h ON (h.object_id = s.id)
+snk_schema1 true
+
+> CREATE SINK snk_schema2
+  IN CLUSTER test
+  FROM schema2
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk_schema1-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+# If we have a bug, the sink's hydration status might toggle between `false`
+# and `true`, rather than always being `true`. Using retries might therefore
+# cause this test to pass even if it shouldn't. We instead disable retries and
+# manually check the hydration status a couple times.
+$ set-max-tries max-tries=1
+
+> SELECT s.name, h.hydrated
+  FROM mz_sinks s
+  JOIN mz_internal.mz_hydration_statuses h ON (h.object_id = s.id)
+snk_schema1 true
+snk_schema2 false
+
+> SELECT s.name, h.hydrated
+  FROM mz_sinks s
+  JOIN mz_internal.mz_hydration_statuses h ON (h.object_id = s.id)
+snk_schema1 true
+snk_schema2 false
+
+> SELECT s.name, h.hydrated
+  FROM mz_sinks s
+  JOIN mz_internal.mz_hydration_statuses h ON (h.object_id = s.id)
+snk_schema1 true
+snk_schema2 false
+
+> SELECT s.name, h.hydrated
+  FROM mz_sinks s
+  JOIN mz_internal.mz_hydration_statuses h ON (h.object_id = s.id)
+snk_schema1 true
+snk_schema2 false
+
+> SELECT s.name, h.hydrated
+  FROM mz_sinks s
+  JOIN mz_internal.mz_hydration_statuses h ON (h.object_id = s.id)
+snk_schema1 true
+snk_schema2 false


### PR DESCRIPTION
This PR tries to reduce the chance of having FPs for the hydration status of sinks in `mz_hydration_statuses` by also requiring their frontiers to be greater than the minimum. The proper fix would be to have actual hydration reporting for sinks (#28459), but that's more effort to implement.

### Motivation

  * This PR fixes a previously unreported bug.

Misconfigured sinks can show as hydrated. Reported by @SangJunBak in [Slack](https://materializeinc.slack.com/archives/C0761MZ3QD9/p1721677761289059).

### Tips for reviewer

@MaterializeInc/testing I'm not sure how to test this. I tried adding this to `hydration-status.td`:

```sql
# Test that incorrectly configured sinks do _not_ show as hydrated.

> CREATE TABLE schema1 (a int)
> CREATE TABLE schema2 (a text)

> CREATE SINK snk_schema1
  IN CLUSTER test
  FROM schema1
  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk_schema1-${testdrive.seed}')
  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
  ENVELOPE DEBEZIUM

> SELECT s.name, h.hydrated
  FROM mz_sinks s
  JOIN mz_internal.mz_hydration_statuses h ON (h.object_id = s.id)
snk_schema1 true

> CREATE SINK snk_schema2
  IN CLUSTER test
  FROM schema2
  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk_schema1-${testdrive.seed}')
  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
  ENVELOPE DEBEZIUM

> SELECT s.name, h.hydrated
  FROM mz_sinks s
  JOIN mz_internal.mz_hydration_statuses h ON (h.object_id = s.id)
snk_schema1 true
snk_schema2 false
```

... but it succeeds even without this change. I think that's because the `snk_schema2` sink toggles between "running" and "stalled" status, so it does show as "not hydrated" some of the time. I'm not sure how to assert a negative such as "this sink never shows as hydrated" with testdrive.

@SangJunBak Do you have a way to test that this change solves the issue you were observing?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
