### PR TITLE
bazel: Use cargo to run `bin/bazel gen`

### DIFF
--- a/misc/python/materialize/cli/bazel.py
+++ b/misc/python/materialize/cli/bazel.py
@@ -84,7 +84,7 @@ def gen(path):
 
     # Note: We build cargo-gazelle with optimizations because the speedup is
     # worth it and Bazel should cache the resulting binary.
-    
+
     # TODO(parkmycar): Use Bazel to run this lint.
     cmd_args = [
         "cargo",

--- a/misc/python/materialize/cli/bazel.py
+++ b/misc/python/materialize/cli/bazel.py
@@ -84,12 +84,14 @@ def gen(path):
 
     # Note: We build cargo-gazelle with optimizations because the speedup is
     # worth it and Bazel should cache the resulting binary.
+    
+    # TODO(parkmycar): Use Bazel to run this lint.
     cmd_args = [
-        "bazel",
+        "cargo",
         "run",
-        "//misc/bazel/cargo-gazelle:main",
-        "-c",
-        "opt",
+        "--release",
+        "--no-default-features",
+        "--manifest-path=misc/bazel/cargo-gazelle/Cargo.toml",
         "--",
         "--path",
         f"{str(path)}",


### PR DESCRIPTION
This PR switches from using bazel to run `bin/bazel gen` to cargo since there are some issues to workout with the setup on Linux

### Motivation

Unbreaks `bin/bazel gen`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a