### PR TITLE
compute: make `SequentialHydration::recv` cancel safe

### DIFF
--- a/src/cluster/src/server.rs
+++ b/src/cluster/src/server.rs
@@ -357,8 +357,14 @@ where
         }
     }
 
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
+    /// statement and some other branch completes first, it is guaranteed that no messages were
+    /// received by this client.
     async fn recv(&mut self) -> Result<Option<R>, Error> {
         if let Some(client) = self.inner.as_mut() {
+            // `Partitioned::recv` is documented as cancel safe.
             client.recv().await
         } else {
             future::pending().await

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -18,7 +18,7 @@ use mz_cluster_client::client::{ClusterReplicaLocation, ClusterStartupEpoch, Tim
 use mz_dyncfg::ConfigSet;
 use mz_ore::retry::Retry;
 use mz_ore::task::AbortOnDropHandle;
-use mz_service::client::{GenericClient, Partitioned};
+use mz_service::client::GenericClient;
 use mz_service::params::GrpcClientParameters;
 use tokio::select;
 use tokio::sync::mpsc::error::SendError;
@@ -33,8 +33,7 @@ use crate::protocol::command::{ComputeCommand, InstanceConfig};
 use crate::protocol::response::ComputeResponse;
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
-type Client<T> =
-    SequentialHydration<Partitioned<ComputeGrpcClient, ComputeCommand<T>, ComputeResponse<T>>, T>;
+type Client<T> = SequentialHydration<T>;
 
 /// Replica-specific configuration.
 #[derive(Clone, Debug)]

--- a/src/compute-client/src/controller/sequential_hydration.rs
+++ b/src/compute-client/src/controller/sequential_hydration.rs
@@ -252,7 +252,13 @@ where
         self.absorb_command(cmd)
     }
 
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
+    /// statement and some other branch completes first, it is guaranteed that no messages were
+    /// received by this client.
     async fn recv(&mut self) -> Result<Option<ComputeResponse<T>>, anyhow::Error> {
+        // `mpsc::UnboundedReceiver::recv` is documented as cancel safe.
         match self.response_rx.recv().await {
             Some(Ok(response)) => {
                 self.observe_response(&response)?;

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -53,7 +53,14 @@ impl<T: Send> GenericClient<ComputeCommand<T>, ComputeResponse<T>> for Box<dyn C
     async fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
         (**self).send(cmd).await
     }
+
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
+    /// statement and some other branch completes first, it is guaranteed that no messages were
+    /// received by this client.
     async fn recv(&mut self) -> Result<Option<ComputeResponse<T>>, anyhow::Error> {
+        // `GenericClient::recv` is required to be cancel safe.
         (**self).recv().await
     }
 }

--- a/src/service/src/grpc.rs
+++ b/src/service/src/grpc.rs
@@ -166,7 +166,14 @@ where
         Ok(())
     }
 
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
+    /// statement and some other branch completes first, it is guaranteed that no messages were
+    /// received by this client.
     async fn recv(&mut self) -> Result<Option<R>, anyhow::Error> {
+        // `TryStreamExt::try_next` is cancel safe. The returned future only holds onto a
+        // reference to the underlying stream, so dropping it will never lose a value.
         match self.rx.try_next().await? {
             None => Ok(None),
             Some(response) => Ok(Some(response.into_rust()?)),

--- a/src/service/src/local.rs
+++ b/src/service/src/local.rs
@@ -64,7 +64,13 @@ where
         Ok(())
     }
 
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
+    /// statement and some other branch completes first, it is guaranteed that no messages were
+    /// received by this client.
     async fn recv(&mut self) -> Result<Option<R>, anyhow::Error> {
+        // `mpsc::UnboundedReceiver::recv` is documented as cancel safe.
         Ok(self.rx.recv().await)
     }
 }

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -57,7 +57,13 @@ impl<T: Send> GenericClient<StorageCommand<T>, StorageResponse<T>> for Box<dyn S
         (**self).send(cmd).await
     }
 
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a [`tokio::select!`]
+    /// statement and some other branch completes first, it is guaranteed that no messages were
+    /// received by this client.
     async fn recv(&mut self) -> Result<Option<StorageResponse<T>>, anyhow::Error> {
+        // `GenericClient::recv` is required to be cancel safe.
         (**self).recv().await
     }
 }


### PR DESCRIPTION
@petrosagg's comments on https://github.com/MaterializeInc/materialize/pull/28380 made me realize that `SequentialHydration::recv` was not cancel safe: Observing received responses might lead to more dataflows getting scheduled, which requires sending commands to the replica, but `GenericClient::send` is not required to be cancel safe.

This is fixed now by introducing a forwarder task that does the direct interaction with the wrapped client. `SequentialHydration` now only needs to send commands to a channel connected to that forwarder, which is non-async and therefore cancel safe.

A slightly annoying bit is that send errors aren't directly returned from `SequentialHydration::send` anymore, since that call is not waiting for the send to be successful. Instead they are returned on the next call to `SequentialHydration::recv`.

### Motivation

  * This PR fixes a previously unreported bug.

`SequentialHydration::recv` is not cancel safe, even though the `GenericClient` contract demands it to be.

### Tips for reviewer

I also added a second commit explicitly documenting the cancel safety on each implementation site of `GenericClient::recv`. Hopefully that will make it harder to introduce the same bug in the future.

I think long-term we want to move away from an architecture that requires us to be careful of ensuring cancel safety. For example, you could imagine having each of the various protocol clients be a separate task and having them communicate through channels.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
