### PR TITLE
storage/sources: Send per-export details on SourceExports instead of SourceDesc

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -520,6 +520,7 @@ impl CatalogState {
                         DataSourceDesc::IngestionExport {
                             ingestion_id,
                             external_reference: UnresolvedItemName(external_reference),
+                            details: _,
                         } => {
                             let ingestion_entry = self
                                 .get_entry(ingestion_id)

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -839,9 +839,11 @@ impl CatalogState {
                     mz_sql::plan::DataSourceDesc::IngestionExport {
                         ingestion_id,
                         external_reference,
+                        details,
                     } => DataSourceDesc::IngestionExport {
                         ingestion_id,
                         external_reference,
+                        details,
                     },
                     mz_sql::plan::DataSourceDesc::Progress => DataSourceDesc::Progress,
                     mz_sql::plan::DataSourceDesc::Webhook {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2428,10 +2428,12 @@ impl Coordinator {
                 DataSourceDesc::IngestionExport {
                     ingestion_id,
                     external_reference,
+                    details,
                 } => (
                     DataSource::IngestionExport {
                         ingestion_id,
                         external_reference,
+                        details,
                     },
                     Some(source_status_collection_id),
                 ),

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1025,6 +1025,11 @@ pub enum PgConfigOptionName {
     /// The name of the publication to sync
     Publication,
     /// Columns whose types you want to unconditionally format as text
+    /// NOTE(roshan): This value is kept around to allow round-tripping a
+    /// `CREATE SOURCE` statement while we still allow creating implicit
+    /// subsources from `CREATE SOURCE`, but will be removed once
+    /// fully deprecating that feature and forcing users to use explicit
+    /// `CREATE TABLE .. FROM SOURCE` statements
     TextColumns,
 }
 
@@ -1069,8 +1074,18 @@ pub enum MySqlConfigOptionName {
     /// `mz_storage_types::sources::mysql::MySqlSourceDetails`
     Details,
     /// Columns whose types you want to unconditionally format as text
+    /// NOTE(roshan): This value is kept around to allow round-tripping a
+    /// `CREATE SOURCE` statement while we still allow creating implicit
+    /// subsources from `CREATE SOURCE`, but will be removed once
+    /// fully deprecating that feature and forcing users to use explicit
+    /// `CREATE TABLE .. FROM SOURCE` statements
     TextColumns,
     /// Columns you want to ignore
+    /// NOTE(roshan): This value is kept around to allow round-tripping a
+    /// `CREATE SOURCE` statement while we still allow creating implicit
+    /// subsources from `CREATE SOURCE`, but will be removed once
+    /// fully deprecating that feature and forcing users to use explicit
+    /// `CREATE TABLE .. FROM SOURCE` statements
     IgnoreColumns,
 }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -32,7 +32,7 @@ use mz_repr::{ColumnName, GlobalId, RelationDesc};
 use mz_sql_parser::ast::{Expr, QualifiedReplica, UnresolvedItemName};
 use mz_storage_types::connections::inline::{ConnectionResolver, ReferencedConnection};
 use mz_storage_types::connections::{Connection, ConnectionContext};
-use mz_storage_types::sources::SourceDesc;
+use mz_storage_types::sources::{SourceDesc, SourceExportDetails};
 use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
 use regex::Regex;
@@ -613,9 +613,11 @@ pub trait CatalogItem {
     /// Returns the IDs of the catalog items that depend upon this catalog item.
     fn used_by(&self) -> &[GlobalId];
 
-    /// Reports whether this catalog entry is a subsource and, if it is, the
-    /// ingestion it is a subsource of, as well as the item it exports.
-    fn subsource_details(&self) -> Option<(GlobalId, &UnresolvedItemName)>;
+    /// Reports whether this catalog entry is a source export and, if it is, the
+    /// ingestion it is an export of, as well as the item it exports.
+    fn source_export_details(
+        &self,
+    ) -> Option<(GlobalId, &UnresolvedItemName, &SourceExportDetails)>;
 
     /// Reports whether this catalog item is a progress source.
     fn is_progress_source(&self) -> bool;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -53,7 +53,7 @@ use mz_storage_types::connections::inline::ReferencedConnection;
 use mz_storage_types::sinks::{
     S3SinkFormat, SinkEnvelope, SinkPartitionStrategy, StorageSinkConnection,
 };
-use mz_storage_types::sources::{SourceDesc, Timeline};
+use mz_storage_types::sources::{SourceDesc, SourceExportDetails, Timeline};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -1334,6 +1334,7 @@ pub enum DataSourceDesc {
     IngestionExport {
         ingestion_id: GlobalId,
         external_reference: UnresolvedItemName,
+        details: SourceExportDetails,
     },
     /// Receives data from the source's reclocking/remapping operations.
     Progress,

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -253,8 +253,8 @@ pub enum PlanError {
         expected_type: ObjectType,
     },
     /// MZ failed to generate cast for the data type.
-    PublicationContainsUningestableTypes {
-        publication: String,
+    TableContainsUningestableTypes {
+        name: String,
         type_: String,
         column: String,
     },
@@ -435,8 +435,8 @@ impl PlanError {
             | Self::InvalidRefreshEveryAlignedTo => {
                 Some("Calling `mz_now()` is allowed.".into())
             },
-            Self::PublicationContainsUningestableTypes { column,.. } => {
-                Some(format!("Remove the table from the publication or use TEXT COLUMNS ({column}, ..) to ingest this column as text"))
+            Self::TableContainsUningestableTypes { column,.. } => {
+                Some(format!("Remove the table or use TEXT COLUMNS ({column}, ..) to ingest this column as text"))
             }
             Self::RetainHistoryLow { .. } | Self::RetainHistoryRequired => {
                 Some("Use ALTER ... RESET (RETAIN HISTORY) to set the retain history to its default and lowest value.".into())
@@ -728,8 +728,8 @@ impl fmt::Display for PlanError {
                     expected_type.to_string().to_lowercase()
                 )
             }
-            Self::PublicationContainsUningestableTypes { publication, type_, column } => {
-                write!(f, "publication {publication} contains column {column} of type {type_} which Materialize cannot currently ingest")
+            Self::TableContainsUningestableTypes { name, type_, column } => {
+                write!(f, "table {name} contains column {column} of type {type_} which Materialize cannot currently ingest")
             },
             Self::RetainHistoryLow { limit } => {
                 write!(f, "RETAIN HISTORY cannot be set lower than {}ms", limit.as_millis())

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -27,13 +27,12 @@ use mz_interchange::avro::{AvroSchemaGenerator, DocTarget};
 use mz_ore::cast::{CastFrom, TryCastFrom};
 use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::num::NonNeg;
+use mz_ore::soft_panic_or_log;
 use mz_ore::str::StrExt;
 use mz_ore::vec::VecExt;
-use mz_ore::{assert_none, soft_panic_or_log};
 use mz_proto::RustType;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
-use mz_repr::adt::system::Oid;
 use mz_repr::optimize::OptimizerFeatureOverrides;
 use mz_repr::refresh_schedule::{RefreshEvery, RefreshSchedule};
 use mz_repr::role_id::RoleId;
@@ -98,12 +97,13 @@ use mz_storage_types::sources::mysql::{
     MySqlSourceConnection, MySqlSourceDetails, ProtoMySqlSourceDetails,
 };
 use mz_storage_types::sources::postgres::{
-    CastType, PostgresSourceConnection, PostgresSourcePublicationDetails,
+    PostgresSourceConnection, PostgresSourcePublicationDetails,
     ProtoPostgresSourcePublicationDetails,
 };
 use mz_storage_types::sources::{
-    GenericSourceConnection, ProtoSourceExportStatementDetails, SourceConnection, SourceDesc,
-    SourceExportStatementDetails, SourceReferenceResolver, Timeline,
+    GenericSourceConnection, MySqlSourceExportDetails, PostgresSourceExportDetails,
+    ProtoSourceExportStatementDetails, SourceConnection, SourceDesc, SourceExportDetails,
+    SourceExportStatementDetails, Timeline,
 };
 use prost::Message;
 
@@ -120,12 +120,11 @@ use crate::names::{
 };
 use crate::normalize::{self, ident};
 use crate::plan::error::PlanError;
-use crate::plan::expr::ColumnRef;
 use crate::plan::query::{plan_expr, scalar_type_from_catalog, ExprContext, QueryLifetime};
 use crate::plan::scope::Scope;
 use crate::plan::statement::ddl::connection::{INALTERABLE_OPTIONS, MUTUALLY_EXCLUSIVE_SETS};
 use crate::plan::statement::{scl, StatementContext, StatementDesc};
-use crate::plan::typeconv::{plan_cast, CastContext};
+use crate::plan::typeconv::CastContext;
 use crate::plan::with_options::{OptionalDuration, OptionalString, TryFromValue};
 use crate::plan::{
     literal, plan_utils, query, transform_ast, AlterClusterPlan, AlterClusterRenamePlan,
@@ -139,7 +138,7 @@ use crate::plan::{
     CreateConnectionPlan, CreateDatabasePlan, CreateIndexPlan, CreateMaterializedViewPlan,
     CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan,
     CreateTablePlan, CreateTypePlan, CreateViewPlan, DataSourceDesc, DropObjectsPlan,
-    DropOwnedPlan, FullItemName, HirScalarExpr, Index, Ingestion, MaterializedView, Params, Plan,
+    DropOwnedPlan, FullItemName, Index, Ingestion, MaterializedView, Params, Plan,
     PlanClusterOption, PlanNotice, QueryContext, ReplicaConfig, Secret, Sink, Source, Table, Type,
     VariableValue, View, WebhookBodyFormat, WebhookHeaderFilters, WebhookHeaders,
 };
@@ -802,17 +801,14 @@ pub fn plan_create_source(
             options,
         } => {
             let connection_item = scx.get_item_by_resolved_name(connection)?;
-            let connection = match connection_item.connection()? {
-                Connection::Postgres(connection) => connection.clone(),
-                _ => sql_bail!(
-                    "{} is not a postgres connection",
-                    scx.catalog.resolve_full_name(connection_item.name())
-                ),
-            };
+
             let PgConfigOptionExtracted {
                 details,
                 publication,
-                text_columns,
+                // text columns are already part of the source-exports and are only included
+                // in these options for round-tripping of a `CREATE SOURCE` statement. This should
+                // be removed once we drop support for implicitly created subsources.
+                text_columns: _,
                 seen: _,
             } = options.clone().try_into()?;
 
@@ -826,199 +822,10 @@ pub fn plan_create_source(
             let publication_details = PostgresSourcePublicationDetails::from_proto(details)
                 .map_err(|e| sql_err!("{}", e))?;
 
-            let reference_resolver =
-                SourceReferenceResolver::new(&connection.database, &publication_details.tables)
-                    .expect("references validated during purification");
-
-            let mut text_cols: BTreeMap<Oid, BTreeSet<String>> = BTreeMap::new();
-
-            // Look up the referenced text_columns in the publication_catalog.
-            for name in text_columns {
-                let (col, qual) = name.0.split_last().expect("must have at least one element");
-
-                let idx = reference_resolver
-                    .resolve_idx(qual)
-                    .expect("known to exist from purification");
-
-                let table_desc = &publication_details.tables[idx];
-
-                assert!(
-                    table_desc
-                        .columns
-                        .iter()
-                        .find(|column| column.name == col.as_str())
-                        .is_some(),
-                    "validated column exists in table during purification"
-                );
-
-                text_cols
-                    .entry(Oid(table_desc.oid))
-                    .or_default()
-                    .insert(col.clone().into_string());
-            }
-
-            // Here we will generate the cast expressions required to convert the text encoded
-            // columns into the appropriate target types, creating a Vec<MirScalarExpr> per table.
-            // The postgres source reader will then eval each of those on the incoming rows based
-            // on the target table
-            let mut table_casts = BTreeMap::new();
-
-            for (i, table) in publication_details.tables.iter().enumerate() {
-                // First, construct an expression context where the expression is evaluated on an
-                // imaginary row which has the same number of columns as the upstream table but all
-                // of the types are text
-                let mut cast_scx = scx.clone();
-                cast_scx.param_types = Default::default();
-                let cast_qcx = QueryContext::root(&cast_scx, QueryLifetime::Source);
-                let mut column_types = vec![];
-                for column in table.columns.iter() {
-                    column_types.push(ColumnType {
-                        nullable: column.nullable,
-                        scalar_type: ScalarType::String,
-                    });
-                }
-
-                let cast_ecx = ExprContext {
-                    qcx: &cast_qcx,
-                    name: "plan_postgres_source_cast",
-                    scope: &Scope::empty(),
-                    relation_type: &RelationType {
-                        column_types,
-                        keys: vec![],
-                    },
-                    allow_aggregates: false,
-                    allow_subqueries: false,
-                    allow_parameters: false,
-                    allow_windows: false,
-                };
-
-                // Then, for each column we will generate a MirRelationExpr that extracts the nth
-                // column and casts it to the appropriate target type
-                let mut column_casts = vec![];
-                for (i, column) in table.columns.iter().enumerate() {
-                    let (cast_type, ty) = match text_cols.get(&Oid(table.oid)) {
-                        // Treat the column as text if it was referenced in
-                        // `TEXT COLUMNS`. This is the only place we need to
-                        // perform this logic; even if the type is unsupported,
-                        // we'll be able to ingest its values as text in
-                        // storage.
-                        Some(names) if names.contains(&column.name) => {
-                            (CastType::Text, mz_pgrepr::Type::Text)
-                        }
-                        _ => {
-                            match mz_pgrepr::Type::from_oid_and_typmod(
-                                column.type_oid,
-                                column.type_mod,
-                            ) {
-                                Ok(t) => (CastType::Natural, t),
-                                // If this reference survived purification, we
-                                // do not expect it to be from a table that the
-                                // user will consume., i.e. expect this table to
-                                // be filtered out of table casts.
-                                Err(_) => {
-                                    column_casts.push((
-                                        CastType::Natural,
-                                        HirScalarExpr::CallVariadic {
-                                            func: mz_expr::VariadicFunc::ErrorIfNull,
-                                            exprs: vec![
-                                                HirScalarExpr::literal_null(ScalarType::String),
-                                                HirScalarExpr::literal(
-                                                    mz_repr::Datum::from(
-                                                        format!(
-                                                            "Unsupported type with OID {}",
-                                                            column.type_oid
-                                                        )
-                                                        .as_str(),
-                                                    ),
-                                                    ScalarType::String,
-                                                ),
-                                            ],
-                                        }
-                                        .lower_uncorrelated()
-                                        .expect("no correlation"),
-                                    ));
-                                    continue;
-                                }
-                            }
-                        }
-                    };
-
-                    let data_type = scx.resolve_type(ty)?;
-                    let scalar_type = query::scalar_type_from_sql(scx, &data_type)?;
-
-                    let col_expr = HirScalarExpr::Column(ColumnRef {
-                        level: 0,
-                        column: i,
-                    });
-
-                    let cast_expr =
-                        plan_cast(&cast_ecx, CastContext::Explicit, col_expr, &scalar_type)?;
-
-                    let cast = if column.nullable {
-                        cast_expr
-                    } else {
-                        // We must enforce nullability constraint on cast
-                        // because PG replication stream does not propagate
-                        // constraint changes and we want to error subsource if
-                        // e.g. the constraint is dropped and we don't notice
-                        // it.
-                        HirScalarExpr::CallVariadic {
-                            func: mz_expr::VariadicFunc::ErrorIfNull,
-                            exprs: vec![
-                                cast_expr,
-                                HirScalarExpr::literal(
-                                    mz_repr::Datum::from(
-                                        format!(
-                                            "PG column {}.{}.{} contained NULL data, despite having NOT NULL constraint",
-                                            table.namespace.clone(),
-                                            table.name.clone(),
-                                            column.name.clone())
-                                            .as_str(),
-                                    ),
-                                    ScalarType::String,
-                                ),
-                            ],
-                        }
-                    };
-
-                    // We expect only reg* types to encounter this issue. Users
-                    // can ingest the data as text if they need to ingest it.
-                    // This is acceptable because we don't expect the OIDs from
-                    // an external PG source to be unilaterally usable in
-                    // resolving item names in MZ.
-                    let mir_cast = cast.lower_uncorrelated().map_err(|_e| {
-                        tracing::info!(
-                            "cannot ingest {:?} data from PG source because cast is correlated",
-                            scalar_type
-                        );
-
-                        let publication = match publication.clone() {
-                            Some(publication) => publication,
-                            None => return sql_err!("[internal error]: missing publication"),
-                        };
-
-                        PlanError::PublicationContainsUningestableTypes {
-                            publication,
-                            type_: scx.humanize_scalar_type(&scalar_type),
-                            column: UnresolvedItemName::qualified(&[
-                                Ident::new_unchecked(table.name.to_string()),
-                                Ident::new_unchecked(column.name.to_string()),
-                            ])
-                            .to_ast_string(),
-                        }
-                    })?;
-
-                    column_casts.push((cast_type, mir_cast));
-                }
-                let r = table_casts.insert(i + 1, column_casts);
-                assert_none!(r, "cannot have table defined multiple times");
-            }
-
             let connection =
                 GenericSourceConnection::<ReferencedConnection>::from(PostgresSourceConnection {
                     connection: connection_item.id(),
                     connection_id: connection_item.id(),
-                    table_casts,
                     publication: publication.expect("validated exists during purification"),
                     publication_details,
                 });
@@ -1039,8 +846,11 @@ pub fn plan_create_source(
             };
             let MySqlConfigOptionExtracted {
                 details,
-                text_columns,
-                ignore_columns,
+                // text/ignore columns are already part of the source-exports and are only included
+                // in these options for round-tripping of a `CREATE SOURCE` statement. This should
+                // be removed once we drop support for implicitly created subsources.
+                text_columns: _,
+                ignore_columns: _,
                 seen: _,
             } = options.clone().try_into()?;
 
@@ -1052,22 +862,11 @@ pub fn plan_create_source(
                 ProtoMySqlSourceDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
             let details = MySqlSourceDetails::from_proto(details).map_err(|e| sql_err!("{}", e))?;
 
-            let text_columns = text_columns
-                .into_iter()
-                .map(|name| name.try_into().map_err(|e| sql_err!("{}", e)))
-                .collect::<Result<Vec<_>, _>>()?;
-            let ignore_columns = ignore_columns
-                .into_iter()
-                .map(|name| name.try_into().map_err(|e| sql_err!("{}", e)))
-                .collect::<Result<Vec<_>, _>>()?;
-
             let connection =
                 GenericSourceConnection::<ReferencedConnection>::from(MySqlSourceConnection {
                     connection: connection_item.id(),
                     connection_id: connection_item.id(),
                     details,
-                    text_columns,
-                    ignore_columns,
                 });
 
             connection
@@ -1578,15 +1377,35 @@ pub fn plan_create_subsource(
             ProtoSourceExportStatementDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
         let details =
             SourceExportStatementDetails::from_proto(details).map_err(|e| sql_err!("{}", e))?;
-        // TODO(roshan): Use these options in the IngestionExport struct below. For now we just
-        // decode here to ensure that the details are present and valid.
-        let _ = details;
-        let _ = text_columns;
-        let _ = ignore_columns;
-
+        let details = match details {
+            SourceExportStatementDetails::Postgres { table } => {
+                SourceExportDetails::Postgres(PostgresSourceExportDetails {
+                    table_cast: crate::pure::postgres::generate_table_cast(
+                        scx,
+                        &table,
+                        &text_columns,
+                    )?,
+                    table,
+                })
+            }
+            SourceExportStatementDetails::MySql {
+                table,
+                initial_gtid_set,
+            } => SourceExportDetails::MySql(MySqlSourceExportDetails {
+                table,
+                initial_gtid_set,
+                text_columns: text_columns.into_iter().map(|c| c.into_string()).collect(),
+                ignore_columns: ignore_columns
+                    .into_iter()
+                    .map(|c| c.into_string())
+                    .collect(),
+            }),
+            SourceExportStatementDetails::LoadGenerator {} => SourceExportDetails::LoadGenerator,
+        };
         DataSourceDesc::IngestionExport {
             ingestion_id,
             external_reference,
+            details,
         }
     } else if progress {
         DataSourceDesc::Progress

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1380,7 +1380,7 @@ pub fn plan_create_subsource(
         let details = match details {
             SourceExportStatementDetails::Postgres { table } => {
                 SourceExportDetails::Postgres(PostgresSourceExportDetails {
-                    table_cast: crate::pure::postgres::generate_table_cast(
+                    column_casts: crate::pure::postgres::generate_column_casts(
                         scx,
                         &table,
                         &text_columns,
@@ -1402,9 +1402,9 @@ pub fn plan_create_subsource(
             }),
             SourceExportStatementDetails::LoadGenerator => {
                 SourceExportDetails::LoadGenerator(LoadGeneratorSourceExportDetails {
-                    // get the table from the external reference to figure out which output this
-                    // subsource is for
-                    output: external_reference.0[2].as_str().into(),
+                    output: mz_storage_types::sources::load_generator::external_reference_to_output(
+                        &external_reference,
+                    ),
                 })
             }
         };
@@ -1639,7 +1639,7 @@ pub(crate) fn load_generator_ast_to_generator(
     };
 
     let mut available_subsources = BTreeMap::new();
-    for (name, desc) in load_generator.views().into_iter() {
+    for (name, desc) in load_generator.views() {
         let name = FullItemName {
             database: RawDatabaseSpecifier::Name(
                 mz_storage_types::sources::load_generator::LOAD_GENERATOR_DATABASE_NAME.to_owned(),

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -961,20 +961,18 @@ async fn purify_create_source(
 
             match external_references {
                 Some(ExternalReferences::All) => {
-                    let available_subsources = match &available_subsources {
+                    let available_subsources = match available_subsources {
                         Some(available_subsources) => available_subsources,
                         None => Err(LoadGeneratorSourcePurificationError::ForAllTables)?,
                     };
-                    for (name, (_, desc)) in available_subsources {
-                        let external_reference = UnresolvedItemName::from(name.clone());
+                    for (name, desc) in available_subsources {
                         let subsource_name = source_export_name_gen(source_name, &name.item)?;
+                        let external_reference = UnresolvedItemName::from(name);
                         requested_subsource_map.insert(
                             subsource_name,
                             PurifiedSourceExport {
                                 external_reference,
-                                details: PurifiedExportDetails::LoadGenerator {
-                                    table: desc.clone(),
-                                },
+                                details: PurifiedExportDetails::LoadGenerator { table: desc },
                             },
                         );
                     }
@@ -1381,13 +1379,13 @@ pub fn generate_subsource_statements(
         PurifiedExportDetails::LoadGenerator { .. } => {
             let mut subsource_stmts = Vec::with_capacity(subsources.len());
             for (subsource_name, purified_export) in subsources {
-                let desc = match &purified_export.details {
+                let desc = match purified_export.details {
                     PurifiedExportDetails::LoadGenerator { table } => table,
                     _ => unreachable!("purified export details must be load generator"),
                 };
 
-                let (columns, table_constraints) = scx.relation_desc_into_table_defs(desc)?;
-                let details = SourceExportStatementDetails::LoadGenerator {};
+                let (columns, table_constraints) = scx.relation_desc_into_table_defs(&desc)?;
+                let details = SourceExportStatementDetails::LoadGenerator;
                 // Create the subsource statement
                 let subsource = CreateSubsourceStatement {
                     name: subsource_name,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -789,7 +789,6 @@ async fn purify_create_source(
 
             let postgres::PurifiedSourceExports {
                 source_exports: subsources,
-                referenced_tables,
                 normalized_text_columns,
             } = postgres::purify_source_exports(
                 &client,
@@ -821,7 +820,6 @@ async fn purify_create_source(
             // Remove any old detail references
             options.retain(|PgConfigOption { name, .. }| name != &PgConfigOptionName::Details);
             let details = PostgresSourcePublicationDetails {
-                tables: referenced_tables,
                 slot: format!(
                     "materialize_{}",
                     Uuid::new_v4().to_string().replace('-', "")
@@ -915,7 +913,6 @@ async fn purify_create_source(
 
             let mysql::PurifiedSourceExports {
                 source_exports: subsources,
-                tables,
                 normalized_text_columns,
                 normalized_ignore_columns,
             } = mysql::purify_source_exports(
@@ -929,15 +926,9 @@ async fn purify_create_source(
             .await?;
             requested_subsource_map.extend(subsources);
 
-            // Create/Update the details for the source to include the new tables
-            let details = MySqlSourceDetails {
-                tables,
-                // Since we're creating a new source, we can just use a single
-                // value in this vector which is assumed to be for all tables.
-                // If we ever alter this source, this will be expanded to have a
-                // distinct value for each table.
-                initial_gtid_set: vec![initial_gtid_set],
-            };
+            // We don't have any fields in this details struct but keep this around for
+            // conformity with postgres and in-case we end up needing it again in the future.
+            let details = MySqlSourceDetails {};
             // Update options with the purified details
             options
                 .retain(|MySqlConfigOption { name, .. }| name != &MySqlConfigOptionName::Details);
@@ -1201,7 +1192,6 @@ async fn purify_alter_source(
 
             let postgres::PurifiedSourceExports {
                 source_exports: subsources,
-                referenced_tables,
                 normalized_text_columns,
             } = postgres::purify_source_exports(
                 &client,
@@ -1222,47 +1212,6 @@ async fn purify_alter_source(
             }
 
             requested_subsource_map.extend(subsources);
-
-            let timeline_id = match pg_source_connection.publication_details.timeline_id {
-                None => {
-                    // If we had not yet been able to fill in the source's timeline ID, fill it in now.
-                    let replication_client = config
-                        .connect_replication(
-                            &storage_configuration.connection_context.ssh_tunnel_manager,
-                        )
-                        .await?;
-                    let timeline_id =
-                        mz_postgres_util::get_timeline_id(&replication_client).await?;
-                    Some(timeline_id)
-                }
-                timeline_id => timeline_id,
-            };
-
-            // These new details need to be merged with the existing details and cannot
-            // simply overwrite the existing details. This suggests they should be their
-            // own options, but it's nice to be able to take the values to and from a
-            // hex-encoded string.
-            let new_details = PostgresSourcePublicationDetails {
-                // In this context, we only track the referenced tables; we will merge these with the tables
-                // referenced in the catalog.
-                //
-                // We MUST check for duplicate references when we rejoin the main coordinator thread! We do
-                // that later because the sources that are present might have changed while this
-                // purification occurs.
-                tables: referenced_tables,
-                timeline_id,
-                // This value is not allowed to be altered in the source.
-                slot: pg_source_connection.publication_details.slot,
-                // This value is not allowed to be altered in the source.
-                database: pg_source_connection.publication_details.database,
-            };
-
-            options.push(AlterSourceAddSubsourceOption {
-                name: mz_sql_parser::ast::AlterSourceAddSubsourceOptionName::Details,
-                value: Some(WithOptionValue::Value(Value::String(hex::encode(
-                    new_details.into_proto().encode_to_vec(),
-                )))),
-            });
         }
         GenericSourceConnection::MySql(mysql_source_connection) => {
             let mysql_connection = &mysql_source_connection.connection;
@@ -1290,7 +1239,6 @@ async fn purify_alter_source(
 
             let mysql::PurifiedSourceExports {
                 source_exports: subsources,
-                tables,
                 normalized_text_columns,
                 normalized_ignore_columns,
             } = mysql::purify_source_exports(
@@ -1303,30 +1251,6 @@ async fn purify_alter_source(
             )
             .await?;
             requested_subsource_map.extend(subsources);
-
-            // These new details need to be merged with the existing details and cannot
-            // simply overwrite the existing details. This suggests they should be their
-            // own options, but it's nice to be able to take the values to and from a
-            // hex-encoded string.
-            let new_details = MySqlSourceDetails {
-                // In this context, we only track the referenced tables; we will merge these with the tables
-                // referenced in the catalog.
-                //
-                // We MUST check for duplicate references when we rejoin the main coordinator thread! We do
-                // that later because the sources that are present might have changed while this
-                // purification occurs.
-                tables,
-                // This value will be expanded and merged with the existing value during sequencing to
-                // match the final set of tables.
-                initial_gtid_set: vec![initial_gtid_set],
-            };
-
-            options.push(AlterSourceAddSubsourceOption {
-                name: mz_sql_parser::ast::AlterSourceAddSubsourceOptionName::Details,
-                value: Some(WithOptionValue::Value(Value::String(hex::encode(
-                    new_details.into_proto().encode_to_vec(),
-                )))),
-            });
 
             // Update options with the purified details
             if let Some(text_cols_option) = options

--- a/src/sql/src/pure/mysql.rs
+++ b/src/sql/src/pure/mysql.rs
@@ -287,7 +287,12 @@ pub(super) async fn validate_requested_references_privileges(
 pub(super) struct PurifiedSourceExports {
     /// map of source export names to the details of the export
     pub(super) source_exports: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
-    pub(super) tables: Vec<MySqlTableDesc>,
+    // NOTE(roshan): The text columns and ignore columns are already part of their
+    // appropriate `source_exports` above, but these are returned to allow
+    // round-tripping a `CREATE SOURCE` statement while we still allow creating
+    // implicit subsources from `CREATE SOURCE`. Remove once
+    // fully deprecating that feature and forcing users to use explicit
+    // `CREATE TABLE .. FROM SOURCE` statements.
     pub(super) normalized_text_columns: Vec<WithOptionValue<Aug>>,
     pub(super) normalized_ignore_columns: Vec<WithOptionValue<Aug>>,
 }
@@ -481,6 +486,5 @@ pub(super) async fn purify_source_exports(
             &reference_resolver,
             &tables,
         )?,
-        tables,
     })
 }

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -476,7 +476,7 @@ pub(super) async fn purify_source_exports(
     })
 }
 
-pub(crate) fn generate_table_cast(
+pub(crate) fn generate_column_casts(
     scx: &StatementContext,
     table: &PostgresTableDesc,
     text_columns: &Vec<Ident>,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -45,7 +45,7 @@ use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sinks::{MetadataUnfilled, StorageSinkConnection, StorageSinkDesc};
 use mz_storage_types::sources::{
-    GenericSourceConnection, IngestionDescription, SourceData, SourceDesc,
+    GenericSourceConnection, IngestionDescription, SourceData, SourceDesc, SourceExportDetails,
 };
 use serde::{Deserialize, Serialize};
 use timely::progress::Timestamp as TimelyTimestamp;
@@ -108,6 +108,7 @@ pub enum DataSource {
         // be sufficiently genericized to support all multi-output sources we
         // support.
         external_reference: UnresolvedItemName,
+        details: SourceExportDetails,
     },
     /// Data comes from introspection sources, which the controller itself is
     /// responsible for generating.

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -48,7 +48,7 @@ use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sources::{
     ExportReference, GenericSourceConnection, IngestionDescription, SourceData, SourceDesc,
-    SourceExport,
+    SourceExport, SourceExportDetails,
 };
 use mz_txn_wal::metrics::Metrics as TxnMetrics;
 use mz_txn_wal::txn_read::{DataSnapshot, TxnsRead};
@@ -1541,6 +1541,7 @@ where
                     SourceExport {
                         ingestion_output: None,
                         storage_metadata: (),
+                        details: SourceExportDetails::None,
                     },
                 );
             }
@@ -1632,6 +1633,7 @@ where
                 DataSource::IngestionExport {
                     ingestion_id,
                     external_reference,
+                    details,
                 } => {
                     // Adjust the source to contain this export.
                     let source_collection = self_collections
@@ -1648,6 +1650,7 @@ where
                                     external_reference.clone(),
                                 )),
                                 storage_metadata: (),
+                                details: details.clone(),
                             },
                         ),
                         _ => unreachable!(

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -211,7 +211,7 @@ mod tests {
     use mz_storage_types::sources::load_generator::LoadGenerator;
     use mz_storage_types::sources::{
         GenericSourceConnection, IngestionDescription, LoadGeneratorSourceConnection, SourceDesc,
-        SourceEnvelope, SourceExport,
+        SourceEnvelope, SourceExport, SourceExportDetails,
     };
     use timely::progress::Antichain;
 
@@ -255,6 +255,7 @@ mod tests {
                         ),
                         txns_shard: Default::default(),
                     },
+                    details: SourceExportDetails::None,
                 };
                 (GlobalId::User(id), export)
             })

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -71,8 +71,8 @@ use mz_storage_types::read_holds::{ReadHold, ReadHoldError};
 use mz_storage_types::read_policy::ReadPolicy;
 use mz_storage_types::sinks::{StorageSinkConnection, StorageSinkDesc};
 use mz_storage_types::sources::{
-    ExportReference, GenericSourceConnection, IngestionDescription, SourceConnection, SourceData,
-    SourceDesc, SourceExport,
+    ExportReference, GenericSourceConnection, IngestionDescription, SourceData, SourceDesc,
+    SourceExport, SourceExportDetails,
 };
 use mz_storage_types::AlterCompatible;
 use mz_txn_wal::metrics::Metrics as TxnMetrics;
@@ -656,6 +656,7 @@ where
                     SourceExport {
                         ingestion_output: None,
                         storage_metadata: (),
+                        details: SourceExportDetails::None,
                     },
                 );
             }
@@ -732,6 +733,7 @@ where
                 DataSource::IngestionExport {
                     ingestion_id,
                     external_reference,
+                    details,
                 } => {
                     debug!(data_source = ?collection_state.data_source, meta = ?metadata, "not registering {} with a controller persist worker", id);
                     // Adjust the source to contain this export.
@@ -749,6 +751,7 @@ where
                                         external_reference.clone(),
                                     )),
                                     storage_metadata: (),
+                                    details: details.clone(),
                                 },
                             );
 
@@ -905,45 +908,6 @@ where
                 cur_ingestion
                     .desc
                     .alter_compatible(ingestion_id, source_desc)?;
-
-                let reference_resolver = cur_ingestion.desc.connection.get_reference_resolver();
-
-                // Ensure updated `SourceDesc` contains reference to all
-                // current external references.
-                for export_id in cur_ingestion
-                    .source_exports
-                    .keys()
-                    .filter(|export| **export != ingestion_id)
-                {
-                    let collection = self
-                        .collections
-                        .get(export_id)
-                        .ok_or(AlterError { id: ingestion_id })?;
-
-                    let external_reference = match &collection.data_source {
-                        DataSource::IngestionExport {
-                            external_reference, ..
-                        } => external_reference,
-                        o => {
-                            tracing::warn!(
-                                "{export_id:?} not DataSource::IngestionExport but {o:#?}",
-                            );
-                            Err(AlterError { id: ingestion_id })?
-                        }
-                    };
-
-                    if reference_resolver
-                        .resolve_idx(&external_reference.0)
-                        .is_err()
-                    {
-                        tracing::warn!(
-                            "subsource {export_id} of {ingestion_id} refers to \
-                            {external_reference:?}, which is missing from \
-                            updated SourceDesc \n{source_desc:#?}"
-                        );
-                        Err(AlterError { id: ingestion_id })?
-                    }
-                }
             }
             o => {
                 tracing::info!(
@@ -3681,6 +3645,7 @@ where
             SourceExport {
                 ingestion_output,
                 storage_metadata: (),
+                details,
             },
         ) in ingestion_description.source_exports
         {
@@ -3690,6 +3655,7 @@ where
                 SourceExport {
                     ingestion_output,
                     storage_metadata: export_storage_metadata,
+                    details,
                 },
             );
         }

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -75,7 +75,7 @@ message ProtoSourceExportDetails {
         google.protobuf.Empty kafka = 1;
         mz_storage_types.sources.postgres.ProtoPostgresSourceExportDetails postgres = 2;
         mz_storage_types.sources.mysql.ProtoMySqlSourceExportDetails mysql = 3;
-        google.protobuf.Empty loadgen = 4;
+        mz_storage_types.sources.load_generator.ProtoLoadGeneratorSourceExportDetails loadgen = 4;
     }
 }
 

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -70,6 +70,15 @@ message ProtoCompression {
     }
 }
 
+message ProtoSourceExportDetails {
+    oneof kind {
+        google.protobuf.Empty kafka = 1;
+        mz_storage_types.sources.postgres.ProtoPostgresSourceExportDetails postgres = 2;
+        mz_storage_types.sources.mysql.ProtoMySqlSourceExportDetails mysql = 3;
+        google.protobuf.Empty loadgen = 4;
+    }
+}
+
 // NOTE: this message is encoded and stored as part of a source export
 // statement option (currently only `CREATE SUBSOURCE` statements)
 // Be extra careful about changes, ensuring that all changes are backwards compatible
@@ -94,6 +103,7 @@ message ProtoIngestionDescription {
         // uint64 output_index = 2;
         mz_storage_types.controller.ProtoCollectionMetadata storage_metadata = 3;
         repeated string ingestion_output = 4;
+        ProtoSourceExportDetails details = 5;
     }
 
     reserved 1;

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -253,10 +253,6 @@ impl<C: ConnectionAccess> SourceConnection for KafkaSourceConnection<C> {
             })
             .collect()
     }
-
-    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
-        super::SourceReferenceResolver::default()
-    }
 }
 
 impl<C: ConnectionAccess> crate::AlterCompatible for KafkaSourceConnection<C> {

--- a/src/storage-types/src/sources/load_generator.proto
+++ b/src/storage-types/src/sources/load_generator.proto
@@ -58,31 +58,39 @@ message ProtoLoadGeneratorSourceExportDetails {
     ProtoLoadGeneratorOutput output = 1;
 }
 
-enum ProtoLoadGeneratorOutput {
-    Default = 0;
+message ProtoLoadGeneratorOutput {
+    oneof kind {
+        google.protobuf.Empty default = 1;
+        ProtoLoadGeneratorAuctionOutput auction = 2;
+        ProtoLoadGeneratorMarketingOutput marketing = 3;
+        ProtoLoadGeneratorTpchOutput tpch = 4;
+    }
+}
 
-    // Auction tables
-    Organizations = 2;
-    Users = 3;
-    Accounts = 4;
-    Auctions = 5;
-    Bids = 6;
+enum ProtoLoadGeneratorAuctionOutput {
+    Organizations = 0;
+    Users = 1;
+    Accounts = 2;
+    Auctions = 3;
+    Bids = 4;
+}
 
-    // Marketing tables
-    Customers = 7;
-    Impressions = 8;
-    Clicks = 9;
-    Leads = 10;
-    Coupons = 11;
-    ConversionPredictions = 12;
+enum ProtoLoadGeneratorMarketingOutput {
+    Customers = 0;
+    Impressions = 1;
+    Clicks = 2;
+    Leads = 3;
+    Coupons = 4;
+    ConversionPredictions = 5;
+}
 
-    // Tpch tables
-    Supplier = 13;
-    Part = 14;
-    Partsupp = 15;
-    Customer = 16;
-    Orders = 17;
-    Lineitem = 18;
-    Nation = 19;
-    Region = 20;
+enum ProtoLoadGeneratorTpchOutput {
+    Supplier = 0;
+    Part = 1;
+    Partsupp = 2;
+    Customer = 3;
+    Orders = 4;
+    Lineitem = 5;
+    Nation = 6;
+    Region = 7;
 }

--- a/src/storage-types/src/sources/load_generator.proto
+++ b/src/storage-types/src/sources/load_generator.proto
@@ -53,3 +53,36 @@ message ProtoKeyValueLoadGenerator {
     uint64 seed = 8;
     optional string include_offset = 9;
 }
+
+message ProtoLoadGeneratorSourceExportDetails {
+    ProtoLoadGeneratorOutput output = 1;
+}
+
+enum ProtoLoadGeneratorOutput {
+    Default = 0;
+
+    // Auction tables
+    Organizations = 2;
+    Users = 3;
+    Accounts = 4;
+    Auctions = 5;
+    Bids = 6;
+
+    // Marketing tables
+    Customers = 7;
+    Impressions = 8;
+    Clicks = 9;
+    Leads = 10;
+    Coupons = 11;
+    ConversionPredictions = 12;
+
+    // Tpch tables
+    Supplier = 13;
+    Part = 14;
+    Partsupp = 15;
+    Customer = 16;
+    Orders = 17;
+    Lineitem = 18;
+    Nation = 19;
+    Region = 20;
+}

--- a/src/storage-types/src/sources/load_generator.rs
+++ b/src/storage-types/src/sources/load_generator.rs
@@ -122,17 +122,6 @@ impl SourceConnection for LoadGeneratorSourceConnection {
     fn metadata_columns(&self) -> Vec<(&str, ColumnType)> {
         vec![]
     }
-
-    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
-        let views: Vec<_> = self
-            .load_generator
-            .views()
-            .into_iter()
-            .map(|(name, _)| (self.load_generator.schema_name(), name))
-            .collect();
-        super::SourceReferenceResolver::new(LOAD_GENERATOR_DATABASE_NAME, &views)
-            .expect("already validated that SourceReferenceResolver elements are valid")
-    }
 }
 
 impl crate::AlterCompatible for LoadGeneratorSourceConnection {}

--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -15,24 +15,16 @@ import "mysql-util/src/desc.proto";
 
 package mz_storage_types.sources.mysql;
 
-message ProtoMySqlColumnRef {
-    string schema_name = 1;
-    string table_name = 2;
-    string column_name = 3;
-}
-
 message ProtoMySqlSourceConnection {
+    reserved 4, 5;
     mz_repr.global_id.ProtoGlobalId connection_id = 1;
     mz_storage_types.connections.ProtoMySqlConnection connection = 2;
     ProtoMySqlSourceDetails details = 3;
-
-    repeated ProtoMySqlColumnRef text_columns = 4;
-    repeated ProtoMySqlColumnRef ignore_columns = 5;
 }
 
 message ProtoMySqlSourceDetails {
-    // NOTE(roshan): These fields are planned for deprecation, since relevant table descriptions
-    // and initial_gtid_sets are now stored on source export statements directly.
+    // These fields marked 'deprecated_' are kept around to migrate old sources since
+    // this message is serialized as proto in the catalog.
     repeated mz_mysql_util.ProtoMySqlTableDesc deprecated_tables = 1;
     // This was changed from a string to a repeated string in order to support
     // separate GTID sets for each table. If this field contains a single element,
@@ -42,6 +34,12 @@ message ProtoMySqlSourceDetails {
     repeated string deprecated_initial_gtid_set = 3;
 }
 
+message ProtoMySqlSourceExportDetails {
+    mz_mysql_util.ProtoMySqlTableDesc table = 1;
+    string initial_gtid_set = 2;
+    repeated string text_columns = 3;
+    repeated string ignore_columns = 4;
+}
 
 // NOTE: this message is encoded and stored as part of a source export
 // statement option (currently only `CREATE SUBSOURCE` statements)

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -13,9 +13,8 @@ use std::fmt;
 use std::io;
 use std::num::NonZeroU64;
 
-use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, RustType, TryFromProtoError};
 use mz_repr::{ColumnType, Datum, GlobalId, RelationDesc, Row, ScalarType};
-use mz_sql_parser::ast::UnresolvedItemName;
 use mz_timely_util::order::Partitioned;
 use mz_timely_util::order::Step;
 use once_cell::sync::Lazy;
@@ -42,68 +41,10 @@ include!(concat!(
 ));
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
-pub struct MySqlColumnRef {
-    pub schema_name: String,
-    pub table_name: String,
-    pub column_name: String,
-}
-
-impl RustType<ProtoMySqlColumnRef> for MySqlColumnRef {
-    fn into_proto(&self) -> ProtoMySqlColumnRef {
-        ProtoMySqlColumnRef {
-            schema_name: self.schema_name.clone(),
-            table_name: self.table_name.clone(),
-            column_name: self.column_name.clone(),
-        }
-    }
-
-    fn from_proto(proto: ProtoMySqlColumnRef) -> Result<Self, TryFromProtoError> {
-        Ok(MySqlColumnRef {
-            schema_name: proto.schema_name,
-            table_name: proto.table_name,
-            column_name: proto.column_name,
-        })
-    }
-}
-
-pub struct IntoMySqlColumnRefError(String);
-
-impl fmt::Display for IntoMySqlColumnRefError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl TryFrom<UnresolvedItemName> for MySqlColumnRef {
-    type Error = IntoMySqlColumnRefError;
-
-    /// Convert an UnresolvedItemName into a MySqlColumnRef
-    fn try_from(item: UnresolvedItemName) -> Result<Self, Self::Error> {
-        let mut iter = item.0.into_iter();
-        match (iter.next(), iter.next(), iter.next()) {
-            (Some(schema_name), Some(table_name), Some(column_name)) => Ok(MySqlColumnRef {
-                // We need to be careful not to accidentally introduce postgres/mz-style
-                // quoting in the schema_name, table_name, or column_name fields, which
-                // happens if naively using the to_string()/fmt method on the Ident values.
-                schema_name: schema_name.into_string(),
-                table_name: table_name.into_string(),
-                column_name: column_name.into_string(),
-            }),
-            ref other => Err(IntoMySqlColumnRefError(format!(
-                "expected fully-qualified column name, got: {:?}",
-                other
-            ))),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct MySqlSourceConnection<C: ConnectionAccess = InlinedConnection> {
     pub connection_id: GlobalId,
     pub connection: C::MySql,
     pub details: MySqlSourceDetails,
-    pub text_columns: Vec<MySqlColumnRef>,
-    pub ignore_columns: Vec<MySqlColumnRef>,
 }
 
 impl<R: ConnectionResolver> IntoInlineConnection<MySqlSourceConnection, R>
@@ -114,16 +55,12 @@ impl<R: ConnectionResolver> IntoInlineConnection<MySqlSourceConnection, R>
             connection_id,
             connection,
             details,
-            text_columns,
-            ignore_columns,
         } = self;
 
         MySqlSourceConnection {
             connection_id,
             connection: r.resolve_connection(connection).unwrap_mysql(),
             details,
-            text_columns,
-            ignore_columns,
         }
     }
 }
@@ -195,11 +132,6 @@ impl<C: ConnectionAccess> SourceConnection for MySqlSourceConnection<C> {
     fn metadata_columns(&self) -> Vec<(&str, ColumnType)> {
         vec![]
     }
-
-    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
-        super::SourceReferenceResolver::new("mysql", &self.details.tables)
-            .expect("already validated that SourceReferenceResolver elements are valid")
-    }
 }
 
 impl<C: ConnectionAccess> AlterCompatible for MySqlSourceConnection<C> {
@@ -212,8 +144,6 @@ impl<C: ConnectionAccess> AlterCompatible for MySqlSourceConnection<C> {
             connection_id,
             connection,
             details,
-            text_columns: _,
-            ignore_columns: _,
         } = self;
 
         let compatibility_checks = [
@@ -250,8 +180,6 @@ impl RustType<ProtoMySqlSourceConnection> for MySqlSourceConnection {
             connection: Some(self.connection.into_proto()),
             connection_id: Some(self.connection_id.into_proto()),
             details: Some(self.details.into_proto()),
-            text_columns: self.text_columns.into_proto(),
-            ignore_columns: self.ignore_columns.into_proto(),
         }
     }
 
@@ -266,79 +194,27 @@ impl RustType<ProtoMySqlSourceConnection> for MySqlSourceConnection {
             details: proto
                 .details
                 .into_rust_if_some("ProtoMySqlSourceConnection::details")?,
-            text_columns: proto.text_columns.into_rust()?,
-            ignore_columns: proto.ignore_columns.into_rust()?,
         })
     }
 }
 
+/// This struct allows storing any mysql-specific details for a source, serialized as
+/// an option in the `CREATE SOURCE` statement. It was previously used but is not currently
+/// necessary, though we keep it around to maintain conformity with other sources.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
-pub struct MySqlSourceDetails {
-    // NOTE(roshan): These fields are planned for deprecation, since relevant table descriptions
-    // and initial_gtid_sets are now stored on source export statements directly.
-    #[proptest(
-        strategy = "proptest::collection::vec(any::<mz_mysql_util::MySqlTableDesc>(), 0..4)"
-    )]
-    pub tables: Vec<mz_mysql_util::MySqlTableDesc>,
-    /// The initial 'gtid_executed' set for each subsource. The index of each string in this
-    /// vector corresponds to the index of the corresponding table in the `tables` field.
-    /// If this vector has only one element, it is the initial gtid set for all tables.
-    ///
-    /// This is used as the effective snapshot point for each subsource to ensure correctness
-    /// if the source is interrupted but commits one or more tables before the initial snapshot
-    /// of all tables is complete.
-    #[proptest(strategy = "proptest::collection::vec(any_gtidset(), 1..4)")]
-    pub initial_gtid_set: Vec<String>,
-}
-
-impl MySqlSourceDetails {
-    /// The initial 'gtid_executed' set for the given table index.
-    pub fn table_initial_gtid_set(&self, table_index: usize) -> &str {
-        match &*self.initial_gtid_set {
-            [gtid] => gtid,
-            gtids => &gtids[table_index],
-        }
-    }
-}
-
-fn any_gtidset() -> impl Strategy<Value = String> {
-    any::<(u128, u64)>().prop_map(|(uuid, tx_id)| format!("{}:{}", Uuid::from_u128(uuid), tx_id))
-}
+pub struct MySqlSourceDetails {}
 
 impl RustType<ProtoMySqlSourceDetails> for MySqlSourceDetails {
     fn into_proto(&self) -> ProtoMySqlSourceDetails {
         ProtoMySqlSourceDetails {
-            deprecated_tables: self.tables.iter().map(|t| t.into_proto()).collect(),
-            deprecated_initial_gtid_set: self.initial_gtid_set.clone(),
+            deprecated_tables: vec![],
+            deprecated_initial_gtid_set: vec![],
             deprecated_legacy_initial_gtid_set: "".to_string(),
         }
     }
 
-    fn from_proto(proto: ProtoMySqlSourceDetails) -> Result<Self, TryFromProtoError> {
-        // Handle the migration of the legacy_initial_gtid_set field to the initial_gtid_set field
-        let gtid_set = match (
-            proto.deprecated_initial_gtid_set,
-            proto.deprecated_legacy_initial_gtid_set,
-        ) {
-            (gtid_set, legacy_gtid_set) if legacy_gtid_set.is_empty() => gtid_set,
-            (gtid_set, legacy_gtid_set) if gtid_set.is_empty() => vec![legacy_gtid_set],
-            (gtid_set, legacy_gtid_set) => {
-                return Err(TryFromProtoError::InvalidFieldError(format!(
-                    "initial_gtid_set and legacy_initial_gtid_set both contain values:\n{}\n{}",
-                    gtid_set.join(", "),
-                    legacy_gtid_set
-                )));
-            }
-        };
-
-        Ok(MySqlSourceDetails {
-            tables: proto
-                .deprecated_tables
-                .into_iter()
-                .map(mz_mysql_util::MySqlTableDesc::from_proto)
-                .collect::<Result<_, _>>()?,
-            initial_gtid_set: gtid_set,
-        })
+    fn from_proto(_proto: ProtoMySqlSourceDetails) -> Result<Self, TryFromProtoError> {
+        Ok(MySqlSourceDetails {})
     }
 }
 
@@ -348,13 +224,58 @@ impl AlterCompatible for MySqlSourceDetails {
         _id: mz_repr::GlobalId,
         _other: &Self,
     ) -> Result<(), crate::controller::AlterError> {
-        // TODO(roshan): We should verify here that the initial_gtid_set value for a given
-        // subsource remains the same. However, since a DROP SOURCE operation can drop a specific
-        // subsource without updating these `details`, and then an `ALTER SOURCE .. ADD SUBSOURCE`
-        // can re-add the same subsource with a new initial_gtid_set, there is no way for us to
-        // know that was a valid operation. We could consider updating `details` on DROP SOURCE
-        // but a better long-term fix is to store the initial_gtid_set in the catalog on each subsource
-        // itself, rather than in the source details.
+        Ok(())
+    }
+}
+
+fn any_gtidset() -> impl Strategy<Value = String> {
+    any::<(u128, u64)>().prop_map(|(uuid, tx_id)| format!("{}:{}", Uuid::from_u128(uuid), tx_id))
+}
+
+/// Specifies the details of a MySQL source export.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
+pub struct MySqlSourceExportDetails {
+    pub table: mz_mysql_util::MySqlTableDesc,
+    /// The initial 'gtid_executed' set for this export.
+    /// This is used as the effective snapshot point for this export to ensure correctness
+    /// if the source is interrupted but commits one or more tables before the initial snapshot
+    /// of all tables is complete.
+    #[proptest(strategy = "any_gtidset()")]
+    pub initial_gtid_set: String,
+    pub text_columns: Vec<String>,
+    pub ignore_columns: Vec<String>,
+}
+
+impl RustType<ProtoMySqlSourceExportDetails> for MySqlSourceExportDetails {
+    fn into_proto(&self) -> ProtoMySqlSourceExportDetails {
+        ProtoMySqlSourceExportDetails {
+            table: Some(self.table.into_proto()),
+            initial_gtid_set: self.initial_gtid_set.clone(),
+            text_columns: self.text_columns.clone(),
+            ignore_columns: self.ignore_columns.clone(),
+        }
+    }
+
+    fn from_proto(proto: ProtoMySqlSourceExportDetails) -> Result<Self, TryFromProtoError> {
+        Ok(MySqlSourceExportDetails {
+            table: proto
+                .table
+                .into_rust_if_some("ProtoMySqlSourceExportDetails::table")?,
+            initial_gtid_set: proto.initial_gtid_set,
+            text_columns: proto.text_columns,
+            ignore_columns: proto.ignore_columns,
+        })
+    }
+}
+
+impl AlterCompatible for MySqlSourceExportDetails {
+    fn alter_compatible(
+        &self,
+        _id: mz_repr::GlobalId,
+        _other: &Self,
+    ) -> Result<(), crate::controller::AlterError> {
+        // compatibility checks are performed against the upstream table in the source
+        // render operators instead
         Ok(())
     }
 }

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -276,6 +276,12 @@ impl AlterCompatible for MySqlSourceExportDetails {
     ) -> Result<(), crate::controller::AlterError> {
         // compatibility checks are performed against the upstream table in the source
         // render operators instead
+        let Self {
+            table: _,
+            initial_gtid_set: _,
+            text_columns: _,
+            ignore_columns: _,
+        } = self;
         Ok(())
     }
 }

--- a/src/storage-types/src/sources/postgres.proto
+++ b/src/storage-types/src/sources/postgres.proto
@@ -17,36 +17,39 @@ import "expr/src/scalar.proto";
 
 package mz_storage_types.sources.postgres;
 
+message ProtoCastType {
+    oneof kind {
+        google.protobuf.Empty natural = 1;
+        google.protobuf.Empty text = 2;
+    }
+}
+
+message ProtoPostgresTableCast {
+    repeated mz_expr.scalar.ProtoMirScalarExpr column_casts = 1;
+    repeated ProtoCastType column_cast_types = 2;
+}
+
 message ProtoPostgresSourceConnection {
-    message ProtoCastType {
-        oneof kind {
-            google.protobuf.Empty natural = 1;
-            google.protobuf.Empty text = 2;
-        }
-    }
-
-    message ProtoPostgresTableCast {
-        repeated mz_expr.scalar.ProtoMirScalarExpr column_casts = 1;
-        repeated ProtoCastType column_cast_types = 2;
-    }
-
+    reserved 5, 7;
     mz_repr.global_id.ProtoGlobalId connection_id = 6;
     mz_storage_types.connections.ProtoPostgresConnection connection = 1;
     string publication = 2;
     ProtoPostgresSourcePublicationDetails details = 4;
-    repeated ProtoPostgresTableCast table_casts = 5;
-    // Describes the position in the source's publication that the table cast
-    // correlates to; meant to be iterated over in tandem with table_casts
-    repeated uint64 table_cast_pos = 7;
 }
 
 message ProtoPostgresSourcePublicationDetails {
-    // NOTE(roshan): This field is planned for deprecation, since relevant table descriptions
-    // are now stored on source export statements directly.
+    // This field is deprecated, but kept around to migrate old sources since this
+    // field is serialized as proto in the catalog.
     repeated mz_postgres_util.desc.ProtoPostgresTableDesc deprecated_tables = 1;
+
     string slot = 2;
     optional uint64 timeline_id = 3;
     string database = 4;
+}
+
+message ProtoPostgresSourceExportDetails {
+    mz_postgres_util.desc.ProtoPostgresTableDesc table = 1;
+    ProtoPostgresTableCast table_cast = 2;
 }
 
 // NOTE: this message is encoded and stored as part of a source export

--- a/src/storage-types/src/sources/postgres.proto
+++ b/src/storage-types/src/sources/postgres.proto
@@ -24,9 +24,9 @@ message ProtoCastType {
     }
 }
 
-message ProtoPostgresTableCast {
-    repeated mz_expr.scalar.ProtoMirScalarExpr column_casts = 1;
-    repeated ProtoCastType column_cast_types = 2;
+message ProtoPostgresColumnCast {
+    mz_expr.scalar.ProtoMirScalarExpr cast = 1;
+    ProtoCastType cast_type = 2;
 }
 
 message ProtoPostgresSourceConnection {
@@ -49,7 +49,7 @@ message ProtoPostgresSourcePublicationDetails {
 
 message ProtoPostgresSourceExportDetails {
     mz_postgres_util.desc.ProtoPostgresTableDesc table = 1;
-    ProtoPostgresTableCast table_cast = 2;
+    repeated ProtoPostgresColumnCast column_casts = 2;
 }
 
 // NOTE: this message is encoded and stored as part of a source export

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -9,8 +9,6 @@
 
 //! Types related to postgres sources
 
-use std::collections::BTreeMap;
-
 use itertools::Itertools;
 use mz_expr::MirScalarExpr;
 use mz_postgres_util::desc::PostgresTableDesc;
@@ -38,12 +36,6 @@ include!(concat!(
 pub struct PostgresSourceConnection<C: ConnectionAccess = InlinedConnection> {
     pub connection_id: GlobalId,
     pub connection: C::Pg,
-    /// The cast expressions to convert the incoming string encoded rows to
-    /// their target types, keyed by their position in the source.
-    #[proptest(
-        strategy = "proptest::collection::btree_map(any::<usize>(), proptest::collection::vec((any::<CastType>(), any::<MirScalarExpr>()), 0..4), 0..4)"
-    )]
-    pub table_casts: BTreeMap<usize, Vec<(CastType, MirScalarExpr)>>,
     pub publication: String,
     pub publication_details: PostgresSourcePublicationDetails,
 }
@@ -55,7 +47,6 @@ impl<R: ConnectionResolver> IntoInlineConnection<PostgresSourceConnection, R>
         let PostgresSourceConnection {
             connection_id,
             connection,
-            table_casts,
             publication,
             publication_details,
         } = self;
@@ -63,7 +54,6 @@ impl<R: ConnectionResolver> IntoInlineConnection<PostgresSourceConnection, R>
         PostgresSourceConnection {
             connection_id,
             connection: r.resolve_connection(connection).unwrap_pg(),
-            table_casts,
             publication,
             publication_details,
         }
@@ -132,14 +122,6 @@ impl<C: ConnectionAccess> SourceConnection for PostgresSourceConnection<C> {
     fn metadata_columns(&self) -> Vec<(&str, ColumnType)> {
         vec![]
     }
-
-    fn get_reference_resolver(&self) -> super::SourceReferenceResolver {
-        super::SourceReferenceResolver::new(
-            &self.publication_details.database,
-            &self.publication_details.tables,
-        )
-        .expect("already validated that SourceReferenceResolver elements are valid")
-    }
 }
 
 impl<C: ConnectionAccess> AlterCompatible for PostgresSourceConnection<C> {
@@ -151,15 +133,6 @@ impl<C: ConnectionAccess> AlterCompatible for PostgresSourceConnection<C> {
         let PostgresSourceConnection {
             connection_id,
             connection,
-            // Table casts may change and we will not, in the long term, have a
-            // means of understanding which tables are actually being used by
-            // the source so it's unclear if these changes will be breaking or
-            // not. This suggests that we might not want to maintain this
-            // information here statically––we could, instead, derive these
-            // casts dynamically from the table's schema for the subsource, and
-            // then the subsource itself understands how to cast its data from
-            // the source.
-            table_casts: _,
             publication,
             publication_details,
         } = self;
@@ -203,10 +176,10 @@ pub enum CastType {
     Text,
 }
 
-impl RustType<proto_postgres_source_connection::ProtoCastType> for CastType {
-    fn into_proto(&self) -> proto_postgres_source_connection::ProtoCastType {
-        use proto_postgres_source_connection::proto_cast_type::Kind::*;
-        proto_postgres_source_connection::ProtoCastType {
+impl RustType<ProtoCastType> for CastType {
+    fn into_proto(&self) -> ProtoCastType {
+        use proto_cast_type::Kind::*;
+        ProtoCastType {
             kind: Some(match self {
                 CastType::Natural => Natural(()),
                 CastType::Text => Text(()),
@@ -214,10 +187,8 @@ impl RustType<proto_postgres_source_connection::ProtoCastType> for CastType {
         }
     }
 
-    fn from_proto(
-        proto: proto_postgres_source_connection::ProtoCastType,
-    ) -> Result<Self, TryFromProtoError> {
-        use proto_postgres_source_connection::proto_cast_type::Kind::*;
+    fn from_proto(proto: ProtoCastType) -> Result<Self, TryFromProtoError> {
+        use proto_cast_type::Kind::*;
         Ok(match proto.kind {
             Some(Natural(())) => CastType::Natural,
             Some(Text(())) => CastType::Text,
@@ -232,66 +203,15 @@ impl RustType<proto_postgres_source_connection::ProtoCastType> for CastType {
 
 impl RustType<ProtoPostgresSourceConnection> for PostgresSourceConnection {
     fn into_proto(&self) -> ProtoPostgresSourceConnection {
-        use proto_postgres_source_connection::ProtoPostgresTableCast;
-        let mut table_casts = Vec::with_capacity(self.table_casts.len());
-        let mut table_cast_pos = Vec::with_capacity(self.table_casts.len());
-        for (pos, table_cast_inner) in self.table_casts.iter() {
-            let mut column_casts = Vec::with_capacity(table_casts.len());
-            let mut column_cast_types = Vec::with_capacity(table_casts.len());
-
-            for (table_cast_col_type, table_cast_col) in table_cast_inner {
-                column_casts.push(table_cast_col.into_proto());
-                column_cast_types.push(table_cast_col_type.into_proto());
-            }
-
-            table_casts.push(ProtoPostgresTableCast {
-                column_casts,
-                column_cast_types,
-            });
-            table_cast_pos.push(mz_ore::cast::usize_to_u64(*pos));
-        }
-
         ProtoPostgresSourceConnection {
             connection: Some(self.connection.into_proto()),
             connection_id: Some(self.connection_id.into_proto()),
             publication: self.publication.clone(),
             details: Some(self.publication_details.into_proto()),
-            table_casts,
-            table_cast_pos,
         }
     }
 
     fn from_proto(proto: ProtoPostgresSourceConnection) -> Result<Self, TryFromProtoError> {
-        // If we get the wrong number of table cast positions, we have to just
-        // accept all of the table casts. This is somewhat harmless, as the
-        // worst thing that happens is that we generate unused snapshots from
-        // the upstream PG publication, and this will (hopefully) correct
-        // itself on the next version upgrade.
-        let table_cast_pos = if proto.table_casts.len() == proto.table_cast_pos.len() {
-            proto.table_cast_pos
-        } else {
-            (1..proto.table_casts.len() + 1)
-                .map(mz_ore::cast::usize_to_u64)
-                .collect()
-        };
-
-        let mut table_casts = BTreeMap::new();
-        for (pos, cast) in table_cast_pos
-            .into_iter()
-            .zip_eq(proto.table_casts.into_iter())
-        {
-            let mut column_casts = vec![];
-            for (cast, cast_type) in cast
-                .column_casts
-                .into_iter()
-                .zip_eq(cast.column_cast_types.into_iter())
-            {
-                column_casts.push((cast_type.into_rust()?, cast.into_rust()?));
-            }
-
-            table_casts.insert(mz_ore::cast::u64_to_usize(pos), column_casts);
-        }
-
         Ok(PostgresSourceConnection {
             connection: proto
                 .connection
@@ -303,17 +223,72 @@ impl RustType<ProtoPostgresSourceConnection> for PostgresSourceConnection {
             publication_details: proto
                 .details
                 .into_rust_if_some("ProtoPostgresSourceConnection::details")?,
-            table_casts,
+        })
+    }
+}
+
+/// The details of a source export from a postgres source.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
+pub struct PostgresSourceExportDetails {
+    /// The cast expressions to convert the incoming string encoded rows to
+    /// their target types
+    #[proptest(
+        strategy = "proptest::collection::vec((any::<CastType>(), any::<MirScalarExpr>()), 0..4)"
+    )]
+    pub table_cast: Vec<(CastType, MirScalarExpr)>,
+    pub table: PostgresTableDesc,
+}
+
+impl AlterCompatible for PostgresSourceExportDetails {
+    fn alter_compatible(&self, _id: GlobalId, _other: &Self) -> Result<(), AlterError> {
+        // compatibility checks are performed against the upstream table in the source
+        // render operators instead
+        Ok(())
+    }
+}
+
+impl RustType<ProtoPostgresSourceExportDetails> for PostgresSourceExportDetails {
+    fn into_proto(&self) -> ProtoPostgresSourceExportDetails {
+        let mut column_casts = Vec::with_capacity(self.table_cast.len());
+        let mut column_cast_types = Vec::with_capacity(self.table_cast.len());
+
+        for (table_cast_col_type, table_cast_col) in self.table_cast.iter() {
+            column_casts.push(table_cast_col.into_proto());
+            column_cast_types.push(table_cast_col_type.into_proto());
+        }
+
+        ProtoPostgresSourceExportDetails {
+            table: Some(self.table.into_proto()),
+            table_cast: Some(ProtoPostgresTableCast {
+                column_casts,
+                column_cast_types,
+            }),
+        }
+    }
+
+    fn from_proto(proto: ProtoPostgresSourceExportDetails) -> Result<Self, TryFromProtoError> {
+        let mut column_casts = vec![];
+        if let Some(table_cast) = proto.table_cast {
+            for (cast, cast_type) in table_cast
+                .column_casts
+                .into_iter()
+                .zip_eq(table_cast.column_cast_types.into_iter())
+            {
+                column_casts.push((cast_type.into_rust()?, cast.into_rust()?));
+            }
+        }
+
+        Ok(PostgresSourceExportDetails {
+            table: proto
+                .table
+                .into_rust_if_some("ProtoPostgresSourceExportDetails::table")?,
+            table_cast: column_casts,
         })
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct PostgresSourcePublicationDetails {
-    // NOTE(roshan): This field is planned for deprecation, since relevant table descriptions
-    // are now stored on source export statements directly.
-    #[proptest(strategy = "proptest::collection::vec(any::<PostgresTableDesc>(), 0..4)")]
-    pub tables: Vec<PostgresTableDesc>,
     pub slot: String,
     /// The active timeline_id when this source was created
     /// The None value indicates an unknown timeline, to account for sources that existed
@@ -325,7 +300,7 @@ pub struct PostgresSourcePublicationDetails {
 impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicationDetails {
     fn into_proto(&self) -> ProtoPostgresSourcePublicationDetails {
         ProtoPostgresSourcePublicationDetails {
-            deprecated_tables: self.tables.iter().map(|t| t.into_proto()).collect(),
+            deprecated_tables: vec![],
             slot: self.slot.clone(),
             timeline_id: self.timeline_id.clone(),
             database: self.database.clone(),
@@ -334,11 +309,6 @@ impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicati
 
     fn from_proto(proto: ProtoPostgresSourcePublicationDetails) -> Result<Self, TryFromProtoError> {
         Ok(PostgresSourcePublicationDetails {
-            tables: proto
-                .deprecated_tables
-                .into_iter()
-                .map(PostgresTableDesc::from_proto)
-                .collect::<Result<_, _>>()?,
             slot: proto.slot,
             timeline_id: proto.timeline_id,
             database: proto.database,
@@ -349,7 +319,6 @@ impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicati
 impl AlterCompatible for PostgresSourcePublicationDetails {
     fn alter_compatible(&self, id: mz_repr::GlobalId, other: &Self) -> Result<(), AlterError> {
         let PostgresSourcePublicationDetails {
-            tables: _,
             slot,
             timeline_id,
             database,

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -17,8 +17,8 @@ use futures::StreamExt;
 use mz_repr::Row;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::load_generator::{
-    Event, Generator, KeyValueLoadGenerator, LoadGenerator, LoadGeneratorSourceConnection,
-    LoadGeneratorView,
+    Event, Generator, KeyValueLoadGenerator, LoadGenerator, LoadGeneratorOutput,
+    LoadGeneratorSourceConnection,
 };
 use mz_storage_types::sources::{MzOffset, SourceExportDetails, SourceTimestamp};
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
@@ -194,7 +194,7 @@ fn render_simple_generator<G: Scope<Timestamp = MzOffset>>(
     for (_, export) in config.source_exports.iter() {
         let output_type = match &export.details {
             SourceExportDetails::LoadGenerator(details) => details.output,
-            SourceExportDetails::None => LoadGeneratorView::Default,
+            SourceExportDetails::None => LoadGeneratorOutput::Default,
             _ => panic!("unexpected source export details: {:?}", export.details),
         };
         output_map

--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -12,7 +12,7 @@ use std::iter;
 
 use mz_ore::now::{to_datetime, NowFn};
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::load_generator::{Event, Generator};
+use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorView};
 use mz_storage_types::sources::MzOffset;
 use rand::prelude::{Rng, SmallRng};
 use rand::seq::SliceRandom;
@@ -61,12 +61,6 @@ use rand::SeedableRng;
 ///   );
 pub struct Auction {}
 
-const ORGANIZATION_OUTPUT: usize = 1;
-const USERS_OUTPUT: usize = 2;
-const ACCOUNTS_OUTPUT: usize = 3;
-const AUCTIONS_OUTPUT: usize = 4;
-const BIDS_OUTPUT: usize = 5;
-
 // Note that this generator never issues retractions; if you change this,
 // `mz_storage_types::sources::LoadGenerator::is_monotonic`
 // must be updated.
@@ -76,7 +70,7 @@ impl Generator for Auction {
         now: NowFn,
         seed: Option<u64>,
         _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<(dyn Iterator<Item = (LoadGeneratorView, Event<Option<MzOffset>, (Row, i64)>)>)> {
         let mut rng = SmallRng::seed_from_u64(seed.unwrap_or_default());
 
         let organizations = COMPANIES.iter().enumerate().map(|(offset, name)| {
@@ -86,7 +80,7 @@ impl Generator for Auction {
             let id = i64::try_from(offset + 1).expect("demo entries less than i64::MAX");
             packer.push(Datum::Int64(id));
             packer.push(Datum::String(*name));
-            (ORGANIZATION_OUTPUT, company)
+            (LoadGeneratorView::Organizations, company)
         });
 
         let users = CELEBRETIES.iter().enumerate().map(|(offset, name)| {
@@ -99,7 +93,7 @@ impl Generator for Auction {
                 .expect("demo entries less than i64::MAX");
             packer.push(Datum::Int64(org_id));
             packer.push(Datum::String(name));
-            (USERS_OUTPUT, user)
+            (LoadGeneratorView::Users, user)
         });
 
         let accounts = (1..=COMPANIES.len()).map(|org_id| {
@@ -110,11 +104,11 @@ impl Generator for Auction {
             packer.push(Datum::Int64(id));
             packer.push(Datum::Int64(org_id));
             packer.push(Datum::Int64(10000)); // balance
-            (ACCOUNTS_OUTPUT, org)
+            (LoadGeneratorView::Accounts, org)
         });
 
         let mut counter = 0;
-        let mut pending: VecDeque<(usize, Row)> =
+        let mut pending: VecDeque<(LoadGeneratorView, Row)> =
             organizations.chain(users).chain(accounts).collect();
 
         let mut offset = 0;
@@ -136,7 +130,7 @@ impl Generator for Auction {
                                 .try_into()
                                 .expect("timestamp must fit"),
                         )); // end time
-                        pending.push_back((AUCTIONS_OUTPUT, auction));
+                        pending.push_back((LoadGeneratorView::Auctions, auction));
                         const MAX_BIDS: i64 = 10;
                         for i in 0..rng.gen_range(2..MAX_BIDS) {
                             let bid_id = Datum::Int64(counter * MAX_BIDS + i);
@@ -155,7 +149,7 @@ impl Generator for Auction {
                                 )); // bid time
                                 bid
                             };
-                            pending.push_back((BIDS_OUTPUT, bid));
+                            pending.push_back((LoadGeneratorView::Bids, bid));
                         }
                     }
                     // Pop from the front so auctions always appear before bids.

--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -12,7 +12,9 @@ use std::iter;
 
 use mz_ore::now::{to_datetime, NowFn};
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorView};
+use mz_storage_types::sources::load_generator::{
+    AuctionView, Event, Generator, LoadGeneratorOutput,
+};
 use mz_storage_types::sources::MzOffset;
 use rand::prelude::{Rng, SmallRng};
 use rand::seq::SliceRandom;
@@ -70,7 +72,8 @@ impl Generator for Auction {
         now: NowFn,
         seed: Option<u64>,
         _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (LoadGeneratorView, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<(dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, i64)>)>)>
+    {
         let mut rng = SmallRng::seed_from_u64(seed.unwrap_or_default());
 
         let organizations = COMPANIES.iter().enumerate().map(|(offset, name)| {
@@ -80,7 +83,7 @@ impl Generator for Auction {
             let id = i64::try_from(offset + 1).expect("demo entries less than i64::MAX");
             packer.push(Datum::Int64(id));
             packer.push(Datum::String(*name));
-            (LoadGeneratorView::Organizations, company)
+            (AuctionView::Organizations, company)
         });
 
         let users = CELEBRETIES.iter().enumerate().map(|(offset, name)| {
@@ -93,7 +96,7 @@ impl Generator for Auction {
                 .expect("demo entries less than i64::MAX");
             packer.push(Datum::Int64(org_id));
             packer.push(Datum::String(name));
-            (LoadGeneratorView::Users, user)
+            (AuctionView::Users, user)
         });
 
         let accounts = (1..=COMPANIES.len()).map(|org_id| {
@@ -104,11 +107,11 @@ impl Generator for Auction {
             packer.push(Datum::Int64(id));
             packer.push(Datum::Int64(org_id));
             packer.push(Datum::Int64(10000)); // balance
-            (LoadGeneratorView::Accounts, org)
+            (AuctionView::Accounts, org)
         });
 
         let mut counter = 0;
-        let mut pending: VecDeque<(LoadGeneratorView, Row)> =
+        let mut pending: VecDeque<(AuctionView, Row)> =
             organizations.chain(users).chain(accounts).collect();
 
         let mut offset = 0;
@@ -130,7 +133,7 @@ impl Generator for Auction {
                                 .try_into()
                                 .expect("timestamp must fit"),
                         )); // end time
-                        pending.push_back((LoadGeneratorView::Auctions, auction));
+                        pending.push_back((AuctionView::Auctions, auction));
                         const MAX_BIDS: i64 = 10;
                         for i in 0..rng.gen_range(2..MAX_BIDS) {
                             let bid_id = Datum::Int64(counter * MAX_BIDS + i);
@@ -149,18 +152,24 @@ impl Generator for Auction {
                                 )); // bid time
                                 bid
                             };
-                            pending.push_back((LoadGeneratorView::Bids, bid));
+                            pending.push_back((AuctionView::Bids, bid));
                         }
                     }
                     // Pop from the front so auctions always appear before bids.
                     let pend = pending.pop_front();
                     pend.map(|(output, row)| {
-                        let msg = (output, Event::Message(MzOffset::from(offset), (row, 1)));
+                        let msg = (
+                            LoadGeneratorOutput::Auction(output),
+                            Event::Message(MzOffset::from(offset), (row, 1)),
+                        );
 
                         // The first batch (orgs, users, accounts) is a single txn, all others (auctions and bids) are separate.
                         let progress = if counter != 0 || pending.is_empty() {
                             offset += 1;
-                            Some((output, Event::Progress(Some(MzOffset::from(offset)))))
+                            Some((
+                                LoadGeneratorOutput::Auction(output),
+                                Event::Progress(Some(MzOffset::from(offset))),
+                            ))
                         } else {
                             None
                         };

--- a/src/storage/src/source/generator/counter.rs
+++ b/src/storage/src/source/generator/counter.rs
@@ -9,7 +9,7 @@
 
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorView};
+use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorOutput};
 use mz_storage_types::sources::MzOffset;
 
 pub struct Counter {
@@ -27,7 +27,8 @@ impl Generator for Counter {
         _now: NowFn,
         _seed: Option<u64>,
         resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (LoadGeneratorView, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<(dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, i64)>)>)>
+    {
         let max_cardinality = self.max_cardinality;
 
         Box::new(
@@ -46,7 +47,7 @@ impl Generator for Counter {
                             let retracted_value = i64::try_from(offset - max + 1).unwrap();
                             let row = Row::pack_slice(&[Datum::Int64(retracted_value)]);
                             Some((
-                                LoadGeneratorView::Default,
+                                LoadGeneratorOutput::Default,
                                 Event::Message(MzOffset::from(offset), (row, -1)),
                             ))
                         }
@@ -57,11 +58,11 @@ impl Generator for Counter {
                     let row = Row::pack_slice(&[Datum::Int64(inserted_value)]);
                     let insertion = [
                         (
-                            LoadGeneratorView::Default,
+                            LoadGeneratorOutput::Default,
                             Event::Message(MzOffset::from(offset), (row, 1)),
                         ),
                         (
-                            LoadGeneratorView::Default,
+                            LoadGeneratorOutput::Default,
                             Event::Progress(Some(MzOffset::from(offset + 1))),
                         ),
                     ];

--- a/src/storage/src/source/generator/counter.rs
+++ b/src/storage/src/source/generator/counter.rs
@@ -9,7 +9,7 @@
 
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::load_generator::{Event, Generator};
+use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorView};
 use mz_storage_types::sources::MzOffset;
 
 pub struct Counter {
@@ -27,7 +27,7 @@ impl Generator for Counter {
         _now: NowFn,
         _seed: Option<u64>,
         resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<(dyn Iterator<Item = (LoadGeneratorView, Event<Option<MzOffset>, (Row, i64)>)>)> {
         let max_cardinality = self.max_cardinality;
 
         Box::new(
@@ -45,7 +45,10 @@ impl Generator for Counter {
                         Some(max) if offset >= max => {
                             let retracted_value = i64::try_from(offset - max + 1).unwrap();
                             let row = Row::pack_slice(&[Datum::Int64(retracted_value)]);
-                            Some((0, Event::Message(MzOffset::from(offset), (row, -1))))
+                            Some((
+                                LoadGeneratorView::Default,
+                                Event::Message(MzOffset::from(offset), (row, -1)),
+                            ))
                         }
                         _ => None,
                     };
@@ -53,8 +56,14 @@ impl Generator for Counter {
                     let inserted_value = i64::try_from(offset + 1).unwrap();
                     let row = Row::pack_slice(&[Datum::Int64(inserted_value)]);
                     let insertion = [
-                        (0, Event::Message(MzOffset::from(offset), (row, 1))),
-                        (0, Event::Progress(Some(MzOffset::from(offset + 1)))),
+                        (
+                            LoadGeneratorView::Default,
+                            Event::Message(MzOffset::from(offset), (row, 1)),
+                        ),
+                        (
+                            LoadGeneratorView::Default,
+                            Event::Progress(Some(MzOffset::from(offset + 1))),
+                        ),
                     ];
                     retraction.into_iter().chain(insertion)
                 })

--- a/src/storage/src/source/generator/datums.rs
+++ b/src/storage/src/source/generator/datums.rs
@@ -11,7 +11,7 @@ use std::iter;
 
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row, ScalarType};
-use mz_storage_types::sources::load_generator::{Event, Generator};
+use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorView};
 use mz_storage_types::sources::MzOffset;
 
 pub struct Datums {}
@@ -25,7 +25,7 @@ impl Generator for Datums {
         _: NowFn,
         _seed: Option<u64>,
         _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<(dyn Iterator<Item = (LoadGeneratorView, Event<Option<MzOffset>, (Row, i64)>)>)> {
         let typs = ScalarType::enumerate();
         let mut datums: Vec<Vec<Datum>> = typs
             .iter()
@@ -58,12 +58,18 @@ impl Generator for Datums {
                 for d in &datums {
                     packer.push(d[idx]);
                 }
-                let msg = (0, Event::Message(MzOffset::from(offset), (row, 1)));
+                let msg = (
+                    LoadGeneratorView::Default,
+                    Event::Message(MzOffset::from(offset), (row, 1)),
+                );
 
                 idx += 1;
                 let progress = if idx == len {
                     offset += 1;
-                    Some((0, Event::Progress(Some(MzOffset::from(offset)))))
+                    Some((
+                        LoadGeneratorView::Default,
+                        Event::Progress(Some(MzOffset::from(offset))),
+                    ))
                 } else {
                     None
                 };

--- a/src/storage/src/source/generator/datums.rs
+++ b/src/storage/src/source/generator/datums.rs
@@ -11,7 +11,7 @@ use std::iter;
 
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row, ScalarType};
-use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorView};
+use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorOutput};
 use mz_storage_types::sources::MzOffset;
 
 pub struct Datums {}
@@ -25,7 +25,8 @@ impl Generator for Datums {
         _: NowFn,
         _seed: Option<u64>,
         _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (LoadGeneratorView, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<(dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, i64)>)>)>
+    {
         let typs = ScalarType::enumerate();
         let mut datums: Vec<Vec<Datum>> = typs
             .iter()
@@ -59,7 +60,7 @@ impl Generator for Datums {
                     packer.push(d[idx]);
                 }
                 let msg = (
-                    LoadGeneratorView::Default,
+                    LoadGeneratorOutput::Default,
                     Event::Message(MzOffset::from(offset), (row, 1)),
                 );
 
@@ -67,7 +68,7 @@ impl Generator for Datums {
                 let progress = if idx == len {
                     offset += 1;
                     Some((
-                        LoadGeneratorView::Default,
+                        LoadGeneratorOutput::Default,
                         Event::Progress(Some(MzOffset::from(offset))),
                     ))
                 } else {

--- a/src/storage/src/source/generator/marketing.rs
+++ b/src/storage/src/source/generator/marketing.rs
@@ -14,7 +14,9 @@ use std::{
 
 use mz_ore::now::to_datetime;
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorView};
+use mz_storage_types::sources::load_generator::{
+    Event, Generator, LoadGeneratorOutput, MarketingView,
+};
 use mz_storage_types::sources::MzOffset;
 use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
 
@@ -32,13 +34,14 @@ impl Generator for Marketing {
         now: mz_ore::now::NowFn,
         seed: Option<u64>,
         _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (LoadGeneratorView, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<(dyn Iterator<Item = (LoadGeneratorOutput, Event<Option<MzOffset>, (Row, i64)>)>)>
+    {
         let mut rng: SmallRng = SmallRng::seed_from_u64(seed.unwrap_or_default());
 
         let mut counter = 0;
 
         let mut future_updates = FutureUpdates::default();
-        let mut pending: Vec<(LoadGeneratorView, Row, i64)> = CUSTOMERS
+        let mut pending: Vec<(MarketingView, Row, i64)> = CUSTOMERS
             .into_iter()
             .enumerate()
             .map(|(id, email)| {
@@ -49,7 +52,7 @@ impl Generator for Marketing {
                 packer.push(Datum::String(email));
                 packer.push(Datum::Int64(rng.gen_range(5_000_000..10_000_000i64)));
 
-                (LoadGeneratorView::Customers, customer, 1)
+                (MarketingView::Customers, customer, 1)
             })
             .collect();
 
@@ -75,7 +78,7 @@ impl Generator for Marketing {
                             .expect("timestamp must fit"),
                     ));
 
-                    pending.push((LoadGeneratorView::Impressions, impression, 1));
+                    pending.push((MarketingView::Impressions, impression, 1));
 
                     // 1 in 10 impressions have a click. Making us the
                     // most successful marketing organization in the world.
@@ -92,7 +95,7 @@ impl Generator for Marketing {
                                 .expect("timestamp must fit"),
                         ));
 
-                        future_updates.insert(click_time, (LoadGeneratorView::Clicks, click, 1));
+                        future_updates.insert(click_time, (MarketingView::Clicks, click, 1));
                     }
 
                     let mut updates = future_updates.retrieve(now());
@@ -110,7 +113,7 @@ impl Generator for Marketing {
                             conversion_amount: None,
                         };
 
-                        pending.push((LoadGeneratorView::Leads, lead.to_row(), 1));
+                        pending.push((MarketingView::Leads, lead.to_row(), 1));
 
                         // a highly scientific statistical model
                         // predicting the likelyhood of a conversion
@@ -133,7 +136,7 @@ impl Generator for Marketing {
                         ));
                         packer.push(Datum::Float64(score.into()));
 
-                        pending.push((LoadGeneratorView::ConversionPredictions, prediction, 1));
+                        pending.push((MarketingView::ConversionPredictions, prediction, 1));
 
                         let mut sent_coupon = false;
                         if !label && bucket == EXPERIMENT {
@@ -152,7 +155,7 @@ impl Generator for Marketing {
                             ));
                             packer.push(Datum::Int64(amount));
 
-                            pending.push((LoadGeneratorView::Coupons, coupon, 1));
+                            pending.push((MarketingView::Coupons, coupon, 1));
                         }
 
                         // Decide if a lead will convert. We assume our model is fairly
@@ -166,26 +169,30 @@ impl Generator for Marketing {
                         if converted {
                             let converted_at = now() + rng.gen_range(1..30);
 
-                            future_updates.insert(
-                                converted_at,
-                                (LoadGeneratorView::Leads, lead.to_row(), -1),
-                            );
+                            future_updates
+                                .insert(converted_at, (MarketingView::Leads, lead.to_row(), -1));
 
                             lead.converted_at = Some(converted_at);
                             lead.conversion_amount = Some(rng.gen_range(1000..25000));
 
                             future_updates
-                                .insert(converted_at, (LoadGeneratorView::Leads, lead.to_row(), 1));
+                                .insert(converted_at, (MarketingView::Leads, lead.to_row(), 1));
                         }
                     }
                 }
 
                 pending.pop().map(|(output, row, diff)| {
-                    let msg = (output, Event::Message(MzOffset::from(offset), (row, diff)));
+                    let msg = (
+                        LoadGeneratorOutput::Marketing(output),
+                        Event::Message(MzOffset::from(offset), (row, diff)),
+                    );
 
                     let progress = if pending.is_empty() {
                         offset += 1;
-                        Some((output, Event::Progress(Some(MzOffset::from(offset)))))
+                        Some((
+                            LoadGeneratorOutput::Marketing(output),
+                            Event::Progress(Some(MzOffset::from(offset))),
+                        ))
                     } else {
                         None
                     };
@@ -292,12 +299,12 @@ const CUSTOMERS: &[&str] = &[
 
 #[derive(Default)]
 struct FutureUpdates {
-    updates: BTreeMap<u64, Vec<(LoadGeneratorView, Row, i64)>>,
+    updates: BTreeMap<u64, Vec<(MarketingView, Row, i64)>>,
 }
 
 impl FutureUpdates {
     /// Schedules a row to be output at a certain time
-    fn insert(&mut self, time: u64, update: (LoadGeneratorView, Row, i64)) {
+    fn insert(&mut self, time: u64, update: (MarketingView, Row, i64)) {
         match self.updates.entry(time) {
             Entry::Vacant(v) => {
                 v.insert(vec![update]);
@@ -310,7 +317,7 @@ impl FutureUpdates {
 
     /// Returns all rows that are scheduled to be output
     /// at or before a certain time.
-    fn retrieve(&mut self, time: u64) -> Vec<(LoadGeneratorView, Row, i64)> {
+    fn retrieve(&mut self, time: u64) -> Vec<(MarketingView, Row, i64)> {
         let mut updates = vec![];
         while let Some(e) = self.updates.first_entry() {
             if *e.key() > time {

--- a/src/storage/src/source/generator/marketing.rs
+++ b/src/storage/src/source/generator/marketing.rs
@@ -14,16 +14,9 @@ use std::{
 
 use mz_ore::now::to_datetime;
 use mz_repr::{Datum, Row};
-use mz_storage_types::sources::load_generator::{Event, Generator};
+use mz_storage_types::sources::load_generator::{Event, Generator, LoadGeneratorView};
 use mz_storage_types::sources::MzOffset;
 use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
-
-const CUSTOMERS_OUTPUT: usize = 1;
-const IMPRESSIONS_OUTPUT: usize = 2;
-const CLICK_OUTPUT: usize = 3;
-const LEADS_OUTPUT: usize = 4;
-const COUPONS_OUTPUT: usize = 5;
-const CONVERSIONS_PREDICTIONS_OUTPUT: usize = 6;
 
 const CONTROL: &str = "control";
 const EXPERIMENT: &str = "experiment";
@@ -39,13 +32,13 @@ impl Generator for Marketing {
         now: mz_ore::now::NowFn,
         seed: Option<u64>,
         _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<(dyn Iterator<Item = (LoadGeneratorView, Event<Option<MzOffset>, (Row, i64)>)>)> {
         let mut rng: SmallRng = SmallRng::seed_from_u64(seed.unwrap_or_default());
 
         let mut counter = 0;
 
         let mut future_updates = FutureUpdates::default();
-        let mut pending: Vec<(usize, Row, i64)> = CUSTOMERS
+        let mut pending: Vec<(LoadGeneratorView, Row, i64)> = CUSTOMERS
             .into_iter()
             .enumerate()
             .map(|(id, email)| {
@@ -56,7 +49,7 @@ impl Generator for Marketing {
                 packer.push(Datum::String(email));
                 packer.push(Datum::Int64(rng.gen_range(5_000_000..10_000_000i64)));
 
-                (CUSTOMERS_OUTPUT, customer, 1)
+                (LoadGeneratorView::Customers, customer, 1)
             })
             .collect();
 
@@ -82,7 +75,7 @@ impl Generator for Marketing {
                             .expect("timestamp must fit"),
                     ));
 
-                    pending.push((IMPRESSIONS_OUTPUT, impression, 1));
+                    pending.push((LoadGeneratorView::Impressions, impression, 1));
 
                     // 1 in 10 impressions have a click. Making us the
                     // most successful marketing organization in the world.
@@ -99,7 +92,7 @@ impl Generator for Marketing {
                                 .expect("timestamp must fit"),
                         ));
 
-                        future_updates.insert(click_time, (CLICK_OUTPUT, click, 1));
+                        future_updates.insert(click_time, (LoadGeneratorView::Clicks, click, 1));
                     }
 
                     let mut updates = future_updates.retrieve(now());
@@ -117,7 +110,7 @@ impl Generator for Marketing {
                             conversion_amount: None,
                         };
 
-                        pending.push((LEADS_OUTPUT, lead.to_row(), 1));
+                        pending.push((LoadGeneratorView::Leads, lead.to_row(), 1));
 
                         // a highly scientific statistical model
                         // predicting the likelyhood of a conversion
@@ -140,7 +133,7 @@ impl Generator for Marketing {
                         ));
                         packer.push(Datum::Float64(score.into()));
 
-                        pending.push((CONVERSIONS_PREDICTIONS_OUTPUT, prediction, 1));
+                        pending.push((LoadGeneratorView::ConversionPredictions, prediction, 1));
 
                         let mut sent_coupon = false;
                         if !label && bucket == EXPERIMENT {
@@ -159,7 +152,7 @@ impl Generator for Marketing {
                             ));
                             packer.push(Datum::Int64(amount));
 
-                            pending.push((COUPONS_OUTPUT, coupon, 1));
+                            pending.push((LoadGeneratorView::Coupons, coupon, 1));
                         }
 
                         // Decide if a lead will convert. We assume our model is fairly
@@ -173,12 +166,16 @@ impl Generator for Marketing {
                         if converted {
                             let converted_at = now() + rng.gen_range(1..30);
 
-                            future_updates.insert(converted_at, (LEADS_OUTPUT, lead.to_row(), -1));
+                            future_updates.insert(
+                                converted_at,
+                                (LoadGeneratorView::Leads, lead.to_row(), -1),
+                            );
 
                             lead.converted_at = Some(converted_at);
                             lead.conversion_amount = Some(rng.gen_range(1000..25000));
 
-                            future_updates.insert(converted_at, (LEADS_OUTPUT, lead.to_row(), 1));
+                            future_updates
+                                .insert(converted_at, (LoadGeneratorView::Leads, lead.to_row(), 1));
                         }
                     }
                 }
@@ -295,12 +292,12 @@ const CUSTOMERS: &[&str] = &[
 
 #[derive(Default)]
 struct FutureUpdates {
-    updates: BTreeMap<u64, Vec<(usize, Row, i64)>>,
+    updates: BTreeMap<u64, Vec<(LoadGeneratorView, Row, i64)>>,
 }
 
 impl FutureUpdates {
     /// Schedules a row to be output at a certain time
-    fn insert(&mut self, time: u64, update: (usize, Row, i64)) {
+    fn insert(&mut self, time: u64, update: (LoadGeneratorView, Row, i64)) {
         match self.updates.entry(time) {
             Entry::Vacant(v) => {
                 v.insert(vec![update]);
@@ -313,7 +310,7 @@ impl FutureUpdates {
 
     /// Returns all rows that are scheduled to be output
     /// at or before a certain time.
-    fn retrieve(&mut self, time: u64) -> Vec<(usize, Row, i64)> {
+    fn retrieve(&mut self, time: u64) -> Vec<(LoadGeneratorView, Row, i64)> {
         let mut updates = vec![];
         while let Some(e) = self.updates.first_entry() {
             if *e.key() > time {

--- a/src/storage/src/source/mysql.rs
+++ b/src/storage/src/source/mysql.rs
@@ -55,6 +55,7 @@ use std::fmt;
 use std::io;
 use std::rc::Rc;
 
+use mz_ore::collections::HashSet;
 use mz_repr::Diff;
 use mz_storage_types::errors::{DataflowError, SourceError};
 use mz_storage_types::sources::SourceExport;
@@ -74,7 +75,7 @@ use mz_mysql_util::{
 use mz_ore::error::ErrorExt;
 use mz_storage_types::errors::SourceErrorDetails;
 use mz_storage_types::sources::mysql::{gtid_set_frontier, GtidPartition, GtidState};
-use mz_storage_types::sources::{MySqlSourceConnection, SourceTimestamp};
+use mz_storage_types::sources::{MySqlSourceConnection, SourceExportDetails, SourceTimestamp};
 use mz_timely_util::builder_async::{AsyncOutputHandle, PressOnDropButton};
 use mz_timely_util::order::Extrema;
 
@@ -109,10 +110,13 @@ impl SourceRender for MySqlSourceConnection {
     ) {
         // Collect the subsources that we will be exporting.
         let mut subsources = Vec::new();
+        let mut upstream_tables = HashSet::new();
         for (
             id,
             SourceExport {
-                ingestion_output, ..
+                ingestion_output,
+                details,
+                storage_metadata: _,
             },
         ) in &config.source_exports
         {
@@ -121,9 +125,13 @@ impl SourceRender for MySqlSourceConnection {
                 continue;
             }
 
-            let table_index = ingestion_output - 1;
-            let desc = self.details.tables[table_index].clone();
-            let initial_gtid_set = self.details.table_initial_gtid_set(table_index).to_string();
+            let details = match details {
+                SourceExportDetails::MySql(details) => details,
+                _ => panic!("unexpected source export details: {:?}", details),
+            };
+
+            let desc = details.table.clone();
+            let initial_gtid_set = details.initial_gtid_set.to_string();
             let resume_upper = Antichain::from_iter(
                 config
                     .source_resume_uppers
@@ -132,13 +140,22 @@ impl SourceRender for MySqlSourceConnection {
                     .iter()
                     .map(GtidPartition::decode_row),
             );
+            let name = MySqlTableName::new(&desc.schema_name, &desc.name);
             subsources.push(SubsourceInfo {
-                name: MySqlTableName::new(&desc.schema_name, &desc.name),
+                name: name.clone(),
                 output_index: *ingestion_output,
                 desc,
+                text_columns: details.text_columns.clone(),
+                ignore_columns: details.ignore_columns.clone(),
                 initial_gtid_set: gtid_set_frontier(&initial_gtid_set).expect("invalid gtid set"),
                 resume_upper,
             });
+            // TODO(roshan): Remove this when we allow multiple source_exports to ingest the same
+            // table in https://github.com/MaterializeInc/materialize/issues/28435
+            assert!(
+                upstream_tables.insert(name),
+                "duplicate table reference in source exports"
+            );
         }
 
         let metrics = config.metrics.get_mysql_source_metrics(config.id);
@@ -215,6 +232,8 @@ struct SubsourceInfo {
     output_index: usize,
     name: MySqlTableName,
     desc: MySqlTableDesc,
+    text_columns: Vec<String>,
+    ignore_columns: Vec<String>,
     initial_gtid_set: Antichain<GtidPartition>,
     resume_upper: Antichain<GtidPartition>,
 }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -94,7 +94,7 @@ use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_types::errors::{DataflowError, SourceError, SourceErrorDetails};
 use mz_storage_types::sources::postgres::CastType;
 use mz_storage_types::sources::{
-    MzOffset, PostgresSourceConnection, SourceExport, SourceTimestamp,
+    MzOffset, PostgresSourceConnection, SourceExport, SourceExportDetails, SourceTimestamp,
 };
 use mz_timely_util::builder_async::PressOnDropButton;
 use serde::{Deserialize, Serialize};
@@ -152,7 +152,9 @@ impl SourceRender for PostgresSourceConnection {
         // Collect the tables that we will be ingesting.
         let mut table_info = BTreeMap::new();
         for SourceExport {
-            ingestion_output, ..
+            ingestion_output,
+            details,
+            storage_metadata: _,
         } in config.source_exports.values()
         {
             // Output index 0 is the primary source which is not a table.
@@ -160,15 +162,20 @@ impl SourceRender for PostgresSourceConnection {
                 continue;
             }
 
-            // The output index is 1 greater than the publication details' index
-            // to account for the primary output being at index 0.
-            let table_idx = *ingestion_output - 1;
-            let desc = self.publication_details.tables[table_idx].clone();
+            let details = match details {
+                SourceExportDetails::Postgres(details) => details,
+                _ => panic!("unexpected source export details: {:?}", details),
+            };
 
-            // Tables are indexed by their native index, but table casts are
-            // indexed by the output index.
-            let casts = self.table_casts[ingestion_output].clone();
-            table_info.insert(desc.oid, (*ingestion_output, desc.clone(), casts.clone()));
+            let desc = details.table.clone();
+
+            let casts = details.table_cast.clone();
+            let exists =
+                table_info.insert(desc.oid, (*ingestion_output, desc.clone(), casts.clone()));
+
+            // TODO(roshan): Remove this when we allow multiple source_exports to ingest the same
+            // table in https://github.com/MaterializeInc/materialize/issues/28435
+            assert!(exists.is_none(), "duplicate table oid in source exports");
         }
 
         let metrics = config.metrics.get_postgres_source_metrics(config.id);

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -169,7 +169,7 @@ impl SourceRender for PostgresSourceConnection {
 
             let desc = details.table.clone();
 
-            let casts = details.table_cast.clone();
+            let casts = details.column_casts.clone();
             let exists =
                 table_info.insert(desc.oid, (*ingestion_output, desc.clone(), casts.clone()));
 

--- a/test/mysql-cdc/alter-source.td
+++ b/test/mysql-cdc/alter-source.td
@@ -57,7 +57,7 @@ contains:Invalid MySQL table reference: table_a
 
 # We are not aware that the new table_a is different
 ! ALTER SOURCE mz_source ADD SUBSOURCE public.table_a;
-contains:another subsource already refers to public.table_a
+contains:catalog item 'table_a' already exists
 
 # TODO: #27585 (expected table was dropped)
 $ skip-end
@@ -225,7 +225,7 @@ mz_source_progress    progress
 > ALTER SOURCE mz_source ADD SUBSOURCE public.table_g;
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE public.table_g;
-contains:another subsource already refers to public.table_g
+contains:catalog item 'table_g' already exists
 
 > ALTER SOURCE mz_source ADD SUBSOURCE public.table_a, public.table_b AS tb;
 
@@ -234,7 +234,7 @@ contains:another subsource already refers to public.table_g
 2 two
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE public.table_a;
-contains:another subsource already refers to public.table_a
+contains:catalog item 'table_a' already exists
 
 > SELECT * FROM tb;
 1 one

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -69,7 +69,7 @@ INSERT INTO table_a VALUES (9, 'nine');
 
 # We are not aware that the new table_a is different
 !ALTER SOURCE mz_source ADD SUBSOURCE table_a;
-contains:another subsource already refers to postgres.public.table_a
+contains:catalog item 'table_a' already exists
 
 > DROP SOURCE mz_source CASCADE;
 
@@ -225,7 +225,7 @@ mz_source_progress    progress
 > ALTER SOURCE mz_source ADD SUBSOURCE table_g;
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_g;
-contains:another subsource already refers to postgres.public.table_g
+contains:catalog item 'table_g' already exists
 
 > ALTER SOURCE mz_source ADD SUBSOURCE table_a, table_b AS tb;
 
@@ -234,7 +234,7 @@ contains:another subsource already refers to postgres.public.table_g
 2 two
 
 ! ALTER SOURCE mz_source ADD SUBSOURCE table_a;
-contains:another subsource already refers to postgres.public.table_a
+contains:catalog item 'table_a' already exists
 
 > SELECT * FROM tb;
 1 one

--- a/test/pg-cdc/types-reg.td
+++ b/test/pg-cdc/types-reg.td
@@ -45,17 +45,17 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 !CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES (regtype_table);
-contains:publication mz_source contains column regtype_table.f1 of type regtype which Materialize cannot currently ingest
+contains:table regtype_table contains column f1 of type regtype which Materialize cannot currently ingest
 
 !CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES (regclass_table);
-contains:publication mz_source contains column regclass_table.f1 of type regclass which Materialize cannot currently ingest
+contains:table regclass_table contains column f1 of type regclass which Materialize cannot currently ingest
 
 !CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
   FOR TABLES (regproc_table);
-contains:publication mz_source contains column regproc_table.f1 of type regproc which Materialize cannot currently ingest
+contains:table regproc_table contains column f1 of type regproc which Materialize cannot currently ingest
 
 > CREATE SOURCE mz_source
   FROM POSTGRES CONNECTION pg (


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature.
  Fixes https://github.com/MaterializeInc/materialize/issues/28451

Part of https://github.com/MaterializeInc/materialize/issues/28430


This PR is a precursor to two critical pieces of the design in https://github.com/MaterializeInc/materialize/pull/27907:
- Since all per-output details used by sources now live on each `SourceExport`, we can easily add support for `CREATE TABLE .. FROM SOURCE` statements alongside existing `CREATE SUBSOURCE` statements. Both statements will generate a plan for an `IngestionExport` which then creates the appropriate `SourceExport` sent to the source for rendering. The source operator doesn't know whether each `SourceExport` is for a 'subsource' or a 'table'.
- 'source-export-demuxing' -- this is different than the previous 'arity-based' demuxing propsal. We completely separate things by source_export rather than demuxing using some sort of 'projection' downstream of the source outputs, because we want to ensure that a newly added source-export gets its own entirely separate snapshot of the upstream data for that table which might include new default values in the upstream for any newly added columns. Part of this work is done in WIP commit (https://github.com/MaterializeInc/materialize/commit/3aaa07f3b434702202e0f58fd8d58bd0c820a169) if you'd like to see where this is going

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Sorry for the long-review -- this refactor touched a lot of moving pieces and removes a lot of now unnecessary code related to create-source statement planning.

Definitely easier to review commit-by-commit.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
