### PR TITLE
feature benchmark: improve output

### DIFF
--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -225,9 +225,9 @@ class Report:
         output_lines = []
 
         output_lines.append(
-            f"{'NAME':<35} | {'TYPE':<15} | {'THIS':^15} | {'OTHER':^15} | {'UNIT':^6} | {'THRESHOLD':^10} | {'Regression?':^13} | 'THIS' is:"
+            f"{'NAME':<35} | {'TYPE':<15} | {'THIS':^15} | {'OTHER':^15} | {'UNIT':^6} | {'THRESHOLD':^10} | {'Regression?':^13} | 'THIS' is"
         )
-        output_lines.append("-" * 150)
+        output_lines.append("-" * 152)
 
         for comparison in self._comparisons:
             if not comparison.has_values():

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -19,7 +19,7 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {}
 SHA256_OF_FRAMEWORK["*"] = (
-    "2486656c8a9dd7bc044c2c6c86f9970af0b2a043dcc86c169c7d1ca4a6478e6b"
+    "1b4cb4e8d87f11e471847669a445067775afe386634c1bfb39a13f73b5772019"
 )
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!

--- a/misc/python/materialize/feature_benchmark/comparator.py
+++ b/misc/python/materialize/feature_benchmark/comparator.py
@@ -116,28 +116,30 @@ class RelativeThresholdComparator(Comparator[float | None]):
 
         ratio = self.ratio()
         if ratio is None:
-            return "     N/A"
+            return "not comparable"
         if ratio >= 2:
             return with_conditional_formatting(
-                f"{ratio:4.1f} TIMES {deterioration}", COLOR_BAD, condition=use_colors
+                f"worse:  {ratio:4.1f} TIMES {deterioration}",
+                COLOR_BAD,
+                condition=use_colors,
             )
         elif ratio > 1:
             return with_conditional_formatting(
-                f"{-(1-ratio)*100:4.1f} pct   {deterioration}",
+                f"worse:  {-(1-ratio)*100:4.1f}% {deterioration}",
                 COLOR_BAD,
                 condition=use_colors,
             )
         elif ratio == 1:
-            return "           same"
+            return "the same"
         elif ratio > 0.5:
             return with_conditional_formatting(
-                f"{(1-ratio)*100:4.1f} pct   {improvement}",
+                f"better: {(1-ratio)*100:4.1f}% {improvement}",
                 COLOR_GOOD,
                 condition=use_colors,
             )
         else:
             return with_conditional_formatting(
-                f"{(1/ratio):4.1f} times {improvement}",
+                f"better: {(1/ratio):4.1f} times {improvement}",
                 COLOR_GOOD,
                 condition=use_colors,
             )


### PR DESCRIPTION
### Before
```
NAME                                | TYPE            |      THIS       |      OTHER      |  UNIT  | THRESHOLD  |  Regression?  | 'THIS' is:
------------------------------------------------------------------------------------------------------------------------------------------------------
CrossJoin                           | wallclock       |           1.123 |           1.170 |   s    |    10%     |      no       |  4.0 pct   faster
CrossJoin                           | memory_mz       |        3067.017 |        2947.807 |   MB   |    10%     |      no       |  4.0 pct   more
CrossJoin                           | memory_clusterd |         391.102 |         395.679 |   MB   |    10%     |      no       |  1.2 pct   less
```

### After
```
+++ Benchmark Report for cycle 1:
NAME                                | TYPE            |      THIS       |      OTHER      |  UNIT  | THRESHOLD  |  Regression?  | 'THIS' is
--------------------------------------------------------------------------------------------------------------------------------------------------------
CrossJoin                           | wallclock       |           1.137 |           1.151 |   s    |     1%     |      no       | better:  1.2% faster
CrossJoin                           | messages        |            None |     1000006.000 |   #    |     1%     |      no       | not comparable
CrossJoin                           | memory_mz       |        2965.927 |        2963.066 |   MB   |     1%     |      no       | worse:   0.1% more
CrossJoin                           | memory_clusterd |         406.456 |         406.933 |   MB   |     1%     |      no       | better:  0.1% less
```