### PR TITLE
persist: enable schema reg flags by default

### DIFF
--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -49,13 +49,13 @@ impl TryFrom<String> for SchemaId {
 
 pub(crate) const SCHEMA_REGISTER: Config<bool> = Config::new(
     "persist_schema_register",
-    false,
+    true,
     "register schemas with the shard when opening a read or write handle",
 );
 
 pub(crate) const SCHEMA_REQUIRE: Config<bool> = Config::new(
     "persist_schema_require",
-    false,
+    true,
     "error if schema registration is unsuccessful when opening a read or write handle",
 );
 


### PR DESCRIPTION
We construct the only write handles to the "catalog" and "txns" shards before syncing dyncfgs from LD (and before getting the previously saved values in the catalog), so those are the last two holdouts in staging/prod from being in the schema reg. Feels worthwhile to keep the momentum going on this and get every shard opted into it.

This PR means we'd have to build a patch release if any issues crop up during the rollout, but the uses of these two shards are much less varied than other shards, so I'm more comfortable saying that CI would shake out any issues (plus we'll see staging first). And worst case, it's just the extra cmd on writer registration and a sentry error, still no panics for more than one schema.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
