### PR TITLE
docs: rm obsolete RBAC enable statement

### DIFF
--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -37,8 +37,6 @@ Unlike PostgreSQL, Materialize does not use role attributes to determine a role'
 top level objects such as databases and other roles. Instead, Materialize uses system level
 privileges. See [GRANT PRIVILEGE](../grant-privilege) for more details.
 
-When RBAC is enabled a role must have the `CREATEROLE` system privilege to create another role.
-
 ## Examples
 
 ```mzsql


### PR DESCRIPTION
Remove the RBAC enable statement.  The page has privileges section. 