### PR TITLE
storage/sources: Copy subsource-specific option values to `CREATE SUBSOURCE` statements

### DIFF
--- a/misc/python/materialize/checks/all_checks/load_generator.py
+++ b/misc/python/materialize/checks/all_checks/load_generator.py
@@ -23,6 +23,8 @@ class LoadGeneratorAsOfUpTo(Check):
             dedent(
                 """
             > CREATE SOURCE counter1 FROM LOAD GENERATOR COUNTER (AS OF 100, UP TO 200);
+
+            > CREATE SOURCE auction1 FROM LOAD GENERATOR AUCTION (AS OF 100, UP TO 200) FOR ALL TABLES;
         """
             )
         )
@@ -50,6 +52,8 @@ class LoadGeneratorAsOfUpTo(Check):
                 1200
                 > SELECT COUNT(*) FROM counter3;
                 11200
+                > SELECT COUNT(*) FROM users;
+                4076
             """
             )
         )

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -16,6 +16,7 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::now::NowFn;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::ast::display::AstDisplay;
+use mz_sql::ast::visit_mut::VisitMut;
 use mz_sql_parser::ast::{Raw, Statement};
 use mz_storage_types::connections::ConnectionContext;
 use semver::Version;
@@ -94,7 +95,7 @@ pub(crate) async fn migrate(
         catalog_version
     );
 
-    rewrite_ast_items(tx, |_tx, _id, _stmt| {
+    rewrite_ast_items(tx, |tx, _id, stmt| {
         let _catalog_version = catalog_version.clone();
         Box::pin(async move {
             // Add per-item AST migrations below.
@@ -105,6 +106,7 @@ pub(crate) async fn migrate(
             //
             // Migration functions may also take `tx` as input to stage
             // arbitrary changes to the catalog.
+            ast_rewrite_create_subsource_options(tx, stmt)?;
             Ok(())
         })
     })
@@ -162,6 +164,312 @@ pub(crate) async fn migrate(
 //
 // Please include the adapter team on any code reviews that add or edit
 // migrations.
+
+/// Copies options from relevant `CREATE SOURCE` statements to any relevant `CREATE SUBSOURCE`
+/// statements. This preps for the eventual removal of these options from the `CREATE SOURCE`
+/// statement.
+fn ast_rewrite_create_subsource_options(
+    tx: &mut Transaction,
+    stmt: &mut Statement<Raw>,
+) -> Result<(), anyhow::Error> {
+    use mz_sql::ast::{
+        CreateSourceConnection, CreateSubsourceOption, CreateSubsourceOptionName,
+        CreateSubsourceStatement, MySqlConfigOptionName, PgConfigOptionName, RawItemName, Value,
+        WithOptionValue,
+    };
+    use mz_storage_types::sources::load_generator::ProtoLoadGeneratorSourceExportStatementDetails;
+    use mz_storage_types::sources::mysql::{
+        ProtoMySqlSourceDetails, ProtoMySqlSourceExportStatementDetails,
+    };
+    use mz_storage_types::sources::postgres::{
+        ProtoPostgresSourceExportStatementDetails, ProtoPostgresSourcePublicationDetails,
+    };
+    use mz_storage_types::sources::proto_source_export_statement_details;
+    use mz_storage_types::sources::ProtoSourceExportStatementDetails;
+    use prost::Message;
+
+    struct Rewriter<'a, 'b> {
+        tx: &'a Transaction<'b>,
+    }
+
+    impl<'ast> VisitMut<'ast, Raw> for Rewriter<'_, '_> {
+        fn visit_create_subsource_statement_mut(
+            &mut self,
+            node: &'ast mut CreateSubsourceStatement<Raw>,
+        ) {
+            match &node.of_source {
+                // Not a source export subsource
+                None => (),
+                Some(source) => {
+                    let details = node
+                        .with_options
+                        .iter()
+                        .find(|o| o.name == CreateSubsourceOptionName::Details);
+                    if details.is_some() {
+                        // this subsource has already had its details written, so it's either new or was already
+                        // migrated
+                        return;
+                    }
+
+                    let external_reference = node
+                        .with_options
+                        .iter()
+                        .find(|o| o.name == CreateSubsourceOptionName::ExternalReference)
+                        .expect("subsources must have external reference");
+                    let (external_schema, external_table) = match &external_reference.value {
+                        Some(WithOptionValue::UnresolvedItemName(name)) => {
+                            let name_len = name.0.len();
+                            (
+                                name.0[name_len - 2].clone().into_string(),
+                                name.0[name_len - 1].clone().into_string(),
+                            )
+                        }
+                        _ => unreachable!("external reference must be an unresolved item name"),
+                    };
+
+                    let source = match &source {
+                        RawItemName::Name(_) => {
+                            panic!("named item reference in durable catalog")
+                        }
+                        RawItemName::Id(id, _) => {
+                            let gid = id
+                                .parse()
+                                .expect("RawItenName::Id must be uncorrupted GlobalId");
+                            self.tx.get_item(&gid).expect("source must exist")
+                        }
+                    };
+                    let source_statement =
+                        mz_sql_parser::parser::parse_statements(&source.create_sql)
+                            .expect("parsing persisted create_sql must succeed")
+                            .into_element()
+                            .ast;
+                    match source_statement {
+                        Statement::CreateSource(stmt) => match &stmt.connection {
+                            CreateSourceConnection::Postgres {
+                                connection: _,
+                                options,
+                            } => {
+                                // Copy the PostgresTableDesc from the top-level source publication details proto
+                                // into the subsource details proto.
+                                let details = options
+                                    .iter()
+                                    .find(|o| o.name == PgConfigOptionName::Details)
+                                    .expect("Sources must have details");
+                                let details_val = match &details.value {
+                                    Some(WithOptionValue::Value(Value::String(details))) => details,
+                                    _ => unreachable!("Source details' value must be a string"),
+                                };
+                                let details = hex::decode(details_val)
+                                    .expect("Source details must be a hex-encoded string");
+                                let details =
+                                    ProtoPostgresSourcePublicationDetails::decode(&*details)
+                                        .expect("Source details must be a hex-encoded protobuf");
+                                let table = details
+                                    .deprecated_tables
+                                    .iter()
+                                    .find(|t| {
+                                        t.namespace == external_schema && t.name == external_table
+                                    })
+                                    .expect("subsource table must be in source details");
+                                let subsource_details = ProtoSourceExportStatementDetails {
+                                    kind: Some(
+                                        proto_source_export_statement_details::Kind::Postgres(
+                                            ProtoPostgresSourceExportStatementDetails {
+                                                table: Some(table.clone()),
+                                            },
+                                        ),
+                                    ),
+                                };
+                                node.with_options.push(CreateSubsourceOption {
+                                    name: CreateSubsourceOptionName::Details,
+                                    value: Some(WithOptionValue::Value(Value::String(
+                                        hex::encode(subsource_details.encode_to_vec()),
+                                    ))),
+                                });
+
+                                // Copy the relevant Text Columns from the top-level source option into the subsource option
+                                let text_columns = options
+                                    .iter()
+                                    .find(|o| o.name == PgConfigOptionName::TextColumns);
+                                if let Some(text_columns) = text_columns {
+                                    let table_text_columns = self.columns_for_table(
+                                        &external_schema,
+                                        &external_table,
+                                        &text_columns.value,
+                                    );
+                                    if table_text_columns.len() > 0 {
+                                        node.with_options.push(CreateSubsourceOption {
+                                            name: CreateSubsourceOptionName::TextColumns,
+                                            value: Some(WithOptionValue::Sequence(
+                                                table_text_columns,
+                                            )),
+                                        });
+                                    }
+                                }
+                            }
+                            CreateSourceConnection::MySql {
+                                connection: _,
+                                options,
+                            } => {
+                                let details = options
+                                    .iter()
+                                    .find(|o| o.name == MySqlConfigOptionName::Details)
+                                    .expect("Sources must have details");
+
+                                let details_val = match &details.value {
+                                    Some(WithOptionValue::Value(Value::String(details))) => details,
+                                    _ => unreachable!("Source details' value must be a string"),
+                                };
+
+                                let details = hex::decode(details_val)
+                                    .expect("Source details must be a hex-encoded string");
+                                let details = ProtoMySqlSourceDetails::decode(&*details)
+                                    .expect("Source details must be a hex-encoded protobuf");
+
+                                let (table_idx, table) = details
+                                    .deprecated_tables
+                                    .iter()
+                                    .enumerate()
+                                    .find(|(_, t)| {
+                                        t.schema_name == external_schema && t.name == external_table
+                                    })
+                                    .expect("subsource table must be in source details");
+                                // Handle the 2 versions of the initial_gtid_set fields in the top-level source details
+                                let initial_gtid_set = if details.deprecated_initial_gtid_set.len()
+                                    == 1
+                                {
+                                    details.deprecated_initial_gtid_set[0].clone()
+                                } else if details.deprecated_initial_gtid_set.len()
+                                    == details.deprecated_tables.len()
+                                {
+                                    details.deprecated_initial_gtid_set[table_idx].clone()
+                                } else if details.deprecated_legacy_initial_gtid_set.len() > 0 {
+                                    details.deprecated_legacy_initial_gtid_set.clone()
+                                } else {
+                                    unreachable!("invalid initial GTID set(s) in source details")
+                                };
+
+                                let subsource_details = ProtoSourceExportStatementDetails {
+                                    kind: Some(proto_source_export_statement_details::Kind::Mysql(
+                                        ProtoMySqlSourceExportStatementDetails {
+                                            table: Some(table.clone()),
+                                            initial_gtid_set,
+                                        },
+                                    )),
+                                };
+                                node.with_options.push(CreateSubsourceOption {
+                                    name: CreateSubsourceOptionName::Details,
+                                    value: Some(WithOptionValue::Value(Value::String(
+                                        hex::encode(subsource_details.encode_to_vec()),
+                                    ))),
+                                });
+
+                                // Copy the relevant Text Columns from the top-level source option into the subsource option
+                                let text_columns = options
+                                    .iter()
+                                    .find(|o| o.name == MySqlConfigOptionName::TextColumns);
+                                if let Some(text_columns) = text_columns {
+                                    let table_text_columns = self.columns_for_table(
+                                        &external_schema,
+                                        &external_table,
+                                        &text_columns.value,
+                                    );
+                                    if table_text_columns.len() > 0 {
+                                        node.with_options.push(CreateSubsourceOption {
+                                            name: CreateSubsourceOptionName::TextColumns,
+                                            value: Some(WithOptionValue::Sequence(
+                                                table_text_columns,
+                                            )),
+                                        });
+                                    }
+                                }
+                                // Copy the relevant Ignore Columns from the top-level source option into the subsource option
+                                let ignore_columns = options
+                                    .iter()
+                                    .find(|o| o.name == MySqlConfigOptionName::IgnoreColumns);
+                                if let Some(ignore_columns) = ignore_columns {
+                                    let table_ignore_columns = self.columns_for_table(
+                                        &external_schema,
+                                        &external_table,
+                                        &ignore_columns.value,
+                                    );
+                                    if table_ignore_columns.len() > 0 {
+                                        node.with_options.push(CreateSubsourceOption {
+                                            name: CreateSubsourceOptionName::IgnoreColumns,
+                                            value: Some(WithOptionValue::Sequence(
+                                                table_ignore_columns,
+                                            )),
+                                        });
+                                    }
+                                }
+                            }
+                            CreateSourceConnection::LoadGenerator { .. } => {
+                                // Load generator sources don't have any information we need to copy
+                                // to the subsource, so we just create an empty details for the subsource
+                                // which is used as a stub to ensure conformity with other source-export subsources
+                                let subsource_details = ProtoSourceExportStatementDetails {
+                                    kind: Some(
+                                        proto_source_export_statement_details::Kind::Loadgen(
+                                            ProtoLoadGeneratorSourceExportStatementDetails {},
+                                        ),
+                                    ),
+                                };
+                                node.with_options.push(CreateSubsourceOption {
+                                    name: CreateSubsourceOptionName::Details,
+                                    value: Some(WithOptionValue::Value(Value::String(
+                                        hex::encode(subsource_details.encode_to_vec()),
+                                    ))),
+                                });
+                            }
+                            _ => unreachable!("unexpected source type for existing subsource"),
+                        },
+                        _ => unreachable!("source must be a source"),
+                    };
+                }
+            }
+        }
+    }
+
+    impl Rewriter<'_, '_> {
+        fn columns_for_table(
+            &self,
+            external_schema: &str,
+            external_table: &str,
+            all_columns: &Option<WithOptionValue<Raw>>,
+        ) -> Vec<WithOptionValue<Raw>> {
+            let all_table_columns = match all_columns {
+                Some(WithOptionValue::Sequence(columns)) => columns
+                    .into_iter()
+                    .map(|column| match column {
+                        WithOptionValue::UnresolvedItemName(name) => name,
+                        _ => unreachable!("text columns must be UnresolvedItemName"),
+                    })
+                    .collect::<Vec<_>>(),
+                _ => {
+                    unreachable!("Source columns value must be a sequence")
+                }
+            };
+
+            all_table_columns
+                .into_iter()
+                .filter_map(|name| {
+                    // source text columns are an UnresolvedItemName with (schema, table, column) tuples
+                    // and we only need to copy the column name for the subsource option
+                    if name.0[0].clone().into_string() == external_schema
+                        && name.0[1].clone().into_string() == external_table
+                    {
+                        Some(WithOptionValue::Ident(name.0[2].clone()))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        }
+    }
+    Rewriter { tx }.visit_statement_mut(stmt);
+
+    Ok(())
+}
 
 // Durable migrations
 

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -373,19 +373,9 @@ impl Catalog {
 
         // Migrate item ASTs.
         let item_updates = if !config.skip_migrations {
-            let migration_item_updates = item_updates
-                .iter()
-                .cloned()
-                .map(|(kind, ts, diff)| StateUpdate {
-                    kind: kind.into(),
-                    ts,
-                    diff: diff.try_into().expect("valid diff"),
-                })
-                .collect();
             migrate::migrate(
                 &state,
                 &mut txn,
-                migration_item_updates,
                 config.now,
                 config.boot_ts,
                 &state.config.connection_context,

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -172,6 +172,13 @@ impl<'a> Transaction<'a> {
         })
     }
 
+    pub fn get_item(&self, id: &GlobalId) -> Option<Item> {
+        let key = ItemKey { gid: *id };
+        self.items
+            .get(&key)
+            .map(|v| DurableType::from_key_value(key, v.clone()))
+    }
+
     pub fn get_items(&self) -> impl Iterator<Item = Item> {
         self.items
             .items()

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -562,6 +562,13 @@ CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red')
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
+CREATE SUBSOURCE mz_subsource (c int) OF SOURCE public.foo.mz_source WITH (EXTERNAL REFERENCE = public.foo.bar, IGNORE COLUMNS (bar), TEXT COLUMNS (baz, foobar), DETAILS = 'details');
+----
+CREATE SUBSOURCE mz_subsource (c int4) OF SOURCE public.foo.mz_source WITH (EXTERNAL REFERENCE = public.foo.bar, IGNORE COLUMNS = (bar), TEXT COLUMNS = (baz, foobar), DETAILS = 'details')
+=>
+CreateSubsource(CreateSubsourceStatement { name: UnresolvedItemName([Ident("mz_subsource")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], of_source: Some(Name(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("mz_source")]))), constraints: [], if_not_exists: false, with_options: [CreateSubsourceOption { name: ExternalReference, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("public"), Ident("foo"), Ident("bar")]))) }, CreateSubsourceOption { name: IgnoreColumns, value: Some(Sequence([Ident(Ident("bar"))])) }, CreateSubsourceOption { name: TextColumns, value: Some(Sequence([Ident(Ident("baz")), Ident(Ident("foobar"))])) }, CreateSubsourceOption { name: Details, value: Some(Value(String("details"))) }] })
+
+parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic', PROGRESS GROUP ID PREFIX 'prefix', COMPRESSION TYPE = gzip) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic', PROGRESS GROUP ID PREFIX = 'prefix', COMPRESSION TYPE = gzip) FORMAT BYTES

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1813,6 +1813,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 Item(item_name)
             }
             UnresolvedItemName(name) => UnresolvedItemName(self.fold_unresolved_item_name(name)),
+            Ident(name) => Ident(self.fold_ident(name)),
             ClusterReplicas(replicas) => ClusterReplicas(
                 replicas
                     .into_iter()

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -102,7 +102,8 @@ use mz_storage_types::sources::postgres::{
     ProtoPostgresSourcePublicationDetails,
 };
 use mz_storage_types::sources::{
-    GenericSourceConnection, SourceConnection, SourceDesc, SourceReferenceResolver, Timeline,
+    GenericSourceConnection, ProtoSourceExportStatementDetails, SourceConnection, SourceDesc,
+    SourceExportStatementDetails, SourceReferenceResolver, Timeline,
 };
 use prost::Message;
 
@@ -1448,7 +1449,10 @@ pub fn plan_create_subsource(
     let CreateSubsourceOptionExtracted {
         progress,
         external_reference,
-        ..
+        text_columns,
+        ignore_columns,
+        details,
+        seen: _,
     } = with_options.clone().try_into()?;
 
     // This invariant is enforced during purification; we are responsible for
@@ -1563,6 +1567,22 @@ pub fn plan_create_subsource(
         // not a legacy subsource with the inverted structure.
         let ingestion_id = *source_reference.item_id();
         let external_reference = external_reference.unwrap();
+
+        // Decode the details option stored on the subsource statement, which contains information
+        // created during the purification process.
+        let details = details
+            .as_ref()
+            .ok_or_else(|| sql_err!("internal error: source-export subsource missing details"))?;
+        let details = hex::decode(details).map_err(|e| sql_err!("{}", e))?;
+        let details =
+            ProtoSourceExportStatementDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
+        let details =
+            SourceExportStatementDetails::from_proto(details).map_err(|e| sql_err!("{}", e))?;
+        // TODO(roshan): Use these options in the IngestionExport struct below. For now we just
+        // decode here to ensure that the details are present and valid.
+        let _ = details;
+        let _ = text_columns;
+        let _ = ignore_columns;
 
         DataSourceDesc::IngestionExport {
             ingestion_id,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1426,7 +1426,10 @@ pub fn plan_create_source(
 generate_extracted_config!(
     CreateSubsourceOption,
     (Progress, bool, Default(false)),
-    (ExternalReference, UnresolvedItemName)
+    (ExternalReference, UnresolvedItemName),
+    (TextColumns, Vec::<Ident>, Default(vec![])),
+    (IgnoreColumns, Vec::<Ident>, Default(vec![])),
+    (Details, String)
 );
 
 pub fn plan_create_subsource(

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -70,6 +70,17 @@ message ProtoCompression {
     }
 }
 
+// NOTE: this message is encoded and stored as part of a source export
+// statement option (currently only `CREATE SUBSOURCE` statements)
+// Be extra careful about changes, ensuring that all changes are backwards compatible
+message ProtoSourceExportStatementDetails {
+    oneof kind {
+        mz_storage_types.sources.postgres.ProtoPostgresSourceExportStatementDetails postgres = 1;
+        mz_storage_types.sources.mysql.ProtoMySqlSourceExportStatementDetails mysql = 2;
+        mz_storage_types.sources.load_generator.ProtoLoadGeneratorSourceExportStatementDetails loadgen = 3;
+    }
+}
+
 message ProtoIngestionDescription {
     message ProtoSourceImport {
         mz_repr.global_id.ProtoGlobalId id = 1;

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -77,7 +77,7 @@ message ProtoSourceExportStatementDetails {
     oneof kind {
         mz_storage_types.sources.postgres.ProtoPostgresSourceExportStatementDetails postgres = 1;
         mz_storage_types.sources.mysql.ProtoMySqlSourceExportStatementDetails mysql = 2;
-        mz_storage_types.sources.load_generator.ProtoLoadGeneratorSourceExportStatementDetails loadgen = 3;
+        google.protobuf.Empty loadgen = 3;
     }
 }
 

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1124,7 +1124,7 @@ pub enum SourceExportStatementDetails {
         table: mz_mysql_util::MySqlTableDesc,
         initial_gtid_set: String,
     },
-    LoadGenerator {},
+    LoadGenerator,
 }
 
 impl RustType<ProtoSourceExportStatementDetails> for SourceExportStatementDetails {
@@ -1148,10 +1148,8 @@ impl RustType<ProtoSourceExportStatementDetails> for SourceExportStatementDetail
                     },
                 )),
             },
-            SourceExportStatementDetails::LoadGenerator {} => ProtoSourceExportStatementDetails {
-                kind: Some(proto_source_export_statement_details::Kind::Loadgen(
-                    load_generator::ProtoLoadGeneratorSourceExportStatementDetails {},
-                )),
+            SourceExportStatementDetails::LoadGenerator => ProtoSourceExportStatementDetails {
+                kind: Some(proto_source_export_statement_details::Kind::Loadgen(())),
             },
         }
     }
@@ -1178,7 +1176,7 @@ impl RustType<ProtoSourceExportStatementDetails> for SourceExportStatementDetail
                 )?)?,
                 initial_gtid_set: details.initial_gtid_set,
             },
-            Some(Kind::Loadgen(_details)) => SourceExportStatementDetails::LoadGenerator {},
+            Some(Kind::Loadgen(_)) => SourceExportStatementDetails::LoadGenerator,
             None => {
                 return Err(TryFromProtoError::missing_field(
                     "ProtoSourceExportStatementDetails::kind",

--- a/src/storage-types/src/sources/load_generator.proto
+++ b/src/storage-types/src/sources/load_generator.proto
@@ -53,8 +53,3 @@ message ProtoKeyValueLoadGenerator {
     uint64 seed = 8;
     optional string include_offset = 9;
 }
-
-// NOTE: this message is encoded and stored as part of a source export
-// statement option (currently only `CREATE SUBSOURCE` statements)
-// Be extra careful about changes, ensuring that all changes are backwards compatible
-message ProtoLoadGeneratorSourceExportStatementDetails {}

--- a/src/storage-types/src/sources/load_generator.proto
+++ b/src/storage-types/src/sources/load_generator.proto
@@ -53,3 +53,8 @@ message ProtoKeyValueLoadGenerator {
     uint64 seed = 8;
     optional string include_offset = 9;
 }
+
+// NOTE: this message is encoded and stored as part of a source export
+// statement option (currently only `CREATE SUBSOURCE` statements)
+// Be extra careful about changes, ensuring that all changes are backwards compatible
+message ProtoLoadGeneratorSourceExportStatementDetails {}

--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -31,11 +31,22 @@ message ProtoMySqlSourceConnection {
 }
 
 message ProtoMySqlSourceDetails {
-    repeated mz_mysql_util.ProtoMySqlTableDesc tables = 1;
+    // NOTE(roshan): These fields are planned for deprecation, since relevant table descriptions
+    // and initial_gtid_sets are now stored on source export statements directly.
+    repeated mz_mysql_util.ProtoMySqlTableDesc deprecated_tables = 1;
     // This was changed from a string to a repeated string in order to support
     // separate GTID sets for each table. If this field contains a single element,
     // or the `legacy_initial_gtid_set` field is populated, it
     // is the initial GTID set for all tables.
-    string legacy_initial_gtid_set = 2;
-    repeated string initial_gtid_set = 3;
+    string deprecated_legacy_initial_gtid_set = 2;
+    repeated string deprecated_initial_gtid_set = 3;
+}
+
+
+// NOTE: this message is encoded and stored as part of a source export
+// statement option (currently only `CREATE SUBSOURCE` statements)
+// Be extra careful about changes, ensuring that all changes are backwards compatible
+message ProtoMySqlSourceExportStatementDetails {
+    mz_mysql_util.ProtoMySqlTableDesc table = 1;
+    string initial_gtid_set = 2;
 }

--- a/src/storage-types/src/sources/postgres.proto
+++ b/src/storage-types/src/sources/postgres.proto
@@ -41,8 +41,17 @@ message ProtoPostgresSourceConnection {
 }
 
 message ProtoPostgresSourcePublicationDetails {
-    repeated mz_postgres_util.desc.ProtoPostgresTableDesc tables = 1;
+    // NOTE(roshan): This field is planned for deprecation, since relevant table descriptions
+    // are now stored on source export statements directly.
+    repeated mz_postgres_util.desc.ProtoPostgresTableDesc deprecated_tables = 1;
     string slot = 2;
     optional uint64 timeline_id = 3;
     string database = 4;
+}
+
+// NOTE: this message is encoded and stored as part of a source export
+// statement option (currently only `CREATE SUBSOURCE` statements)
+// Be extra careful about changes, ensuring that all changes are backwards compatible
+message ProtoPostgresSourceExportStatementDetails {
+    mz_postgres_util.desc.ProtoPostgresTableDesc table = 1;
 }

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -310,6 +310,8 @@ impl RustType<ProtoPostgresSourceConnection> for PostgresSourceConnection {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct PostgresSourcePublicationDetails {
+    // NOTE(roshan): This field is planned for deprecation, since relevant table descriptions
+    // are now stored on source export statements directly.
     #[proptest(strategy = "proptest::collection::vec(any::<PostgresTableDesc>(), 0..4)")]
     pub tables: Vec<PostgresTableDesc>,
     pub slot: String,
@@ -323,7 +325,7 @@ pub struct PostgresSourcePublicationDetails {
 impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicationDetails {
     fn into_proto(&self) -> ProtoPostgresSourcePublicationDetails {
         ProtoPostgresSourcePublicationDetails {
-            tables: self.tables.iter().map(|t| t.into_proto()).collect(),
+            deprecated_tables: self.tables.iter().map(|t| t.into_proto()).collect(),
             slot: self.slot.clone(),
             timeline_id: self.timeline_id.clone(),
             database: self.database.clone(),
@@ -333,7 +335,7 @@ impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicati
     fn from_proto(proto: ProtoPostgresSourcePublicationDetails) -> Result<Self, TryFromProtoError> {
         Ok(PostgresSourcePublicationDetails {
             tables: proto
-                .tables
+                .deprecated_tables
                 .into_iter()
                 .map(PostgresTableDesc::from_proto)
                 .collect::<Result<_, _>>()?,

--- a/test/legacy-upgrade/create-in-v0.108.0-sources.td
+++ b/test/legacy-upgrade/create-in-v0.108.0-sources.td
@@ -1,0 +1,80 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# IMPORTANT: The Postgres server has a custom pg_hba.conf that only
+# accepts connections from specific users. You will have to update
+# pg_hba.conf if you modify the existing user names or add new ones.
+
+$ skip-if
+SELECT mz_version_num() >= 6000;
+
+## Create a MySQL source to ensure that its subsources can be upgraded through
+## migrations in v0.110.0
+
+> CREATE SECRET mysqlpass AS '${arg.mysql-root-password}'
+> CREATE CONNECTION mysql_conn TO MYSQL (
+    HOST mysql,
+    USER root,
+    PASSWORD SECRET mysqlpass
+  )
+
+$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
+
+$ mysql-execute name=mysql
+DROP DATABASE IF EXISTS public_1;
+CREATE DATABASE public_1;
+USE public_1;
+CREATE TABLE table_a (pk INTEGER PRIMARY KEY, f2 TEXT, f3 ENUM ('var0', 'var1'));
+INSERT INTO table_a VALUES (1, 'one', 'var0');
+INSERT INTO table_a VALUES (2, 'two', 'var1');
+
+> CREATE SOURCE mz_source
+  FROM MYSQL CONNECTION mysql_conn (
+   TEXT COLUMNS (public_1.table_a.f3)
+  )
+  FOR TABLES (public_1.table_a);
+
+
+## Create a Postgres source to ensure that its subsources can be upgraded through
+## migrations in v0.110.0
+
+> CREATE SECRET IF NOT EXISTS pgpass AS 'postgres'
+> CREATE CONNECTION IF NOT EXISTS pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP SCHEMA public_1 CASCADE;
+CREATE SCHEMA public_1;
+ALTER USER postgres WITH replication;
+DROP PUBLICATION IF EXISTS mz_source_1;
+CREATE PUBLICATION mz_source_1 FOR ALL TABLES;
+CREATE TYPE an_enum AS ENUM ('var0', 'var1');
+CREATE TABLE public_1.table_a (pk INTEGER PRIMARY KEY, f2 TEXT, f3 an_enum);
+INSERT INTO public_1.table_a VALUES (1, 'one', 'var0');
+ALTER TABLE public_1.table_a REPLICA IDENTITY FULL;
+INSERT INTO public_1.table_a VALUES (2, 'two', 'var1');
+
+
+> CREATE SOURCE "mz_source"
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source_1',
+    TEXT COLUMNS [public_1.table_f.f2]
+  )
+  FOR TABLES (public_1.table_a);
+
+
+## Create a Loadgen source to ensure that its subsources can be upgraded through
+## migrations in v0.110.0
+
+> CREATE SOURCE demo_1
+  FROM LOAD GENERATOR AUCTION (TICK INTERVAL '500ms') FOR ALL TABLES

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -18,6 +18,7 @@ from materialize.mzcompose.composition import Composition, WorkflowArgumentParse
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
+from materialize.mzcompose.services.mysql import MySql
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.test_certs import TestCerts
@@ -37,6 +38,7 @@ SERVICES = [
     Kafka(),
     SchemaRegistry(),
     Postgres(),
+    MySql(),
     Cockroach(setup_materialize=True),
     Materialized(
         options=list(mz_options.values()),
@@ -141,7 +143,7 @@ def test_upgrade_from_version(
     print(">>> Version glob pattern: " + version_glob)
 
     c.down(destroy_volumes=True)
-    c.up("zookeeper", "kafka", "schema-registry", "postgres")
+    c.up("zookeeper", "kafka", "schema-registry", "postgres", "mysql")
 
     if from_version != "current_source":
         mz_from = Materialized(
@@ -171,6 +173,8 @@ def test_upgrade_from_version(
         "--no-reset",
         f"--var=upgrade-from-version={from_version}",
         f"--var=created-cluster={created_cluster}",
+        f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
+        "--var=mysql-user-password=us3rp4ssw0rd",
         temp_dir,
         seed,
         f"create-in-{version_glob}-{filter}.td",

--- a/test/mysql-cdc/30-text-columns.td
+++ b/test/mysql-cdc/30-text-columns.td
@@ -88,6 +88,9 @@ INSERT INTO t1 SELECT * FROM t1;
 "0000-00-00 00:00:00.0000"
 "0000-00-00 00:00:00.0000"
 
+> SHOW CREATE SOURCE t1;
+materialize.public.t1 "CREATE SUBSOURCE \"materialize\".\"public\".\"t1\" (\"f1\" \"pg_catalog\".\"text\", \"f2\" \"pg_catalog\".\"text\", \"f3\" \"pg_catalog\".\"text\", \"f4\" \"pg_catalog\".\"text\", \"f5\" \"pg_catalog\".\"text\", \"f6\" \"pg_catalog\".\"text\", \"f7\" \"pg_catalog\".\"text\", \"f8\" \"pg_catalog\".\"text\", \"f9\" \"pg_catalog\".\"text\") OF SOURCE \"materialize\".\"public\".\"da\" WITH (EXTERNAL REFERENCE = \"public\".\"t1\", TEXT COLUMNS = (\"f1\", \"f2\", \"f3\", \"f4\", \"f5\", \"f6\", \"f7\", \"f8\", \"f9\"))"
+
 > DROP SOURCE da CASCADE;
 
 #

--- a/test/mysql-cdc/35-ignore-columns.td
+++ b/test/mysql-cdc/35-ignore-columns.td
@@ -61,6 +61,9 @@ INSERT INTO t1 SELECT * FROM t1;
 "test"
 "test"
 
+> SHOW CREATE SOURCE t1;
+materialize.public.t1 "CREATE SUBSOURCE \"materialize\".\"public\".\"t1\" (\"f1\" \"pg_catalog\".\"int4\", \"f4\" \"pg_catalog\".\"varchar\"(64)) OF SOURCE \"materialize\".\"public\".\"da\" WITH (EXTERNAL REFERENCE = \"public\".\"t1\", IGNORE COLUMNS = (\"f2\", \"f3\"))"
+
 ! SELECT f2 FROM t1;
 contains:column "f2" does not exist
 

--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -342,6 +342,9 @@ contains: invalid TEXT COLUMNS option value: unexpected multiple references to p
 > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 "\"public\".\"table_f\".\"f2\""
 
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE table_f);
+"\"f2\""
+
 # Drop a table, which shuffles the tables' output indexes, then add a table and ensure it can be added.
 $ mysql-execute name=mysql
 DROP TABLE table_c, table_d;
@@ -355,6 +358,9 @@ INSERT INTO table_f VALUES (3, 'var1');
 
 > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 "\"public\".\"table_f\".\"f2\", \"public\".\"table_i\".\"f2\""
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE table_i);
+"\"f2\""
 
 > SELECT * FROM table_f
 1 var0
@@ -408,6 +414,9 @@ contains: invalid IGNORE COLUMNS option value: unexpected multiple references to
 
 > SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 "\"public\".\"table_f\".\"f2\", \"public\".\"table_i\".\"f2\""
+
+> SELECT regexp_match(create_sql, 'IGNORE COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE table_i);
+"\"f2\""
 
 > SELECT * FROM table_i
 1

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -136,6 +136,9 @@ table_g               subsource
 > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 "\"postgres\".\"public\".\"table_f\".\"f2\""
 
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE table_f);
+"\"f2\""
+
 #
 # State checking
 #
@@ -357,6 +360,9 @@ INSERT INTO table_f VALUES (3, 'var1');
 
 > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 "\"postgres\".\"public\".\"table_f\".\"f2\", \"postgres\".\"public\".\"table_i\".\"f2\""
+
+> SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE table_i);
+"\"f2\""
 
 > SELECT * FROM table_f
 1 var0

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -800,6 +800,9 @@ enum_table              subsource ${arg.default-replica-size} cdc_cluster
 var0
 var1
 
+> SHOW CREATE SOURCE enum_table
+materialize.public.enum_table "CREATE SUBSOURCE \"materialize\".\"public\".\"enum_table\" (\"a\" \"pg_catalog\".\"text\") OF SOURCE \"materialize\".\"public\".\"enum_source\" WITH (EXTERNAL REFERENCE = \"postgres\".\"public\".\"enum_table\", TEXT COLUMNS = (\"a\"))"
+
 # Test that TEXT COLUMN types can change
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 BEGIN;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.
Fixes https://github.com/MaterializeInc/materialize/issues/28491

This is prep work for accomplishing https://github.com/MaterializeInc/materialize/issues/28451

I initially wrote a PR that does both tasks together but found it too big to review, so if you'd like to see where this is going you can check out that draft PR here: https://github.com/MaterializeInc/materialize/pull/28453

In that PR we drop the fields in each top-level source `details` option that are now stored on each subsource `details` option instead. And we can remove a lot of the extra work we have to do in sequencing to merge those details values when an `ALTER SOURCE ADD SUBSOURCES` statement happens. And we get rid of the index-based approach of mapping values in the details struct to the appropriate source-export. So while this PR is adding a lot of new code, we will end up removing a lot more in the next one 😄 

The downside here is that we are now storing redundant values in both the `CREATE SOURCE` statement options and the `CREATE SUBSOURCE` statement options. I'm not worried about them getting out of sync since we only populate these things once during statement purification, and in the next PR will we immediately remove them from the top-level source (except the 'text columns' and 'ignore columns' options, since those will be kept-around to allow statement roundtripping while we continue to support auto-created subsources).


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Reviewing commit by commit should be easier

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
