### PR TITLE
dbt-materialize: handle absence of default cluster in data tests

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
@@ -69,8 +69,13 @@
   {% set fail_calc = config.get('fail_calc') %}
   {% set warn_if = config.get('warn_if') %}
   {% set error_if = config.get('error_if') %}
+  --Tests compile to ad-hoc queries, which need a cluster to run against. If no
+  --cluster is configured for data tests, use the target cluster from
+  --profiles.yml.
   {% set cluster = config.get('cluster') %}
-  {% if cluster == none %}{% set cluster = target.cluster %}{% endif %}
+  {% if cluster == none %}
+    {% set cluster = target.cluster %}
+  {% endif %}
 
   {% call statement('main', fetch_result=True) -%}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
@@ -70,6 +70,7 @@
   {% set warn_if = config.get('warn_if') %}
   {% set error_if = config.get('error_if') %}
   {% set cluster = config.get('cluster') %}
+  {% if cluster == none %}{% set cluster = target.cluster %}{% endif %}
 
   {% call statement('main', fetch_result=True) -%}
 

--- a/misc/dbt-materialize/tests/adapter/test_clusters.py
+++ b/misc/dbt-materialize/tests/adapter/test_clusters.py
@@ -107,15 +107,20 @@ class TestModelCluster:
     def test_materialize_override_noexist(self, project):
         run_dbt(["run", "--models", "invalid_cluster"], expect_pass=False)
 
-    # In the absence of the pre-installed `default` cluster, Materialize should
-    # not error if a user-provided cluster is specified as a connection or
-    # model config, but will error otherwise.
+    # In the absence of the pre-installed `quickstart` cluster, Materialize
+    # should not error if a user-provided cluster is specified as a profile,
+    # model or test config, but will error otherwise.
     # See #17197: https://github.com/MaterializeInc/materialize/pull/17197
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"data_tests": {"cluster": "not_default"}}
+
     def test_materialize_drop_quickstart(self, project):
         project.run_sql("DROP CLUSTER quickstart CASCADE")
 
         run_dbt(["run", "--models", "override_cluster"], expect_pass=True)
         run_dbt(["run", "--models", "default_cluster"], expect_pass=False)
+        run_dbt(["test", "--models", "override_cluster"], expect_pass=True)
 
         project.run_sql("CREATE CLUSTER quickstart SIZE = '1'")
 


### PR DESCRIPTION
`dbt test` picks up the `cluster` configuration from `dbt_project.yml`, if it exists, but otherwise defaults to `quickstart` if no cluster is specified. Although we can't enforce that a valid cluster is specified, we should fall back to the cluster specified in `profiles.yml` in that scenario.

Reported on [Slack](https://materializeinc.slack.com/archives/C077R8Z9XGC/p1721926079069049).