### PR TITLE
persist: Support adding `Datum::Null` for missing columns

### DIFF
--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -130,15 +130,22 @@ impl Row {
             col_idx += 1;
         }
 
-        // TODO(parkmycar): This is where we'll add new default values to Codec
-        // data whose upstream relation has had columns added.
+        let num_columns = desc.typ().column_types.len();
+
+        // TODO(parkmycar): Make sure the already pushed data matches V0 of `RelationDesc`.
+        if col_idx < num_columns {
+            let missing_columns = col_idx..num_columns;
+            for _ in missing_columns {
+                packer.push(Datum::Null);
+                col_idx += 1;
+            }
+        }
 
         // HACK(parkmycar): Only validate that the decoded Row matches the RelationDesc if it was
         // non-empty. We have an optimization for queries like COUNT(*) that returns a fake empty
         // Part instead of decoding the data, which this assertion will fail on.
         //
         // TODO(#28146): Remove the check for if the num_columns is 0.
-        let num_columns = desc.typ().column_types.len();
         if num_columns != 0 && col_idx != 0 {
             mz_ore::soft_assert_eq_or_log!(
                 col_idx,


### PR DESCRIPTION
To support `ALTER TABLE ... ADD COLUMN ...` this PR allows pushing `Datum::Null` for missing columns when decoding `Codec` data, and add extra columnar decoders when decoding structured data.

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/28082

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
