### PR TITLE
ci-builder: Support git worktrees

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -318,6 +318,11 @@ case "$cmd" in
                 --env SCCACHE_BUCKET
             )
         fi
+        # For git-worktrees add the original repository at its original path
+        if [[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]]; then
+            GIT_ROOT_DIR="$(git rev-parse --git-dir | sed -e "s#/.git/worktrees/.*#/#")"
+            args+=(--volume "$GIT_ROOT_DIR:$GIT_ROOT_DIR")
+        fi
         rm -f "$cid_file"
         docker run "${args[@]}" "materialize/ci-builder:$tag" "${docker_command[@]}"
         ;;

--- a/ci/test/lint-main/checks/check-bazel.sh
+++ b/ci/test/lint-main/checks/check-bazel.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")/../../../.."
 try bin/bazel gen
 
 # Make sure we didn't generate any changes.
-try git diff --compact-summary --exit-code
+try git diff --compact-summary --exit-code -- '*/BUILD.bazel'
 if try_last_failed; then
     echo "lint: $(red error:) discrepancies found in generated 'BUILD.bazel' files"
     echo "lint: $(green hint:) run $(white bin/bazel gen)" >&2


### PR DESCRIPTION
Came out of trying out bazel: https://materializeinc.slack.com/archives/CM7ATT65S/p1721819297335879?thread_ts=1721794029.046489&cid=CM7ATT65S
```
ERROR: <builtin>: BazelWorkspaceStatusAction stable-status.txt failed: Failed to determine workspace status: Process exited with status 1
fatal: not a git repository: /home/deen/git/materialize/.git/worktrees/materialize3
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
