### PR TITLE
[dnm] persist: Add columnar encoders to `ColumnarRecordsBuilder`

### DIFF
--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -680,11 +680,11 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
 /// return static Codec names, and rebind the names if/when we get a CodecMismatch, so we can convince
 /// the type system and our safety checks that we really can read the data.
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct K;
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct V;
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 struct T;
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 struct D(i64);

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -523,7 +523,11 @@ where
     ///
     /// NB: Until we implement full projection pushdown, this doesn't guarantee
     /// any projection.
-    pub fn maybe_optimize(&mut self, cfg: &ConfigSet, project: &ProjectionPushdown) {
+    pub fn maybe_optimize<K: Codec, V: Codec>(
+        &mut self,
+        cfg: &ConfigSet,
+        project: &ProjectionPushdown<K, V>,
+    ) {
         let as_of = match &self.filter {
             FetchBatchFilter::Snapshot { as_of } => as_of,
             FetchBatchFilter::Listen { .. } | FetchBatchFilter::Compaction { .. } => return,

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1303,8 +1303,7 @@ pub mod datadriven {
     use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
 
     use crate::batch::{
-        validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
-        BLOB_TARGET_SIZE,
+        validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BLOB_TARGET_SIZE,
     };
     use crate::fetch::{Cursor, EncodedPart};
     use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
@@ -1642,7 +1641,7 @@ pub mod datadriven {
         if consolidate {
             consolidate_updates(&mut updates);
         }
-        let builder = BatchBuilderInternal::new(
+        let mut builder = BatchBuilder::new(
             cfg.clone(),
             Arc::clone(&datadriven.client.metrics),
             Arc::clone(&datadriven.machine.applier.shard_metrics),
@@ -1651,18 +1650,12 @@ pub mod datadriven {
             Arc::clone(&datadriven.client.blob),
             Arc::clone(&datadriven.client.isolated_runtime),
             datadriven.shard_id.clone(),
+            schemas.clone(),
             datadriven.client.cfg.build_version.clone(),
             since,
             Some(upper.clone()),
             consolidate,
         );
-        let mut builder = BatchBuilder {
-            stats_schemas: schemas.clone(),
-            builder,
-            metrics: Arc::clone(&datadriven.client.metrics),
-            key_buf: vec![],
-            val_buf: vec![],
-        };
         for ((k, ()), t, d) in updates {
             builder.add(&k, &(), &t, &d).await.expect("invalid batch");
         }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -879,6 +879,7 @@ mod tests {
     use mz_persist::indexed::encoding::{BlobTraceBatchPart, BlobTraceUpdates};
     use mz_persist::location::Blob;
     use mz_persist::mem::{MemBlob, MemBlobConfig};
+    use mz_persist_types::codec_impls::VecU8Schema;
     use proptest::collection::vec;
     use proptest::prelude::*;
     use timely::progress::Antichain;
@@ -932,7 +933,8 @@ mod tests {
                             [part, part_2]
                                 .into_iter()
                                 .map(|part| {
-                                    let mut records = ColumnarRecordsBuilder::default();
+                                    let mut records =
+                                        ColumnarRecordsBuilder::new(&VecU8Schema, &VecU8Schema);
                                     for ((k, v), t, d) in &part {
                                         assert!(records.push((
                                             (k, v),

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -80,7 +80,7 @@ pub fn shard_source<'g, K, V, T, D, F, DT, G, C>(
     listen_sleep: Option<impl Fn() -> RetryParameters + 'static>,
     start_signal: impl Future<Output = ()> + 'static,
     error_handler: impl FnOnce(String) -> Pin<Box<dyn Future<Output = ()>>> + 'static,
-    project: ProjectionPushdown,
+    project: ProjectionPushdown<K, V>,
 ) -> (
     Stream<Child<'g, G, T>, FetchedBlob<K, V, G::Timestamp, D>>,
     Vec<PressOnDropButton>,
@@ -224,7 +224,7 @@ pub(crate) fn shard_source_descs<K, V, D, F, G>(
     listen_sleep: Option<impl Fn() -> RetryParameters + 'static>,
     start_signal: impl Future<Output = ()> + 'static,
     error_handler: impl FnOnce(String) -> Pin<Box<dyn Future<Output = ()>>> + 'static,
-    project: ProjectionPushdown,
+    project: ProjectionPushdown<K, V>,
 ) -> (Stream<G, (usize, SerdeLeasedBatchPart)>, PressOnDropButton)
 where
     K: Debug + Codec,

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -33,8 +33,8 @@ use tracing::{debug_span, info, warn, Instrument};
 use uuid::Uuid;
 
 use crate::batch::{
-    validate_truncate_batch, Added, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
-    ProtoBatch, BATCH_DELETE_ENABLED,
+    validate_truncate_batch, Added, Batch, BatchBuilder, BatchBuilderConfig, ProtoBatch,
+    BATCH_DELETE_ENABLED,
 };
 use crate::error::{InvalidUsage, UpperMismatch};
 use crate::internal::compact::Compactor;
@@ -604,7 +604,7 @@ where
     /// enough that we can reasonably chunk them up: O(KB) is definitely fine,
     /// O(MB) come talk to us.
     pub fn builder(&mut self, lower: Antichain<T>) -> BatchBuilder<K, V, T, D> {
-        let builder = BatchBuilderInternal::new(
+        BatchBuilder::new(
             BatchBuilderConfig::new(&self.cfg, &self.writer_id),
             Arc::clone(&self.metrics),
             Arc::clone(&self.machine.applier.shard_metrics),
@@ -613,18 +613,12 @@ where
             Arc::clone(&self.blob),
             Arc::clone(&self.isolated_runtime),
             self.machine.shard_id().clone(),
+            self.schemas.clone(),
             self.cfg.build_version.clone(),
             Antichain::from_elem(T::minimum()),
             None,
             false,
-        );
-        BatchBuilder {
-            builder,
-            stats_schemas: self.schemas.clone(),
-            metrics: Arc::clone(&self.metrics),
-            key_buf: vec![],
-            val_buf: vec![],
-        }
+        )
     }
 
     /// Uploads the given `updates` as one `Batch` to the blob store and returns

--- a/src/persist-types/build.rs
+++ b/src/persist-types/build.rs
@@ -14,6 +14,13 @@ fn main() {
     prost_build::Config::new()
         .type_attribute(".", "#[derive(serde::Serialize)]")
         .btree_map(["."])
-        .compile_protos(&["persist-types/src/stats.proto"], &[".."])
+        .bytes([".mz_persist_types.arrow.Buffer"])
+        .compile_protos(
+            &[
+                "persist-types/src/arrow.proto",
+                "persist-types/src/stats.proto",
+            ],
+            &[".."],
+        )
         .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/persist-types/src/arrow.proto
+++ b/src/persist-types/src/arrow.proto
@@ -22,7 +22,7 @@ message ArrayData {
     DataType data_type = 1;
     uint64 length = 2;
     uint64 offset = 3;
-    
+
     repeated Buffer buffers = 4;
     repeated ArrayData children = 5;
 

--- a/src/persist-types/src/arrow.proto
+++ b/src/persist-types/src/arrow.proto
@@ -18,91 +18,60 @@ import "google/protobuf/empty.proto";
 
 package mz_persist_types.arrow;
 
-message NullArray {
-    uint64 len = 1;
+message ArrayData {
+    DataType data_type = 1;
+    uint64 length = 2;
+    uint64 offset = 3;
+    
+    repeated Buffer buffers = 4;
+    repeated ArrayData children = 5;
+
+    BooleanBuffer nulls = 6;
 }
 
-message BooleanArray {
-    BooleanBuffer buffer = 1;
-}
+message DataType {
+    message Struct {
+        repeated Field children = 1;
+    }
 
-message U64Array {
-    repeated uint64 values = 1;
-}
-
-message I64Array {
-    repeated int64 values = 1;
-}
-
-message F32Array {
-    repeated float values = 1;
-}
-
-message F64Array {
-    repeated double values = 1;
-}
-
-message PrimitiveArray {
-    Buffer data = 1;
-}
-
-message FixedSizeArray {
-    Buffer data = 1;
-    int32 size = 2;
-}
-
-message VariableSizeArray {
-    Buffer data = 1;
-    repeated int32 offsets = 2;
-}
-
-message ListArray {
-    Array values = 1;
-    repeated int32 offsets = 2;
-}
-
-message MapArray {
-    Array values = 1;
-    repeated int32 offsets = 2;
-    bool sorted = 3;
-}
-
-message StructArray {
-    repeated Array children = 1;
-}
-
-message Array {
-    string name = 1;
-    bool nullable = 2;
-    BooleanBuffer nulls = 3;
+    message Map {
+        Field value = 1;
+        bool sorted = 2;
+    }
 
     // Protobuf tags [1, 15] get encoded in a single byte, so order these by
     // what is most common.
     oneof kind {
-        VariableSizeArray string = 4;
-        VariableSizeArray binary = 5;
-        FixedSizeArray fixed_binary = 6;
-        I64Array int32 = 7;
-        I64Array int64 = 8;
-        U64Array uint32 = 9;
-        U64Array uint64 = 10;
-        F32Array float32 = 11;
-        F64Array float64 = 12;
-        StructArray struct = 13;
-        ListArray list = 14;
+        google.protobuf.Empty string = 1;
+        google.protobuf.Empty binary = 2;
+        int32 fixed_binary = 3;
+        google.protobuf.Empty int32 = 4;
+        google.protobuf.Empty int64 = 5;
+        google.protobuf.Empty uint32 = 6;
+        google.protobuf.Empty uint64 = 7;
+        google.protobuf.Empty float32 = 8;
+        google.protobuf.Empty float64 = 9;
+        Struct struct = 10;
+        Field list = 11;
+        google.protobuf.Empty uint8 = 12;
+        google.protobuf.Empty boolean = 13;
 
-        // Note: 15 is intentionally unused. It's a bet that future Persist
-        // folks will maybe want to add a new array type and leverage the
-        // single byte optimization.
+        // Note: 14 and 15 are intentionally unused. It's a bet that future
+        // Persist folks will maybe want to add a new array type and leverage
+        // the single byte optimization.
 
-        U64Array uint8 = 16;
-        BooleanArray boolean = 17;
-        NullArray null = 18;
-        I64Array int8 = 19;
-        I64Array int16 = 20;
-        U64Array uint16 = 21;
-        MapArray map = 22;
+        google.protobuf.Empty null = 16;
+        google.protobuf.Empty int8 = 17;
+        google.protobuf.Empty int16 = 18;
+        google.protobuf.Empty uint16 = 19;
+        Map map = 20;
     }
+}
+
+message Field {
+    string name = 1;
+    bool nullable = 2;
+    DataType data_type = 3;
 }
 
 message Buffer {

--- a/src/persist-types/src/arrow.proto
+++ b/src/persist-types/src/arrow.proto
@@ -1,0 +1,120 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// BE CAREFUL! Unlike other Materialize Protos, Persist's messages need to
+// be forward-compatible and roundtrip losslessly between versions. Consider
+// making your Proto changes in a release before you populate non-default values,
+// or guard the code changes behind a feature flag.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package mz_persist_types.arrow;
+
+message NullArray {
+    uint64 len = 1;
+}
+
+message BooleanArray {
+    BooleanBuffer buffer = 1;
+}
+
+message U64Array {
+    repeated uint64 values = 1;
+}
+
+message I64Array {
+    repeated int64 values = 1;
+}
+
+message F32Array {
+    repeated float values = 1;
+}
+
+message F64Array {
+    repeated double values = 1;
+}
+
+message PrimitiveArray {
+    Buffer data = 1;
+}
+
+message FixedSizeArray {
+    Buffer data = 1;
+    int32 size = 2;
+}
+
+message VariableSizeArray {
+    Buffer data = 1;
+    repeated int32 offsets = 2;
+}
+
+message ListArray {
+    Array values = 1;
+    repeated int32 offsets = 2;
+}
+
+message MapArray {
+    Array values = 1;
+    repeated int32 offsets = 2;
+    bool sorted = 3;
+}
+
+message StructArray {
+    repeated Array children = 1;
+}
+
+message Array {
+    string name = 1;
+    bool nullable = 2;
+    NullBuffer nulls = 3;
+
+    // Protobuf tags [1, 15] get encoded in a single byte, so order these by
+    // what is most common.
+    oneof kind {
+        VariableSizeArray string = 4;
+        VariableSizeArray binary = 5;
+        FixedSizeArray fixed_binary = 6;
+        I64Array int32 = 7;
+        I64Array int64 = 8;
+        U64Array uint32 = 9;
+        U64Array uint64 = 10;
+        F32Array float32 = 11;
+        F64Array float64 = 12;
+        StructArray struct = 13;
+        ListArray list = 14;
+
+        // Note: 15 is intentionally unused. It's a bet that future Persist
+        // folks will maybe want to add a new array type and leverage the
+        // single byte optimization.
+
+        U64Array uint8 = 16;
+        BooleanArray boolean = 17;
+        NullArray null = 18;
+        I64Array int8 = 19;
+        I64Array int16 = 20;
+        U64Array uint16 = 21;
+        MapArray map = 22;
+    }
+}
+
+message Buffer {
+    bytes data = 1;
+}
+
+message BooleanBuffer {
+    Buffer buffer = 1;
+    uint64 offset = 2;
+    uint64 length = 3;
+}
+
+message NullBuffer {
+    BooleanBuffer buf = 1;
+}

--- a/src/persist-types/src/arrow.proto
+++ b/src/persist-types/src/arrow.proto
@@ -18,13 +18,13 @@ import "google/protobuf/empty.proto";
 
 package mz_persist_types.arrow;
 
-message ArrayData {
+message ProtoArrayData {
     DataType data_type = 1;
     uint64 length = 2;
     uint64 offset = 3;
 
     repeated Buffer buffers = 4;
-    repeated ArrayData children = 5;
+    repeated ProtoArrayData children = 5;
 
     BooleanBuffer nulls = 6;
 }

--- a/src/persist-types/src/arrow.proto
+++ b/src/persist-types/src/arrow.proto
@@ -111,6 +111,5 @@ message Buffer {
 
 message BooleanBuffer {
     Buffer buffer = 1;
-    uint64 offset = 2;
-    uint64 length = 3;
+    uint64 length = 2;
 }

--- a/src/persist-types/src/arrow.proto
+++ b/src/persist-types/src/arrow.proto
@@ -74,7 +74,7 @@ message StructArray {
 message Array {
     string name = 1;
     bool nullable = 2;
-    NullBuffer nulls = 3;
+    BooleanBuffer nulls = 3;
 
     // Protobuf tags [1, 15] get encoded in a single byte, so order these by
     // what is most common.
@@ -113,8 +113,4 @@ message BooleanBuffer {
     Buffer buffer = 1;
     uint64 offset = 2;
     uint64 length = 3;
-}
-
-message NullBuffer {
-    BooleanBuffer buf = 1;
 }

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -17,37 +17,16 @@
 //! or [Arrow IPC], include data that we don't need and would be wasteful to
 //! store.
 //!
-//! # Design Considerations
-//!
-//! Initially this was implemented as a "protobuf port" of
-//! [`arrow::array::ArrayData`], with the goal of zero-copy deserialization
-//! via [`arrow::buffer::Buffer`]s and [`bytes::Bytes`]. This doesn't work
-//! though because Arrow needs the underlying Buffers to be aligned for the
-//! type of data stored, e.g. an array of `u64`s needs to be 8 byte aligned.
-//! While it is technically possible to make this work, it is much easier to
-//! structure the data in protobuf and use native types.
-//!
-//! Using protobuf native types like `uint64` is nice because we benefit from
-//! the space savings of `LEB128` encoding, with a tradeoff being runtime
-//! performance. Given the above complications, and the need to store only a
-//! small amount of data, this is a decent tradeoff.
-//!
-//!
 //! [protobuf]: https://protobuf.dev/
-//! [Arrow]: https://arrow.apache.org/
+//! [Apache Arrow]: https://arrow.apache.org/
 //! [Parquet]: https://parquet.apache.org/docs/
 //! [Arrow IPC]: https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc
 
 use std::sync::Arc;
 
-use arrow::array::{
-    Array, BinaryArray, BooleanArray, FixedSizeBinaryArray, Float32Array, Float64Array,
-    GenericByteArray, Int16Array, Int32Array, Int64Array, Int8Array, ListArray, MapArray,
-    NullArray, StringArray, StructArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
-};
-use arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
-use arrow::datatypes::{ByteArrayType, DataType, Field, Fields};
-use mz_ore::assert_none;
+use arrow::array::ArrayDataBuilder;
+use arrow::buffer::{BooleanBuffer, NullBuffer};
+use arrow::datatypes::{DataType, Field, Fields};
 use mz_ore::cast::CastFrom;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 
@@ -55,498 +34,151 @@ use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 mod proto {
     include!(concat!(env!("OUT_DIR"), "/mz_persist_types.arrow.rs"));
 }
-pub use proto::Array as ProtoArray;
+pub use proto::ArrayData as ProtoArrayData;
 
-/// Encode an [`arrow::array::Array`] to and from a [`proto::Array`].
-pub trait ArrayProtobuf: Sized + arrow::array::Array {
-    /// Encodes `self` and the provided [`Field`] into a [`proto::Array`].
-    ///
-    /// # Panics
-    ///
-    /// * Not all Arrow Array types are supported, panics on unsupported arrays.
-    ///
-    fn into_proto(self, field: Arc<Field>) -> proto::Array;
-
-    /// Decodes an instance of `Self` and a [`Field`] from the provided
-    /// [`proto::Array`]. Returns an error if we can't decode an instance of [`Self`].
-    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError>;
-}
-
-impl ArrayProtobuf for Arc<dyn arrow::array::Array> {
-    fn into_proto(self, field: Arc<Field>) -> proto::Array {
-        fn inner<T>(field: Arc<Field>, array: Arc<dyn arrow::array::Array>) -> proto::Array
-        where
-            T: ArrayProtobuf + arrow::array::Array + Clone + 'static,
-        {
-            let Some(array) = array.as_any().downcast_ref::<T>() else {
-                panic!("expected {} but got {array:?}", std::any::type_name::<T>());
-            };
-            array.clone().into_proto(field)
-        }
-
-        match self.data_type() {
-            DataType::Boolean => inner::<BooleanArray>(field, self),
-            DataType::UInt8 => inner::<UInt8Array>(field, self),
-            DataType::UInt16 => inner::<UInt16Array>(field, self),
-            DataType::UInt32 => inner::<UInt32Array>(field, self),
-            DataType::UInt64 => inner::<UInt64Array>(field, self),
-            DataType::Int8 => inner::<Int8Array>(field, self),
-            DataType::Int16 => inner::<Int16Array>(field, self),
-            DataType::Int32 => inner::<Int32Array>(field, self),
-            DataType::Int64 => inner::<Int64Array>(field, self),
-            DataType::Float32 => inner::<Float32Array>(field, self),
-            DataType::Float64 => inner::<Float64Array>(field, self),
-            DataType::Utf8 => inner::<StringArray>(field, self),
-            DataType::Binary => inner::<BinaryArray>(field, self),
-            DataType::FixedSizeBinary(_) => inner::<FixedSizeBinaryArray>(field, self),
-            DataType::List(_) => inner::<ListArray>(field, self),
-            DataType::Map(_, _) => inner::<MapArray>(field, self),
-            DataType::Struct(_) => inner::<StructArray>(field, self),
-            DataType::Null => inner::<NullArray>(field, self),
-            other => unimplemented!("unsupported array type {other:?}"),
+impl RustType<proto::ArrayData> for arrow::array::ArrayData {
+    fn into_proto(&self) -> proto::ArrayData {
+        proto::ArrayData {
+            data_type: Some(self.data_type().into_proto()),
+            length: u64::cast_from(self.len()),
+            offset: u64::cast_from(self.offset()),
+            buffers: self.buffers().iter().map(|b| b.into_proto()).collect(),
+            children: self.child_data().iter().map(|c| c.into_proto()).collect(),
+            nulls: self.nulls().map(|n| n.inner().into_proto()),
         }
     }
 
-    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
-        fn inner<T: ArrayProtobuf + 'static>(
-            array: proto::Array,
-        ) -> Result<(Field, Arc<dyn arrow::array::Array>), mz_proto::TryFromProtoError> {
-            let (field, array) = T::from_proto(array)?;
-            let array: Arc<dyn arrow::array::Array> = Arc::new(array);
-
-            Ok((field, array))
-        }
-
-        match &proto.kind {
-            None => Err(TryFromProtoError::missing_field("kind")),
-            Some(proto::array::Kind::Boolean(_)) => inner::<BooleanArray>(proto),
-            Some(proto::array::Kind::Uint8(_)) => inner::<UInt8Array>(proto),
-            Some(proto::array::Kind::Uint16(_)) => inner::<UInt16Array>(proto),
-            Some(proto::array::Kind::Uint32(_)) => inner::<UInt32Array>(proto),
-            Some(proto::array::Kind::Uint64(_)) => inner::<UInt64Array>(proto),
-            Some(proto::array::Kind::Int8(_)) => inner::<Int8Array>(proto),
-            Some(proto::array::Kind::Int16(_)) => inner::<Int16Array>(proto),
-            Some(proto::array::Kind::Int32(_)) => inner::<Int32Array>(proto),
-            Some(proto::array::Kind::Int64(_)) => inner::<Int64Array>(proto),
-            Some(proto::array::Kind::Float32(_)) => inner::<Float32Array>(proto),
-            Some(proto::array::Kind::Float64(_)) => inner::<Float64Array>(proto),
-            Some(proto::array::Kind::String(_)) => inner::<StringArray>(proto),
-            Some(proto::array::Kind::Binary(_)) => inner::<BinaryArray>(proto),
-            Some(proto::array::Kind::FixedBinary(_)) => inner::<FixedSizeBinaryArray>(proto),
-            Some(proto::array::Kind::List(_)) => inner::<ListArray>(proto),
-            Some(proto::array::Kind::Map(_)) => inner::<MapArray>(proto),
-            Some(proto::array::Kind::Struct(_)) => inner::<StructArray>(proto),
-            Some(proto::array::Kind::Null(_)) => inner::<NullArray>(proto),
-        }
-    }
-}
-
-impl ArrayProtobuf for BooleanArray {
-    fn into_proto(self, field: Arc<Field>) -> proto::Array {
-        let (buffer, nulls) = self.into_parts();
-        let buffer = Some(buffer.into_proto());
-        let array = proto::BooleanArray { buffer };
-
-        proto::Array {
-            name: field.name().clone(),
-            nullable: field.is_nullable(),
-            nulls: nulls.map(|n| n.into_inner().into_proto()),
-            kind: Some(proto::array::Kind::Boolean(array)),
-        }
-    }
-
-    fn from_proto(proto: proto::Array) -> Result<(Field, Self), TryFromProtoError> {
-        let proto::Array {
-            name,
-            nullable,
+    fn from_proto(proto: proto::ArrayData) -> Result<Self, TryFromProtoError> {
+        let proto::ArrayData {
+            data_type,
+            length,
+            offset,
+            buffers,
+            children,
             nulls,
-            kind,
         } = proto;
-
-        let Some(proto::array::Kind::Boolean(array)) = kind else {
-            return Err(TryFromProtoError::missing_field("kind.boolean"));
-        };
-
-        let bool_buffer: BooleanBuffer = array.buffer.into_rust_if_some("buffer")?;
+        let data_type = data_type.into_rust_if_some("data_type")?;
         let nulls = nulls
             .map(|n| n.into_rust())
             .transpose()?
-            .map(NullBuffer::new);
-        let field = Field::new(name, DataType::Boolean, nullable);
-        let array = BooleanArray::new(bool_buffer, nulls);
+            .map(|b| NullBuffer::new(b));
 
-        Ok((field, array))
+        let mut builder = ArrayDataBuilder::new(data_type)
+            .len(usize::cast_from(length))
+            .offset(usize::cast_from(offset))
+            .nulls(nulls);
+
+        for b in buffers.into_iter().map(|b| b.into_rust()) {
+            builder = builder.add_buffer(b?);
+        }
+        for c in children.into_iter().map(|c| c.into_rust()) {
+            builder = builder.add_child_data(c?);
+        }
+
+        // Construct the builder which validates all inputs and aligns data.
+        builder
+            .build_aligned()
+            .map_err(|e| TryFromProtoError::RowConversionError(e.to_string()))
     }
 }
 
-macro_rules! primitive_array {
-    ($rust_ty:ty, $arrow_array:ty, $proto_var:ident, $proto_array:ident) => {
-        impl ArrayProtobuf for $arrow_array {
-            fn into_proto(self, field: Arc<Field>) -> proto::Array {
-                let nulls = self.logical_nulls().map(|n| n.into_inner().into_proto());
-                let values = self.values().iter().map(|x| (*x).into()).collect();
-                let array = proto::$proto_array { values };
-
-                proto::Array {
-                    name: field.name().clone(),
-                    nullable: field.is_nullable(),
-                    nulls,
-                    kind: Some(proto::array::Kind::$proto_var(array)),
-                }
-            }
-
-            fn from_proto(
-                proto: proto::Array,
-            ) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
-                let proto::Array {
-                    name,
-                    nullable,
-                    nulls,
-                    kind,
-                } = proto;
-                let kind_str = stringify!($proto_var);
-
-                let Some(proto::array::Kind::$proto_var(array)) = kind else {
-                    let msg = format!("expected {kind_str}, found {kind:?}");
-                    return Err(TryFromProtoError::missing_field(msg));
+impl RustType<proto::DataType> for arrow::datatypes::DataType {
+    fn into_proto(&self) -> proto::DataType {
+        let kind = match self {
+            DataType::Null => proto::data_type::Kind::Null(()),
+            DataType::Boolean => proto::data_type::Kind::Boolean(()),
+            DataType::UInt8 => proto::data_type::Kind::Uint8(()),
+            DataType::UInt16 => proto::data_type::Kind::Uint16(()),
+            DataType::UInt32 => proto::data_type::Kind::Uint32(()),
+            DataType::UInt64 => proto::data_type::Kind::Uint64(()),
+            DataType::Int8 => proto::data_type::Kind::Int8(()),
+            DataType::Int16 => proto::data_type::Kind::Int16(()),
+            DataType::Int32 => proto::data_type::Kind::Int32(()),
+            DataType::Int64 => proto::data_type::Kind::Int64(()),
+            DataType::Float32 => proto::data_type::Kind::Float32(()),
+            DataType::Float64 => proto::data_type::Kind::Float64(()),
+            DataType::Utf8 => proto::data_type::Kind::String(()),
+            DataType::Binary => proto::data_type::Kind::Binary(()),
+            DataType::FixedSizeBinary(size) => proto::data_type::Kind::FixedBinary(*size),
+            DataType::List(inner) => proto::data_type::Kind::List(Box::new(inner.into_proto())),
+            DataType::Map(inner, sorted) => {
+                let map = proto::data_type::Map {
+                    value: Some(Box::new(inner.into_proto())),
+                    sorted: *sorted,
                 };
+                proto::data_type::Kind::Map(Box::new(map))
+            }
+            DataType::Struct(children) => {
+                let children = children.into_iter().map(|f| f.into_proto()).collect();
+                proto::data_type::Kind::Struct(proto::data_type::Struct { children })
+            }
+            other => unimplemented!("unsupported data type {other:?}"),
+        };
 
-                let values: Vec<$rust_ty> = array
-                    .values
+        proto::DataType { kind: Some(kind) }
+    }
+
+    fn from_proto(proto: proto::DataType) -> Result<Self, TryFromProtoError> {
+        let data_type = proto
+            .kind
+            .ok_or_else(|| TryFromProtoError::missing_field("kind"))?;
+        let data_type = match data_type {
+            proto::data_type::Kind::Null(()) => DataType::Null,
+            proto::data_type::Kind::Boolean(()) => DataType::Boolean,
+            proto::data_type::Kind::Uint8(()) => DataType::UInt8,
+            proto::data_type::Kind::Uint16(()) => DataType::UInt16,
+            proto::data_type::Kind::Uint32(()) => DataType::UInt32,
+            proto::data_type::Kind::Uint64(()) => DataType::UInt64,
+            proto::data_type::Kind::Int8(()) => DataType::Int8,
+            proto::data_type::Kind::Int16(()) => DataType::Int16,
+            proto::data_type::Kind::Int32(()) => DataType::Int32,
+            proto::data_type::Kind::Int64(()) => DataType::Int64,
+            proto::data_type::Kind::Float32(()) => DataType::Float32,
+            proto::data_type::Kind::Float64(()) => DataType::Float64,
+            proto::data_type::Kind::String(()) => DataType::Utf8,
+            proto::data_type::Kind::Binary(()) => DataType::Binary,
+            proto::data_type::Kind::FixedBinary(size) => DataType::FixedSizeBinary(size),
+            proto::data_type::Kind::List(inner) => DataType::List(Arc::new((*inner).into_rust()?)),
+            proto::data_type::Kind::Map(inner) => {
+                let value = inner
+                    .value
+                    .ok_or_else(|| TryFromProtoError::missing_field("map.value"))?;
+                DataType::Map(Arc::new((*value).into_rust()?), inner.sorted)
+            }
+            proto::data_type::Kind::Struct(inner) => {
+                let children: Vec<Field> = inner
+                    .children
                     .into_iter()
-                    .map(|x| {
-                        x.try_into().map_err(|x| {
-                            let msg = format!("failed to roundtrip {kind_str}, found {x:?}");
-                            TryFromProtoError::RowConversionError(msg)
-                        })
-                    })
+                    .map(|c| c.into_rust())
                     .collect::<Result<_, _>>()?;
-                let buffer = ScalarBuffer::from(values);
-
-                let nulls = nulls
-                    .map(|n| n.into_rust())
-                    .transpose()?
-                    .map(NullBuffer::new);
-                let array = <$arrow_array>::new(buffer, nulls);
-                let field = Field::new(name, array.data_type().clone(), nullable);
-
-                Ok((field, array))
-            }
-        }
-    };
-}
-
-primitive_array!(i8, Int8Array, Int8, I64Array);
-primitive_array!(i16, Int16Array, Int16, I64Array);
-primitive_array!(i32, Int32Array, Int32, I64Array);
-primitive_array!(i64, Int64Array, Int64, I64Array);
-primitive_array!(u8, UInt8Array, Uint8, U64Array);
-primitive_array!(u16, UInt16Array, Uint16, U64Array);
-primitive_array!(u32, UInt32Array, Uint32, U64Array);
-primitive_array!(u64, UInt64Array, Uint64, U64Array);
-primitive_array!(f32, Float32Array, Float32, F32Array);
-primitive_array!(f64, Float64Array, Float64, F64Array);
-
-impl<T> ArrayProtobuf for arrow::array::GenericByteArray<T>
-where
-    T: ByteArrayType<Offset = i32>,
-{
-    fn into_proto(self, field: Arc<Field>) -> proto::Array {
-        let data_type = self.data_type().clone();
-        let (offsets, buffer, nulls) = self.into_parts();
-
-        let array = proto::VariableSizeArray {
-            data: Some(buffer.into_proto()),
-            offsets: offsets.into_iter().copied().collect(),
-        };
-        let kind = match data_type {
-            DataType::Binary => proto::array::Kind::Binary(array),
-            DataType::Utf8 => proto::array::Kind::String(array),
-            other => unimplemented!("{other:?}"),
-        };
-
-        proto::Array {
-            name: field.name().clone(),
-            nullable: field.is_nullable(),
-            nulls: nulls.map(|n| n.into_inner().into_proto()),
-            kind: Some(kind),
-        }
-    }
-
-    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
-        let proto::Array {
-            name,
-            nullable,
-            nulls,
-            kind,
-        } = proto;
-        let kind = kind.ok_or_else(|| TryFromProtoError::missing_field("kind"))?;
-        let nulls = nulls
-            .map(|n| n.into_rust())
-            .transpose()?
-            .map(NullBuffer::new);
-
-        let array = match (T::DATA_TYPE, kind) {
-            (DataType::Binary, proto::array::Kind::Binary(array)) => {
-                let offsets = ScalarBuffer::from(array.offsets);
-                let offsets = OffsetBuffer::new(offsets);
-                let values = array.data.into_rust_if_some("data")?;
-
-                GenericByteArray::new(offsets, values, nulls)
-            }
-            (DataType::Utf8, proto::array::Kind::String(array)) => {
-                let offsets = ScalarBuffer::from(array.offsets);
-                let offsets = OffsetBuffer::new(offsets);
-                let values = array.data.into_rust_if_some("data")?;
-
-                GenericByteArray::new(offsets, values, nulls)
-            }
-            other => {
-                let msg = format!("wrong type, found {other:?}");
-                return Err(TryFromProtoError::missing_field(msg));
+                DataType::Struct(Fields::from(children))
             }
         };
 
-        let field = Field::new(name, array.data_type().clone(), nullable);
-
-        Ok((field, array))
+        Ok(data_type)
     }
 }
 
-impl ArrayProtobuf for FixedSizeBinaryArray {
-    fn into_proto(self, field: Arc<Field>) -> proto::Array {
-        let (size, buffer, nulls) = self.into_parts();
-        let array = proto::FixedSizeArray {
-            data: Some(buffer.into_proto()),
-            size,
-        };
-
-        proto::Array {
-            name: field.name().clone(),
-            nullable: field.is_nullable(),
-            nulls: nulls.map(|n| n.into_inner().into_proto()),
-            kind: Some(proto::array::Kind::FixedBinary(array)),
+impl RustType<proto::Field> for arrow::datatypes::Field {
+    fn into_proto(&self) -> proto::Field {
+        proto::Field {
+            name: self.name().clone(),
+            nullable: self.is_nullable(),
+            data_type: Some(Box::new(self.data_type().into_proto())),
         }
     }
 
-    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
-        let proto::Array {
+    fn from_proto(proto: proto::Field) -> Result<Self, TryFromProtoError> {
+        let proto::Field {
             name,
             nullable,
-            nulls,
-            kind,
+            data_type,
         } = proto;
+        let data_type =
+            data_type.ok_or_else(|| TryFromProtoError::missing_field("field.data_type"))?;
+        let data_type = (*data_type).into_rust()?;
 
-        let Some(proto::array::Kind::FixedBinary(array)) = kind else {
-            return Err(TryFromProtoError::missing_field("kind.fixed_size"));
-        };
-
-        let nulls = nulls
-            .map(|n| n.into_rust())
-            .transpose()?
-            .map(NullBuffer::new);
-        let values = array.data.into_rust_if_some("data")?;
-        let array = FixedSizeBinaryArray::new(array.size, values, nulls);
-        let field = Field::new(name, array.data_type().clone(), nullable);
-
-        Ok((field, array))
-    }
-}
-
-impl ArrayProtobuf for ListArray {
-    fn into_proto(self, field: Arc<Field>) -> proto::Array {
-        let (child_field, offsets, child, nulls) = self.into_parts();
-        let child = child.into_proto(child_field);
-        let array = Box::new(proto::ListArray {
-            values: Some(Box::new(child)),
-            offsets: offsets.into_iter().copied().collect(),
-        });
-
-        proto::Array {
-            name: field.name().clone(),
-            nullable: field.is_nullable(),
-            nulls: nulls.map(|n| n.into_inner().into_proto()),
-            kind: Some(proto::array::Kind::List(array)),
-        }
-    }
-
-    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
-        let proto::Array {
-            name,
-            nullable,
-            nulls,
-            kind,
-        } = proto;
-
-        let Some(proto::array::Kind::List(array)) = kind else {
-            let msg = format!("expected kind.list, found {kind:?}");
-            return Err(TryFromProtoError::missing_field(msg));
-        };
-
-        let values = array
-            .values
-            .ok_or_else(|| TryFromProtoError::missing_field("values"))?;
-        let (values_field, values): (_, Arc<dyn arrow::array::Array>) =
-            ArrayProtobuf::from_proto(*values)?;
-        let values_field = Arc::new(values_field);
-
-        let nulls: Option<NullBuffer> = nulls
-            .map(|n| n.into_rust())
-            .transpose()?
-            .map(NullBuffer::new);
-        let offsets = ScalarBuffer::from(array.offsets);
-        let offsets = OffsetBuffer::new(offsets);
-
-        let array = ListArray::new(values_field, offsets, values, nulls);
-        let field = Field::new(name, array.data_type().clone(), nullable);
-
-        Ok((field, array))
-    }
-}
-
-impl ArrayProtobuf for MapArray {
-    fn into_proto(self, field: Arc<Field>) -> proto::Array {
-        let (child_field, offsets, child, nulls, sorted) = self.into_parts();
-        let child = child.into_proto(child_field);
-        let array = Box::new(proto::MapArray {
-            values: Some(Box::new(child)),
-            offsets: offsets.into_iter().copied().collect(),
-            sorted,
-        });
-
-        proto::Array {
-            name: field.name().clone(),
-            nullable: field.is_nullable(),
-            nulls: nulls.map(|n| n.into_inner().into_proto()),
-            kind: Some(proto::array::Kind::Map(array)),
-        }
-    }
-
-    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
-        let proto::Array {
-            name,
-            nullable,
-            nulls,
-            kind,
-        } = proto;
-
-        let Some(proto::array::Kind::Map(array)) = kind else {
-            let msg = format!("expected kind.map, found {kind:?}");
-            return Err(TryFromProtoError::missing_field(msg));
-        };
-
-        let values = array
-            .values
-            .ok_or_else(|| TryFromProtoError::missing_field("values"))?;
-        let (entries_field, entries): (_, StructArray) = ArrayProtobuf::from_proto(*values)?;
-
-        let offsets = ScalarBuffer::from(array.offsets);
-        let offsets = OffsetBuffer::new(offsets);
-        let nulls = nulls
-            .map(|n| n.into_rust())
-            .transpose()?
-            .map(NullBuffer::new);
-
-        let array = MapArray::new(
-            Arc::new(entries_field),
-            offsets,
-            entries,
-            nulls,
-            array.sorted,
-        );
-        let field = Field::new(name, array.data_type().clone(), nullable);
-
-        Ok((field, array))
-    }
-}
-
-impl ArrayProtobuf for StructArray {
-    fn into_proto(self, field: Arc<Field>) -> proto::Array {
-        let (fields, children, nulls) = self.into_parts();
-
-        assert_eq!(fields.len(), children.len());
-        let children = fields
-            .into_iter()
-            .zip(children.into_iter())
-            .map(|(field, child)| child.into_proto(Arc::clone(field)))
-            .collect();
-        let array = proto::StructArray { children };
-
-        proto::Array {
-            name: field.name().clone(),
-            nullable: field.is_nullable(),
-            nulls: nulls.map(|n| n.into_inner().into_proto()),
-            kind: Some(proto::array::Kind::Struct(array)),
-        }
-    }
-
-    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
-        let proto::Array {
-            name,
-            nullable,
-            nulls,
-            kind,
-        } = proto;
-
-        let Some(proto::array::Kind::Struct(array)) = kind else {
-            let msg = format!("expected kind.struct, found {kind:?}");
-            return Err(TryFromProtoError::missing_field(msg));
-        };
-
-        let mut fields = Vec::with_capacity(array.children.len());
-        let mut arrays = Vec::with_capacity(array.children.len());
-        for child in array.children {
-            let (child_field, child_array): (_, Arc<dyn arrow::array::Array>) =
-                ArrayProtobuf::from_proto(child)?;
-            fields.push(child_field);
-            arrays.push(child_array);
-        }
-
-        let fields = Fields::from(fields);
-        let nulls = nulls
-            .map(|n| n.into_rust())
-            .transpose()?
-            .map(NullBuffer::new);
-
-        let array = StructArray::new(fields, arrays, nulls);
-        let field = Field::new(name, array.data_type().clone(), nullable);
-
-        Ok((field, array))
-    }
-}
-
-impl ArrayProtobuf for NullArray {
-    fn into_proto(self, field: Arc<Field>) -> proto::Array {
-        let array = proto::NullArray {
-            len: u64::cast_from(self.len()),
-        };
-
-        proto::Array {
-            name: field.name().clone(),
-            nullable: field.is_nullable(),
-            nulls: None,
-            kind: Some(proto::array::Kind::Null(array)),
-        }
-    }
-
-    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
-        let proto::Array {
-            name,
-            nullable,
-            nulls,
-            kind,
-        } = proto;
-        assert_none!(nulls);
-
-        let Some(proto::array::Kind::Null(array)) = kind else {
-            let msg = format!("expected kind.null, found {kind:?}");
-            return Err(TryFromProtoError::missing_field(msg));
-        };
-
-        let array = NullArray::new(usize::cast_from(array.len));
-        let field = Field::new(name, array.data_type().clone(), nullable);
-
-        Ok((field, array))
+        Ok(Field::new(name, data_type, nullable))
     }
 }
 

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -34,11 +34,11 @@ use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 mod proto {
     include!(concat!(env!("OUT_DIR"), "/mz_persist_types.arrow.rs"));
 }
-pub use proto::ArrayData as ProtoArrayData;
+pub use proto::ProtoArrayData;
 
-impl RustType<proto::ArrayData> for arrow::array::ArrayData {
-    fn into_proto(&self) -> proto::ArrayData {
-        proto::ArrayData {
+impl RustType<ProtoArrayData> for arrow::array::ArrayData {
+    fn into_proto(&self) -> ProtoArrayData {
+        ProtoArrayData {
             data_type: Some(self.data_type().into_proto()),
             length: u64::cast_from(self.len()),
             offset: u64::cast_from(self.offset()),
@@ -48,8 +48,8 @@ impl RustType<proto::ArrayData> for arrow::array::ArrayData {
         }
     }
 
-    fn from_proto(proto: proto::ArrayData) -> Result<Self, TryFromProtoError> {
-        let proto::ArrayData {
+    fn from_proto(proto: ProtoArrayData) -> Result<Self, TryFromProtoError> {
+        let ProtoArrayData {
             data_type,
             length,
             offset,

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -61,7 +61,7 @@ impl RustType<proto::ArrayData> for arrow::array::ArrayData {
         let nulls = nulls
             .map(|n| n.into_rust())
             .transpose()?
-            .map(|b| NullBuffer::new(b));
+            .map(NullBuffer::new);
 
         let mut builder = ArrayDataBuilder::new(data_type)
             .len(usize::cast_from(length))

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -186,7 +186,7 @@ impl RustType<proto::Buffer> for arrow::buffer::Buffer {
     fn into_proto(&self) -> proto::Buffer {
         // TODO(parkmycar): There is probably something better we can do here.
         proto::Buffer {
-            data: bytes::Bytes::from(self.as_slice().to_vec()),
+            data: bytes::Bytes::copy_from_slice(self.as_slice()),
         }
     }
 

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -566,23 +566,14 @@ impl RustType<proto::Buffer> for arrow::buffer::Buffer {
 impl RustType<proto::BooleanBuffer> for arrow::buffer::BooleanBuffer {
     fn into_proto(&self) -> proto::BooleanBuffer {
         proto::BooleanBuffer {
-            buffer: Some(self.inner().clone().into_proto()),
-            offset: u64::cast_from(self.offset()),
+            buffer: Some(self.sliced().into_proto()),
             length: u64::cast_from(self.len()),
         }
     }
 
     fn from_proto(proto: proto::BooleanBuffer) -> Result<Self, TryFromProtoError> {
-        let proto::BooleanBuffer {
-            buffer,
-            offset,
-            length,
-        } = proto;
-
+        let proto::BooleanBuffer { buffer, length } = proto;
         let buffer = buffer.into_rust_if_some("buffer")?;
-        let offset = usize::cast_from(offset);
-        let length = usize::cast_from(length);
-
-        Ok(BooleanBuffer::new(buffer, offset, length))
+        Ok(BooleanBuffer::new(buffer, 0, usize::cast_from(length)))
     }
 }

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -1,3 +1,12 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 //! A [protobuf] representation of [Apache Arrow] arrays.
 //!
 //! # Motivation

--- a/src/persist-types/src/arrow.rs
+++ b/src/persist-types/src/arrow.rs
@@ -1,0 +1,572 @@
+//! A [protobuf] representation of [Apache Arrow] arrays.
+//!
+//! # Motivation
+//!
+//! Persist can store a small amount of data inline at the consensus layer.
+//! Because we are space constrained, we take particular care to store only the
+//! data that is necessary. Other Arrow serialization formats, e.g. [Parquet]
+//! or [Arrow IPC], include data that we don't need and would be wasteful to
+//! store.
+//!
+//! # Design Considerations
+//!
+//! Initially this was implemented as a "protobuf port" of
+//! [`arrow::array::ArrayData`], with the goal of zero-copy deserialization
+//! via [`arrow::buffer::Buffer`]s and [`bytes::Bytes`]. This doesn't work
+//! though because Arrow needs the underlying Buffers to be aligned for the
+//! type of data stored, e.g. an array of `u64`s needs to be 8 byte aligned.
+//! While it is technically possible to make this work, it is much easier to
+//! structure the data in protobuf and use native types.
+//!
+//! Using protobuf native types like `uint64` is nice because we benefit from
+//! the space savings of `LEB128` encoding, with a tradeoff being runtime
+//! performance. Given the above complications, and the need to store only a
+//! small amount of data, this is a decent tradeoff.
+//!
+//!
+//! [protobuf]: https://protobuf.dev/
+//! [Arrow]: https://arrow.apache.org/
+//! [Parquet]: https://parquet.apache.org/docs/
+//! [Arrow IPC]: https://arrow.apache.org/docs/format/Columnar.html#serialization-and-interprocess-communication-ipc
+
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, BinaryArray, BooleanArray, FixedSizeBinaryArray, Float32Array, Float64Array,
+    GenericByteArray, Int16Array, Int32Array, Int64Array, Int8Array, ListArray, MapArray,
+    NullArray, StringArray, StructArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow::datatypes::{ByteArrayType, DataType, Field, Fields};
+use mz_ore::assert_none;
+use mz_ore::cast::CastFrom;
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+
+#[allow(missing_docs)]
+mod proto {
+    include!(concat!(env!("OUT_DIR"), "/mz_persist_types.arrow.rs"));
+}
+pub use proto::Array as ProtoArray;
+
+/// Encode an [`arrow::array::Array`] to and from a [`proto::Array`].
+pub trait ArrayProtobuf: Sized + arrow::array::Array {
+    /// Encodes `self` and the provided [`Field`] into a [`proto::Array`].
+    ///
+    /// # Panics
+    ///
+    /// * Not all Arrow Array types are supported, panics on unsupported arrays.
+    ///
+    fn into_proto(self, field: Arc<Field>) -> proto::Array;
+
+    /// Decodes an instance of `Self` and a [`Field`] from the provided
+    /// [`proto::Array`]. Returns an error if we can't decode an instance of [`Self`].
+    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError>;
+}
+
+impl ArrayProtobuf for Arc<dyn arrow::array::Array> {
+    fn into_proto(self, field: Arc<Field>) -> proto::Array {
+        fn inner<T>(field: Arc<Field>, array: Arc<dyn arrow::array::Array>) -> proto::Array
+        where
+            T: ArrayProtobuf + arrow::array::Array + Clone + 'static,
+        {
+            let Some(array) = array.as_any().downcast_ref::<T>() else {
+                panic!("expected {} but got {array:?}", std::any::type_name::<T>());
+            };
+            array.clone().into_proto(field)
+        }
+
+        match self.data_type() {
+            DataType::Boolean => inner::<BooleanArray>(field, self),
+            DataType::UInt8 => inner::<UInt8Array>(field, self),
+            DataType::UInt16 => inner::<UInt16Array>(field, self),
+            DataType::UInt32 => inner::<UInt32Array>(field, self),
+            DataType::UInt64 => inner::<UInt64Array>(field, self),
+            DataType::Int8 => inner::<Int8Array>(field, self),
+            DataType::Int16 => inner::<Int16Array>(field, self),
+            DataType::Int32 => inner::<Int32Array>(field, self),
+            DataType::Int64 => inner::<Int64Array>(field, self),
+            DataType::Float32 => inner::<Float32Array>(field, self),
+            DataType::Float64 => inner::<Float64Array>(field, self),
+            DataType::Utf8 => inner::<StringArray>(field, self),
+            DataType::Binary => inner::<BinaryArray>(field, self),
+            DataType::FixedSizeBinary(_) => inner::<FixedSizeBinaryArray>(field, self),
+            DataType::List(_) => inner::<ListArray>(field, self),
+            DataType::Map(_, _) => inner::<MapArray>(field, self),
+            DataType::Struct(_) => inner::<StructArray>(field, self),
+            DataType::Null => inner::<NullArray>(field, self),
+            other => unimplemented!("unsupported array type {other:?}"),
+        }
+    }
+
+    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
+        fn inner<T: ArrayProtobuf + 'static>(
+            array: proto::Array,
+        ) -> Result<(Field, Arc<dyn arrow::array::Array>), mz_proto::TryFromProtoError> {
+            let (field, array) = T::from_proto(array)?;
+            let array: Arc<dyn arrow::array::Array> = Arc::new(array);
+
+            Ok((field, array))
+        }
+
+        match &proto.kind {
+            None => Err(TryFromProtoError::missing_field("kind")),
+            Some(proto::array::Kind::Boolean(_)) => inner::<BooleanArray>(proto),
+            Some(proto::array::Kind::Uint8(_)) => inner::<UInt8Array>(proto),
+            Some(proto::array::Kind::Uint16(_)) => inner::<UInt16Array>(proto),
+            Some(proto::array::Kind::Uint32(_)) => inner::<UInt32Array>(proto),
+            Some(proto::array::Kind::Uint64(_)) => inner::<UInt64Array>(proto),
+            Some(proto::array::Kind::Int8(_)) => inner::<Int8Array>(proto),
+            Some(proto::array::Kind::Int16(_)) => inner::<Int16Array>(proto),
+            Some(proto::array::Kind::Int32(_)) => inner::<Int32Array>(proto),
+            Some(proto::array::Kind::Int64(_)) => inner::<Int64Array>(proto),
+            Some(proto::array::Kind::Float32(_)) => inner::<Float32Array>(proto),
+            Some(proto::array::Kind::Float64(_)) => inner::<Float64Array>(proto),
+            Some(proto::array::Kind::String(_)) => inner::<StringArray>(proto),
+            Some(proto::array::Kind::Binary(_)) => inner::<BinaryArray>(proto),
+            Some(proto::array::Kind::FixedBinary(_)) => inner::<FixedSizeBinaryArray>(proto),
+            Some(proto::array::Kind::List(_)) => inner::<ListArray>(proto),
+            Some(proto::array::Kind::Map(_)) => inner::<MapArray>(proto),
+            Some(proto::array::Kind::Struct(_)) => inner::<StructArray>(proto),
+            Some(proto::array::Kind::Null(_)) => inner::<NullArray>(proto),
+        }
+    }
+}
+
+impl ArrayProtobuf for BooleanArray {
+    fn into_proto(self, field: Arc<Field>) -> proto::Array {
+        let (buffer, nulls) = self.into_parts();
+        let buffer = Some(buffer.into_proto());
+        let array = proto::BooleanArray { buffer };
+
+        proto::Array {
+            name: field.name().clone(),
+            nullable: field.is_nullable(),
+            nulls: nulls.into_proto(),
+            kind: Some(proto::array::Kind::Boolean(array)),
+        }
+    }
+
+    fn from_proto(proto: proto::Array) -> Result<(Field, Self), TryFromProtoError> {
+        let proto::Array {
+            name,
+            nullable,
+            nulls,
+            kind,
+        } = proto;
+
+        let Some(proto::array::Kind::Boolean(array)) = kind else {
+            return Err(TryFromProtoError::missing_field("kind.boolean"));
+        };
+
+        let bool_buffer: BooleanBuffer = array.buffer.into_rust_if_some("buffer")?;
+        let nulls = nulls.into_rust()?;
+        let field = Field::new(name, DataType::Boolean, nullable);
+        let array = BooleanArray::new(bool_buffer, nulls);
+
+        Ok((field, array))
+    }
+}
+
+macro_rules! primitive_array {
+    ($rust_ty:ty, $arrow_array:ty, $proto_var:ident, $proto_array:ident) => {
+        impl ArrayProtobuf for $arrow_array {
+            fn into_proto(self, field: Arc<Field>) -> proto::Array {
+                let nulls = self.logical_nulls().into_proto();
+                let values = self.values().iter().map(|x| (*x).into()).collect();
+                let array = proto::$proto_array { values };
+
+                proto::Array {
+                    name: field.name().clone(),
+                    nullable: field.is_nullable(),
+                    nulls,
+                    kind: Some(proto::array::Kind::$proto_var(array)),
+                }
+            }
+
+            fn from_proto(
+                proto: proto::Array,
+            ) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
+                let proto::Array {
+                    name,
+                    nullable,
+                    nulls,
+                    kind,
+                } = proto;
+                let kind_str = stringify!($proto_var);
+
+                let Some(proto::array::Kind::$proto_var(array)) = kind else {
+                    let msg = format!("expected {kind_str}, found {kind:?}");
+                    return Err(TryFromProtoError::missing_field(msg));
+                };
+
+                let values: Vec<$rust_ty> = array
+                    .values
+                    .into_iter()
+                    .map(|x| {
+                        x.try_into().map_err(|x| {
+                            let msg = format!("failed to roundtrip {kind_str}, found {x:?}");
+                            TryFromProtoError::RowConversionError(msg)
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                let buffer = ScalarBuffer::from(values);
+
+                let nulls = nulls.into_rust()?;
+                let array = <$arrow_array>::new(buffer, nulls);
+                let field = Field::new(name, array.data_type().clone(), nullable);
+
+                Ok((field, array))
+            }
+        }
+    };
+}
+
+primitive_array!(i8, Int8Array, Int8, I64Array);
+primitive_array!(i16, Int16Array, Int16, I64Array);
+primitive_array!(i32, Int32Array, Int32, I64Array);
+primitive_array!(i64, Int64Array, Int64, I64Array);
+primitive_array!(u8, UInt8Array, Uint8, U64Array);
+primitive_array!(u16, UInt16Array, Uint16, U64Array);
+primitive_array!(u32, UInt32Array, Uint32, U64Array);
+primitive_array!(u64, UInt64Array, Uint64, U64Array);
+primitive_array!(f32, Float32Array, Float32, F32Array);
+primitive_array!(f64, Float64Array, Float64, F64Array);
+
+impl<T> ArrayProtobuf for arrow::array::GenericByteArray<T>
+where
+    T: ByteArrayType<Offset = i32>,
+{
+    fn into_proto(self, field: Arc<Field>) -> proto::Array {
+        let data_type = self.data_type().clone();
+        let (offsets, buffer, nulls) = self.into_parts();
+
+        let array = proto::VariableSizeArray {
+            data: Some(buffer.into_proto()),
+            offsets: offsets.into_iter().copied().collect(),
+        };
+        let kind = match data_type {
+            DataType::Binary => proto::array::Kind::Binary(array),
+            DataType::Utf8 => proto::array::Kind::String(array),
+            other => unimplemented!("{other:?}"),
+        };
+
+        proto::Array {
+            name: field.name().clone(),
+            nullable: field.is_nullable(),
+            nulls: nulls.into_proto(),
+            kind: Some(kind),
+        }
+    }
+
+    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
+        let proto::Array {
+            name,
+            nullable,
+            nulls,
+            kind,
+        } = proto;
+        let kind = kind.ok_or_else(|| TryFromProtoError::missing_field("kind"))?;
+        let nulls = nulls.into_rust()?;
+
+        let array = match (T::DATA_TYPE, kind) {
+            (DataType::Binary, proto::array::Kind::Binary(array)) => {
+                let offsets = ScalarBuffer::from(array.offsets);
+                let offsets = OffsetBuffer::new(offsets);
+                let values = array.data.into_rust_if_some("data")?;
+
+                GenericByteArray::new(offsets, values, nulls)
+            }
+            (DataType::Utf8, proto::array::Kind::String(array)) => {
+                let offsets = ScalarBuffer::from(array.offsets);
+                let offsets = OffsetBuffer::new(offsets);
+                let values = array.data.into_rust_if_some("data")?;
+
+                GenericByteArray::new(offsets, values, nulls)
+            }
+            other => {
+                let msg = format!("wrong type, found {other:?}");
+                return Err(TryFromProtoError::missing_field(msg));
+            }
+        };
+
+        let field = Field::new(name, array.data_type().clone(), nullable);
+
+        Ok((field, array))
+    }
+}
+
+impl ArrayProtobuf for FixedSizeBinaryArray {
+    fn into_proto(self, field: Arc<Field>) -> proto::Array {
+        let (size, buffer, nulls) = self.into_parts();
+        let array = proto::FixedSizeArray {
+            data: Some(buffer.into_proto()),
+            size,
+        };
+
+        proto::Array {
+            name: field.name().clone(),
+            nullable: field.is_nullable(),
+            nulls: nulls.into_proto(),
+            kind: Some(proto::array::Kind::FixedBinary(array)),
+        }
+    }
+
+    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
+        let proto::Array {
+            name,
+            nullable,
+            nulls,
+            kind,
+        } = proto;
+
+        let Some(proto::array::Kind::FixedBinary(array)) = kind else {
+            return Err(TryFromProtoError::missing_field("kind.fixed_size"));
+        };
+
+        let nulls = nulls.into_rust()?;
+        let values = array.data.into_rust_if_some("data")?;
+        let array = FixedSizeBinaryArray::new(array.size, values, nulls);
+        let field = Field::new(name, array.data_type().clone(), nullable);
+
+        Ok((field, array))
+    }
+}
+
+impl ArrayProtobuf for ListArray {
+    fn into_proto(self, field: Arc<Field>) -> proto::Array {
+        let (child_field, offsets, child, nulls) = self.into_parts();
+        let child = child.into_proto(child_field);
+        let array = Box::new(proto::ListArray {
+            values: Some(Box::new(child)),
+            offsets: offsets.into_iter().copied().collect(),
+        });
+
+        proto::Array {
+            name: field.name().clone(),
+            nullable: field.is_nullable(),
+            nulls: nulls.into_proto(),
+            kind: Some(proto::array::Kind::List(array)),
+        }
+    }
+
+    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
+        let proto::Array {
+            name,
+            nullable,
+            nulls,
+            kind,
+        } = proto;
+
+        let Some(proto::array::Kind::List(array)) = kind else {
+            let msg = format!("expected kind.list, found {kind:?}");
+            return Err(TryFromProtoError::missing_field(msg));
+        };
+
+        let values = array
+            .values
+            .ok_or_else(|| TryFromProtoError::missing_field("values"))?;
+        let (values_field, values): (_, Arc<dyn arrow::array::Array>) =
+            ArrayProtobuf::from_proto(*values)?;
+        let values_field = Arc::new(values_field);
+
+        let nulls: Option<NullBuffer> = nulls.into_rust()?;
+        let offsets = ScalarBuffer::from(array.offsets);
+        let offsets = OffsetBuffer::new(offsets);
+
+        let array = ListArray::new(values_field, offsets, values, nulls);
+        let field = Field::new(name, array.data_type().clone(), nullable);
+
+        Ok((field, array))
+    }
+}
+
+impl ArrayProtobuf for MapArray {
+    fn into_proto(self, field: Arc<Field>) -> proto::Array {
+        let (child_field, offsets, child, nulls, sorted) = self.into_parts();
+        let child = child.into_proto(child_field);
+        let array = Box::new(proto::MapArray {
+            values: Some(Box::new(child)),
+            offsets: offsets.into_iter().copied().collect(),
+            sorted,
+        });
+
+        proto::Array {
+            name: field.name().clone(),
+            nullable: field.is_nullable(),
+            nulls: nulls.into_proto(),
+            kind: Some(proto::array::Kind::Map(array)),
+        }
+    }
+
+    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
+        let proto::Array {
+            name,
+            nullable,
+            nulls,
+            kind,
+        } = proto;
+
+        let Some(proto::array::Kind::Map(array)) = kind else {
+            let msg = format!("expected kind.map, found {kind:?}");
+            return Err(TryFromProtoError::missing_field(msg));
+        };
+
+        let values = array
+            .values
+            .ok_or_else(|| TryFromProtoError::missing_field("values"))?;
+        let (entries_field, entries): (_, StructArray) = ArrayProtobuf::from_proto(*values)?;
+
+        let offsets = ScalarBuffer::from(array.offsets);
+        let offsets = OffsetBuffer::new(offsets);
+        let nulls = nulls.into_rust()?;
+
+        let array = MapArray::new(
+            Arc::new(entries_field),
+            offsets,
+            entries,
+            nulls,
+            array.sorted,
+        );
+        let field = Field::new(name, array.data_type().clone(), nullable);
+
+        Ok((field, array))
+    }
+}
+
+impl ArrayProtobuf for StructArray {
+    fn into_proto(self, field: Arc<Field>) -> proto::Array {
+        let (fields, children, nulls) = self.into_parts();
+
+        assert_eq!(fields.len(), children.len());
+        let children = fields
+            .into_iter()
+            .zip(children.into_iter())
+            .map(|(field, child)| child.into_proto(Arc::clone(field)))
+            .collect();
+        let array = proto::StructArray { children };
+
+        proto::Array {
+            name: field.name().clone(),
+            nullable: field.is_nullable(),
+            nulls: nulls.into_proto(),
+            kind: Some(proto::array::Kind::Struct(array)),
+        }
+    }
+
+    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
+        let proto::Array {
+            name,
+            nullable,
+            nulls,
+            kind,
+        } = proto;
+
+        let Some(proto::array::Kind::Struct(array)) = kind else {
+            let msg = format!("expected kind.struct, found {kind:?}");
+            return Err(TryFromProtoError::missing_field(msg));
+        };
+
+        let mut fields = Vec::with_capacity(array.children.len());
+        let mut arrays = Vec::with_capacity(array.children.len());
+        for child in array.children {
+            let (child_field, child_array): (_, Arc<dyn arrow::array::Array>) =
+                ArrayProtobuf::from_proto(child)?;
+            fields.push(child_field);
+            arrays.push(child_array);
+        }
+
+        let fields = Fields::from(fields);
+        let nulls = nulls.into_rust()?;
+
+        let array = StructArray::new(fields, arrays, nulls);
+        let field = Field::new(name, array.data_type().clone(), nullable);
+
+        Ok((field, array))
+    }
+}
+
+impl ArrayProtobuf for NullArray {
+    fn into_proto(self, field: Arc<Field>) -> proto::Array {
+        let array = proto::NullArray {
+            len: u64::cast_from(self.len()),
+        };
+
+        proto::Array {
+            name: field.name().clone(),
+            nullable: field.is_nullable(),
+            nulls: None,
+            kind: Some(proto::array::Kind::Null(array)),
+        }
+    }
+
+    fn from_proto(proto: proto::Array) -> Result<(Field, Self), mz_proto::TryFromProtoError> {
+        let proto::Array {
+            name,
+            nullable,
+            nulls,
+            kind,
+        } = proto;
+        assert_none!(nulls);
+
+        let Some(proto::array::Kind::Null(array)) = kind else {
+            let msg = format!("expected kind.null, found {kind:?}");
+            return Err(TryFromProtoError::missing_field(msg));
+        };
+
+        let array = NullArray::new(usize::cast_from(array.len));
+        let field = Field::new(name, array.data_type().clone(), nullable);
+
+        Ok((field, array))
+    }
+}
+
+impl RustType<proto::Buffer> for arrow::buffer::Buffer {
+    fn into_proto(&self) -> proto::Buffer {
+        // TODO(parkmycar): There is probably something better we can do here.
+        proto::Buffer {
+            data: bytes::Bytes::from(self.as_slice().to_vec()),
+        }
+    }
+
+    fn from_proto(proto: proto::Buffer) -> Result<Self, TryFromProtoError> {
+        Ok(arrow::buffer::Buffer::from_bytes(proto.data.into()))
+    }
+}
+
+impl RustType<proto::BooleanBuffer> for arrow::buffer::BooleanBuffer {
+    fn into_proto(&self) -> proto::BooleanBuffer {
+        proto::BooleanBuffer {
+            buffer: Some(self.inner().clone().into_proto()),
+            offset: u64::cast_from(self.offset()),
+            length: u64::cast_from(self.len()),
+        }
+    }
+
+    fn from_proto(proto: proto::BooleanBuffer) -> Result<Self, TryFromProtoError> {
+        let proto::BooleanBuffer {
+            buffer,
+            offset,
+            length,
+        } = proto;
+
+        let buffer = buffer.into_rust_if_some("buffer")?;
+        let offset = usize::cast_from(offset);
+        let length = usize::cast_from(length);
+
+        Ok(BooleanBuffer::new(buffer, offset, length))
+    }
+}
+
+impl RustType<proto::NullBuffer> for arrow::buffer::NullBuffer {
+    fn into_proto(&self) -> proto::NullBuffer {
+        proto::NullBuffer {
+            buf: Some(self.inner().into_proto()),
+        }
+    }
+
+    fn from_proto(proto: proto::NullBuffer) -> Result<Self, mz_proto::TryFromProtoError> {
+        let proto::NullBuffer { buf } = proto;
+        let buf = buf.into_rust_if_some("buf")?;
+        Ok(NullBuffer::new(buf))
+    }
+}

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -329,7 +329,8 @@ pub trait Schema2<T>: Debug + Send + Sync {
     type Decoder: ColumnDecoder<T> + Debug;
     /// Type that is able to encoder values of `T`.
     type Encoder: ColumnEncoder<T, FinishedColumn = Self::ArrowColumn, FinishedStats = Self::Statistics>
-        + Debug;
+        + Debug
+        + Send;
 
     /// Returns a type that is able to decode instances of `T` from the provider column.
     fn decoder(&self, col: Self::ArrowColumn) -> Result<Self::Decoder, anyhow::Error>;

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 
 use crate::columnar::{Schema, Schema2};
 
+pub mod arrow;
 pub mod codec_impls;
 pub mod columnar;
 pub mod dyn_col;

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -38,7 +38,7 @@ pub mod txn;
 
 /// Encoding and decoding operations for a type usable as a persisted key or
 /// value.
-pub trait Codec: Sized + PartialEq + 'static {
+pub trait Codec: Sized + Default + PartialEq + Send + Sync + 'static {
     /// The type of the associated schema for [Self].
     ///
     /// This is a separate type because Row is not self-describing. For Row, you
@@ -86,7 +86,7 @@ pub trait Codec: Sized + PartialEq + 'static {
 
     /// A type used with [Self::decode_from] for allocation reuse. Set to `()`
     /// if unnecessary.
-    type Storage: Default;
+    type Storage: Default + Send + Sync;
     /// An alternate form of [Self::decode] which enables amortizing allocs.
     ///
     /// First, instead of returning `Self`, it takes `&mut Self` as a parameter,

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -597,6 +597,7 @@ pub fn arb_relation_desc(num_cols: std::ops::Range<usize>) -> impl Strategy<Valu
             (1, Just(1024..4096)),
         ]);
     }
+    let name_length = Union::new_weighted(weights);
 
     let name_strat = name_length
         .prop_flat_map(|length| proptest::collection::vec(any::<char>(), length))

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -569,15 +569,16 @@ impl Arbitrary for RelationDesc {
     type Strategy = BoxedStrategy<RelationDesc>;
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        let num_columns = Union::new_weighted(vec![
-            (100, Just(0..4)),
-            (50, Just(4..8)),
-            (25, Just(8..16)),
-            (12, Just(16..32)),
-            (6, Just(32..64)),
-            (3, Just(64..128)),
-            (1, Just(128..256)),
-        ]);
+        let mut weights = vec![(100, Just(0..4)), (50, Just(4..8)), (25, Just(8..16))];
+        if std::env::var("PROPTEST_LARGE_DATA").is_ok() {
+            weights.extend([
+                (12, Just(16..32)),
+                (6, Just(32..64)),
+                (3, Just(64..128)),
+                (1, Just(128..256)),
+            ]);
+        }
+        let num_columns = Union::new_weighted(weights);
 
         num_columns.prop_flat_map(arb_relation_desc).boxed()
     }
@@ -588,13 +589,14 @@ impl Arbitrary for RelationDesc {
 pub fn arb_relation_desc(num_cols: std::ops::Range<usize>) -> impl Strategy<Value = RelationDesc> {
     // Long column names are generally uninteresting, and can greatly
     // increase the runtime for a test case, so bound the max length.
-    let name_length = Union::new_weighted(vec![
-        (50, Just(0..8)),
-        (20, Just(8..16)),
-        (5, Just(16..128)),
-        (1, Just(128..1024)),
-        (1, Just(1024..4096)),
-    ]);
+    let mut weights = vec![(50, Just(0..8)), (20, Just(8..16))];
+    if std::env::var("PROPTEST_LARGE_DATA").is_ok() {
+        weights.extend([
+            (5, Just(16..128)),
+            (1, Just(128..1024)),
+            (1, Just(1024..4096)),
+        ]);
+    }
 
     let name_strat = name_length
         .prop_flat_map(|length| proptest::collection::vec(any::<char>(), length))

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1881,11 +1881,11 @@ impl Schema2<SourceData> for RelationDesc {
 
 #[cfg(test)]
 mod tests {
+    use arrow::array::ArrayData;
     use bytes::Bytes;
     use mz_ore::assert_err;
     use mz_persist::indexed::columnar::arrow::realloc_array;
     use mz_persist::metrics::ColumnarMetrics;
-    use mz_persist_types::arrow::ArrayProtobuf;
     use mz_repr::{arb_datum_for_scalar, ScalarType};
     use proptest::prelude::*;
     use proptest::strategy::{Union, ValueTree};
@@ -1969,14 +1969,12 @@ mod tests {
 
         // Roundtrip through ProtoArray format.
         {
-            let field = Field::new("k_s", col.data_type().clone(), col.is_nullable());
-            let field = Arc::new(field);
-            let proto = col.clone().into_proto(Arc::clone(&field));
+            let proto = col.to_data().into_proto();
             let bytes = proto.encode_to_vec();
-            let proto = mz_persist_types::arrow::ProtoArray::decode(&bytes[..]).unwrap();
-            let (field_rnd, col_rnd) = StructArray::from_proto(proto).unwrap();
+            let proto = mz_persist_types::arrow::ProtoArrayData::decode(&bytes[..]).unwrap();
+            let array_data: ArrayData = proto.into_rust().unwrap();
+            let col_rnd = StructArray::from(array_data);
 
-            assert_eq!(&*field, &field_rnd);
             assert_eq!(col, col_rnd);
         }
 
@@ -2018,25 +2016,25 @@ mod tests {
     #[mz_ore::test]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
     fn all_source_data_roundtrips() {
-        let num_rows = Union::new_weighted(vec![
-            (500, Just(0..8)),
-            (50, Just(8..32)),
-            (10, Just(32..128)),
-            (5, Just(128..256)),
-            (1, Just(256..1050)),
-        ]);
+        let mut weights = vec![(500, Just(0..8)), (50, Just(8..32))];
+        if std::env::var("PROPTEST_LARGE_DATA").is_ok() {
+            weights.extend([
+                (10, Just(32..128)),
+                (5, Just(128..512)),
+                (3, Just(512..2048)),
+                (1, Just(2048..8192)),
+            ]);
+        }
+        let num_rows = Union::new_weighted(weights);
 
         let strat = (any::<RelationDesc>(), num_rows).prop_flat_map(|(desc, num_rows)| {
             proptest::collection::vec(arb_source_data_for_relation_desc(&desc), num_rows)
                 .prop_map(move |datas| (desc.clone(), datas))
         });
 
-        proptest!(
-            ProptestConfig::with_cases(80),
-            |((desc, source_datas) in strat)| {
-                roundtrip_source_data(desc, source_datas);
-            }
-        );
+        proptest!(|((desc, source_datas) in strat)| {
+            roundtrip_source_data(desc, source_datas);
+        });
     }
 
     #[mz_ore::test]


### PR DESCRIPTION
This PR adds structured columnar encoders to `ColumnarRecordsBuilder`.

_work in progress_

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
