### PR TITLE
platform-checks: Fix alter sink flake

### DIFF
--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -1015,24 +1015,25 @@ class AlterSinkOrder(Check):
             for s in [
                 """
                 > CREATE TABLE table_alter_order2 (x int, y string)
-                > INSERT INTO table_alter_order2 VALUES (1, 'b')
+
                 > ALTER SINK sink_alter_order SET FROM table_alter_order2;
 
                 # Wait for the actual restart to have occurred before inserting
                 $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=8s
 
+                > INSERT INTO table_alter_order2 VALUES (1, 'b')
                 > INSERT INTO table_alter_order1 VALUES (10, 'aa')
                 > INSERT INTO table_alter_order2 VALUES (11, 'bb')
                 """,
                 """
                 > CREATE TABLE table_alter_order3 (x int, y string)
-                > INSERT INTO table_alter_order3 VALUES (2, 'c')
-                > INSERT INTO table_alter_order3 VALUES (12, 'cc')
                 > ALTER SINK sink_alter_order SET FROM table_alter_order3;
 
                 # Wait for the actual restart to have occurred before inserting
                 $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=8s
 
+                > INSERT INTO table_alter_order3 VALUES (2, 'c')
+                > INSERT INTO table_alter_order3 VALUES (12, 'cc')
                 > INSERT INTO table_alter_order1 VALUES (100, 'aaa')
                 > INSERT INTO table_alter_order2 VALUES (101, 'bbb')
                 > INSERT INTO table_alter_order3 VALUES (102, 'ccc')
@@ -1053,7 +1054,10 @@ class AlterSinkOrder(Check):
 
                 > SELECT before IS NULL, (after).x, (after).y FROM sink_alter_order_source
                 true 0 a
+                true 1 b
+                true 2 c
                 true 11 bb
+                true 12 cc
                 true 102 ccc
 
                 > DROP SOURCE sink_alter_order_source CASCADE;


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/test/builds/87438

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
