### PR TITLE
compute: 10s bucket for wallclock lag metric

### DIFF
--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -169,7 +169,7 @@ impl ComputeControllerMetrics {
                 help: "A histogram of the second-by-second lag of the dataflow frontier relative to \
                        wallclock time.",
                 var_labels: ["instance_id", "replica_id", "collection_id"],
-                buckets: vec![1., 2., 5., 30.],
+                buckets: vec![1., 2., 5., 10., 30.],
             )),
         }
     }


### PR DESCRIPTION
Turns out that not having a 10s bucket is very confusing in practice because the human brain just assumes it must exist. Add that bucket to give our brains some slack.

[Relevant Slack thread.](https://materializeinc.slack.com/archives/C073FCHFWV6/p1722518350885899)

### Motivation

   * This PR refines an internal metric.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
