### PR TITLE
Feature/graceful reconfig until ready sql

### DIFF
--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -696,6 +696,7 @@ impl Coordinator {
                     }
                     finalization_needed = FinalizationNeeded::In(duration);
                 }
+                AlterClusterPlanStrategy::UntilReady { .. } => coord_bail!("Unimplemented"),
             }
         } else if new_replication_factor < replication_factor {
             // Adjust replica count down

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -333,6 +333,7 @@ Range
 Rate
 Raw
 Read
+Ready
 Real
 Reassign
 Recursion
@@ -447,6 +448,7 @@ Uncommitted
 Union
 Unique
 Unknown
+Until
 Up
 Update
 Upsert

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1864,8 +1864,43 @@ pub struct ClusterOption<T: AstInfo> {
 impl_display_for_with_option!(ClusterOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ClusterAlterUntilReadyOptionName {
+    Timeout,
+    OnTimeout,
+}
+
+impl AstDisplay for ClusterAlterUntilReadyOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            Self::Timeout => f.write_str("TIMEOUT"),
+            Self::OnTimeout => f.write_str("ON TIMEOUT"),
+        }
+    }
+}
+
+impl WithOptionName for ClusterAlterUntilReadyOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            ClusterAlterUntilReadyOptionName::Timeout
+            | ClusterAlterUntilReadyOptionName::OnTimeout => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ClusterAlterUntilReadyOption<T: AstInfo> {
+    pub name: ClusterAlterUntilReadyOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+impl_display_for_with_option!(ClusterAlterUntilReadyOption);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ClusterAlterOptionName {
-    /// The `Wait` option.
     Wait,
 }
 
@@ -1891,16 +1926,22 @@ impl WithOptionName for ClusterAlterOptionName {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum ClusterAlterOptionValue {
+pub enum ClusterAlterOptionValue<T: AstInfo> {
     For(Value),
+    UntilReady(Vec<ClusterAlterUntilReadyOption<T>>),
 }
 
-impl AstDisplay for ClusterAlterOptionValue {
+impl<T: AstInfo> AstDisplay for ClusterAlterOptionValue<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             ClusterAlterOptionValue::For(duration) => {
                 f.write_str("FOR ");
                 f.write_node(duration);
+            }
+            ClusterAlterOptionValue::UntilReady(options) => {
+                f.write_str("UNTIL READY (");
+                f.write_node(&display::comma_separated(options));
+                f.write_str(")");
             }
         }
     }
@@ -3721,7 +3762,7 @@ pub enum WithOptionValue<T: AstInfo> {
     RetainHistoryFor(Value),
     Refresh(RefreshOptionValue<T>),
     ClusterScheduleOptionValue(ClusterScheduleOptionValue),
-    ClusterAlterStrategy(ClusterAlterOptionValue),
+    ClusterAlterStrategy(ClusterAlterOptionValue<T>),
 }
 
 impl<T: AstInfo> AstDisplay for WithOptionValue<T> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3937,10 +3937,22 @@ impl<'a> Parser<'a> {
         let (name, value) = match self.expect_one_of_keywords(&[WAIT])? {
             WAIT => {
                 let _ = self.consume_token(&Token::Eq);
-                let v = match self.expect_one_of_keywords(&[FOR])? {
+                let v = match self.expect_one_of_keywords(&[FOR, UNTIL])? {
                     FOR => Some(WithOptionValue::ClusterAlterStrategy(
                         ClusterAlterOptionValue::For(self.parse_value()?),
                     )),
+                    UNTIL => {
+                        self.expect_keyword(READY)?;
+                        let _ = self.consume_token(&Token::Eq);
+                        let _ = self.expect_token(&Token::LParen)?;
+                        let opts = Some(WithOptionValue::ClusterAlterStrategy(
+                            ClusterAlterOptionValue::UntilReady(self.parse_comma_separated(
+                                Parser::parse_cluster_alter_until_ready_option,
+                            )?),
+                        ));
+                        let _ = self.expect_token(&Token::RParen)?;
+                        opts
+                    }
                     _ => unreachable!(),
                 };
                 (ClusterAlterOptionName::Wait, v)
@@ -3948,6 +3960,21 @@ impl<'a> Parser<'a> {
             _ => unreachable!(),
         };
         Ok(ClusterAlterOption { name, value })
+    }
+
+    fn parse_cluster_alter_until_ready_option(
+        &mut self,
+    ) -> Result<ClusterAlterUntilReadyOption<Raw>, ParserError> {
+        let name = match self.expect_one_of_keywords(&[TIMEOUT, ON])? {
+            ON => {
+                self.expect_keywords(&[TIMEOUT])?;
+                ClusterAlterUntilReadyOptionName::OnTimeout
+            }
+            TIMEOUT => ClusterAlterUntilReadyOptionName::Timeout,
+            _ => unreachable!(),
+        };
+        let value = self.parse_optional_option_value()?;
+        Ok(ClusterAlterUntilReadyOption { name, value })
     }
 
     fn parse_cluster_option_replicas(&mut self) -> Result<ClusterOption<Raw>, ParserError> {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1819,6 +1819,14 @@ ALTER CLUSTER cluster SET (SIZE = '1') WITH (WAIT = FOR '1s')
 =>
 AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), action: SetOptions { options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }], with_options: [ClusterAlterOption { name: Wait, value: Some(ClusterAlterStrategy(For(String("1s")))) }] } })
 
+
+parse-statement
+ALTER CLUSTER cluster SET (SIZE '1') WITH ( WAIT UNTIL READY ( TIMEOUT '1s', ON TIMEOUT = 'COMMIT' ) )
+----
+ALTER CLUSTER cluster SET (SIZE = '1') WITH (WAIT = UNTIL READY (TIMEOUT = '1s', ON TIMEOUT = 'COMMIT'))
+=>
+AlterCluster(AlterClusterStatement { if_exists: false, name: Ident("cluster"), action: SetOptions { options: [ClusterOption { name: Size, value: Some(Value(String("1"))) }], with_options: [ClusterAlterOption { name: Wait, value: Some(ClusterAlterStrategy(UntilReady([ClusterAlterUntilReadyOption { name: Timeout, value: Some(Value(String("1s"))) }, ClusterAlterUntilReadyOption { name: OnTimeout, value: Some(Value(String("COMMIT"))) }]))) }] } })
+
 parse-statement
 ALTER CLUSTER IF EXISTS cluster SET (MANAGED)
 ----

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1827,7 +1827,9 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
             RetainHistoryFor(value) => RetainHistoryFor(self.fold_value(value)),
             Refresh(refresh) => Refresh(self.fold_refresh_option_value(refresh)),
             ClusterScheduleOptionValue(value) => ClusterScheduleOptionValue(value),
-            ClusterAlterStrategy(value) => ClusterAlterStrategy(value),
+            ClusterAlterStrategy(value) => {
+                ClusterAlterStrategy(self.fold_cluster_alter_option_value(value))
+            }
         }
     }
 

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -262,6 +262,7 @@ pub enum PlanError {
         limit: Duration,
     },
     RetainHistoryRequired,
+    UntilReadyTimeoutRequired,
     SubsourceResolutionError(ExternalReferenceResolutionError),
     Replan(String),
     // TODO(benesch): eventually all errors should be structured.
@@ -371,7 +372,7 @@ impl PlanError {
                         if cause.kind() == io::ErrorKind::TimedOut {
                             return Some(
                                 "Do you have a firewall or security group that is \
-                                preventing Materialize from conecting to your PostgreSQL server?"
+                                preventing Materialize from connecting to your PostgreSQL server?"
                                     .into(),
                             );
                         }
@@ -739,6 +740,9 @@ impl fmt::Display for PlanError {
             },
             Self::SubsourceResolutionError(e) => write!(f, "{}", e),
             Self::Replan(msg) => write!(f, "internal error while replanning, please contact support: {msg}"),
+            Self::UntilReadyTimeoutRequired => {
+                write!(f, "TIMEOUT=<duration> option is required for ALTER CLUSTER ... WITH (WAIT UNTIL READY ( ... ))")
+            },
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -49,7 +49,8 @@ use mz_sql_parser::ast::{
     AlterSourceAddSubsourceOptionName, AlterSourceStatement, AlterSystemResetAllStatement,
     AlterSystemResetStatement, AlterSystemSetStatement, AlterTableAddColumnStatement, AvroSchema,
     AvroSchemaOption, AvroSchemaOptionName, ClusterAlterOption, ClusterAlterOptionName,
-    ClusterAlterOptionValue, ClusterFeature, ClusterFeatureName, ClusterOption, ClusterOptionName,
+    ClusterAlterOptionValue, ClusterAlterUntilReadyOption, ClusterAlterUntilReadyOptionName,
+    ClusterFeature, ClusterFeatureName, ClusterOption, ClusterOptionName,
     ClusterScheduleOptionValue, ColumnOption, CommentObjectType, CommentStatement,
     CreateClusterReplicaStatement, CreateClusterStatement, CreateConnectionOption,
     CreateConnectionOptionName, CreateConnectionStatement, CreateConnectionType,
@@ -3460,7 +3461,13 @@ generate_extracted_config!(
     (WorkloadClass, OptionalString)
 );
 
-generate_extracted_config!(ClusterAlterOption, (Wait, ClusterAlterOptionValue));
+generate_extracted_config!(ClusterAlterOption, (Wait, ClusterAlterOptionValue<Aug>));
+
+generate_extracted_config!(
+    ClusterAlterUntilReadyOption,
+    (Timeout, Duration),
+    (OnTimeout, String)
+);
 
 generate_extracted_config!(
     ClusterFeature,
@@ -4893,6 +4900,9 @@ pub fn plan_alter_cluster(
                             scx.require_feature_flag(
                                 &crate::session::vars::ENABLE_GRACEFUL_CLUSTER_RECONFIGURATION,
                             )?;
+                        }
+                        AlterClusterPlanStrategy::UntilReady { .. } => {
+                            bail_unsupported!("ALTER CLUSTER .. WITH (WAIT UNTIL READY...) is not yet implemented");
                         }
                     }
 

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -800,7 +800,7 @@ impl ImpliedValue for ClusterScheduleOptionValue {
     }
 }
 
-impl ImpliedValue for ClusterAlterOptionValue {
+impl ImpliedValue for ClusterAlterOptionValue<Aug> {
     fn implied_value() -> Result<Self, PlanError> {
         sql_bail!("must provide a value")
     }
@@ -859,7 +859,7 @@ impl<V: TryFromValue<WithOptionValue<Aug>>> TryFromValue<WithOptionValue<Aug>>
     }
 }
 
-impl TryFromValue<WithOptionValue<Aug>> for ClusterAlterOptionValue {
+impl TryFromValue<WithOptionValue<Aug>> for ClusterAlterOptionValue<Aug> {
     fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
         if let WithOptionValue::ClusterAlterStrategy(r) = v {
             Ok(r)


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Adds SQL parsing for `ALTER CLUSTER ... WITH ( WAIT UNTIL READY=(<options>) )`
where options are `TIMEOUT=<duration>` and `ON TIMEOUT=<COMMIT|ROLLBACK>`

https://github.com/MaterializeInc/materialize/issues/20010


This PR is stacked on the following PRs

* https://github.com/MaterializeInc/materialize/pull/27904
* https://github.com/MaterializeInc/materialize/pull/28092


This was formerly known as `until caught up` but the language has been changed to `until ready` for both clarity and to allow us to shift the definition of "ready" internally for this feature without needing to add new sql changes. 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
