### PR TITLE
catalog: Actually improve error message

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -806,9 +806,9 @@ impl CatalogState {
                         // This makes it difficult to use the `UpdateFrom` trait, but the structure
                         // is still the same as the trait.
                         if retraction.create_sql() != create_sql {
-                            let item = self
-                                .deserialize_item(&create_sql)
-                                .expect("invalid persisted SQL: {create_sql}");
+                            let item = self.deserialize_item(&create_sql).unwrap_or_else(|e| {
+                                panic!("{e:?}: invalid persisted SQL: {create_sql}")
+                            });
                             retraction.item = item;
                         }
                         retraction.id = id;
@@ -820,9 +820,9 @@ impl CatalogState {
                         retraction
                     }
                     None => {
-                        let catalog_item = self
-                            .deserialize_item(&create_sql)
-                            .expect("invalid persisted SQL: {create_sql}");
+                        let catalog_item = self.deserialize_item(&create_sql).unwrap_or_else(|e| {
+                            panic!("{e:?}: invalid persisted SQL: {create_sql}")
+                        });
                         CatalogEntry {
                             item: catalog_item,
                             referenced_by: Vec::new(),


### PR DESCRIPTION
### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
