### PR TITLE
aws-secrets-controller: basic logging for secret reading time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4344,6 +4344,7 @@ dependencies = [
  "mz-repr",
  "mz-secrets",
  "tracing",
+ "uuid",
  "workspace-hack",
 ]
 

--- a/src/aws-secrets-controller/Cargo.toml
+++ b/src/aws-secrets-controller/Cargo.toml
@@ -25,6 +25,7 @@ mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 tracing = "0.1.37"
+uuid = "1.7.0"
 
 [features]
 default = ["workspace-hack"]


### PR DESCRIPTION
We have some evidence that reading secrets from AWS might stall indefinitely. Add a basic log line that indicates when an AWS secret read starts and ends to prove or disprove this hypothesis if it occurs again in production.

We log at an `info!` level so that we have visibility into every secrets read. These are relatively infrequent, so this shouldn't be a meaningful increase in log volume. We don't want to log at a lower level because the hang has only occured rarely, so we want the logs on by default for when it happens next.

Fix #27933.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

None.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
