### PR TITLE
feature benchmark: measure duration for OptBench in nanoseconds

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -19,7 +19,7 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {}
 SHA256_OF_FRAMEWORK["*"] = (
-    "bed2e00943061489499aa2e57624bbc62225100dd03f4be58b2579f488c9bcb7"
+    "5e0a37dbde2024c8a8b52a08229e4e58fbd3f7c1975a6722435fd5a60e67a69a"
 )
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!
@@ -34,7 +34,7 @@ SHA256_BY_SCENARIO_FILE["customer.py"] = (
     "d1e72837a342c3ebf1f4a32ec583b1b78a78644cdba495030a6df45ebbffe703"
 )
 SHA256_BY_SCENARIO_FILE["optbench.py"] = (
-    "f363bcdd49d133befebc45273f320540058e7d00edc57fba34451b675fceddd8"
+    "265dc123c1589d46d118dd3e3d41cec30c8ce210c0f120e9389b4b65330ed794"
 )
 SHA256_BY_SCENARIO_FILE["scale.py"] = (
     "c4c8749d166e4df34e0b0e92220434fdb508c5c2ac56eb80c07043be0048dded"

--- a/misc/python/materialize/feature_benchmark/measurement.py
+++ b/misc/python/materialize/feature_benchmark/measurement.py
@@ -15,7 +15,7 @@ from enum import Enum, auto
 
 class WallclockUnit(Enum):
     SECONDS = auto()
-    TRIPLE_NANOSECONDS = auto()
+    NANOSECONDS = auto()
 
 
 @dataclass

--- a/misc/python/materialize/feature_benchmark/scenarios/optbench.py
+++ b/misc/python/materialize/feature_benchmark/scenarios/optbench.py
@@ -81,12 +81,12 @@ class OptbenchRun(MeasurementSource):
         optimization_time = explain_output.optimization_time()
         assert optimization_time is not None
         optimization_time_in_ns = optimization_time.astype("timedelta64[ns]")
-        optimization_duration_in_triple_ns = float(optimization_time_in_ns) / 3
+        optimization_duration_in_ns = float(optimization_time_in_ns)
         timestamps = [
-            WallclockMeasurement(0, WallclockUnit.TRIPLE_NANOSECONDS),
+            WallclockMeasurement(0, WallclockUnit.NANOSECONDS),
             WallclockMeasurement(
-                optimization_duration_in_triple_ns,
-                WallclockUnit.TRIPLE_NANOSECONDS,
+                optimization_duration_in_ns,
+                WallclockUnit.NANOSECONDS,
             ),
         ]
         return timestamps

--- a/misc/python/materialize/test_analytics/test_analytics_db.py
+++ b/misc/python/materialize/test_analytics/test_analytics_db.py
@@ -33,7 +33,7 @@ from materialize.test_analytics.data.scalability_framework.scalability_framework
     ScalabilityFrameworkResultStorage,
 )
 
-TEST_ANALYTICS_DATA_VERSION: int = 18
+TEST_ANALYTICS_DATA_VERSION: int = 19
 
 
 class TestAnalyticsDb:


### PR DESCRIPTION
This removes the obscure `NANOSECONDS / 3` and changes the optbench unit to `NANOSECONDS`.

### Migration

This will require a migration in the test analytics database:
```
UPDATE feature_benchmark_result SET wallclock = wallclock * 3 WHERE build_job_id IN (SELECT build_job_id FROM build_job bj INNER JOIN build b ON bj.build_id = b.build_id WHERE b.data_version < 19) AND scenario_name LIKE 'OptbenchTPCHQ%';

UPDATE feature_benchmark_discarded_result SET wallclock = wallclock * 3 WHERE build_job_id IN (SELECT build_job_id FROM build_job bj INNER JOIN build b ON bj.build_id = b.build_id WHERE b.data_version < 19) AND scenario_name LIKE 'OptbenchTPCHQ%';
```