### PR TITLE
bazel/ci-builder: Faster uncompression

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,3 +42,5 @@ common --experimental_remote_cache_compression_threshold=2097152
 common --experimental_remote_merkle_tree_cache
 # Number of merkle trees to memoize (default 1000).
 common --experimental_remote_merkle_tree_cache_size=5000
+
+action_env=XZ_OPT=-T0

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -48,6 +48,9 @@ RUN apt-get update --fix-missing && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-ge
 
 COPY crosstool.asc ./
 
+# Faster uncompression
+ARG XZ_OPT=-T0
+
 RUN gpg --import crosstool.asc \
     && rm crosstool.asc \
     && echo "trusted-key 09f6dd5f1f30ef2e" >> ~/.gnupg/gpg.conf \


### PR DESCRIPTION
Quick experiment:

    $ wget https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
    $ time tar xf clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
    36.30s user 10.79s system 123% cpu 38.096 total
    $ time XZ_OPT=-T0 tar xf clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
    51.04s user 13.14s system 646% cpu 9.921 total

This doesn't seem to work in Bazel though, @ParkMyCar: Any idea? I remember you talked about using zstd instead of xz for Bazel, extracting seems to be very slow indeed and single-threaded
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
