### PR TITLE
dbt-materialize: add cleanup_schema macro

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,20 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Added new macro `cleanup_schema` for resetting the target schema during development or testing.
+  The macro drops and recreates the target schema, removing all objects within it.
+  It supports a dry run mode for safely previewing the actions without making changes.
+
+  Example usage:
+  ```sql
+  -- Preview the cleanup without making changes
+  dbt run-operation cleanup_schema --args '{dry_run: true}'
+
+  -- Reset the target schema
+  dbt run-operation cleanup_schema
+  ```
+
 ## 1.8.3 - 2024-07-19
 
 * Enable cross-database references ([#27686](https://github.com/MaterializeInc/materialize/pull/27686)). Although cross-database references are not supported in `dbt-postgres`, databases in Materialize are purely used for namespacing, and therefore do not present the same constraint.

--- a/misc/dbt-materialize/dbt/include/materialize/macros/cleanup_schema.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/cleanup_schema.sql
@@ -1,0 +1,45 @@
+-- Copyright 2020 Josh Wills. All rights reserved.
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- This macro resets the target schema by dropping and recreating it.
+{% macro cleanup_schema(dry_run=False) %}
+  {% set target_schema = target.schema %}
+  {% set target_database = target.database %}
+
+  {% if execute %}
+    {% set drop_schema_sql %}
+      DROP SCHEMA IF EXISTS {{ target_database }}.{{ target_schema }} CASCADE;
+    {% endset %}
+
+    {% set create_schema_sql %}
+      CREATE SCHEMA {{ target_database }}.{{ target_schema }};
+    {% endset %}
+
+    {% if dry_run %}
+      {{ log("Dry run. Would execute:", info=True) }}
+      {{ log(drop_schema_sql, info=True) }}
+      {{ log(create_schema_sql, info=True) }}
+    {% else %}
+      {% do log("Executing cleanup SQL...", info=True) %}
+      {% do adapter.commit() %}
+      {% do adapter.execute(drop_schema_sql) %}
+      {% do adapter.commit() %}
+      {% do adapter.execute(create_schema_sql) %}
+      {% do adapter.commit() %}
+      {% do log("Cleanup complete. Schema " ~ target_database ~ "." ~ target_schema ~ " has been reset.", info=True) %}
+    {% endif %}
+  {% endif %}
+{% endmacro %}

--- a/misc/dbt-materialize/tests/adapter/test_cleanup_schema.py
+++ b/misc/dbt-materialize/tests/adapter/test_cleanup_schema.py
@@ -1,0 +1,77 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dbt.tests.util import run_dbt
+
+
+class TestCleanupSchema:
+    @pytest.fixture(autouse=True)
+    def cleanup(self, project):
+        project.run_sql(f"DROP SCHEMA IF EXISTS {project.test_schema} CASCADE")
+        project.run_sql("DROP ROLE IF EXISTS test_role")
+
+    def test_cleanup_schema(self, project):
+        # Setup
+        project.run_sql(f"CREATE SCHEMA {project.test_schema}")
+        project.run_sql(f"CREATE TABLE {project.test_schema}.test_table (id INT)")
+        project.run_sql("CREATE ROLE test_role")
+        project.run_sql(f"GRANT USAGE ON SCHEMA {project.test_schema} TO test_role")
+
+        # Run the macro
+        run_dbt(["run-operation", "cleanup_schema"])
+
+        # Verify the schema was dropped and recreated
+        schema_exists = project.run_sql(
+            f"SELECT count(*) FROM mz_schemas WHERE name = '{project.test_schema}'",
+            fetch="one",
+        )[0]
+        assert schema_exists == 1, "Schema should exist after cleanup"
+
+        # Verify the table was dropped
+        table_exists = project.run_sql(
+            f"SELECT count(*) FROM mz_tables WHERE name = 'test_table' AND schema_id = (SELECT id FROM mz_schemas WHERE name = '{project.test_schema}')",
+            fetch="one",
+        )[0]
+        assert table_exists == 0, "Table should not exist after cleanup"
+
+        can_use_schema = project.run_sql(
+            f"SELECT has_schema_privilege('test_role', '{project.test_schema}', 'USAGE')",
+            fetch="one",
+        )[0]
+        assert not can_use_schema, "Grant should not exist after cleanup"
+
+    def test_cleanup_schema_dry_run(self, project):
+        # Setup
+        project.run_sql(f"CREATE SCHEMA {project.test_schema}")
+        project.run_sql(f"CREATE TABLE {project.test_schema}.test_table (id INT)")
+
+        # Run the macro in dry run mode
+        run_dbt(
+            ["run-operation", "cleanup_schema", "--args", "{dry_run: True}"]
+        )
+
+        # Verify the schema and table still exist
+        schema_exists = project.run_sql(
+            f"SELECT count(*) FROM mz_schemas WHERE name = '{project.test_schema}'",
+            fetch="one",
+        )[0]
+        assert schema_exists == 1, "Schema should still exist after dry run"
+
+        table_exists = project.run_sql(
+            f"SELECT count(*) FROM mz_tables WHERE name = 'test_table' AND schema_id = (SELECT id FROM mz_schemas WHERE name = '{project.test_schema}')",
+            fetch="one",
+        )[0]
+        assert table_exists == 1, "Table should still exist after dry run"


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
As discussed in the community Slack, adding a new macro that is run using `dbt run-operation` to allow users to completely drop a target schema and recreate it.

Example usage:
```sql
-- Preview the cleanup without making changes
dbt run-operation cleanup_schema --args '{dry_run: true}'

-- Reset the target schema
dbt run-operation cleanup_schema
```