### PR TITLE
Remove deprecated `REHYDRATION TIME ESTIMATE`

### DIFF
--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -344,7 +344,6 @@ Refresh
 Regex
 Region
 Registry
-Rehydration
 Rename
 Reoptimize
 Repeatable

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3959,10 +3959,7 @@ impl<'a> Parser<'a> {
                 self.expect_keyword(REFRESH)?;
                 // Parse optional `(HYDRATION TIME ESTIMATE ...)`
                 let hydration_time_estimate = if self.consume_token(&Token::LParen) {
-                    // `REHYDRATION` is the legacy way of writing this. We'd like to eventually
-                    // remove this, and allow only `HYDRATION`. (Dbt needs to be updated for this.)
-                    self.expect_one_of_keywords(&[HYDRATION, REHYDRATION])?;
-                    self.expect_keywords(&[TIME, ESTIMATE])?;
+                    self.expect_keywords(&[HYDRATION, TIME, ESTIMATE])?;
                     let _ = self.consume_token(&Token::Eq);
                     let interval = self.parse_interval_value()?;
                     self.expect_token(&Token::RParen)?;

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1756,14 +1756,6 @@ CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMA
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [] })
 
-# Legacy version: `REHYDRATION TIME ESTIMATE`
-parse-statement
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (REHYDRATION TIME ESTIMATE = '1 hour'))
-----
-CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE = '1 hour'))
-=>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }, ClusterOption { name: Schedule, value: Some(ClusterScheduleOptionValue(Refresh { hydration_time_estimate: Some(IntervalValue { value: "1 hour", precision_high: Year, precision_low: Second, fsec_max_precision: None }) })) }], features: [] })
-
 parse-statement
 CREATE CLUSTER cluster (SIZE = '1', SCHEDULE = ON REFRESH (HYDRATION TIME ESTIMATE '1 hour'))
 ----


### PR DESCRIPTION
Removes the old `REHYDRATION TIME ESTIMATE` option, which is superseded by `HYDRATION TIME ESTIMATE` (with the same meaning). This is a private preview feature, and the two users who have it are using it through dbt, which already redirects both versions to `HYDRATION TIME ESTIMATE`. Also note that they were forced to switch to the new dbt version. (Forcing them to the new dbt version was an accident, and quite unfortunate in general, but good for making sure that we can remove the old option in a timely manner, before anyone else starts using it.)

### Motivation

- Removing a deprecated version of a feature: #28140

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
