### PR TITLE
adapter: Allow multi table write transactions

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -179,8 +179,6 @@ pub enum AdapterError {
     },
     /// The transaction is in write-only mode.
     WriteOnlyTransaction,
-    /// The transaction only supports single table writes
-    MultiTableWriteTransaction,
     /// The transaction can only execute a single statement.
     SingleStatementTransaction,
     /// The transaction can only execute simple DDL.
@@ -528,7 +526,6 @@ impl AdapterError {
             // transaction" are not things in Postgres. This error code is the generic "bad txn
             // thing" code, so it's probably the best choice.
             AdapterError::WriteOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::MultiTableWriteTransaction => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::DDLOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::Storage(_) | AdapterError::Compute(_) | AdapterError::Orchestrator(_) => {
                 SqlState::INTERNAL_ERROR
@@ -721,9 +718,6 @@ impl fmt::Display for AdapterError {
             ),
             AdapterError::UntargetedLogRead { .. } => {
                 f.write_str("log source reads must target a replica")
-            }
-            AdapterError::MultiTableWriteTransaction => {
-                f.write_str("write transactions only support writes to a single table")
             }
             AdapterError::DDLOnlyTransaction => f.write_str(
                 "transactions which modify objects are restricted to just modifying objects",

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -12,7 +12,7 @@
 #![warn(missing_docs)]
 
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::mem;
 use std::sync::Arc;
@@ -1183,16 +1183,6 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
                             // it anyway.
                             assert!(!matches!(access, Some(TransactionAccessMode::ReadOnly)));
                             txn_writes.append(&mut add_writes);
-
-                            if txn_writes
-                                .iter()
-                                .map(|op| op.id)
-                                .collect::<BTreeSet<_>>()
-                                .len()
-                                > 1
-                            {
-                                return Err(AdapterError::MultiTableWriteTransaction);
-                            }
                         }
                         // Iff peeks do not have a timestamp (i.e. they are
                         // constant), we can permit them.

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -531,6 +531,8 @@ pub trait StorageController: Debug {
     /// The method returns a oneshot that can be awaited to indicate completion of the write.
     /// The method may return an error, indicating an immediately visible error, and also the
     /// oneshot may return an error if one is encountered during the write.
+    ///
+    /// All updates in `commands` are applied atomically.
     // TODO(petrosagg): switch upper to `Antichain<Timestamp>`
     fn append_table(
         &mut self,

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -573,11 +573,21 @@ BEGIN
 statement ok
 INSERT INTO foo VALUES (42)
 
-statement error write transactions only support writes to a single table
-INSERT INTO bar VALUES (42)
+statement ok
+INSERT INTO bar VALUES (43)
 
 statement ok
-ROLLBACK
+COMMIT
+
+query I
+SELECT a FROM foo
+----
+42
+
+query I
+SELECT a FROM bar
+----
+43
 
 # Test that constant reads are allowed in write-only transactions
 


### PR DESCRIPTION
Previously, we disabled write transactions that try to write to more than one table. The reason was that we had no way of atomically writing to multiple tables. With the introduction of txn-wal we do have a method of writing to multiple tables atomically and in fact all writes in a single group commit are written atomically in a single txn-wal transaction.

This commit removes the restriction on multi table transactions, because it is now safe.

Resolves #14567

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow write transactions to write to multiple tables.
