### PR TITLE
test analytics: configurable QA notifications

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -207,9 +207,6 @@ def notify_qa_team_about_failure(failure: str) -> None:
     if not is_in_buildkite():
         return
 
-    if not is_on_default_branch():
-        return
-
     # TODO(def-): Remove when #28472 is fixed
     if "network error" in failure:
         return

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -29,7 +29,6 @@ from materialize import ci_util, ui
 from materialize.buildkite import (
     add_annotation_raw,
     get_artifact_url,
-    notify_qa_team_about_failure,
 )
 from materialize.buildkite_insights.buildkite_api import builds_api, generic_api
 from materialize.buildkite_insights.buildkite_api.buildkite_constants import (
@@ -340,12 +339,12 @@ and finds associated open GitHub issues in Materialize repository.""",
     parser.add_argument("log_files", nargs="+", help="log files to search in")
     args = parser.parse_args()
 
-    try:
-        test_analytics_config = create_test_analytics_config_with_hostname(
-            args.cloud_hostname
-        )
-        test_analytics = TestAnalyticsDb(test_analytics_config)
+    test_analytics_config = create_test_analytics_config_with_hostname(
+        args.cloud_hostname
+    )
+    test_analytics = TestAnalyticsDb(test_analytics_config)
 
+    try:
         # always insert a build job regardless whether it has annotations or not
         test_analytics.builds.add_build_job(
             was_successful=has_successful_buildkite_status()
@@ -353,7 +352,7 @@ and finds associated open GitHub issues in Materialize repository.""",
 
         return_code = annotate_logged_errors(args.log_files, test_analytics)
     except Exception as e:
-        notify_qa_team_about_failure(f"ci_annotate_errors failed! {e}")
+        test_analytics.on_upload_failed(e)
         raise
 
     try:
@@ -363,7 +362,7 @@ and finds associated open GitHub issues in Materialize repository.""",
             print(traceback.format_exc())
 
         # An error during an upload must never cause the build to fail
-        notify_qa_team_about_failure(f"Uploading results failed! {e}")
+        test_analytics.on_upload_failed(e)
 
     return return_code
 
@@ -759,9 +758,7 @@ def get_failures_on_main(test_analytics: TestAnalyticsDb) -> BuildHistory:
         else:
             return build_history
     except Exception as e:
-        notify_qa_team_about_failure(
-            f"Loading build history from test analytics failed: {e}"
-        )
+        test_analytics.on_data_retrieval_failed(e)
 
     print("Loading build history from buildkite instead")
     return _get_failures_on_main_from_buildkite(

--- a/misc/python/materialize/output_consistency/output_consistency_test.py
+++ b/misc/python/materialize/output_consistency/output_consistency_test.py
@@ -283,7 +283,7 @@ def upload_output_consistency_results_to_test_analytics(
         print("Uploaded results.")
     except Exception as e:
         # An error during an upload must never cause the build to fail
-        buildkite.notify_qa_team_about_failure(f"Uploading results failed! {e}")
+        test_analytics.on_upload_failed(e)
 
 
 def connect(host: str, port: int, user: str, password: str | None = None) -> Connection:

--- a/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
+++ b/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
@@ -138,6 +138,12 @@ class DatabaseConnector:
         self.cached_settings = settings
         return settings
 
+    def try_get_or_query_settings(self) -> TestAnalyticsSettings | None:
+        try:
+            return self._get_or_query_settings(self.create_cursor())
+        except:
+            return None
+
     def add_update_statements(self, sql_statements: list[str]) -> None:
         self.update_statements.extend(sql_statements)
 

--- a/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
+++ b/misc/python/materialize/test_analytics/connector/test_analytics_connector.py
@@ -38,6 +38,7 @@ class TestAnalyticsSettings:
 
     uploads_enabled: bool
     min_required_data_version_for_uploads: int
+    only_notify_about_communication_failures_on_main: bool
 
 
 class DatabaseConnector:
@@ -121,7 +122,8 @@ class DatabaseConnector:
             """
             SELECT
                 uploads_enabled,
-                min_required_data_version_for_uploads
+                min_required_data_version_for_uploads,
+                only_notify_about_communication_failures_on_main
             FROM config;
             """
         )
@@ -129,10 +131,12 @@ class DatabaseConnector:
         rows = cursor.fetchall()
         assert len(rows) == 1, f"Expected exactly one row, got {len(rows)}"
 
-        row = rows[0]
+        column_values = rows[0]
 
         settings = TestAnalyticsSettings(
-            uploads_enabled=row[0], min_required_data_version_for_uploads=row[1]
+            uploads_enabled=column_values[0],
+            min_required_data_version_for_uploads=column_values[1],
+            only_notify_about_communication_failures_on_main=column_values[2],
         )
 
         self.cached_settings = settings

--- a/misc/python/materialize/test_analytics/setup/tables/00-config.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/00-config.sql
@@ -9,16 +9,19 @@
 
 CREATE TABLE config (
    uploads_enabled BOOL NOT NULL,
-   min_required_data_version_for_uploads INT NOT NULL
+   min_required_data_version_for_uploads INT NOT NULL,
+   only_notify_about_communication_failures_on_main BOOL NOT NULL
 );
 
 INSERT INTO config
 (
     uploads_enabled,
-    min_required_data_version_for_uploads
+    min_required_data_version_for_uploads,
+    only_notify_about_communication_failures_on_main
 )
 VALUES
 (
     TRUE,
-    6
+    6,
+    FALSE
 );

--- a/misc/python/materialize/test_analytics/test_analytics_db.py
+++ b/misc/python/materialize/test_analytics/test_analytics_db.py
@@ -71,7 +71,18 @@ class TestAnalyticsDb:
         self._communication_failed(f"Loading data failed! {e}")
 
     def _communication_failed(self, message: str) -> None:
-        if not buildkite.is_on_default_branch():
+        if not self.shall_notify_qa_team():
             return
 
         buildkite.notify_qa_team_about_failure(message)
+
+    def shall_notify_qa_team(self) -> bool:
+        if buildkite.is_on_default_branch():
+            return True
+
+        settings = self.database_connector.try_get_or_query_settings()
+
+        if settings is None:
+            return True
+
+        return not settings.only_notify_about_communication_failures_on_main

--- a/misc/python/materialize/test_analytics/test_analytics_db.py
+++ b/misc/python/materialize/test_analytics/test_analytics_db.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 """Test analytics database."""
+from materialize import buildkite
 from materialize.test_analytics.config.mz_db_config import MzDbConfig
 from materialize.test_analytics.connector.test_analytics_connector import (
     DatabaseConnector,
@@ -62,3 +63,12 @@ class TestAnalyticsDb:
         Make sure that this method is always invoked within a try-catch block.
         """
         self.database_connector.submit_update_statements()
+
+    def on_upload_failed(self, e: Exception) -> None:
+        self._communication_failed(f"Uploading results failed! {e}")
+
+    def on_data_retrieval_failed(self, e: Exception) -> None:
+        self._communication_failed(f"Loading data failed! {e}")
+
+    def _communication_failed(self, message: str) -> None:
+        buildkite.notify_qa_team_about_failure(message)

--- a/misc/python/materialize/test_analytics/test_analytics_db.py
+++ b/misc/python/materialize/test_analytics/test_analytics_db.py
@@ -33,7 +33,7 @@ from materialize.test_analytics.data.scalability_framework.scalability_framework
     ScalabilityFrameworkResultStorage,
 )
 
-TEST_ANALYTICS_DATA_VERSION: int = 15
+TEST_ANALYTICS_DATA_VERSION: int = 16
 
 
 class TestAnalyticsDb:

--- a/misc/python/materialize/test_analytics/test_analytics_db.py
+++ b/misc/python/materialize/test_analytics/test_analytics_db.py
@@ -71,4 +71,7 @@ class TestAnalyticsDb:
         self._communication_failed(f"Loading data failed! {e}")
 
     def _communication_failed(self, message: str) -> None:
+        if not buildkite.is_on_default_branch():
+            return
+
         buildkite.notify_qa_team_about_failure(message)

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -781,4 +781,4 @@ def upload_results_to_test_analytics(
         print("Uploaded results.")
     except Exception as e:
         # An error during an upload must never cause the build to fail
-        buildkite.notify_qa_team_about_failure(f"Uploading results failed! {e}")
+        test_analytics.on_upload_failed(e)

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -601,7 +601,7 @@ def upload_results_to_test_analytics(
         print("Uploaded results.")
     except Exception as e:
         # An error during an upload must never cause the build to fail
-        buildkite.notify_qa_team_about_failure(f"Uploading results failed! {e}")
+        test_analytics.on_upload_failed(e)
 
 
 def _get_head_target_endpoint(endpoints: list[Endpoint]) -> Endpoint | None:


### PR DESCRIPTION
I propose to make it configurable whether to notify QA about issues going wrong on non-main branches. I learnt that If something breaks, it takes long until the fix is propagated to most feature branches.

### Commits
b91eb8d472 test analytics: qa notification: refactoring
d3d3066dca qa notifications: move restriction to default branch
3f40dd8f5d test analytics: cache settings
e267dc3f65 test analytics: expose settings
bb63f05530 test analytics: settings: add only_notify_about_communication_failures_on_main
4e37ad8437 test analytics: qa notifications: consider only_notify_about_communication_failures_on_main
