### PR TITLE
0dt tests: IsLeader tells us when ready

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -388,6 +388,7 @@ class WaitReadyMz(MzcomposeAction):
                 c.exec(
                     self.mz_service,
                     "curl",
+                    "-s",
                     "localhost:6878/api/leader/status",
                     capture=True,
                 ).stdout
@@ -412,6 +413,7 @@ class PromoteMz(MzcomposeAction):
             c.exec(
                 self.mz_service,
                 "curl",
+                "-s",
                 "-X",
                 "POST",
                 "http://127.0.0.1:6878/api/leader/promote",
@@ -423,8 +425,6 @@ class PromoteMz(MzcomposeAction):
         mz_version = MzVersion.parse_mz(c.query_mz_version(service=self.mz_service))
         e.current_mz_version = mz_version
 
-        time.sleep(5)
-
         # Wait until new Materialize is ready to handle queries
         for i in range(300):
             try:
@@ -432,19 +432,12 @@ class PromoteMz(MzcomposeAction):
                     c.exec(
                         self.mz_service,
                         "curl",
+                        "-s",
                         "localhost:6878/api/leader/status",
                         capture=True,
                     ).stdout
                 )
                 assert result["status"] == "IsLeader"
-                result = c.exec(
-                    self.mz_service,
-                    "curl",
-                    "http://127.0.0.1:6878/api/readyz",
-                    capture=True,
-                ).stdout
-                assert result == "ready", f"Unexpected result {result}"
-                assert c.sql_query("SELECT 1", service=self.mz_service) == ([1],)
             except:
                 time.sleep(1)
                 continue

--- a/misc/python/materialize/data_ingest/transaction_def.py
+++ b/misc/python/materialize/data_ingest/transaction_def.py
@@ -169,8 +169,6 @@ class ZeroDowntimeDeploy(TransactionDef):
                 )
                 assert result["result"] == "Success", f"Unexpected result {result}"
 
-                time.sleep(5)
-
                 # Wait until new Materialize is ready to handle queries
                 for i in range(300):
                     try:
@@ -184,17 +182,6 @@ class ZeroDowntimeDeploy(TransactionDef):
                             ).stdout
                         )
                         assert result["status"] == "IsLeader"
-                        result = self.composition.exec(
-                            self.workload.mz_service,
-                            "curl",
-                            "-s",
-                            "http://127.0.0.1:6878/api/readyz",
-                            capture=True,
-                        ).stdout
-                        assert result == "ready", f"Unexpected result {result}"
-                        assert self.composition.sql_query(
-                            "SELECT 1", service=self.workload.mz_service
-                        ) == ([1],)
                     except:
                         time.sleep(1)
                         continue


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
