### PR TITLE
doc/user: link to changelog when no release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,5 +54,4 @@ Delete this section if no tips.
 - [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
 - [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
   <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
-- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
-  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
+- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.

--- a/doc/user/content/releases/v0.102.md
+++ b/doc/user/content/releases/v0.102.md
@@ -2,6 +2,6 @@
 title: "Materialize v0.102"
 date: 2024-06-05
 released: true
+_build:
+  render: never
 ---
-
-## v0.102

--- a/doc/user/content/releases/v0.103.md
+++ b/doc/user/content/releases/v0.103.md
@@ -2,6 +2,6 @@
 title: "Materialize v0.103"
 date: 2024-06-12
 released: true
+_build:
+  render: never
 ---
-
-## v0.103

--- a/doc/user/content/releases/v0.104.md
+++ b/doc/user/content/releases/v0.104.md
@@ -1,7 +1,7 @@
 ---
 title: "Materialize v0.104"
-date: 2024-06-18
+date: 2024-06-19
 released: true
+_build:
+  render: never
 ---
-
-## v0.104

--- a/doc/user/content/releases/v0.105.md
+++ b/doc/user/content/releases/v0.105.md
@@ -1,7 +1,7 @@
 ---
 title: "Materialize v0.105"
-date: 2024-06-27
+date: 2024-06-26
 released: true
+_build:
+  render: never
 ---
-
-## v0.105

--- a/doc/user/content/releases/v0.106.md
+++ b/doc/user/content/releases/v0.106.md
@@ -1,6 +1,6 @@
 ---
 title: "Materialize v0.106"
-date: 2024-07-04
+date: 2024-07-03
 released: true
 patch: 2
 ---

--- a/doc/user/content/releases/v0.107.md
+++ b/doc/user/content/releases/v0.107.md
@@ -1,6 +1,6 @@
 ---
 title: "Materialize v0.107"
-date: 2024-07-11
+date: 2024-07-10
 released: true
 patch: 5
 ---

--- a/doc/user/content/releases/v0.109.md
+++ b/doc/user/content/releases/v0.109.md
@@ -3,6 +3,6 @@ title: "Materialize v0.109"
 date: 2024-07-24
 released: true
 patch: 1
+_build:
+  render: never
 ---
-
-## v0.109

--- a/doc/user/content/releases/v0.110.md
+++ b/doc/user/content/releases/v0.110.md
@@ -1,8 +1,10 @@
 ---
 title: "Materialize v0.110"
-date: 2024-08-01
+date: 2024-07-31
 released: true
 patch: 1
+_build:
+  render: never
 ---
 
 ## v0.110

--- a/doc/user/content/releases/v0.111.md
+++ b/doc/user/content/releases/v0.111.md
@@ -1,11 +1,7 @@
 ---
 title: "Materialize v0.111"
-date: 2024-08-09
+date: 2024-08-07
 released: false
+_build:
+  render: never
 ---
-
-## v0.111
-
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}

--- a/doc/user/content/releases/v0.112.md
+++ b/doc/user/content/releases/v0.112.md
@@ -1,11 +1,7 @@
 ---
 title: "Materialize v0.112"
-date: 2024-08-16
+date: 2024-08-14
 released: false
+_build:
+  render: never
 ---
-
-## v0.112
-
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}

--- a/doc/user/layouts/shortcodes/version-list.html
+++ b/doc/user/layouts/shortcodes/version-list.html
@@ -3,21 +3,28 @@
     <thead>
       <th>Version</th>
       <th>Release date</th>
+      <th>Details</th>
     </thead>
 
     <tbody>
       {{range $i, $page := .Page.Pages.ByDate.Reverse }}
         <tr>
           <td>
-            <strong>
-              <a href="{{.Page.RelPermalink}}">
-                {{$page.File.ContentBaseName}}
-              </a>
-            </strong>
+            {{if $page.RelPermalink}}
+              <a href="{{.Page.RelPermalink}}">{{$page.File.ContentBaseName}}</a>
+            {{else}}
+            {{$page.File.ContentBaseName}}
+            {{end}}
           </td>
           <td>
             {{$page.Date.Format "January 2, 2006"}}
-            {{if not $page.Params.released}}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<em>Not yet released.</em>{{end}}
+          </td>
+          <td>
+            {{if not $page.Params.released}}
+              <em>Not yet released.</em>
+            {{else if not $page.RelPermalink}}
+              See the <a href="https://materialize.com/changelog">Changelog</a> for any significant user-facing changes.
+            {{end}}
           </td>
         </tr>
       {{end}}

--- a/doc/user/layouts/shortcodes/warn-if-unreleased-inline.html
+++ b/doc/user/layouts/shortcodes/warn-if-unreleased-inline.html
@@ -6,7 +6,7 @@
 
 {{if not $isReleased}}
 <strong>Unreleased: </strong>This feature will be released in
-<a href="{{$releasePage.RelPermalink}}"><strong>{{$version}}</strong></a>.
+<a href="{{ .Site.BaseURL }}releases#release-notes"><strong>{{$version}}</strong></a>.
 It may not be available in your region yet.
 The release is scheduled to complete by <strong>{{dateFormat "January 2, 2006" $releaseDate}}</strong>.
 {{end}}

--- a/doc/user/layouts/shortcodes/warn-if-unreleased.html
+++ b/doc/user/layouts/shortcodes/warn-if-unreleased.html
@@ -8,7 +8,7 @@
   <div class="warning">
     <strong class="gutter">Unreleased</strong>
     This feature will be released in
-    <a href="{{$releasePage.RelPermalink}}"><strong>{{$version}}</strong></a>.
+    <a href="{{ .Site.BaseURL }}releases#release-notes"><strong>{{$version}}</strong></a>.
     It may not be available in your region yet.
     The release is scheduled to complete by <strong>{{dateFormat "January 2, 2006" $releaseDate}}</strong>.
   </div>


### PR DESCRIPTION
We've had a few releases recently with no detailed release notes. Link these releases to the changelog rather than an empty page for a smoother user experience.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
