### PR TITLE
orchestrator-process: Fix context for reading secret

### DIFF
--- a/src/orchestrator-process/src/secrets.rs
+++ b/src/orchestrator-process/src/secrets.rs
@@ -87,7 +87,7 @@ impl SecretsReader for ProcessSecretsReader {
     async fn read(&self, id: GlobalId) -> Result<Vec<u8>, anyhow::Error> {
         let contents = fs::read(self.secrets_dir.join(id.to_string()))
             .await
-            .with_context(|| "reading secret {id}")?;
+            .with_context(|| format!("reading secret {id}"))?;
         Ok(contents)
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/28812

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
