### PR TITLE
transform: fix array access to results

### DIFF
--- a/src/transform/src/analysis.rs
+++ b/src/transform/src/analysis.rs
@@ -715,11 +715,13 @@ mod non_negative {
                     .map(|r| r.iter().all(|(_, diff)| diff >= &0))
                     .unwrap_or(true),
                 MirRelationExpr::Get { id, .. } => match id {
-                    Id::Local(id) => depends
-                        .bindings()
-                        .get(id)
-                        .map(|off| results[*off])
-                        .unwrap_or(false),
+                    Id::Local(id) => {
+                        let index = *depends
+                            .bindings()
+                            .get(id)
+                            .expect("Dependency info not found");
+                        *results.get(index).unwrap_or(&false)
+                    }
                     Id::Global(_) => true,
                 },
                 // Negate must be false unless input is "non-positive".


### PR DESCRIPTION
While working on #28375, it was noticed that the wrong `Option` was being unwrapped. `depends` should definitely have the binding information, but `results` might be missing. The current code unconditionally tries to access the later, and presumably we never hit the case where it is missing.

This PR makes sure to use unwrap correctly.

### Tips for reviewer

This is potentially a change in earlier behaviour, although if the above assumptions are correct, the change should be OK.
