### PR TITLE
Minimize equivalence classes before applying projection analysis

### DIFF
--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -178,6 +178,11 @@ impl Analysis for Equivalences {
                             .classes
                             .push(vec![MirScalarExpr::Column(input_arity + pos), expr.clone()]);
                     }
+
+                    // Having added classes to `equivalences`, we should minimize the classes to fold the
+                    // information in before applying the `project`, to set it up for success.
+                    equivalences.minimize(&None);
+
                     // TODO: MIN, MAX, ANY, ALL aggregates pass through all certain properties of their columns.
                     // They also pass through equivalences of them and other constant columns (e.g. key columns).
                     // However, it is not correct to simply project onto these columns, as relationships amongst


### PR DESCRIPTION
It is important to minimize equivalence classes before applying the `project` action (which drops columns, but finds surrogate expressions). Failing to do this results in a confused equivalence class, which results in a more conservative output than is needed. We are unable to re-minimize as we execute, because we do not maintain a canonical form in this code (we are not looking for "canonical" terms, but ones that are supported by the columns supplied to the `project` call).

### Motivation

This enables predicates to survive the `Project` and `Reduce` operators, and most clearly make their way through grouping expressions. Although simplification "just happens" in non-recursive queries, recursive queries end up failing to determine that the predicates hold across iterations, because even if true in the input for `Reduce` they are not true in the output and do not survive through the next iteration.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
