### PR TITLE
adapter: default Kafka sink compression to LZ4

### DIFF
--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -65,7 +65,7 @@ _item&lowbar;name_ | The name of the source, table or materialized view you want
 Field                               | Value  | Description
 ------------------------------------|--------|------------
 `TOPIC`                             | `text`              | The name of the Kafka topic to write to.
-`COMPRESSION TYPE`                  | `text`              | The type of compression to apply to messages before they are sent to Kafka: `none`, `gzip`, `snappy`, `lz4`, or `zstd`.<br>Default: `none`.
+`COMPRESSION TYPE`                  | `text`              | The type of compression to apply to messages before they are sent to Kafka: `none`, `gzip`, `snappy`, `lz4`, or `zstd`.<br>Default: {{< if-unreleased "v0.112" >}}`none`{{< /if-unreleased >}}{{< if-released "v0.112" >}}`lz4`{{< /if-released >}}
 `TRANSACTIONAL ID PREFIX`           | `text`              | The prefix of the transactional ID to use when producing to the Kafka topic.<br>Default: `materialize-{REGION ID}-{CONNECTION ID}-{SINK ID}`.
 `PROGRESS GROUP ID PREFIX`          | `text`              | The prefix of the consumer group ID to use when reading from the progress topic.<br>Default: `materialize-{REGION ID}-{CONNECTION ID}-{SINK ID}`.
 `TOPIC REPLICATION FACTOR`          | `int`               | The replication factor to use when creating the Kafka topic (if the Kafka topic does not already exist).<br>Default: Broker's default.

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -49,7 +49,7 @@ generate_extracted_config!(
     (
         CompressionType,
         KafkaSinkCompressionType,
-        Default(KafkaSinkCompressionType::None)
+        Default(KafkaSinkCompressionType::Lz4)
     ),
     (ProgressGroupIdPrefix, String),
     (TransactionalIdPrefix, String),

--- a/test/legacy-upgrade/check-from-v0.111.0-kafka-sink.td
+++ b/test/legacy-upgrade/check-from-v0.111.0-kafka-sink.td
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-from-sql var=expected-compression-implicit-create-sql
+SELECT sql FROM expected_compression_implicit_create_sql
+
+> SHOW CREATE SINK compression_implicit;
+"materialize.public.compression_implicit" ${expected-compression-implicit-create-sql}
+
+> SHOW CREATE SINK compression_none_explicit;
+"materialize.public.compression_none_explicit" "CREATE SINK \"materialize\".\"public\".\"compression_none_explicit\" IN CLUSTER \"quickstart\" FROM \"materialize\".\"public\".\"kafka_sink_from\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'kafka-sink', COMPRESSION TYPE = 'none') FORMAT JSON ENVELOPE DEBEZIUM WITH (PARTITION STRATEGY = 'v0')"
+
+> SHOW CREATE SINK compression_lz4_explicit;
+"materialize.public.compression_lz4_explicit" "CREATE SINK \"materialize\".\"public\".\"compression_lz4_explicit\" IN CLUSTER \"quickstart\" FROM \"materialize\".\"public\".\"kafka_sink_from\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'kafka-sink', COMPRESSION TYPE = 'lz4') FORMAT JSON ENVELOPE DEBEZIUM WITH (PARTITION STRATEGY = 'v0')"
+
+> SHOW CREATE SINK compression_gzip_explicit;
+"materialize.public.compression_gzip_explicit" "CREATE SINK \"materialize\".\"public\".\"compression_gzip_explicit\" IN CLUSTER \"quickstart\" FROM \"materialize\".\"public\".\"kafka_sink_from\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'kafka-sink', COMPRESSION TYPE = 'gzip') FORMAT JSON ENVELOPE DEBEZIUM WITH (PARTITION STRATEGY = 'v0')"

--- a/test/legacy-upgrade/create-in-v0.111.0-kafka-sink.td
+++ b/test/legacy-upgrade/create-in-v0.111.0-kafka-sink.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (
+    BROKER '${testdrive.kafka-addr}',
+    SECURITY PROTOCOL PLAINTEXT
+  )
+
+> CREATE TABLE IF NOT EXISTS kafka_sink_from (a int)
+
+> CREATE SINK compression_implicit FROM kafka_sink_from
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-sink')
+  FORMAT JSON
+  ENVELOPE DEBEZIUM
+
+> CREATE TABLE expected_compression_implicit_create_sql (sql text)
+>[version<11200] INSERT INTO expected_compression_implicit_create_sql
+  VALUES ('CREATE SINK "materialize"."public"."compression_implicit" IN CLUSTER "quickstart" FROM "materialize"."public"."kafka_sink_from" INTO KAFKA CONNECTION "materialize"."public"."kafka_conn" (TOPIC = ''kafka-sink'', COMPRESSION TYPE = ''none'') FORMAT JSON ENVELOPE DEBEZIUM WITH (PARTITION STRATEGY = ''v0'')')
+>[version>=11200] INSERT INTO expected_compression_implicit_create_sql
+  VALUES ('CREATE SINK "materialize"."public"."compression_implicit" IN CLUSTER "quickstart" FROM "materialize"."public"."kafka_sink_from" INTO KAFKA CONNECTION "materialize"."public"."kafka_conn" (TOPIC = ''kafka-sink'') FORMAT JSON ENVELOPE DEBEZIUM WITH (PARTITION STRATEGY = ''v0'')')
+
+> CREATE SINK compression_none_explicit FROM kafka_sink_from
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-sink', COMPRESSION TYPE = 'none')
+  FORMAT JSON
+  ENVELOPE DEBEZIUM
+
+> CREATE SINK compression_lz4_explicit FROM kafka_sink_from
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-sink', COMPRESSION TYPE = 'lz4')
+  FORMAT JSON
+  ENVELOPE DEBEZIUM
+
+> CREATE SINK compression_gzip_explicit FROM kafka_sink_from
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-sink', COMPRESSION TYPE = 'gzip')
+  FORMAT JSON
+  ENVELOPE DEBEZIUM

--- a/test/testdrive/kafka-compression.td
+++ b/test/testdrive/kafka-compression.td
@@ -99,10 +99,10 @@ world
   FORMAT JSON ENVELOPE UPSERT
 contains:invalid COMPRESSION TYPE: pied-piper
 
-> CREATE CLUSTER none_sink_implicit_cluster SIZE '${arg.default-storage-size}';
+> CREATE CLUSTER lz4_sink_implicit_cluster SIZE '${arg.default-storage-size}';
 
-> CREATE SINK none_sink_implicit
-  IN CLUSTER none_sink_implicit_cluster
+> CREATE SINK lz4_sink_implicit
+  IN CLUSTER lz4_sink_implicit_cluster
   FROM feed
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-compression', COMPRESSION TYPE 'none')
   KEY (a) NOT ENFORCED
@@ -156,7 +156,7 @@ contains:invalid COMPRESSION TYPE: pied-piper
 # The Kafka APIs do not make it possible to assess whether the compression
 # actually took place, so we settle for just validating that the data is
 # readable.
-$ kafka-verify-data format=json key=false sink=materialize.public.none_sink_implicit
+$ kafka-verify-data format=json key=false sink=materialize.public.lz4_sink_implicit
 {"a": "hello"}
 {"a": "world"}
 {"a": "hello"}


### PR DESCRIPTION
Per Confluent best practice and user request.

This patch is a bit complicated so that we can preserve the existing
`COMPRESSION TYPE = NONE` setting for sinks that already exist.

Forcing all *new* sinks to default to LZ4 unless explicitly configured
seems safe enough (i.e., no need to slow roll this to certain customers)
because compression is very well tolerated in the Kafka ecosystem.

Fix https://github.com/MaterializeInc/materialize/issues/25242.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
