### PR TITLE
txn-wal: clean up K, V, T, D bounds on structs

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -66,10 +66,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_persist_client.batch.rs"));
 /// A [Batch] needs to be marked as consumed or it needs to be deleted via [Self::delete].
 /// Otherwise, a dangling batch will leak and backing blobs will remain in blob storage.
 #[derive(Debug)]
-pub struct Batch<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
+pub struct Batch<K, V, T, D> {
     pub(crate) batch_delete_enabled: bool,
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) shard_metrics: Arc<ShardMetrics>,
@@ -88,10 +85,7 @@ where
     pub(crate) _phantom: PhantomData<fn() -> (K, V, T, D)>,
 }
 
-impl<K, V, T, D> Drop for Batch<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
+impl<K, V, T, D> Drop for Batch<K, V, T, D> {
     fn drop(&mut self) {
         if self.batch.part_count() > 0 {
             warn!(

--- a/src/txn-wal/src/lib.rs
+++ b/src/txn-wal/src/lib.rs
@@ -579,10 +579,7 @@ pub mod tests {
 
     /// A [`Txn`] wrapper that exposes extra functionality for tests.
     #[derive(Debug)]
-    pub struct TestTxn<K, V, T, D>
-    where
-        T: Timestamp + Lattice + Codec64,
-    {
+    pub struct TestTxn<K, V, T, D> {
         txn: Txn<K, V, T, D>,
         /// A copy of every write to use in tests.
         writes: BTreeMap<ShardId, Vec<(K, V, D)>>,

--- a/src/txn-wal/src/txn_cache.rs
+++ b/src/txn-wal/src/txn_cache.rs
@@ -77,7 +77,7 @@ use crate::TxnsCodecDefault;
 /// unchanged and simply manipulating capabilities in response to data and txns
 /// shard progress. See [crate::operator::txns_progress].
 #[derive(Debug)]
-pub struct TxnsCacheState<T: Timestamp + Lattice + Codec64> {
+pub struct TxnsCacheState<T> {
     txns_id: ShardId,
     /// The since of the txn_shard when this cache was initialized.
     /// Some writes with a timestamp < than this may have been applied and
@@ -119,7 +119,7 @@ pub struct TxnsCacheState<T: Timestamp + Lattice + Codec64> {
 
 /// A self-updating [TxnsCacheState].
 #[derive(Debug)]
-pub struct TxnsCache<T: Timestamp + Lattice + Codec64, C: TxnsCodec = TxnsCodecDefault> {
+pub struct TxnsCache<T, C: TxnsCodec = TxnsCodecDefault> {
     /// A subscribe over the txn shard.
     pub(crate) txns_subscribe: Subscribe<C::Key, C::Val, T, i64>,
     /// Pending updates for timestamps that haven't closed.
@@ -964,14 +964,14 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
     }
 }
 
-impl<T: Timestamp + Lattice + Codec64, C: TxnsCodec> Deref for TxnsCache<T, C> {
+impl<T, C: TxnsCodec> Deref for TxnsCache<T, C> {
     type Target = TxnsCacheState<T>;
     fn deref(&self) -> &Self::Target {
         &self.state
     }
 }
 
-impl<T: Timestamp + Lattice + Codec64, C: TxnsCodec> DerefMut for TxnsCache<T, C> {
+impl<T, C: TxnsCodec> DerefMut for TxnsCache<T, C> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.state
     }

--- a/src/txn-wal/src/txn_read.rs
+++ b/src/txn-wal/src/txn_read.rs
@@ -335,7 +335,7 @@ pub(crate) struct DataSubscribe<T> {
 
 /// An active subscription of [`DataRemapEntry`]s for a data shard.
 #[derive(Debug)]
-pub struct DataSubscription<T: Timestamp + Lattice + Codec64> {
+pub struct DataSubscription<T> {
     /// Metadata and current [`DataRemapEntry`] for the data shard.
     subscribe: DataSubscribe<T>,
     /// Channel to send [`DataRemapEntry`]s.
@@ -583,7 +583,7 @@ impl<T: Ord> PartialOrd for WaitTs<T> {
     }
 }
 
-impl<T: Timestamp + Lattice + Codec64> WaitTs<T> {
+impl<T: Timestamp + Lattice> WaitTs<T> {
     /// Returns `true` iff (sic) this [WaitTs] is ready.
     fn is_ready(&self, frontier: &T) -> bool {
         match &self {
@@ -604,7 +604,7 @@ impl<T: Timestamp + Lattice + Codec64> WaitTs<T> {
 }
 
 #[derive(Debug)]
-struct TxnsReadTask<T: Timestamp + Lattice + Codec64> {
+struct TxnsReadTask<T> {
     rx: mpsc::UnboundedReceiver<TxnsReadCmd<T>>,
     cache: TxnsCacheState<T>,
     pending_waits_by_ts: BTreeSet<(WaitTs<T>, Uuid)>,
@@ -615,7 +615,7 @@ struct TxnsReadTask<T: Timestamp + Lattice + Codec64> {
 /// A pending "wait" notification that we will complete once the frontier
 /// advances far enough.
 #[derive(Debug)]
-struct PendingWait<T: Timestamp + Lattice + Codec64> {
+struct PendingWait<T> {
     ts: WaitTs<T>,
     tx: Option<oneshot::Sender<()>>,
 }
@@ -791,7 +791,7 @@ where
 /// Reads txn updates from a [Subscribe] and forwards them to a [TxnsReadTask]
 /// when receiving a progress update.
 #[derive(Debug)]
-struct TxnsSubscribeTask<T: Timestamp + Lattice + Codec64, C: TxnsCodec = TxnsCodecDefault> {
+struct TxnsSubscribeTask<T, C: TxnsCodec = TxnsCodecDefault> {
     txns_subscribe: Subscribe<C::Key, C::Val, T, i64>,
 
     /// Staged update that we will consume and forward to the [TxnsReadTask]

--- a/src/txn-wal/src/txn_write.rs
+++ b/src/txn-wal/src/txn_write.rs
@@ -34,18 +34,12 @@ use crate::txns::{Tidy, TxnsHandle};
 
 /// Pending writes to a shard for an in-progress transaction.
 #[derive(Debug)]
-pub(crate) struct TxnWrite<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
+pub(crate) struct TxnWrite<K, V, T, D> {
     pub(crate) batches: Vec<Batch<K, V, T, D>>,
     pub(crate) writes: Vec<(K, V, D)>,
 }
 
-impl<K, V, T, D> TxnWrite<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
+impl<K, V, T, D> TxnWrite<K, V, T, D> {
     /// Merges the staged writes in `other` into this.
     pub fn merge(&mut self, other: Self) {
         self.batches.extend(other.batches);
@@ -53,10 +47,7 @@ where
     }
 }
 
-impl<K, V, T, D> Default for TxnWrite<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
+impl<K, V, T, D> Default for TxnWrite<K, V, T, D> {
     fn default() -> Self {
         Self {
             batches: Vec::default(),
@@ -67,10 +58,7 @@ where
 
 /// An in-progress transaction.
 #[derive(Debug)]
-pub struct Txn<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
+pub struct Txn<K, V, T, D> {
     pub(crate) writes: BTreeMap<ShardId, TxnWrite<K, V, T, D>>,
     tidy: Tidy,
 }

--- a/src/txn-wal/src/txns.rs
+++ b/src/txn-wal/src/txns.rs
@@ -100,15 +100,7 @@ use crate::TxnsCodecDefault;
 /// (d1, <empty>, 2, 1)
 /// ```
 #[derive(Debug)]
-pub struct TxnsHandle<K, V, T, D, O = u64, C = TxnsCodecDefault>
-where
-    K: Debug + Codec,
-    V: Debug + Codec,
-    T: Timestamp + Lattice + TotalOrder + Codec64,
-    D: Semigroup + Codec64 + Send + Sync,
-    O: Opaque + Debug + Codec64,
-    C: TxnsCodec,
-{
+pub struct TxnsHandle<K: Codec, V: Codec, T, D, O = u64, C: TxnsCodec = TxnsCodecDefault> {
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) txns_cache: TxnsCache<T, C>,
     pub(crate) txns_write: WriteHandle<C::Key, C::Val, T, i64>,
@@ -691,13 +683,7 @@ impl Tidy {
 
 /// A helper to make a more targeted mutable borrow of self.
 #[derive(Debug)]
-pub(crate) struct DataHandles<K, V, T, D>
-where
-    K: Debug + Codec,
-    V: Debug + Codec,
-    T: Timestamp + Lattice + TotalOrder + Codec64,
-    D: Semigroup + Codec64 + Send + Sync,
-{
+pub(crate) struct DataHandles<K: Codec, V: Codec, T, D> {
     pub(crate) client: PersistClient,
     data_write: BTreeMap<ShardId, WriteHandle<K, V, T, D>>,
     key_schema: Arc<K::Schema>,


### PR DESCRIPTION
Newly enabled by #28669. No behavior change.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
