### PR TITLE
sql-pretty: fix create source format printing

### DIFF
--- a/src/sql-pretty/src/doc.rs
+++ b/src/sql-pretty/src/doc.rs
@@ -59,7 +59,7 @@ pub(crate) fn doc_create_source<T: AstInfo>(v: &CreateSourceStatement<T>) -> RcD
     }
     docs.push(nest_title("FROM", doc_display_pass(&v.connection)));
     if let Some(format) = &v.format {
-        docs.push(doc_display(format, "FormatSpecifier"));
+        docs.push(doc_format_specifier(format));
     }
     if !v.include_metadata.is_empty() {
         docs.push(nest_title(
@@ -84,6 +84,19 @@ pub(crate) fn doc_create_source<T: AstInfo>(v: &CreateSourceStatement<T>) -> RcD
         ));
     }
     RcDoc::intersperse(docs, Doc::line()).group()
+}
+
+fn doc_format_specifier<T: AstInfo>(v: &FormatSpecifier<T>) -> RcDoc {
+    match v {
+        FormatSpecifier::Bare(format) => nest_title("FORMAT", doc_display_pass(format)),
+        FormatSpecifier::KeyValue { key, value } => {
+            let docs = vec![
+                nest_title("KEY FORMAT", doc_display_pass(key)),
+                nest_title("VALUE FORMAT", doc_display_pass(value)),
+            ];
+            RcDoc::intersperse(docs, Doc::line()).group()
+        }
+    }
 }
 
 fn doc_external_references(v: &ExternalReferences) -> RcDoc {


### PR DESCRIPTION
Was showing up with leading space.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a