### PR TITLE
adapter: add guarantees for AdapterClient::end_transaction

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -71,6 +71,10 @@ pub enum Command {
         outer_ctx_extra: Option<ExecuteContextExtra>,
     },
 
+    /// Attempts to commit or abort the session's transaction. Guarantees that the Coordinator's
+    /// transaction state has been cleared, even if the commit or abort fails. (A failure can
+    /// happen, for example, if the session's role id has been dropped which will prevent
+    /// sequence_end_transaction from running.)
     Commit {
         action: EndTransactionAction,
         session: Session,

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -192,6 +192,12 @@ impl Coordinator {
         &mut self,
         session: &mut Session,
     ) -> TransactionStatus<mz_repr::Timestamp> {
+        // This function is *usually* called when transactions end, but it can fail to be called in
+        // some cases (for example if the session's role id was dropped, then we return early and
+        // don't go through the normal sequence_end_transaction path). The `Command::Commit` handler
+        // and `AdapterClient::end_transaction` protect against this by each executing their parts
+        // of this function. Thus, if this function changes, ensure that the changes are propogated
+        // to either of those components.
         self.clear_connection(session.conn_id()).await;
         session.clear_transaction()
     }


### PR DESCRIPTION
Both the HTTP and pgwire protocols automatically commit implicit transactions by calling AdapterClient::end_transaction which sends a Command::Commit to the Coordinator. That command produced a Plan::CommitTransaction (equivalent to the user typing `COMMIT`). Since this was a normal plan, the same as if it came from a SQL statement, the RBAC checks run. One of the checks verifies that the user's role still exists (regardless of the statement being executed). It is thus possible for the Plan::CommitTransaction to fail and not sequence its plan (in this case `sequence_end_transaction`). However, both the AdapterClient (and HTTP and pgwire protocols) had assumed that Command::Commit would always clean up the session's transaction state. But since the cleanup action happens in `sequence_end_transaction` which isn't guaranteed to execute (if, say, the user's role was dropped), that assumption is not guaranteed.

Change Command::Commit to guarantee that the Coordinator cleans up the txn state, and change AdapterClient::end_transaction to guarantee it cleans up the session's txn state. This leaves all usages of end_transaction as is by changing the implementation to do what the callers assumed it had been doing.

No explicit test was added because the parallel DDL tests have reliably been finding this bug, so adding the soft panic should produce a panic if this bug is still present when running that nightly.

Alternatives considered:

- Add a Command::ClearTransaction command that AdapterClient::end_transaction calls which would cleanup the state. This seemed unneeded and another message sent to the Coordinator that could be avoided by adding the desired behavior to Commit and having the AdapterClient take care of the session's state.
- Have callers of AdapterClient::end_transaction terminate the connection. This sounded nice but ended up being tricky because the higher level callers often support generic errors that get serialized and sent off to the user, leaving the connection intact. We'd have to plumb some new logic through that would indicate a termination was needed which didn't seem worth it.
- Teach Command::Commit to produce a Plan that would skip the rbac checks. Skipping RBAC checks seemed dangerous.

Fixes #28400

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a