### PR TITLE
Shadow columns equal to a literal with that literal

### DIFF
--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -68,6 +68,39 @@ impl crate::Transform for EquivalencePropagation {
             &mut get_equivalences,
         );
 
+        // Literal columns at the root can be projected away and replaced with a constant.
+        // This removes an apparent demand for the column, and may allow the column to be pruned.
+        // We should follow with MFP normalization, as we may be stacking the MFP to implement
+        // this action atop the same MFP only recently installed, and we needn't duplicate it.
+        let arity = *derived.value::<Arity>().expect("Arity required");
+        let equivs = derived
+            .value::<Equivalences>()
+            .expect("Equivalences required");
+        let mut literal_columns = Vec::new();
+        if let Some(equivs) = equivs {
+            for column in 0..arity {
+                let mut expr = MirScalarExpr::Column(column);
+                equivs.reduce_expr(&mut expr);
+                if expr.is_literal() {
+                    literal_columns.push((column, expr));
+                }
+            }
+        }
+        // The result can be a bit messy, and in particular may have MFPs in a `Let::body` that we don't want to compound.
+        if !literal_columns.is_empty() {
+            let mut columns = (0..arity).collect::<Vec<_>>();
+            for (index, (column, _)) in literal_columns.iter().enumerate() {
+                columns[*column] = arity + index;
+            }
+            let scalars = literal_columns
+                .into_iter()
+                .map(|(_column, expr)| expr)
+                .collect::<Vec<_>>();
+            *relation = relation.take_dangerous().map(scalars).project(columns);
+            crate::normalize_lets::normalize_lets(relation, ctx.features)?;
+            crate::canonicalize_mfp::CanonicalizeMfp.action(relation)?;
+        }
+
         mz_repr::explain::trace_plan(&*relation);
         Ok(())
     }


### PR DESCRIPTION
Columns that are equivalent to a literal can be replaced by that literal. Often we do this explicitly, in expressions that reference the column. However, there are other contexts where columns are used implicitly, for example the returned columns. By replacing those columns with the literals themselves, we remove the demand for the column and allow it to be projected away earlier.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
