### PR TITLE
new CLA assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,3 +1,28 @@
+# Copyright 2020 SAP SE
+# Modifications Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Portions of this file are derived from the README examples in the 
+# Contributor Assistant project. The original source code was retrieved on
+# July 31, 2024 from:
+#
+#     https://github.com/contributor-assistant/github-action/blob/master/README.md
+
+# Check if PR authors have signed the Materialize CLA, and if not have them sign
+# and record their signature. The CLA and signatures are stored in 
+# https://github.com/MaterializeInc/cla
+
 name: "CLA Assistant"
 on:
   issue_comment:
@@ -5,6 +30,7 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
   actions: write
   contents: read
@@ -12,7 +38,7 @@ permissions:
   statuses: write
 
 jobs:
-  cla-assistant:
+  CLAAssistant:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
@@ -23,9 +49,20 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/signatures.json'
-          path-to-document: 'https://github.com/MaterializeInc/cla/blob/main/Materialize_CLA.md'
+          path-to-document: 'https://gist.github.com/af3262c2eb70b14b8e96260e8acfc2cf' # CLA document
+          # branch should not be protected
           branch: 'main'
-          allowlist: "materialize-bot,materialize-bot-monitoring,dependabot[bot]"
+          allowlist: “materialize-bot,materialize-bot-monitoring,dependabot[bot]”
 
+         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
           remote-organization-name: MaterializeInc
+          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
           remote-repository-name: cla
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,43 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/signatures.json'
+          path-to-document: 'https://gist.github.com/af3262c2eb70b14b8e96260e8acfc2cf' # CLA document
+          # branch should not be protected
+          branch: 'main'
+          allowlist: “materialize-bot,materialize-bot-monitoring,dependabot[bot]”
+
+         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          remote-organization-name: MaterializeInc
+          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          remote-repository-name: cla
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,7 +5,6 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
-# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
   actions: write
   contents: read
@@ -13,7 +12,7 @@ permissions:
   statuses: write
 
 jobs:
-  CLAAssistant:
+  cla-assistant:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
@@ -24,20 +23,10 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/signatures.json'
-          path-to-document: 'https://gist.github.com/af3262c2eb70b14b8e96260e8acfc2cf' # CLA document
+          path-to-document: 'https://github.com/MaterializeInc/cla/blob/main/Materialize_CLA.md'
           # branch should not be protected
           branch: 'main'
           allowlist: “materialize-bot,materialize-bot-monitoring,dependabot[bot]”
 
-         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
           remote-organization-name: MaterializeInc
-          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
           remote-repository-name: cla
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Portions of this file are derived from the README examples in the 
+# Portions of this file are derived from the README examples in the
 # Contributor Assistant project. The original source code was retrieved on
 # July 31, 2024 from:
 #
 #     https://github.com/contributor-assistant/github-action/blob/master/README.md
 
 # Check if PR authors have signed the Materialize CLA, and if not have them sign
-# and record their signature. The CLA and signatures are stored in 
+# and record their signature. The CLA and signatures are stored in
 # https://github.com/MaterializeInc/cla
 
 name: "CLA Assistant"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           path-to-signatures: 'signatures/version1/signatures.json'
           path-to-document: 'https://github.com/MaterializeInc/cla/blob/main/Materialize_CLA.md'
-          # branch should not be protected
           branch: 'main'
           allowlist: "materialize-bot,materialize-bot-monitoring,dependabot[bot]"
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,7 +26,7 @@ jobs:
           path-to-document: 'https://github.com/MaterializeInc/cla/blob/main/Materialize_CLA.md'
           # branch should not be protected
           branch: 'main'
-          allowlist: “materialize-bot,materialize-bot-monitoring,dependabot[bot]”
+          allowlist: "materialize-bot,materialize-bot-monitoring,dependabot[bot]"
 
           remote-organization-name: MaterializeInc
           remote-repository-name: cla


### PR DESCRIPTION

Switch to using [the GitHub Actions based version](https://github.com/contributor-assistant/github-action) of the CLA Assistant that we have been using.

### Motivation

The [hosted version of the CLA Assistant](https://cla-assistant.io/) has been flaky recently. We will use the Actions version instead, configured to write the signatures into a new public repo: https://github.com/MaterializeInc/cla

Once this PR is pushed we will see if we can merge the existing signatures into the signature file. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
