### PR TITLE
catalog: Add env arg to trigger builtin migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4348,6 +4348,7 @@ dependencies = [
  "bytes",
  "bytesize",
  "chrono",
+ "clap",
  "derivative",
  "differential-dataflow",
  "fail",

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1918,7 +1918,7 @@ mod tests {
     use uuid::Uuid;
 
     use mz_catalog::builtin::{
-        Builtin, BuiltinType, BUILTINS,
+        Builtin, BuiltinType, DangerousTableFingerprintWhitespace, BUILTINS,
         REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE,
     };
     use mz_catalog::durable::{CatalogError, DurableCatalogError};
@@ -3199,7 +3199,7 @@ mod tests {
                 REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE
                     .lock()
                     .expect("lock poisoned");
-            *guard = Some("\n".to_string());
+            *guard = Some((DangerousTableFingerprintWhitespace::All, "\n".to_string()));
         }
         {
             let catalog = Catalog::open_debug_catalog(persist_client, organization_id)

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1918,8 +1918,8 @@ mod tests {
     use uuid::Uuid;
 
     use mz_catalog::builtin::{
-        Builtin, BuiltinType, DangerousTableFingerprintWhitespace, BUILTINS,
-        REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE,
+        Builtin, BuiltinType, UnsafeBuiltinTableFingerprintWhitespace, BUILTINS,
+        UNSAFE_DO_NOT_CALL_THIS_IN_PRODUCTION_BUILTIN_TABLE_FINGERPRINT_WHITESPACE,
     };
     use mz_catalog::durable::{CatalogError, DurableCatalogError};
     use mz_catalog::SYSTEM_CONN_ID;
@@ -3196,10 +3196,13 @@ mod tests {
         // Forcibly migrate all tables.
         {
             let mut guard =
-                REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE
+                UNSAFE_DO_NOT_CALL_THIS_IN_PRODUCTION_BUILTIN_TABLE_FINGERPRINT_WHITESPACE
                     .lock()
                     .expect("lock poisoned");
-            *guard = Some((DangerousTableFingerprintWhitespace::All, "\n".to_string()));
+            *guard = Some((
+                UnsafeBuiltinTableFingerprintWhitespace::All,
+                "\n".to_string(),
+            ));
         }
         {
             let catalog = Catalog::open_debug_catalog(persist_client, organization_id)

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1.68"
 bytes = { version = "1.3.0", features = ["serde"] }
 bytesize = "1.1.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
+clap = { version = "3.2.24", features = ["derive"] }
 derivative = "2.2.0"
 differential-dataflow = "0.12.0"
 fail = { version = "0.5.1", features = ["failpoints"] }
@@ -49,6 +50,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.9" }
 postgres-openssl = { version = "0.5.0" }
+rand = "0.8.5"
 semver = { version = "1.0.16" }
 serde = "1.0.152"
 serde_json = "1.0.89"
@@ -65,7 +67,6 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 base64 = "0.13.1"
 insta = "1.32"
 mz-postgres-util = { path = "../postgres-util" }
-rand = "0.8.5"
 similar-asserts = "1.4"
 tokio = { version = "1.38.0" }
 tokio-postgres = { version = "0.7.8" }

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -29,6 +29,7 @@ use std::hash::Hash;
 use std::string::ToString;
 use std::sync::Mutex;
 
+use clap::clap_derive::ArgEnum;
 use mz_compute_client::logging::{ComputeLog, DifferentialLog, LogVariant, TimelyLog};
 use mz_pgrepr::oid;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
@@ -55,6 +56,7 @@ use mz_storage_client::healthcheck::{
 };
 use mz_storage_client::statistics::{MZ_SINK_STATISTICS_RAW_DESC, MZ_SOURCE_STATISTICS_RAW_DESC};
 use once_cell::sync::Lazy;
+use rand::Rng;
 use serde::Serialize;
 
 use crate::durable::objects::SystemObjectDescription;
@@ -277,12 +279,17 @@ impl Fingerprint for &BuiltinLog {
 }
 
 /// Allows tests to inject arbitrary amounts of whitespace to forcibly change the fingerprint and
-/// trigger a builtin migration. Ideally this would be guarded by a `#[cfg(test)]` but unfortunately,
-/// the builtin migrations are in a different crate and would not be able to modify this value.
-/// There is an open issue to move builtin migrations to this crate:
-/// <https://github.com/MaterializeInc/materialize/issues/22593>
+/// trigger a builtin migration.
+#[derive(Debug, Clone, ArgEnum)]
+pub enum DangerousTableFingerprintWhitespace {
+    /// Inject whitespace into all builtin table fingerprints.
+    All,
+    /// Inject whitespace into half of the builtin table fingerprints,
+    /// which are randomly selected.
+    Half,
+}
 pub static REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE: Mutex<
-    Option<String>,
+    Option<(DangerousTableFingerprintWhitespace, String)>,
 > = Mutex::new(None);
 
 impl Fingerprint for &BuiltinTable {
@@ -292,10 +299,20 @@ impl Fingerprint for &BuiltinTable {
         let guard = REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE
             .lock()
             .expect("lock poisoned");
-        if let Some(whitespace) = &*guard {
-            format!("{}{}", self.desc.fingerprint(), whitespace)
-        } else {
-            self.desc.fingerprint()
+        match &*guard {
+            Some((DangerousTableFingerprintWhitespace::All, whitespace)) => {
+                format!("{}{}", self.desc.fingerprint(), whitespace)
+            }
+            Some((DangerousTableFingerprintWhitespace::Half, whitespace)) => {
+                let mut rng = rand::thread_rng();
+                let migrate: bool = rng.gen();
+                if migrate {
+                    format!("{}{}", self.desc.fingerprint(), whitespace)
+                } else {
+                    self.desc.fingerprint()
+                }
+            }
+            None => self.desc.fingerprint(),
         }
     }
 }

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -281,29 +281,29 @@ impl Fingerprint for &BuiltinLog {
 /// Allows tests to inject arbitrary amounts of whitespace to forcibly change the fingerprint and
 /// trigger a builtin migration.
 #[derive(Debug, Clone, ArgEnum)]
-pub enum DangerousTableFingerprintWhitespace {
+pub enum UnsafeBuiltinTableFingerprintWhitespace {
     /// Inject whitespace into all builtin table fingerprints.
     All,
     /// Inject whitespace into half of the builtin table fingerprints,
     /// which are randomly selected.
     Half,
 }
-pub static REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE: Mutex<
-    Option<(DangerousTableFingerprintWhitespace, String)>,
+pub static UNSAFE_DO_NOT_CALL_THIS_IN_PRODUCTION_BUILTIN_TABLE_FINGERPRINT_WHITESPACE: Mutex<
+    Option<(UnsafeBuiltinTableFingerprintWhitespace, String)>,
 > = Mutex::new(None);
 
 impl Fingerprint for &BuiltinTable {
     fn fingerprint(&self) -> String {
         // This is only called during bootstrapping, so it's not that big of a deal to lock a mutex,
         // though it's not great.
-        let guard = REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE
+        let guard = UNSAFE_DO_NOT_CALL_THIS_IN_PRODUCTION_BUILTIN_TABLE_FINGERPRINT_WHITESPACE
             .lock()
             .expect("lock poisoned");
         match &*guard {
-            Some((DangerousTableFingerprintWhitespace::All, whitespace)) => {
+            Some((UnsafeBuiltinTableFingerprintWhitespace::All, whitespace)) => {
                 format!("{}{}", self.desc.fingerprint(), whitespace)
             }
-            Some((DangerousTableFingerprintWhitespace::Half, whitespace)) => {
+            Some((UnsafeBuiltinTableFingerprintWhitespace::Half, whitespace)) => {
                 let mut rng = rand::thread_rng();
                 let migrate: bool = rng.gen();
                 if migrate {

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -556,7 +556,7 @@ pub struct Args {
     #[clap(long, arg_enum, requires = "unsafe-mode")]
     unsafe_builtin_table_fingerprint_whitespace: Option<UnsafeBuiltinTableFingerprintWhitespace>,
     /// Controls the amount of whitespace injected by
-    /// `really_dangerous_do_not_call_this_in_production_table_fingerprint_whitespace`.
+    /// `unsafe_builtin_table_fingerprint_whitespace`.
     /// Incrementing this value can allow triggering multiple builtin
     /// migrations from a single test. This argument is meant for testing only
     /// and as the names suggests should not be set in production.

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -550,7 +550,7 @@ pub struct Args {
     /// Injects arbitrary whitespace into builtin table fingerprints, which can
     /// trigger builtin item migrations. The amount of whitespace is determined
     /// by
-    /// `really_dangerous_do_not_call_this_in_production_table_fingerprint_whitespace_version`.
+    /// `unsafe_builtin_table_fingerprint_whitespace_version`.
     /// This argument is meant for testing only and as the names suggests
     /// should not be set in production.
     #[clap(long, arg_enum, requires = "unsafe-mode")]

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -28,8 +28,8 @@ use itertools::Itertools;
 use mz_aws_secrets_controller::AwsSecretsController;
 use mz_build_info::BuildInfo;
 use mz_catalog::builtin::{
-    DangerousTableFingerprintWhitespace,
-    REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE,
+    UnsafeBuiltinTableFingerprintWhitespace,
+    UNSAFE_DO_NOT_CALL_THIS_IN_PRODUCTION_BUILTIN_TABLE_FINGERPRINT_WHITESPACE,
 };
 use mz_catalog::config::ClusterReplicaSizeMap;
 use mz_cloud_resources::{AwsExternalIdPrefix, CloudResourceController};
@@ -554,15 +554,14 @@ pub struct Args {
     /// This argument is meant for testing only and as the names suggests
     /// should not be set in production.
     #[clap(long, arg_enum, requires = "unsafe-mode")]
-    really_dangerous_do_not_call_this_in_production_table_fingerprint_whitespace:
-        Option<DangerousTableFingerprintWhitespace>,
+    unsafe_builtin_table_fingerprint_whitespace: Option<UnsafeBuiltinTableFingerprintWhitespace>,
     /// Controls the amount of whitespace injected by
     /// `really_dangerous_do_not_call_this_in_production_table_fingerprint_whitespace`.
     /// Incrementing this value can allow triggering multiple builtin
     /// migrations from a single test. This argument is meant for testing only
     /// and as the names suggests should not be set in production.
     #[clap(long, requires = "unsafe-mode", default_value = "1")]
-    really_dangerous_do_not_call_this_in_production_table_fingerprint_whitespace_version: usize,
+    unsafe_builtin_table_fingerprint_whitespace_version: usize,
 }
 
 #[derive(ArgEnum, Debug, Clone)]
@@ -602,12 +601,10 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     sys::enable_termination_signal_cleanup()?;
 
     // Configure testing options.
-    if let Some(fingerprint_whitespace) =
-        args.really_dangerous_do_not_call_this_in_production_table_fingerprint_whitespace
-    {
+    if let Some(fingerprint_whitespace) = args.unsafe_builtin_table_fingerprint_whitespace {
         assert!(args.unsafe_mode);
-        let whitespace = "\n".repeat(args.really_dangerous_do_not_call_this_in_production_table_fingerprint_whitespace_version);
-        *REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_TABLE_FINGERPRINT_WHITESPACE
+        let whitespace = "\n".repeat(args.unsafe_builtin_table_fingerprint_whitespace_version);
+        *UNSAFE_DO_NOT_CALL_THIS_IN_PRODUCTION_BUILTIN_TABLE_FINGERPRINT_WHITESPACE
             .lock()
             .expect("lock poisoned") = Some((fingerprint_whitespace, whitespace));
     }


### PR DESCRIPTION
This commit adds a CLI argument to environmentd that can trigger builtin migrations. Usually builtin migrations can only be triggered by modifying builtin item definitions that are compiled into the binary, making them extremely difficult to test. The CLI arg added in this commit "tricks" environmentd into thinking that builtin tables are migrated making it much easier to test.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
