### PR TITLE
test-analytics: Run SETs only once per connection

### DIFF
--- a/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
+++ b/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
@@ -83,7 +83,6 @@ class DatabaseConnector:
         connection.run(f"SET database = {self.config.database}")
         connection.run(f"SET search_path = {self.config.search_path}")
         connection.run("SET cluster = 'test_analytics'")
-        connection.run("SET transaction_isolation = 'serializable'")
         connection.autocommit = autocommit
 
         return connection

--- a/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
+++ b/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
@@ -60,7 +60,9 @@ class DatabaseConnector:
         return self.open_connection
 
     def create_connection(
-        self, autocommit: bool = False, timeout_in_seconds: int = 60
+        self,
+        autocommit: bool = False,
+        timeout_in_seconds: int = 60,
     ) -> Connection:
         try:
             connection = pg8000.connect(
@@ -78,6 +80,10 @@ class DatabaseConnector:
             )
             raise
 
+        connection.run(f"SET database = {self.config.database}")
+        connection.run(f"SET search_path = {self.config.search_path}")
+        connection.run("SET cluster = 'test_analytics'")
+        connection.run("SET transaction_isolation = 'serializable'")
         connection.autocommit = autocommit
 
         return connection
@@ -96,11 +102,7 @@ class DatabaseConnector:
                 connection = self.create_connection(autocommit=autocommit)
 
         cursor = connection.cursor()
-        cursor.execute(f"SET database = {self.config.database}")
-        cursor.execute(f"SET search_path = {self.config.search_path}")
         cursor.execute(f"SET statement_timeout = '{statement_timeout}'")
-        cursor.execute("SET cluster = 'test_analytics'")
-        cursor.execute("SET transaction_isolation = 'serializable'")
         return cursor
 
     def set_read_only(self) -> None:

--- a/misc/python/materialize/test_analytics/data/base_data_storage.py
+++ b/misc/python/materialize/test_analytics/data/base_data_storage.py
@@ -24,7 +24,7 @@ class BaseDataStorage:
         self,
         query: str,
         verbose: bool = True,
-        statement_timeout: str = "1s",
+        statement_timeout: str = "60s",
     ) -> Sequence[Sequence[Any]]:
         cursor = self.database_connector.create_cursor(
             allow_reusing_connection=True, statement_timeout=statement_timeout


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
