### PR TITLE
feature benchmark: error annotation: only include matching matching scenario

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -215,7 +215,7 @@ class Report:
     def extend(self, comparisons: Iterable[Comparator]) -> None:
         self._comparisons.extend(comparisons)
 
-    def as_string(self, use_colors: bool) -> str:
+    def as_string(self, use_colors: bool, limit_to_scenario: str | None = None) -> str:
         output_lines = []
 
         output_lines.append(
@@ -224,6 +224,9 @@ class Report:
         output_lines.append("-" * 100)
 
         for comparison in self._comparisons:
+            if limit_to_scenario is not None and comparison.name != limit_to_scenario:
+                continue
+
             regression = "!!YES!!" if comparison.is_regression() else "no"
             output_lines.append(
                 f"{comparison.name:<35} | {comparison.type:<15} | {comparison.this_as_str():>15} | {comparison.other_as_str():>15} | {regression:^13} | {comparison.human_readable(use_colors)}"

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -19,7 +19,7 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {}
 SHA256_OF_FRAMEWORK["*"] = (
-    "5e0a37dbde2024c8a8b52a08229e4e58fbd3f7c1975a6722435fd5a60e67a69a"
+    "60e11caf402da3fa967ad1a898e3a2426fded8c979595101032a75f3e68f03ca"
 )
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -698,7 +698,9 @@ def _regressions_to_failure_details(
             TestFailureDetails(
                 test_case_name_override=f"Scenario '{scenario_name}'",
                 message=f"New regression against {regression_against_tag} (conducted {report.cycle_number} cycles)",
-                details=report.as_string(use_colors=False),
+                details=report.as_string(
+                    use_colors=False, limit_to_scenario=scenario_name
+                ),
             )
         )
 


### PR DESCRIPTION
Avoid that all failing rows are listed under all scenarios.