### PR TITLE
adapter: persisted sql: fix error message

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -808,7 +808,7 @@ impl CatalogState {
                         if retraction.create_sql() != create_sql {
                             let item = self
                                 .deserialize_item(&create_sql)
-                                .expect("invalid persisted SQL: {create_sql}");
+                                .unwrap_or_else(|_| panic!("invalid persisted SQL: {create_sql}"));
                             retraction.item = item;
                         }
                         retraction.id = id;
@@ -822,7 +822,7 @@ impl CatalogState {
                     None => {
                         let catalog_item = self
                             .deserialize_item(&create_sql)
-                            .expect("invalid persisted SQL: {create_sql}");
+                            .unwrap_or_else(|_| panic!("invalid persisted SQL: {create_sql}"));
                         CatalogEntry {
                             item: catalog_item,
                             referenced_by: Vec::new(),


### PR DESCRIPTION
The variable `{create_sql}` in the string is not resolved:
```
parallel-workload-materialized-1     | thread 'coordinator' panicked at src/adapter/src/catalog/apply.rs:825:30: invalid persisted SQL: {create_sql}: PlanError(Catalog(UnknownItem("db-pw-1722343493-0_\"`'><script>\\xE2.s-0-45_<img\\x13src=x on.v-119-3_\u{321}\u{353}\u{31e}\u{345}I\u{317}\u{318}\u{326}")))
```

Observed in https://buildkite.com/materialize/nightly/builds/8867#annotation-019103a7-e1f7-406f-8c65-d778b9912adb-error.