### PR TITLE
adapter: Fix concurrent DDL

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4518,7 +4518,7 @@ impl Coordinator {
     #[instrument]
     pub(crate) async fn handle_deferred_statement(&mut self) {
         // It is possible Message::DeferredStatementReady was sent but then a session cancellation
-        // was processed, removing the single element from deferred_statements, so it is exepcted
+        // was processed, removing the single element from deferred_statements, so it is expected
         // that this is sometimes empty.
         let Some(DeferredPlanStatement { ctx, ps }) = self.serialized_ddl.pop_front() else {
             return;


### PR DESCRIPTION
Certain DDL statements can trigger an extended DDL transaction, when
run in a multi-statement transaction. These extended DDL
multi-statement transactions have special handling at all stages,
including when they attempt to acquire the DDL lock.

Previously, when executing a statement and acquiring the DDL lock, we
would try and deduce if we are in an extended DDL transaction, by
looking at the type of statement being executed. This is not a robust
check, because those statement that trigger an extended DDL transaction
in multi-statement transactions do not trigger an extended DDL
transaction in single-statement transactions. Currently, the statements
that can trigger an extended DDL transaction are renames and swaps. As
a consequence of this behavior, when a rename or swap are executed in
a single-statement transaction, they never acquire the DDL lock.

This commit fixes this issue, by explicitly checking if we are in an
extended DDL transaction, instead of trying to deduce that state from
the current statement.

Fixes #28640

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
