### PR TITLE
test-analytics: Add primary key to detect inconsistencies earlier

### DIFF
--- a/misc/python/materialize/test_analytics/setup/tables/01-build.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/01-build.sql
@@ -20,4 +20,5 @@ CREATE TABLE build (
    build_url TEXT, -- nullable, will eventually be removed
    data_version UINT4 NOT NULL,
    remarks TEXT
+   -- , PRIMARY KEY (build_id)
 );

--- a/misc/python/materialize/test_analytics/setup/tables/02-build-job.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/02-build-job.sql
@@ -21,4 +21,5 @@ CREATE TABLE build_job (
     success BOOL NOT NULL,
     aws_instance_type TEXT NOT NULL,
     remarks TEXT
+    -- , PRIMARY KEY (build_job_id)
 );

--- a/misc/python/materialize/test_analytics/setup/tables/10-feature-benchmark.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/10-feature-benchmark.sql
@@ -21,6 +21,7 @@ CREATE TABLE feature_benchmark_result (
    messages INT,
    memory_mz DOUBLE,
    memory_clusterd DOUBLE
+   -- , PRIMARY KEY (build_job_id, scenario_name)
 );
 
 -- This table holds results of runs that were discarded.
@@ -32,4 +33,5 @@ CREATE TABLE feature_benchmark_discarded_result (
    messages INT,
    memory_mz DOUBLE,
    memory_clusterd DOUBLE
+   -- , PRIMARY KEY (build_job_id, scenario_name)
 );

--- a/misc/python/materialize/test_analytics/setup/tables/11-scalability-framework.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/11-scalability-framework.sql
@@ -18,4 +18,5 @@ CREATE TABLE scalability_framework_result (
    concurrency INT NOT NULL,
    count INT,
    tps DOUBLE
+   -- , PRIMARY KEY (build_job_id, workload_name)
 );

--- a/misc/python/materialize/test_analytics/setup/tables/20-build-annotation.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/20-build-annotation.sql
@@ -14,6 +14,7 @@ CREATE TABLE build_annotation (
    test_retry_count UINT4 NOT NULL,
    is_failure BOOL NOT NULL,
    insert_date TIMESTAMPTZ NOT NULL
+   -- , PRIMARY KEY (build_job_id)
 );
 
 CREATE TABLE build_annotation_error (

--- a/misc/python/materialize/test_analytics/setup/tables/30-output-consistency-stats.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/30-output-consistency-stats.sql
@@ -20,4 +20,5 @@ CREATE TABLE output_consistency_stats (
    count_available_data_types UINT4 NOT NULL,
    count_available_ops UINT4 NOT NULL,
    count_used_ops UINT4 NOT NULL
+   -- , PRIMARY KEY (build_job_id)
 );

--- a/misc/python/materialize/test_analytics/setup/tables/40-issues.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/40-issues.sql
@@ -7,4 +7,10 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-CREATE TABLE issue (issue_id TEXT NOT NULL, title TEXT NOT NULL, ci_regexp TEXT NOT NULL, state TEXT NOT NULL);
+CREATE TABLE issue (
+   issue_id TEXT NOT NULL,
+   title TEXT NOT NULL,
+   ci_regexp TEXT NOT NULL,
+   state TEXT NOT NULL
+   -- , PRIMARY KEY (issue_id)
+);

--- a/misc/python/materialize/test_analytics/setup/views/100-data-integrity.sql
+++ b/misc/python/materialize/test_analytics/setup/views/100-data-integrity.sql
@@ -48,6 +48,11 @@ CREATE OR REPLACE VIEW v_data_integrity (table_name, own_item_key, referenced_it
     FROM build_annotation
     GROUP BY build_job_id
     HAVING count(*) > 1
+    UNION
+    SELECT 'issue', issue_id, NULL, 'duplicate issue_id for issue'
+    FROM issue
+    GROUP BY issue_id
+    HAVING count(*) > 1
     -- other
     UNION
     SELECT 'build_job', build_job_id, NULL, 'build job id is not unique'
@@ -71,10 +76,5 @@ CREATE OR REPLACE VIEW v_data_integrity (table_name, own_item_key, referenced_it
     UNION
     SELECT 'config', 'config', NULL, 'more than one config entry exists'
     FROM config
-    HAVING count(*) > 1
-    UNION
-    SELECT 'issue', issue_id, NULL, 'more than one issue entry exists'
-    FROM issue
-    GROUP BY issue_id
     HAVING count(*) > 1
 ;


### PR DESCRIPTION
As comments, but we can also ask if primary keys can be enabled via

    ALTER SYSTEM SET enable_table_keys = true

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
