### PR TITLE
persist: fix rustdoc

### DIFF
--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -370,8 +370,8 @@ pub trait Consensus: std::fmt::Debug + Send + Sync {
         new: VersionedData,
     ) -> Result<CaSResult, ExternalError>;
 
-    /// Return `limit` versions of data stored for this `key` at sequence numbers
-    /// >= `from`, in ascending order of sequence number.
+    /// Return `limit` versions of data stored for this `key` at sequence numbers >= `from`,
+    /// in ascending order of sequence number.
     ///
     /// Returns an empty vec if `from` is greater than the current sequence
     /// number or if there is no data at this key.


### PR DESCRIPTION
This should fix the deploy job observed failing in https://buildkite.com/materialize/deploy/builds/15335#019118b4-bb90-42b7-8d96-292bbd9848b0.

```
error: unportable markdown
   --> src/persist/src/location.rs:373:5
    |
373 | /     /// Return `limit` versions of data stored for this `key` at sequence numbers
374 | |     /// >= `from`, in ascending order of sequence number.
375 | |     ///
376 | |     /// Returns an empty vec if `from` is greater than the current sequence
377 | |     /// number or if there is no data at this key.
    | |__________________________________________________^
    |
    = help: confusing block quote with no space after the `>` marker
```