### PR TITLE
ci: Properly handle ci-annotate-errors failing

### DIFF
--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -87,8 +87,14 @@ mapfile -t artifacts < <(printf "run.log\nkubectl-get-logs.log\nkubectl-get-logs
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 # Continue even if ci-annotate-errors fails
-bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log || true
+CI_ANNOTATE_ERRORS_RESULT=0
+bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
 buildkite-agent artifact upload "$artifacts_str;ci-annotate-errors.log"
 
 # File should not be empty, see #25369
 test -s kubectl-get-logs-previous.log
+
+if [ "$CI_ANNOTATE_ERRORS_RESULT" -ne 0 ]; then
+  echo "+++ ci-annotate-errors failed, which indicates that an unknown error was found"
+  exit "$CI_ANNOTATE_ERRORS_RESULT"
+fi

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -76,7 +76,8 @@ mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nne
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 # Continue even if ci-annotate-errors fails
-bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log || true
+CI_ANNOTATE_ERRORS_RESULT=0
+bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
 buildkite-agent artifact upload "$artifacts_str;ci-annotate-errors.log"
 
 if [ ! -s services.log ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Long single-node Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of txn-wal" ] && [ "$BUILDKITE_LABEL" != "Mz E2E Test" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version for DFR)" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version for CTF)" ] && [ "$BUILDKITE_LABEL" != "QA Canary Environment Base Load" ]; then
@@ -124,4 +125,9 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ] && [ -z "${BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_
             buildkite-agent artifact upload coverage/"$BUILDKITE_JOB_ID".lcov.zst
         fi
     fi
+fi
+
+if [ "$CI_ANNOTATE_ERRORS_RESULT" -ne 0 ]; then
+  echo "+++ ci-annotate-errors failed, which indicates that an unknown error was found"
+  exit "$CI_ANNOTATE_ERRORS_RESULT"
 fi

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -353,7 +353,8 @@ and finds associated open GitHub issues in Materialize repository.""",
         return_code = annotate_logged_errors(args.log_files, test_analytics)
     except Exception as e:
         test_analytics.on_upload_failed(e)
-        raise
+        # Don't fail
+        return 0
 
     try:
         test_analytics.submit_updates()


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
