### PR TITLE
persist: Wire Parquet dictionary encoding and compression to `LaunchDarkly`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1069,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -3796,6 +3832,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5629,6 +5674,7 @@ dependencies = [
  "serde",
  "serde_json",
  "timely",
+ "tracing",
  "uuid",
  "workspace-hack",
 ]
@@ -7376,10 +7422,13 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64 0.22.0",
+ "brotli",
  "bytes",
  "chrono",
+ "flate2",
  "half 2.4.1",
  "hashbrown 0.14.5",
+ "lz4_flex",
  "num",
  "num-bigint",
  "paste",
@@ -7387,6 +7436,7 @@ dependencies = [
  "snap",
  "thrift",
  "twox-hash",
+ "zstd",
 ]
 
 [[package]]

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -10,6 +10,16 @@ Certification of this crate means the reviewer has confirmed the crate is:
 """
 implies = "safe-to-deploy"
 
+[[audits.alloc-no-stdlib]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
+version = "2.0.4"
+
+[[audits.alloc-stdlib]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.2.2"
+
 [[audits.array-concat]]
 who = "Matt Arthur <matthewleearthur@gmail.com>"
 criteria = "safe-to-deploy"
@@ -155,6 +165,16 @@ version = "2.1.0"
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "1.0.1"
+
+[[audits.brotli]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
+version = "3.5.0"
+
+[[audits.brotli-decompressor]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
+version = "2.5.1"
 
 [[audits.built]]
 who = "Parker Timmerman <parker.timmerman@materialize.com>"
@@ -477,6 +497,11 @@ version = "0.2.8"
 who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.16.0+8.10.0"
+
+[[audits.lz4_flex]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.11.3"
 
 [[audits.mappings]]
 who = "Moritz Hoffmann <mh@materialize.com>"

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -998,7 +998,7 @@ who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
-end = "2024-03-10"
+end = "2025-07-30"
 
 [[audits.bytecode-alliance.audits.adler]]
 who = "Alex Crichton <alex@alexcrichton.com>"

--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -25,6 +25,7 @@ use mz_persist::metrics::ColumnarMetrics;
 use mz_persist::workload::{self, DataGenerator};
 use mz_persist_client::internals_bench::trace_push_batch_one_iter;
 use mz_persist_client::ShardId;
+use mz_persist_types::parquet::EncodingConfig;
 use timely::progress::Antichain;
 use tokio::runtime::Runtime;
 use uuid::Uuid;
@@ -192,6 +193,7 @@ pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data:
     }
 
     let metrics = ColumnarMetrics::disconnected();
+    let config = EncodingConfig::default();
     let trace = BlobTraceBatchPart {
         desc: Description::new(
             Antichain::from_elem(0u64),
@@ -209,7 +211,7 @@ pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data:
         b.iter(|| {
             // Intentionally alloc a new buf each iter.
             let mut buf = Vec::new();
-            trace.encode(&mut buf, &metrics);
+            trace.encode(&mut buf, &metrics, &config);
         })
     });
 }

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -329,6 +329,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::BLOB_TARGET_SIZE)
         .add(&crate::batch::INLINE_WRITES_TOTAL_MAX_BYTES)
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)
+        .add(&crate::batch::ENCODING_ENABLE_DICTIONARY)
+        .add(&crate::batch::ENCODING_COMPRESSION_FORMAT)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL)
         .add(&crate::cfg::CRDB_CONNECT_TIMEOUT)

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -21,11 +21,12 @@ mz-ore = { path = "../ore", features = ["metrics", "test"], default-features = f
 mz-proto = { path = "../proto", default-features = false }
 parquet = { version = "51.0.0", default-features = false, features = ["arrow"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 timely = { version = "0.12.0", default-features = false, features = ["bincode", "getopts"] }
+tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 

--- a/src/persist-types/src/parquet.rs
+++ b/src/persist-types/src/parquet.rs
@@ -21,21 +21,164 @@ use arrow::array::{Array, RecordBatch};
 use arrow::datatypes::{Fields, Schema as ArrowSchema};
 use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder};
 use parquet::arrow::ArrowWriter;
-use parquet::basic::{Compression, Encoding};
+use parquet::basic::Encoding;
 use parquet::file::properties::{EnabledStatistics, WriterProperties, WriterVersion};
 use parquet::file::reader::ChunkReader;
+use proptest::prelude::*;
+use proptest_derive::Arbitrary;
 
 use crate::codec_impls::UnitSchema;
 use crate::columnar::{PartDecoder, Schema};
 use crate::part::{Part, PartBuilder};
+
+/// Configuration for encoding columnar data.
+#[derive(Debug, Copy, Clone, Arbitrary)]
+pub struct EncodingConfig {
+    /// Enable dictionary encoding for Parquet data.
+    pub use_dictionary: bool,
+    /// Compression format for Parquet data.
+    pub compression: CompressionFormat,
+}
+
+impl Default for EncodingConfig {
+    fn default() -> Self {
+        EncodingConfig {
+            use_dictionary: false,
+            compression: CompressionFormat::default(),
+        }
+    }
+}
+
+/// Compression format to apply to columnar data.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Arbitrary)]
+pub enum CompressionFormat {
+    /// No compression.
+    #[default]
+    None,
+    /// snappy
+    Snappy,
+    /// lz4
+    Lz4,
+    /// brotli
+    Brotli(CompressionLevel<1, 11, 1>),
+    /// zstd
+    Zstd(CompressionLevel<1, 22, 1>),
+    /// gzip
+    Gzip(CompressionLevel<1, 9, 6>),
+}
+
+impl CompressionFormat {
+    /// Parse a [`CompressionFormat`] from a string, falling back to defaults if the string is not valid.
+    pub fn from_str(s: &str) -> Self {
+        fn parse_level<const MIN: i32, const MAX: i32, const D: i32>(
+            name: &'static str,
+            val: &str,
+        ) -> CompressionLevel<MIN, MAX, D> {
+            match CompressionLevel::from_str(val) {
+                Ok(level) => level,
+                Err(err) => {
+                    mz_ore::soft_panic_or_log!("invalid {name} compression level, err: {err}");
+                    CompressionLevel::default()
+                }
+            }
+        }
+
+        match s.to_lowercase().as_str() {
+            "" => CompressionFormat::None,
+            "none" => CompressionFormat::None,
+            "snappy" => CompressionFormat::Snappy,
+            "lz4" => CompressionFormat::Lz4,
+            other => match other.split_once('-') {
+                Some(("brotli", level)) => CompressionFormat::Brotli(parse_level("brotli", level)),
+                Some(("zstd", level)) => CompressionFormat::Zstd(parse_level("zstd", level)),
+                Some(("gzip", level)) => CompressionFormat::Gzip(parse_level("gzip", level)),
+                _ => {
+                    mz_ore::soft_panic_or_log!(
+                        "unrecognized compression format {s}, returning None"
+                    );
+                    CompressionFormat::None
+                }
+            },
+        }
+    }
+}
+
+impl From<CompressionFormat> for parquet::basic::Compression {
+    fn from(value: CompressionFormat) -> Self {
+        match value {
+            CompressionFormat::None => parquet::basic::Compression::UNCOMPRESSED,
+            CompressionFormat::Lz4 => parquet::basic::Compression::LZ4_RAW,
+            CompressionFormat::Snappy => parquet::basic::Compression::SNAPPY,
+            CompressionFormat::Brotli(level) => {
+                let level: u32 = level.0.try_into().expect("known not negative");
+                let level = parquet::basic::BrotliLevel::try_new(level).expect("known valid");
+                parquet::basic::Compression::BROTLI(level)
+            }
+            CompressionFormat::Zstd(level) => {
+                let level = parquet::basic::ZstdLevel::try_new(level.0).expect("known valid");
+                parquet::basic::Compression::ZSTD(level)
+            }
+            CompressionFormat::Gzip(level) => {
+                let level: u32 = level.0.try_into().expect("known not negative");
+                let level = parquet::basic::GzipLevel::try_new(level).expect("known valid");
+                parquet::basic::Compression::GZIP(level)
+            }
+        }
+    }
+}
+
+/// Level of compression for columnar data.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct CompressionLevel<const MIN: i32, const MAX: i32, const DEFAULT: i32>(i32);
+
+impl<const MIN: i32, const MAX: i32, const DEFAULT: i32> Default
+    for CompressionLevel<MIN, MAX, DEFAULT>
+{
+    fn default() -> Self {
+        CompressionLevel(DEFAULT)
+    }
+}
+
+impl<const MIN: i32, const MAX: i32, const DEFAULT: i32> CompressionLevel<MIN, MAX, DEFAULT> {
+    /// Try creating a [`CompressionLevel`] from the provided value, returning an error if it is
+    /// outside the `MIN` and `MAX` bounds.
+    pub const fn try_new(val: i32) -> Result<Self, i32> {
+        if val < MIN {
+            Err(val)
+        } else if val > MAX {
+            Err(val)
+        } else {
+            Ok(CompressionLevel(val))
+        }
+    }
+
+    /// Parse a [`CompressionLevel`] form the provided string, returning an error if the string is
+    /// not valid.
+    pub fn from_str(s: &str) -> Result<Self, String> {
+        let val = s.parse::<i32>().map_err(|e| e.to_string())?;
+        Self::try_new(val).map_err(|e| e.to_string())
+    }
+}
+
+impl<const MIN: i32, const MAX: i32, const DEFAULT: i32> Arbitrary
+    for CompressionLevel<MIN, MAX, DEFAULT>
+{
+    type Parameters = ();
+    type Strategy = BoxedStrategy<CompressionLevel<MIN, MAX, DEFAULT>>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        ({ MIN }..={ MAX }).prop_map(CompressionLevel).boxed()
+    }
+}
 
 /// Encodes the given part into our parquet-based serialization format.
 ///
 /// It doesn't particularly get any anything to use more than one "chunk" per
 /// blob, and it's simpler to only have one, so do that.
 pub fn encode_part<W: Write + Send>(w: &mut W, part: &Part) -> Result<(), anyhow::Error> {
+    let config = EncodingConfig::default();
     let (fields, arrays) = part.to_arrow();
-    encode_arrays(w, Fields::from(fields), arrays)
+    encode_arrays(w, Fields::from(fields), arrays, &config)
 }
 
 /// Encodes a set of [`Array`]s into Parquet.
@@ -43,13 +186,14 @@ pub fn encode_arrays<W: Write + Send>(
     w: &mut W,
     fields: Fields,
     arrays: Vec<Arc<dyn Array>>,
+    config: &EncodingConfig,
 ) -> Result<(), anyhow::Error> {
     let schema = Arc::new(ArrowSchema::new(fields));
     let props = WriterProperties::builder()
-        .set_dictionary_enabled(false)
+        .set_dictionary_enabled(config.use_dictionary)
         .set_encoding(Encoding::PLAIN)
         .set_statistics_enabled(EnabledStatistics::None)
-        .set_compression(Compression::UNCOMPRESSED)
+        .set_compression(config.compression.into())
         .set_writer_version(WriterVersion::PARQUET_2_0)
         .set_data_page_size_limit(1024 * 1024)
         .set_max_row_group_size(usize::MAX)
@@ -152,4 +296,40 @@ pub fn validate_roundtrip<T: Default + Clone + PartialEq + Debug, S: Schema<T>>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mz_ore::test]
+    fn smoketest_compression_level_parsing() {
+        let cases = &[
+            ("", CompressionFormat::None),
+            ("none", CompressionFormat::None),
+            ("snappy", CompressionFormat::Snappy),
+            ("lz4", CompressionFormat::Lz4),
+            ("lZ4", CompressionFormat::Lz4),
+            ("gzip-1", CompressionFormat::Gzip(CompressionLevel(1))),
+            ("GZIp-6", CompressionFormat::Gzip(CompressionLevel(6))),
+            ("gzip-9", CompressionFormat::Gzip(CompressionLevel(9))),
+            ("brotli-1", CompressionFormat::Brotli(CompressionLevel(1))),
+            ("BROtli-8", CompressionFormat::Brotli(CompressionLevel(8))),
+            ("brotli-11", CompressionFormat::Brotli(CompressionLevel(11))),
+            ("zstd-1", CompressionFormat::Zstd(CompressionLevel(1))),
+            ("zstD-10", CompressionFormat::Zstd(CompressionLevel(10))),
+            ("zstd-22", CompressionFormat::Zstd(CompressionLevel(22))),
+            ("foo", CompressionFormat::None),
+            // Invalid values that fallback to the default values.
+            ("gzip-0", CompressionFormat::Gzip(Default::default())),
+            ("gzip-10", CompressionFormat::Gzip(Default::default())),
+            ("brotli-0", CompressionFormat::Brotli(Default::default())),
+            ("brotli-12", CompressionFormat::Brotli(Default::default())),
+            ("zstd-0", CompressionFormat::Zstd(Default::default())),
+            ("zstd-23", CompressionFormat::Zstd(Default::default())),
+        ];
+        for (s, val) in cases {
+            assert_eq!(CompressionFormat::from_str(s), *val);
+        }
+    }
 }

--- a/src/persist-types/src/parquet.rs
+++ b/src/persist-types/src/parquet.rs
@@ -77,7 +77,7 @@ impl CompressionFormat {
             match CompressionLevel::from_str(val) {
                 Ok(level) => level,
                 Err(err) => {
-                    mz_ore::soft_panic_or_log!("invalid {name} compression level, err: {err}");
+                    tracing::error!("invalid {name} compression level, err: {err}");
                     CompressionLevel::default()
                 }
             }
@@ -93,9 +93,7 @@ impl CompressionFormat {
                 Some(("zstd", level)) => CompressionFormat::Zstd(parse_level("zstd", level)),
                 Some(("gzip", level)) => CompressionFormat::Gzip(parse_level("gzip", level)),
                 _ => {
-                    mz_ore::soft_panic_or_log!(
-                        "unrecognized compression format {s}, returning None"
-                    );
+                    tracing::error!("unrecognized compression format {s}, returning None");
                     CompressionFormat::None
                 }
             },

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -46,7 +46,7 @@ mz-postgres-client = { path = "../postgres-client" }
 mz-proto = { path = "../proto" }
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow"] }
+parquet = { version = "51.0.0", default-features = false, features = ["arrow", "brotli", "flate2", "snap", "lz4", "zstd"] }
 postgres-openssl = { version = "0.5.0" }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -82,7 +82,7 @@ num-traits = { version = "0.2.15", features = ["i128", "libm"] }
 openssl = { version = "0.10.66", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
+parquet = { version = "51.0.0", default-features = false, features = ["arrow", "brotli", "flate2", "lz4", "snap", "zstd"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
@@ -206,7 +206,7 @@ num-traits = { version = "0.2.15", features = ["i128", "libm"] }
 openssl = { version = "0.10.66", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
+parquet = { version = "51.0.0", default-features = false, features = ["arrow", "brotli", "flate2", "lz4", "snap", "zstd"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }


### PR DESCRIPTION
This PR adds two dyncfgs for Parquet encoding, one to enable dictionary encoding and a second to enable compression.

### Motivation

* This PR adds a feature that has not yet been specified.

Parquet supports dictionary encoding and compression which can both seriously reduce the size of the encoded data. We need to run benchmarks to determine if we should enable these features, adding these dyncfgs is the first step in doing that.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a