### PR TITLE
storage: add support for YugabyteDB to PostgreSQL source

### DIFF
--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -25,7 +25,7 @@ pub use schemas::{get_schemas, publication_info};
 #[cfg(feature = "tunnel")]
 pub mod tunnel;
 #[cfg(feature = "tunnel")]
-pub use tunnel::{Config, TunnelConfig, DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT};
+pub use tunnel::{Client, Config, TunnelConfig, DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT};
 
 pub mod query;
 pub use query::simple_query_opt;

--- a/src/postgres-util/src/replication.rs
+++ b/src/postgres-util/src/replication.rs
@@ -112,8 +112,14 @@ pub async fn drop_replication_slots(
                 continue;
             }
             1 => {
+                // YugabyteDB does not yet support `DROP_REPLICATION_SLOT ...
+                // WAIT`.
+                let wait = match replication_client.is_yugabyte() {
+                    true => "",
+                    false => "WAIT",
+                };
                 replication_client
-                    .simple_query(&format!("DROP_REPLICATION_SLOT {} WAIT", slot))
+                    .simple_query(&format!("DROP_REPLICATION_SLOT {} {wait}", slot))
                     .await?;
             }
             _ => {

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -405,6 +405,12 @@ async fn fetch_slot_metadata(
 
 /// Fetch the `pg_current_wal_lsn`, used to report metrics.
 async fn fetch_max_lsn(client: &Client) -> Result<MzOffset, TransientError> {
+    // NOTE(benesch): this doesn't work for YugabyteDB, where LSNs are specific
+    // to a replication slot. We need a YugabyteDB-specific function which
+    // returns the latest LSN for a specific replication slot.
+    //
+    // We also need to be careful to report YugabyteDB WAL as "message lag"
+    // rather than "WAL byte" lag.
     let query = "SELECT pg_current_wal_lsn()";
     let row = simple_query_opt(client, query).await?;
 

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -88,7 +88,7 @@ use itertools::Itertools as _;
 use mz_expr::{EvalError, MirScalarExpr};
 use mz_ore::error::ErrorExt;
 use mz_postgres_util::desc::PostgresTableDesc;
-use mz_postgres_util::{simple_query_opt, PostgresError};
+use mz_postgres_util::{simple_query_opt, Client, PostgresError};
 use mz_repr::{Datum, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_types::errors::{DataflowError, SourceError, SourceErrorDetails};
@@ -103,7 +103,6 @@ use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 use tokio_postgres::error::SqlState;
 use tokio_postgres::types::PgLsn;
-use tokio_postgres::Client;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::source::types::{ProgressStatisticsUpdate, SourceRender, StackedCollection};

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -85,7 +85,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::HashSet;
 use mz_ore::future::InTask;
 use mz_postgres_util::desc::PostgresTableDesc;
-use mz_postgres_util::simple_query_opt;
+use mz_postgres_util::{simple_query_opt, Client};
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_ssh_util::tunnel_manager::SshTunnelManager;
@@ -113,7 +113,6 @@ use timely::progress::Antichain;
 use tokio_postgres::error::SqlState;
 use tokio_postgres::replication::LogicalReplicationStream;
 use tokio_postgres::types::PgLsn;
-use tokio_postgres::Client;
 use tracing::{error, trace};
 
 use crate::metrics::source::postgres::PgSourceMetrics;

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -144,7 +144,7 @@ use futures::{StreamExt as _, TryStreamExt};
 use mz_expr::MirScalarExpr;
 use mz_ore::future::InTask;
 use mz_postgres_util::desc::PostgresTableDesc;
-use mz_postgres_util::{simple_query_opt, PostgresError};
+use mz_postgres_util::{simple_query_opt, Client, PostgresError};
 use mz_repr::{Datum, DatumVec, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_types::errors::DataflowError;
@@ -160,7 +160,6 @@ use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, ConnectLoop,
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp};
 use tokio_postgres::types::{Oid, PgLsn};
-use tokio_postgres::Client;
 use tracing::{error, trace};
 
 use crate::metrics::source::postgres::PgSnapshotMetrics;


### PR DESCRIPTION
WIP. See comments within for some details about what's still TODO.

For expediency, this patch currently jams support for YugabyteDB into
the existing PostgreSQL source. But YugabyteDB and PostgreSQL are
different enough that I think a better design would introduce dedicated
connection and source types, like:

    CREATE CONNECTION ... TO YUGABYTE ...
    CREATE SOURCE ... TO YUGABYTE ...

Internally we'd still share most of the code, of course.


### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add YugabyteDB compatibility to the PostgreSQL source.
