### PR TITLE
ci: Also print QA-relevant failures & other improvements

### DIFF
--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -85,9 +85,9 @@ sudo journalctl --merge --since "$(cat step_start_timestamp)" > journalctl-merge
 
 mapfile -t artifacts < <(printf "run.log\nkubectl-get-logs.log\nkubectl-get-logs-previous.log\nkubectl-get-events.log\nkubectl-get-all.log\nkubectl-describe-all.log\nkubectl-pods-with-nodes.log\nkubectl-get-events-kube-system.log\nkubectl-get-all-kube-system.log\nkubectl-describe-all-kube-system.log\njournalctl-merge.log\nkail-output.log\n"; find . -name 'junit_*.xml')
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
-buildkite-agent artifact upload "$artifacts_str"
 unset CI_EXTRA_ARGS # We don't want extra args for the annotation
-bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}"
+bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log
+buildkite-agent artifact upload "$artifacts_str;ci-annotate-errors.log"
 
 # File should not be empty, see #25369
 test -s kubectl-get-logs-previous.log

--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -205,12 +205,14 @@ def _upload_shard_info_metadata(items: list[str]) -> None:
 
 def add_failure_for_qa_team(failure: str) -> None:
     step_key = get_var(BuildkiteEnvVar.BUILDKITE_STEP_KEY)
+    message = f"{step_key}: {failure}"
+    print(message)
     pipeline = {
         "notify": [
             {
                 "slack": {
                     "channels": ["#team-testing-bots"],
-                    "message": f"{step_key}: {failure}",
+                    "message": message,
                 }
             }
         ]

--- a/misc/python/materialize/test_analytics/config/mz_db_config.py
+++ b/misc/python/materialize/test_analytics/config/mz_db_config.py
@@ -14,6 +14,7 @@ class MzDbConfig:
     hostname: str
     username: str
     app_password: str | None
+    application_name: str | None
 
     database: str
     search_path: str

--- a/misc/python/materialize/test_analytics/config/sandbox_db_config.py
+++ b/misc/python/materialize/test_analytics/config/sandbox_db_config.py
@@ -30,4 +30,5 @@ def create_local_dev_config_for_sandbox() -> MzDbConfig:
         database=database,
         search_path=search_path,
         enabled=True,
+        application_name="sandbox",
     )

--- a/misc/python/materialize/test_analytics/config/test_analytics_db_config.py
+++ b/misc/python/materialize/test_analytics/config/test_analytics_db_config.py
@@ -51,4 +51,5 @@ def create_test_analytics_config_with_credentials(
         database=database,
         search_path=search_path,
         enabled=enabled,
+        application_name="test-analytics",
     )

--- a/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
+++ b/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
@@ -70,7 +70,7 @@ class DatabaseConnector:
                 port=self.config.port,
                 ssl_context=ssl.SSLContext(),
                 timeout=timeout_in_seconds,
-                application_name="test-analytics",
+                application_name=self.config.application_name,
             )
         except Exception:
             print(

--- a/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
+++ b/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
@@ -60,7 +60,7 @@ class DatabaseConnector:
         return self.open_connection
 
     def create_connection(
-        self, autocommit: bool = False, timeout_in_seconds: int = 5
+        self, autocommit: bool = False, timeout_in_seconds: int = 60
     ) -> Connection:
         try:
             connection = pg8000.connect(
@@ -70,6 +70,7 @@ class DatabaseConnector:
                 port=self.config.port,
                 ssl_context=ssl.SSLContext(),
                 timeout=timeout_in_seconds,
+                application_name="test-analytics",
             )
         except Exception:
             print(
@@ -86,7 +87,7 @@ class DatabaseConnector:
         connection: Connection | None = None,
         autocommit: bool = False,
         allow_reusing_connection: bool = False,
-        statement_timeout: str = "1s",
+        statement_timeout: str = "60s",
     ) -> Cursor:
         if connection is None:
             if allow_reusing_connection:
@@ -98,6 +99,8 @@ class DatabaseConnector:
         cursor.execute(f"SET database = {self.config.database}")
         cursor.execute(f"SET search_path = {self.config.search_path}")
         cursor.execute(f"SET statement_timeout = '{statement_timeout}'")
+        cursor.execute("SET cluster = 'test_analytics'")
+        cursor.execute("SET transaction_isolation = 'serializable'")
         return cursor
 
     def set_read_only(self) -> None:
@@ -133,9 +136,7 @@ class DatabaseConnector:
         if len(self.update_statements) == 0:
             return
 
-        cursor = self.create_cursor(
-            autocommit=not self._use_transaction, statement_timeout="30s"
-        )
+        cursor = self.create_cursor(autocommit=not self._use_transaction)
 
         self._disable_if_uploads_not_allowed(cursor)
 

--- a/misc/python/stubs/pg8000/__init__.pyi
+++ b/misc/python/stubs/pg8000/__init__.pyi
@@ -46,4 +46,5 @@ def connect(
     password: str | None = ...,
     timeout: int | None = ...,
     ssl_context: SSLContext | None = ...,
+    application_name: str | None = ...,
 ) -> Connection: ...


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
