### PR TITLE
testdrive: Rename mz-arrangement-sharing.td

### DIFF
--- a/test/testdrive/distinct-arrangements.td
+++ b/test/testdrive/distinct-arrangements.td
@@ -19,8 +19,8 @@ ALTER SYSTEM SET enable_introspection_subscribes = false
 
 # Run the majority of this test on its own cluster to ensure it doesn't
 # interfere with any other tests.
-> CREATE CLUSTER arrangement_sharing REPLICAS (r1 (SIZE '${arg.default-replica-size}'))
-> SET cluster TO arrangement_sharing
+> CREATE CLUSTER distinct_arrangements REPLICAS (r1 (SIZE '${arg.default-replica-size}'))
+> SET cluster TO distinct_arrangements
 > SET cluster_replica = r1
 
 # from attributes/mir_unique_keys.slt
@@ -575,7 +575,7 @@ ArrangeBy[[]]
 ReduceAccumulable
 
 > DROP TABLE t1 CASCADE
-> SET cluster=arrangement_sharing
+> SET cluster=distinct_arrangements
 > DROP CLUSTER linear_join CASCADE
 
 # from negative-multiplicities.td
@@ -764,11 +764,11 @@ ArrangeBy[[Column(13)]]                       1
 "ReduceMinsMaxes"                             2
 "Threshold local"                             4
 
-> SET cluster TO arrangement_sharing
+> SET cluster TO distinct_arrangements
 
 # Check dataflows of our logging infrastructure with log_logging
-> ALTER CLUSTER arrangement_sharing SET (MANAGED = false);
-> CREATE CLUSTER REPLICA arrangement_sharing.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
+> ALTER CLUSTER distinct_arrangements SET (MANAGED = false);
+> CREATE CLUSTER REPLICA distinct_arrangements.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
 
 > SET cluster_replica = replica;
 
@@ -809,10 +809,10 @@ ALTER SYSTEM SET enable_introspection_subscribes = true
 
 # Flipping `enable_introspection_subscribes` affects new replicas, so force a
 # restart.
-> DROP CLUSTER REPLICA arrangement_sharing.replica
-> ALTER CLUSTER arrangement_sharing SET (MANAGED = true)
-> ALTER CLUSTER arrangement_sharing SET (REPLICATION FACTOR = 0)
-> ALTER CLUSTER arrangement_sharing SET (REPLICATION FACTOR = 1)
+> DROP CLUSTER REPLICA distinct_arrangements.replica
+> ALTER CLUSTER distinct_arrangements SET (MANAGED = true)
+> ALTER CLUSTER distinct_arrangements SET (REPLICATION FACTOR = 0)
+> ALTER CLUSTER distinct_arrangements SET (REPLICATION FACTOR = 1)
 > RESET cluster_replica
 
 > SELECT mdod.name, count(*)


### PR DESCRIPTION
While it uses mz_arrangement_sharing, it doesn't actually care about the sharing of arrangements, just their existence

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
