### PR TITLE
ci-builder: Downgrade cryptography again

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -8,7 +8,7 @@ black==24.4.2
 boto3-stubs[ec2,iam,kinesis,s3,sqs,ssm,sts]==1.26.89
 boto3==1.34.63
 click==8.1.3
-cryptography==43.0.0
+cryptography==42.0.8 # TODO(def-) Upgrade when https://github.com/paramiko/paramiko/issues/2419 is fixed
 colored==1.4.4
 docker==7.1.0
 ec2instanceconnectcli==1.0.2


### PR DESCRIPTION
To fix deploy step: https://buildkite.com/materialize/deploy/builds/15131#0190e31e-0836-48f3-a33b-1f0b7ad34349

cryptography.utils.CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.

Will require a paramiko upgrade to accomodate the new cryptography version

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
