### PR TITLE
feature-flag consistency test: preparations

### DIFF
--- a/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
+++ b/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
@@ -29,6 +29,13 @@ from materialize.output_consistency.selection.selection import (
     TableColumnByNameSelection,
 )
 
+EVALUATION_STRATEGY_NAME_DFR = "dataflow_rendering"
+EVALUATION_STRATEGY_NAME_CTF = "constant_folding"
+INTERNAL_EVALUATION_STRATEGY_NAMES = [
+    EVALUATION_STRATEGY_NAME_DFR,
+    EVALUATION_STRATEGY_NAME_CTF,
+]
+
 
 class EvaluationStrategyKey(Enum):
     DUMMY = 1

--- a/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
+++ b/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
@@ -316,3 +316,28 @@ class ConstantFoldingEvaluation(EvaluationStrategy):
         )
 
         return [create_view_statement]
+
+
+def create_internal_evaluation_strategy_twice(
+    evaluation_strategy_name: str,
+) -> list[EvaluationStrategy]:
+    strategies: list[EvaluationStrategy]
+
+    if evaluation_strategy_name == EVALUATION_STRATEGY_NAME_DFR:
+        strategies = [DataFlowRenderingEvaluation(), DataFlowRenderingEvaluation()]
+        strategies[1].identifier = EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_OTHER_DB
+        return strategies
+
+    if evaluation_strategy_name == EVALUATION_STRATEGY_NAME_CTF:
+        strategies = [ConstantFoldingEvaluation(), ConstantFoldingEvaluation()]
+        strategies[1].identifier = EvaluationStrategyKey.MZ_CONSTANT_FOLDING_OTHER_DB
+        return strategies
+
+    raise RuntimeError(f"Unexpected strategy name: { evaluation_strategy_name}")
+
+
+def is_other_db_evaluation_strategy(evaluation_key: EvaluationStrategyKey) -> bool:
+    return evaluation_key in {
+        EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_OTHER_DB,
+        EvaluationStrategyKey.MZ_CONSTANT_FOLDING_OTHER_DB,
+    }

--- a/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
+++ b/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
@@ -61,6 +61,7 @@ class EvaluationStrategy:
         self.object_name_base = object_name_base
         self.simple_db_object_name = simple_db_object_name
         self.sql_adjuster = sql_adjuster
+        self.additional_setup_info: str | None = None
 
     def generate_sources(
         self,

--- a/misc/python/materialize/output_consistency/execution/multi_mz_executors.py
+++ b/misc/python/materialize/output_consistency/execution/multi_mz_executors.py
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.execution.evaluation_strategy import (
+    EvaluationStrategy,
+    EvaluationStrategyKey,
+)
+from materialize.output_consistency.execution.sql_executor import SqlExecutor
+from materialize.output_consistency.execution.sql_executors import SqlExecutors
+
+
+class MultiMzSqlExecutors(SqlExecutors):
+    def __init__(self, executor1: SqlExecutor, executor2: SqlExecutor):
+        super().__init__(executor1)
+        self.executor2 = executor2
+
+    def get_executor(self, strategy: EvaluationStrategy) -> SqlExecutor:
+        if strategy.identifier in [
+            EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_OTHER_DB,
+            EvaluationStrategyKey.MZ_CONSTANT_FOLDING_OTHER_DB,
+        ]:
+            return self.executor2
+
+        return super().get_executor(strategy)
+
+    def get_database_infos(self) -> str:
+        return (
+            f"Using {self.executor.name} in version '{self.executor.query_version()}'. "
+            f"Using {self.executor2.name} in version '{self.executor2.query_version()}'."
+        )
+
+    def uses_different_versions(self) -> bool:
+        return self.executor.query_version() != self.executor2.query_version()

--- a/misc/python/materialize/output_consistency/execution/query_execution_manager.py
+++ b/misc/python/materialize/output_consistency/execution/query_execution_manager.py
@@ -113,7 +113,9 @@ class QueryExecutionManager:
         if commit_previous_tx:
             self.commit_tx(strategy)
 
+        self.executors.get_executor(strategy).before_new_tx()
         self.executors.get_executor(strategy).begin_tx("SERIALIZABLE")
+        self.executors.get_executor(strategy).after_new_tx()
 
     def commit_tx(
         self,
@@ -158,8 +160,14 @@ class QueryExecutionManager:
             start_time = datetime.now()
 
             try:
+                self.executors.get_executor(strategy).before_query_execution()
+
+                start_time = datetime.now()
                 data = self.executors.get_executor(strategy).query(sql_query_string)
                 duration = self._get_duration_in_ms(start_time)
+
+                self.executors.get_executor(strategy).after_query_execution()
+
                 result = QueryResult(
                     strategy, sql_query_string, query_template.column_count(), data
                 )

--- a/misc/python/materialize/output_consistency/execution/sql_executor.py
+++ b/misc/python/materialize/output_consistency/execution/sql_executor.py
@@ -58,6 +58,18 @@ class SqlExecutor:
     def query_version(self) -> str:
         raise NotImplementedError
 
+    def before_query_execution(self) -> None:
+        pass
+
+    def after_query_execution(self) -> None:
+        pass
+
+    def before_new_tx(self):
+        pass
+
+    def after_new_tx(self):
+        pass
+
 
 class PgWireDatabaseSqlExecutor(SqlExecutor):
     def __init__(

--- a/misc/python/materialize/output_consistency/execution/sql_executor.py
+++ b/misc/python/materialize/output_consistency/execution/sql_executor.py
@@ -15,9 +15,6 @@ from pg8000 import Connection
 from pg8000.dbapi import ProgrammingError
 from pg8000.exceptions import DatabaseError, InterfaceError
 
-from materialize.output_consistency.common.configuration import (
-    ConsistencyTestConfiguration,
-)
 from materialize.output_consistency.output.output_printer import OutputPrinter
 
 
@@ -190,29 +187,3 @@ class DryRunSqlExecutor(SqlExecutor):
 
     def query_version(self) -> str:
         return "(dry-run)"
-
-
-def create_sql_executor(
-    config: ConsistencyTestConfiguration,
-    default_connection: Connection,
-    mz_system_connection: Connection | None,
-    output_printer: OutputPrinter,
-    name: str,
-    is_mz: bool = True,
-) -> SqlExecutor:
-    if config.dry_run:
-        return DryRunSqlExecutor(output_printer, name)
-
-    if is_mz:
-        assert mz_system_connection is not None
-        return MzDatabaseSqlExecutor(
-            default_connection,
-            mz_system_connection,
-            config.use_autocommit,
-            output_printer,
-            name,
-        )
-
-    return PgWireDatabaseSqlExecutor(
-        default_connection, config.use_autocommit, output_printer, name
-    )

--- a/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
+++ b/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from __future__ import annotations
 
 from materialize.output_consistency.execution.evaluation_strategy import (
     EvaluationStrategy,
@@ -45,10 +46,14 @@ class ReproductionCodePrinter(BaseOutputPrinter):
         self.input_data = input_data
         self.query_output_mode = query_output_mode
 
-    def clone(self, print_mode: OutputPrinterMode):
-        return ReproductionCodePrinter(
+    def clone(self, print_mode: OutputPrinterMode) -> ReproductionCodePrinter:
+        cloned_printer = ReproductionCodePrinter(
             self.input_data, self.query_output_mode, print_mode
         )
+        assert type(cloned_printer) == type(
+            self
+        ), "clone must be overridden when inheriting this class"
+        return cloned_printer
 
     def get_reproduction_code_of_error(self, error: ValidationError) -> str:
         reproduction_code_generator = self.clone(OutputPrinterMode.COLLECT)

--- a/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
+++ b/misc/python/materialize/output_consistency/output/reproduction_code_printer.py
@@ -133,6 +133,10 @@ class ReproductionCodePrinter(BaseOutputPrinter):
         apply_row_filter: bool,
     ) -> None:
         self._print_text(f"Setup for evaluation strategy '{evaluation_strategy.name}':")
+
+        if evaluation_strategy.additional_setup_info is not None:
+            self._print_text(evaluation_strategy.additional_setup_info)
+
         row_selection = (
             query_template.row_selection if apply_row_filter else ALL_ROWS_SELECTION
         )

--- a/misc/python/materialize/output_consistency/output_consistency_test.py
+++ b/misc/python/materialize/output_consistency/output_consistency_test.py
@@ -65,6 +65,7 @@ class OutputConsistencyTest:
         mz_system_connection: Connection,
         args: argparse.Namespace,
         query_output_mode: QueryOutputMode,
+        override_max_runtime_in_sec: int | None = None,
     ) -> ConsistencyTestSummary:
         """Entry point for output consistency tests"""
 
@@ -76,7 +77,7 @@ class OutputConsistencyTest:
             args.fail_fast,
             args.verbose,
             args.max_cols_per_query,
-            args.max_runtime_in_sec,
+            override_max_runtime_in_sec or args.max_runtime_in_sec,
             args.max_iterations,
             args.avoid_expressions_expecting_db_error,
             args.disable_predefined_queries,

--- a/misc/python/materialize/postgres_consistency/postgres_consistency_test.py
+++ b/misc/python/materialize/postgres_consistency/postgres_consistency_test.py
@@ -19,7 +19,6 @@ from materialize.output_consistency.execution.evaluation_strategy import (
     EvaluationStrategy,
 )
 from materialize.output_consistency.execution.query_output_mode import QueryOutputMode
-from materialize.output_consistency.execution.sql_executor import create_sql_executor
 from materialize.output_consistency.execution.sql_executors import SqlExecutors
 from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter import (
     GenericInconsistencyIgnoreFilter,
@@ -69,10 +68,10 @@ class PostgresConsistencyTest(OutputConsistencyTest):
             raise RuntimeError("Postgres connection is not initialized")
 
         return PgSqlExecutors(
-            create_sql_executor(
+            self.create_sql_executor(
                 config, default_connection, mz_system_connection, output_printer, "mz"
             ),
-            create_sql_executor(
+            self.create_sql_executor(
                 config, self.pg_connection, None, output_printer, "pg", is_mz=False
             ),
         )

--- a/misc/python/materialize/postgres_consistency/postgres_consistency_test.py
+++ b/misc/python/materialize/postgres_consistency/postgres_consistency_test.py
@@ -61,16 +61,19 @@ class PostgresConsistencyTest(OutputConsistencyTest):
     def create_sql_executors(
         self,
         config: ConsistencyTestConfiguration,
-        connection: Connection,
+        default_connection: Connection,
+        mz_system_connection: Connection,
         output_printer: OutputPrinter,
     ) -> SqlExecutors:
         if self.pg_connection is None:
             raise RuntimeError("Postgres connection is not initialized")
 
         return PgSqlExecutors(
-            create_sql_executor(config, connection, output_printer, "mz"),
             create_sql_executor(
-                config, self.pg_connection, output_printer, "pg", is_mz=False
+                config, default_connection, mz_system_connection, output_printer, "mz"
+            ),
+            create_sql_executor(
+                config, self.pg_connection, None, output_printer, "pg", is_mz=False
             ),
         )
 
@@ -122,6 +125,7 @@ def main() -> int:
 
     parser.add_argument("--mz-host", default="localhost", type=str)
     parser.add_argument("--mz-port", default=6875, type=int)
+    parser.add_argument("--mz-system-port", default=6877, type=int)
     parser.add_argument("--pg-host", default="localhost", type=str)
     parser.add_argument("--pg-port", default=5432, type=int)
     parser.add_argument("--pg-password", default=None, type=str)
@@ -130,6 +134,7 @@ def main() -> int:
     try:
         mz_db_user = "materialize"
         mz_connection = connect(args.mz_host, args.mz_port, mz_db_user)
+        mz_system_connection = connect(args.mz_host, args.mz_system_port, mz_db_user)
 
         pg_db_user = "postgres"
         test.pg_connection = connect(
@@ -139,7 +144,10 @@ def main() -> int:
         return 1
 
     result = test.run_output_consistency_tests(
-        mz_connection, args, query_output_mode=QueryOutputMode.SELECT
+        mz_connection,
+        mz_system_connection,
+        args,
+        query_output_mode=QueryOutputMode.SELECT,
     )
     return 0 if result.all_passed() else 1
 

--- a/misc/python/materialize/version_consistency/execution/multi_version_executors.py
+++ b/misc/python/materialize/version_consistency/execution/multi_version_executors.py
@@ -7,33 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from materialize.output_consistency.execution.evaluation_strategy import (
-    EvaluationStrategy,
-    EvaluationStrategyKey,
+from materialize.output_consistency.execution.multi_mz_executors import (
+    MultiMzSqlExecutors,
 )
-from materialize.output_consistency.execution.sql_executor import SqlExecutor
-from materialize.output_consistency.execution.sql_executors import SqlExecutors
 
 
-class MultiVersionSqlExecutors(SqlExecutors):
-    def __init__(self, executor1: SqlExecutor, executor2: SqlExecutor):
-        super().__init__(executor1)
-        self.executor2 = executor2
-
-    def get_executor(self, strategy: EvaluationStrategy) -> SqlExecutor:
-        if strategy.identifier in [
-            EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_OTHER_DB,
-            EvaluationStrategyKey.MZ_CONSTANT_FOLDING_OTHER_DB,
-        ]:
-            return self.executor2
-
-        return super().get_executor(strategy)
-
-    def get_database_infos(self) -> str:
-        return (
-            f"Using {self.executor.name} in version '{self.executor.query_version()}'. "
-            f"Using {self.executor2.name} in version '{self.executor2.query_version()}'."
-        )
-
-    def uses_different_versions(self) -> bool:
-        return self.executor.query_version() != self.executor2.query_version()
+class MultiVersionSqlExecutors(MultiMzSqlExecutors):
+    pass

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -16,13 +16,10 @@ from materialize.output_consistency.common.configuration import (
     ConsistencyTestConfiguration,
 )
 from materialize.output_consistency.execution.evaluation_strategy import (
-    EVALUATION_STRATEGY_NAME_CTF,
     EVALUATION_STRATEGY_NAME_DFR,
     INTERNAL_EVALUATION_STRATEGY_NAMES,
-    ConstantFoldingEvaluation,
-    DataFlowRenderingEvaluation,
     EvaluationStrategy,
-    EvaluationStrategyKey,
+    create_internal_evaluation_strategy_twice,
 )
 from materialize.output_consistency.execution.query_output_mode import (
     QUERY_OUTPUT_MODE_CHOICES,
@@ -139,20 +136,9 @@ class VersionConsistencyTest(OutputConsistencyTest):
             self.evaluation_strategy_name is not None
         ), "Evaluation strategy name is not initialized"
 
-        strategies: list[EvaluationStrategy]
-
-        if self.evaluation_strategy_name == EVALUATION_STRATEGY_NAME_DFR:
-            strategies = [DataFlowRenderingEvaluation(), DataFlowRenderingEvaluation()]
-            strategies[1].identifier = (
-                EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_OTHER_DB
-            )
-        elif self.evaluation_strategy_name == EVALUATION_STRATEGY_NAME_CTF:
-            strategies = [ConstantFoldingEvaluation(), ConstantFoldingEvaluation()]
-            strategies[1].identifier = (
-                EvaluationStrategyKey.MZ_CONSTANT_FOLDING_OTHER_DB
-            )
-        else:
-            raise RuntimeError(f"Unexpected name: {self.evaluation_strategy_name}")
+        strategies = create_internal_evaluation_strategy_twice(
+            self.evaluation_strategy_name
+        )
 
         for i, strategy in enumerate(strategies):
             number = i + 1

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -25,7 +25,6 @@ from materialize.output_consistency.execution.query_output_mode import (
     QUERY_OUTPUT_MODE_CHOICES,
     QueryOutputMode,
 )
-from materialize.output_consistency.execution.sql_executor import create_sql_executor
 from materialize.output_consistency.execution.sql_executors import SqlExecutors
 from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter import (
     GenericInconsistencyIgnoreFilter,
@@ -98,10 +97,10 @@ class VersionConsistencyTest(OutputConsistencyTest):
             self.mz2_system_connection is not None
         ), "Second system connection is not initialized"
 
-        mz1_sql_executor = create_sql_executor(
+        mz1_sql_executor = self.create_sql_executor(
             config, default_connection, mz_system_connection, output_printer, "mz1"
         )
-        mz2_sql_executor = create_sql_executor(
+        mz2_sql_executor = self.create_sql_executor(
             config,
             self.mz2_connection,
             self.mz2_system_connection,

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -16,6 +16,9 @@ from materialize.output_consistency.common.configuration import (
     ConsistencyTestConfiguration,
 )
 from materialize.output_consistency.execution.evaluation_strategy import (
+    EVALUATION_STRATEGY_NAME_CTF,
+    EVALUATION_STRATEGY_NAME_DFR,
+    INTERNAL_EVALUATION_STRATEGY_NAMES,
     ConstantFoldingEvaluation,
     DataFlowRenderingEvaluation,
     EvaluationStrategy,
@@ -51,10 +54,6 @@ from materialize.version_consistency.ignore_filter.version_consistency_ignore_fi
 from materialize.version_consistency.validation.version_consistency_error_message_normalizer import (
     VersionConsistencyErrorMessageNormalizer,
 )
-
-EVALUATION_STRATEGY_NAME_DFR = "dataflow_rendering"
-EVALUATION_STRATEGY_NAME_CTF = "constant_folding"
-EVALUATION_STRATEGY_NAMES = [EVALUATION_STRATEGY_NAME_DFR, EVALUATION_STRATEGY_NAME_CTF]
 
 
 class VersionConsistencyTest(OutputConsistencyTest):
@@ -222,7 +221,7 @@ def main() -> int:
         "--evaluation-strategy",
         default=EVALUATION_STRATEGY_NAME_DFR,
         type=str,
-        choices=EVALUATION_STRATEGY_NAMES,
+        choices=INTERNAL_EVALUATION_STRATEGY_NAMES,
     )
     parser.add_argument(
         "--other-tag",

--- a/test/output-consistency/mzcompose.py
+++ b/test/output-consistency/mzcompose.py
@@ -36,10 +36,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     test = OutputConsistencyTest()
     args = test.parse_output_consistency_input_args(parser)
-    connection = c.sql_connection()
+    default_connection = c.sql_connection()
+    mz_system_connection = c.sql_connection(user="mz_system", port=6877)
 
     test_summary = test.run_output_consistency_tests(
-        connection, args, query_output_mode=QueryOutputMode.SELECT
+        default_connection,
+        mz_system_connection,
+        args,
+        query_output_mode=QueryOutputMode.SELECT,
     )
 
     upload_output_consistency_results_to_test_analytics(c, test_summary)

--- a/test/postgres-consistency/mzcompose.py
+++ b/test/postgres-consistency/mzcompose.py
@@ -40,7 +40,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     test = PostgresConsistencyTest()
     args = test.parse_output_consistency_input_args(parser)
-    connection = c.sql_connection()
+    default_connection = c.sql_connection()
+    mz_system_connection = c.sql_connection(user="mz_system", port=6877)
     test.pg_connection = c.sql_connection(
         service="postgres",
         user="postgres",
@@ -48,7 +49,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     test_summary = test.run_output_consistency_tests(
-        connection, args, query_output_mode=QueryOutputMode.SELECT
+        default_connection,
+        mz_system_connection,
+        args,
+        query_output_mode=QueryOutputMode.SELECT,
     )
 
     upload_output_consistency_results_to_test_analytics(c, test_summary)

--- a/test/version-consistency/mzcompose.py
+++ b/test/version-consistency/mzcompose.py
@@ -14,6 +14,10 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.mz import Mz
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.test_result import FailedTestExecutionError
+from materialize.output_consistency.execution.evaluation_strategy import (
+    EVALUATION_STRATEGY_NAME_DFR,
+    INTERNAL_EVALUATION_STRATEGY_NAMES,
+)
 from materialize.output_consistency.execution.query_output_mode import (
     QUERY_OUTPUT_MODE_CHOICES,
     QueryOutputMode,
@@ -25,8 +29,6 @@ from materialize.version_ancestor_overrides import (
     ANCESTOR_OVERRIDES_FOR_CORRECTNESS_REGRESSIONS,
 )
 from materialize.version_consistency.version_consistency_test import (
-    EVALUATION_STRATEGY_NAME_DFR,
-    EVALUATION_STRATEGY_NAMES,
     VersionConsistencyTest,
 )
 from materialize.version_list import (
@@ -55,7 +57,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--evaluation-strategy",
         default=EVALUATION_STRATEGY_NAME_DFR,
         type=str,
-        choices=EVALUATION_STRATEGY_NAMES,
+        choices=INTERNAL_EVALUATION_STRATEGY_NAMES,
     )
 
     parser.add_argument(


### PR DESCRIPTION
This is the base for https://github.com/MaterializeInc/materialize/pull/28439.

### Commits
3475f94dd9 output consistency: provide mz_system connection
7a6d173753 output consistency: trigger events around query execution
1fb942c7dc output consistency: move creation of SqlExecutors
8bb89546e9 output consistency: reproduction code printer: add assertion
79ce0c3e6b output consistency: reproduction code printer: allow including further infos
fc79c7ade8 output consistency: allow overriding desired runtime
f8e3039c42 output consistency: allow merging test summaries
d27dc7a5cb version consistency: move evaluation strategy constants
c6b5e287e4 version consistency: extract evaluation strategy creation
d56893b22e version consistency: generalize MultiMzSqlExecutors

### Nightly
https://buildkite.com/materialize/nightly/builds/8943