### PR TITLE
adapter,compute,controller: attach workload_class label to relevant metrics

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1800,6 +1800,7 @@ impl Coordinator {
                 instance.id,
                 ClusterConfig {
                     arranged_logs: instance.log_indexes.clone(),
+                    workload_class: instance.config.workload_class.clone(),
                 },
             )?;
             for replica in instance.replicas() {

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -376,6 +376,7 @@ impl Coordinator {
                 cluster_id,
                 mz_controller::clusters::ClusterConfig {
                     arranged_logs: cluster.log_indexes.clone(),
+                    workload_class: cluster.config.workload_class.clone(),
                 },
             )
             .expect("creating cluster must not fail");

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -242,7 +242,8 @@ impl Coordinator {
                     cluster_id,
                     new_config,
                     options.replicas,
-                )?;
+                )
+                .await?;
             }
         }
 

--- a/src/adapter/src/coord/sequencer/inner/cluster.rs
+++ b/src/adapter/src/coord/sequencer/inner/cluster.rs
@@ -215,6 +215,7 @@ impl Coordinator {
             )));
         }
 
+        let new_workload_class = new_config.workload_class.clone();
         match (&config.variant, &new_config.variant) {
             (Managed(_), Managed(_)) => {
                 self.sequence_alter_cluster_managed_to_managed(
@@ -244,6 +245,10 @@ impl Coordinator {
                 )?;
             }
         }
+
+        self.controller
+            .update_cluster_workload_class(cluster_id, new_workload_class)?;
+
         Ok(StageResult::Response(ExecuteResponse::AlteredObject(
             ObjectType::Cluster,
         )))

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -25,6 +25,7 @@ use mz_timestamp_oracle::postgres_oracle::PostgresTimestampOracleParameters;
 /// Return the current compute configuration, derived from the system configuration.
 pub fn compute_config(config: &SystemVars) -> ComputeParameters {
     ComputeParameters {
+        workload_class: None,
         max_result_size: Some(config.max_result_size()),
         tracing: tracing_config(config),
         grpc_client: grpc_client_config(config),

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2517,10 +2517,10 @@ pub static MZ_CLUSTER_WORKLOAD_CLASSES: Lazy<BuiltinTable> = Lazy::new(|| Builti
 
 pub const MZ_CLUSTER_WORKLOAD_CLASSES_IND: BuiltinIndex = BuiltinIndex {
     name: "mz_cluster_workload_classes_ind",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     oid: oid::INDEX_MZ_CLUSTER_WORKLOAD_CLASSES_IND_OID,
     sql: "IN CLUSTER mz_catalog_server
-ON mz_catalog.mz_cluster_workload_classes (id)",
+ON mz_internal.mz_cluster_workload_classes (id)",
     is_retained_metrics_object: false,
 };
 

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -76,8 +76,13 @@ message ProtoPeek {
 }
 
 message ProtoComputeParameters {
+    optional ProtoWorkloadClass workload_class = 7;
     optional uint64 max_result_size = 1;
     mz_dyncfg.ConfigUpdates dyncfg_updates = 2;
     mz_tracing.params.ProtoTracingParameters tracing = 5;
     mz_service.params.ProtoGrpcClientParameters grpc_client = 6;
+}
+
+message ProtoWorkloadClass {
+    optional string value = 1;
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -357,12 +357,16 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         info!("Applying configuration update: {params:?}");
 
         let ComputeParameters {
+            workload_class,
             max_result_size,
             tracing,
             grpc_client: _grpc_client,
             dyncfg_updates,
         } = params;
 
+        if let Some(v) = workload_class {
+            self.compute_state.metrics.set_workload_class(v);
+        }
         if let Some(v) = max_result_size {
             self.compute_state.max_result_size = v;
         }

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -51,6 +51,9 @@ pub struct ClusterConfig {
     /// Each logging variant is mapped to the identifier under which to register
     /// the arrangement storing the log's data.
     pub arranged_logs: BTreeMap<LogVariant, GlobalId>,
+    /// An optional arbitrary string that describes the class of the workload
+    /// this cluster is running (e.g., `production` or `staging`).
+    pub workload_class: Option<String>,
 }
 
 /// The status of a cluster.
@@ -330,7 +333,19 @@ where
         config: ClusterConfig,
     ) -> Result<(), anyhow::Error> {
         self.storage.create_instance(id);
-        self.compute.create_instance(id, config.arranged_logs)?;
+        self.compute
+            .create_instance(id, config.arranged_logs, config.workload_class)?;
+        Ok(())
+    }
+
+    /// Updates the workload class for a cluster.
+    pub fn update_cluster_workload_class(
+        &mut self,
+        id: ClusterId,
+        workload_class: Option<String>,
+    ) -> Result<(), anyhow::Error> {
+        self.compute
+            .update_instance_workload_class(id, workload_class)?;
         Ok(())
     }
 


### PR DESCRIPTION
This commit attaches a `workload_class` label whenever a metric is
associated with a workload with a known class (e.g., production,
staging). Relevant metrics are identified as followed:

  * All metrics in a `clusterd` process inherit the workload class of
    the cluster.

  * All metrics in an `environmentd` process that have an `instance_id`
    label inherit the workload class of the identified compute instance
    (cluster).

This will allow us to filter our monitoring based on workload class.

The implementation introduces a new API to the metrics registry called a
"postprocessor", which can mutate the state of all metrics on every call
to `MetricsRegistry::gather`. This was the most efficient implementation
available. In the future, we may want to consider a more explicit
approach of plumbing the `workload_class` label more directly to all
metrics that need it, but that would be an order of magnitude more work
than the approach taken here.

Part of https://github.com/MaterializeInc/materialize/issues/28097.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

This PR has no tests. That's plausibly fine, but not ideal. Let me know if you strongly object to me merging this PR without tests.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
