### PR TITLE
persist: turn off persist_schema_require in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "mz-balancerd"
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "mz-catalog-debug"
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "mz-clusterd"
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -4803,7 +4803,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 dependencies = [
  "anyhow",
  "askama",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.4",
@@ -6632,7 +6632,7 @@ dependencies = [
 
 [[package]]
 name = "mz-testdrive"
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 dependencies = [
  "anyhow",
  "arrow",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -108,7 +108,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "wait_catalog_consolidation_on_startup": "true",
     "persist_batch_record_part_format": "true",
     "storage_use_reclock_v2": "true",
-    "persist_schema_require": "true",
 }
 
 
@@ -117,7 +116,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
 def version_dependent_system_parameters(version: MzVersion) -> dict[str, str]:
     return {
         "persist_schema_register": (
-            "false" if version < MzVersion.parse_mz("v0.111.0") else "true"
+            "false" if version < MzVersion.parse_mz("v0.111.0-dev") else "true"
         )
     }
 

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-balancerd"
 description = "Balancer service."
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-catalog-debug"
 description = "Durable metadata storage debug tool."
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-clusterd"
 description = "Materialize's cluster server."
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-testdrive"
 description = "Integration test driver for Materialize."
-version = "0.111.0-dev"
+version = "0.112.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
The edge case on the persist_schema_register check (which use of this dyncfg is gated behind) was wrong, and so we thought this was running on main, but it wasn't. The release process caused it to find the cursed txn-wal TODO. Reverting until we fix the problematic callers.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
