### PR TITLE
storage/sources: Handle SourceExports with the same external reference (upstream table) in MySQL sources

### DIFF
--- a/src/mysql-util/src/lib.rs
+++ b/src/mysql-util/src/lib.rs
@@ -28,7 +28,7 @@ pub use replication::{
 };
 
 pub mod schemas;
-pub use schemas::{schema_info, QualifiedTableRef, SchemaRequest};
+pub use schemas::{schema_info, MySqlTableSchema, QualifiedTableRef, SchemaRequest};
 
 pub mod privileges;
 pub use privileges::validate_source_privileges;

--- a/src/ore/src/iter.rs
+++ b/src/ore/src/iter.rs
@@ -15,7 +15,8 @@
 
 //! Iterator utilities.
 
-use std::iter::{self, Chain, Once};
+use std::fmt::Debug;
+use std::iter::{self, Chain, Once, Peekable};
 
 /// Extension methods for iterators.
 pub trait IteratorExt
@@ -60,6 +61,23 @@ where
 
         ExactSize { inner: self, len }
     }
+
+    /// Wrap this iterator with one that yields a tuple of the iterator element and the extra
+    /// value on each iteration. The extra value is cloned for each but the last `Some` element
+    /// returned.
+    ///
+    /// This is useful to provide an owned extra value to each iteration, but only clone it
+    /// when necessary.
+    ///
+    /// NOTE: Once the iterator starts producing `None` values, the extra value will be consumed
+    /// and no longer be available. This should not be used for iterators that may produce
+    /// `Some` values after producing `None`.
+    fn repeat_clone<A: Clone>(self, extra_val: A) -> RepeatClone<Self, A> {
+        RepeatClone {
+            iter: self.peekable(),
+            extra_val: Some(extra_val),
+        }
+    }
 }
 
 impl<I> IteratorExt for I where I: Iterator {}
@@ -85,6 +103,38 @@ impl<I: Iterator> Iterator for ExactSize<I> {
 }
 
 impl<I: Iterator> ExactSizeIterator for ExactSize<I> {}
+
+/// Iterator type returned by [`IteratorExt::repeat_clone`].
+pub struct RepeatClone<I: Iterator, A> {
+    iter: Peekable<I>,
+    extra_val: Option<A>,
+}
+
+impl<I: Iterator, A: Clone> Iterator for RepeatClone<I, A> {
+    type Item = (I::Item, A);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.iter.next()?;
+
+        // Clone the extra_val only if there is an item to return on the next call to `next`.
+        let val = match self.iter.peek() {
+            Some(_) => self.extra_val.clone(),
+            None => self.extra_val.take(),
+        };
+
+        // We should always return a value if there is a current element.
+        Some((next, val.expect("RepeatClone invariant violated")))
+    }
+}
+
+impl<I: Iterator<Item: Debug> + Debug, A: Debug> Debug for RepeatClone<I, A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RepeatClone")
+            .field("iter", &self.iter)
+            .field("extra_val", &self.extra_val)
+            .finish()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/storage/src/source/mysql/replication/events.rs
+++ b/src/storage/src/source/mysql/replication/events.rs
@@ -7,15 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use maplit::btreemap;
 use mysql_common::binlog::events::{QueryEvent, RowsEventData};
-
+use mz_mysql_util::{pack_mysql_row, MySqlError};
+use mz_ore::iter::IteratorExt;
+use mz_repr::Row;
 use mz_storage_types::errors::DataflowError;
+use mz_storage_types::sources::mysql::GtidPartition;
 use timely::progress::Timestamp;
 use tracing::trace;
-
-use mz_mysql_util::{pack_mysql_row, MySqlError};
-use mz_repr::Row;
-use mz_storage_types::sources::mysql::GtidPartition;
 
 use crate::source::types::SourceMessage;
 
@@ -90,22 +90,24 @@ pub(super) async fn handle_query_event(
                         &ctx.config.config.connection_context.ssh_tunnel_manager,
                     )
                     .await?;
-                if let Some((err_table, err)) = verify_schemas(&mut *conn, &[(&table, info)])
-                    .await?
-                    .into_iter()
-                    .next()
+                for (err_output, err) in
+                    verify_schemas(&mut *conn, btreemap! { &table => info }).await?
                 {
-                    assert_eq!(err_table, &table, "Unexpected table verification error");
                     trace!(%id, "timely-{worker_id} DDL change \
-                           verification error for {table:?}: {err:?}");
+                           verification error for {table:?}[{}]: {err:?}",
+                           err_output.output_index);
                     let gtid_cap = ctx.data_cap_set.delayed(new_gtid);
                     ctx.data_output
                         .give_fueled(
                             &gtid_cap,
-                            ((info.output_index, Err(err.into())), new_gtid.clone(), 1),
+                            (
+                                (err_output.output_index, Err(err.into())),
+                                new_gtid.clone(),
+                                1,
+                            ),
                         )
                         .await;
-                    ctx.errored_tables.insert(table.clone());
+                    ctx.errored_outputs.insert(err_output.output_index);
                 }
             }
         }
@@ -122,27 +124,31 @@ pub(super) async fn handle_query_event(
             let expected = ctx
                 .table_info
                 .iter()
-                .filter(|(t, _)| !ctx.errored_tables.contains(t))
-                .collect::<Vec<_>>();
-            let schema_errors = verify_schemas(&mut *conn, &expected).await?;
+                .map(|(t, info)| {
+                    (
+                        t,
+                        info.iter()
+                            .filter(|output| !ctx.errored_outputs.contains(&output.output_index)),
+                    )
+                })
+                .collect();
+            let schema_errors = verify_schemas(&mut *conn, expected).await?;
             is_complete_event = true;
-            for (dropped_table, err) in schema_errors {
-                if ctx.table_info.contains_key(dropped_table)
-                    && !ctx.errored_tables.contains(dropped_table)
-                {
-                    trace!(%id, "timely-{worker_id} DDL change \
-                           dropped table: {dropped_table:?}: {err:?}");
-                    if let Some(info) = ctx.table_info.get(dropped_table) {
-                        let gtid_cap = ctx.data_cap_set.delayed(new_gtid);
-                        ctx.data_output
-                            .give_fueled(
-                                &gtid_cap,
-                                ((info.output_index, Err(err.into())), new_gtid.clone(), 1),
-                            )
-                            .await;
-                        ctx.errored_tables.insert(dropped_table.clone());
-                    }
-                }
+            for (dropped_output, err) in schema_errors {
+                trace!(%id, "timely-{worker_id} DDL change \
+                           dropped output: {dropped_output:?}: {err:?}");
+                let gtid_cap = ctx.data_cap_set.delayed(new_gtid);
+                ctx.data_output
+                    .give_fueled(
+                        &gtid_cap,
+                        (
+                            (dropped_output.output_index, Err(err.into())),
+                            new_gtid.clone(),
+                            1,
+                        ),
+                    )
+                    .await;
+                ctx.errored_outputs.insert(dropped_output.output_index);
             }
         }
         // Detect `TRUNCATE [TABLE] <tbl>` statements
@@ -165,22 +171,24 @@ pub(super) async fn handle_query_event(
                        for {table:?}");
                 if let Some(info) = ctx.table_info.get(&table) {
                     let gtid_cap = ctx.data_cap_set.delayed(new_gtid);
-                    ctx.data_output
-                        .give_fueled(
-                            &gtid_cap,
-                            (
+                    for output in info {
+                        ctx.data_output
+                            .give_fueled(
+                                &gtid_cap,
                                 (
-                                    info.output_index,
-                                    Err(DataflowError::from(DefiniteError::TableTruncated(
-                                        table.to_string(),
-                                    ))),
+                                    (
+                                        output.output_index,
+                                        Err(DataflowError::from(DefiniteError::TableTruncated(
+                                            table.to_string(),
+                                        ))),
+                                    ),
+                                    new_gtid.clone(),
+                                    1,
                                 ),
-                                new_gtid.clone(),
-                                1,
-                            ),
-                        )
-                        .await;
-                    ctx.errored_tables.insert(table);
+                            )
+                            .await;
+                        ctx.errored_outputs.insert(output.output_index);
+                    }
                 }
             }
         }
@@ -224,14 +232,16 @@ pub(super) async fn handle_rows_event(
         &*table_map_event.table_name(),
     );
 
-    if ctx.errored_tables.contains(&table) {
-        return Ok(());
-    }
-
-    let (output_index, table_desc) = match &ctx.table_info.get(&table) {
-        Some(info) => (info.output_index, &info.desc),
+    let outputs = ctx.table_info.get(&table).map(|outputs| {
+        outputs
+            .into_iter()
+            .filter(|output| !ctx.errored_outputs.contains(&output.output_index))
+            .collect::<Vec<_>>()
+    });
+    let outputs = match outputs {
+        Some(outputs) => outputs,
         None => {
-            // We don't know about this table, so skip this event
+            // We don't know about this table, or there are no un-errored outputs for it.
             return Ok(());
         }
     };
@@ -267,36 +277,39 @@ pub(super) async fn handle_rows_event(
         let updates = [before_row.map(|r| (r, -1)), after_row.map(|r| (r, 1))];
         for (binlog_row, diff) in updates.into_iter().flatten() {
             let row = mysql_async::Row::try_from(binlog_row)?;
-            let event = match pack_mysql_row(&mut final_row, row, table_desc) {
-                Ok(row) => Ok(SourceMessage {
-                    key: Row::default(),
-                    value: row,
-                    metadata: Row::default(),
-                }),
-                // Produce a DefiniteError in the stream for any rows that fail to decode
-                Err(err @ MySqlError::ValueDecodeError { .. }) => Err(DataflowError::from(
-                    DefiniteError::ValueDecodeError(err.to_string()),
-                )),
-                Err(err) => Err(err)?,
-            };
+            for (output, row_val) in outputs.iter().repeat_clone(row) {
+                let event = match pack_mysql_row(&mut final_row, row_val, &output.desc) {
+                    Ok(row) => Ok(SourceMessage {
+                        key: Row::default(),
+                        value: row,
+                        metadata: Row::default(),
+                    }),
+                    // Produce a DefiniteError in the stream for any rows that fail to decode
+                    Err(err @ MySqlError::ValueDecodeError { .. }) => Err(DataflowError::from(
+                        DefiniteError::ValueDecodeError(err.to_string()),
+                    )),
+                    Err(err) => Err(err)?,
+                };
 
-            let data = (output_index, event);
+                let data = (output.output_index, event);
 
-            // Rewind this update if it was already present in the snapshot
-            if let Some((_rewind_data_cap, rewind_req)) = ctx.rewinds.get(&table) {
-                if !rewind_req.snapshot_upper.less_equal(new_gtid) {
-                    rewind_count += 1;
-                    event_buffer.push((data.clone(), GtidPartition::minimum(), -diff));
+                // Rewind this update if it was already present in the snapshot
+                if let Some((_rewind_data_cap, rewind_req)) = ctx.rewinds.get(&output.output_index)
+                {
+                    if !rewind_req.snapshot_upper.less_equal(new_gtid) {
+                        rewind_count += 1;
+                        event_buffer.push((data.clone(), GtidPartition::minimum(), -diff));
+                    }
                 }
+                if diff > 0 {
+                    additions += 1;
+                } else {
+                    retractions += 1;
+                }
+                ctx.data_output
+                    .give_fueled(&gtid_cap, (data, new_gtid.clone(), diff))
+                    .await;
             }
-            if diff > 0 {
-                additions += 1;
-            } else {
-                retractions += 1;
-            }
-            ctx.data_output
-                .give_fueled(&gtid_cap, (data, new_gtid.clone(), diff))
-                .await;
         }
     }
 
@@ -307,8 +320,8 @@ pub(super) async fn handle_rows_event(
     // Instead, we buffer rewind events into a reusable buffer, and emit all at once here at the end.
 
     if !event_buffer.is_empty() {
-        let (rewind_data_cap, _) = ctx.rewinds.get(&table).unwrap();
         for d in event_buffer.drain(..) {
+            let (rewind_data_cap, _) = ctx.rewinds.get(&d.0 .0).unwrap();
             ctx.data_output.give_fueled(rewind_data_cap, d).await;
         }
     }

--- a/src/storage/src/source/mysql/schemas.rs
+++ b/src/storage/src/source/mysql/schemas.rs
@@ -10,24 +10,22 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use mysql_async::prelude::Queryable;
-use mz_mysql_util::{schema_info, MySqlError, MySqlTableDesc, QualifiedTableRef, SchemaRequest};
+use mz_mysql_util::{schema_info, MySqlError, SchemaRequest};
 
-use super::{DefiniteError, MySqlTableName, SubsourceInfo};
+use super::{DefiniteError, MySqlTableName, SourceOutputInfo};
 
-/// Given a list of tables and their expected schemas, retrieve the current schema for each table
-/// and verify they are compatible with the expected schema.
+/// Given a map of tables and the expected schemas of their outputs, retrieve the current
+/// schema for each and verify they are compatible with the expected schema.
 ///
-/// Returns a vec of tables that have incompatible schema changes.
-pub(super) async fn verify_schemas<'a, Q>(
+/// Returns a vec of outputs that have incompatible schema changes.
+pub(super) async fn verify_schemas<'a, Q, I>(
     conn: &mut Q,
-    expected: &[(&'a MySqlTableName, &SubsourceInfo)],
-) -> Result<Vec<(&'a MySqlTableName, DefiniteError)>, MySqlError>
+    expected: BTreeMap<&'a MySqlTableName, I>,
+) -> Result<Vec<(&'a SourceOutputInfo, DefiniteError)>, MySqlError>
 where
     Q: Queryable,
+    I: IntoIterator<Item = &'a SourceOutputInfo>,
 {
-    let (text_column_map, ignore_column_map) = map_columns(expected);
-
-    // Get the current schema for each requested table from mysql
     let cur_schemas: BTreeMap<_, _> = schema_info(
         conn,
         &SchemaRequest::Tables(
@@ -36,8 +34,6 @@ where
                 .map(|(f, _)| (f.0.as_str(), f.1.as_str()))
                 .collect(),
         ),
-        &text_column_map,
-        &ignore_column_map,
     )
     .await?
     .into_iter()
@@ -51,60 +47,36 @@ where
 
     Ok(expected
         .into_iter()
-        .filter_map(|(table, info)| {
-            if let Err(err) = verify_schema(table, &info.desc, &cur_schemas) {
-                Some((*table, err))
-            } else {
-                None
-            }
+        .flat_map(|(table, outputs)| {
+            // For each output for this upstream table, verify that the existing output
+            // desc is compatible with the new desc.
+            outputs
+                .into_iter()
+                .filter_map(|output| match &cur_schemas.get(table) {
+                    None => Some((output, DefiniteError::TableDropped(table.to_string()))),
+                    Some(schema) => {
+                        let new_desc = (*schema).clone().to_desc(
+                            Some(&BTreeSet::from_iter(
+                                output.text_columns.iter().map(|s| s.as_str()),
+                            )),
+                            Some(&BTreeSet::from_iter(
+                                output.ignore_columns.iter().map(|s| s.as_str()),
+                            )),
+                        );
+                        match new_desc {
+                            Ok(desc) => match output.desc.determine_compatibility(&desc) {
+                                Ok(()) => None,
+                                Err(err) => Some((
+                                    output,
+                                    DefiniteError::IncompatibleSchema(err.to_string()),
+                                )),
+                            },
+                            Err(err) => {
+                                Some((output, DefiniteError::IncompatibleSchema(err.to_string())))
+                            }
+                        }
+                    }
+                })
         })
         .collect())
-}
-
-/// Ensures that the specified table is still compatible with the current upstream schema
-/// and that it has not been dropped.
-fn verify_schema(
-    table: &MySqlTableName,
-    expected_desc: &MySqlTableDesc,
-    upstream_info: &BTreeMap<MySqlTableName, MySqlTableDesc>,
-) -> Result<(), DefiniteError> {
-    let current_desc = upstream_info
-        .get(table)
-        .ok_or_else(|| DefiniteError::TableDropped(table.to_string()))?;
-
-    match expected_desc.determine_compatibility(current_desc) {
-        Ok(()) => Ok(()),
-        Err(err) => Err(DefiniteError::IncompatibleSchema(err.to_string())),
-    }
-}
-
-fn map_columns<'a>(
-    tables: &'a [(&'a MySqlTableName, &SubsourceInfo)],
-) -> (
-    BTreeMap<QualifiedTableRef<'a>, BTreeSet<&'a str>>,
-    BTreeMap<QualifiedTableRef<'a>, BTreeSet<&'a str>>,
-) {
-    let mut text_column_map = BTreeMap::new();
-    let mut ignore_column_map = BTreeMap::new();
-    for (table, info) in tables {
-        if !info.text_columns.is_empty() {
-            text_column_map.insert(
-                QualifiedTableRef {
-                    schema_name: &table.0,
-                    table_name: &table.1,
-                },
-                info.text_columns.iter().map(|s| s.as_str()).collect(),
-            );
-        }
-        if !info.ignore_columns.is_empty() {
-            ignore_column_map.insert(
-                QualifiedTableRef {
-                    schema_name: &table.0,
-                    table_name: &table.1,
-                },
-                info.ignore_columns.iter().map(|s| s.as_str()).collect(),
-            );
-        }
-    }
-    (text_column_map, ignore_column_map)
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


  * This PR adds a known-desirable feature.
Implements https://github.com/MaterializeInc/materialize/issues/28435 for MySQL Sources

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

There aren't any added tests since we still restrict subsources from being added with the same external-reference at the SQL planning layer. This is intentional -- we don't plan to enable this capability for subsources, since those will be removed very soon. Instead the new `CREATE TABLE .. FROM SOURCE` statements will be allowed to reference the same external-reference and we will need to add tests then to validate that they function correctly.


You might note that this looks very different than previous implementation attempts and designs for 'subsource demuxing'. I took this approach of completely separating things by `SourceExport` rather than demuxing using a 'projection' downstream in the source-render dataflow because we want to ensure that a newly added `SourceExport` has its own `resume_upper` such that we will re-snapshot the upstream table into this new `SourceExport` using the new schema.
This is for two reasons:
- to avoid a potential correctness issue when a new `SourceExport` for an existing upstream table might include a newly added column that was backfilled in the upstream for all existing records
- since we might apply different decoding to the same upstream column in different `SourceExport`s -- e.g. if a column was previously being decoded as TEXT but is now supported using its native format
- to backfill data in the new SourceExport at all timestamps that were still available in the upstream replication-log/kafka-topic/etc, such that the SourceExport can be used at an as_of() in the recent past in addition to future timestamps


<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
