### PR TITLE
persist: hook up decoding from only the structured arrow data

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -256,8 +256,8 @@ steps:
               composition: testdrive
               args: [--default-size=8]
 
-      - id: testdrive-structured-persist
-        label: ":racing_car: testdrive with Structured Persist"
+      - id: testdrive-structured-persist-validate
+        label: ":racing_car: testdrive with Structured Persist (Row + Validate)"
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
@@ -267,6 +267,20 @@ steps:
               composition: testdrive
               args: [
                 --system-param=persist_part_decode_format=row_with_validate,
+                --system-param=persist_batch_columnar_format=both_v2,
+              ]
+
+      - id: testdrive-structured-persist-arrow
+        label: ":racing_car: testdrive with Structured Persist (Only Structured)"
+        depends_on: build-aarch64
+        timeout_in_minutes: 180
+        agents:
+          queue: hetzner-aarch64-16cpu-32gb
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: testdrive
+              args: [
+                --system-param=persist_part_decode_format=arrow,
                 --system-param=persist_batch_columnar_format=both_v2,
               ]
 

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1010,6 +1010,10 @@ class FlipFlagsAction(Action):
         self.flags_with_values["persist_batch_columnar_stats_only_override"] = (
             BOOLEAN_FLAG_VALUES
         )
+        self.flags_with_values["persist_part_decode_format"] = [
+            "row_with_validate",
+            "arrow",
+        ]
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -106,6 +106,12 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                     x.add_dynamic("persist_schema_register", ::mz_dyncfg::ConfigVal::Bool(true));
                     x.add_dynamic("persist_schema_require", ::mz_dyncfg::ConfigVal::Bool(true));
                     x
+                },
+                {
+                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
+                    x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
+                    x.add_dynamic("persist_part_decode_format", ::mz_dyncfg::ConfigVal::String("arrow".into()));
+                    x
                 }
             ];
 


### PR DESCRIPTION
This is done in a way that  relies on the Codec data still being
populated (i.e. for the consolidate optimization above it). Eventually
we'll have to rewrite this path to work entirely without Codec data, but
in the meantime, putting in here allows us to see the performance impact
of decoding entirely from arrow instead of Codec.

Plus, it'll likely be easier to port all the logic here to work solely
on arrow data once we finish migrating things like the
ConsolidatingIter.

Touches https://github.com/MaterializeInc/materialize/issues/24830

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
