### PR TITLE
storage: relax check on dependency since when upper.is_empty()

### DIFF
--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1554,6 +1554,7 @@ where
                         // as far the dependent's upper.
                         mz_ore::soft_assert_or_log!(
                             write_frontier.elements() == &[T::minimum()]
+                                || write_frontier.is_empty()
                                 || PartialOrder::less_than(&dependency_since, write_frontier),
                             "dependency ({dep}) since has advanced past dependent ({id}) upper \n
                             dependent ({id}): since {:?}, upper {:?} \n

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -1541,17 +1541,24 @@ where
                     // establishing a new persist connection, still have data we
                     // said _could_ be compacted.
                     if PartialOrder::less_than(&data_shard_since, &dependency_since) {
-                        // The dependency since cannot be in advance of the
-                        // dependent upper unless the collection is new. If the
-                        // dependency since advanced past the dependent's upper,
-                        // the dependent cannot read data from the dependency at
-                        // its upper.
+                        // The dependency since cannot be beyond the dependent
+                        // (our) upper unless the collection is new. In
+                        // practice, the depdenency is the remap shard of a
+                        // source (export), and if the since is allowed to
+                        // "catch up" to the upper, that is `upper <= since`, a
+                        // restarting ingestion cannot differentiate between
+                        // updates that have already been written out to the
+                        // backing persist shard and updates that have yet to be
+                        // written. We would write duplicate updates.
                         //
-                        // Another way of understanding that this is a problem
-                        // is that this means that the read hold installed on
-                        // the dependency was probably not been upheld––if it
-                        // were, the dependency's since could not have advanced
-                        // as far the dependent's upper.
+                        // If this check fails, it means that the read hold
+                        // installed on the dependency was probably not upheld
+                        // –– if it were, the dependency's since could not have
+                        // advanced as far the dependent's upper.
+                        //
+                        // We don't care about the dependency since when the
+                        // write frontier is empty. In that case, no-one can
+                        // write down any more updates.
                         mz_ore::soft_assert_or_log!(
                             write_frontier.elements() == &[T::minimum()]
                                 || write_frontier.is_empty()

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -672,17 +672,23 @@ where
 
             // Assert some invariants.
             if !dependency_read_holds.is_empty() {
-                // The dependency since cannot be in advance of the
-                // dependent upper unless the collection is new. If the
-                // dependency since advanced past the dependent's upper,
-                // the dependent cannot read data from the dependency at
-                // its upper.
+                // The dependency since cannot be beyond the dependent (our)
+                // upper unless the collection is new. In practice, the
+                // depdenency is the remap shard of a source (export), and if
+                // the since is allowed to "catch up" to the upper, that is
+                // `upper <= since`, a restarting ingestion cannot differentiate
+                // between updates that have already been written out to the
+                // backing persist shard and updates that have yet to be
+                // written. We would write duplicate updates.
                 //
-                // Another way of understanding that this is a problem
-                // is that this means that the read hold installed on
-                // the dependency was probably not been upheld––if it
-                // were, the dependency's since could not have advanced
-                // as far the dependent's upper.
+                // If this check fails, it means that the read hold installed on
+                // the dependency was probably not upheld –– if it were, the
+                // dependency's since could not have advanced as far the
+                // dependent's upper.
+                //
+                // We don't care about the dependency since when the write
+                // frontier is empty. In that case, no-one can write down any
+                // more updates.
                 mz_ore::soft_assert_or_log!(
                     write_frontier.elements() == &[T::minimum()]
                         || write_frontier.is_empty()

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -685,6 +685,7 @@ where
                 // as far the dependent's upper.
                 mz_ore::soft_assert_or_log!(
                     write_frontier.elements() == &[T::minimum()]
+                        || write_frontier.is_empty()
                         || PartialOrder::less_than(&dependency_since, write_frontier),
                     "dependency since has advanced past dependent ({id}) upper \n
                             dependent ({id}): upper {:?} \n


### PR DESCRIPTION
Fixes #28634

Apparently, this can happen! But when the upper is empty, we don't really care about what dependency since we get: we don't write anymore.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
