### PR TITLE
dbt-materialize: add lag tolerance arg to dbt deploy

### DIFF
--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -137,7 +137,7 @@ Materialize integrates with dbt through the [`dbt-materialize`](https://github.c
 
 | Service   | Support level                    | Notes                                                                                                                                                                                                                          |             |
 | --------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| dbt Core  | {{< supportLevel beta >}}        | See the [dbt documentation](https://docs.getdbt.com/reference/warehouse-profiles/materialize-profile) for more details, and the [dbt + Materialize guide](/integrations/dbt/) for a step-by-step breakdown of the integration. | [](#notify) |
+| dbt Core  | {{< supportLevel beta >}}        | See the [`dbt-materialize` reference documentation](https://materialize.com/docs/manage/dbt/) for more details, and the [development workflows guide](/integrations/dbt/) for common dbt patterns. | [](#notify) |
 | dbt Cloud | {{< supportLevel in-progress >}} | Not supported yet. We are working with the dbt community to bring native Materialize support to dbt Cloud soon.                                                                                                                | [](#notify) |
 
 ### Terraform

--- a/doc/user/content/manage/dbt/development-workflows.md
+++ b/doc/user/content/manage/dbt/development-workflows.md
@@ -419,7 +419,7 @@ environment before cutting over.
 
     Argument                             | Default   | Description
     -------------------------------------|-----------|--------------------------------------------------
-    `dry_run`                            | `false`   | Whether to print out the sequence of commands that dbt will execute for validation, without actually promoting the deployment.
+    `dry_run`                            | `false`   | Whether to print out the sequence of commands that dbt will execute without actually promoting the deployment, for validation.
     `wait`                               | `false`   | Whether to wait for all objects in the deployment environment to fully hydrate before promoting the deployment. We recommend setting this argument to `true` if you skip the [validation](#validation) step.
     `poll_interval`                      | `15s`     | When `wait` is set to `true`, the time (in seconds) between each cluster readiness check.
     `lag_threshold`                      | `1s`      | When `wait` is set to `true`, the maximum lag threshold, which determines when all objects in the environment are considered hydrated and it's safe to perform the cutover step.

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,17 +2,20 @@
 
 ## Unreleased
 
-* Add `application_name` to the connection parameters [#28813](https://github.com/MaterializeInc/materialize/pull/28813).
+* Include the dbt version in the `application_name` connection parameter [#28813](https://github.com/MaterializeInc/materialize/pull/28813).
 
-* Add `lag_tolerance` argument to the `deploy_promote` operation [#28831](https://github.com/MaterializeInc/materialize/issues/28831).
-  - Allows users to specify a custom maximum acceptable lag duration when waiting for deployment readiness
-  - Default value is '1s' (1 second)
-  - Can be used in combination with `wait: true` and `poll_interval`
-  - Example usage:
-    ```bash
-    dbt run-operation deploy_await --args '{lag_tolerance: "5s"}'
-    dbt run-operation deploy_promote --args '{wait: true, poll_interval: 30, lag_tolerance: "5s"}'
-    ```
+* Allow users to override the maximum lag threshold in [blue/green deployment
+  macros](https://materialize.com/docs/manage/dbt/development-workflows/#bluegreen-deployments)
+  using the new `lag_threshold` argument.
+
+  **Example**
+  ```bash
+  dbt run-operation deploy_await --args '{lag_threshold: "5s"}'
+  dbt run-operation deploy_promote --args '{wait: true, poll_interval: 30, lag_threshold: "5s"}'
+  ```
+
+  **We do not recommend** changing the default value of the `lag_threshold`
+  (`1s`), unless prompted by the Materialize team.
 
 ## 1.8.3 - 2024-07-19
 

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,19 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Add `application_name` to the connection parameters [#28813](https://github.com/MaterializeInc/materialize/pull/28813).
+
+* Add `lag_tolerance` argument to the `deploy_promote` operation [#28831](https://github.com/MaterializeInc/materialize/issues/28831).
+  - Allows users to specify a custom maximum acceptable lag duration when waiting for deployment readiness
+  - Default value is '1s' (1 second)
+  - Can be used in combination with `wait: true` and `poll_interval`
+  - Example usage:
+    ```bash
+    dbt run-operation deploy_await --args '{lag_tolerance: "5s"}'
+    dbt run-operation deploy_promote --args '{wait: true, poll_interval: 30, lag_tolerance: "5s"}'
+    ```
+
 ## 1.8.3 - 2024-07-19
 
 * Enable cross-database references ([#27686](https://github.com/MaterializeInc/materialize/pull/27686)). Although cross-database references are not supported in `dbt-postgres`, databases in Materialize are purely used for namespacing, and therefore do not present the same constraint.

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_await.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_await.sql
@@ -13,13 +13,14 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro deploy_await(poll_interval=15) %}
+{% macro deploy_await(poll_interval=15, lag_tolerance='1s') %}
 {#
   Waits for all objects within the deployment clusters to be fully hydrated,
   polling the cluster's readiness status at a specified interval.
 
   ## Arguments
   - `poll_interval` (integer): The interval, in seconds, between each readiness check.
+  - `lag_tolerance` (string): The maximum acceptable lag time for the cluster to be considered ready.
 
   ## Returns
   None: This macro does not return a value but will halt execution until the specified
@@ -39,6 +40,6 @@
 
 {% for cluster in clusters %}
     {% set deploy_cluster = adapter.generate_final_cluster_name(cluster, force_deploy_suffix=True) %}
-    {{ await_cluster_ready(deploy_cluster, poll_interval) }}
+    {{ await_cluster_ready(deploy_cluster, poll_interval, lag_tolerance) }}
 {% endfor %}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_await.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_await.sql
@@ -13,18 +13,20 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro deploy_await(poll_interval=15, lag_tolerance='1s') %}
+{% macro deploy_await(poll_interval=15, lag_threshold='1s') %}
 {#
   Waits for all objects within the deployment clusters to be fully hydrated,
   polling the cluster's readiness status at a specified interval.
 
   ## Arguments
-  - `poll_interval` (integer): The interval, in seconds, between each readiness check.
-  - `lag_tolerance` (string): The maximum acceptable lag time for the cluster to be considered ready.
+  - `poll_interval` (integer): The interval, in seconds, between each readiness
+    check.
+  - `lag_threshold` (string): The maximum lag threshold, which determines when
+    all objects in the environment are considered hydrated and it''s safe to
+    perform the cutover step.
 
-  ## Returns
-  None: This macro does not return a value but will halt execution until the specified
-  cluster's objects are fully hydrated.
+  ## Returns None: This macro does not return a value but will halt execution
+     until the specified cluster's objects are fully hydrated.
 #}
 
 {% set current_target_name = target.name %}
@@ -40,6 +42,6 @@
 
 {% for cluster in clusters %}
     {% set deploy_cluster = adapter.generate_final_cluster_name(cluster, force_deploy_suffix=True) %}
-    {{ await_cluster_ready(deploy_cluster, poll_interval, lag_tolerance) }}
+    {{ await_cluster_ready(deploy_cluster, poll_interval, lag_threshold) }}
 {% endfor %}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro deploy_promote(wait=False, poll_interval=15, dry_run=False) %}
+{% macro deploy_promote(wait=False, poll_interval=15, lag_tolerance='1s', dry_run=False) %}
 {#
   Performs atomic deployment of current dbt targets to production,
   based on the deployment configuration specified in the dbt_project.yml file.
@@ -27,6 +27,7 @@
       Defaults to false. It is recommended you call `deploy_await` manually and
       run additional validation checks before promoting a deployment to production.
   - `poll_interval` (integer): The interval, in seconds, between each readiness check.
+  - `lag_tolerance` (string): The maximum acceptable lag duration. Default is '1s' (1 second).
   - `dry_run` (boolean, optional): When True, prints out the commands that would
     be executed as part of the deployment workflow (without executing them).
 
@@ -71,7 +72,7 @@
 {% endfor %}
 
 {% if wait %}
-    {{ deploy_await(poll_interval) }}
+    {{ deploy_await(poll_interval, lag_tolerance) }}
 {% endif %}
 
 {% if not dry_run %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/deploy/deploy_promote.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro deploy_promote(wait=False, poll_interval=15, lag_tolerance='1s', dry_run=False) %}
+{% macro deploy_promote(wait=False, poll_interval=15, lag_threshold='1s', dry_run=False) %}
 {#
   Performs atomic deployment of current dbt targets to production,
   based on the deployment configuration specified in the dbt_project.yml file.
@@ -24,12 +24,16 @@
 
   ## Arguments
   - `wait` (boolean, optional): Waits for the deployment to be fully hydrated.
-      Defaults to false. It is recommended you call `deploy_await` manually and
-      run additional validation checks before promoting a deployment to production.
-  - `poll_interval` (integer): The interval, in seconds, between each readiness check.
-  - `lag_tolerance` (string): The maximum acceptable lag duration. Default is '1s' (1 second).
-  - `dry_run` (boolean, optional): When True, prints out the commands that would
-    be executed as part of the deployment workflow (without executing them).
+    Defaults to false. We recommend calling `deploy_await` manually and running
+    additional validation checks before promoting a deployment.
+  - `poll_interval` (integer): The interval, in seconds, between each readiness
+    check. Default: '15s'.
+  - `lag_threshold` (string): The maximum lag threshold, which determines when
+    all objects in the environment are considered hydrated and it''s safe to
+    perform the cutover step. Default: '1s'.
+  - `dry_run` (boolean, optional): When `true`, prints out the sequence of
+    commands dbt would execute without actually promoting the deployment, for
+    validation.
 
   ## Returns
   None: This macro performs deployment actions but does not return a value.
@@ -72,7 +76,7 @@
 {% endfor %}
 
 {% if wait %}
-    {{ deploy_await(poll_interval, lag_tolerance) }}
+    {{ deploy_await(poll_interval, lag_threshold) }}
 {% endif %}
 
 {% if not dry_run %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/await_cluster_ready.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/await_cluster_ready.sql
@@ -13,10 +13,10 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro await_cluster_ready(cluster, poll_interval=15, lag_tolerance='1s') %}
+{% macro await_cluster_ready(cluster, poll_interval=15, lag_threshold='1s') %}
 
 {% for i in range(1, 100000) %}
-    {% if is_cluster_ready(cluster, lag_tolerance) %}
+    {% if is_cluster_ready(cluster, lag_threshold) %}
         {{ return(true) }}
     {% endif %}
     -- Hydration takes time. Be a good

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/await_cluster_ready.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/await_cluster_ready.sql
@@ -13,10 +13,10 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro await_cluster_ready(cluster, poll_interval=15) %}
+{% macro await_cluster_ready(cluster, poll_interval=15, lag_tolerance='1s') %}
 
 {% for i in range(1, 100000) %}
-    {% if is_cluster_ready(cluster) %}
+    {% if is_cluster_ready(cluster, lag_tolerance) %}
         {{ return(true) }}
     {% endif %}
     -- Hydration takes time. Be a good

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/is_cluster_ready.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/is_cluster_ready.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro is_cluster_ready(cluster=target.cluster|default(none), lag_tolerance='1s') %}
+{% macro is_cluster_ready(cluster=target.cluster|default(none), lag_threshold='1s') %}
 
 {% if cluster is none %}
     {{ exceptions.raise_compiler_error("No cluster specified and no default cluster found in target profile. " ~ current_target_name) }}
@@ -103,7 +103,7 @@ ready_dataflows AS (
     FROM dataflows
     JOIN mz_internal.mz_hydration_statuses AS h USING (object_id, replica_id)
     LEFT JOIN mz_internal.mz_materialization_lag AS l USING (object_id)
-    WHERE h.hydrated AND (l.local_lag <= {{ dbt.string_literal(lag_tolerance) }} OR l.local_lag IS NULL)
+    WHERE h.hydrated AND (l.local_lag <= {{ dbt.string_literal(lag_threshold) }} OR l.local_lag IS NULL)
 ),
 
 pending_dataflows AS (

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/is_cluster_ready.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/is_cluster_ready.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro is_cluster_ready(cluster=target.cluster|default(none)) %}
+{% macro is_cluster_ready(cluster=target.cluster|default(none), lag_tolerance='1s') %}
 
 {% if cluster is none %}
     {{ exceptions.raise_compiler_error("No cluster specified and no default cluster found in target profile. " ~ current_target_name) }}
@@ -103,7 +103,7 @@ ready_dataflows AS (
     FROM dataflows
     JOIN mz_internal.mz_hydration_statuses AS h USING (object_id, replica_id)
     LEFT JOIN mz_internal.mz_materialization_lag AS l USING (object_id)
-    WHERE h.hydrated AND (l.local_lag <= '1s' OR l.local_lag IS NULL)
+    WHERE h.hydrated AND (l.local_lag <= {{ dbt.string_literal(lag_tolerance) }} OR l.local_lag IS NULL)
 ),
 
 pending_dataflows AS (

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -617,43 +617,43 @@ class TestLagTolerance:
         project.run_sql("DROP CLUSTER IF EXISTS quickstart_dbt_deploy CASCADE")
         project.run_sql("DROP SCHEMA IF EXISTS public_dbt_deploy CASCADE")
 
-    def test_deploy_await_custom_lag_tolerance(self, project):
+    def test_deploy_await_custom_lag_threshold(self, project):
         run_dbt(["run-operation", "deploy_init"])
         result = run_dbt(
             [
                 "run-operation",
                 "deploy_await",
                 "--args",
-                "{poll_interval: 5, lag_tolerance: '5s'}",
+                "{poll_interval: 5, lag_threshold: '5s'}",
             ]
         )
         assert len(result) > 0 and result[0].status == "success"
 
-    def test_deploy_promote_custom_lag_tolerance(self, project):
+    def test_deploy_promote_custom_lag_threshold(self, project):
         run_dbt(["run-operation", "deploy_init"])
         result = run_dbt(
             [
                 "run-operation",
                 "deploy_promote",
                 "--args",
-                "{wait: true, poll_interval: 5, lag_tolerance: '5s'}",
+                "{wait: true, poll_interval: 5, lag_threshold: '5s'}",
             ]
         )
         assert len(result) > 0 and result[0].status == "success"
 
-    def test_default_lag_tolerance(self, project):
+    def test_default_lag_threshold(self, project):
         run_dbt(["run-operation", "deploy_init"])
         result = run_dbt(["run-operation", "deploy_await"])
         assert len(result) > 0 and result[0].status == "success"
 
-    def test_large_lag_tolerance(self, project):
+    def test_large_lag_threshold(self, project):
         run_dbt(["run-operation", "deploy_init"])
         result = run_dbt(
             [
                 "run-operation",
                 "deploy_await",
                 "--args",
-                "{poll_interval: 5, lag_tolerance: '1h'}",
+                "{poll_interval: 5, lag_threshold: '1h'}",
             ]
         )
         assert len(result) > 0 and result[0].status == "success"

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -601,6 +601,64 @@ class TestTargetDeploy:
         )
 
 
+class TestLagTolerance:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "vars": {
+                "deployment": {
+                    "default": {"clusters": ["quickstart"], "schemas": ["public"]}
+                }
+            }
+        }
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self, project):
+        project.run_sql("DROP CLUSTER IF EXISTS quickstart_dbt_deploy CASCADE")
+        project.run_sql("DROP SCHEMA IF EXISTS public_dbt_deploy CASCADE")
+
+    def test_deploy_await_custom_lag_tolerance(self, project):
+        run_dbt(["run-operation", "deploy_init"])
+        result = run_dbt(
+            [
+                "run-operation",
+                "deploy_await",
+                "--args",
+                "{poll_interval: 5, lag_tolerance: '5s'}",
+            ]
+        )
+        assert len(result) > 0 and result[0].status == "success"
+
+    def test_deploy_promote_custom_lag_tolerance(self, project):
+        run_dbt(["run-operation", "deploy_init"])
+        result = run_dbt(
+            [
+                "run-operation",
+                "deploy_promote",
+                "--args",
+                "{wait: true, poll_interval: 5, lag_tolerance: '5s'}",
+            ]
+        )
+        assert len(result) > 0 and result[0].status == "success"
+
+    def test_default_lag_tolerance(self, project):
+        run_dbt(["run-operation", "deploy_init"])
+        result = run_dbt(["run-operation", "deploy_await"])
+        assert len(result) > 0 and result[0].status == "success"
+
+    def test_large_lag_tolerance(self, project):
+        run_dbt(["run-operation", "deploy_init"])
+        result = run_dbt(
+            [
+                "run-operation",
+                "deploy_await",
+                "--args",
+                "{poll_interval: 5, lag_tolerance: '1h'}",
+            ]
+        )
+        assert len(result) > 0 and result[0].status == "success"
+
+
 class TestEndToEndDeployment:
     @pytest.fixture(scope="class")
     def models(self):


### PR DESCRIPTION
### Motivation

This PR introduces a new `lag_tolerance` argument to the `deploy_promote` and `deploy_await` operations in the db adapter. This allows users to specify a custom maximum acceptable lag duration when waiting for deployment readiness, providing a better control over the deployment process.

Fixes #28831 