### PR TITLE
[persist] Fix a flipped conditional and try not to do it again

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -2286,6 +2286,7 @@ pub struct ConsolidationMetrics {
     pub(crate) parts_fetched: IntCounter,
     pub(crate) parts_skipped: IntCounter,
     pub(crate) parts_wasted: IntCounter,
+    pub(crate) wrong_sort: IntCounter,
 }
 
 impl ConsolidationMetrics {
@@ -2302,6 +2303,10 @@ impl ConsolidationMetrics {
             parts_wasted: registry.register(metric!(
                 name: "mz_persist_consolidation_parts_wasted_count",
                 help: "count of parts that were fetched but not needed during consolidation",
+            )),
+            wrong_sort: registry.register(metric!(
+                name: "mz_persist_consolidation_wrong_sort_count",
+                help: "count of runs that were sorted using the wrong ordering for the current consolidation",
             )),
         }
     }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -70,7 +70,7 @@ impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
         let min_version = WriterKey::for_version(&MINIMUM_CONSOLIDATED_VERSION);
         match self {
             FetchData::Unfetched { part, .. } => {
-                part.writer_key().map_or(false, |k| k >= min_version)
+                part.writer_key().map_or(false, |k| k < min_version)
             }
             FetchData::AlreadyFetched => false,
         }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -66,12 +66,19 @@ pub(crate) enum FetchData<T> {
 }
 
 impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
-    fn maybe_unconsolidated(&self) -> bool {
+    /// Returns true iff we were using a different ordering for data or timestamps
+    /// when the part was created. This means parts or runs may not be ordered according to
+    /// our modern definition, even if the metadata indicates they've been compacted before.
+    fn wrong_sort(&self) -> bool {
         let min_version = WriterKey::for_version(&MINIMUM_CONSOLIDATED_VERSION);
         match self {
-            FetchData::Unfetched { part, .. } => {
-                part.writer_key().map_or(false, |k| k < min_version)
-            }
+            FetchData::Unfetched { part, .. } => match part.writer_key() {
+                // Old hollow parts may have used a different sort
+                Some(key) => key < min_version,
+                // Inline parts are all recent enough to have been sorted using the latest ordering,
+                // if they're sorted at all.
+                None => false,
+            },
             FetchData::AlreadyFetched => false,
         }
     }
@@ -121,7 +128,7 @@ pub(crate) enum ConsolidationPart<T, D> {
     },
     Prefetched {
         handle: JoinHandle<anyhow::Result<EncodedPart<T>>>,
-        maybe_unconsolidated: bool,
+        wrong_sort: bool,
         key_lower: Vec<u8>,
     },
     Encoded {
@@ -142,10 +149,10 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidation
     pub(crate) fn from_encoded(
         part: EncodedPart<T>,
         filter: &'a FetchBatchFilter<T>,
-        maybe_unconsolidated: bool,
+        force_reconsolidation: bool,
     ) -> Self {
         let mut cursor = Cursor::default();
-        if part.maybe_unconsolidated() || maybe_unconsolidated {
+        if part.maybe_unconsolidated() || force_reconsolidation {
             let mut cursors = vec![];
 
             // For every valid entry in the encoded part, keep a cursor and the decoded T/D.
@@ -325,16 +332,14 @@ where
         // Normally unconsolidated parts are in their own run, but we can end up with unconsolidated
         // runs if we change our sort order or have bugs, for example. Defend against this by
         // splitting up a run if it contains possibly-unconsolidated parts.
-        let maybe_unconsolidated = run.iter().any(|(p, _)| match p {
-            ConsolidationPart::Queued { data } => data.maybe_unconsolidated(),
-            ConsolidationPart::Prefetched {
-                maybe_unconsolidated,
-                ..
-            } => *maybe_unconsolidated,
-            ConsolidationPart::Encoded { part, .. } => part.maybe_unconsolidated(),
+        let wrong_sort = run.iter().any(|(p, _)| match p {
+            ConsolidationPart::Queued { data } => data.wrong_sort(),
+            ConsolidationPart::Prefetched { wrong_sort, .. } => *wrong_sort,
+            // ConsolidationPart::from_encoded will only keep the original part if the sort is correct.
+            ConsolidationPart::Encoded { .. } => false,
             ConsolidationPart::Sorted { .. } => false,
         });
-        if run.len() > 1 && maybe_unconsolidated && self.split_old_runs {
+        if run.len() > 1 && wrong_sort && self.split_old_runs {
             for part in run {
                 self.runs.push(VecDeque::from([part]));
             }
@@ -433,7 +438,7 @@ where
                     ConsolidationPart::Queued { data } => {
                         self.metrics.compaction.parts_waited.inc();
                         self.metrics.consolidation.parts_fetched.inc();
-                        let maybe_unconsolidated = data.maybe_unconsolidated();
+                        let wrong_sort = data.wrong_sort();
                         *part = ConsolidationPart::from_encoded(
                             data.take()
                                 .fetch(
@@ -445,13 +450,11 @@ where
                                 )
                                 .await?,
                             &self.filter,
-                            maybe_unconsolidated,
+                            wrong_sort,
                         );
                     }
                     ConsolidationPart::Prefetched {
-                        handle,
-                        maybe_unconsolidated,
-                        ..
+                        handle, wrong_sort, ..
                     } => {
                         if handle.is_finished() {
                             self.metrics.compaction.parts_prefetched.inc();
@@ -462,7 +465,7 @@ where
                         *part = ConsolidationPart::from_encoded(
                             handle.await??,
                             &self.filter,
-                            *maybe_unconsolidated,
+                            *wrong_sort,
                         );
                     }
                     ConsolidationPart::Encoded { .. } | ConsolidationPart::Sorted { .. } => {}
@@ -549,7 +552,7 @@ where
                         _ => continue,
                     };
                     let key_lower = data.key_lower().to_vec();
-                    let maybe_unconsolidated = data.maybe_unconsolidated();
+                    let wrong_sort = data.wrong_sort();
                     let span = debug_span!("compaction::prefetch");
                     let handle = mz_ore::task::spawn(|| "persist::compaction::prefetch", {
                         let shard_id = self.shard_id;
@@ -565,7 +568,7 @@ where
                     });
                     *c_part = ConsolidationPart::Prefetched {
                         handle,
-                        maybe_unconsolidated,
+                        wrong_sort,
                         key_lower,
                     };
                 }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -339,6 +339,11 @@ where
             ConsolidationPart::Encoded { .. } => false,
             ConsolidationPart::Sorted { .. } => false,
         });
+
+        if wrong_sort {
+            self.metrics.consolidation.wrong_sort.inc();
+        }
+
         if run.len() > 1 && wrong_sort && self.split_old_runs {
             for part in run {
                 self.runs.push(VecDeque::from([part]));


### PR DESCRIPTION
### Motivation

Fixes: https://github.com/MaterializeInc/materialize/issues/26170

### Tips for reviewer

This inversion dates way back, and has survived several refactorings. Not great!

The first commit fixes the bug, and tries two things to make it less likely to have similar issues in the future:
- Renames the method etc. to `wrong_sort` instead of `maybe_unconsolidated`. (I suspect part of the confusion is that maybe-unconsolidated is a weirdly negated name, making it less likely to notice that we had it backwards.)
- Adds a metric; hard to imagine this would have lasted as long as it did with proper visibility.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
