### PR TITLE
cargo: allow unportable_markdown in rustdoc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,6 +342,9 @@ store = { path = "misc/cargo-vet" }
 unknown_lints = "allow"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bazel, coverage, nightly_doc_features, release, tokio_unstable)'] }
 
+[workspace.lints.rustdoc]
+unportable_markdown = "allow"
+
 [workspace.lints.clippy]
 style = { level = "allow", priority = -1 }
 complexity = { level = "allow", priority = -1 }

--- a/misc/python/materialize/cli/gen-lints.py
+++ b/misc/python/materialize/cli/gen-lints.py
@@ -24,6 +24,12 @@ ALLOW_RUST_LINTS = [
     "unknown_lints",
 ]
 
+ALLOW_RUST_DOC_LINTS = [
+    # Allows us to use footnotes in rustdoc.
+    "unportable_markdown"
+]
+
+
 ALLOW_CLIPPY_LINTS = [
     # The style and complexity lints frustrated too many engineers and caused
     # more bikeshedding than they saved. These lint categories are largely a
@@ -190,6 +196,9 @@ def main() -> None:
         "[workspace.lints.rust]\n",
         *(f'{lint} = "allow"\n' for lint in ALLOW_RUST_LINTS),
         f"unexpected_cfgs = {{ level = \"warn\", check-cfg = ['cfg({CHECK_CFGS})'] }}\n",
+        "\n",
+        "[workspace.lints.rustdoc]\n",
+        *(f'{lint} = "allow"\n' for lint in ALLOW_RUST_DOC_LINTS),
         "\n",
         "[workspace.lints.clippy]\n",
         *(

--- a/misc/wasm/Cargo.toml
+++ b/misc/wasm/Cargo.toml
@@ -18,6 +18,9 @@ store = { path = "../cargo-vet" }
 unknown_lints = "allow"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bazel, coverage, nightly_doc_features, release, tokio_unstable)'] }
 
+[workspace.lints.rustdoc]
+unportable_markdown = "allow"
+
 [workspace.lints.clippy]
 style = { level = "allow", priority = -1 }
 complexity = { level = "allow", priority = -1 }


### PR DESCRIPTION
This should fix https://buildkite.com/materialize/deploy/builds/15342#01912114-aee8-476a-8140-fdac2e7ee221 by allowing us footnotes in rustdoc:

```
error: unportable markdown
   --> src/compute-types/src/plan/reduce.rs:374:69
    |
374 |     /// More details in the monotonic one-shot `SELECT`s design doc.[^1]
    |                                                                     -^^^
    |                                                                     |
    |                                                                     help: if it should not be a footnote, escape it: `\`
    |
    = note: `-D rustdoc::unportable-markdown` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(rustdoc::unportable_markdown)]`
```