### PR TITLE
DRAFT: platform-checks: Add readonly

### DIFF
--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -113,3 +113,18 @@ class Validate(Action):
     def join(self, e: Executor) -> None:
         for check in self.checks:
             check.join_validate(e)
+
+
+class ReadOnly(Action):
+    def __init__(self, scenario: "Scenario", mz_service: str | None = None) -> None:
+        self.checks = scenario.check_objects
+        self.mz_service = mz_service
+
+    def execute(self, e: Executor) -> None:
+        for check in self.checks:
+            print(f"Running readonly() from {check}")
+            check.start_readonly(e, self)
+
+    def join(self, e: Executor) -> None:
+        for check in self.checks:
+            check.join_readonly(e)

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -67,6 +67,9 @@ class Check:
         """Note that the validation method may be invoked multiple times (depending on the scenario)."""
         assert False
 
+    def readonly(self) -> Testdrive:
+        return Testdrive(TESTDRIVE_NOP)
+
     def start_initialize(self, e: Executor, a: "Action") -> None:
         if self._can_run(e) and self.enabled:
             self.current_version = e.current_mz_version
@@ -102,6 +105,16 @@ class Check:
     def join_validate(self, e: Executor) -> None:
         if self._can_run(e) and self.enabled:
             self._validate.join(e)
+
+    def start_readonly(self, e: Executor, a: "Action") -> None:
+        if self._can_run(e) and self.enabled:
+            self.current_version = e.current_mz_version
+            self._readonly = self.readonly()
+            self._readonly.execute(e, a.mz_service)
+
+    def join_readonly(self, e: Executor) -> None:
+        if self._can_run(e) and self.enabled:
+            self._readonly.join(e)
 
 
 def disabled(ignore_reason: str):

--- a/misc/python/materialize/checks/scenarios_zero_downtime.py
+++ b/misc/python/materialize/checks/scenarios_zero_downtime.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 
-from materialize.checks.actions import Action, Initialize, Manipulate, Validate
+from materialize.checks.actions import Action, Initialize, Manipulate, Validate, ReadOnly
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
 from materialize.checks.mzcompose_actions import (
@@ -43,6 +43,7 @@ class ZeroDowntimeRestartEntireMz(Scenario):
             Manipulate(self, phase=2, mz_service="mz_2"),
             *wait_ready_and_promote("mz_3"),
             start_mz_read_only(self, deploy_generation=3, mz_service="mz_4"),
+            ReadOnly("mz_4"),
             Validate(self, mz_service="mz_3"),
             *wait_ready_and_promote("mz_4"),
             Validate(self, mz_service="mz_4"),


### PR DESCRIPTION
I'm not sure how useful this actually is


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
