### PR TITLE
txn-wal: fix persist schema hygiene

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -108,6 +108,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "wait_catalog_consolidation_on_startup": "true",
     "persist_batch_record_part_format": "true",
     "storage_use_reclock_v2": "true",
+    "persist_schema_require": "true",
 }
 
 

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -72,6 +72,7 @@ impl Transactor {
         let txns = TxnsHandle::open(
             init_ts,
             client.clone(),
+            mz_txn_wal::all_dyncfgs(client.dyncfgs().clone()),
             Arc::new(TxnMetrics::new(&MetricsRegistry::new())),
             txns_id,
             Arc::new(StringSchema),

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -53,6 +53,7 @@ use crate::internal::paths::{PartId, PartialBatchKey, WriterKey};
 use crate::internal::state::{
     BatchPart, HollowBatch, HollowBatchPart, ProtoInlineBatchPart, WRITE_DIFFS_SUM,
 };
+use crate::schema::SchemaId;
 use crate::stats::{
     encode_updates, untrimmable_columns, STATS_BUDGET_BYTES, STATS_COLLECTION_ENABLED,
 };
@@ -171,6 +172,11 @@ where
                 &self.metrics.retries.external.batch_delete,
             )
             .await;
+    }
+
+    /// Returns the schemas of parts in this batch.
+    pub fn schemas(&self) -> impl Iterator<Item = SchemaId> + '_ {
+        self.batch.parts.iter().flat_map(|b| b.schema_id())
     }
 
     /// Turns this [`Batch`] into a `HollowBatch`.

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -265,6 +265,13 @@ impl<T> BatchPart<T> {
             BatchPart::Inline { ts_rewrite, .. } => ts_rewrite.as_ref(),
         }
     }
+
+    pub fn schema_id(&self) -> Option<SchemaId> {
+        match self {
+            BatchPart::Hollow(x) => x.schema_id,
+            BatchPart::Inline { schema_id, .. } => *schema_id,
+        }
+    }
 }
 
 impl<T: Ord> PartialOrd for BatchPart<T> {

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -43,6 +43,7 @@ use crate::internal::machine::{CompareAndAppendRes, ExpireFn, Machine};
 use crate::internal::metrics::Metrics;
 use crate::internal::state::{HandleDebugState, HollowBatch};
 use crate::read::ReadHandle;
+use crate::schema::SchemaId;
 use crate::{parse_id, GarbageCollector, IsolatedRuntime, PersistConfig, ShardId};
 
 /// An opaque identifier for a writer of a persist durable TVC (aka shard).
@@ -190,6 +191,11 @@ where
     /// This handle's shard id.
     pub fn shard_id(&self) -> ShardId {
         self.machine.shard_id()
+    }
+
+    /// Returns the schema of this writer.
+    pub fn schema_id(&self) -> Option<SchemaId> {
+        self.schemas.id
     }
 
     /// A cached version of the shard-global `upper` frontier.

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -447,6 +447,7 @@ where
             TxnsHandle::open(
                 T::minimum(),
                 txns_client.clone(),
+                txns_client.dyncfgs().clone(),
                 Arc::clone(&txns_metrics),
                 txns_id,
                 Arc::new(RelationDesc::empty()),

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2384,6 +2384,7 @@ where
             let txns = TxnsHandle::open(
                 T::minimum(),
                 txns_client.clone(),
+                txns_client.dyncfgs().clone(),
                 Arc::clone(&txns_metrics),
                 txns_id,
                 Arc::new(RelationDesc::empty()),

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1834,9 +1834,7 @@ impl SourceDataRowColumnarEncoder {
         match self {
             SourceDataRowColumnarEncoder::Row(encoder) => encoder.append(row),
             SourceDataRowColumnarEncoder::EmptyRow => {
-                // TODO(#28146): Make this into an `assert_eq` once #28539 goes
-                // in.
-                mz_ore::soft_assert_eq_no_log!(row.iter().count(), 0)
+                assert_eq!(row.iter().count(), 0)
             }
         }
     }


### PR DESCRIPTION
This closes the "cursed txn-wal TODO" \o/!

Before, we would sometimes fall back to a default "placeholder" schema
in txn-wal (in prod, an empty RelationDesc), but this causes issues with
the soon-to-be-rolled out persist columnar work (see #28146).

Now, we make sure to keep track of data shard write handles that are
handed directly to `register` and use only those for `commit` calls.
This ensures that only a real schema is used to encode batches.

For additional sanity, when applying a batch, use the matching schema by
fetching it from persist if necessary. This fixes issues with background
compaction work spawned as a result of the CaA call.

Closes #28146

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
