### PR TITLE
fix merge skew

### DIFF
--- a/src/persist-types/BUILD.bazel
+++ b/src/persist-types/BUILD.bazel
@@ -78,7 +78,10 @@ rust_doc_test(
 
 filegroup(
 	name = "all_protos",
-	srcs = ["src/stats.proto"],
+	srcs = [
+		"src/arrow.proto",
+		"src/stats.proto",
+	],
 )
 
 cargo_build_script(


### PR DESCRIPTION
I merged a PR that added a new protobuf file which skewed with the change to introduce `BUILD.bazel` files.

### Motivation

Fix main

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
