### PR TITLE
QA notifications: Remove ignores

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -210,10 +210,6 @@ def notify_qa_team_about_failure(failure: str) -> None:
     if not is_on_default_branch():
         return
 
-    # TODO(def-): Remove when #28472 is fixed
-    if "network error" in failure:
-        return
-
     step_key = get_var(BuildkiteEnvVar.BUILDKITE_STEP_KEY)
     message = f"{step_key}: {failure}"
     print(message)


### PR DESCRIPTION
There should be no common failures anymore.

See Slack for progress on fixing the network error we are seeing. If we disable the ignore, it will be easier to iterate on potential fixes: https://materializeinc.slack.com/archives/C07ESLCMFL1/p1722189329807719

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
