### PR TITLE
Add panicking ALTER SINK test to testdrive, platform-checks, parallel-workload

### DIFF
--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -539,6 +539,7 @@ class KafkaSink(DBObject):
     rename: int
     cluster: "Cluster"
     schema: Schema
+    base_object: DBObject
     envelope: str
     key: str
 

--- a/test/testdrive/alter-sink.td
+++ b/test/testdrive/alter-sink.td
@@ -107,3 +107,25 @@ SELECT pg_cancel_backend(CAST(${backend-pid} AS int4));
 
 ! ALTER SINK wedged_sink SET FROM post_alter;
 contains:canceling statement due to user request
+
+
+# There is a meaninful difference in having an object created after the sink
+# already exists, see incident-131:
+> CREATE TABLE created_post_alter (created_post_name string, created_post_value int);
+# This value should be ignored by the sink because the alter will happen after
+# this record has been inserted and we don't re-emit a snapshot of the new
+# collection when it changes.
+> INSERT INTO created_post_alter VALUES ('ignored', 0);
+> INSERT INTO created_post_alter VALUES ('ignored2', 1);
+
+> ALTER SINK sink SET FROM created_post_alter;
+
+# The sink will start sinking updates from `post_alter` at the timestamp that
+# the previous dataflow happens to stop. This happens pretty quickly but we
+# wait a few seconds more for good measure to avoid flaking.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=4s
+
+> INSERT INTO post_alter VALUES ('hundred', 99);
+
+$ kafka-verify-data format=json sink=materialize.public.sink key=false
+{"before": null, "after": {"created_post_name": "hundred", "created_post_value": 99}}


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
