### PR TITLE
storage: Support updating the `WriteHandle`/`RelationDesc` for a table owned by txn-wal

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -467,6 +467,13 @@ pub trait StorageController: Debug {
         source_connections: BTreeMap<GlobalId, GenericSourceConnection<InlinedConnection>>,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
+    async fn alter_table_desc(
+        &mut self,
+        table_id: GlobalId,
+        new_desc: RelationDesc,
+        update_ts: Self::Timestamp,
+    ) -> Result<(), StorageError<Self::Timestamp>>;
+
     /// Acquire an immutable reference to the export state, should it exist.
     fn export(
         &self,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -471,7 +471,8 @@ pub trait StorageController: Debug {
         &mut self,
         table_id: GlobalId,
         new_desc: RelationDesc,
-        update_ts: Self::Timestamp,
+        forget_ts: Self::Timestamp,
+        register_ts: Self::Timestamp,
     ) -> Result<(), StorageError<Self::Timestamp>>;
 
     /// Acquire an immutable reference to the export state, should it exist.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1037,7 +1037,8 @@ where
         &mut self,
         table_id: GlobalId,
         new_desc: RelationDesc,
-        update_ts: Self::Timestamp,
+        forget_ts: Self::Timestamp,
+        register_ts: Self::Timestamp,
     ) -> Result<(), StorageError<Self::Timestamp>> {
         let shard_id = {
             let Controller {
@@ -1083,7 +1084,7 @@ where
             .await;
 
         self.persist_table_worker
-            .update(table_id, update_ts, write_handle);
+            .update(table_id, forget_ts, register_ts, write_handle);
 
         Ok(())
     }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1033,6 +1033,61 @@ where
         Ok(())
     }
 
+    async fn alter_table_desc(
+        &mut self,
+        table_id: GlobalId,
+        new_desc: RelationDesc,
+        update_ts: Self::Timestamp,
+    ) -> Result<(), StorageError<Self::Timestamp>> {
+        let shard_id = {
+            let Controller {
+                collections,
+                storage_collections,
+                ..
+            } = self;
+
+            // TODO(parkmycar): We're threading a needle here to make sure we don't
+            // leave either the Controller or StorageCollections in an inconsistent
+            // state. We should refactor this to be more robust.
+
+            // Before letting StorageCollections know, make sure we know about this
+            // collection.
+            let collection = collections
+                .get_mut(&table_id)
+                .ok_or(StorageError::IdentifierMissing(table_id))?;
+            if !matches!(
+                collection.data_source,
+                DataSource::Other(DataSourceOther::TableWrites)
+            ) {
+                return Err(StorageError::IdentifierInvalid(table_id));
+            }
+
+            // Now also let StorageCollections know!
+            storage_collections
+                .alter_table_desc(table_id, new_desc.clone())
+                .await?;
+            // StorageCollections was successfully updated, now we can update our
+            // in-memory state.
+            collection.collection_metadata.relation_desc = new_desc.clone();
+
+            collection.collection_metadata.data_shard
+        };
+
+        let persist_client = self
+            .persist
+            .open(self.persist_location.clone())
+            .await
+            .expect("invalid persist location");
+        let write_handle = self
+            .open_data_handles(&table_id, shard_id, new_desc.clone(), &persist_client)
+            .await;
+
+        self.persist_table_worker
+            .update(table_id, update_ts, write_handle);
+
+        Ok(())
+    }
+
     fn export(
         &self,
         id: GlobalId,

--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -507,10 +507,18 @@ async fn read_only_mode_table_worker<T: Timestamp + Lattice + Codec64 + Timestam
                     // We don't care if our waiter has gone away.
                     let _ = tx.send(());
                 }
-                PersistTableWriteCmd::Update(id, write_handle) => {
-                    write_handles.insert(id, write_handle).expect(
+                PersistTableWriteCmd::Update {
+                    table_id,
+                    handle,
+                    forget_ts: _,
+                    register_ts: _,
+                    tx,
+                } => {
+                    write_handles.insert(table_id, handle).expect(
                         "PersistTableWriteCmd::Update only valid for updating extant write handles",
                     );
+                    // We don't care if our waiter has gone away.
+                    let _ = tx.send(());
                 }
                 PersistTableWriteCmd::DropHandles {
                     forget_ts: _,


### PR DESCRIPTION
This PR adds a new method, `alter_table_desc(...)` to the `StorageController` and `StorageCollections` to support updating the `RelationDesc` of a table. It also implements a `todo!(...)` in `txn-wal` to support updating the `WriteHandle` for a managed collection. 

### Motivation

Progress towards: https://github.com/MaterializeInc/materialize/issues/28082

### Tips for reviewer

Two things I'm unsure about and would love feedback on:
1. How does this fit with Pv2? I saw there is a "can_write" when creating collections that I didn't consider here.
2. How do the timestamps for forgetting and registering in txn-wal look? It's easy enough to plumb in another timestamp if necessary.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a