### PR TITLE
Add index for build (build_id)

### DIFF
--- a/misc/python/materialize/test_analytics/setup/tables/01-build.sql
+++ b/misc/python/materialize/test_analytics/setup/tables/01-build.sql
@@ -21,3 +21,5 @@ CREATE TABLE build (
    data_version UINT4 NOT NULL,
    remarks TEXT -- not in use, remove eventually
 );
+
+CREATE INDEX IN CLUSTER test_analytics ON build (build_id);


### PR DESCRIPTION
Lack of it causes slowness in `INSERT INTO build ... SELECT ... WHERE NOT EXISTS ...`
Verified its usage with `EXPLAIN PLAN`:
```
Explained Query:
  Project (#1..=#7, #0, #8, #9) // { arity: 10 }
    Map (2024-07-29 13:37:23.198 UTC, "release-qualification", 559, "0190f863-e476-46fa-8f83-35b2d5407830", "v0.110.1", "6bb4a5f1a20024e7d48c7938248443c3d64e9629", "6cfefe42fce15783876941ac124870ac4c1359f7", "v0.110.1", 12, null) // { arity: 10 }
      Union // { arity: 0 }
        Negate // { arity: 0 }
          Distinct project=[] // { arity: 0 }
            Project () // { arity: 0 }
              ReadIndex on=raw.test_analytics.build build_build_id_idx=[lookup value=("0190f863-e476-46fa-8f83-35b2d5407830")] // { arity: 12 }
        Constant // { arity: 0 }
          - ()

Used Indexes:
  - raw.test_analytics.build_build_id_idx (lookup)

Target cluster: test_analytics
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
