### PR TITLE
catalog: Store fingerprints in 0dt migrations

### DIFF
--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -522,12 +522,12 @@ impl CatalogState {
         }
 
         if let Some(entry) = retractions.system_object_mappings.remove(&id) {
-            // System objects can only be updated through the builtin migration process, which
-            // allocates new IDs for each object.
-            panic!(
-                "cannot update system objects in place, entry: {:?}, durable: {:?}",
-                entry, system_object_mapping
-            )
+            // This implies that we updated the fingerprint for some builtin item. The retraction
+            // was parsed, planned, and optimized using the compiled in definition, not the
+            // definition from a previous version. So we can just stick the old entry back into the
+            // catalog.
+            self.insert_entry(entry);
+            return;
         }
 
         let builtin = BUILTIN_LOOKUP


### PR DESCRIPTION
This commit fixes an issue with 0dt builtin item migrations. Materialize determines if a builtin item is migrated by comparing a compiled in fingerprint with a durably stored fingerprint. Previously, the 0dt builtin item migrations did not update the durably stored fingerprint after migrating an item. This commit fixes that issue.

Resolves #28636

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
