### PR TITLE
[persist] Switch the Consolidator to a more-columnar style

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -734,7 +734,10 @@ where
                 break;
             };
             timings.part_fetching += fetch_start.elapsed();
-            for ((k, v), t, d) in updates.iter() {
+            // We now have a full set of consolidated columnar data here, but no way to push it
+            // into the batch builder yet. Instead, iterate over the codec records and push those
+            // in directly.
+            for ((k, v), t, d) in updates.records().iter() {
                 key_vec.clear();
                 key_vec.extend_from_slice(k);
                 val_vec.clear();

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -731,7 +731,7 @@ where
                 break;
             };
             timings.part_fetching += fetch_start.elapsed();
-            for (k, v, t, d) in updates.take(cfg.compaction_yield_after_n_updates) {
+            for ((k, v), t, d) in updates.take(cfg.compaction_yield_after_n_updates) {
                 key_vec.clear();
                 key_vec.extend_from_slice(k);
                 val_vec.clear();

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -694,7 +694,7 @@ where
             true,
         );
 
-        let mut consolidator = Consolidator::new(
+        let mut consolidator = Consolidator::<T, D>::new(
             format!(
                 "{}[lower={:?},upper={:?}]",
                 shard_id,

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -384,7 +384,7 @@ where
     /// Return an iterator over the next consolidated chunk of output, if there's any left.
     ///
     /// Requirement: at least the first part of each run should be fetched and nonempty.
-    fn iter(&mut self) -> Option<ConsolidatingIter<T, D>> {
+    fn iter(&mut self) -> Option<impl Iterator<Item = TupleRef<T, D>>> {
         // At this point, the `initial_state` of the previously-returned iterator has either been
         // fully consolidated and returned, or put back into `drop_stash`. In either case, this is
         // safe to overwrite.
@@ -502,7 +502,9 @@ where
     /// Wait until data is available, then return an iterator over the next
     /// consolidated chunk of output. If this method returns `None`, that all the data has been
     /// exhausted and the full consolidated dataset has been returned.
-    pub(crate) async fn next(&mut self) -> anyhow::Result<Option<ConsolidatingIter<T, D>>> {
+    pub(crate) async fn next(
+        &mut self,
+    ) -> anyhow::Result<Option<impl Iterator<Item = TupleRef<T, D>>>> {
         self.trim();
         self.unblock_progress().await?;
         Ok(self.iter())

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -920,7 +920,7 @@ where
             .next()
             .await
             .expect("fetching a leased part")?;
-        let iter = iter.map(|(k, v, t, d)| {
+        let iter = iter.map(|((k, v), t, d)| {
             let key = K::decode(k, &self.schemas.key);
             let val = V::decode(v, &self.schemas.val);
             ((key, val), t, d)

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -103,6 +103,25 @@ impl fmt::Debug for ColumnarRecords {
 }
 
 impl ColumnarRecords {
+    /// Construct a columnar records instance from the given arrays, checking invariants.
+    pub fn new(
+        key_data: BinaryArray,
+        val_data: BinaryArray,
+        timestamps: Int64Array,
+        diffs: Int64Array,
+    ) -> Self {
+        let len = key_data.len();
+        let records = Self {
+            len,
+            key_data,
+            val_data,
+            timestamps,
+            diffs,
+        };
+        assert_eq!(records.borrow().validate(), Ok(()));
+        records
+    }
+
     /// The number of (potentially duplicated) ((Key, Val), Time, i64) records
     /// stored in Self.
     pub fn len(&self) -> usize {
@@ -117,6 +136,16 @@ impl ColumnarRecords {
     /// The vals in this columnar records as an array.
     pub fn vals(&self) -> &BinaryArray {
         &self.val_data
+    }
+
+    /// The timestamps in this columnar records as an array.
+    pub fn timestamps(&self) -> &Int64Array {
+        &self.timestamps
+    }
+
+    /// The diffs in this columnar records as an array.
+    pub fn diffs(&self) -> &Int64Array {
+        &self.diffs
     }
 
     /// The number of logical bytes in the represented data, excluding offsets

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -203,6 +203,14 @@ impl BlobTraceUpdates {
             BlobTraceUpdates::Both(c, _structured) => c,
         }
     }
+
+    /// Return the [`ColumnarRecordsStructuredExt`] of the blob.
+    pub fn structured(&self) -> Option<&ColumnarRecordsStructuredExt> {
+        match self {
+            BlobTraceUpdates::Row(_) => None,
+            BlobTraceUpdates::Both(_, structured) => Some(structured),
+        }
+    }
 }
 
 impl TraceBatchMeta {


### PR DESCRIPTION
Two major changes to consolidation:
- Adds a method that applies timestamp rewriting / truncation directly to the columnar data. (Instead of incrementally while streaming it out.) 
- Reworks consolidation to thread indices through along with the actual keys and values. (If two updates have identical key-value pairs, the choice is arbitrary.)

These changes let us use `arrow::compute::interleave` to construct the output key/value arrays from the set of inputs to the consolidating iterator. This is particularly important for our new structured data - since there's no way to pass around a specific row of an arbitrary `ArrayRef`, it's important to do those manipulations by index.

### Motivation

Support for #24830.

### Tips for reviewer

Two things to sort out from nightlies:
- [x] ~I'm getting a persist-txn nightly failure in maelstrom. Unclear how concerning, looking into this now.~ Real bug; dumb mistake; fixed by accident in the latest refactoring. 😬 
- [x] The feature benchmark seems happy with this change, but I can't believe that it has no performance impact, for good or ill. (I think it may be somewhat worse for non-structured data, but I'm not sure.) I'm going to try and get more specific benchmark numbers to know for sure.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
