### PR TITLE
test-analytics: Reduce memory for mv_recent_build_job_success_on_main

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -748,11 +748,12 @@ def get_failures_on_main(test_analytics: TestAnalyticsDb) -> BuildHistory:
         parallel_job = int(parallel_job)
 
     try:
-        build_history = test_analytics.build_history.get_recent_build_job_failures(
-            pipeline=pipeline_slug,
-            branch="main",
-            step_key=step_key,
-            parallel_job_index=parallel_job,
+        build_history = (
+            test_analytics.build_history.get_recent_build_job_failures_on_main(
+                pipeline=pipeline_slug,
+                step_key=step_key,
+                parallel_job_index=parallel_job,
+            )
         )
 
         if len(build_history.last_build_step_outcomes) < 5:

--- a/misc/python/materialize/test_analytics/setup/views/02-build-job.sql
+++ b/misc/python/materialize/test_analytics/setup/views/02-build-job.sql
@@ -87,114 +87,23 @@ GROUP BY
     bju.build_step_key
 ;
 
--- history of build job success
-CREATE OR REPLACE VIEW v_build_job_success AS
-WITH MUTUALLY RECURSIVE data (build_id TEXT, pipeline TEXT, branch TEXT, build_number INT, build_job_id TEXT, build_step_key TEXT, date TIMESTAMPTZ, success BOOL, predecessor_index INT, predecessor_build_number INT) AS
-(
+CREATE OR REPLACE MATERIALIZED VIEW mv_recent_build_job_success_on_main_v2
+IN CLUSTER test_analytics AS
+SELECT * FROM (
     SELECT
-        bj.build_id, b.pipeline, b.branch, b.build_number, bj.build_job_id, bj.build_step_key, b.date, bj.success, 0, b.build_number
-    FROM
-        build_job bj
-    INNER JOIN build b
-    ON b.build_id = bj.build_id
-    WHERE bj.is_latest_retry = TRUE
-    UNION
-    SELECT
-        d.build_id, d.pipeline, d.branch, d.build_number, d.build_job_id, d.build_step_key, d.date, d.success, d.predecessor_index + 1, max(b2.build_number)
-    FROM
-        data d
-    INNER JOIN build b2
-    ON d.pipeline = b2.pipeline
-    AND d.branch = b2.branch
-    AND d.predecessor_build_number > b2.build_number
-    INNER JOIN build_job bj2
-    ON b2.build_id = bj2.build_id
-    WHERE d.predecessor_index < 10
-    AND bj2.is_latest_retry = TRUE
-    GROUP BY
-        d.build_id,
-        d.pipeline,
-        d.branch,
-        d.build_number,
-        d.build_job_id,
-        d.build_step_key,
-        d.date,
-        d.predecessor_index,
-        d.success
-    -- this applies to max(b2.build_number)
-    OPTIONS (AGGREGATE INPUT GROUP SIZE = 10)
-)
-SELECT
-    d.build_id,
-    d.pipeline,
-    d.branch,
-    d.build_number,
-    d.build_job_id,
-    d.build_step_key,
-    d.date,
-    d.success,
-    d.predecessor_index,
-    d.predecessor_build_number AS predecessor_build_number,
-    pred_b.build_id AS predecessor_build_id,
-    pred_bj.build_job_id AS predecessor_build_job_id,
-    pred_bj.success AS predecessor_build_step_success,
-    pred_bj.is_latest_retry AS predecessor_is_latest_retry
-FROM
-    data d
-INNER JOIN build pred_b
-ON d.pipeline = pred_b.pipeline
-AND d.predecessor_build_number = pred_b.build_number
-INNER JOIN build_job pred_bj
-ON pred_b.build_id = pred_bj.build_id
-AND d.build_step_key = pred_bj.build_step_key
-WHERE d.predecessor_index <> 0
-;
-
-CREATE OR REPLACE MATERIALIZED VIEW mv_recent_build_job_success_on_main IN CLUSTER test_analytics AS
-SELECT
-    build_job_id,
-    predecessor_build_number,
-    predecessor_build_id,
-    predecessor_build_job_id,
-    predecessor_build_step_success,
-    predecessor_index,
-    predecessor_is_latest_retry,
-    pipeline -- no longer in use, remove eventually
-FROM v_build_job_success
-WHERE branch = 'main'
-AND date + INTERVAL '5' DAY > mz_now()
-AND predecessor_index <= 10;
-
-CREATE OR REPLACE VIEW v_most_recent_build_job AS
-WITH most_recent_build_with_completed_build_step AS (
-    SELECT
-        b.branch,
-        b.pipeline,
-        bj.build_step_key,
-        max(b.build_number) AS highest_build_number
-    FROM build b
-    INNER JOIN build_job bj
-    ON b.build_id = bj.build_id
-    GROUP BY
-        b.branch,
-        b.pipeline,
-        bj.build_step_key
-)
-SELECT
-    b.pipeline,
-    b.branch,
-    b.build_id,
-    bj.build_job_id,
-    bj.build_step_id,
-    bj.build_step_key,
-    bj.shard_index,
-    bj.success
-FROM build_job bj
-INNER JOIN build b
-    ON bj.build_id = b.build_id
-INNER JOIN most_recent_build_with_completed_build_step mrb
-    ON b.pipeline = mrb.pipeline
-    AND b.build_number = mrb.highest_build_number
-    AND bj.build_step_key = mrb.build_step_key
-WHERE bj.is_latest_retry = TRUE
+        row_number() OVER (
+            PARTITION BY pipeline, build_step_key, shard_index
+            ORDER BY build_number DESC
+        ),
+        pipeline,
+        build_step_key,
+        shard_index,
+        build_number,
+        build.build_id,
+        build_job_id,
+        success AS build_step_success
+    FROM build_job
+    INNER JOIN build
+    ON build.build_id = build_job.build_id AND build.branch = 'main' AND is_latest_retry = TRUE
+) WHERE row_number <= 5
 ;


### PR DESCRIPTION
From 5.35 GB to 54 MB
![Screenshot 2024-08-02 at 16 45 14](https://github.com/user-attachments/assets/a7a8c908-4033-4593-9762-82ac6a32bdc7)
Proof that this still works: https://buildkite.com/materialize/test/builds/87398#_
![Screenshot 2024-08-02 at 17 33 20](https://github.com/user-attachments/assets/b3954ad9-cccb-4db1-8cbd-bb3aed975545)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
