### PR TITLE
zippy tests: Add 0dt deploys

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -140,8 +140,8 @@ IGNORE_RE = re.compile(
     # Old versions won't support new parameters
     | (platform-checks|legacy-upgrade|upgrade-matrix|feature-benchmark)-materialized-.* \| .*cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage
     # Fencing warnings are OK in fencing/0dt tests
-    | (txn-wal-fencing-mz_first-|platform-checks-mz_|parallel-workload-data-ingest-).* \| .*unexpected\ fence\ epoch
-    | (txn-wal-fencing-mz_first-|platform-checks-mz_|parallel-workload-|data-ingest-).* \| .*fenced\ by\ new\ catalog
+    | (txn-wal-fencing-mz_first-|platform-checks-mz_|parallel-workload-|data-ingest-|zippy-).* \| .*unexpected\ fence\ epoch
+    | (txn-wal-fencing-mz_first-|platform-checks-mz_|parallel-workload-|data-ingest-|zippy-).* \| .*fenced\ by\ new\ catalog
     | internal\ error:\ no\ AWS\ external\ ID\ prefix\ configured
     # For platform-checks upgrade tests
     | platform-checks-.* \| .* received\ persist\ state\ from\ the\ future

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -1337,8 +1337,8 @@ class Composition:
             """,
         )
 
-    def restore_mz(self) -> None:
-        self.kill("materialized")
+    def restore_mz(self, mz_service: str = "materialized") -> None:
+        self.kill(mz_service)
         self.exec(
             "cockroach",
             "cockroach",
@@ -1362,7 +1362,7 @@ class Composition:
             f"--blob-uri={minio_blob_uri()}",
             "--consensus-uri=postgres://root@cockroach:26257?options=--search_path=consensus",
         )
-        self.up("materialized")
+        self.up(mz_service)
 
     def await_mz_deployment_status(
         self,

--- a/misc/python/materialize/mzcompose/services/balancerd.py
+++ b/misc/python/materialize/mzcompose/services/balancerd.py
@@ -23,6 +23,9 @@ class Balancerd(Service):
         command: list[str] | None = None,
         volumes: list[str] = [],
         depends_on: list[str] = [],
+        https_resolver_template: str | None = None,
+        frontegg_resolver_template: str | None = None,
+        static_resolver_addr: str | None = None,
     ) -> None:
         if command is None:
             command = [
@@ -30,9 +33,18 @@ class Balancerd(Service):
                 "--pgwire-listen-addr=0.0.0.0:6875",
                 "--https-listen-addr=0.0.0.0:6876",
                 "--internal-http-listen-addr=0.0.0.0:6878",
-                "--static-resolver-addr=materialized:6875",
-                "--https-resolver-template=materialized:6876",
+                f"--static-resolver-addr={static_resolver_addr or 'materialized:6875'}",
+                f"--https-resolver-template={https_resolver_template or 'materialized:6876'}",
             ]
+        else:
+            if static_resolver_addr is not None:
+                command.append(f"--static-resolver-addr={static_resolver_addr}")
+            if https_resolver_template is not None:
+                command.append(f"--https-resolver-template={https_resolver_template}")
+        if frontegg_resolver_template is not None:
+            command.append(
+                f"--frontegg-reesolver-template={frontegg_resolver_template}"
+            )
 
         depends_graph: dict[str, ServiceDependency] = {
             s: {"condition": "service_started"} for s in depends_on

--- a/misc/python/materialize/zippy/all_actions.py
+++ b/misc/python/materialize/zippy/all_actions.py
@@ -9,7 +9,12 @@
 
 
 from materialize.zippy.balancerd_actions import BalancerdIsRunning
-from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
+from materialize.zippy.framework import (
+    Action,
+    ActionFactory,
+    Capabilities,
+    Capability,
+)
 from materialize.zippy.mz_actions import MzIsRunning
 from materialize.zippy.table_actions import ValidateTable
 from materialize.zippy.table_capabilities import TableExists

--- a/misc/python/materialize/zippy/crdb_actions.py
+++ b/misc/python/materialize/zippy/crdb_actions.py
@@ -11,13 +11,13 @@ import time
 
 from materialize.mzcompose.composition import Composition
 from materialize.zippy.crdb_capabilities import CockroachIsRunning
-from materialize.zippy.framework import Action, Capability
+from materialize.zippy.framework import Action, Capability, State
 
 
 class CockroachStart(Action):
     """Starts a CockroachDB instance."""
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         c.up("cockroach")
 
     def provides(self) -> list[Capability]:
@@ -31,7 +31,7 @@ class CockroachRestart(Action):
     def requires(cls) -> set[type[Capability]]:
         return {CockroachIsRunning}
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         c.kill("cockroach")
         time.sleep(1)
         c.up("cockroach")

--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -18,7 +18,7 @@ from materialize.zippy.debezium_capabilities import (
     DebeziumSourceExists,
     PostgresTableExists,
 )
-from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.framework import Action, Capabilities, Capability, State
 from materialize.zippy.kafka_capabilities import KafkaRunning
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.replica_capabilities import source_capable_clusters
@@ -31,7 +31,7 @@ class DebeziumStart(Action):
     def provides(self) -> list[Capability]:
         return [DebeziumRunning()]
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         c.up("debezium")
 
 
@@ -45,7 +45,7 @@ class DebeziumStop(Action):
     def withholds(self) -> set[type[Capability]]:
         return {DebeziumRunning}
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         c.kill("debezium")
 
 
@@ -93,7 +93,7 @@ class CreateDebeziumSource(Action):
 
         super().__init__(capabilities)
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         if self.new_debezium_source:
             c.testdrive(
                 dedent(

--- a/misc/python/materialize/zippy/framework.py
+++ b/misc/python/materialize/zippy/framework.py
@@ -18,6 +18,15 @@ if TYPE_CHECKING:
     from materialize.zippy.scenarios import Scenario
 
 
+class State:
+    mz_service: str
+    deploy_generation: int
+
+    def __init__(self):
+        self.mz_service = "materialized"
+        self.deploy_generation = 0
+
+
 class Capability:
     """Base class for a Zippy capability.
 
@@ -125,7 +134,7 @@ class Action:
         """Compute the capabilities that this action will make available."""
         return []
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         """Run this action on the provided copmosition."""
         assert False
 
@@ -174,6 +183,7 @@ class Test:
         self._actions_with_weight: dict[ActionOrFactory, float] = (
             self._scenario.actions_with_weight()
         )
+        self._state = State()
         self._max_execution_time: timedelta = max_execution_time
 
         for action_or_factory in self._scenario.bootstrap():
@@ -208,7 +218,7 @@ class Test:
         max_time = datetime.now() + self._max_execution_time
         for action in self._actions:
             print(action)
-            action.run(c)
+            action.run(c, self._state)
             if datetime.now() > max_time:
                 print(
                     f"--- Desired execution time of {self._max_execution_time} has been reached."
@@ -217,7 +227,7 @@ class Test:
 
         for action in self._final_actions:
             print(action)
-            action.run(c)
+            action.run(c, self._state)
 
     def _pick_action_or_factory(self) -> ActionOrFactory:
         """Select the next Action to run in the Test"""

--- a/misc/python/materialize/zippy/minio_actions.py
+++ b/misc/python/materialize/zippy/minio_actions.py
@@ -10,14 +10,14 @@
 import time
 
 from materialize.mzcompose.composition import Composition
-from materialize.zippy.framework import Action, Capability
+from materialize.zippy.framework import Action, Capability, State
 from materialize.zippy.minio_capabilities import MinioIsRunning
 
 
 class MinioStart(Action):
     """Starts a Minio instance."""
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         c.up("minio")
 
     def provides(self) -> list[Capability]:
@@ -31,7 +31,7 @@ class MinioRestart(Action):
     def requires(cls) -> set[type[Capability]]:
         return {MinioIsRunning}
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         c.kill("minio")
         time.sleep(1)
         c.up("minio")

--- a/misc/python/materialize/zippy/mysql_cdc_actions.py
+++ b/misc/python/materialize/zippy/mysql_cdc_actions.py
@@ -14,7 +14,7 @@ from textwrap import dedent
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.mysql import MySql
 from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
-from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.framework import Action, Capabilities, Capability, State
 from materialize.zippy.mysql_capabilities import MySqlRunning, MySqlTableExists
 from materialize.zippy.mysql_cdc_capabilities import MySqlCdcTableExists
 from materialize.zippy.mz_capabilities import MzIsRunning
@@ -62,7 +62,7 @@ class CreateMySqlCdcTable(Action):
 
         super().__init__(capabilities)
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         if self.new_mysql_cdc_table:
             assert self.mysql_cdc_table is not None
             assert self.mysql_cdc_table.mysql_table is not None
@@ -82,7 +82,8 @@ class CreateMySqlCdcTable(Action):
                       FROM MYSQL CONNECTION {name}_conn
                       FOR TABLES (public.{self.mysql_cdc_table.mysql_table.name} AS {name})
                     """
-                )
+                ),
+                mz_service=state.mz_service,
             )
 
     def provides(self) -> list[Capability]:

--- a/misc/python/materialize/zippy/peek_actions.py
+++ b/misc/python/materialize/zippy/peek_actions.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
 from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
-from materialize.zippy.framework import Action, Capability
+from materialize.zippy.framework import Action, Capability, State
 from materialize.zippy.mz_capabilities import MzIsRunning
 
 
@@ -22,7 +22,7 @@ class PeekCancellation(Action):
     def requires(cls) -> set[type[Capability]]:
         return {BalancerdIsRunning, MzIsRunning}
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         c.testdrive(
             dedent(
                 """
@@ -36,5 +36,6 @@ class PeekCancellation(Action):
                       SELECT 1 FROM peek_cancellation AS a1, peek_cancellation AS a2, peek_cancellation AS a3;
                     contains: timeout
                     """
-            )
+            ),
+            mz_service=state.mz_service,
         )

--- a/misc/python/materialize/zippy/pg_cdc_actions.py
+++ b/misc/python/materialize/zippy/pg_cdc_actions.py
@@ -13,7 +13,7 @@ from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
 from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
-from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.framework import Action, Capabilities, Capability, State
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.pg_cdc_capabilities import PostgresCdcTableExists
 from materialize.zippy.postgres_capabilities import PostgresRunning, PostgresTableExists
@@ -61,7 +61,7 @@ class CreatePostgresCdcTable(Action):
 
         super().__init__(capabilities)
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         if self.new_postgres_cdc_table:
             assert self.postgres_cdc_table is not None
             assert self.postgres_cdc_table.postgres_table is not None
@@ -87,7 +87,8 @@ class CreatePostgresCdcTable(Action):
                       FROM POSTGRES CONNECTION {name}_connection (PUBLICATION '{name}_publication')
                       FOR TABLES ({self.postgres_cdc_table.postgres_table.name} AS {name})
                     """
-                )
+                ),
+                mz_service=state.mz_service,
             )
 
     def provides(self) -> list[Capability]:

--- a/misc/python/materialize/zippy/replica_actions.py
+++ b/misc/python/materialize/zippy/replica_actions.py
@@ -11,7 +11,7 @@ import random
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
-from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.framework import Action, Capabilities, Capability, State
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.replica_capabilities import ReplicaExists, ReplicaSizeType
 
@@ -23,17 +23,18 @@ class DropDefaultReplica(Action):
     def requires(cls) -> set[type[Capability]]:
         return {MzIsRunning}
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         # Default cluster is not owned by materialize, thus can't be dropped by
         # it if enable_rbac_checks is on.
         c.testdrive(
             dedent(
                 """
-            $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+            $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
             ALTER CLUSTER quickstart SET (MANAGED = false)
             DROP CLUSTER REPLICA quickstart.r1
             """
-            )
+            ),
+            mz_service=state.mz_service,
         )
 
 
@@ -83,17 +84,18 @@ class CreateReplica(Action):
 
         super().__init__(capabilities)
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         if self.new_replica:
             # Default cluster is not owned by materialize, thus can't have a replica
             # added if enable_rbac_checks is on.
             c.testdrive(
                 dedent(
                     f"""
-                $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $ postgres-execute connection=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
                 CREATE CLUSTER REPLICA quickstart.{self.replica.name} SIZE '{self.replica.size}'
                 """
-                )
+                ),
+                mz_service=state.mz_service,
             )
 
     def provides(self) -> list[Capability]:
@@ -120,15 +122,16 @@ class DropReplica(Action):
 
         super().__init__(capabilities)
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         if self.replica is not None:
             # Default cluster is not owned by materialize, thus can't have a replica
             # removed if enable_rbac_checks is on.
             c.testdrive(
                 dedent(
                     f"""
-                $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                $ postgres-execute connection=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
                 DROP CLUSTER REPLICA IF EXISTS quickstart.{self.replica.name}
                 """
-                )
+                ),
+                mz_service=state.mz_service,
             )

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -35,6 +35,7 @@ from materialize.zippy.mysql_actions import (
 from materialize.zippy.mysql_cdc_actions import CreateMySqlCdcTable
 from materialize.zippy.mz_actions import (
     KillClusterd,
+    Mz0dtDeploy,
     MzRestart,
     MzStart,
     MzStop,
@@ -98,9 +99,11 @@ class KafkaSources(Scenario):
         return {
             MzStart: 5,
             MzStop: 1,
+            Mz0dtDeploy: 5,
             KillClusterd: 5,
-            StoragedKill: 5,
-            StoragedStart: 5,
+            # Disabled because a separate clusterd is not supported by Mz0dtDeploy yet
+            # StoragedKill: 5,
+            # StoragedStart: 5,
             CreateTopicParameterized(): 5,
             CreateSourceParameterized(): 5,
             CreateViewParameterized(max_inputs=2): 5,
@@ -118,9 +121,11 @@ class AlterConnectionWithKafkaSources(Scenario):
         return {
             MzStart: 5,
             MzStop: 1,
+            Mz0dtDeploy: 1,
             KillClusterd: 5,
-            StoragedKill: 5,
-            StoragedStart: 5,
+            # Disabled because a separate clusterd is not supported by Mz0dtDeploy yet
+            # StoragedKill: 5,
+            # StoragedStart: 5,
             CreateTopicParameterized(): 5,
             CreateSourceParameterized(): 5,
             CreateViewParameterized(max_inputs=2): 5,
@@ -140,11 +145,13 @@ class UserTables(Scenario):
             MzStart: 5,
             BalancerdStart: 1,
             MzStop: 10,
+            Mz0dtDeploy: 10,
             BalancerdStop: 1,
             BalancerdRestart: 1,
             BackupAndRestore: 1,
             KillClusterd: 10,
-            StoragedRestart: 5,
+            # Disabled because a separate clusterd is not supported by Mz0dtDeploy yet
+            # StoragedRestart: 5,
             CreateTableParameterized(): 10,
             CreateViewParameterized(): 10,
             CreateSinkParameterized(): 10,
@@ -274,8 +281,10 @@ class CrdbMinioRestart(Scenario):
             DML: 50,
             ValidateView: 15,
             MzRestart: 5,
+            Mz0dtDeploy: 5,
             KillClusterd: 5,
-            StoragedRestart: 10,
+            # Disabled because a separate clusterd is not supported by Mz0dtDeploy yet
+            # StoragedRestart: 10,
             CockroachRestart: 15,
             MinioRestart: 15,
         }
@@ -295,8 +304,10 @@ class CrdbRestart(Scenario):
             DML: 50,
             ValidateView: 15,
             MzRestart: 5,
+            Mz0dtDeploy: 5,
             KillClusterd: 5,
-            StoragedRestart: 10,
+            # Disabled because a separate clusterd is not supported by Mz0dtDeploy yet
+            # StoragedRestart: 10,
             CockroachRestart: 15,
         }
 

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -12,7 +12,13 @@ from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
 from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
-from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
+from materialize.zippy.framework import (
+    Action,
+    ActionFactory,
+    Capabilities,
+    Capability,
+    State,
+)
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.replica_capabilities import source_capable_clusters
 from materialize.zippy.sink_capabilities import SinkExists
@@ -74,7 +80,7 @@ class CreateSink(Action):
         self.sink = sink
         super().__init__(capabilities)
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         # The sink-derived source has upsert semantics, so produce a "normal" ViewExists output
         # from the 'before' and the 'after'
 
@@ -127,7 +133,8 @@ class CreateSink(Action):
                   ENVELOPE NONE
             """
             )
-            + dest_view_sql
+            + dest_view_sql,
+            mz_service=state.mz_service,
         )
 
     def provides(self) -> list[Capability]:

--- a/misc/python/materialize/zippy/storaged_actions.py
+++ b/misc/python/materialize/zippy/storaged_actions.py
@@ -10,7 +10,7 @@
 
 from materialize.mzcompose.composition import Composition
 from materialize.zippy.crdb_capabilities import CockroachIsRunning
-from materialize.zippy.framework import Action, Capability
+from materialize.zippy.framework import Action, Capability, State
 from materialize.zippy.minio_capabilities import MinioIsRunning
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.storaged_capabilities import StoragedRunning
@@ -27,7 +27,7 @@ class StoragedStart(Action):
     def incompatible_with(cls) -> set[type[Capability]]:
         return {StoragedRunning}
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         c.up("storaged")
 
     def provides(self) -> list[Capability]:
@@ -41,7 +41,7 @@ class StoragedRestart(Action):
     def requires(cls) -> set[type[Capability]]:
         return {MzIsRunning, StoragedRunning}
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         c.kill("storaged")
         c.up("storaged")
 
@@ -51,7 +51,7 @@ class StoragedKill(Action):
     def requires(cls) -> set[type[Capability]]:
         return {MzIsRunning, StoragedRunning}
 
-    def run(self, c: Composition) -> None:
+    def run(self, c: Composition, state: State) -> None:
         c.kill("storaged")
 
     def withholds(self) -> set[type[Capability]]:


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
