### PR TITLE
parallel-workload: Fix calling data-ingest workloads

### DIFF
--- a/misc/python/materialize/data_ingest/workload.py
+++ b/misc/python/materialize/data_ingest/workload.py
@@ -45,7 +45,9 @@ class Workload:
     mz_service: str
     deploy_generation: int
 
-    def __init__(self, mz_service: str, deploy_generation: int) -> None:
+    def __init__(
+        self, mz_service: str = "materailized", deploy_generation: int = 0
+    ) -> None:
         self.mz_service = mz_service
         self.deploy_generation = deploy_generation
 
@@ -59,7 +61,10 @@ class Workload:
 
 class SingleSensorUpdating(Workload):
     def __init__(
-        self, composition: Composition | None, mz_service: str, deploy_generation: int
+        self,
+        composition: Composition | None = None,
+        mz_service: str = "materialized",
+        deploy_generation: int = 0,
     ) -> None:
         super().__init__(mz_service, deploy_generation)
         self.cycle = [
@@ -77,7 +82,10 @@ class SingleSensorUpdating(Workload):
 
 class SingleSensorUpdatingDisruptions(Workload):
     def __init__(
-        self, composition: Composition | None, mz_service: str, deploy_generation: int
+        self,
+        composition: Composition | None = None,
+        mz_service: str = "materialized",
+        deploy_generation: int = 0,
     ) -> None:
         super().__init__(mz_service, deploy_generation)
         self.cycle = [
@@ -97,7 +105,10 @@ class SingleSensorUpdatingDisruptions(Workload):
 
 class SingleSensorUpdating0dtDeploy(Workload):
     def __init__(
-        self, composition: Composition | None, mz_service: str, deploy_generation: int
+        self,
+        composition: Composition | None = None,
+        mz_service: str = "materialized",
+        deploy_generation: int = 0,
     ) -> None:
         super().__init__(mz_service, deploy_generation)
         self.cycle = [
@@ -119,7 +130,10 @@ class SingleSensorUpdating0dtDeploy(Workload):
 
 class DeleteDataAtEndOfDay(Workload):
     def __init__(
-        self, composition: Composition | None, mz_service: str, deploy_generation: int
+        self,
+        composition: Composition | None = None,
+        mz_service: str = "materialized",
+        deploy_generation: int = 0,
     ) -> None:
         super().__init__(mz_service, deploy_generation)
         insert = Insert(
@@ -148,7 +162,10 @@ class DeleteDataAtEndOfDay(Workload):
 
 class DeleteDataAtEndOfDayDisruptions(Workload):
     def __init__(
-        self, composition: Composition | None, mz_service: str, deploy_generation: int
+        self,
+        composition: Composition | None = None,
+        mz_service: str = "materialized",
+        deploy_generation: int = 0,
     ) -> None:
         super().__init__(mz_service, deploy_generation)
         insert = Insert(
@@ -180,7 +197,10 @@ class DeleteDataAtEndOfDayDisruptions(Workload):
 
 class DeleteDataAtEndOfDay0dtDeploys(Workload):
     def __init__(
-        self, composition: Composition | None, mz_service: str, deploy_generation: int
+        self,
+        composition: Composition | None = None,
+        mz_service: str = "materialized",
+        deploy_generation: int = 0,
     ) -> None:
         super().__init__(mz_service, deploy_generation)
         insert = Insert(
@@ -215,7 +235,7 @@ class DeleteDataAtEndOfDay0dtDeploys(Workload):
 # TODO: Implement
 # class ProgressivelyEnrichRecords(Workload):
 #    def __init__(
-#        self, composition: Composition | None, mz_service: str, deploy_generation: int
+#        self, composition: Composition | None = None, mz_service: str = "materialized", deploy_generation: int = 0
 #    ) -> None:
 #        super().__init__(mz_service, deploy_generation)
 #        self.cycle: list[Definition] = [

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2052,9 +2052,9 @@ class HttpPostAction(Action):
                     raise
             except QueryError as e:
                 # expected, see #20465
-                # TODO(def-): Why in 0dt?
                 if exe.db.scenario not in (
                     Scenario.Kill,
+                    # TODO(def-): Why in 0dt? Add explicit webhook test to verify
                     Scenario.ZeroDowntimeDeploy,
                 ) or ("404: no object was found at the path" not in e.msg):
                     raise e

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -516,7 +516,7 @@ class KafkaSource(DBObject):
             schema.name(),
             cluster.name(),
         )
-        workload = rng.choice(list(WORKLOADS))("materialized", 0)
+        workload = rng.choice(list(WORKLOADS))()
         for transaction_def in workload.cycle:
             for definition in transaction_def.operations:
                 if type(definition) == Insert and definition.count > MAX_ROWS:
@@ -658,7 +658,7 @@ class MySqlSource(DBObject):
             schema.name(),
             cluster.name(),
         )
-        self.generator = rng.choice(list(WORKLOADS))("materialized", 0).generate(fields)
+        self.generator = rng.choice(list(WORKLOADS))().generate(fields)
         self.lock = threading.Lock()
 
     def name(self) -> str:
@@ -726,7 +726,7 @@ class PostgresSource(DBObject):
             schema.name(),
             cluster.name(),
         )
-        self.generator = rng.choice(list(WORKLOADS))("materialized", 0).generate(fields)
+        self.generator = rng.choice(list(WORKLOADS))().generate(fields)
         self.lock = threading.Lock()
 
     def name(self) -> str:


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/8814#_

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
