### PR TITLE
tracing: Use package@version

### DIFF
--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -522,7 +522,7 @@ where
                 sentry_config.dsn,
                 sentry::ClientOptions {
                     attach_stacktrace: true,
-                    release: Some(config.build_version.into()),
+                    release: Some(format!("materialize@{0}", config.build_version).into()),
                     environment: sentry_config.environment.map(Into::into),
                     integrations: vec![Arc::new(DebugImagesIntegration::new())],
                     ..Default::default()


### PR DESCRIPTION
This should allow us to use semantic versioning to compare releases: https://docs.sentry.io/platforms/rust/configuration/releases/

> Semantic Versioning: package@version or package@version+build (for example, my.project.name@2.3.12+1234)

> We automatically detect whether a project is using semantic or time-based versioning based on:
> If ≤ 2 releases total: we look at most recent release.
> If 3-9 releases (inclusive): if any of the most recent 3 releases is semver, project is semver.
> If 10 or more releases: if any of the most recent 3 releases is semver, and 3 out of the most recent 10 releases is semver, then the project is semver.

I decided against using clusterd@v0.111.0, environmentd@v0.111.0 because we already have the binary information and they are all released in unison.

Should fix issues like this: https://materializeinc.slack.com/archives/CQY8LN96Y/p1722957814979619

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
