### PR TITLE
catalog: Optimize 0dt builtin item migrations

### DIFF
--- a/src/adapter/src/catalog/open/builtin_item_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_item_migration.rs
@@ -313,7 +313,7 @@ async fn migrate_builtin_items_0dt(
 
     // It's very important that we use the same `upper` that was used to read in a snapshot of the
     // shard. If someone updated the shard after we read then this write will fail.
-    let next_upper = if !migrated_shard_updates.is_empty() {
+    let upper = if !migrated_shard_updates.is_empty() {
         write_to_migration_shard(
             migrated_shard_updates,
             upper,
@@ -367,15 +367,15 @@ async fn migrate_builtin_items_0dt(
         if !read_only {
             let updates: Vec<_> = migration_shards_to_finalize
                 .into_iter()
-                .map(|(table_key, shard_id)| ((table_key, shard_id), next_upper, -1))
+                .map(|(table_key, shard_id)| ((table_key, shard_id), upper, -1))
                 .collect();
             if !updates.is_empty() {
                 // Ignore any errors, these shards will get cleaned up in the next upgrade.
-                // It's important to use `next_upper` here. If there was another concurrent write at
-                // `next_upper`, then `updates` are no longer valid.
+                // It's important to use `upper` here. If there was another concurrent write at
+                // `upper`, then `updates` are no longer valid.
                 let res = write_to_migration_shard(
                     updates,
-                    next_upper,
+                    upper,
                     &mut write_handle,
                     &mut since_handle,
                 )

--- a/src/adapter/src/catalog/open/builtin_item_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_item_migration.rs
@@ -373,13 +373,9 @@ async fn migrate_builtin_items_0dt(
                 // Ignore any errors, these shards will get cleaned up in the next upgrade.
                 // It's important to use `upper` here. If there was another concurrent write at
                 // `upper`, then `updates` are no longer valid.
-                let res = write_to_migration_shard(
-                    updates,
-                    upper,
-                    &mut write_handle,
-                    &mut since_handle,
-                )
-                .await;
+                let res =
+                    write_to_migration_shard(updates, upper, &mut write_handle, &mut since_handle)
+                        .await;
                 if let Err(e) = res {
                     error!("Unable to remove old entries from migration shard: {e:?}");
                 }

--- a/src/adapter/src/catalog/open/builtin_item_migration.rs
+++ b/src/adapter/src/catalog/open/builtin_item_migration.rs
@@ -313,13 +313,17 @@ async fn migrate_builtin_items_0dt(
 
     // It's very important that we use the same `upper` that was used to read in a snapshot of the
     // shard. If someone updated the shard after we read then this write will fail.
-    let next_upper = write_to_migration_shard(
-        migrated_shard_updates,
-        upper,
-        &mut write_handle,
-        &mut since_handle,
-    )
-    .await?;
+    let next_upper = if !migrated_shard_updates.is_empty() {
+        write_to_migration_shard(
+            migrated_shard_updates,
+            upper,
+            &mut write_handle,
+            &mut since_handle,
+        )
+        .await?
+    } else {
+        upper
+    };
 
     // 6. Update `GlobalId` to `ShardId` mapping and register old `ShardId`s for finalization. We don't do the finalization here and instead rely on the background finalization task.
     {
@@ -365,14 +369,20 @@ async fn migrate_builtin_items_0dt(
                 .into_iter()
                 .map(|(table_key, shard_id)| ((table_key, shard_id), next_upper, -1))
                 .collect();
-            // Ignore any errors, these shards will get cleaned up in the next upgrade.
-            // It's important to use `next_upper` here. If there was another concurrent write at
-            // `next_upper`, then `updates` are no longer valid.
-            let res =
-                write_to_migration_shard(updates, next_upper, &mut write_handle, &mut since_handle)
-                    .await;
-            if let Err(e) = res {
-                error!("Unable to remove old entries from migration shard: {e:?}");
+            if !updates.is_empty() {
+                // Ignore any errors, these shards will get cleaned up in the next upgrade.
+                // It's important to use `next_upper` here. If there was another concurrent write at
+                // `next_upper`, then `updates` are no longer valid.
+                let res = write_to_migration_shard(
+                    updates,
+                    next_upper,
+                    &mut write_handle,
+                    &mut since_handle,
+                )
+                .await;
+                if let Err(e) = res {
+                    error!("Unable to remove old entries from migration shard: {e:?}");
+                }
             }
         }
     }


### PR DESCRIPTION
This commit optimizes 0dt builtin item migrations by only writing to the migration shard when there is a migration. Previously, the migrations would always write to the migration shard, and commit an empty write if there are no migrations. Additionally, removing the empty write reduces some contention on the migration shard, for example when a read-only instance is starting up at the same time as a writeable instance.

Resolves #28605

### Motivation
This PR fixes a CI flake.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
