### PR TITLE
ore: consolidate `DeleteOnDrop*` metrics types

### DIFF
--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -19,8 +19,8 @@ use mz_ore::cast::CastFrom;
 use mz_ore::metric;
 use mz_ore::metrics::raw::UIntGaugeVec;
 use mz_ore::metrics::{
-    CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, GaugeVec,
-    GaugeVecExt, HistogramVec, HistogramVecExt, IntCounterVec, MetricsRegistry,
+    DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, GaugeVec, HistogramVec,
+    IntCounterVec, MetricVecExt, MetricsRegistry,
 };
 use mz_ore::stats::histogram_seconds_buckets;
 use mz_repr::GlobalId;
@@ -177,33 +177,32 @@ impl ComputeControllerMetrics {
     /// Return an object suitable for tracking metrics for the given compute instance.
     pub fn for_instance(&self, instance_id: ComputeInstanceId) -> InstanceMetrics {
         let labels = vec![instance_id.to_string()];
-        let replica_count = self.replica_count.get_delete_on_drop_gauge(labels.clone());
+        let replica_count = self.replica_count.get_delete_on_drop_metric(labels.clone());
         let collection_count = self
             .collection_count
-            .get_delete_on_drop_gauge(labels.clone());
+            .get_delete_on_drop_metric(labels.clone());
         let collection_unscheduled_count = self
             .collection_unscheduled_count
-            .get_delete_on_drop_gauge(labels.clone());
-        let peek_count = self.peek_count.get_delete_on_drop_gauge(labels.clone());
+            .get_delete_on_drop_metric(labels.clone());
+        let peek_count = self.peek_count.get_delete_on_drop_metric(labels.clone());
         let subscribe_count = self
             .subscribe_count
-            .get_delete_on_drop_gauge(labels.clone());
-        let copy_to_count = self.copy_to_count.get_delete_on_drop_gauge(labels.clone());
+            .get_delete_on_drop_metric(labels.clone());
+        let copy_to_count = self.copy_to_count.get_delete_on_drop_metric(labels.clone());
         let history_command_count = CommandMetrics::build(|typ| {
             let labels = labels.iter().cloned().chain([typ.into()]).collect();
-            self.history_command_count.get_delete_on_drop_gauge(labels)
+            self.history_command_count.get_delete_on_drop_metric(labels)
         });
         let history_dataflow_count = self
             .history_dataflow_count
-            .get_delete_on_drop_gauge(labels.clone());
+            .get_delete_on_drop_metric(labels.clone());
         let peeks_total = PeekMetrics::build(|typ| {
             let labels = labels.iter().cloned().chain([typ.into()]).collect();
-            self.peeks_total.get_delete_on_drop_counter(labels)
+            self.peeks_total.get_delete_on_drop_metric(labels)
         });
         let peek_duration_seconds = PeekMetrics::build(|typ| {
             let labels = labels.iter().cloned().chain([typ.into()]).collect();
-            self.peek_duration_seconds
-                .get_delete_on_drop_histogram(labels)
+            self.peek_duration_seconds.get_delete_on_drop_metric(labels)
         });
 
         InstanceMetrics {
@@ -267,39 +266,39 @@ impl InstanceMetrics {
             let labels = extended_labels(typ);
             self.metrics
                 .commands_total
-                .get_delete_on_drop_counter(labels)
+                .get_delete_on_drop_metric(labels)
         });
         let command_message_bytes_total = CommandMetrics::build(|typ| {
             let labels = extended_labels(typ);
             self.metrics
                 .command_message_bytes_total
-                .get_delete_on_drop_counter(labels)
+                .get_delete_on_drop_metric(labels)
         });
         let responses_total = ResponseMetrics::build(|typ| {
             let labels = extended_labels(typ);
             self.metrics
                 .responses_total
-                .get_delete_on_drop_counter(labels)
+                .get_delete_on_drop_metric(labels)
         });
         let response_message_bytes_total = ResponseMetrics::build(|typ| {
             let labels = extended_labels(typ);
             self.metrics
                 .response_message_bytes_total
-                .get_delete_on_drop_counter(labels)
+                .get_delete_on_drop_metric(labels)
         });
 
         let command_queue_size = self
             .metrics
             .command_queue_size
-            .get_delete_on_drop_gauge(labels.clone());
+            .get_delete_on_drop_metric(labels.clone());
         let response_queue_size = self
             .metrics
             .response_queue_size
-            .get_delete_on_drop_gauge(labels.clone());
+            .get_delete_on_drop_metric(labels.clone());
         let hydration_queue_size = self
             .metrics
             .hydration_queue_size
-            .get_delete_on_drop_gauge(labels.clone());
+            .get_delete_on_drop_metric(labels.clone());
 
         ReplicaMetrics {
             instance_id: self.instance_id,
@@ -324,12 +323,12 @@ impl InstanceMetrics {
             let labels = labels.iter().cloned().chain([typ.into()]).collect();
             self.metrics
                 .history_command_count
-                .get_delete_on_drop_gauge(labels)
+                .get_delete_on_drop_metric(labels)
         });
         let dataflow_count = self
             .metrics
             .history_dataflow_count
-            .get_delete_on_drop_gauge(labels);
+            .get_delete_on_drop_metric(labels);
 
         HistoryMetrics {
             command_counts,
@@ -394,11 +393,11 @@ impl ReplicaMetrics {
         let initial_output_duration_seconds = self
             .metrics
             .dataflow_initial_output_duration_seconds
-            .get_delete_on_drop_gauge(labels.clone());
+            .get_delete_on_drop_metric(labels.clone());
         let wallclock_lag_seconds = self
             .metrics
             .dataflow_wallclock_lag_seconds
-            .get_delete_on_drop_histogram(labels);
+            .get_delete_on_drop_metric(labels);
 
         Some(ReplicaCollectionMetrics {
             initial_output_duration_seconds,

--- a/src/ore/src/metrics.rs
+++ b/src/ore/src/metrics.rs
@@ -153,34 +153,13 @@ impl<M: MakeCollector> MakeCollector for DeleteOnDropWrapper<M> {
     }
 }
 
-impl<M: GaugeVecExt> GaugeVecExt for DeleteOnDropWrapper<M> {
-    type GaugeType = M::GaugeType;
-
-    fn get_delete_on_drop_gauge<'a, L: PromLabelsExt<'a>>(
+impl<M: MetricVecExt> DeleteOnDropWrapper<M> {
+    /// Returns a metric that deletes its labels from this metrics vector when dropped.
+    pub fn get_delete_on_drop_metric<'a, L: PromLabelsExt<'a>>(
         &self,
         labels: L,
-    ) -> DeleteOnDropGauge<'a, Self::GaugeType, L> {
-        self.inner.get_delete_on_drop_gauge(labels)
-    }
-}
-
-impl<M: CounterVecExt> CounterVecExt for DeleteOnDropWrapper<M> {
-    type CounterType = M::CounterType;
-
-    fn get_delete_on_drop_counter<'a, L: PromLabelsExt<'a>>(
-        &self,
-        labels: L,
-    ) -> DeleteOnDropCounter<'a, Self::CounterType, L> {
-        self.inner.get_delete_on_drop_counter(labels)
-    }
-}
-
-impl<M: HistogramVecExt> HistogramVecExt for DeleteOnDropWrapper<M> {
-    fn get_delete_on_drop_histogram<'a, L: PromLabelsExt<'a>>(
-        &self,
-        labels: L,
-    ) -> DeleteOnDropHistogram<'a, L> {
-        self.inner.get_delete_on_drop_histogram(labels)
+    ) -> DeleteOnDropMetric<'a, M, L> {
+        self.inner.get_delete_on_drop_metric(labels)
     }
 }
 

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -24,9 +24,9 @@ use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::instrument;
 use mz_ore::metric;
 use mz_ore::metrics::{
-    raw, ComputedGauge, ComputedIntGauge, ComputedUIntGauge, Counter, CounterVecExt,
-    DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt, IntCounter, MakeCollector,
-    MetricsRegistry, UIntGauge, UIntGaugeVec,
+    raw, ComputedGauge, ComputedIntGauge, ComputedUIntGauge, Counter, DeleteOnDropCounter,
+    DeleteOnDropGauge, IntCounter, MakeCollector, MetricVecExt, MetricsRegistry, UIntGauge,
+    UIntGaugeVec,
 };
 use mz_ore::stats::histogram_seconds_buckets;
 use mz_persist::location::{
@@ -1532,127 +1532,127 @@ impl ShardMetrics {
             shard_id: *shard_id,
             since: shards_metrics
                 .since
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             upper: shards_metrics
                 .upper
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             latest_rollup_size: shards_metrics
                 .encoded_rollup_size
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             encoded_diff_size: shards_metrics
                 .encoded_diff_size
-                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             hollow_batch_count: shards_metrics
                 .hollow_batch_count
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             spine_batch_count: shards_metrics
                 .spine_batch_count
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             batch_part_count: shards_metrics
                 .batch_part_count
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             update_count: shards_metrics
                 .update_count
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             rollup_count: shards_metrics
                 .rollup_count
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             largest_batch_size: shards_metrics
                 .largest_batch_size
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             seqnos_held: shards_metrics
                 .seqnos_held
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             seqnos_since_last_rollup: shards_metrics
                 .seqnos_since_last_rollup
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             gc_seqno_held_parts: shards_metrics
                 .gc_seqno_held_parts
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             gc_live_diffs: shards_metrics
                 .gc_live_diffs
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             gc_finished: shards_metrics
                 .gc_finished
-                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             compaction_applied: shards_metrics
                 .compaction_applied
-                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             cmd_succeeded: shards_metrics
                 .cmd_succeeded
-                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             usage_current_state_batches_bytes: shards_metrics
                 .usage_current_state_batches_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             usage_current_state_rollups_bytes: shards_metrics
                 .usage_current_state_rollups_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             usage_referenced_not_current_state_bytes: shards_metrics
                 .usage_referenced_not_current_state_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             usage_not_leaked_not_referenced_bytes: shards_metrics
                 .usage_not_leaked_not_referenced_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             usage_leaked_bytes: shards_metrics
                 .usage_leaked_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             pubsub_push_diff_applied: shards_metrics
                 .pubsub_push_diff_applied
-                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             pubsub_push_diff_not_applied_stale: shards_metrics
                 .pubsub_push_diff_not_applied_stale
-                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             pubsub_push_diff_not_applied_out_of_order: shards_metrics
                 .pubsub_push_diff_not_applied_out_of_order
-                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             blob_gets: shards_metrics
                 .blob_gets
-                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             blob_sets: shards_metrics
                 .blob_sets
-                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             live_writers: shards_metrics
                 .live_writers
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             unconsolidated_snapshot: shards_metrics
                 .unconsolidated_snapshot
-                .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             backpressure_emitted_bytes: Arc::new(
                 shards_metrics
                     .backpressure_emitted_bytes
-                    .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                    .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             ),
             backpressure_last_backpressured_bytes: Arc::new(
                 shards_metrics
                     .backpressure_last_backpressured_bytes
-                    .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                    .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             ),
             backpressure_retired_bytes: Arc::new(
                 shards_metrics
                     .backpressure_retired_bytes
-                    .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
+                    .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             ),
             rewrite_part_count: shards_metrics
                 .rewrite_part_count
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             inline_part_count: shards_metrics
                 .inline_part_count
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             inline_part_bytes: shards_metrics
                 .inline_part_bytes
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             compact_batches: shards_metrics
                 .compact_batches
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             compacting_batches: shards_metrics
                 .compacting_batches
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             noncompact_batches: shards_metrics
                 .noncompact_batches
-                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard.clone(), name.to_string()]),
             inline_backpressure_count: shards_metrics
                 .inline_backpressure_count
-                .get_delete_on_drop_counter(vec![shard, name.to_string()]),
+                .get_delete_on_drop_metric(vec![shard, name.to_string()]),
         }
     }
 

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_ore::metrics::{CounterVecExt, HistogramVecExt};
+use mz_ore::metrics::MetricVecExt;
 use mz_rocksdb::config::SharedWriteBufferManager;
 use mz_rocksdb::{
     InstanceOptions, KeyUpdate, RocksDBConfig, RocksDBInstance, RocksDBInstanceMetrics,
@@ -22,8 +22,8 @@ fn shared_metrics_for_tests() -> Result<Box<RocksDBSharedMetrics>, anyhow::Error
         HistogramVec::new(HistogramOpts::new("fake", "fake_help"), &["fake_label"])?;
 
     Ok(Box::new(RocksDBSharedMetrics {
-        multi_get_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["one".to_string()]),
-        multi_put_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["four".to_string()]),
+        multi_get_latency: fake_hist_vec.get_delete_on_drop_metric(vec!["one".to_string()]),
+        multi_put_latency: fake_hist_vec.get_delete_on_drop_metric(vec!["four".to_string()]),
     }))
 }
 
@@ -32,14 +32,14 @@ fn instance_metrics_for_tests() -> Result<Box<RocksDBInstanceMetrics>, anyhow::E
         IntCounterVec::new(Opts::new("fake_counter", "fake_help"), &["fake_label"])?;
 
     Ok(Box::new(RocksDBInstanceMetrics {
-        multi_get_size: face_counter_vec.get_delete_on_drop_counter(vec!["two".to_string()]),
+        multi_get_size: face_counter_vec.get_delete_on_drop_metric(vec!["two".to_string()]),
         multi_get_result_count: face_counter_vec
-            .get_delete_on_drop_counter(vec!["three".to_string()]),
+            .get_delete_on_drop_metric(vec!["three".to_string()]),
         multi_get_result_bytes: face_counter_vec
-            .get_delete_on_drop_counter(vec!["four".to_string()]),
-        multi_get_count: face_counter_vec.get_delete_on_drop_counter(vec!["five".to_string()]),
-        multi_put_count: face_counter_vec.get_delete_on_drop_counter(vec!["six".to_string()]),
-        multi_put_size: face_counter_vec.get_delete_on_drop_counter(vec!["seven".to_string()]),
+            .get_delete_on_drop_metric(vec!["four".to_string()]),
+        multi_get_count: face_counter_vec.get_delete_on_drop_metric(vec!["five".to_string()]),
+        multi_put_count: face_counter_vec.get_delete_on_drop_metric(vec!["six".to_string()]),
+        multi_put_size: face_counter_vec.get_delete_on_drop_metric(vec!["seven".to_string()]),
     }))
 }
 

--- a/src/service/src/grpc.rs
+++ b/src/service/src/grpc.rs
@@ -15,7 +15,7 @@ use futures::future;
 use futures::stream::{Stream, StreamExt, TryStreamExt};
 use http::uri::PathAndQuery;
 use mz_ore::metric;
-use mz_ore::metrics::{DeleteOnDropGauge, GaugeVecExt, MetricsRegistry, UIntGaugeVec};
+use mz_ore::metrics::{DeleteOnDropGauge, MetricsRegistry, UIntGaugeVec};
 use mz_ore::netio::{Listener, SocketAddr, SocketAddrType};
 use mz_proto::{ProtoType, RustType};
 use once_cell::sync::Lazy;
@@ -433,7 +433,7 @@ impl GrpcServerMetrics {
         PerGrpcServerMetrics {
             last_command_received: self
                 .last_command_received
-                .get_delete_on_drop_gauge(vec![name]),
+                .get_delete_on_drop_metric(vec![name]),
         }
     }
 }

--- a/src/storage-client/src/metrics.rs
+++ b/src/storage-client/src/metrics.rs
@@ -14,8 +14,7 @@ use std::sync::Arc;
 use mz_ore::cast::{CastFrom, TryCastFrom};
 use mz_ore::metric;
 use mz_ore::metrics::{
-    CounterVecExt, DeleteOnDropCounter, DeleteOnDropHistogram, HistogramVecExt, IntCounterVec,
-    MetricsRegistry,
+    DeleteOnDropCounter, DeleteOnDropHistogram, IntCounterVec, MetricVecExt, MetricsRegistry,
 };
 use mz_ore::stats::HISTOGRAM_BYTE_BUCKETS;
 use mz_service::codec::StatsCollector;
@@ -66,7 +65,7 @@ impl StorageControllerMetrics {
         id: mz_repr::GlobalId,
     ) -> DeleteOnDropCounter<'static, prometheus::core::AtomicU64, Vec<String>> {
         self.regressed_offset_known
-            .get_delete_on_drop_counter(vec![id.to_string()])
+            .get_delete_on_drop_metric(vec![id.to_string()])
     }
 
     pub fn for_instance(&self, id: StorageInstanceId) -> RehydratingStorageClientMetrics {
@@ -75,10 +74,10 @@ impl StorageControllerMetrics {
             inner: Arc::new(RehydratingStorageClientMetricsInner {
                 messages_sent_bytes: self
                     .messages_sent_bytes
-                    .get_delete_on_drop_histogram(labels.clone()),
+                    .get_delete_on_drop_metric(labels.clone()),
                 messages_received_bytes: self
                     .messages_received_bytes
-                    .get_delete_on_drop_histogram(labels),
+                    .get_delete_on_drop_metric(labels),
             }),
         }
     }

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -34,7 +34,7 @@ use mz_ore::channel::{
     instrumented_unbounded_channel, InstrumentedUnboundedReceiver, InstrumentedUnboundedSender,
 };
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, GaugeVecExt};
+use mz_ore::metrics::{DeleteOnDropCounter, MetricVecExt};
 use mz_repr::GlobalId;
 use prometheus::core::AtomicU64;
 
@@ -93,17 +93,17 @@ impl StorageMetrics {
             emitted_bytes: Arc::new(
                 self.upsert_backpressure_defs
                     .emitted_bytes
-                    .get_delete_on_drop_counter(vec![id.to_string(), index.to_string()]),
+                    .get_delete_on_drop_metric(vec![id.to_string(), index.to_string()]),
             ),
             last_backpressured_bytes: Arc::new(
                 self.upsert_backpressure_defs
                     .last_backpressured_bytes
-                    .get_delete_on_drop_gauge(vec![id.to_string(), index.to_string()]),
+                    .get_delete_on_drop_metric(vec![id.to_string(), index.to_string()]),
             ),
             retired_bytes: Arc::new(
                 self.upsert_backpressure_defs
                     .retired_bytes
-                    .get_delete_on_drop_counter(vec![id.to_string(), index.to_string()]),
+                    .get_delete_on_drop_metric(vec![id.to_string(), index.to_string()]),
             ),
         }
     }
@@ -206,7 +206,7 @@ impl StorageMetrics {
             .source_defs
             .channel_metric_defs
             .sends
-            .get_delete_on_drop_counter(vec![
+            .get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 worker_count.to_string(),
@@ -216,7 +216,7 @@ impl StorageMetrics {
             .source_defs
             .channel_metric_defs
             .recvs
-            .get_delete_on_drop_counter(vec![
+            .get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 worker_count.to_string(),

--- a/src/storage/src/metrics/sink/kafka.rs
+++ b/src/storage/src/metrics/sink/kafka.rs
@@ -10,7 +10,7 @@
 //! Metrics for kafka sinks.
 
 use mz_ore::metric;
-use mz_ore::metrics::{DeleteOnDropGauge, GaugeVecExt, IntGaugeVec, MetricsRegistry, UIntGaugeVec};
+use mz_ore::metrics::{DeleteOnDropGauge, IntGaugeVec, MetricsRegistry, UIntGaugeVec};
 use mz_repr::GlobalId;
 use prometheus::core::{AtomicI64, AtomicU64};
 
@@ -207,56 +207,56 @@ impl KafkaSinkMetrics {
         Self {
             rdkafka_msg_cnt: defs
                 .rdkafka_msg_cnt
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_msg_size: defs
                 .rdkafka_msg_size
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_txmsgs: defs
                 .rdkafka_txmsgs
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_txmsg_bytes: defs
                 .rdkafka_txmsg_bytes
-                .get_delete_on_drop_gauge(labels.to_vec()),
-            rdkafka_tx: defs.rdkafka_tx.get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
+            rdkafka_tx: defs.rdkafka_tx.get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_tx_bytes: defs
                 .rdkafka_tx_bytes
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_outbuf_cnt: defs
                 .rdkafka_outbuf_cnt
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_outbuf_msg_cnt: defs
                 .rdkafka_outbuf_msg_cnt
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_waitresp_cnt: defs
                 .rdkafka_waitresp_cnt
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_waitresp_msg_cnt: defs
                 .rdkafka_waitresp_msg_cnt
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_txerrs: defs
                 .rdkafka_txerrs
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_txretries: defs
                 .rdkafka_txretries
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_req_timeouts: defs
                 .rdkafka_req_timeouts
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_connects: defs
                 .rdkafka_connects
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             rdkafka_disconnects: defs
                 .rdkafka_disconnects
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             outstanding_progress_records: defs
                 .outstanding_progress_records
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             consumed_progress_records: defs
                 .consumed_progress_records
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             partition_count: defs
                 .partition_count
-                .get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
         }
     }
 }

--- a/src/storage/src/metrics/source.rs
+++ b/src/storage/src/metrics/source.rs
@@ -16,8 +16,8 @@
 
 use mz_ore::metric;
 use mz_ore::metrics::{
-    CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt, IntCounter, IntCounterVec,
-    IntGaugeVec, MetricsRegistry, UIntGaugeVec,
+    DeleteOnDropCounter, DeleteOnDropGauge, IntCounter, IntCounterVec, IntGaugeVec,
+    MetricsRegistry, UIntGaugeVec,
 };
 use mz_repr::GlobalId;
 use prometheus::core::{AtomicI64, AtomicU64};
@@ -152,19 +152,19 @@ impl SourceMetrics {
             worker_id.to_string(),
         ];
         SourceMetrics {
-            capability: defs.capability.get_delete_on_drop_gauge(labels.to_vec()),
+            capability: defs.capability.get_delete_on_drop_metric(labels.to_vec()),
             resume_upper: defs
                 .resume_upper
-                .get_delete_on_drop_gauge(vec![source_id.to_string()]),
+                .get_delete_on_drop_metric(vec![source_id.to_string()]),
             inmemory_remap_bindings: defs
                 .inmemory_remap_bindings
-                .get_delete_on_drop_gauge(vec![source_id.to_string(), worker_id.to_string()]),
+                .get_delete_on_drop_metric(vec![source_id.to_string(), worker_id.to_string()]),
             commit_upper_ready_times: defs
                 .commit_upper_ready_times
-                .get_delete_on_drop_gauge(vec![source_id.to_string(), worker_id.to_string()]),
+                .get_delete_on_drop_metric(vec![source_id.to_string(), worker_id.to_string()]),
             commit_upper_accepted_times: defs
                 .commit_upper_accepted_times
-                .get_delete_on_drop_gauge(vec![source_id.to_string(), worker_id.to_string()]),
+                .get_delete_on_drop_metric(vec![source_id.to_string(), worker_id.to_string()]),
         }
     }
 }
@@ -191,31 +191,31 @@ impl SourcePersistSinkMetrics {
     ) -> SourcePersistSinkMetrics {
         let shard = shard_id.to_string();
         SourcePersistSinkMetrics {
-            progress: defs.progress.get_delete_on_drop_gauge(vec![
+            progress: defs.progress.get_delete_on_drop_metric(vec![
                 parent_source_id.to_string(),
                 output_index.to_string(),
                 shard.clone(),
                 worker_id.to_string(),
             ]),
-            row_inserts: defs.row_inserts.get_delete_on_drop_counter(vec![
+            row_inserts: defs.row_inserts.get_delete_on_drop_metric(vec![
                 parent_source_id.to_string(),
                 output_index.to_string(),
                 shard.clone(),
                 worker_id.to_string(),
             ]),
-            row_retractions: defs.row_retractions.get_delete_on_drop_counter(vec![
+            row_retractions: defs.row_retractions.get_delete_on_drop_metric(vec![
                 parent_source_id.to_string(),
                 output_index.to_string(),
                 shard.clone(),
                 worker_id.to_string(),
             ]),
-            error_inserts: defs.error_inserts.get_delete_on_drop_counter(vec![
+            error_inserts: defs.error_inserts.get_delete_on_drop_metric(vec![
                 parent_source_id.to_string(),
                 output_index.to_string(),
                 shard.clone(),
                 worker_id.to_string(),
             ]),
-            error_retractions: defs.error_retractions.get_delete_on_drop_counter(vec![
+            error_retractions: defs.error_retractions.get_delete_on_drop_metric(vec![
                 parent_source_id.to_string(),
                 output_index.to_string(),
                 shard.clone(),
@@ -223,7 +223,7 @@ impl SourcePersistSinkMetrics {
             ]),
             processed_batches: defs
                 .persist_sink_processed_batches
-                .get_delete_on_drop_counter(vec![
+                .get_delete_on_drop_metric(vec![
                     parent_source_id.to_string(),
                     output_index.to_string(),
                     shard,
@@ -245,7 +245,7 @@ impl OffsetCommitMetrics {
         OffsetCommitMetrics {
             offset_commit_failures: defs
                 .offset_commit_failures
-                .get_delete_on_drop_counter(vec![source_id.to_string()]),
+                .get_delete_on_drop_metric(vec![source_id.to_string()]),
         }
     }
 }

--- a/src/storage/src/metrics/source/kafka.rs
+++ b/src/storage/src/metrics/source/kafka.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 
 use mz_ore::iter::IteratorExt;
 use mz_ore::metric;
-use mz_ore::metrics::{DeleteOnDropGauge, GaugeVecExt, IntGaugeVec, MetricsRegistry};
+use mz_ore::metrics::{DeleteOnDropGauge, IntGaugeVec, MetricsRegistry};
 use mz_repr::GlobalId;
 use prometheus::core::AtomicI64;
 use tracing::debug;
@@ -57,7 +57,7 @@ impl KafkaSourceMetrics {
                 (
                     *id,
                     defs.partition_offset_max
-                        .get_delete_on_drop_gauge(labels.to_vec()),
+                        .get_delete_on_drop_metric(labels.to_vec()),
                 )
             })),
             labels: vec![topic.clone(), source_id.to_string()],
@@ -79,7 +79,7 @@ impl KafkaSourceMetrics {
         self.partition_offset_map
             .entry(id)
             .or_insert_with_key(|id| {
-                self.defs.partition_offset_max.get_delete_on_drop_gauge(
+                self.defs.partition_offset_max.get_delete_on_drop_metric(
                     self.labels
                         .iter()
                         .cloned()

--- a/src/storage/src/metrics/source/mysql.rs
+++ b/src/storage/src/metrics/source/mysql.rs
@@ -14,8 +14,7 @@ use std::sync::Mutex;
 
 use mz_ore::metric;
 use mz_ore::metrics::{
-    CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVec, GaugeVecExt, IntCounterVec,
-    MetricsRegistry, UIntGaugeVec,
+    DeleteOnDropCounter, DeleteOnDropGauge, GaugeVec, IntCounterVec, MetricsRegistry, UIntGaugeVec,
 };
 use mz_repr::GlobalId;
 use prometheus::core::{AtomicF64, AtomicU64};
@@ -93,17 +92,17 @@ impl MySqlSourceMetrics {
     pub(crate) fn new(defs: &MySqlSourceMetricDefs, source_id: GlobalId) -> Self {
         let labels = &[source_id.to_string()];
         Self {
-            inserts: defs.insert_rows.get_delete_on_drop_counter(labels.to_vec()),
-            updates: defs.update_rows.get_delete_on_drop_counter(labels.to_vec()),
-            deletes: defs.delete_rows.get_delete_on_drop_counter(labels.to_vec()),
+            inserts: defs.insert_rows.get_delete_on_drop_metric(labels.to_vec()),
+            updates: defs.update_rows.get_delete_on_drop_metric(labels.to_vec()),
+            deletes: defs.delete_rows.get_delete_on_drop_metric(labels.to_vec()),
             ignored: defs
                 .ignored_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             total: defs
                 .total_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
-            tables: defs.tables.get_delete_on_drop_gauge(labels.to_vec()),
-            gtid_txids: defs.gtid_txids.get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
+            tables: defs.tables.get_delete_on_drop_metric(labels.to_vec()),
+            gtid_txids: defs.gtid_txids.get_delete_on_drop_metric(labels.to_vec()),
             snapshot_metrics: MySqlSnapshotMetrics {
                 source_id,
                 gauges: Default::default(),
@@ -147,11 +146,10 @@ impl MySqlSnapshotMetrics {
         schema: String,
         latency: f64,
     ) {
-        let latency_gauge = self.defs.table_count_latency.get_delete_on_drop_gauge(vec![
-            self.source_id.to_string(),
-            table_name,
-            schema,
-        ]);
+        let latency_gauge = self
+            .defs
+            .table_count_latency
+            .get_delete_on_drop_metric(vec![self.source_id.to_string(), table_name, schema]);
         latency_gauge.set(latency);
         self.gauges.lock().expect("poisoned").push(latency_gauge)
     }

--- a/src/storage/src/metrics/source/postgres.rs
+++ b/src/storage/src/metrics/source/postgres.rs
@@ -11,8 +11,7 @@
 
 use mz_ore::metric;
 use mz_ore::metrics::{
-    CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVec, GaugeVecExt, IntCounterVec,
-    MetricsRegistry, UIntGaugeVec,
+    DeleteOnDropCounter, DeleteOnDropGauge, GaugeVec, IntCounterVec, MetricsRegistry, UIntGaugeVec,
 };
 use mz_repr::GlobalId;
 use prometheus::core::{AtomicF64, AtomicU64};
@@ -102,11 +101,14 @@ impl PgSnapshotMetrics {
         latency: f64,
         strict: bool,
     ) {
-        let latency_gauge = self.defs.table_count_latency.get_delete_on_drop_gauge(vec![
-            self.source_id.to_string(),
-            table_name,
-            strict.to_string(),
-        ]);
+        let latency_gauge = self
+            .defs
+            .table_count_latency
+            .get_delete_on_drop_metric(vec![
+                self.source_id.to_string(),
+                table_name,
+                strict.to_string(),
+            ]);
         latency_gauge.set(latency);
         self.gauges.lock().expect("poisoned").push(latency_gauge)
     }
@@ -133,26 +135,24 @@ impl PgSourceMetrics {
         Self {
             inserts: defs
                 .insert_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             updates: defs
                 .update_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             deletes: defs
                 .delete_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             ignored: defs
                 .ignored_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
             total: defs
                 .total_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
-            transactions: defs
-                .transactions
-                .get_delete_on_drop_counter(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
+            transactions: defs.transactions.get_delete_on_drop_metric(labels.to_vec()),
             tables: defs
                 .tables_in_publication
-                .get_delete_on_drop_gauge(labels.to_vec()),
-            lsn: defs.wal_lsn.get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_metric(labels.to_vec()),
+            lsn: defs.wal_lsn.get_delete_on_drop_metric(labels.to_vec()),
             snapshot_metrics: PgSnapshotMetrics {
                 source_id,
                 gauges: Default::default(),

--- a/src/storage/src/metrics/upsert.rs
+++ b/src/storage/src/metrics/upsert.rs
@@ -14,8 +14,8 @@ use std::sync::{Arc, Mutex, Weak};
 
 use mz_ore::metric;
 use mz_ore::metrics::{
-    CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, GaugeVec,
-    GaugeVecExt, HistogramVec, HistogramVecExt, IntCounterVec, MetricsRegistry, UIntGaugeVec,
+    DeleteOnDropCounter, DeleteOnDropGauge, DeleteOnDropHistogram, GaugeVec, HistogramVec,
+    IntCounterVec, MetricsRegistry, UIntGaugeVec,
 };
 use mz_ore::stats::histogram_seconds_buckets;
 use mz_repr::GlobalId;
@@ -292,10 +292,10 @@ impl UpsertMetricDefs {
             mz_rocksdb::RocksDBSharedMetrics {
                 multi_get_latency: self
                     .rocksdb_multi_get_latency
-                    .get_delete_on_drop_histogram(vec![source_id.clone()]),
+                    .get_delete_on_drop_metric(vec![source_id.clone()]),
                 multi_put_latency: self
                     .rocksdb_multi_put_latency
-                    .get_delete_on_drop_histogram(vec![source_id.clone()]),
+                    .get_delete_on_drop_metric(vec![source_id.clone()]),
             }
         };
 
@@ -322,13 +322,13 @@ impl UpsertSharedMetrics {
         UpsertSharedMetrics {
             merge_snapshot_latency: metrics
                 .merge_snapshot_latency
-                .get_delete_on_drop_histogram(vec![source_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id.clone()]),
             multi_get_latency: metrics
                 .multi_get_latency
-                .get_delete_on_drop_histogram(vec![source_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id.clone()]),
             multi_put_latency: metrics
                 .multi_put_latency
-                .get_delete_on_drop_histogram(vec![source_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id.clone()]),
         }
     }
 }
@@ -410,73 +410,73 @@ impl UpsertMetrics {
         Self {
             rehydration_latency: defs
                 .rehydration_latency
-                .get_delete_on_drop_gauge(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             rehydration_total: defs
                 .rehydration_total
-                .get_delete_on_drop_gauge(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             rehydration_updates: defs
                 .rehydration_updates
-                .get_delete_on_drop_gauge(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             rocksdb_autospill_in_use: Arc::new(
                 defs.rocksdb_autospill_in_use
-                    .get_delete_on_drop_gauge(vec![source_id_s.clone(), worker_id.clone()]),
+                    .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             ),
             merge_snapshot_updates: defs
                 .merge_snapshot_updates
-                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             merge_snapshot_inserts: defs
                 .merge_snapshot_inserts
-                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             merge_snapshot_deletes: defs
                 .merge_snapshot_deletes
-                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             upsert_inserts: defs
                 .upsert_inserts
-                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             upsert_updates: defs
                 .upsert_updates
-                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             upsert_deletes: defs
                 .upsert_deletes
-                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             multi_get_size: defs
                 .multi_get_size
-                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             multi_get_result_count: defs
                 .multi_get_result_count
-                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             multi_get_result_bytes: defs
                 .multi_get_result_bytes
-                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
             multi_put_size: defs
                 .multi_put_size
-                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
 
             legacy_value_errors: defs
                 .legacy_value_errors
-                .get_delete_on_drop_gauge(vec![source_id_s.clone(), worker_id.clone()]),
+                .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
 
             shared: defs.shared(&source_id),
             rocksdb_shared: defs.rocksdb_shared(&source_id),
             rocksdb_instance_metrics: Arc::new(RocksDBInstanceMetrics {
                 multi_get_size: defs
                     .rocksdb_multi_get_size
-                    .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                    .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
                 multi_get_result_count: defs
                     .rocksdb_multi_get_result_count
-                    .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                    .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
                 multi_get_result_bytes: defs
                     .rocksdb_multi_get_result_bytes
-                    .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                    .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
                 multi_get_count: defs
                     .rocksdb_multi_get_count
-                    .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                    .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
                 multi_put_count: defs
                     .rocksdb_multi_put_count
-                    .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                    .get_delete_on_drop_metric(vec![source_id_s.clone(), worker_id.clone()]),
                 multi_put_size: defs
                     .rocksdb_multi_put_size
-                    .get_delete_on_drop_counter(vec![source_id_s, worker_id]),
+                    .get_delete_on_drop_metric(vec![source_id_s, worker_id]),
             }),
             _backpressure_metrics: backpressure_metrics,
         }

--- a/src/storage/src/statistics.rs
+++ b/src/storage/src/statistics.rs
@@ -29,8 +29,8 @@ use std::time::Instant;
 
 use mz_ore::metric;
 use mz_ore::metrics::{
-    CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt, IntCounterVec, IntGaugeVec,
-    MetricsRegistry, UIntGaugeVec,
+    DeleteOnDropCounter, DeleteOnDropGauge, IntCounterVec, IntGaugeVec, MetricsRegistry,
+    UIntGaugeVec,
 };
 use mz_repr::{GlobalId, Timestamp};
 use mz_storage_client::statistics::{Gauge, SinkStatisticsUpdate, SourceStatisticsUpdate};
@@ -179,47 +179,47 @@ impl SourceStatisticsMetrics {
         };
 
         SourceStatisticsMetrics {
-            snapshot_committed: defs.snapshot_committed.get_delete_on_drop_gauge(vec![
+            snapshot_committed: defs.snapshot_committed.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 parent_source_id.to_string(),
                 shard.clone(),
             ]),
-            messages_received: defs.messages_received.get_delete_on_drop_counter(vec![
+            messages_received: defs.messages_received.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 parent_source_id.to_string(),
             ]),
-            updates_staged: defs.updates_staged.get_delete_on_drop_counter(vec![
-                id.to_string(),
-                worker_id.to_string(),
-                parent_source_id.to_string(),
-                shard.clone(),
-            ]),
-            updates_committed: defs.updates_committed.get_delete_on_drop_counter(vec![
+            updates_staged: defs.updates_staged.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 parent_source_id.to_string(),
                 shard.clone(),
             ]),
-            bytes_received: defs.bytes_received.get_delete_on_drop_counter(vec![
-                id.to_string(),
-                worker_id.to_string(),
-                parent_source_id.to_string(),
-            ]),
-            bytes_indexed: defs.bytes_indexed.get_delete_on_drop_gauge(vec![
+            updates_committed: defs.updates_committed.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 parent_source_id.to_string(),
                 shard.clone(),
             ]),
-            records_indexed: defs.records_indexed.get_delete_on_drop_gauge(vec![
+            bytes_received: defs.bytes_received.get_delete_on_drop_metric(vec![
+                id.to_string(),
+                worker_id.to_string(),
+                parent_source_id.to_string(),
+            ]),
+            bytes_indexed: defs.bytes_indexed.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 parent_source_id.to_string(),
                 shard.clone(),
             ]),
-            envelope_state_tombstones: defs.envelope_state_tombstones.get_delete_on_drop_gauge(
+            records_indexed: defs.records_indexed.get_delete_on_drop_metric(vec![
+                id.to_string(),
+                worker_id.to_string(),
+                parent_source_id.to_string(),
+                shard.clone(),
+            ]),
+            envelope_state_tombstones: defs.envelope_state_tombstones.get_delete_on_drop_metric(
                 vec![
                     id.to_string(),
                     worker_id.to_string(),
@@ -227,29 +227,29 @@ impl SourceStatisticsMetrics {
                     shard.clone(),
                 ],
             ),
-            rehydration_latency_ms: defs.rehydration_latency_ms.get_delete_on_drop_gauge(vec![
+            rehydration_latency_ms: defs.rehydration_latency_ms.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 parent_source_id.to_string(),
                 shard.clone(),
                 envelope.to_string(),
             ]),
-            offset_known: defs.offset_known.get_delete_on_drop_gauge(vec![
+            offset_known: defs.offset_known.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 parent_source_id.to_string(),
             ]),
-            offset_committed: defs.offset_committed.get_delete_on_drop_gauge(vec![
+            offset_committed: defs.offset_committed.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 parent_source_id.to_string(),
             ]),
-            snapshot_records_known: defs.snapshot_records_known.get_delete_on_drop_gauge(vec![
+            snapshot_records_known: defs.snapshot_records_known.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 parent_source_id.to_string(),
             ]),
-            snapshot_records_staged: defs.snapshot_records_staged.get_delete_on_drop_gauge(vec![
+            snapshot_records_staged: defs.snapshot_records_staged.get_delete_on_drop_metric(vec![
                 id.to_string(),
                 worker_id.to_string(),
                 parent_source_id.to_string(),
@@ -313,16 +313,16 @@ impl SinkStatisticsMetrics {
         SinkStatisticsMetrics {
             messages_staged: defs
                 .messages_staged
-                .get_delete_on_drop_counter(vec![id.to_string(), worker_id.to_string()]),
+                .get_delete_on_drop_metric(vec![id.to_string(), worker_id.to_string()]),
             messages_committed: defs
                 .messages_committed
-                .get_delete_on_drop_counter(vec![id.to_string(), worker_id.to_string()]),
+                .get_delete_on_drop_metric(vec![id.to_string(), worker_id.to_string()]),
             bytes_staged: defs
                 .bytes_staged
-                .get_delete_on_drop_counter(vec![id.to_string(), worker_id.to_string()]),
+                .get_delete_on_drop_metric(vec![id.to_string(), worker_id.to_string()]),
             bytes_committed: defs
                 .bytes_committed
-                .get_delete_on_drop_counter(vec![id.to_string(), worker_id.to_string()]),
+                .get_delete_on_drop_metric(vec![id.to_string(), worker_id.to_string()]),
         }
     }
 }


### PR DESCRIPTION
This PR cleans up the implementation of the delete-on-drop metrics by replacing the previous three specialized implementations (`DeleteOnDropCounter`, `DeleteOnDropGauge`, `DeleteOnDropHistogram`) with a single `DeleteOnDropMetric` type. The previous three types still exist but are now aliases that pin the concrete `MetricVec` type of the `DeleteOnDropMetric`.

The result is less redundancy in the implementation of the delete-on-drop wrappers, and more uniformity at the usage sites.

### Motivation

   * This PR refactors existing code.

This is originally motivated by the #28097 work, for which I wanted to add a way to change the labels of delete-on-drop metrics and was annoyed by having to implement that functionality three times, for each of the three `DeleteOnDrop*` types. We are using a different approach that doesn't require replacement of labels anymore, but I think this refactor is still an improvement.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
