### PR TITLE
postgres consistency: ignore to account for different evaluation order

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/jsonb_operations_provider.py
@@ -47,12 +47,14 @@ JSONB_OPERATION_TYPES: list[DbOperationOrFunction] = []
 
 TAG_JSONB_TO_TEXT = "jsonb_to_text"
 TAG_JSONB_AGGREGATION = "jsonb_aggregation"
+TAG_JSONB_VALUE_ACCESS = "jsonb_value_access"
 
 JSONB_OPERATION_TYPES.append(
     DbOperation(
         "$ -> $",
         [JsonbOperationParam(), JSON_FIELD_NAME_PARAM],
         JsonbReturnTypeSpec(),
+        tags={TAG_JSONB_VALUE_ACCESS},
     )
 )
 JSONB_OPERATION_TYPES.append(
@@ -60,6 +62,7 @@ JSONB_OPERATION_TYPES.append(
         "$ -> $",
         [JsonbOperationParam(), JSON_FIELD_INDEX_PARAM],
         JsonbReturnTypeSpec(),
+        tags={TAG_JSONB_VALUE_ACCESS},
     )
 )
 JSONB_OPERATION_TYPES.append(
@@ -67,7 +70,7 @@ JSONB_OPERATION_TYPES.append(
         "$ ->> $",
         [JsonbOperationParam(), JSON_FIELD_NAME_PARAM],
         StringReturnTypeSpec(),
-        tags={TAG_JSONB_TO_TEXT},
+        tags={TAG_JSONB_TO_TEXT, TAG_JSONB_VALUE_ACCESS},
     )
 )
 JSONB_OPERATION_TYPES.append(
@@ -75,7 +78,7 @@ JSONB_OPERATION_TYPES.append(
         "$ ->> $",
         [JsonbOperationParam(), JSON_FIELD_INDEX_PARAM],
         StringReturnTypeSpec(),
-        tags={TAG_JSONB_TO_TEXT},
+        tags={TAG_JSONB_TO_TEXT, TAG_JSONB_VALUE_ACCESS},
     )
 )
 JSONB_OPERATION_TYPES.append(
@@ -83,6 +86,7 @@ JSONB_OPERATION_TYPES.append(
         "$ #> $",
         [JsonbOperationParam(), JSON_PATH_PARAM],
         JsonbReturnTypeSpec(),
+        tags={TAG_JSONB_VALUE_ACCESS},
     )
 )
 JSONB_OPERATION_TYPES.append(
@@ -90,7 +94,7 @@ JSONB_OPERATION_TYPES.append(
         "$ #>> $",
         [JsonbOperationParam(), JSON_PATH_PARAM],
         StringReturnTypeSpec(),
-        tags={TAG_JSONB_TO_TEXT},
+        tags={TAG_JSONB_TO_TEXT, TAG_JSONB_VALUE_ACCESS},
     )
 )
 JSONB_OPERATION_TYPES.append(

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -59,6 +59,7 @@ from materialize.output_consistency.input_data.operations.generic_operations_pro
 from materialize.output_consistency.input_data.operations.jsonb_operations_provider import (
     TAG_JSONB_AGGREGATION,
     TAG_JSONB_TO_TEXT,
+    TAG_JSONB_VALUE_ACCESS,
 )
 from materialize.output_consistency.input_data.operations.record_operations_provider import (
     TAG_RECORD_CREATION,
@@ -579,6 +580,15 @@ class PgPostExecutionInconsistencyIgnoreFilter(
             )
         ):
             return YesIgnore("#28141: jsonb_object_agg with non-scalar key")
+
+        if query_template.matches_any_expression(
+            partial(
+                is_operation_tagged,
+                tag=TAG_JSONB_VALUE_ACCESS,
+            ),
+            True,
+        ):
+            return YesIgnore("Different evaluation order")
 
         return NoIgnore()
 


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/8987#01912c9e-6d7f-4b94-ad4d-3d80dfc8e831.