### PR TITLE
Shadow literal columns with literals

### DIFF
--- a/src/transform/src/analysis/equivalences.rs
+++ b/src/transform/src/analysis/equivalences.rs
@@ -657,4 +657,21 @@ impl EquivalenceClasses {
         }
         false
     }
+
+    /// Replace `index` with a smaller equivalent column index, if one exists.
+    pub fn reduce_column(&self, index: &mut usize) {
+        for class in self.classes.iter() {
+            if let Some(pos) = class
+                .iter()
+                .position(|e| e == &MirScalarExpr::Column(*index))
+            {
+                if let Some(expr) = class[..pos].iter().find(|e| e.is_column()) {
+                    if let MirScalarExpr::Column(col) = expr {
+                        *index = *col;
+                        return;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/test/sqllogictest/explain/view.slt
+++ b/test/sqllogictest/explain/view.slt
@@ -51,19 +51,20 @@ EXPLAIN LOCALLY OPTIMIZED PLAN FOR
 VIEW v;
 ----
 Return
-  Project (#0, #1, #3)
-    Union
-      Get l0
-      Project (#0, #3..=#5)
-        Map (100, null, null)
-          Join on=(#0 = #1)
-            Union
-              Negate
+  Project (#0, #4, #3)
+    Map (100)
+      Union
+        Get l0
+        Project (#0, #3..=#5)
+          Map (100, null, null)
+            Join on=(#0 = #1)
+              Union
+                Negate
+                  Distinct project=[#0]
+                    Get l0
                 Distinct project=[#0]
-                  Get l0
-              Distinct project=[#0]
-                Get l1
-            Get l1
+                  Get l1
+              Get l1
 With
   cte l1 =
     Filter (#1 = 100)
@@ -83,19 +84,20 @@ EXPLAIN LOCALLY OPTIMIZED PLAN FOR
 REPLAN VIEW v;
 ----
 Return
-  Project (#0, #1, #3)
-    Union
-      Get l0
-      Project (#0, #3..=#5)
-        Map (100, null, null)
-          Join on=(#0 = #1)
-            Union
-              Negate
+  Project (#0, #4, #3)
+    Map (100)
+      Union
+        Get l0
+        Project (#0, #3..=#5)
+          Map (100, null, null)
+            Join on=(#0 = #1)
+              Union
+                Negate
+                  Distinct project=[#0]
+                    Get l0
                 Distinct project=[#0]
-                  Get l0
-              Distinct project=[#0]
-                Get l1
-            Get l1
+                  Get l1
+              Get l1
 With
   cte l1 =
     Filter (#1 = 100)
@@ -116,21 +118,22 @@ EXPLAIN LOCALLY OPTIMIZED PLAN WITH(ENABLE NEW OUTER JOIN LOWERING = TRUE) FOR
 REPLAN VIEW v;
 ----
 Return
-  Project (#0, #1, #3)
-    Union
-      Map (null, null)
-        Union
-          Project (#0, #1)
-            Negate
-              Join on=(#2 = integer_to_bigint(#0))
-                Filter (#1 = 100) AND (#0) IS NOT NULL
-                  Get materialize.public.accounts
-                Distinct project=[#2]
-                  Get l0
-          Filter (#1 = 100)
-            Get materialize.public.accounts
-      Filter (#1 = 100)
-        Get l0
+  Project (#0, #4, #3)
+    Map (100)
+      Union
+        Map (null, null)
+          Union
+            Project (#0, #1)
+              Negate
+                Join on=(#2 = integer_to_bigint(#0))
+                  Filter (#1 = 100) AND (#0) IS NOT NULL
+                    Get materialize.public.accounts
+                  Distinct project=[#2]
+                    Get l0
+            Filter (#1 = 100)
+              Get materialize.public.accounts
+        Filter (#1 = 100)
+          Get l0
 With
   cte l0 =
     Join on=(#2 = integer_to_bigint(#0))
@@ -164,21 +167,22 @@ EXPLAIN LOCALLY OPTIMIZED PLAN FOR
 VIEW v;
 ----
 Return
-  Project (#0, #1, #3)
-    Union
-      Map (null, null)
-        Union
-          Project (#0, #1)
-            Negate
-              Join on=(#2 = integer_to_bigint(#0))
-                Filter (#1 = 100) AND (#0) IS NOT NULL
-                  Get materialize.public.accounts
-                Distinct project=[#2]
-                  Get l0
-          Filter (#1 = 100)
-            Get materialize.public.accounts
-      Filter (#1 = 100)
-        Get l0
+  Project (#0, #4, #3)
+    Map (100)
+      Union
+        Map (null, null)
+          Union
+            Project (#0, #1)
+              Negate
+                Join on=(#2 = integer_to_bigint(#0))
+                  Filter (#1 = 100) AND (#0) IS NOT NULL
+                    Get materialize.public.accounts
+                  Distinct project=[#2]
+                    Get l0
+            Filter (#1 = 100)
+              Get materialize.public.accounts
+        Filter (#1 = 100)
+          Get l0
 With
   cte l0 =
     Join on=(#2 = integer_to_bigint(#0))
@@ -195,19 +199,20 @@ EXPLAIN LOCALLY OPTIMIZED PLAN WITH(ENABLE NEW OUTER JOIN LOWERING = FALSE) FOR
 REPLAN VIEW v;
 ----
 Return
-  Project (#0, #1, #3)
-    Union
-      Get l0
-      Project (#0, #3..=#5)
-        Map (100, null, null)
-          Join on=(#0 = #1)
-            Union
-              Negate
+  Project (#0, #4, #3)
+    Map (100)
+      Union
+        Get l0
+        Project (#0, #3..=#5)
+          Map (100, null, null)
+            Join on=(#0 = #1)
+              Union
+                Negate
+                  Distinct project=[#0]
+                    Get l0
                 Distinct project=[#0]
-                  Get l0
-              Distinct project=[#0]
-                Get l1
-            Get l1
+                  Get l1
+              Get l1
 With
   cte l1 =
     Filter (#1 = 100)

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -796,9 +796,9 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM (SELECT 123, COUNT(right_table.f1) AS aggregate FROM t1 AS left_table LEFT JOIN t1 AS right_table ON FALSE GROUP BY 1) AS subquery, t1 AS outer_table WHERE outer_table.f1 = subquery.aggregate;
 ----
 Explained Query:
-  Project (#2, #1, #0) // { arity: 3 }
+  Project (#1, #2, #0) // { arity: 3 }
     Filter (0 = integer_to_bigint(#0)) // { arity: 3 }
-      Map (0, 123) // { arity: 3 }
+      Map (123, 0) // { arity: 3 }
         ReadStorage materialize.public.t1 // { arity: 1 }
 
 Source materialize.public.t1

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -33,8 +33,9 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE t1.f1 = 123 AND t1.f1 = t1.f2
 ----
 Explained Query:
-  Filter (#0 = 123) AND (#0 = #1) // { arity: 2 }
-    ReadStorage materialize.public.t1 // { arity: 2 }
+  Project (#1, #1) // { arity: 2 }
+    Filter (#0 = 123) AND (#0 = #1) // { arity: 2 }
+      ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123) AND (#0 = #1))
@@ -49,15 +50,19 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 , t2 WHERE t1.f1 = 123 AND t1.f1 = t2.f1
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 4 }
-    implementation
-      %0:t1[×]Uef » %1:t2[×]Uef
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t2 // { arity: 2 }
+  Project (#2, #0, #3, #1) // { arity: 4 }
+    Map (123, 123) // { arity: 4 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0:t1[×]Uef » %1:t2[×]Uef
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -76,27 +81,30 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 LEFT JOIN t2 ON (t1.f
 ----
 Explained Query:
   Return // { arity: 4 }
-    Union // { arity: 4 }
-      Map (null, null) // { arity: 4 }
-        Union // { arity: 2 }
-          Negate // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l1 // { arity: 4 }
-          Get l0 // { arity: 2 }
-      Get l1 // { arity: 4 }
+    Project (#3, #0..=#2) // { arity: 4 }
+      Map (123) // { arity: 4 }
+        Union // { arity: 3 }
+          Map (null, null) // { arity: 3 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Get l1 // { arity: 3 }
+              Get l0 // { arity: 1 }
+          Get l1 // { arity: 3 }
   With
     cte l1 =
-      CrossJoin type=differential // { arity: 4 }
+      CrossJoin type=differential // { arity: 3 }
         implementation
           %0:l0[×]Uef » %1:t2[×]Uef
-        ArrangeBy keys=[[]] // { arity: 2 }
-          Get l0 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Get l0 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 2 }
           Filter (#0 = 123) // { arity: 2 }
             ReadStorage materialize.public.t2 // { arity: 2 }
     cte l0 =
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
+      Project (#1) // { arity: 1 }
+        Filter (#0 = 123) // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -112,28 +120,31 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 LEFT JOIN t2 USING (f
 ----
 Explained Query:
   Return // { arity: 3 }
-    Union // { arity: 3 }
-      Map (null) // { arity: 3 }
+    Project (#2, #0, #1) // { arity: 3 }
+      Map (123) // { arity: 3 }
         Union // { arity: 2 }
-          Negate // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l1 // { arity: 3 }
-          Get l0 // { arity: 2 }
-      Get l1 // { arity: 3 }
+          Map (null) // { arity: 2 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Get l1 // { arity: 2 }
+              Get l0 // { arity: 1 }
+          Get l1 // { arity: 2 }
   With
     cte l1 =
-      CrossJoin type=differential // { arity: 3 }
+      CrossJoin type=differential // { arity: 2 }
         implementation
           %0:l0[×]Uef » %1:t2[×]Uef
-        ArrangeBy keys=[[]] // { arity: 2 }
-          Get l0 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Get l0 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#1) // { arity: 1 }
             Filter (#0 = 123) // { arity: 2 }
               ReadStorage materialize.public.t2 // { arity: 2 }
     cte l0 =
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
+      Project (#1) // { arity: 1 }
+        Filter (#0 = 123) // { arity: 2 }
+          ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -148,15 +159,19 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 LEFT JOIN t2 ON (TRUE) WHERE t1.f1 = t2.f1 AND t1.f1 = 123;
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 4 }
-    implementation
-      %0:t1[×]Uef » %1:t2[×]Uef
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t2 // { arity: 2 }
+  Project (#2, #0, #3, #1) // { arity: 4 }
+    Map (123, 123) // { arity: 4 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0:t1[×]Uef » %1:t2[×]Uef
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -173,20 +188,25 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1, t2, t3 WHERE t1.f1 = 123 AND t1.f1 = t2.f1 AND t2.f1 = t3.f1;
 ----
 Explained Query:
-  CrossJoin type=delta // { arity: 6 }
-    implementation
-      %0:t1 » %1:t2[×]Uef » %2:t3[×]Uef
-      %1:t2 » %0:t1[×]Uef » %2:t3[×]Uef
-      %2:t3 » %0:t1[×]Uef » %1:t2[×]Uef
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t2 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t3 // { arity: 2 }
+  Project (#3, #0, #4, #1, #5, #2) // { arity: 6 }
+    Map (123, 123, 123) // { arity: 6 }
+      CrossJoin type=delta // { arity: 3 }
+        implementation
+          %0:t1 » %1:t2[×]Uef » %2:t3[×]Uef
+          %1:t2 » %0:t1[×]Uef » %2:t3[×]Uef
+          %2:t3 » %0:t1[×]Uef » %1:t2[×]Uef
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t3 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -326,16 +346,19 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE t1.f1 = 123 AND EXISTS (SELECT * FROM t2 WHERE t2.f1 = t1.f1);
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 2 }
-    implementation
-      %0:t1[×]Uef » %1:t2[×]Uef
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 0 }
-      Project () // { arity: 0 }
-        Filter (#0 = 123) // { arity: 2 }
-          ReadStorage materialize.public.t2 // { arity: 2 }
+  Project (#1, #0) // { arity: 2 }
+    Map (123) // { arity: 2 }
+      CrossJoin type=differential // { arity: 1 }
+        implementation
+          %0:t1[×]Uef » %1:t2[×]Uef
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -350,22 +373,25 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE t1.f1 = 123 AND EXISTS (SELECT * FROM t2 WHERE t2.f1 = t1.f1) AND EXISTS (SELECT * FROM t3 WHERE t3.f1 = t1.f1);
 ----
 Explained Query:
-  CrossJoin type=delta // { arity: 2 }
-    implementation
-      %0:t1 » %1:t2[×]Uef » %2:t3[×]Uef
-      %1:t2 » %0:t1[×]Uef » %2:t3[×]Uef
-      %2:t3 » %0:t1[×]Uef » %1:t2[×]Uef
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 0 }
-      Project () // { arity: 0 }
-        Filter (#0 = 123) // { arity: 2 }
-          ReadStorage materialize.public.t2 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 0 }
-      Project () // { arity: 0 }
-        Filter (#0 = 123) // { arity: 2 }
-          ReadStorage materialize.public.t3 // { arity: 2 }
+  Project (#1, #0) // { arity: 2 }
+    Map (123) // { arity: 2 }
+      CrossJoin type=delta // { arity: 1 }
+        implementation
+          %0:t1 » %1:t2[×]Uef » %2:t3[×]Uef
+          %1:t2 » %0:t1[×]Uef » %2:t3[×]Uef
+          %2:t3 » %0:t1[×]Uef » %1:t2[×]Uef
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t3 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -382,16 +408,19 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1, (SELECT t2.f1 FROM t2) AS dt1 WHERE dt1.f1 = t1.f1 AND t1.f1 = 123;
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 3 }
-    implementation
-      %0:t1[×]Uef » %1:t2[×]Uef
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 1 }
-      Project (#0) // { arity: 1 }
-        Filter (#0 = 123) // { arity: 2 }
-          ReadStorage materialize.public.t2 // { arity: 2 }
+  Project (#1, #0, #2) // { arity: 3 }
+    Map (123, 123) // { arity: 3 }
+      CrossJoin type=differential // { arity: 1 }
+        implementation
+          %0:t1[×]Uef » %1:t2[×]Uef
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -433,22 +462,25 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE t1.f1 = 123 AND t1.f1 = (SELECT t2.f1 FROM t2);
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 2 }
-    implementation
-      %0:t1[×]Uef » %1[×]ef
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 0 }
-      Union // { arity: 0 }
-        Project () // { arity: 0 }
-          Filter (#0 = 123) // { arity: 2 }
-            ReadStorage materialize.public.t2 // { arity: 2 }
-        Project () // { arity: 0 }
-          Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-            Reduce aggregates=[count(*)] // { arity: 1 }
-              Project () // { arity: 0 }
+  Project (#1, #0) // { arity: 2 }
+    Map (123) // { arity: 2 }
+      CrossJoin type=differential // { arity: 1 }
+        implementation
+          %0:t1[×]Uef » %1[×]ef
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Union // { arity: 0 }
+            Project () // { arity: 0 }
+              Filter (#0 = 123) // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
+            Project () // { arity: 0 }
+              Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+                Reduce aggregates=[count(*)] // { arity: 1 }
+                  Project () // { arity: 0 }
+                    ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -547,15 +579,18 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT * FROM t1, t2 WHERE t1.f1 = 123 AND t1.f1 > t2.f1;
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 4 }
-    implementation
-      %0:t1[×]Uef » %1:t2[×]eif
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 123) // { arity: 2 }
-        ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (123 > #0) // { arity: 2 }
-        ReadStorage materialize.public.t2 // { arity: 2 }
+  Project (#3, #0..=#2) // { arity: 4 }
+    Map (123) // { arity: 4 }
+      CrossJoin type=differential // { arity: 3 }
+        implementation
+          %0:t1[×]Uef » %1:t2[×]eif
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 123) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Filter (123 > #0) // { arity: 2 }
+            ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -632,8 +667,9 @@ SELECT f1, f2, f1 + f2 FROM c0;
 ----
 Explained Query:
   Return // { arity: 3, types: "(integer, integer, integer)" }
-    Map (8) // { arity: 3, types: "(integer, integer, integer)" }
-      Get l0 // { arity: 2, types: "(integer, integer)" }
+    Project (#2..=#4) // { arity: 3, types: "(integer, integer, integer)" }
+      Map (3, 5, 8) // { arity: 5, types: "(integer, integer, integer, integer, integer)" }
+        Get l0 // { arity: 2, types: "(integer, integer)" }
   With Mutually Recursive
     cte l0 =
       Map (3, 5) // { arity: 2, types: "(integer, integer)" }
@@ -673,8 +709,9 @@ SELECT f1, f2, f1 + f2 FROM c0;
 ----
 Explained Query:
   Return // { arity: 3, types: "(integer, integer, integer)" }
-    Map (8) // { arity: 3, types: "(integer, integer, integer)" }
-      Get l0 // { arity: 2, types: "(integer, integer)" }
+    Project (#2..=#4) // { arity: 3, types: "(integer, integer, integer)" }
+      Map (3, 5, 8) // { arity: 5, types: "(integer, integer, integer, integer, integer)" }
+        Get l0 // { arity: 2, types: "(integer, integer)" }
   With Mutually Recursive [recursion_limit=1]
     cte l0 =
       Map (3, 5) // { arity: 2, types: "(integer, integer)" }
@@ -775,7 +812,9 @@ SELECT * FROM c0;
 ----
 Explained Query:
   Return // { arity: 3, types: "(integer, integer?, integer?)" }
-    Get l1 // { arity: 3, types: "(integer, integer?, integer?)" }
+    Project (#3, #1, #2) // { arity: 3, types: "(integer, integer?, integer?)" }
+      Map (2) // { arity: 4, types: "(integer, integer?, integer?, integer)" }
+        Get l1 // { arity: 3, types: "(integer, integer?, integer?)" }
   With Mutually Recursive
     cte l1 =
       Project (#2, #0, #1) // { arity: 3, types: "(integer, integer?, integer?)" }
@@ -828,7 +867,9 @@ SELECT * FROM c0;
 ----
 Explained Query:
   Return // { arity: 3, types: "(boolean, integer?, integer?)" }
-    Get l1 // { arity: 3, types: "(boolean, integer?, integer?)" }
+    Project (#3, #1, #2) // { arity: 3, types: "(boolean, integer?, integer?)" }
+      Map (false) // { arity: 4, types: "(boolean, integer?, integer?, boolean)" }
+        Get l1 // { arity: 3, types: "(boolean, integer?, integer?)" }
   With Mutually Recursive
     cte l1 =
       Project (#2, #0, #1) // { arity: 3, types: "(boolean, integer?, integer?)" }

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -77,15 +77,18 @@ query T multiline
 explain with(arity, join implementations) select * from foo, bar where foo.a = abs(bar.a) and foo.a = 3
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 6 }
-    implementation
-      %0:foo[×]ef » %1:bar[×]ef
-    ArrangeBy keys=[[]] // { arity: 3 }
-      Filter (#0 = 3) // { arity: 3 }
-        ReadStorage materialize.public.foo // { arity: 3 }
-    ArrangeBy keys=[[]] // { arity: 3 }
-      Filter (3 = abs(#0)) // { arity: 3 }
-        ReadStorage materialize.public.bar // { arity: 3 }
+  Project (#5, #0..=#4) // { arity: 6 }
+    Map (3) // { arity: 6 }
+      CrossJoin type=differential // { arity: 5 }
+        implementation
+          %0:foo[×]ef » %1:bar[×]ef
+        ArrangeBy keys=[[]] // { arity: 2 }
+          Project (#1, #2) // { arity: 2 }
+            Filter (#0 = 3) // { arity: 3 }
+              ReadStorage materialize.public.foo // { arity: 3 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Filter (3 = abs(#0)) // { arity: 3 }
+            ReadStorage materialize.public.bar // { arity: 3 }
 
 Source materialize.public.foo
   filter=((#0 = 3))

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -249,21 +249,22 @@ EXPLAIN WITH(arity, join implementations) SELECT *
 ----
 Explained Query:
   Return // { arity: 15 }
-    Project (#0..=#9, #4, #5, #12..=#14) // { arity: 15 }
-      Join on=(#4 = #10 AND #5 = #11) type=delta // { arity: 15 }
-        implementation
-          %0:lineitem » %1:orders[#2, #3]KKe » %2:customer[×]e
-          %1:orders » %0:lineitem[#4, #5]KKf » %2:customer[×]e
-          %2:customer » %1:orders[×]e » %0:lineitem[#4, #5]KKf
-        ArrangeBy keys=[[#4, #5]] // { arity: 8 }
-          Filter (date_to_timestamp(#7) = (#5 + 6 days)) // { arity: 8 }
-            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 8 }
-        ArrangeBy keys=[[], [#2, #3]] // { arity: 4 }
-          Project (#0..=#3) // { arity: 4 }
-            ReadIndex on=materialize.public.orders fk_orders_custkey=[lookup values=<Get l0>] // { arity: 5 }
-        ArrangeBy keys=[[]] // { arity: 3 }
-          Project (#0..=#2) // { arity: 3 }
-            ReadIndex on=materialize.public.customer pk_customer_custkey=[lookup values=<Get l0>] // { arity: 4 }
+    Project (#0..=#8, #13, #4, #5, #14, #11, #12) // { arity: 15 }
+      Map (229, 229) // { arity: 15 }
+        Join on=(#4 = #9 AND #5 = #10) type=delta // { arity: 13 }
+          implementation
+            %0:lineitem » %1:orders[#1, #2]KKe » %2:customer[×]e
+            %1:orders » %0:lineitem[#4, #5]KKf » %2:customer[×]e
+            %2:customer » %1:orders[×]e » %0:lineitem[#4, #5]KKf
+          ArrangeBy keys=[[#4, #5]] // { arity: 8 }
+            Filter (date_to_timestamp(#7) = (#5 + 6 days)) // { arity: 8 }
+              ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 8 }
+          ArrangeBy keys=[[], [#1, #2]] // { arity: 3 }
+            Project (#0, #2, #3) // { arity: 3 }
+              ReadIndex on=materialize.public.orders fk_orders_custkey=[lookup values=<Get l0>] // { arity: 5 }
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Project (#1, #2) // { arity: 2 }
+              ReadIndex on=materialize.public.customer pk_customer_custkey=[lookup values=<Get l0>] // { arity: 4 }
   With
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 1 }

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -35,15 +35,19 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select * from foo inner join bar on foo.a = bar.a where foo.a = 1
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 4 }
-    implementation
-      %0:foo[×]ef » %1:bar[×]ef
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 1) // { arity: 2 }
-        ReadStorage materialize.public.foo // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 1) // { arity: 2 }
-        ReadStorage materialize.public.bar // { arity: 2 }
+  Project (#2, #0, #3, #1) // { arity: 4 }
+    Map (1, 1) // { arity: 4 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0:foo[×]ef » %1:bar[×]ef
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 1) // { arity: 2 }
+              ReadStorage materialize.public.foo // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 1) // { arity: 2 }
+              ReadStorage materialize.public.bar // { arity: 2 }
 
 Source materialize.public.foo
   filter=((#0 = 1))
@@ -104,15 +108,19 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select * from (select * from foo where a = 1) filtered_foo, bar where filtered_foo.a = bar.a
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 4 }
-    implementation
-      %0:foo[×]ef » %1:bar[×]ef
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 1) // { arity: 2 }
-        ReadStorage materialize.public.foo // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#0 = 1) // { arity: 2 }
-        ReadStorage materialize.public.bar // { arity: 2 }
+  Project (#2, #0, #3, #1) // { arity: 4 }
+    Map (1, 1) // { arity: 4 }
+      CrossJoin type=differential // { arity: 2 }
+        implementation
+          %0:foo[×]ef » %1:bar[×]ef
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 1) // { arity: 2 }
+              ReadStorage materialize.public.foo // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Filter (#0 = 1) // { arity: 2 }
+              ReadStorage materialize.public.bar // { arity: 2 }
 
 Source materialize.public.foo
   filter=((#0 = 1))
@@ -696,19 +704,20 @@ t0.s LIKE 'a%'
 ;
 ----
 Explained Query:
-  Project (#0..=#14, #0, #16..=#27, #29, #30, #0, #32..=#42) // { arity: 42 }
-    Filter like["a%"](#13) // { arity: 43 }
-      Join on=(#0 = #15 = #31) type=delta // { arity: 43 }
-        implementation
-          %0:big » %1:big[#1]KAe » %2:big[#2]KA
-          %1:big » %0:big[#0]KAlf » %2:big[#2]KA
-          %2:big » %1:big[#1]KAe » %0:big[#0]KAlf
-        ArrangeBy keys=[[#0]] // { arity: 14 }
-          ReadIndex on=big big_idx_a=[delta join 1st input (full scan)] // { arity: 14 }
-        ArrangeBy keys=[[#1]] // { arity: 15 }
-          ReadIndex on=materialize.public.big big_idx_y=[lookup value=(42)] // { arity: 15 }
-        ArrangeBy keys=[[#2]] // { arity: 14 }
-          ReadIndex on=big big_idx_c=[delta join lookup] // { arity: 14 }
+  Project (#0..=#14, #0, #16..=#25, #43, #27, #29, #30, #0, #32..=#42) // { arity: 42 }
+    Filter like["a%"](#13) // { arity: 44 }
+      Map (42) // { arity: 44 }
+        Join on=(#0 = #15 = #31) type=delta // { arity: 43 }
+          implementation
+            %0:big » %1:big[#1]KAe » %2:big[#2]KA
+            %1:big » %0:big[#0]KAlf » %2:big[#2]KA
+            %2:big » %1:big[#1]KAe » %0:big[#0]KAlf
+          ArrangeBy keys=[[#0]] // { arity: 14 }
+            ReadIndex on=big big_idx_a=[delta join 1st input (full scan)] // { arity: 14 }
+          ArrangeBy keys=[[#1]] // { arity: 15 }
+            ReadIndex on=materialize.public.big big_idx_y=[lookup value=(42)] // { arity: 15 }
+          ArrangeBy keys=[[#2]] // { arity: 14 }
+            ReadIndex on=big big_idx_c=[delta join lookup] // { arity: 14 }
 
 Used Indexes:
   - materialize.public.big_idx_a (delta join 1st input (full scan))

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -911,22 +911,24 @@ query T multiline
 explain with(arity, join implementations) select * from t1 as a1 join t1 as a2 on (a2.f2 = (select 6 from t1)) where a2.f2 = 9;
 ----
 Explained Query:
-  CrossJoin type=delta // { arity: 4 }
-    implementation
-      %0:t1 » %2[×]U » %1:t1[×]ef
-      %1:t1 » %2[×]U » %0:t1[×]
-      %2 » %1:t1[×]ef » %0:t1[×]
-    ArrangeBy keys=[[]] // { arity: 2 }
-      ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Filter (#1 = 9) // { arity: 2 }
+  Map (9) // { arity: 4 }
+    CrossJoin type=delta // { arity: 3 }
+      implementation
+        %0:t1 » %2[×]U » %1:t1[×]ef
+        %1:t1 » %2[×]U » %0:t1[×]
+        %2 » %1:t1[×]ef » %0:t1[×]
+      ArrangeBy keys=[[]] // { arity: 2 }
         ReadStorage materialize.public.t1 // { arity: 2 }
-    ArrangeBy keys=[[]] // { arity: 0 }
-      Project () // { arity: 0 }
-        Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-          Reduce aggregates=[count(*)] // { arity: 1 }
-            Project () // { arity: 0 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Filter (#1 = 9) // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+      ArrangeBy keys=[[]] // { arity: 0 }
+        Project () // { arity: 0 }
+          Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+            Reduce aggregates=[count(*)] // { arity: 1 }
+              Project () // { arity: 0 }
+                ReadStorage materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
 

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -793,15 +793,16 @@ WHERE
     t1.b = 'l2'
 ----
 Explained Query:
-  Project (#0, #1, #5) // { arity: 3 }
-    Filter (#0) IS NOT NULL // { arity: 6 }
-      Join on=(#0 = #3) type=differential // { arity: 6 }
-        implementation
-          %0:t1[#0]KAe » %1:t2[#0]KAe
-        ArrangeBy keys=[[#0]] // { arity: 3 }
-          ReadIndex on=materialize.public.t1 idx_t1_b=[lookup value=("l2")] // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 3 }
-          ReadIndex on=t2 idx_t2_a=[differential join] // { arity: 3 }
+  Project (#0, #6, #5) // { arity: 3 }
+    Filter (#0) IS NOT NULL // { arity: 7 }
+      Map ("l2") // { arity: 7 }
+        Join on=(#0 = #3) type=differential // { arity: 6 }
+          implementation
+            %0:t1[#0]KAe » %1:t2[#0]KAe
+          ArrangeBy keys=[[#0]] // { arity: 3 }
+            ReadIndex on=materialize.public.t1 idx_t1_b=[lookup value=("l2")] // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 3 }
+            ReadIndex on=t2 idx_t2_a=[differential join] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.idx_t2_a (differential join)
@@ -832,15 +833,17 @@ WHERE
     t1.a = 2 AND t1.b = 'l2'
 ----
 Explained Query:
-  CrossJoin type=differential // { arity: 3 }
-    implementation
-      %0:t1[×]e » %1:t2[×]e
-    ArrangeBy keys=[[]] // { arity: 2 }
-      Project (#0, #1) // { arity: 2 }
-        ReadIndex on=materialize.public.t1 idx_t1_a_b=[lookup value=(2, "l2")] // { arity: 4 }
-    ArrangeBy keys=[[]] // { arity: 1 }
-      Project (#2) // { arity: 1 }
-        ReadIndex on=materialize.public.t2 idx_t2_a=[lookup value=(2)] // { arity: 4 }
+  Project (#1, #2, #0) // { arity: 3 }
+    Map (2, "l2") // { arity: 3 }
+      CrossJoin type=differential // { arity: 1 }
+        implementation
+          %0:t1[×]e » %1:t2[×]e
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
+            ReadIndex on=materialize.public.t1 idx_t1_a_b=[lookup value=(2, "l2")] // { arity: 4 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#2) // { arity: 1 }
+            ReadIndex on=materialize.public.t2 idx_t2_a=[lookup value=(2)] // { arity: 4 }
 
 Used Indexes:
   - materialize.public.idx_t1_a_b (lookup)

--- a/test/sqllogictest/transform/literal_lifting.slt
+++ b/test/sqllogictest/transform/literal_lifting.slt
@@ -34,7 +34,9 @@ SELECT * FROM c0
 ----
 Explained Query:
   Return // { arity: 2 }
-    Get l0 // { arity: 2 }
+    Project (#0, #2) // { arity: 2 }
+      Map (42) // { arity: 3 }
+        Get l0 // { arity: 2 }
   With Mutually Recursive
     cte l0 =
       Map (42) // { arity: 2 }
@@ -73,10 +75,11 @@ SELECT * FROM c0 UNION ALL SELECT * FROM c1
 ----
 Explained Query:
   Return // { arity: 2 }
-    Union // { arity: 2 }
-      Map (42) // { arity: 2 }
+    Map (42) // { arity: 2 }
+      Union // { arity: 1 }
         Get l0 // { arity: 1 }
-      Get l1 // { arity: 2 }
+        Project (#0) // { arity: 1 }
+          Get l1 // { arity: 2 }
   With Mutually Recursive
     cte l1 =
       Map (42) // { arity: 2 }

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -18,7 +18,9 @@ SELECT * FROM bar;
 ----
 Explained Query:
   Return
-    Get l0
+    Project (#1)
+      Map (1)
+        Get l0
   With Mutually Recursive
     cte l0 =
       Project (#1)

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -21,9 +21,10 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) SELECT b FROM (SELECT b, not(b) as neg FROM x) WHERE NOT(neg)
 ----
 Explained Query:
-  Project (#2) // { arity: 1 }
-    Filter #2 // { arity: 3 }
-      ReadStorage materialize.public.x // { arity: 3 }
+  Project (#3) // { arity: 1 }
+    Filter #2 // { arity: 4 }
+      Map (true) // { arity: 4 }
+        ReadStorage materialize.public.x // { arity: 3 }
 
 Source materialize.public.x
   filter=(#2)
@@ -136,14 +137,15 @@ EXPLAIN WITH(arity, join implementations)
 SELECT a FROM (SELECT DISTINCT a FROM x UNION ALL SELECT a FROM y) WHERE a = 3
 ----
 Explained Query:
-  Union // { arity: 1 }
-    Map (3) // { arity: 1 }
+  Map (3) // { arity: 1 }
+    Union // { arity: 0 }
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Filter (#0 = 3) // { arity: 3 }
             ReadStorage materialize.public.x // { arity: 3 }
-    Filter (#0 = 3) // { arity: 1 }
-      ReadStorage materialize.public.y // { arity: 1 }
+      Project () // { arity: 0 }
+        Filter (#0 = 3) // { arity: 1 }
+          ReadStorage materialize.public.y // { arity: 1 }
 
 Source materialize.public.x
   filter=((#0 = 3))

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -82,15 +82,17 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 AS a1 , t1 AS a2 WHER
 ----
 Explained Query:
   Return // { arity: 4 }
-    CrossJoin type=differential // { arity: 4 }
-      implementation
-        %0:l0[×]e » %1:l0[×]e
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
+    Project (#2, #0, #3, #1) // { arity: 4 }
+      Map (1, 1) // { arity: 4 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0:l0[×]e » %1:l0[×]e
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
   With
     cte l0 =
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#1) // { arity: 1 }
           ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
@@ -105,18 +107,20 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 AS a1 , t1 AS a2, t1 
 ----
 Explained Query:
   Return // { arity: 6 }
-    CrossJoin type=delta // { arity: 6 }
-      implementation
-        %0:l0 » %1:l0[×]e » %2:l0[×]e
-        %1:l0 » %0:l0[×]e » %2:l0[×]e
-        %2:l0 » %0:l0[×]e » %1:l0[×]e
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
+    Project (#3, #0, #4, #1, #5, #2) // { arity: 6 }
+      Map (1, 1, 1) // { arity: 6 }
+        CrossJoin type=delta // { arity: 3 }
+          implementation
+            %0:l0 » %1:l0[×]e » %2:l0[×]e
+            %1:l0 » %0:l0[×]e » %2:l0[×]e
+            %2:l0 » %0:l0[×]e » %1:l0[×]e
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
   With
     cte l0 =
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#1) // { arity: 1 }
           ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
@@ -135,18 +139,18 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 AS a1 LEFT JOIN t1 AS
 ----
 Explained Query:
   Return // { arity: 3 }
-    CrossJoin type=differential // { arity: 3 }
-      implementation
-        %0:l0[×]e » %1:l0[×]e
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          Get l0 // { arity: 3 }
-      ArrangeBy keys=[[]] // { arity: 1 }
-        Project (#1) // { arity: 1 }
-          Get l0 // { arity: 3 }
+    Project (#2, #0, #1) // { arity: 3 }
+      Map (1) // { arity: 3 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0:l0[×]e » %1:l0[×]e
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
   With
     cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#1) // { arity: 1 }
+          ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -322,15 +326,17 @@ ON TRUE
 ----
 Explained Query:
   Return // { arity: 4 }
-    CrossJoin type=differential // { arity: 4 }
-      implementation
-        %0:l0[×]e » %1:l0[×]e
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
+    Project (#2, #0, #3, #1) // { arity: 4 }
+      Map (1, 1) // { arity: 4 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0:l0[×]e » %1:l0[×]e
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
   With
     cte l0 =
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+      ArrangeBy keys=[[]] // { arity: 1 }
+        Project (#1) // { arity: 1 }
           ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
@@ -349,15 +355,16 @@ AND a2.f2 = 2
 ----
 Explained Query:
   Return // { arity: 4 }
-    CrossJoin type=differential // { arity: 4 }
-      implementation
-        %0:l0[×]ef » %1:l0[×]ef
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
+    Map (1, 2, 1, 2) // { arity: 4 }
+      CrossJoin type=differential // { arity: 0 }
+        implementation
+          %0:l0[×]ef » %1:l0[×]ef
+        Get l0 // { arity: 0 }
+        Get l0 // { arity: 0 }
   With
     cte l0 =
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
+      ArrangeBy keys=[[]] // { arity: 0 }
+        Project () // { arity: 0 }
           Filter (#1 = 2) // { arity: 3 }
             ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
@@ -378,17 +385,18 @@ AND a2.f2 = 3
 ----
 Explained Query:
   Return // { arity: 4 }
-    CrossJoin type=differential // { arity: 4 }
-      implementation
-        %0:l0[×]ef » %1:l0[×]ef
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          Filter (#1 = 2) // { arity: 3 }
-            Get l0 // { arity: 3 }
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          Filter (#1 = 3) // { arity: 3 }
-            Get l0 // { arity: 3 }
+    Map (1, 2, 1, 3) // { arity: 4 }
+      CrossJoin type=differential // { arity: 0 }
+        implementation
+          %0:l0[×]ef » %1:l0[×]ef
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
+            Filter (#1 = 2) // { arity: 3 }
+              Get l0 // { arity: 3 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
+            Filter (#1 = 3) // { arity: 3 }
+              Get l0 // { arity: 3 }
   With
     cte l0 =
       ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
@@ -409,13 +417,15 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 WHERE f1 = 1 UNION AL
 ----
 Explained Query:
   Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
+    Project (#1, #0) // { arity: 2 }
+      Map (1) // { arity: 2 }
+        Union // { arity: 1 }
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
   With
     cte l0 =
-      Project (#0, #1) // { arity: 2 }
+      Project (#1) // { arity: 1 }
         ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
@@ -795,27 +805,22 @@ WHERE s1.f1 = 1 AND s2.f1 = 1
 ----
 Explained Query:
   Return // { arity: 2 }
-    CrossJoin type=delta // { arity: 2 }
-      implementation
-        %0:l1 » %1:l2[×]e » %2:l1[×]e » %3:l2[×]e
-        %1:l2 » %0:l1[×]e » %2:l1[×]e » %3:l2[×]e
-        %2:l1 » %0:l1[×]e » %1:l2[×]e » %3:l2[×]e
-        %3:l2 » %0:l1[×]e » %1:l2[×]e » %2:l1[×]e
-      Get l1 // { arity: 0 }
-      Get l2 // { arity: 1 }
-      Get l1 // { arity: 0 }
-      Get l2 // { arity: 1 }
+    Map (1, 1) // { arity: 2 }
+      CrossJoin type=delta // { arity: 0 }
+        implementation
+          %0:l0 » %1:l0[×]e » %2:l0[×]e » %3:l0[×]e
+          %1:l0 » %0:l0[×]e » %2:l0[×]e » %3:l0[×]e
+          %2:l0 » %0:l0[×]e » %1:l0[×]e » %3:l0[×]e
+          %3:l0 » %0:l0[×]e » %1:l0[×]e » %2:l0[×]e
+        Get l0 // { arity: 0 }
+        Get l0 // { arity: 0 }
+        Get l0 // { arity: 0 }
+        Get l0 // { arity: 0 }
   With
-    cte l2 =
-      ArrangeBy keys=[[]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l0 // { arity: 3 }
-    cte l1 =
+    cte l0 =
       ArrangeBy keys=[[]] // { arity: 0 }
         Project () // { arity: 0 }
-          Get l0 // { arity: 3 }
-    cte l0 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+          ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
   - materialize.public.i1 (lookup)
@@ -833,29 +838,26 @@ WHERE s1.f1 = 1 AND s2.f1 = 2
 ----
 Explained Query:
   Return // { arity: 2 }
-    CrossJoin type=delta // { arity: 2 }
-      implementation
-        %0:l1 » %1:l1[×]e » %2:l2[×]e » %3:l2[×]e
-        %1:l1 » %0:l1[×]e » %2:l2[×]e » %3:l2[×]e
-        %2:l2 » %0:l1[×]e » %1:l1[×]e » %3:l2[×]e
-        %3:l2 » %0:l1[×]e » %1:l1[×]e » %2:l2[×]e
-      ArrangeBy keys=[[]] // { arity: 0 }
-        Project () // { arity: 0 }
-          Get l1 // { arity: 3 }
-      ArrangeBy keys=[[]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l1 // { arity: 3 }
-      ArrangeBy keys=[[]] // { arity: 0 }
-        Project () // { arity: 0 }
-          Get l2 // { arity: 3 }
-      ArrangeBy keys=[[]] // { arity: 1 }
-        Project (#0) // { arity: 1 }
-          Get l2 // { arity: 3 }
+    Map (1, 2) // { arity: 2 }
+      CrossJoin type=delta // { arity: 0 }
+        implementation
+          %0:l1 » %1:l1[×]e » %2:l2[×]e » %3:l2[×]e
+          %1:l1 » %0:l1[×]e » %2:l2[×]e » %3:l2[×]e
+          %2:l2 » %0:l1[×]e » %1:l1[×]e » %3:l2[×]e
+          %3:l2 » %0:l1[×]e » %1:l1[×]e » %2:l2[×]e
+        Get l1 // { arity: 0 }
+        Get l1 // { arity: 0 }
+        Get l2 // { arity: 0 }
+        Get l2 // { arity: 0 }
   With
     cte l2 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
+      ArrangeBy keys=[[]] // { arity: 0 }
+        Project () // { arity: 0 }
+          ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
     cte l1 =
-      ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+      ArrangeBy keys=[[]] // { arity: 0 }
+        Project () // { arity: 0 }
+          ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 2 }
         ReadIndex on=t1 i1=[lookup] // { arity: 2 }
@@ -879,12 +881,13 @@ SELECT * FROM t1 WHERE f1 = 1 AND f2 = 2
 ----
 Explained Query:
   Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
+    Map (1, 2) // { arity: 2 }
+      Union // { arity: 0 }
+        Get l0 // { arity: 0 }
+        Get l0 // { arity: 0 }
   With
     cte l0 =
-      Project (#0, #1) // { arity: 2 }
+      Project () // { arity: 0 }
         Filter (#1 = 2) // { arity: 3 }
           ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
@@ -1174,14 +1177,16 @@ UNION ALL
 ----
 Explained Query:
   Return // { arity: 2 }
-    Union // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
-      Get l0 // { arity: 2 }
+    Project (#1, #0) // { arity: 2 }
+      Map (1) // { arity: 2 }
+        Union // { arity: 1 }
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
   With
     cte l0 =
-      Project (#0, #1) // { arity: 2 }
+      Project (#1) // { arity: 1 }
         ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
 Used Indexes:
@@ -1363,15 +1368,17 @@ EXPLAIN WITH(arity, join implementations) SELECT * FROM t1 AS a1, t1 AS a2 WHERE
 ----
 Explained Query:
   Return // { arity: 4 }
-    CrossJoin type=differential // { arity: 4 }
-      implementation
-        %0:t1[×]e » %1:t1[×]e
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
+    Project (#2, #0, #3, #1) // { arity: 4 }
+      Map (1, 2) // { arity: 4 }
+        CrossJoin type=differential // { arity: 2 }
+          implementation
+            %0:t1[×]e » %1:t1[×]e
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              ReadIndex on=materialize.public.t1 i1=[lookup value=(2)] // { arity: 3 }
   With
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 2 }


### PR DESCRIPTION
Columns that are known to be literals aren't actually needed, but there are situations where we use the column nonetheless. For example, the root of a query "uses" all columns, although some may be known to be literals. By capping expressions with a map and project that introduce literals and project away the columns known to be literals, we remove the unintended "demand" for the columns, and may allow them to be projected away earlier in the AST.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
