### PR TITLE
test analytics: add more logging on connection failure

### DIFF
--- a/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
+++ b/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
@@ -62,14 +62,20 @@ class DatabaseConnector:
     def create_connection(
         self, autocommit: bool = False, timeout_in_seconds: int = 5
     ) -> Connection:
-        connection = pg8000.connect(
-            host=self.config.hostname,
-            user=self.config.username,
-            password=self.config.app_password,
-            port=self.config.port,
-            ssl_context=ssl.SSLContext(),
-            timeout=timeout_in_seconds,
-        )
+        try:
+            connection = pg8000.connect(
+                host=self.config.hostname,
+                user=self.config.username,
+                password=self.config.app_password,
+                port=self.config.port,
+                ssl_context=ssl.SSLContext(),
+                timeout=timeout_in_seconds,
+            )
+        except Exception:
+            print(
+                f"Failed to connect to {self.config.hostname} on port {self.config.port}"
+            )
+            raise
 
         connection.autocommit = autocommit
 


### PR DESCRIPTION
Trying to trace down the failure `encoding with 'idna' codec failed` observed in https://buildkite.com/materialize/test/builds/86741#0190e89e-758c-43f7-ae74-1c9191590130:

```
  File "/var/lib/buildkite-agent/builds/buildkite-builders-aarch64-585fc7f-i-0f89f4771e00c06c4-1/materialize/test/misc/python/materialize/test_analytics/connector/test_analytics_connector.py", line 65, in create_connection
    connection = pg8000.connect(
                 ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pg8000/__init__.py", line 111, in connect
    return Connection(
           ^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pg8000/legacy.py", line 443, in __init__
    super().__init__(*args, **kwargs)
  File "/usr/local/lib/python3.11/dist-packages/pg8000/core.py", line 312, in __init__
    self.channel_binding, self._usock = _make_socket(
                                        ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pg8000/core.py", line 199, in _make_socket
    sock = socket.create_connection((host, port), timeout, source_address)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/socket.py", line 827, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/socket.py", line 962, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeError: encoding with 'idna' codec failed (UnicodeError: label empty or too long)
```