### PR TITLE
persist: re-enable now fixed schema assertion

### DIFF
--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1834,10 +1834,9 @@ impl SourceDataRowColumnarEncoder {
         match self {
             SourceDataRowColumnarEncoder::Row(encoder) => encoder.append(row),
             SourceDataRowColumnarEncoder::EmptyRow => {
-                // TODO(#28146): Re-enable this check.
-                if false {
-                    assert_eq!(row.iter().count(), 0)
-                }
+                // TODO(#28146): Make this into an `assert_eq` once #28539 goes
+                // in.
+                mz_ore::soft_assert_eq_no_log!(row.iter().count(), 0)
             }
         }
     }


### PR DESCRIPTION
It turns out we mis-diagnosed the testdrive kafka failures that Parker was seeing as being caused by the txn-wal TODO. They were actually caused by shard finalization's placeholder schema, which was fixed in the #28454 schema registry PR.

This should be enough to get CI green with the desired assertion. However, since there's a known second occurrence of the bad schema behavior, keep it as a soft_assert to prevent it from regressing in CI but also eliminate the possibility for it to cause issues in prod.

Touches #28146

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
