### PR TITLE
nix-shell: add more dependencies

### DIFF
--- a/misc/nix/shell.nix
+++ b/misc/nix/shell.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation {
     openssh
     docker
 
+    # For docs
+    hugo
+
     # For lint checks
     shellcheck
     buf

--- a/misc/nix/shell.nix
+++ b/misc/nix/shell.nix
@@ -22,9 +22,9 @@ stdenv.mkDerivation {
     python3
     openssl
 
+    # CLI tools
     postgresql
     git
-    openssh
     docker
 
     # For docs
@@ -35,6 +35,7 @@ stdenv.mkDerivation {
     buf
     nodejs_22
     jq
+    openssh
   ] ++ lib.optionals stdenv.isDarwin [
     libiconv
     darwin.apple_sdk.frameworks.DiskArbitration

--- a/misc/nix/shell.nix
+++ b/misc/nix/shell.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
     postgresql
     git
     openssh
+    docker
 
     # For lint checks
     shellcheck

--- a/misc/nix/shell.nix
+++ b/misc/nix/shell.nix
@@ -24,11 +24,13 @@ stdenv.mkDerivation {
 
     postgresql
     git
+    openssh
 
     # For lint checks
     shellcheck
     buf
     nodejs_22
+    jq
   ] ++ lib.optionals stdenv.isDarwin [
     libiconv
     darwin.apple_sdk.frameworks.DiskArbitration


### PR DESCRIPTION
Some more packages needed to make `nix-shell --pure` work.
