### PR TITLE
parallel-workload: Prevent deadlocks when swapping

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -874,7 +874,9 @@ class SwapSchemaAction(Action):
             ]
             if len(schemas) < 2:
                 return False
-            schema1, schema2 = self.rng.sample(schemas, 2)
+            schema_ids = sorted(self.rng.sample(range(0, len(schemas)), 2))
+            schema1 = schemas[schema_ids[0]]
+            schema2 = schemas[schema_ids[1]]
         with schema1.lock, schema2.lock:
             if schema1 not in exe.db.schemas:
                 return False
@@ -1175,7 +1177,9 @@ class SwapClusterAction(Action):
         with exe.db.lock:
             if len(exe.db.clusters) < 2:
                 return False
-            cluster1, cluster2 = self.rng.sample(exe.db.clusters, 2)
+            cluster_ids = sorted(self.rng.sample(range(0, len(exe.db.clusters)), 2))
+            cluster1 = exe.db.clusters[cluster_ids[0]]
+            cluster2 = exe.db.clusters[cluster_ids[1]]
         with cluster1.lock, cluster2.lock:
             if cluster1 not in exe.db.clusters:
                 return False

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -356,9 +356,6 @@ def run(
                 print(f"{thread.name} still running: {worker.exe.last_log}")
         print("Threads have not stopped within 5 minutes, exiting hard")
         print_stats(num_queries, workers, num_threads)
-        if scenario == Scenario.Rename:
-            # TODO(def-): Switch to failing exit code when #28182 is fixed
-            os._exit(0)
         if num_threads >= 50:
             # Under high load some queries can't finish quickly, especially UPDATE/DELETE
             os._exit(0)


### PR DESCRIPTION
Noticed in https://github.com/MaterializeInc/materialize/issues/28182#issuecomment-2257973674

Fixes: https://github.com/MaterializeInc/materialize/issues/28182

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
