### PR TITLE
Introduce `MirScalarExpr::reduce_safely`

### DIFF
--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -219,12 +219,7 @@ impl Analysis for Equivalences {
             MirRelationExpr::ArrangeBy { .. } => results.get(index - 1).unwrap().clone(),
         };
 
-        // Capture the expression type, but remove statements about column nullability.
-        // Using such statements will optimize away equivalence expressions stating the same.
-        let mut expr_type = depends.results::<RelationType>().unwrap()[index].clone();
-        for typ in expr_type.as_mut().unwrap().iter_mut() {
-            typ.nullable = true;
-        }
+        let expr_type = depends.results::<RelationType>().unwrap()[index].clone();
         equivalences.as_mut().map(|e| e.minimize(&expr_type));
         equivalences
     }
@@ -345,7 +340,7 @@ impl EquivalenceClasses {
             for class in self.classes.iter_mut() {
                 for expr in class.iter_mut() {
                     let prev_expr = expr.clone();
-                    expr.reduce(columns);
+                    expr.reduce_safely(columns);
                     if &prev_expr != expr {
                         stable = false;
                     }


### PR DESCRIPTION
Our `MirScalarExpr::reduce` function uses the nullability in column types provided as inputs. However, this nullability information is not certain to remain true as we reshape the expression (specifically our nullability information feeding in to types depends on whether things are joins or filters, whether `Get::typ` information has been recently refreshed).

This adds a method `MirScalarExpr::reduce_safely` that does not rely on this information (or rather, unsets the information before calling in to `reduce`). This function should be safe to call in any context, even if the input type nullability changes.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
