### PR TITLE
catalog: Improve error message in read-only write

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -1397,9 +1397,9 @@ impl DurableCatalogState for PersistCatalogState {
             // If the transaction is empty then we don't error, even in read-only mode. This matches the
             // semantics that the stash uses.
             if !txn_batch.is_empty() && catalog.is_read_only() {
-                return Err(DurableCatalogError::NotWritable(
-                    "cannot commit a transaction in a read-only catalog".to_string(),
-                )
+                return Err(DurableCatalogError::NotWritable(format!(
+                    "cannot commit a transaction in a read-only catalog: {txn_batch:?}"
+                ))
                 .into());
             }
 


### PR DESCRIPTION
This commit improves the error message that is returned when a read only catalog attempts to commit a write by including the contents of the write in the error.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
