### PR TITLE
adapter: detect when a serialized ddl deadlock would occur

### DIFF
--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -359,9 +359,6 @@ def run(
         if scenario == Scenario.Rename:
             # TODO(def-): Switch to failing exit code when #28182 is fixed
             os._exit(0)
-        if complexity in (Complexity.DDLOnly, Complexity.DDL):
-            # TODO(def-): Switch to failing exit code when #28400 is fixed
-            os._exit(0)
         if num_threads >= 50:
             # Under high load some queries can't finish quickly, especially UPDATE/DELETE
             os._exit(0)


### PR DESCRIPTION
In some rare cases the serialized ddl lock could be owned by a session and then that session tries to execute another statement without clearing its transaction state (which release the lock). As a workaround, detect this and fail the second statement instead of deadlocking.

This is not a full fix because we should never be entering this state, but will suffice as a workaround and unblock the release.

See #28400

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a