### PR TITLE
ci: qa-canary: decrease runtime

### DIFF
--- a/ci/qa-canary/pipeline.template.yml
+++ b/ci/qa-canary/pipeline.template.yml
@@ -25,6 +25,6 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: canary-load
-          args: ["--runtime=82800"] # 23 hours
+          args: ["--runtime=79200"] # 22 hours
     agents:
       queue: linux-aarch64-small


### PR DESCRIPTION
6 of the last 10 builds timed out: https://buildkite.com/materialize/qa-canary/builds?branch=main

<img width="497" alt="Bildschirmfoto 2024-07-24 um 11 31 48" src="https://github.com/user-attachments/assets/20aba9bc-b8ef-44e7-bea7-387842f161a7">
