### PR TITLE
doc: fix typo in create sink statement

### DIFF
--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -520,7 +520,7 @@ There are three ways to resolve this error:
   INTO KAFKA CONNECTION kafka_connection (TOPIC 't')
   -- We have outside knowledge that `k` is a unique key of `original_input`, but
   -- Materialize cannot prove this, so we disable its key uniqueness check.
-  KEY k NOT ENFORCED
+  KEY (k) NOT ENFORCED
   FORMAT JSON ENVELOPE UPSERT;
   ```
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
As is, the statement would throw the following error:

```sql
Error: Expected a list of columns in parentheses, found identifier "k"
```