### PR TITLE
ci: Annotations have to be uploaded before ci-annotate-errors

### DIFF
--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -88,8 +88,10 @@ artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 # Continue even if ci-annotate-errors fails
 CI_ANNOTATE_ERRORS_RESULT=0
+# We have to upload artifacts before ci-annotate-errors, so that the annotations can link to the artifacts
+buildkite-agent artifact upload "$artifacts_str"
 bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
-buildkite-agent artifact upload "$artifacts_str;ci-annotate-errors.log"
+buildkite-agent artifact upload "ci-annotate-errors.log"
 
 # File should not be empty, see #25369
 test -s kubectl-get-logs-previous.log

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -77,8 +77,10 @@ artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 # Continue even if ci-annotate-errors fails
 CI_ANNOTATE_ERRORS_RESULT=0
+# We have to upload artifacts before ci-annotate-errors, so that the annotations can link to the artifacts
+buildkite-agent artifact upload "$artifacts_str"
 bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
-buildkite-agent artifact upload "$artifacts_str;ci-annotate-errors.log"
+buildkite-agent artifact upload "ci-annotate-errors.log"
 
 if [ ! -s services.log ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Long single-node Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of txn-wal" ] && [ "$BUILDKITE_LABEL" != "Mz E2E Test" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version for DFR)" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version for CTF)" ] && [ "$BUILDKITE_LABEL" != "QA Canary Environment Base Load" ]; then
     echo "+++ services.log is empty, failing"

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -583,7 +583,10 @@ def annotate_logged_errors(
     annotate_errors(unknown_errors, known_errors, build_history_on_main, test_analytics)
 
     if unknown_errors:
-        print(f"+++ Failing test because of {len(unknown_errors)} unknown error(s)")
+        print(
+            f"+++ Failing test because of {len(unknown_errors)} unknown error{'s' if len(unknown_errors) != 1 else ''}",
+            file=sys.stderr,
+        )
 
     # No need for rest of the logic as no error logs were found, but since
     # this script was called the test still failed, so showing the current


### PR DESCRIPTION
Print failure to stderr so we still see it in normal output

Kind of messy again, starts to feel like we need a test for our testing infrastructure.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
