### PR TITLE
adapter: support unmaterializeable fns in ReadThenWrite plans

### DIFF
--- a/test/sqllogictest/updates.slt
+++ b/test/sqllogictest/updates.slt
@@ -202,3 +202,16 @@ COMPLETE 0
 
 statement error db error: ERROR: result exceeds max size of 1048.6 KB
 INSERT INTO t SELECT * FROM t_big
+
+# Test unmat fns in the SET clause.
+statement ok
+CREATE TABLE dt (t TIMESTAMP)
+
+statement count 1
+INSERT INTO dt VALUES (now())
+
+statement count 1
+UPDATE dt SET t = now()
+
+statement error db error: ERROR: calls to mz_now in write statements are not supported
+UPDATE dt SET t = mz_now()


### PR DESCRIPTION
Although the `selection` part of the RTW plan supported `now()` (because it goes through the normal peek pipeline which resolves those), the `assignment` part did not. Add scalar prep to support this.

Fixes #28561

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support functions like `now()` in `SET` clauses of `UPDATE`: `UPDATE t SET x = now()`