### PR TITLE
adapter: downgrade "cannot update system variable" to info! for read-only error

### DIFF
--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -47,14 +47,23 @@ impl SystemParameterBackend {
                 Ok(()) => {
                     info!(name = param.name, value = param.value, "sync parameter");
                 }
-                Err(error) => {
-                    error!(
-                        name = param.name,
-                        value = param.value,
-                        "cannot update system variable: {}",
-                        error
-                    );
-                }
+                Err(error) => match error {
+                    AdapterError::ReadOnly => {
+                        info!(
+                            name = param.name,
+                            value = param.value,
+                            "cannot update system variable in read-only mode",
+                        );
+                    }
+                    error => {
+                        error!(
+                            name = param.name,
+                            value = param.value,
+                            "cannot update system variable: {}",
+                            error
+                        );
+                    }
+                },
             }
         }
     }


### PR DESCRIPTION
@jkosh44  & @benesch What do you think of this one? I changed it because it showed up as a sentry issue, which can be misleading: https://materializeinc.sentry.io/issues/5647730831/?project=6780145&referrer=github_integration

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
