### PR TITLE
[persist] Avoid re-encoding structured data when possible

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -752,32 +752,16 @@ impl<K: Codec, V: Codec, T: Timestamp + Lattice + Codec64, D> FetchedPart<K, V, 
                     validate_structured: true,
                 },
             ) => {
-                let maybe_key = structured
-                    .key
-                    .as_ref()
-                    .map(|col| {
-                        let decoder = Schema2::decoder_any(schemas.key.as_ref(), col)?;
-                        Ok::<_, anyhow::Error>(Arc::new(decoder))
-                    })
-                    .transpose();
-                let key = match maybe_key {
-                    Ok(key) => key,
+                let key = match Schema2::decoder_any(schemas.key.as_ref(), &*structured.key) {
+                    Ok(key) => Some(Arc::new(key)),
                     Err(err) => {
                         tracing::error!(?err, "failed to create key decoder");
                         None
                     }
                 };
 
-                let maybe_val = structured
-                    .val
-                    .as_ref()
-                    .map(|col| {
-                        let decoder = Schema2::decoder_any(schemas.val.as_ref(), col)?;
-                        Ok::<_, anyhow::Error>(Arc::new(decoder))
-                    })
-                    .transpose();
-                let val = match maybe_val {
-                    Ok(val) => val,
+                let val = match Schema2::decoder_any(schemas.val.as_ref(), &*structured.val) {
+                    Ok(val) => Some(Arc::new(val)),
                     Err(err) => {
                         tracing::error!(?err, "failed to create val decoder");
                         None

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -12,9 +12,8 @@
 
 use std::fmt;
 use std::mem::size_of;
-use std::sync::Arc;
 
-use ::arrow::array::{Array, AsArray, BinaryArray, BinaryBuilder, Int64Array};
+use ::arrow::array::{Array, ArrayRef, AsArray, BinaryArray, BinaryBuilder, Int64Array};
 use ::arrow::buffer::OffsetBuffer;
 use ::arrow::datatypes::ToByteSlice;
 use bytes::Bytes;
@@ -466,20 +465,26 @@ impl ColumnarRecords {
 /// which we interface with via Arrow.
 ///
 /// [`Codec`]: mz_persist_types::Codec
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ColumnarRecordsStructuredExt {
     /// The structured `k` column.
     ///
     /// [`arrow`] does not allow empty [`StructArray`]s so we model an empty `key` column as None.
     ///
     /// [`StructArray`]: ::arrow::array::StructArray
-    pub key: Option<Arc<dyn Array>>,
+    pub key: ArrayRef,
     /// The structured `v` column.
     ///
     /// [`arrow`] does not allow empty [`StructArray`]s so we model an empty `val` column as None.
     ///
     /// [`StructArray`]: ::arrow::array::StructArray
-    pub val: Option<Arc<dyn Array>>,
+    pub val: ArrayRef,
+}
+
+impl PartialEq for ColumnarRecordsStructuredExt {
+    fn eq(&self, other: &Self) -> bool {
+        *self.key == *other.key && *self.val == *other.val
+    }
 }
 
 #[cfg(test)]

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -111,6 +111,11 @@ impl ColumnarRecords {
         &self.key_data
     }
 
+    /// The vals in this columnar records as an array.
+    pub fn vals(&self) -> &BinaryArray {
+        &self.val_data
+    }
+
     /// The number of logical bytes in the represented data, excluding offsets
     /// and lengths.
     pub fn goodbytes(&self) -> usize {


### PR DESCRIPTION
- Add a couple codec-to-structured helpers.
- Remove an unnecessary option. (In practice data written to `ColumnarRecordsStructuredExt` is always `Some`.)
- Use the new helpers in `encode_updates`, avoiding some unnecessary re-encoding of data.

### Motivation

Support for #24830 - aside from the modest amount of work this currently saves, it's needed to avoid re-encoding structured data here once compaction is producing it directly.

### Tips for reviewer

`schema2_to_codec` is not used in this PR, but it's useful for roundtrip testing and for the next step in the migration - when the structured data becomes the canonical representation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
