### PR TITLE
compute,storage: include cause chain on connection errors

### DIFF
--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -195,13 +195,13 @@ where
                             if state.i >= mz_service::retry::INFO_MIN_RETRIES {
                                 info!(
                                     replica = ?self.replica_id,
-                                    "error connecting to replica, retrying in {:?}: {e}",
-                                    state.next_backoff.unwrap()
+                                    "error connecting to replica, retrying in {:?}: {e:#}",
+                                    state.next_backoff.unwrap(),
                                 );
                             } else {
                                 debug!(
                                     replica = ?self.replica_id,
-                                    "error connecting to replica, retrying in {:?}: {e}",
+                                    "error connecting to replica, retrying in {:?}: {e:#}",
                                     state.next_backoff.unwrap()
                                 );
                             }

--- a/src/storage-controller/src/rehydration.rs
+++ b/src/storage-controller/src/rehydration.rs
@@ -295,13 +295,13 @@ where
                 Err(e) => {
                     if state.i >= mz_service::retry::INFO_MIN_RETRIES {
                         tracing::info!(
-                            "error connecting to {:?} for storage, retrying in {:?}: {e}",
+                            "error connecting to {:?} for storage, retrying in {:?}: {e:#}",
                             location,
                             state.next_backoff.unwrap()
                         );
                     } else {
                         tracing::debug!(
-                            "error connecting to {:?} for storage, retrying in {:?}: {e}",
+                            "error connecting to {:?} for storage, retrying in {:?}: {e:#}",
                             location,
                             state.next_backoff.unwrap()
                         );


### PR DESCRIPTION
We're occasionally seeing connection errors in production that report only "transport error", which is not enough information to track down the error. Use anyhow's alternate formatting to print the full cause chain for these errors, which should help track down the issue.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR will help us track down a bug occurring in production.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
