### PR TITLE
storage-controller: further shard finalization improvements

### DIFF
--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -662,6 +662,7 @@ where
         let collections_ctl = storage_collections::StorageCollectionsImpl::new(
             config.persist_location.clone(),
             Arc::clone(&config.persist_clients),
+            &config.metrics_registry,
             config.now.clone(),
             Arc::clone(&txns_metrics),
             envd_epoch,

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -23,6 +23,7 @@ use futures::{Future, FutureExt, StreamExt};
 use itertools::Itertools;
 
 use mz_ore::collections::CollectionExt;
+use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_ore::task::AbortOnDropHandle;
 use mz_ore::{assert_none, instrument};
@@ -63,6 +64,9 @@ use tracing::{debug, info, trace, warn};
 use crate::controller::{
     CollectionDescription, DataSource, DataSourceOther, PersistEpoch, StorageMetadata, StorageTxn,
 };
+use crate::storage_collections::metrics::{ShardIdSet, StorageCollectionsMetrics};
+
+mod metrics;
 
 /// An abstraction for keeping track of storage collections and managing access
 /// to them.
@@ -316,13 +320,13 @@ pub struct StorageCollectionsImpl<
 
     /// The set of [ShardIds](ShardId) that we have to finalize. These will have
     /// been persisted by the caller of [StorageCollections::prepare_state].
-    finalizable_shards: Arc<std::sync::Mutex<BTreeSet<ShardId>>>,
+    finalizable_shards: Arc<ShardIdSet>,
 
     /// The set of [ShardIds](ShardId) that we have finalized. We keep track of
     /// shards here until we are given a chance to let our callers know that
     /// these have been finalized, for example via
     /// [StorageCollections::prepare_state].
-    finalized_shards: Arc<std::sync::Mutex<BTreeSet<ShardId>>>,
+    finalized_shards: Arc<ShardIdSet>,
 
     /// Collections maintained by this [StorageCollections].
     collections: Arc<std::sync::Mutex<BTreeMap<GlobalId, CollectionState<T>>>>,
@@ -388,6 +392,7 @@ where
     pub async fn new(
         persist_location: PersistLocation,
         persist_clients: Arc<PersistClientCache>,
+        metrics_registry: &MetricsRegistry,
         _now: NowFn,
         txns_metrics: Arc<TxnMetrics>,
         envd_epoch: NonZeroI64,
@@ -395,6 +400,8 @@ where
         connection_context: ConnectionContext,
         txn: &dyn StorageTxn<T>,
     ) -> Self {
+        let metrics = StorageCollectionsMetrics::register_into(metrics_registry);
+
         // This value must be already installed because we must ensure it's
         // durably recorded before it is used, otherwise we risk leaking persist
         // state.
@@ -438,8 +445,10 @@ where
         let txns_read = TxnsRead::start::<TxnsCodecRow>(txns_client.clone(), txns_id).await;
 
         let collections = Arc::new(std::sync::Mutex::new(BTreeMap::default()));
-        let finalizable_shards = Arc::new(std::sync::Mutex::new(BTreeSet::default()));
-        let finalized_shards = Arc::new(std::sync::Mutex::new(BTreeSet::default()));
+        let finalizable_shards =
+            Arc::new(ShardIdSet::new(metrics.finalization_outstanding.clone()));
+        let finalized_shards =
+            Arc::new(ShardIdSet::new(metrics.finalization_pending_commit.clone()));
         let config = Arc::new(Mutex::new(StorageConfiguration::new(
             connection_context,
             mz_dyncfgs::all_dyncfgs(),
@@ -472,6 +481,7 @@ where
             finalize_shards_task::<T>(FinalizeShardsTaskConfig {
                 envd_epoch: envd_epoch.clone(),
                 config: Arc::clone(&config),
+                metrics,
                 finalizable_shards: Arc::clone(&finalizable_shards),
                 finalized_shards: Arc::clone(&finalized_shards),
                 persist_location: persist_location.clone(),
@@ -1058,7 +1068,6 @@ where
     fn synchronize_finalized_shards(&self, storage_metadata: &StorageMetadata) {
         self.finalized_shards
             .lock()
-            .expect("lock poisoned")
             .retain(|shard| storage_metadata.unfinalized_shards.contains(shard));
     }
 }
@@ -1105,7 +1114,6 @@ where
 
         self.finalizable_shards
             .lock()
-            .expect("lock poisoned")
             .extend(unfinalized_shards.into_iter());
 
         Ok(())
@@ -1301,13 +1309,7 @@ where
 
         // Reconcile any shards we've successfully finalized with the shard
         // finalization collection.
-        let finalized_shards = self
-            .finalized_shards
-            .lock()
-            .expect("lock poisoned")
-            .iter()
-            .copied()
-            .collect();
+        let finalized_shards = self.finalized_shards.lock().iter().copied().collect();
         txn.mark_shards_as_finalized(finalized_shards);
 
         Ok(())
@@ -2077,7 +2079,7 @@ struct BackgroundTask<T: TimelyTimestamp + Lattice + Codec64> {
     cmds_tx: mpsc::UnboundedSender<BackgroundCmd<T>>,
     cmds_rx: mpsc::UnboundedReceiver<BackgroundCmd<T>>,
     holds_rx: mpsc::UnboundedReceiver<(GlobalId, ChangeBatch<T>)>,
-    finalizable_shards: Arc<std::sync::Mutex<BTreeSet<ShardId>>>,
+    finalizable_shards: Arc<ShardIdSet>,
     collections: Arc<std::sync::Mutex<BTreeMap<GlobalId, CollectionState<T>>>>,
     // So we know what shard ID corresponds to what global ID, which we need
     // when re-enqueing futures for determining the next upper update.
@@ -2391,10 +2393,7 @@ where
 
                 info!(%id, %dropped_shard_id, "enqueing shard finalization due to dropped collection and dropped persist handle");
 
-                self.finalizable_shards
-                    .lock()
-                    .expect("lock poisoned")
-                    .insert(dropped_shard_id);
+                self.finalizable_shards.lock().insert(dropped_shard_id);
 
                 res
             } else {
@@ -2413,8 +2412,9 @@ where
 struct FinalizeShardsTaskConfig {
     envd_epoch: NonZeroI64,
     config: Arc<Mutex<StorageConfiguration>>,
-    finalizable_shards: Arc<std::sync::Mutex<BTreeSet<ShardId>>>,
-    finalized_shards: Arc<std::sync::Mutex<BTreeSet<ShardId>>>,
+    metrics: StorageCollectionsMetrics,
+    finalizable_shards: Arc<ShardIdSet>,
+    finalized_shards: Arc<ShardIdSet>,
     persist_location: PersistLocation,
     persist: Arc<PersistClientCache>,
     read_only: bool,
@@ -2424,6 +2424,7 @@ async fn finalize_shards_task<T>(
     FinalizeShardsTaskConfig {
         envd_epoch,
         config,
+        metrics,
         finalizable_shards,
         finalized_shards,
         persist_location,
@@ -2456,8 +2457,7 @@ async fn finalize_shards_task<T>(
         let current_finalizable_shards = {
             // We hold the lock for as short as possible and pull our cloned set
             // of shards.
-            let shared_shards = finalizable_shards.lock().expect("lock poisoned");
-            shared_shards.iter().cloned().collect_vec()
+            finalizable_shards.lock().iter().cloned().collect_vec()
         };
 
         if current_finalizable_shards.is_empty() {
@@ -2470,6 +2470,7 @@ async fn finalize_shards_task<T>(
         // Open a persist client to delete unused shards.
         let persist_client = persist.open(persist_location.clone()).await.unwrap();
 
+        let metrics = &metrics;
         let persist_client = &persist_client;
         let diagnostics = &Diagnostics::from_purpose("finalizing shards");
 
@@ -2483,6 +2484,8 @@ async fn finalize_shards_task<T>(
                 let persist_client = persist_client.clone();
                 let diagnostics = diagnostics.clone();
                 let epoch = epoch.clone();
+
+                metrics.finalization_started.inc();
 
                 let is_finalized = persist_client
                     .is_finalized::<SourceData, (), T, Diff>(shard_id, diagnostics)
@@ -2591,6 +2594,10 @@ async fn finalize_shards_task<T>(
             // TODO(benesch): the concurrency here should be configurable
             // via LaunchDarkly.
             .buffer_unordered(10)
+            .inspect(|shard_id| match shard_id {
+                None => metrics.finalization_failed.inc(),
+                Some(_) => metrics.finalization_succeeded.inc(),
+            })
             // HERE BE DRAGONS: see warning on other uses of buffer_unordered
             // before any changes to `collect`
             .collect::<BTreeSet<Option<ShardId>>>()
@@ -2599,8 +2606,8 @@ async fn finalize_shards_task<T>(
             .filter_map(|shard| shard)
             .collect();
 
-        let mut shared_finalizable_shards = finalizable_shards.lock().expect("lock poisoned");
-        let mut shared_finalized_shards = finalized_shards.lock().expect("lock poisoned");
+        let mut shared_finalizable_shards = finalizable_shards.lock();
+        let mut shared_finalized_shards = finalized_shards.lock();
 
         for id in current_finalized_shards.iter() {
             shared_finalizable_shards.remove(id);
@@ -2634,7 +2641,7 @@ mod tests {
     use mz_build_info::DUMMY_BUILD_INFO;
     use mz_dyncfg::ConfigSet;
     use mz_ore::assert_err;
-    use mz_ore::metrics::MetricsRegistry;
+    use mz_ore::metrics::{MetricsRegistry, UIntGauge};
     use mz_ore::now::SYSTEM_TIME;
     use mz_persist_client::cache::PersistClientCache;
     use mz_persist_client::cfg::PersistConfig;
@@ -2801,7 +2808,9 @@ mod tests {
                 cmds_tx: cmds_tx.clone(),
                 cmds_rx,
                 holds_rx,
-                finalizable_shards: Arc::new(Mutex::new(BTreeSet::new())),
+                finalizable_shards: Arc::new(ShardIdSet::new(
+                    UIntGauge::new("finalizable_shards", "dummy gauge for tests").unwrap(),
+                )),
                 collections: Arc::new(Mutex::new(BTreeMap::new())),
                 shard_by_id: BTreeMap::new(),
                 since_handles: BTreeMap::new(),

--- a/src/storage-client/src/storage_collections/metrics.rs
+++ b/src/storage-client/src/storage_collections/metrics.rs
@@ -1,0 +1,103 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeSet;
+use std::ops::{Deref, DerefMut};
+use std::sync::{Mutex, MutexGuard};
+
+use mz_ore::cast::CastFrom;
+use mz_ore::metric;
+use mz_ore::metrics::{MetricsRegistry, UIntGauge};
+use mz_persist_types::ShardId;
+use prometheus::Counter;
+
+#[derive(Debug)]
+pub struct StorageCollectionsMetrics {
+    pub finalization_outstanding: UIntGauge,
+    pub finalization_pending_commit: UIntGauge,
+    pub finalization_started: Counter,
+    pub finalization_succeeded: Counter,
+    pub finalization_failed: Counter,
+}
+
+impl StorageCollectionsMetrics {
+    pub fn register_into(registry: &MetricsRegistry) -> Self {
+        StorageCollectionsMetrics {
+            finalization_outstanding: registry.register(metric!(
+                name: "mz_shard_finalization_outstanding",
+                help: "count of shards in need of finalization",
+            )),
+            finalization_pending_commit: registry.register(metric!(
+                name: "mz_shard_finalization_pending_commit",
+                help: "count of shards for which finalization has completed but has not yet been durably recorded",
+            )),
+            finalization_started: registry.register(metric!(
+                name: "mz_shard_finalization_op_started",
+                help: "count of shard finalization operations that have started",
+            )),
+            finalization_succeeded: registry.register(metric!(
+                name: "mz_shard_finalization_op_succeeded",
+                help: "count of shard finalization operations that succeeded",
+            )),
+            finalization_failed: registry.register(metric!(
+                name: "mz_shard_finalization_op_failed",
+                help: "count of shard finalization operations that failed",
+            )),
+        }
+    }
+}
+
+/// A set of shard IDs that maintains a gauge containing the set's size.
+#[derive(Debug)]
+pub struct ShardIdSet {
+    set: Mutex<BTreeSet<ShardId>>,
+    gauge: UIntGauge,
+}
+
+impl ShardIdSet {
+    pub fn new(gauge: UIntGauge) -> ShardIdSet {
+        ShardIdSet {
+            set: Mutex::new(BTreeSet::new()),
+            gauge,
+        }
+    }
+
+    pub fn lock(&self) -> ShardIdSetGuard {
+        ShardIdSetGuard {
+            set: self.set.lock().expect("lock poisoned"),
+            gauge: &self.gauge,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ShardIdSetGuard<'a> {
+    set: MutexGuard<'a, BTreeSet<ShardId>>,
+    gauge: &'a UIntGauge,
+}
+
+impl Drop for ShardIdSetGuard<'_> {
+    fn drop(&mut self) {
+        self.gauge.set(u64::cast_from(self.set.len()));
+    }
+}
+
+impl<'a> Deref for ShardIdSetGuard<'a> {
+    type Target = BTreeSet<ShardId>;
+
+    fn deref(&self) -> &Self::Target {
+        self.set.deref()
+    }
+}
+
+impl DerefMut for ShardIdSetGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.set.deref_mut()
+    }
+}


### PR DESCRIPTION
See commit messages for details.

### Motivation

* This PR addresses issues discovered while investigating MaterializeInc/incidents-and-escalations#37.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
