### PR TITLE
catalog: fix v61 migration

### DIFF
--- a/src/catalog/src/durable/upgrade/v60_to_v61.rs
+++ b/src/catalog/src/durable/upgrade/v60_to_v61.rs
@@ -7,12 +7,79 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use mz_proto::wire_compatible;
+use mz_proto::wire_compatible::WireCompatible;
+
 use crate::durable::upgrade::MigrationAction;
 use crate::durable::upgrade::{objects_v60 as v60, objects_v61 as v61};
 
-/// No-op migration. In v61, we added a new optional field to `ClusterConfig`.
+wire_compatible!(v60::ClusterKey with v61::ClusterKey);
+wire_compatible!(v60::RoleId with v61::RoleId);
+wire_compatible!(v60::MzAclItem with v61::MzAclItem);
+wire_compatible!(v60::cluster_config::ManagedCluster with v61::cluster_config::ManagedCluster);
+
+/// In v61, we added a new optional `workload_class` field to `ClusterConfig`.
 pub fn upgrade(
-    _snapshot: Vec<v60::StateUpdateKind>,
+    snapshot: Vec<v60::StateUpdateKind>,
 ) -> Vec<MigrationAction<v60::StateUpdateKind, v61::StateUpdateKind>> {
-    Vec::new()
+    snapshot
+        .into_iter()
+        .filter_map(|update| {
+            let v60::state_update_kind::Kind::Cluster(v60::state_update_kind::Cluster {
+                key,
+                value,
+            }) = update.kind.as_ref().expect("missing field")
+            else {
+                return None;
+            };
+
+            let old = v60::StateUpdateKind {
+                kind: Some(v60::state_update_kind::Kind::Cluster(
+                    v60::state_update_kind::Cluster {
+                        key: key.clone(),
+                        value: value.clone(),
+                    },
+                )),
+            };
+
+            let new = v61::StateUpdateKind {
+                kind: Some(v61::state_update_kind::Kind::Cluster(
+                    v61::state_update_kind::Cluster {
+                        key: key.as_ref().map(WireCompatible::convert),
+                        value: value.as_ref().map(|old_val| v61::ClusterValue {
+                            name: old_val.name.clone(),
+                            owner_id: old_val.owner_id.as_ref().map(WireCompatible::convert),
+                            privileges: old_val
+                                .privileges
+                                .iter()
+                                .map(WireCompatible::convert)
+                                .collect(),
+                            config: old_val
+                                .config
+                                .as_ref()
+                                .map(|old_config| v61::ClusterConfig {
+                                    workload_class: None,
+                                    variant: old_config.variant.as_ref().map(
+                                        |variant| match variant {
+                                            v60::cluster_config::Variant::Unmanaged(_) => {
+                                                v61::cluster_config::Variant::Unmanaged(
+                                                    v61::Empty {},
+                                                )
+                                            }
+                                            v60::cluster_config::Variant::Managed(c) => {
+                                                v61::cluster_config::Variant::Managed(
+                                                    WireCompatible::convert(c),
+                                                )
+                                            }
+                                        },
+                                    ),
+                                }),
+                        }),
+                    },
+                )),
+            };
+
+            Some(MigrationAction::Update(old, new))
+        })
+        .collect()
 }


### PR DESCRIPTION
Having a no-op migration was wrong, we need to explicitly change all cluster entries in the catalog to have the `workload_class` field.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/28519

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
