### PR TITLE
lint: fix deprecation warning

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -237,6 +237,7 @@ ignore = [
 # Must be manually kept in sync with about.toml.
 # See: https://github.com/EmbarkStudios/cargo-about/issues/201
 [licenses]
+version = 2
 allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
@@ -251,7 +252,7 @@ allow = [
     "Zlib",
     "Unicode-DFS-2016",
 ]
-copyleft = "deny"
+# copyleft is denied by default
 private = { ignore = true }
 [[licenses.clarify]]
 name = "ring"

--- a/deny.toml
+++ b/deny.toml
@@ -225,6 +225,7 @@ wrappers = [
 ]
 
 [advisories]
+version = 2
 ignore = [
     # Consider switching `yaml-rust` to the actively maintained `yaml-rust2` fork of the original project
     "RUSTSEC-2024-0320",


### PR DESCRIPTION
This addresses:
```
✗ check-cargo.sh
--- bin/lint-cargo
--- cargo --locked fmt -- --check
--- cargo --locked deny check licenses bans sources
error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
    ┌─ /Users/nrainer/Workspaces/mz-repo/deny.toml:254:1
    │
254 │ copyleft = "deny"
    │ ━━━━━━━━

2024-08-03 08:00:03 [ERROR] failed to validate configuration file /Users/nrainer/Workspaces/mz-repo/deny.toml
^^^ 🚨 Failed: cargo --locked deny check licenses bans sources
--- cargo hakari generate --diff
info: 
--- original
+++ modified

--- cargo hakari manage-deps --dry-run
info: no operations to perform
--- cargo deplint Cargo.lock ci/test/lint-deps.toml
```

### See also
https://github.com/EmbarkStudios/cargo-deny/pull/611