### PR TITLE
buildkite: recover buildkite section headers

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -72,7 +72,7 @@ def maybe_upload_debuginfo(
     if not bins:
         return
 
-    print(f"Uploading debuginfo for {', '.join(bins)}...")
+    ui.section(f"Uploading debuginfo for {', '.join(bins)}...")
 
     s3 = boto3.client("s3")
     is_tag_build = ui.env_is_truthy("BUILDKITE_TAG")
@@ -122,7 +122,7 @@ def maybe_upload_debuginfo(
         # expensive, so we don't want to upload development or unstable builds
         # that won't ever be profiled by Polar Signals.
         if is_tag_build:
-            print(f"Uploading debuginfo for {bin} to Polar Signals...")
+            ui.section(f"Uploading debuginfo for {bin} to Polar Signals...")
             spawn.runv(
                 [
                     "parca-debuginfo",

--- a/misc/python/materialize/ci_util/__init__.py
+++ b/misc/python/materialize/ci_util/__init__.py
@@ -47,7 +47,7 @@ def upload_junit_report(suite: str, junit_report: Path) -> None:
     """
     if not buildkite.is_in_buildkite():
         return
-    ui.header(f"Uploading report for suite {suite!r} to Buildkite Test Analytics")
+    ui.section(f"Uploading report for suite {suite!r} to Buildkite Test Analytics")
     suite = suite.upper().replace("-", "_")
     token = os.environ[f"BUILDKITE_TEST_ANALYTICS_API_KEY_{suite}"]
     try:
@@ -81,7 +81,7 @@ def get_artifacts() -> Any:
     if not buildkite.is_in_buildkite():
         return []
 
-    ui.header("Getting artifact informations from Buildkite")
+    ui.section("Getting artifact informations from Buildkite")
     build = os.environ["BUILDKITE_BUILD_NUMBER"]
     build_id = os.environ["BUILDKITE_BUILD_ID"]
     job = os.environ["BUILDKITE_JOB_ID"]

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -468,7 +468,7 @@ class DockerComposeCommand(Command):
             return
 
         composition = load_composition(args)
-        ui.header("Collecting mzbuild images")
+        ui.section("Collecting mzbuild images")
         for d in composition.dependencies:
             ui.say(d.spec())
 

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -370,7 +370,7 @@ class CargoBuild(CargoPreImage):
             examples.update(build.examples)
         assert rd
 
-        ui.say(f"Common cargo build for: {', '.join(bins | examples)}")
+        ui.section(f"Common cargo build for: {', '.join(bins | examples)}")
         cargo_build = cls.generate_cargo_build_command(rd, list(bins), list(examples))
         spawn.runv(cargo_build, cwd=rd.root)
 
@@ -628,7 +628,7 @@ class ResolvedImage:
         Requires that the caller has already acquired all dependencies and
         prepared all `PreImage` actions via `PreImage.prepare_batch`.
         """
-        ui.header(f"Building {self.spec()}")
+        ui.section(f"Building {self.spec()}")
         spawn.runv(["git", "clean", "-ffdX", self.image.path])
 
         for pre_image in self.image.pre_images:
@@ -654,7 +654,7 @@ class ResolvedImage:
 
     def try_pull(self, max_retries: int) -> bool:
         """Download the image if it does not exist locally. Returns whether it was found."""
-        ui.header(f"Acquiring {self.spec()}")
+        ui.section(f"Acquiring {self.spec()}")
         if not self.acquired:
             for retry in range(1, max_retries + 1):
                 try:
@@ -860,7 +860,7 @@ class DependencySet:
                 images_to_push.append(dep.spec())
 
         # Push all Docker images in parallel to minimize build time.
-        ui.header("Pushing images")
+        ui.section("Pushing images")
         pushes: list[subprocess.Popen] = []
         for image in images_to_push:
             # Piping through `cat` disables terminal control codes, and so the

--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -59,6 +59,7 @@ def speaker(prefix: str) -> Callable[..., None]:
 
 
 header = speaker("==> ")
+section = speaker("--- ")
 say = speaker("")
 
 


### PR DESCRIPTION
In #22989, we got nice collapsible section headers in buildkite. This
had to be reverted in #24504 because it made some usages spammy. Recover
the ability by adding a new method and selectively opt-in useful and
non-spammy spots.

Example effect on build x86_64

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/20e0ceb3-c6a4-4e8c-93eb-122daebe1b33">

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
