### PR TITLE
feature-benchmark: Pick a better version to compare against

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -75,6 +75,9 @@ def is_in_pull_request() -> bool:
     if git.is_on_release_version():
         return False
 
+    if git.contains_commit("HEAD", "main", fetch=True):
+        return False
+
     return True
 
 

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -37,9 +37,14 @@ _no_0dt_system_parameters = {"enable_0dt_deployment": "false"}
 def get_minor_versions() -> list[MzVersion]:
     global _minor_versions
     if _minor_versions is None:
-        _minor_versions = get_published_minor_mz_versions(
-            limit=4, exclude_current_minor_version=True
-        )
+        current_version = MzVersion.parse_cargo()
+        _minor_versions = [
+            v
+            for v in get_published_minor_mz_versions(
+                limit=4, exclude_current_minor_version=True
+            )
+            if v < current_version
+        ]
     return _minor_versions
 
 

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -21,6 +21,8 @@ from materialize.util import YesNoOnce
 
 VERSION_TYPE = TypeVar("VERSION_TYPE", bound=TypedVersionBase)
 
+MATERIALIZE_REMOTE_URL = "https://github.com/MaterializeInc/materialize"
+
 fetched_tags_in_remotes: set[str | None] = set()
 
 
@@ -93,7 +95,7 @@ def get_version_tags(
     version_type: type[VERSION_TYPE],
     newest_first: bool = True,
     fetch: bool = True,
-    remote_url: str = "https://github.com/MaterializeInc/materialize",
+    remote_url: str = MATERIALIZE_REMOTE_URL,
 ) -> list[VERSION_TYPE]:
     """List all the version-like tags in the repo
 
@@ -258,7 +260,7 @@ def try_get_remote_name_by_url(url: str) -> str | None:
 
 
 def get_remote(
-    url: str = "https://github.com/MaterializeInc/materialize",
+    url: str = MATERIALIZE_REMOTE_URL,
     default_remote_name: str = "origin",
 ) -> str:
     # Alternative syntax
@@ -285,7 +287,16 @@ def is_on_release_version() -> bool:
     return any(MzVersion.is_valid_version_string(git_tag) for git_tag in git_tags)
 
 
-def contains_commit(commit_sha: str, target: str = "HEAD") -> bool:
+def contains_commit(
+    commit_sha: str,
+    target: str = "HEAD",
+    fetch: bool = False,
+    remote_url: str = MATERIALIZE_REMOTE_URL,
+) -> bool:
+    if fetch:
+        remote = get_remote(remote_url)
+        _fetch(remote=remote)
+        target = f"{remote}/{target}"
     command = ["git", "merge-base", "--is-ancestor", commit_sha, target]
     return_code = spawn.run_and_get_return_code(command)
     return return_code == 0


### PR DESCRIPTION
Previously if you picked a commit on main it would use the common-ancestor, which is the commit itself, and thus compare against itself, rendering the test run useless.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
