### PR TITLE
dbt-materialize: add dbt version to application_name

### DIFF
--- a/misc/dbt-materialize/dbt/adapters/materialize/connections.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/connections.py
@@ -23,6 +23,7 @@ from dbt_common.semver import versions_compatible
 
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.postgres import PostgresConnectionManager, PostgresCredentials
+
 from .__version__ import version as __version__
 
 # If you bump this version, bump it in README.md too.

--- a/misc/dbt-materialize/dbt/adapters/materialize/connections.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/connections.py
@@ -23,6 +23,7 @@ from dbt_common.semver import versions_compatible
 
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.postgres import PostgresConnectionManager, PostgresCredentials
+from .__version__ import version as __version__
 
 # If you bump this version, bump it in README.md too.
 SUPPORTED_MATERIALIZE_VERSIONS = ">=0.68.0"
@@ -59,6 +60,7 @@ psycopg2.connect = connect
 @dataclass
 class MaterializeCredentials(PostgresCredentials):
     cluster: Optional[str] = "quickstart"
+    application_name: Optional[str] = f"dbt-materialize v{__version__}"
 
     @property
     def type(self):
@@ -77,6 +79,7 @@ class MaterializeCredentials(PostgresCredentials):
             "connect_timeout",
             "search_path",
             "retries",
+            "application_name",
         )
 
 


### PR DESCRIPTION
### Motivation

When connecting to Materialize using the dbt adaapter, we should pass an additional argument that specifies the application name. This is useful for telemetry.

Fixes #28804 
