### PR TITLE
adapter: handle 0dt deploys in orphaned secrets cleanup

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -584,6 +584,15 @@ impl Catalog {
             .err_into()
     }
 
+    /// Get the next user item ID without allocating it.
+    pub async fn get_next_user_item_id(&self) -> Result<u64, Error> {
+        self.storage()
+            .await
+            .get_next_user_item_id()
+            .await
+            .err_into()
+    }
+
     #[cfg(test)]
     pub async fn allocate_system_id(&self) -> Result<GlobalId, Error> {
         use mz_ore::collections::CollectionExt;
@@ -593,6 +602,15 @@ impl Catalog {
             .await
             .maybe_terminate("allocating system ids")
             .map(|ids| ids.into_element())
+            .err_into()
+    }
+
+    /// Get the next system item ID without allocating it.
+    pub async fn get_next_system_item_id(&self) -> Result<u64, Error> {
+        self.storage()
+            .await
+            .get_next_system_item_id()
+            .await
             .err_into()
     }
 

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -206,6 +206,16 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
     /// Get the next ID of `id_type`, without allocating it.
     async fn get_next_id(&mut self, id_type: &str) -> Result<u64, CatalogError>;
 
+    /// Get the next user ID without allocating it.
+    async fn get_next_user_item_id(&mut self) -> Result<u64, CatalogError> {
+        self.get_next_id(USER_ITEM_ALLOC_KEY).await
+    }
+
+    /// Get the next system ID without allocating it.
+    async fn get_next_system_item_id(&mut self) -> Result<u64, CatalogError> {
+        self.get_next_id(SYSTEM_ITEM_ALLOC_KEY).await
+    }
+
     /// Get the next system replica id without allocating it.
     async fn get_next_system_replica_id(&mut self) -> Result<u64, CatalogError> {
         self.get_next_id(SYSTEM_REPLICA_ID_ALLOC_KEY).await


### PR DESCRIPTION
The existing code to cleanup orphaned secrets during coordinator bootstrap was not properly handling 0dt deployments, and could inappropriately remove secrets that were added by the old environment during the deployment process. The race worked like this:

  * New 0dt deployment created.
  * New envd begins booting in read-only mode.
  * New envd loads catalog and begins bootstrapping coordinator.
  * Old envd creates a secret.
  * New envd finishes bootstrapping.
  * New envd cleans up orphaned secrets based on now-stale catalog and removes the secret that the old envd just added.

This patch adds two safeguards:

  1. The orphaned secrets cleanup is careful to never delete secrets that have a global ID that is larger than the largest global ID known to the catalog.

     This protects not just against the aforementioned race, but also against a theoretical race in which an envd boots up in non-read-only mode and loads its catalog and then, right before starting orphaned secrets cleanup, loses its leadership to a *new* envd that manages to create a secret.

  2. Orphaned secrets cleanup is no longer run in read-only mode.

     While (1) is sufficient to prevent all races on its own, cleaning up secrets is a mutating operation, and so it philosophically should not run in read-only mode.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.
  
    Fixes #28570.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
