### PR TITLE
ci: Minor fixes to test pipeline

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1510,16 +1510,6 @@ steps:
     agents:
       queue: linux-aarch64
 
-  - id: 0dt
-    label: Zero downtime
-    depends_on: build-aarch64
-    timeout_in_minutes: 30
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: 0dt
-    agents:
-      queue: linux-aarch64
-
   - group: "Copy To S3"
     key: copy-to-s3
     steps:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -520,6 +520,7 @@ steps:
         label: Kafka RTR tests
         depends_on: build-aarch64
         timeout_in_minutes: 30
+        parallelism: 2
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/mzcompose:
@@ -537,7 +538,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=KafkaSources, --actions=200]
+          args: [--scenario=KafkaSources, --actions=100]
 
   - group: "Platform checks"
     key: platform-checks
@@ -727,6 +728,16 @@ steps:
           composition: tracing
     agents:
       queue: linux-aarch64-small
+
+  - id: 0dt
+    label: Zero downtime
+    depends_on: build-aarch64
+    timeout_in_minutes: 30
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: 0dt
+    agents:
+      queue: linux-aarch64
 
   - id: skip-version-upgrade
     label: "Skip Version Upgrade"

--- a/test/kafka-rtr/mzcompose.py
+++ b/test/kafka-rtr/mzcompose.py
@@ -14,6 +14,7 @@ from textwrap import dedent
 
 from pg8000 import Cursor
 
+from materialize import buildkite
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
@@ -34,7 +35,12 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    for name in c.workflows:
+    # Otherwise we are running all workflows
+    sharded_workflows = buildkite.shard_list(list(c.workflows), lambda w: w)
+    print(
+        f"Workflows in shard with index {buildkite.get_parallelism_index()}: {sharded_workflows}"
+    )
+    for name in sharded_workflows:
         if name == "default":
             continue
 


### PR DESCRIPTION
Reduce Short Zippy actions
- Since Mz0dtDeploys take a few minutes each and we are sometimes bumping against the 30 min timeout. We don't want to run for longer since this runs on each PR. Seen in https://buildkite.com/materialize/test/builds/87122#019100f5-0255-4ad5-9b77-061f71fdf8c8

Also move explicit 0dt test back to test pipeline, it's been green for a while.

Fix pg-cdc-resumption test to shard properly instead of running the same set in each test.

Add sharding to kafka-rtr test since it is the slowest now.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
