### PR TITLE
Add metrics for outer join lowering cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6180,6 +6180,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "paste",
+ "prometheus",
  "proptest",
  "proptest-derive",
  "prost",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -127,6 +127,7 @@ use mz_secrets::cache::CachingSecretsReader;
 use mz_secrets::{SecretsController, SecretsReader};
 use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::{CatalogCluster, EnvironmentId};
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::{self, AlterSinkPlan, CreateConnectionPlan, Params, QueryWhen};
 use mz_sql::session::vars::{ConnectionCounter, SystemVars};
 use mz_sql_parser::ast::display::AstDisplay;
@@ -185,7 +186,6 @@ use crate::statement_logging::{StatementEndedExecutionReason, StatementLifecycle
 use crate::util::{ClientTransmitter, CompletedClientTransmitter, ResultExt};
 use crate::webhook::{WebhookAppenderInvalidator, WebhookConcurrencyLimiter};
 use crate::{flags, AdapterNotice, ReadHolds, TimestampProvider};
-use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 use self::statement_logging::{StatementLogging, StatementLoggingId};
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -179,13 +179,13 @@ use crate::metrics::Metrics;
 use crate::optimize::dataflows::{
     dataflow_import_id_bundle, ComputeInstanceSnapshot, DataflowBuilder,
 };
-use crate::optimize::metrics::OptimizerMetrics;
 use crate::optimize::{self, Optimize, OptimizerConfig};
 use crate::session::{EndTransactionAction, Session};
 use crate::statement_logging::{StatementEndedExecutionReason, StatementLifecycleEvent};
 use crate::util::{ClientTransmitter, CompletedClientTransmitter, ResultExt};
 use crate::webhook::{WebhookAppenderInvalidator, WebhookConcurrencyLimiter};
 use crate::{flags, AdapterNotice, ReadHolds, TimestampProvider};
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 use self::statement_logging::{StatementLogging, StatementLoggingId};
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2408,7 +2408,9 @@ impl Coordinator {
             // We don't perform any optimizations on an expression that is already
             // a constant for writes, as we want to maximize bulk-insert throughput.
             let expr = return_if_err!(
-                plan.values.clone().lower(self.catalog().system_config()),
+                plan.values
+                    .clone()
+                    .lower(self.catalog().system_config(), None),
                 ctx
             );
             OptimizedMirRelationExpr(expr)

--- a/src/adapter/src/explain/insights.rs
+++ b/src/adapter/src/explain/insights.rs
@@ -23,6 +23,7 @@ use mz_repr::explain::ExprHumanizer;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::ast::Statement;
 use mz_sql::names::Aug;
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::HirRelationExpr;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_transform::EmptyStatisticsOracle;
@@ -34,7 +35,6 @@ use crate::optimize::dataflows::ComputeInstanceSnapshot;
 use crate::optimize::{self, Optimize, OptimizerConfig, OptimizerError};
 use crate::session::SessionMeta;
 use crate::TimestampContext;
-use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 /// Information needed to compute PlanInsights.
 #[derive(Debug)]

--- a/src/adapter/src/explain/insights.rs
+++ b/src/adapter/src/explain/insights.rs
@@ -31,10 +31,10 @@ use serde::Serialize;
 use crate::catalog::Catalog;
 use crate::coord::peek::{FastPathPlan, PeekPlan};
 use crate::optimize::dataflows::ComputeInstanceSnapshot;
-use crate::optimize::metrics::OptimizerMetrics;
 use crate::optimize::{self, Optimize, OptimizerConfig, OptimizerError};
 use crate::session::SessionMeta;
 use crate::TimestampContext;
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 /// Information needed to compute PlanInsights.
 #[derive(Debug)]

--- a/src/adapter/src/optimize.rs
+++ b/src/adapter/src/optimize.rs
@@ -56,7 +56,6 @@ pub mod copy_to;
 pub mod dataflows;
 pub mod index;
 pub mod materialized_view;
-pub mod metrics;
 pub mod peek;
 pub mod subscribe;
 pub mod view;

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -156,7 +156,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
         trace_plan!(at: "raw", &expr);
 
         // HIR ⇒ MIR lowering and decorrelation
-        let expr = expr.lower(&self.config)?;
+        let expr = expr.lower(&self.config, Some(&self.metrics))?;
 
         // MIR ⇒ MIR optimization (local)
         let mut df_meta = DataflowMetainfo::default();

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -38,12 +38,12 @@ use crate::optimize::dataflows::{
     prep_relation_expr, prep_scalar_expr, ComputeInstanceSnapshot, DataflowBuilder, EvalTime,
     ExprPrepStyle,
 };
-use crate::optimize::metrics::OptimizerMetrics;
 use crate::optimize::{
     optimize_mir_local, trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize,
     OptimizeMode, OptimizerConfig, OptimizerError,
 };
 use crate::TimestampContext;
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/copy_to.rs
+++ b/src/adapter/src/optimize/copy_to.rs
@@ -21,6 +21,7 @@ use mz_compute_types::ComputeInstanceId;
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_repr::explain::trace_plan;
 use mz_repr::{GlobalId, Timestamp};
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::HirRelationExpr;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_storage_types::connections::Connection;
@@ -43,7 +44,6 @@ use crate::optimize::{
     OptimizeMode, OptimizerConfig, OptimizerError,
 };
 use crate::TimestampContext;
-use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -43,11 +43,11 @@ use crate::catalog::Catalog;
 use crate::optimize::dataflows::{
     prep_relation_expr, prep_scalar_expr, ComputeInstanceSnapshot, DataflowBuilder, ExprPrepStyle,
 };
-use crate::optimize::metrics::OptimizerMetrics;
 use crate::optimize::{
     trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize, OptimizeMode,
     OptimizerConfig, OptimizerError,
 };
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -33,6 +33,7 @@ use mz_compute_types::plan::Plan;
 use mz_repr::explain::trace_plan;
 use mz_repr::GlobalId;
 use mz_sql::names::QualifiedItemName;
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
 use mz_transform::notice::{IndexAlreadyExists, IndexKeyEmpty};
@@ -47,7 +48,6 @@ use crate::optimize::{
     trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize, OptimizeMode,
     OptimizerConfig, OptimizerError,
 };
-use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -34,6 +34,7 @@ use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_repr::explain::trace_plan;
 use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{ColumnName, GlobalId, RelationDesc};
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::HirRelationExpr;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
@@ -49,7 +50,6 @@ use crate::optimize::{
     optimize_mir_local, trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize,
     OptimizeMode, OptimizerConfig, OptimizerError,
 };
-use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -45,11 +45,11 @@ use crate::catalog::Catalog;
 use crate::optimize::dataflows::{
     prep_relation_expr, prep_scalar_expr, ComputeInstanceSnapshot, DataflowBuilder, ExprPrepStyle,
 };
-use crate::optimize::metrics::OptimizerMetrics;
 use crate::optimize::{
     optimize_mir_local, trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize,
     OptimizeMode, OptimizerConfig, OptimizerError,
 };
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -168,7 +168,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
         trace_plan!(at: "raw", &expr);
 
         // HIR ⇒ MIR lowering and decorrelation
-        let expr = expr.lower(&self.config)?;
+        let expr = expr.lower(&self.config, Some(&self.metrics))?;
 
         // MIR ⇒ MIR optimization (local)
         let mut df_meta = DataflowMetainfo::default();

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -176,7 +176,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
         trace_plan!(at: "raw", &expr);
 
         // HIR ⇒ MIR lowering and decorrelation
-        let expr = expr.lower(&self.config)?;
+        let expr = expr.lower(&self.config, Some(&self.metrics))?;
 
         // MIR ⇒ MIR optimization (local)
         let mut df_meta = DataflowMetainfo::default();

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -34,12 +34,12 @@ use crate::optimize::dataflows::{
     prep_relation_expr, prep_scalar_expr, ComputeInstanceSnapshot, DataflowBuilder, EvalTime,
     ExprPrepStyle,
 };
-use crate::optimize::metrics::OptimizerMetrics;
 use crate::optimize::{
     optimize_mir_local, trace_plan, MirDataflowDescription, Optimize, OptimizeMode,
     OptimizerConfig, OptimizerError,
 };
 use crate::TimestampContext;
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -19,6 +19,7 @@ use mz_compute_types::ComputeInstanceId;
 use mz_expr::{MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_repr::explain::trace_plan;
 use mz_repr::{GlobalId, RelationType, Timestamp};
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::HirRelationExpr;
 use mz_sql::session::metadata::SessionMetadata;
 use mz_transform::dataflow::DataflowMetainfo;
@@ -39,7 +40,6 @@ use crate::optimize::{
     OptimizerConfig, OptimizerError,
 };
 use crate::TimestampContext;
-use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -21,6 +21,7 @@ use mz_compute_types::ComputeInstanceId;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_assert_or_log;
 use mz_repr::{GlobalId, RelationDesc, Timestamp};
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::SubscribeFrom;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
@@ -38,7 +39,6 @@ use crate::optimize::{
     OptimizeMode, OptimizerConfig, OptimizerError,
 };
 use crate::CollectionIdBundle;
-use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -33,12 +33,12 @@ use crate::optimize::dataflows::{
     dataflow_import_id_bundle, prep_relation_expr, prep_scalar_expr, ComputeInstanceSnapshot,
     DataflowBuilder, ExprPrepStyle,
 };
-use crate::optimize::metrics::OptimizerMetrics;
 use crate::optimize::{
     optimize_mir_local, trace_plan, LirDataflowDescription, MirDataflowDescription, Optimize,
     OptimizeMode, OptimizerConfig, OptimizerError,
 };
 use crate::CollectionIdBundle;
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -12,13 +12,13 @@
 use std::time::Instant;
 
 use mz_expr::OptimizedMirRelationExpr;
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 use mz_sql::plan::HirRelationExpr;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
 use mz_transform::TransformCtx;
 
 use crate::optimize::{optimize_mir_local, trace_plan, Optimize, OptimizerConfig, OptimizerError};
-use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -17,8 +17,8 @@ use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
 use mz_transform::TransformCtx;
 
-use crate::optimize::metrics::OptimizerMetrics;
 use crate::optimize::{optimize_mir_local, trace_plan, Optimize, OptimizerConfig, OptimizerError};
+use mz_sql::optimizer_metrics::OptimizerMetrics;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -52,7 +52,7 @@ impl Optimize<HirRelationExpr> for Optimizer {
         trace_plan!(at: "raw", &expr);
 
         // HIR ⇒ MIR lowering and decorrelation
-        let expr = expr.lower(&self.config)?;
+        let expr = expr.lower(&self.config, self.metrics.as_ref())?;
 
         // MIR ⇒ MIR optimization (local)
         let mut df_meta = DataflowMetainfo::default();

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -64,6 +64,7 @@ mz-tracing = { path = "../tracing" }
 mz-txn-wal = { path = "../txn-wal" }
 num_enum = "0.5.7"
 paste = "1.0"
+prometheus = { version = "0.13.3", default-features = false }
 protobuf-native = "0.3.1"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -133,6 +133,7 @@ pub mod kafka_util;
 pub mod names;
 #[macro_use]
 pub mod normalize;
+pub mod optimizer_metrics;
 pub mod parse;
 pub mod plan;
 pub mod pure;

--- a/src/sql/src/optimizer_metrics.rs
+++ b/src/sql/src/optimizer_metrics.rs
@@ -14,12 +14,13 @@ use std::time::Duration;
 use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::stats::histogram_seconds_buckets;
-use prometheus::HistogramVec;
+use prometheus::{HistogramVec, IntCounterVec};
 
 /// Optimizer metrics.
 #[derive(Debug, Clone)]
 pub struct OptimizerMetrics {
     e2e_optimization_time_seconds: HistogramVec,
+    outer_join_lowering_cases: IntCounterVec,
 }
 
 impl OptimizerMetrics {
@@ -31,6 +32,11 @@ impl OptimizerMetrics {
                  var_labels: ["object_type"],
                  buckets: histogram_seconds_buckets(0.000_128, 8.0),
             )),
+            outer_join_lowering_cases: registry.register(metric!(
+                name: "outer_join_lowering_cases",
+                help: "How many times the different outer join lowering cases happened.",
+                var_labels: ["case"],
+            )),
         }
     }
 
@@ -38,5 +44,11 @@ impl OptimizerMetrics {
         self.e2e_optimization_time_seconds
             .with_label_values(&[object_type])
             .observe(duration.as_secs_f64())
+    }
+
+    pub fn inc_outer_join_lowering(&self, case: &str) {
+        self.outer_join_lowering_cases
+            .with_label_values(&[case])
+            .inc()
     }
 }

--- a/src/sql/src/optimizer_metrics.rs
+++ b/src/sql/src/optimizer_metrics.rs
@@ -19,7 +19,7 @@ use prometheus::HistogramVec;
 /// Optimizer metrics.
 #[derive(Debug, Clone)]
 pub struct OptimizerMetrics {
-    pub(super) e2e_optimization_time_seconds: HistogramVec,
+    e2e_optimization_time_seconds: HistogramVec,
 }
 
 impl OptimizerMetrics {
@@ -34,7 +34,7 @@ impl OptimizerMetrics {
         }
     }
 
-    pub(super) fn observe_e2e_optimization_time(&self, object_type: &str, duration: Duration) {
+    pub fn observe_e2e_optimization_time(&self, object_type: &str, duration: Duration) {
         self.e2e_optimization_time_seconds
             .with_label_values(&[object_type])
             .observe(duration.as_secs_f64())

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -736,17 +736,17 @@ impl HirRelationExpr {
                                     config.enable_new_outer_join_lowering,
                                     config.enable_outer_join_null_filter,
                                 )? {
-                                    metrics.iter().for_each(|metrics| {
-                                        metrics.inc_outer_join_lowering("equi")
-                                    });
+                                    if let Some(metrics) = metrics {
+                                        metrics.inc_outer_join_lowering("equi");
+                                    }
                                     return Ok(joined);
                                 }
                             }
 
                             // Otherwise, perform a more general join.
-                            metrics
-                                .iter()
-                                .for_each(|metrics| metrics.inc_outer_join_lowering("general"));
+                            if let Some(metrics) = metrics {
+                                metrics.inc_outer_join_lowering("general");
+                            }
                             let mut join = product.filter(vec![on]);
                             if on_has_subqueries {
                                 // This means that `on.applied_to(...)` appended

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -736,11 +736,17 @@ impl HirRelationExpr {
                                     config.enable_new_outer_join_lowering,
                                     config.enable_outer_join_null_filter,
                                 )? {
+                                    metrics.iter().for_each(|metrics| {
+                                        metrics.inc_outer_join_lowering("equi")
+                                    });
                                     return Ok(joined);
                                 }
                             }
 
                             // Otherwise, perform a more general join.
+                            metrics
+                                .iter()
+                                .for_each(|metrics| metrics.inc_outer_join_lowering("general"));
                             let mut join = product.filter(vec![on]);
                             if on_has_subqueries {
                                 // This means that `on.applied_to(...)` appended

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -633,7 +633,7 @@ impl HirRelationExpr {
                                 rights.push((&**right, on));
                                 left_test = left;
                             }
-                            if rights.len() > 1 && get_outer.arity() == 0 {
+                            if rights.len() > 1 {
                                 // Defensively clone `cte_map` as it may be mutated.
                                 let cte_map_clone = cte_map.clone();
                                 if let Ok(Some(magic)) = variadic_left::attempt_left_join_magic(

--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -11,10 +11,10 @@ use itertools::Itertools;
 use mz_expr::{MirRelationExpr, MirScalarExpr};
 use mz_ore::soft_assert_eq_or_log;
 
+use crate::optimizer_metrics::OptimizerMetrics;
 use crate::plan::expr::{HirRelationExpr, HirScalarExpr};
-use crate::plan::PlanError;
-
 use crate::plan::lowering::{ColumnMap, Config, CteMap};
+use crate::plan::PlanError;
 
 /// Attempt to render a stack of left joins as an inner join against "enriched" right relations.
 ///
@@ -392,7 +392,6 @@ pub(crate) fn attempt_left_join_magic(
     Ok(Some(body))
 }
 
-use crate::optimizer_metrics::OptimizerMetrics;
 use mz_expr::{BinaryFunc, VariadicFunc};
 
 /// If `predicate` can be decomposed as any number of `col(x) = col(y)` expressions anded together, return them.

--- a/src/sql/src/plan/lowering/variadic_left.rs
+++ b/src/sql/src/plan/lowering/variadic_left.rs
@@ -49,9 +49,9 @@ pub(crate) fn attempt_left_join_magic(
     );
 
     let inc_metrics = |case: &str| {
-        metrics
-            .iter()
-            .for_each(|metrics| metrics.inc_outer_join_lowering(case));
+        if let Some(metrics) = metrics {
+            metrics.inc_outer_join_lowering(case);
+        }
     };
 
     let oa = get_outer.arity();

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -690,7 +690,8 @@ pub fn plan_query(
     expr.bind_parameters(params)?;
 
     Ok(query::PlannedRootQuery {
-        expr: expr.lower(scx.catalog.system_vars())?,
+        // No metrics passed! One more reason not to use this deprecated function.
+        expr: expr.lower(scx.catalog.system_vars(), None)?,
         desc,
         finishing,
         scope,


### PR DESCRIPTION
To aid the planning of work on outer joins, this PR adds a metric that counts each of the cases of outer join lowering.

The first commit just moves `OptimizerMetrics` to `mz_sql`. This is somewhat unfortunate, but I didn't see a better way to make it available in the lowering. I'm open to ideas. (In the long run, I guess it would be great to have an `mz_optimizer` crate, which would include the stuff that is currently in `mz_transform`, and also the lowering, and maybe some other minor things.)

The second commit was a lot of typing, but very straightforward: just wires the `OptimizerMetrics` to every part of the lowering. (I couldn't just wire it to a smaller subset of functions, because all of these many functions are co-recursively calling each other.)

The third commit is the main thing, which actually increments the metric at a couple of places in the lowering.

The fourth commit is a minor tweak to make the code simpler. Before this change, the `case = 1` inside `attempt_left_join_magic` was dead code, because we were avoiding calling `attempt_left_join_magic` altogether when the outer arity is non-0. Removing the check that is before the call to `attempt_left_join_magic` makes the `case = 1` code handle this situation. Note that this very slightly decreases the performance of the lowering, but I think it's worth it to make the code simpler. (Alternatively, we could just have some additional debug logging and metrics incrementing in the else branch of that `if` that was checking the outer arity before calling `attempt_left_join_magic`.)

~I'm thinking about adding a fifth commit, which would further decompose the `voj_4` case. This would be just a local change there, so the rest of the PR is ready for review.~ Edit: There is no time.

### Motivation

  * This PR adds a feature that has not yet been specified. It just adds a metric to help the planning of further work on outer join.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
