### PR TITLE
sql: improve errors for sink KEY clause

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2689,18 +2689,20 @@ fn plan_sink(
                 let mut uniq = BTreeSet::new();
                 for col in key_columns.iter() {
                     if !uniq.insert(col) {
-                        sql_bail!("Repeated column name in sink key: {}", col);
+                        sql_bail!("duplicate column referenced in KEY: {}", col);
                     }
                 }
                 let indices = key_columns
                     .iter()
                     .map(|col| -> anyhow::Result<usize> {
-                        let name_idx = desc
-                            .get_by_name(col)
-                            .map(|(idx, _type)| idx)
-                            .ok_or_else(|| sql_err!("No such column: {}", col))?;
+                        let name_idx =
+                            desc.get_by_name(col)
+                                .map(|(idx, _type)| idx)
+                                .ok_or_else(|| {
+                                    sql_err!("column referenced in KEY does not exist: {}", col)
+                                })?;
                         if desc.get_unambiguous_name(name_idx).is_none() {
-                            sql_err!("Ambiguous column: {}", col);
+                            sql_err!("column referenced in KEY is ambiguous: {}", col);
                         }
                         Ok(name_idx)
                     })

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -288,7 +288,7 @@ contains:Invalid name. Must start with [A-Za-z_] and subsequently only contain [
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:Repeated column name in sink key: a
+contains:duplicate column referenced in KEY: a
 
 ! CREATE SINK bad_sink
   IN CLUSTER ${arg.single-replica-cluster}

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -29,7 +29,7 @@ $ set-arg-default single-replica-cluster=quickstart
   KEY(f2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:No such column: f2
+contains:column referenced in KEY does not exist: f2
 
 ! CREATE SINK invalid_legacy_ids
   IN CLUSTER ${arg.single-replica-cluster}


### PR DESCRIPTION
As noticed in #28726, the current brevity of the  error messages made it hard to realize when an `ALTER SINK` command is failing due to the new `FROM` relation missing columns referenced by the sink's `KEY` clause.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR improves error messages to make it easier to diagnose test failures.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
