### PR TITLE
catalog: Add safeguard for corrupt catalogs

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1196,7 +1196,7 @@ impl Catalog {
         &mut self,
     ) -> Result<Vec<BuiltinTableUpdate<&'static BuiltinTable>>, CatalogError> {
         let updates = self.storage().await.sync_to_current_updates().await?;
-        let builtin_table_updates = self.state.apply_updates(updates);
+        let builtin_table_updates = self.state.apply_updates(updates)?;
         Ok(builtin_table_updates)
     }
 }

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -838,7 +838,9 @@ impl CatalogState {
                         }
                     }
                 };
-                if entry.uses().iter().any(|id| *id > entry.id) {
+                // We allow sinks to break this invariant due to a know issue with `ALTER SINK`.
+                // https://github.com/MaterializeInc/materialize/pull/28708.
+                if !entry.is_sink() && entry.uses().iter().any(|id| *id > entry.id) {
                     let msg = format!(
                         "item cannot depend on items with larger GlobalIds, item: {:?}, dependencies: {:?}",
                         entry,

--- a/src/adapter/src/catalog/apply.rs
+++ b/src/adapter/src/catalog/apply.rs
@@ -25,6 +25,7 @@ use mz_catalog::builtin::{
 use mz_catalog::durable::objects::{
     ClusterKey, DatabaseKey, DurableType, ItemKey, RoleKey, SchemaKey,
 };
+use mz_catalog::durable::{CatalogError, DurableCatalogError};
 use mz_catalog::memory::error::{Error, ErrorKind};
 use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, Cluster, ClusterReplica, DataSourceDesc, Database, Func, Index, Log,
@@ -55,7 +56,7 @@ use mz_sql::session::vars::{VarError, VarInput};
 use mz_sql::{plan, rbac};
 use mz_sql_parser::ast::Expr;
 use mz_storage_types::sources::Timeline;
-use tracing::{info_span, warn, Instrument};
+use tracing::{error, info_span, warn, Instrument};
 
 use crate::catalog::{BuiltinTableUpdate, CatalogState};
 use crate::util::index_sql;
@@ -131,18 +132,18 @@ impl CatalogState {
     pub(crate) fn apply_updates(
         &mut self,
         updates: Vec<StateUpdate>,
-    ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
+    ) -> Result<Vec<BuiltinTableUpdate<&'static BuiltinTable>>, CatalogError> {
         let mut builtin_table_updates = Vec::with_capacity(updates.len());
         let updates = sort_updates(updates);
 
         for (_, updates) in &updates.into_iter().group_by(|update| update.ts) {
             let mut retractions = InProgressRetractions::default();
             let builtin_table_update =
-                self.apply_updates_inner(updates.collect(), &mut retractions);
+                self.apply_updates_inner(updates.collect(), &mut retractions)?;
             builtin_table_updates.extend(builtin_table_update);
         }
 
-        builtin_table_updates
+        Ok(builtin_table_updates)
     }
 
     #[must_use]
@@ -151,7 +152,7 @@ impl CatalogState {
         &mut self,
         updates: Vec<StateUpdate>,
         retractions: &mut InProgressRetractions,
-    ) -> Vec<BuiltinTableUpdate<&'static BuiltinTable>> {
+    ) -> Result<Vec<BuiltinTableUpdate<&'static BuiltinTable>>, CatalogError> {
         soft_assert_no_log!(
             updates.iter().map(|update| update.ts).all_equal(),
             "all timestamps should be equal: {updates:?}"
@@ -165,10 +166,10 @@ impl CatalogState {
                     // before applying the update.
                     builtin_table_updates
                         .extend(self.generate_builtin_table_update(kind.clone(), diff));
-                    self.apply_update(kind, diff, retractions);
+                    self.apply_update(kind, diff, retractions)?;
                 }
                 StateDiff::Addition => {
-                    self.apply_update(kind.clone(), diff, retractions);
+                    self.apply_update(kind.clone(), diff, retractions)?;
                     // We want the builtin table addition to match the state of the catalog
                     // after applying the update.
                     builtin_table_updates
@@ -176,7 +177,7 @@ impl CatalogState {
                 }
             }
         }
-        builtin_table_updates
+        Ok(builtin_table_updates)
     }
 
     #[instrument(level = "debug")]
@@ -185,7 +186,7 @@ impl CatalogState {
         kind: StateUpdateKind,
         diff: StateDiff,
         retractions: &mut InProgressRetractions,
-    ) {
+    ) -> Result<(), CatalogError> {
         match kind {
             StateUpdateKind::Role(role) => {
                 self.apply_role_update(role, diff, retractions);
@@ -225,7 +226,7 @@ impl CatalogState {
                 self.apply_temporary_item_update(item, diff, retractions);
             }
             StateUpdateKind::Item(item) => {
-                self.apply_item_update(item, diff, retractions);
+                self.apply_item_update(item, diff, retractions)?;
             }
             StateUpdateKind::Comment(comment) => {
                 self.apply_comment_update(comment, diff, retractions);
@@ -247,6 +248,8 @@ impl CatalogState {
                 self.apply_unfinalized_shard_update(unfinalized_shard, diff, retractions);
             }
         }
+
+        Ok(())
     }
 
     #[instrument(level = "debug")]
@@ -777,7 +780,7 @@ impl CatalogState {
         item: mz_catalog::durable::Item,
         diff: StateDiff,
         retractions: &mut InProgressRetractions,
-    ) {
+    ) -> Result<(), CatalogError> {
         match diff {
             StateDiff::Addition => {
                 let key = item.key();
@@ -835,6 +838,15 @@ impl CatalogState {
                         }
                     }
                 };
+                if entry.uses().iter().any(|id| *id > entry.id) {
+                    let msg = format!(
+                        "item cannot depend on items with larger GlobalIds, item: {:?}, dependencies: {:?}",
+                        entry,
+                        entry.uses()
+                    );
+                    error!("internal catalog errr: {msg}");
+                    return Err(CatalogError::Durable(DurableCatalogError::Internal(msg)));
+                }
                 self.insert_entry(entry);
             }
             StateDiff::Retraction => {
@@ -843,6 +855,7 @@ impl CatalogState {
                 retractions.items.insert(key, entry);
             }
         }
+        Ok(())
     }
 
     #[instrument(level = "debug")]
@@ -1722,11 +1735,13 @@ impl BootstrapApplyState {
                 builtin_table_updates
             }
             BootstrapApplyState::Items(updates) => state.with_enable_for_item_parsing(|state| {
-                state.apply_updates_inner(updates, retractions)
+                state
+                    .apply_updates_inner(updates, retractions)
+                    .expect("corrupt catalog")
             }),
-            BootstrapApplyState::Updates(updates) => {
-                state.apply_updates_inner(updates, retractions)
-            }
+            BootstrapApplyState::Updates(updates) => state
+                .apply_updates_inner(updates, retractions)
+                .expect("corrupt catalog"),
         }
     }
 

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -602,7 +602,7 @@ impl Catalog {
             .map_err(mz_catalog::durable::DurableCatalogError::from)?;
 
         let updates = txn.get_and_commit_op_updates();
-        let builtin_updates = state.apply_updates(updates);
+        let builtin_updates = state.apply_updates(updates)?;
         assert_eq!(builtin_updates, Vec::new());
         txn.commit().await?;
         drop(storage);

--- a/src/adapter/src/catalog/transact.rs
+++ b/src/adapter/src/catalog/transact.rs
@@ -508,7 +508,7 @@ impl Catalog {
 
             let mut updates: Vec<_> = tx.get_and_commit_op_updates();
             updates.extend(temporary_item_updates);
-            let op_builtin_table_updates = state.apply_updates(updates);
+            let op_builtin_table_updates = state.apply_updates(updates)?;
             let op_builtin_table_updates =
                 state.resolve_builtin_table_updates(op_builtin_table_updates);
             builtin_table_updates.extend(op_builtin_table_updates);
@@ -526,7 +526,7 @@ impl Catalog {
             }
 
             let updates = tx.get_and_commit_op_updates();
-            let op_builtin_table_updates = state.apply_updates(updates);
+            let op_builtin_table_updates = state.apply_updates(updates)?;
             let op_builtin_table_updates =
                 state.resolve_builtin_table_updates(op_builtin_table_updates);
             builtin_table_updates.extend(op_builtin_table_updates);

--- a/src/catalog/src/durable/error.rs
+++ b/src/catalog/src/durable/error.rs
@@ -68,6 +68,9 @@ pub enum DurableCatalogError {
     /// A programming error occurred during a [`mz_storage_client::controller::StorageTxn`].
     #[error(transparent)]
     Storage(StorageError<Timestamp>),
+    /// An internal programming error.
+    #[error("Internal catalog error: {0}")]
+    Internal(String),
 }
 
 impl DurableCatalogError {
@@ -82,7 +85,8 @@ impl DurableCatalogError {
             | DurableCatalogError::NotWritable(_)
             | DurableCatalogError::DuplicateKey
             | DurableCatalogError::UniquenessViolation
-            | DurableCatalogError::Storage(_) => false,
+            | DurableCatalogError::Storage(_)
+            | DurableCatalogError::Internal(_) => false,
         }
     }
 


### PR DESCRIPTION
This commit adds a safeguard to error if we every try and commit an item to the catalog that depends on an item with a larger `GlobalId`. `GlobalId` ordering needs to match dependency ordering, otherwise the catalog will become corrupt.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
