### PR TITLE
parallel-workload: Longer timeout, more post-command printing

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1323,7 +1323,7 @@ steps:
         label: "Parallel Workload (DML)"
         depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: linux-aarch64
         plugins:
@@ -1335,7 +1335,7 @@ steps:
         label: "Parallel Workload (DDL)"
         depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: linux-aarch64
         plugins:
@@ -1347,7 +1347,7 @@ steps:
         label: "Parallel Workload (DDL Only)"
         depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: linux-aarch64
         plugins:
@@ -1359,7 +1359,7 @@ steps:
         label: "Parallel Workload (many threads)"
         depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           # Sporadic OoM otherwise
           queue: linux-aarch64-medium
@@ -1372,7 +1372,7 @@ steps:
         label: "Parallel Workload (rename + naughty identifiers)"
         depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: linux-aarch64
         plugins:
@@ -1384,7 +1384,7 @@ steps:
         label: "Parallel Workload (rename)"
         depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: linux-aarch64
         plugins:
@@ -1396,7 +1396,7 @@ steps:
         label: "Parallel Workload (cancel)"
         depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         skip: "TODO(def-): Reenable when #2392 is fixed"
         agents:
           queue: linux-aarch64
@@ -1409,7 +1409,7 @@ steps:
         label: "Parallel Workload (kill)"
         depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: linux-aarch64
         plugins:
@@ -1421,7 +1421,7 @@ steps:
         label: "Parallel Workload (backup & restore)"
         depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         skip: "TODO(def-): Properly stop all db actions during backup & restore"
         agents:
           queue: linux-aarch64
@@ -1434,7 +1434,7 @@ steps:
         label: "Parallel Workload (0dt deploy)"
         depends_on: build-aarch64
         artifact_paths: [parallel-workload-queries.log.zst]
-        timeout_in_minutes: 60
+        timeout_in_minutes: 90
         agents:
           queue: linux-aarch64-large
         plugins:

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -17,8 +17,7 @@ run() {
     bin/ci-builder run stable bin/mzcompose --mz-quiet --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
 
-ci_unimportant_heading "Upload log artifacts"
-
+echo "Collecting logs"
 # Run before potential "run down" in coverage
 docker ps --all --quiet | xargs --no-run-if-empty docker inspect > docker-inspect.log
 # services.log might already exist and contain logs from before composition was downed
@@ -36,8 +35,8 @@ ps aux > ps-aux.log
 docker ps -a --no-trunc > docker-ps-a.log
 docker stats --all --no-stream > docker-stats.log
 
-# Down docker containers to save memory
-run --mz-quiet down --volumes
+echo "Downing docker containers"
+run down --volumes
 
 mv "$HOME"/cores .
 
@@ -55,6 +54,7 @@ if find cores -name 'core.*' | grep -q .; then
     run cp testdrive:/usr/local/bin/testdrive cores/ || true
 fi
 
+echo "Finding core files"
 find cores -name 'core.*' | while read -r core; do
     exe=$(echo "$core" | sed -e "s/core\.\(.*\)\.[0-9]*/\1/" -e "s/.*\!//")
     # Core dumps can take a while to be written, so if extracting the info fails, try again later
@@ -68,8 +68,10 @@ done
 # can be huge, clean up
 rm -rf cores
 
+echo "Compressing parallel-workload-queries.log"
 bin/ci-builder run stable zstd --rm parallel-workload-queries.log || true
 
+echo "Uploading log artifacts"
 mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nnetstat-ant.log\nnetstat-panelot.log\nps-aux.log\ndocker-ps-a.log\ndocker-inspect.log\n"; find . -name 'junit_*.xml')
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 buildkite-agent artifact upload "$artifacts_str"
@@ -94,7 +96,7 @@ export_cov() {
 }
 
 if [ -n "${CI_COVERAGE_ENABLED:-}" ] && [ -z "${BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_COVERAGE:-}" ];  then
-    ci_unimportant_heading "Generate coverage information"
+    echo "Generating coverage information"
     if [ -n "$(find . -name '*.profraw')" ]; then
         # Workaround for "invalid instrumentation profile data (file header is corrupt)"
         rm -rf profraws


### PR DESCRIPTION
Strange timeout seen in https://buildkite.com/materialize/nightly/builds/8822#0190eecf-4a9e-4666-805e-322a1850044b

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
