### PR TITLE
persist: validate that schemas match values in batch construction in CI

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -736,6 +736,7 @@ where
                 key_vec.extend_from_slice(k);
                 val_vec.clear();
                 val_vec.extend_from_slice(v);
+                crate::batch::validate_schema(&real_schemas, &key_vec, &val_vec, None, None);
                 batch.add(&real_schemas, &key_vec, &val_vec, &t, &d).await?;
             }
             tokio::task::yield_now().await;

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -109,6 +109,13 @@ pub trait Codec: Default + Sized + PartialEq + 'static {
         Ok(())
     }
 
+    /// Checks that the given value matches the provided schema.
+    ///
+    /// A no-op default implementation is provided for convenience.
+    fn validate(_val: &Self, _schema: &Self::Schema) -> Result<(), String> {
+        Ok(())
+    }
+
     /// Encode a schema for permanent storage.
     ///
     /// This must perfectly round-trip the schema through [Self::decode_schema].

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1343,6 +1343,13 @@ impl Codec for SourceData {
         }
     }
 
+    fn validate(val: &Self, desc: &Self::Schema) -> Result<(), String> {
+        match &val.0 {
+            Ok(row) => Row::validate(row, desc),
+            Err(_) => Ok(()),
+        }
+    }
+
     fn encode_schema(schema: &Self::Schema) -> Bytes {
         schema.into_proto().encode_to_vec().into()
     }

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -666,7 +666,7 @@ mod tests {
             .with_column(
                 "partition",
                 ScalarType::Range {
-                    element_type: Box::new(ScalarType::Int32),
+                    element_type: Box::new(ScalarType::Numeric { max_scale: None }),
                 }
                 .nullable(false),
             )


### PR DESCRIPTION
This doesn't seem to be happening on the original data write path,
thankfully. However, last week I did end up finding and fixing one known
and one unknown spot where a placeholder schema `RelationDesc::empty`
was used for an empty CaA, which resulted in compaction work being
spawned with the wrong schema. Given that correct schemas are about to
become necessary with the columnar batch work, this will hopefully
prevent regressions.

It's probably too expensive to do this in prod, but seems like a good
idea to catch if any schema shenanigans are happening in CI.

Touches #24830

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

I think there's a couple of mis-uses in reclocking unit tests that I'll fix up once CI finds them again for me.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
