### PR TITLE
tests: Fix git fetch to ignore .git ending

### DIFF
--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -252,9 +252,7 @@ def try_get_remote_name_by_url(url: str) -> str | None:
     result = spawn.capture(["git", "remote", "--verbose"])
     for line in result.splitlines():
         remote, desc = line.split("\t")
-        if desc.lower() == f"{url} (fetch)".lower():
-            return remote
-        if f"{desc.lower()}.git" == f"{url} (fetch)".lower():
+        if desc.lower() in (f"{url} (fetch)".lower(), f"{url}.git (fetch)".lower()):
             return remote
     return None
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
