### PR TITLE
persist: wrap PersistConfig's ConfigSet in an Arc

### DIFF
--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -384,7 +384,7 @@ impl Service for TransactorService {
                     blob_uri,
                     Box::new(config.clone()),
                     metrics.s3_blob.clone(),
-                    config.configs.clone(),
+                    Arc::clone(&config.configs),
                 )
                 .await
                 .expect("blob_uri should be valid");

--- a/src/persist-cli/src/maelstrom/txn_list_append_single.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_single.rs
@@ -617,7 +617,7 @@ impl Service for TransactorService {
                     blob_uri,
                     Box::new(config.clone()),
                     metrics.s3_blob.clone(),
-                    config.configs.clone(),
+                    Arc::clone(&config.configs),
                 )
                 .await
                 .expect("blob_uri should be valid");

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -205,7 +205,7 @@ impl PersistClientCache {
                     x.key(),
                     Box::new(self.cfg.clone()),
                     self.metrics.s3_blob.clone(),
-                    self.cfg.configs.clone(),
+                    Arc::clone(&self.cfg.configs),
                 )
                 .await?;
                 let blob = retry_external(&self.metrics.retries.external.blob_open, || {

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -106,7 +106,7 @@ pub struct PersistConfig {
     /// of a process.
     ///
     /// TODO(cfg): Entirely replace dynamic with this.
-    pub configs: ConfigSet,
+    pub configs: Arc<ConfigSet>,
     /// Indicates whether `configs` has been synced at least once with an
     /// upstream source.
     configs_synced_once: Arc<watch::Sender<bool>>,
@@ -183,7 +183,7 @@ impl PersistConfig {
             is_cc_active: false,
             announce_memory_limit: None,
             now,
-            configs,
+            configs: Arc::new(configs),
             configs_synced_once: Arc::new(configs_synced_once),
             dynamic: Arc::new(DynamicConfig {
                 batch_builder_max_outstanding_parts: AtomicUsize::new(2),

--- a/src/persist-client/src/cli/args.rs
+++ b/src/persist-client/src/cli/args.rs
@@ -152,7 +152,7 @@ pub(super) async fn make_blob(
         blob_uri,
         Box::new(cfg.clone()),
         metrics.s3_blob.clone(),
-        cfg.configs.clone(),
+        Arc::clone(&cfg.configs),
     )
     .await?;
     let blob = blob.clone().open().await?;

--- a/src/persist-client/src/internal/cache.rs
+++ b/src/persist-client/src/internal/cache.rs
@@ -24,7 +24,7 @@ use crate::internal::metrics::Metrics;
 // In-memory cache for [Blob].
 #[derive(Debug)]
 pub struct BlobMemCache {
-    cfg: ConfigSet,
+    cfg: Arc<ConfigSet>,
     metrics: Arc<Metrics>,
     cache: Mutex<lru::Lru<String, SegmentedBytes>>,
     blob: Arc<dyn Blob>,
@@ -48,7 +48,7 @@ impl BlobMemCache {
             eviction_metrics.blob_cache_mem.evictions.inc()
         });
         let blob = BlobMemCache {
-            cfg: cfg.configs.clone(),
+            cfg: Arc::clone(&cfg.configs),
             metrics,
             cache: Mutex::new(cache),
             blob,

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -138,7 +138,7 @@ impl Metrics {
         let columnar = ColumnarMetrics::new(
             registry,
             &s3_blob.lgbytes,
-            cfg.configs.clone(),
+            Arc::clone(&cfg.configs),
             cfg.is_cc_active,
         );
         Metrics {

--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -1011,7 +1011,7 @@ impl proto_persist_pub_sub_server::ProtoPersistPubSub for PersistGrpcPubSubServe
         let (tx, rx) = tokio::sync::mpsc::channel(self.cfg.pubsub_server_connection_channel_size);
 
         let caller = caller_id.clone();
-        let cfg = self.cfg.configs.clone();
+        let cfg = Arc::clone(&self.cfg.configs);
         let server_state = Arc::clone(&self.state);
         // this spawn here to cleanup after connection error / disconnect, otherwise the stream
         // would not be polled after the connection drops. in our case, we want to clear the

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -80,7 +80,7 @@ impl BlobConfig {
         value: &str,
         knobs: Box<dyn BlobKnobs>,
         metrics: S3BlobMetrics,
-        cfg: ConfigSet,
+        cfg: Arc<ConfigSet>,
     ) -> Result<Self, ExternalError> {
         let url = Url::parse(value)
             .map_err(|err| anyhow!("failed to parse blob location {} as a url: {}", &value, err))?;

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -9,6 +9,7 @@
 
 //! Implementation-specific metrics for persist blobs and consensus
 
+use std::sync::Arc;
 use std::time::Instant;
 
 use mz_dyncfg::ConfigSet;
@@ -257,7 +258,7 @@ pub struct ColumnarMetrics {
     pub(crate) arrow: ArrowMetrics,
     // TODO: Having these two here isn't quite the right thing to do, but it
     // saves a LOT of plumbing.
-    pub(crate) cfg: ConfigSet,
+    pub(crate) cfg: Arc<ConfigSet>,
     pub(crate) is_cc_active: bool,
 }
 
@@ -266,7 +267,7 @@ impl ColumnarMetrics {
     pub fn new(
         registry: &MetricsRegistry,
         lgbytes: &LgBytesMetrics,
-        cfg: ConfigSet,
+        cfg: Arc<ConfigSet>,
         is_cc_active: bool,
     ) -> Self {
         ColumnarMetrics {
@@ -296,6 +297,6 @@ impl ColumnarMetrics {
         let lgbytes = LgBytesMetrics::new(&registry);
         let cfg = crate::cfg::all_dyn_configs(ConfigSet::default());
 
-        Self::new(&registry, &lgbytes, cfg, false)
+        Self::new(&registry, &lgbytes, Arc::new(cfg), false)
     }
 }

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -51,7 +51,7 @@ pub struct S3BlobConfig {
     client: S3Client,
     bucket: String,
     prefix: String,
-    cfg: ConfigSet,
+    cfg: Arc<ConfigSet>,
     is_cc_active: bool,
 }
 
@@ -122,7 +122,7 @@ impl S3BlobConfig {
         credentials: Option<(String, String)>,
         knobs: Box<dyn BlobKnobs>,
         metrics: S3BlobMetrics,
-        cfg: ConfigSet,
+        cfg: Arc<ConfigSet>,
     ) -> Result<Self, Error> {
         let is_cc_active = knobs.is_cc_active();
         let mut loader = mz_aws_util::defaults();
@@ -272,9 +272,11 @@ impl S3BlobConfig {
             None,
             Box::new(TestBlobKnobs),
             metrics,
-            ConfigSet::default()
-                .add(&ENABLE_S3_LGALLOC_CC_SIZES)
-                .add(&ENABLE_S3_LGALLOC_NONCC_SIZES),
+            Arc::new(
+                ConfigSet::default()
+                    .add(&ENABLE_S3_LGALLOC_CC_SIZES)
+                    .add(&ENABLE_S3_LGALLOC_NONCC_SIZES),
+            ),
         )
         .await?;
         Ok(Some(config))
@@ -300,7 +302,7 @@ pub struct S3Blob {
     // Defaults to 1000 which is the current AWS max.
     max_keys: i32,
     multipart_config: MultipartConfig,
-    cfg: ConfigSet,
+    cfg: Arc<ConfigSet>,
     is_cc_active: bool,
 }
 
@@ -1051,9 +1053,11 @@ mod tests {
                     client: config.client.clone(),
                     bucket: config.bucket.clone(),
                     prefix: format!("{}/s3_blob_impl_test/{}", config.prefix, path),
-                    cfg: ConfigSet::default()
-                        .add(&ENABLE_S3_LGALLOC_CC_SIZES)
-                        .add(&ENABLE_S3_LGALLOC_NONCC_SIZES),
+                    cfg: Arc::new(
+                        ConfigSet::default()
+                            .add(&ENABLE_S3_LGALLOC_CC_SIZES)
+                            .add(&ENABLE_S3_LGALLOC_NONCC_SIZES),
+                    ),
                     is_cc_active: true,
                 };
                 let mut blob = S3Blob::open(config).await?;

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -193,7 +193,7 @@ where
         // Override the tuning to reduce crdb load. The pubsub fallback
         // responsibility is then replaced by manual "one state" wakeups in the
         // txns_progress operator.
-        let cfg = persist_clients.cfg().configs.clone();
+        let cfg = Arc::clone(&persist_clients.cfg().configs);
         let subscribe_sleep = match metadata.txns_shard {
             Some(_) => Some(move || mz_txn_wal::operator::txns_data_shard_retry_params(&cfg)),
             None => None,


### PR DESCRIPTION
This is how the `DynamicConfig` that it's replacing works, we don't need mutable access, and this will save a good amount of BTreeMap copies.

Happened to notice this while I was working on #28539.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
