### PR TITLE
data-ingest: Disable sanity restart

### DIFF
--- a/misc/python/materialize/data_ingest/transaction_def.py
+++ b/misc/python/materialize/data_ingest/transaction_def.py
@@ -85,6 +85,7 @@ class RestartMz(TransactionDef):
                     external_cockroach=True,
                     additional_system_parameter_defaults={"enable_table_keys": "true"},
                     deploy_generation=self.workload.deploy_generation,
+                    sanity_restart=False,
                 ),
             ):
                 self.composition.kill(self.workload.mz_service)
@@ -130,6 +131,7 @@ class ZeroDowntimeDeploy(TransactionDef):
                     deploy_generation=self.workload.deploy_generation,
                     restart="on-failure",
                     healthcheck=LEADER_STATUS_HEALTHCHECK,
+                    sanity_restart=False,
                 ),
             ):
                 self.composition.up(self.workload.mz_service, detach=True)

--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -53,6 +53,7 @@ SERVICES = [
         external_minio=True,
         external_cockroach=True,
         additional_system_parameter_defaults={"enable_table_keys": "true"},
+        sanity_restart=False,
     ),
     Materialized(
         name="materialized2",
@@ -60,6 +61,7 @@ SERVICES = [
         external_minio=True,
         external_cockroach=True,
         additional_system_parameter_defaults={"enable_table_keys": "true"},
+        sanity_restart=False,
     ),
     Clusterd(name="clusterd1", options=["--scratch-directory=/mzdata/source_data"]),
 ]


### PR DESCRIPTION
Would require setting the correct deployment generation, may be fenced out already. Seen failing in https://buildkite.com/materialize/nightly/builds/8911#01911067-9409-407c-a2eb-9e5796ab351c

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
