### PR TITLE
storage/sources/kafka: Avoid a panic when downgrading to an offset we've already seen

### DIFF
--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -87,6 +87,61 @@ $ kafka-create-topic topic=topic1 partitions=1
 ! SELECT * FROM source1
 contains:topic was recreated: high watermark of partition 0 regressed from 1 to 0
 
+# Test a pathological topic recreation observed in the wild.
+# See incidents-and-escalations#98.
+
+# First we create a topic and successfully ingest some data.
+$ kafka-create-topic topic=topic2 partitions=1
+$ kafka-ingest format=bytes topic=topic2 repeat=100
+one
+> CREATE SOURCE source2
+  IN CLUSTER to_recreate
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic2-${testdrive.seed}')
+  FORMAT TEXT
+  ENVELOPE NONE
+> SELECT count(*) FROM source2
+100
+
+# Then we turn off the source cluster, so that we lose our record of what the
+# high water mark used to be.
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR = 0)
+
+# Then we delete the topic and recreate it...
+# See comment above about needing to sleep after deleting Kafka topics.
+$ kafka-delete-topic-flaky topic=topic2
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=2s
+$ kafka-create-topic topic=topic2 partitions=1
+
+# ...crucially, with *fewer* offsets than we had previously.
+$ kafka-ingest format=bytes topic=topic2 repeat=50
+one
+
+# Finally, we turn the source cluster back on. This would previously cause
+# Materialize to panic because we'd attempt to regress the data shard's
+# capability to offset 2 (the max offset in the new topic) when it was
+# already at offset 3 (the max offset in the old topic).
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR = 1)
+
+# Give the source a few seconds to reconnect to the Kafka partitions and
+# possibly read bad data. This is what actually reproduces the panic we saw in
+# incidents-and-escalations#98. Unfortunately there is no signal we can wait
+# for, so the best we can do is sleep.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
+
+# Ensure the source reports the previous data.
+> SELECT count(*) FROM source2
+100
+
+# Check whether the source is still lumbering along. Correctness has gone out
+# the window here. Data in the new topic will be ignored up until the first new
+# offset, at which point it will start being ingested. In this case, 7 and 8 are
+# the two new data rows.
+$ kafka-ingest format=bytes topic=topic2 repeat=53
+one
+
+> SELECT count(*) FROM source2
+103
+
 # Ensure we don't panic after we restart due to the above finished ingestions.
 $ kafka-create-topic topic=good-topic
 
@@ -114,6 +169,10 @@ name            status    error
 good_source     running   <null>
 source0         paused    <null>
 source1         paused    <null>
+# Ideally source 2 would be permanently stalled because the topic was recreated,
+# but we can't easily distingiush that situation from a temporary ingestion
+# hiccup, and so at the moment we consider source2 to be fully healthy.
+source2         running   <null>
 
 # Testdrive expects all sources to end in a healthy state, so manufacture that
 # by dropping sources.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/incidents-and-escalations/issues/98.

We've seen this issue twice in the last couple of weeks and believe it was introduced by this PR: https://github.com/MaterializeInc/materialize/pull/28058 
The Sentry [logs](https://materializeinc.sentry.io/issues/5655610932/?project=6780145&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&stream_index=0) indicate that we saw a message from an offset we had already seen prior to the panic, and that PR removed the seek-forwarding of the consumer group offset that previously prevented us from downgrading to a frontier we'd already moved beyond:
![image](https://github.com/user-attachments/assets/2c65e523-4dd2-4287-9de2-f2d08b53a60d)

This PR allows the downgrade to fail using `try_downgrade` to account for this case when we are simply skipping over messages we've already seen.

<!--
Which of the following best describes the motivation behind this PR?


    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

We are working on a test to validate this

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
