### PR TITLE
cluster: tools for looking for join-of-unions pattern

### DIFF
--- a/misc/mzexplore/join_of_unions.jq
+++ b/misc/mzexplore/join_of_unions.jq
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# join_of_unions.jq — finds and analyzes joins of unions in MIR plans
+
+def is_join:
+      type == "object"
+  and has("Join")
+;
+
+def is_union:
+      type == "object"
+  and has("Union")
+;
+
+def is_arrangeby:
+      type == "object"
+  and has("ArrangeBy")
+;
+
+def is_union_or_arrangement_of_union:
+      is_union
+  or (is_arrangeby and .ArrangeBy.input | is_union)
+;
+
+def joins:
+  if is_join
+  then ., (.Join.inputs[] | joins)
+  else .[]? | joins
+  end
+;
+
+joins | values |
+  { "file": input_filename
+  , "inputs": .Join.inputs | length
+  , "num_unions": .Join.inputs[] | [select(is_union_or_arrangement_of_union)] | length
+  , "matched": .Join.inputs[] | any(is_union_or_arrangement_of_union)
+  }

--- a/misc/mzexplore/join_of_unions.py
+++ b/misc/mzexplore/join_of_unions.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+#
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# join_of_unions.py — finds and analyzes joins of unions in MIR plans
+#
+# the jq query of the same name is less useful, since jq can't keep state about Let nodes
+
+import json
+import sys
+import traceback
+
+total_joins = 0
+total_joins_of_unions = 0
+
+
+def is_union_or_arrangement_of_union(o):
+    return isinstance(o, dict) and (
+        ("Union" in o) or ("ArrangeBy" in o and "Union" in o["ArrangeBy"]["input"])
+    )
+
+
+def is_known_union(o, known_unions):
+    return (
+        isinstance(o, dict)
+        and ("Get" in o)
+        and ("Local" in o["Get"]["id"])
+        and o["Get"]["id"]["Local"] in known_unions
+    )
+
+
+def go(o, known_unions, info):
+    global total_joins, total_joins_of_unions
+
+    if not isinstance(o, dict):
+        return
+
+    for k, v in o.items():
+        if k == "Join":
+            total_joins += 1
+            num_unions = 0
+            for input in v["inputs"]:
+                if is_union_or_arrangement_of_union(input) or is_known_union(
+                    input, known_unions
+                ):
+                    num_unions += 1
+            if num_unions > 1:
+                total_joins_of_unions += 1
+                print(f"{info}: join of {num_unions} unions")
+        elif k == "Let":
+            var = v["id"]
+            val = v["value"]
+
+            if is_union_or_arrangement_of_union(val):
+                known_unions.add(var)
+        # no LetRec, yolo
+
+        go(v, known_unions, info)
+
+
+def look_in(file):
+    o = json.load(open(file))
+    assert isinstance(o, dict)
+    assert "plans" in o
+
+    for plan in o["plans"]:
+        try:
+            go(plan["plan"], set(), f'{file} plan {plan["id"]}')
+        except Exception:
+            print(f'FAILURE IN {file} plan {plan["id"]}')
+            traceback.print_exc()
+
+
+if __name__ == "__main__":
+    for arg in sys.argv[1:]:
+        look_in(arg)
+
+    print(f"observed {total_joins_of_unions} joins of unions out of {total_joins}")


### PR DESCRIPTION
A (working) Python script and a (working but limited) jq script for finding joins of (arrangements of) unions.

### Motivation

  * This PR adds a known-desirable feature.

Helping us set product priorities for optimizer work.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
