### PR TITLE
adapter,0dt: new rehydration check that compares collection upper against allowed lag

### DIFF
--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -40,7 +40,7 @@ pub const WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL: Config<Duration> = Confi
 
 pub const ENABLE_0DT_CAUGHT_UP_CHECK: Config<bool> = Config::new(
     "enable_0dt_caught_up_check",
-    false,
+    true,
     "Whether to determine rehydration using a more complicated method that compares collection write frontiers against an allowed lag behind wall-clock time.",
 );
 

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -38,6 +38,18 @@ pub const WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL: Config<Duration> = Confi
     "Interval at which to check cluster hydration status, when doing zero-downtime deployment.",
 );
 
+pub const ENABLE_0DT_CAUGHT_UP_CHECK: Config<bool> = Config::new(
+    "enable_0dt_caught_up_check",
+    false,
+    "Whether to determine rehydration using a more complicated method that compares collection write frontiers against an allowed lag behind wall-clock time.",
+);
+
+pub const WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG: Config<Duration> = Config::new(
+    "with_0dt_caught_up_check_allowed_lag",
+    Duration::from_secs(60),
+    "Maximum allowed lag when determining whether collections are caught up for 0dt deployments.",
+);
+
 /// Enable logging of statement lifecycle events in mz_internal.mz_statement_lifecycle_history.
 pub const ENABLE_STATEMENT_LIFECYCLE_LOGGING: Config<bool> = Config::new(
     "enable_statement_lifecycle_logging",
@@ -79,6 +91,8 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_0DT_DEPLOYMENT)
         .add(&WITH_0DT_DEPLOYMENT_MAX_WAIT)
         .add(&WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL)
+        .add(&ENABLE_0DT_CAUGHT_UP_CHECK)
+        .add(&WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG)
         .add(&ENABLE_STATEMENT_LIFECYCLE_LOGGING)
         .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -68,7 +68,10 @@
 
 use anyhow::Context;
 use chrono::{DateTime, Utc};
-use mz_adapter_types::dyncfgs::WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL;
+use mz_adapter_types::dyncfgs::{
+    ENABLE_0DT_CAUGHT_UP_CHECK, WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG,
+    WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL,
+};
 use mz_ore::channel::trigger;
 use mz_sql::names::ResolvedIds;
 use mz_sql::session::user::User;
@@ -93,7 +96,7 @@ use itertools::{Either, Itertools};
 use mz_adapter_types::compaction::{CompactionWindow, ReadCapability};
 use mz_adapter_types::connection::ConnectionId;
 use mz_build_info::BuildInfo;
-use mz_catalog::builtin::{BUILTINS, BUILTINS_STATIC};
+use mz_catalog::builtin::{BUILTINS, BUILTINS_STATIC, MZ_CLUSTER_REPLICA_FRONTIERS};
 use mz_catalog::config::{AwsPrincipalContext, BuiltinItemMigrationConfig, ClusterReplicaSizeMap};
 use mz_catalog::durable::OpenableDurableCatalogState;
 use mz_catalog::memory::objects::{
@@ -3047,15 +3050,11 @@ impl Coordinator {
                     // `tick()` on `Interval` is cancel-safe:
                     // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
                     _ = self.check_clusters_hydrated_interval.tick() => {
-                        if self.clusters_hydrated_trigger.is_some() {
-                            let compute_hydrated = self.controller.compute.clusters_hydrated();
-                            tracing::info!(%compute_hydrated, "checked hydration status of clusters");
-
-                            if compute_hydrated {
-                                let trigger = self.clusters_hydrated_trigger.take().expect("known to exist");
-                                trigger.fire();
-                            }
-                        }
+                        // We do this directly on the main loop instead of
+                        // firing off a message. We are still in read-only mode,
+                        // so optimizing for latency, not blocking the main loop
+                        // is not that important.
+                        self.maybe_check_hydration_status().await;
 
                         continue;
                     },
@@ -3359,6 +3358,113 @@ impl Coordinator {
             ("controller".to_string(), self.controller.dump()?),
         ]);
         Ok(serde_json::Value::Object(map))
+    }
+
+    /// Checks that all clusters/collections are hydrated. If so, this will
+    /// trigger `self.clusters_hydrated_trigger`.
+    ///
+    /// This method is a no-op when the trigger has already been fired.
+    async fn maybe_check_hydration_status(&mut self) {
+        if self.clusters_hydrated_trigger.is_some() {
+            let enable_caught_up_check =
+                ENABLE_0DT_CAUGHT_UP_CHECK.get(self.catalog().system_config().dyncfgs());
+
+            if enable_caught_up_check {
+                let replica_frontier_collection_id = self
+                    .catalog()
+                    .resolve_builtin_storage_collection(&MZ_CLUSTER_REPLICA_FRONTIERS);
+
+                let live_frontiers = self
+                    .controller
+                    .storage
+                    .snapshot_latest(replica_frontier_collection_id)
+                    .await
+                    .expect("can't read mz_cluster_replica_frontiers");
+
+                let live_frontiers = live_frontiers
+                    .into_iter()
+                    .map(|row| {
+                        let mut iter = row.into_iter();
+
+                        let id: GlobalId = iter
+                            .next()
+                            .expect("missing object id")
+                            .unwrap_str()
+                            .parse()
+                            .expect("cannot parse id");
+                        let replica_id = iter
+                            .next()
+                            .expect("missing replica id")
+                            .unwrap_str()
+                            .to_string();
+                        let maybe_upper_ts = iter.next().expect("missing upper_ts");
+                        // The timestamp has a total order, so there can be at
+                        // most one entry in the upper frontier, which is this
+                        // timestamp here. And NULL encodes the empty upper
+                        // frontier.
+                        let upper_frontier = if maybe_upper_ts.is_null() {
+                            Antichain::new()
+                        } else {
+                            let upper_ts = maybe_upper_ts.unwrap_mz_timestamp();
+                            Antichain::from_elem(upper_ts)
+                        };
+
+                        (id, replica_id, upper_frontier)
+                    })
+                    .collect_vec();
+
+                // We care about each collection being hydrated on _some_
+                // replica. We don't check that at least one replica has all
+                // collections of that cluster hydrated.
+                let live_collection_frontiers: BTreeMap<_, _> = live_frontiers
+                    .into_iter()
+                    .map(|(oid, _replica_id, upper_ts)| (oid, upper_ts))
+                    .into_grouping_map()
+                    .fold(
+                        Antichain::from_elem(Timestamp::minimum()),
+                        |mut acc, _key, upper| {
+                            acc.join_assign(&upper);
+                            acc
+                        },
+                    )
+                    .into_iter()
+                    .collect();
+
+                tracing::debug!(?live_collection_frontiers, "checking re-hydration status");
+
+                let allowed_lag = WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG
+                    .get(self.catalog().system_config().dyncfgs());
+                let allowed_lag: u64 = allowed_lag
+                    .as_millis()
+                    .try_into()
+                    .expect("must fit into u64");
+
+                let compute_hydrated = self
+                    .controller
+                    .compute
+                    .clusters_caught_up(allowed_lag.into(), &live_collection_frontiers);
+                tracing::info!(%compute_hydrated, "checked caught-up status of collections");
+
+                if compute_hydrated {
+                    let trigger = self
+                        .clusters_hydrated_trigger
+                        .take()
+                        .expect("known to exist");
+                    trigger.fire();
+                }
+            } else {
+                let compute_hydrated = self.controller.compute.clusters_hydrated();
+                tracing::info!(%compute_hydrated, "checked hydration status of clusters");
+
+                if compute_hydrated {
+                    let trigger = self
+                        .clusters_hydrated_trigger
+                        .take()
+                        .expect("known to exist");
+                    trigger.fire();
+                }
+            }
+        }
     }
 }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -348,7 +348,7 @@ impl<T: ComputeControllerTimestamp> ComputeController<T> {
     pub fn clusters_hydrated(&self) -> bool {
         let mut result = true;
         for (instance_id, i) in &self.instances {
-            let instance_hydrated = i.any_replica_hydrated();
+            let instance_hydrated = i.all_collections_hydrated();
 
             if !instance_hydrated {
                 result = false;

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -598,6 +598,13 @@ pub trait StorageController: Debug {
         as_of: Self::Timestamp,
     ) -> Result<Vec<(Row, Diff)>, StorageError<Self::Timestamp>>;
 
+    /// Returns the snapshot of the contents of the local input named `id` at
+    /// the largest readable `as_of`.
+    async fn snapshot_latest(
+        &mut self,
+        id: GlobalId,
+    ) -> Result<Vec<Row>, StorageError<Self::Timestamp>>;
+
     /// Returns the snapshot of the contents of the local input named `id` at `as_of`.
     async fn snapshot_cursor(
         &mut self,


### PR DESCRIPTION
Work towards zero-downtime upgrades: #27406

Behind multiple LD configration flags.

One problem with this is that newly migrated tables will not have their upper/write frontier continually advanced, meaning dataflows based on them will eventually not pass the are-we-caught-up check, even though they might initially pass that check while other, larger, dataflows are still hydrating.

Additionally, when there is no "old" envd deployment running that is continually pushing uppers forward, the new envd deployment would also eventually report that it's not caught up.

@benesch & @jkosh44 We might want to instead compare against `boot_ts` instead of `now()`. This way, we would not run into problems when there's no old `envd` deployment or when we have migrations. Wdyt?

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
