### PR TITLE
bazel: Upgrade to openssl 3.3.1

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,7 +8,9 @@ common --enable_platform_specific_config
 # environment, which differs between systems and thus breaks remote caching.
 build --incompatible_strict_action_env
 # Prevent actions in the sandbox from accessing the network.
-build --sandbox_default_allow_network=false
+#
+# TODO(parkmycar): `prof-http`s build script downloads resources from npm.
+#build --sandbox_default_allow_network=false
 
 # Bazel provides the macOS 14.5 SDK as the sysroot, we also set the minimum
 # version to prevent breaking the remote cache across developer machines.

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -55,7 +55,6 @@ steps:
         timeout_in_minutes: 60
         agents:
           queue: builder-linux-x86_64
-        skip: "openssl-1.1.1w not found"
 
       - id: build-aarch64-bazel
         label: ":bazel: Build aarch64"
@@ -64,7 +63,6 @@ steps:
         timeout_in_minutes: 60
         agents:
           queue: builder-linux-aarch64
-        skip: "openssl-1.1.1w not found"
 
       - id: build-wasm
         label: Build WASM

--- a/misc/bazel/c_deps/BUILD.openssl.bazel
+++ b/misc/bazel/c_deps/BUILD.openssl.bazel
@@ -76,9 +76,18 @@ configure_make(
     name = "openssl",
     configure_command = "config",
     configure_in_place = True,
-    configure_options = CONFIGURE_OPTIONS,
+    configure_options = CONFIGURE_OPTIONS + select({
+        "@platforms//os:macos": ["ARFLAGS=r"],
+        "//conditions:default": [],
+    }),
+    # darwin/macOS defaults to using libtool but openSSL3 fails linking with
+    # the generated archive, so we switch to `llvm-ar`.
+    build_data = select({
+        "@platforms//os:macos": ["@llvm_toolchain_llvm//:ar"],
+        "//conditions:default": {},
+    }),
     env = select({
-        "@platforms//os:macos": {"ARFLAGS": "-o"},
+        "@platforms//os:macos": {"AR": "$(execpath @llvm_toolchain_llvm//:ar)"},
         "//conditions:default": {},
     }),
     # TODO(parkmycar): Figure out how to dynamically provide a number of jobs to foreign_cc rules.

--- a/misc/bazel/c_deps/repositories.bzl
+++ b/misc/bazel/c_deps/repositories.bzl
@@ -65,8 +65,8 @@ def c_repositories():
         ],
     )
 
-    OPENSSL_VERSION = "1.1.1w"
-    OPENSSL_INTEGRITY = "sha256-zzCYlQy02FOtlcCEHx+cbT3BAtzPys1SHZOSUgi3asg="
+    OPENSSL_VERSION = "3.3.1"
+    OPENSSL_INTEGRITY = "sha256-d3zVlihMiDN1oqehG/XSeG/FQTJV76sgxQ1v/m0CC34="
     maybe(
         http_archive,
         name = "openssl",


### PR DESCRIPTION
`openssl 1.1.1w` was removed from upstream repositories, also the Cargo build already depends on openssl3

### Motivation

Fix Bazel

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a