### PR TITLE
tests: Reenable persist_use_criticial_since_(snapshot|source)

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -108,7 +108,7 @@ $ cargo run --bin testdrive --release -- test/testdrive/TESTFILE.td
 ```
 
 Note that mzcompose has a different default of system parameters in order to
-test more risky features of Materialize, see `DEFAULT_SYSTEM_PARAMETERS` in
+test more risky features of Materialize, see `get_default_system_parameters` in
 [https://github.com/MaterializeInc/materialize/blob/main/misc/python/materialize/mzcompose/__init__.py](mzcompose/__init__.py).
 On the command line specific system parameters can be set using the
 `MZSYSTEM_PARAMETER_DEFAULT` environment variable (`;`-separated).

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -31,8 +31,6 @@ _minor_versions: list[MzVersion] | None = None
 _last_version: MzVersion | None = None
 _previous_version: MzVersion | None = None
 
-_no_0dt_system_parameters = {"enable_0dt_deployment": "false"}
-
 
 def get_minor_versions() -> list[MzVersion]:
     global _minor_versions
@@ -67,6 +65,7 @@ def start_mz_read_only(
     deploy_generation: int,
     mz_service: str = "materialized",
     tag: MzVersion | None = None,
+    system_parameter_defaults: dict[str, str] | None = None,
     system_parameter_version: MzVersion | None = None,
 ) -> StartMz:
     return StartMz(
@@ -76,6 +75,7 @@ def start_mz_read_only(
         deploy_generation=deploy_generation,
         healthcheck=LEADER_STATUS_HEALTHCHECK,
         restart="unless-stopped",
+        system_parameter_defaults=system_parameter_defaults,
         system_parameter_version=system_parameter_version,
     )
 
@@ -92,7 +92,6 @@ class UpgradeEntireMz(Scenario):
             StartMz(
                 self,
                 tag=self.base_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Initialize(self),
             Manipulate(self, phase=1),
@@ -102,7 +101,6 @@ class UpgradeEntireMz(Scenario):
             StartMz(
                 self,
                 tag=None,
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Manipulate(self, phase=2),
             Validate(self),
@@ -111,7 +109,6 @@ class UpgradeEntireMz(Scenario):
             StartMz(
                 self,
                 tag=None,
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Validate(self),
         ]
@@ -131,7 +128,6 @@ class UpgradeEntireMzTwoVersions(Scenario):
             StartMz(
                 self,
                 tag=self.base_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Initialize(self),
             # Upgrade to last_version
@@ -139,7 +135,6 @@ class UpgradeEntireMzTwoVersions(Scenario):
             StartMz(
                 self,
                 tag=get_last_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Manipulate(self, phase=1),
             # Upgrade to current source
@@ -147,7 +142,6 @@ class UpgradeEntireMzTwoVersions(Scenario):
             StartMz(
                 self,
                 tag=None,
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Manipulate(self, phase=2),
             Validate(self),
@@ -156,7 +150,6 @@ class UpgradeEntireMzTwoVersions(Scenario):
             StartMz(
                 self,
                 tag=None,
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Validate(self),
         ]
@@ -182,41 +175,35 @@ class UpgradeEntireMzFourVersions(Scenario):
             StartMz(
                 self,
                 tag=self.minor_versions[3],
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Initialize(self),
             KillMz(capture_logs=True),
             StartMz(
                 self,
                 tag=self.minor_versions[2],
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Manipulate(self, phase=1),
             KillMz(capture_logs=True),
             StartMz(
                 self,
                 tag=get_previous_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Manipulate(self, phase=2),
             KillMz(capture_logs=True),
             StartMz(
                 self,
                 tag=get_last_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             KillMz(capture_logs=True),
             StartMz(
                 self,
                 tag=None,
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Validate(self),
             KillMz(),
             StartMz(
                 self,
                 tag=None,
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Validate(self),
         ]
@@ -242,7 +229,6 @@ class UpgradeClusterdComputeLast(Scenario):
             StartMz(
                 self,
                 tag=self.base_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             StartClusterdCompute(tag=self.base_version()),
             UseClusterdCompute(self),
@@ -253,7 +239,6 @@ class UpgradeClusterdComputeLast(Scenario):
                 self,
                 tag=None,
                 system_parameter_version=self.base_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             # No useful work can be done while clusterd is old-version
             # and environmentd is new-version. So we proceed
@@ -270,7 +255,6 @@ class UpgradeClusterdComputeLast(Scenario):
             StartMz(
                 self,
                 tag=None,
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Validate(self),
         ]
@@ -287,7 +271,6 @@ class UpgradeClusterdComputeFirst(Scenario):
             StartMz(
                 self,
                 tag=self.base_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             StartClusterdCompute(tag=self.base_version()),
             UseClusterdCompute(self),
@@ -305,7 +288,6 @@ class UpgradeClusterdComputeFirst(Scenario):
             StartMz(
                 self,
                 tag=None,
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Manipulate(self, phase=2),
             Validate(self),
@@ -313,7 +295,6 @@ class UpgradeClusterdComputeFirst(Scenario):
             StartMz(
                 self,
                 tag=None,
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Validate(self),
         ]
@@ -344,7 +325,6 @@ class PreflightCheckContinue(Scenario):
             StartMz(
                 self,
                 tag=self.base_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Initialize(self),
             Manipulate(self, phase=1),
@@ -362,7 +342,6 @@ class PreflightCheckContinue(Scenario):
                 self,
                 tag=None,
                 deploy_generation=1,
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Validate(self),
         ]
@@ -380,7 +359,6 @@ class PreflightCheckRollback(Scenario):
             StartMz(
                 self,
                 tag=self.base_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Initialize(self),
             Manipulate(self, phase=1),
@@ -398,7 +376,6 @@ class PreflightCheckRollback(Scenario):
             StartMz(
                 self,
                 tag=self.base_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Manipulate(self, phase=2),
             Validate(self),
@@ -407,7 +384,6 @@ class PreflightCheckRollback(Scenario):
             StartMz(
                 self,
                 tag=self.base_version(),
-                additional_system_parameter_defaults=_no_0dt_system_parameters,
             ),
             Validate(self),
         ]

--- a/misc/python/materialize/checks/scenarios_zero_downtime.py
+++ b/misc/python/materialize/checks/scenarios_zero_downtime.py
@@ -25,6 +25,7 @@ from materialize.checks.scenarios_upgrade import (
     start_mz_read_only,
 )
 from materialize.mz_version import MzVersion
+from materialize.mzcompose import get_default_system_parameters
 
 
 def wait_ready_and_promote(mz_service: str) -> list[MzcomposeAction]:
@@ -33,16 +34,36 @@ def wait_ready_and_promote(mz_service: str) -> list[MzcomposeAction]:
 
 class ZeroDowntimeRestartEntireMz(Scenario):
     def actions(self) -> list[Action]:
+        system_parameter_defaults = get_default_system_parameters(zero_downtime=True)
         return [
-            StartMz(self, mz_service="mz_1"),
+            StartMz(
+                self,
+                mz_service="mz_1",
+                system_parameter_defaults=system_parameter_defaults,
+            ),
             Initialize(self, mz_service="mz_1"),
-            start_mz_read_only(self, deploy_generation=1, mz_service="mz_2"),
+            start_mz_read_only(
+                self,
+                deploy_generation=1,
+                mz_service="mz_2",
+                system_parameter_defaults=system_parameter_defaults,
+            ),
             Manipulate(self, phase=1, mz_service="mz_1"),
             *wait_ready_and_promote("mz_2"),
-            start_mz_read_only(self, deploy_generation=2, mz_service="mz_3"),
+            start_mz_read_only(
+                self,
+                deploy_generation=2,
+                mz_service="mz_3",
+                system_parameter_defaults=system_parameter_defaults,
+            ),
             Manipulate(self, phase=2, mz_service="mz_2"),
             *wait_ready_and_promote("mz_3"),
-            start_mz_read_only(self, deploy_generation=3, mz_service="mz_4"),
+            start_mz_read_only(
+                self,
+                deploy_generation=3,
+                mz_service="mz_4",
+                system_parameter_defaults=system_parameter_defaults,
+            ),
             Validate(self, mz_service="mz_3"),
             *wait_ready_and_promote("mz_4"),
             Validate(self, mz_service="mz_4"),
@@ -57,15 +78,23 @@ class ZeroDowntimeUpgradeEntireMz(Scenario):
 
     def actions(self) -> list[Action]:
         print(f"Upgrading from tag {self.base_version()}")
+        system_parameter_defaults = get_default_system_parameters(
+            self.base_version(), zero_downtime=True
+        )
         return [
-            StartMz(self, tag=self.base_version(), mz_service="mz_1"),
+            StartMz(
+                self,
+                tag=self.base_version(),
+                mz_service="mz_1",
+                system_parameter_defaults=system_parameter_defaults,
+            ),
             Initialize(self, mz_service="mz_1"),
             start_mz_read_only(
                 self,
                 tag=None,
                 deploy_generation=1,
                 mz_service="mz_2",
-                system_parameter_version=self.base_version(),
+                system_parameter_defaults=system_parameter_defaults,
             ),
             Manipulate(self, phase=1, mz_service="mz_1"),
             *wait_ready_and_promote("mz_2"),
@@ -75,7 +104,7 @@ class ZeroDowntimeUpgradeEntireMz(Scenario):
                 tag=None,
                 deploy_generation=2,
                 mz_service="mz_3",
-                system_parameter_version=self.base_version(),
+                system_parameter_defaults=system_parameter_defaults,
             ),
             Validate(self, mz_service="mz_2"),
             *wait_ready_and_promote("mz_3"),
@@ -92,9 +121,17 @@ class ZeroDowntimeUpgradeEntireMzTwoVersions(Scenario):
 
     def actions(self) -> list[Action]:
         print(f"Upgrade path: {self.base_version()} -> {get_last_version()} -> current")
+        system_parameter_defaults = get_default_system_parameters(
+            self.base_version(), zero_downtime=True
+        )
         return [
             # Start with previous_version
-            StartMz(self, tag=self.base_version(), mz_service="mz_1"),
+            StartMz(
+                self,
+                tag=self.base_version(),
+                mz_service="mz_1",
+                system_parameter_defaults=system_parameter_defaults,
+            ),
             Initialize(self, mz_service="mz_1"),
             # Upgrade to last_version
             start_mz_read_only(
@@ -102,7 +139,7 @@ class ZeroDowntimeUpgradeEntireMzTwoVersions(Scenario):
                 tag=get_last_version(),
                 deploy_generation=1,
                 mz_service="mz_2",
-                system_parameter_version=self.base_version(),
+                system_parameter_defaults=system_parameter_defaults,
             ),
             Manipulate(self, phase=1, mz_service="mz_1"),
             *wait_ready_and_promote("mz_2"),
@@ -112,7 +149,7 @@ class ZeroDowntimeUpgradeEntireMzTwoVersions(Scenario):
                 tag=None,
                 deploy_generation=2,
                 mz_service="mz_3",
-                system_parameter_version=self.base_version(),
+                system_parameter_defaults=system_parameter_defaults,
             ),
             Manipulate(self, phase=2, mz_service="mz_2"),
             *wait_ready_and_promote("mz_3"),
@@ -121,7 +158,7 @@ class ZeroDowntimeUpgradeEntireMzTwoVersions(Scenario):
                 tag=None,
                 deploy_generation=3,
                 mz_service="mz_4",
-                system_parameter_version=self.base_version(),
+                system_parameter_defaults=system_parameter_defaults,
             ),
             Validate(self, mz_service="mz_3"),
             *wait_ready_and_promote("mz_4"),
@@ -145,15 +182,23 @@ class ZeroDowntimeUpgradeEntireMzFourVersions(Scenario):
         print(
             f"Upgrade path: {self.minor_versions[3]} -> {self.minor_versions[2]} -> {get_previous_version()} -> {get_last_version()} -> current"
         )
+        system_parameter_defaults = get_default_system_parameters(
+            self.base_version(), zero_downtime=True
+        )
         return [
-            StartMz(self, tag=self.minor_versions[3], mz_service="mz_1"),
+            StartMz(
+                self,
+                tag=self.minor_versions[3],
+                mz_service="mz_1",
+                system_parameter_defaults=system_parameter_defaults,
+            ),
             Initialize(self, mz_service="mz_1"),
             start_mz_read_only(
                 self,
                 tag=self.minor_versions[2],
                 deploy_generation=1,
                 mz_service="mz_2",
-                system_parameter_version=self.base_version(),
+                system_parameter_defaults=system_parameter_defaults,
             ),
             Manipulate(self, phase=1, mz_service="mz_1"),
             *wait_ready_and_promote("mz_2"),
@@ -162,7 +207,7 @@ class ZeroDowntimeUpgradeEntireMzFourVersions(Scenario):
                 tag=get_previous_version(),
                 deploy_generation=2,
                 mz_service="mz_3",
-                system_parameter_version=self.base_version(),
+                system_parameter_defaults=system_parameter_defaults,
             ),
             Manipulate(self, phase=2, mz_service="mz_2"),
             *wait_ready_and_promote("mz_3"),
@@ -171,7 +216,7 @@ class ZeroDowntimeUpgradeEntireMzFourVersions(Scenario):
                 tag=get_last_version(),
                 deploy_generation=3,
                 mz_service="mz_4",
-                system_parameter_version=self.base_version(),
+                system_parameter_defaults=system_parameter_defaults,
             ),
             Validate(self, mz_service="mz_3"),
             *wait_ready_and_promote("mz_4"),
@@ -180,7 +225,7 @@ class ZeroDowntimeUpgradeEntireMzFourVersions(Scenario):
                 tag=None,
                 deploy_generation=4,
                 mz_service="mz_5",
-                system_parameter_version=self.base_version(),
+                system_parameter_defaults=system_parameter_defaults,
             ),
             Validate(self, mz_service="mz_4"),
             *wait_ready_and_promote("mz_5"),

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -27,7 +27,7 @@ from urllib.parse import urlparse
 import psutil
 
 from materialize import MZ_ROOT, rustc_flags, spawn, ui
-from materialize.mzcompose import DEFAULT_SYSTEM_PARAMETERS
+from materialize.mzcompose import get_default_system_parameters
 from materialize.ui import UIError
 from materialize.xcompile import Arch
 
@@ -273,7 +273,8 @@ def main() -> int:
                 command += ["--opentelemetry-endpoint=http://localhost:4317"]
         elif args.program == "sqllogictest":
             formatted_params = [
-                f"{key}={value}" for key, value in DEFAULT_SYSTEM_PARAMETERS.items()
+                f"{key}={value}"
+                for key, value in get_default_system_parameters().items()
             ]
             env["MZ_SYSTEM_PARAMETER_DEFAULT"] = ";".join(formatted_params)
             db = urlparse(args.postgres).path.removeprefix("/")

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -37,7 +37,7 @@ from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_service import K8sService
 from materialize.cloudtest.k8s.api.k8s_stateful_set import K8sStatefulSet
 from materialize.mz_version import MzVersion
-from materialize.mzcompose import DEFAULT_SYSTEM_PARAMETERS
+from materialize.mzcompose import get_default_system_parameters
 
 
 class EnvironmentdService(K8sService):
@@ -255,7 +255,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
 
     def env_vars(self) -> list[V1EnvVar]:
 
-        system_parameter_defaults = DEFAULT_SYSTEM_PARAMETERS
+        system_parameter_defaults = get_default_system_parameters()
 
         if self.log_filter:
             system_parameter_defaults["log_filter"] = self.log_filter

--- a/misc/python/materialize/data_ingest/transaction_def.py
+++ b/misc/python/materialize/data_ingest/transaction_def.py
@@ -17,6 +17,7 @@ from materialize.data_ingest.definition import Definition
 from materialize.data_ingest.field import Field
 from materialize.data_ingest.rowlist import RowList
 from materialize.data_ingest.transaction import Transaction
+from materialize.mzcompose import get_default_system_parameters
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.materialized import (
     LEADER_STATUS_HEALTHCHECK,
@@ -83,6 +84,9 @@ class RestartMz(TransactionDef):
                     ports=ports,
                     external_minio=True,
                     external_cockroach=True,
+                    system_parameter_defaults=get_default_system_parameters(
+                        zero_downtime=True
+                    ),
                     additional_system_parameter_defaults={"enable_table_keys": "true"},
                     deploy_generation=self.workload.deploy_generation,
                     sanity_restart=False,
@@ -127,6 +131,9 @@ class ZeroDowntimeDeploy(TransactionDef):
                     ports=ports,
                     external_minio=True,
                     external_cockroach=True,
+                    system_parameter_defaults=get_default_system_parameters(
+                        zero_downtime=True
+                    ),
                     additional_system_parameter_defaults={"enable_table_keys": "true"},
                     deploy_generation=self.workload.deploy_generation,
                     restart="on-failure",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -40,7 +40,9 @@ DEFAULT_MZ_VOLUMES = [
 ]
 
 
-def get_default_system_parameters(version: MzVersion | None = None) -> dict[str, Any]:
+def get_default_system_parameters(
+    version: MzVersion | None = None, zero_downtime: bool = False
+) -> dict[str, str]:
     """For upgrade tests we only want parameters set when all environmentd /
     clusterd processes have reached a specific version (or higher)
     """
@@ -67,9 +69,9 @@ def get_default_system_parameters(version: MzVersion | None = None) -> dict[str,
         "allow_real_time_recency": "true",
         "cluster_always_use_disk": "true",
         "compute_dataflow_max_inflight_bytes": "134217728",  # 128 MiB
-        "compute_hydration_concurrency": 2,
+        "compute_hydration_concurrency": "2",
         "disk_cluster_replicas_default": "true",
-        "enable_0dt_deployment": "true",
+        "enable_0dt_deployment": "true" if zero_downtime else "false",
         "enable_alter_swap": "true",
         "enable_assert_not_null": "true",
         "enable_columnation_lgalloc": "true",
@@ -111,8 +113,8 @@ def get_default_system_parameters(version: MzVersion | None = None) -> dict[str,
         "persist_stats_audit_percent": "100",
         "persist_txn_tables": "lazy",  # removed, but keep value for older versions
         "persist_use_critical_since_catalog": "true",
-        "persist_use_critical_since_snapshot": "false",  # Disabled because of 0dt upgrades, TODO: reenable
-        "persist_use_critical_since_source": "false",  # Disabled because of 0dt upgrades, TODO: reenable
+        "persist_use_critical_since_snapshot": "false" if zero_downtime else "true",
+        "persist_use_critical_since_source": "false" if zero_downtime else "true",
         "persist_part_decode_format": "row_with_validate",
         "statement_logging_default_sample_rate": "0.01",
         "statement_logging_max_sample_rate": "0.01",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -39,86 +39,89 @@ DEFAULT_MZ_VOLUMES = [
     "scratch:/scratch",
 ]
 
-DEFAULT_SYSTEM_PARAMETERS = {
-    # -----
-    # Unsafe functions
-    "enable_unsafe_functions": "true",
-    "enable_dangerous_functions": "true",  # former name of 'enable_unsafe_functions'
-    # -----
-    # To reduce CRDB load as we are struggling with it in CI (values based on load test environment):
-    "persist_next_listen_batch_retryer_clamp": "16s",
-    "persist_next_listen_batch_retryer_initial_backoff": "100ms",
-    "persist_next_listen_batch_retryer_fixed_sleep": "1200ms",
-    # -----
-    # Persist internals changes: advance coverage
-    "persist_enable_arrow_lgalloc_noncc_sizes": "true",
-    "persist_enable_s3_lgalloc_noncc_sizes": "true",
-    # -----
-    # Others (ordered by name)
-    "allow_real_time_recency": "true",
-    "cluster_always_use_disk": "true",
-    "compute_dataflow_max_inflight_bytes": "134217728",  # 128 MiB
-    "compute_hydration_concurrency": 2,
-    "disk_cluster_replicas_default": "true",
-    "enable_0dt_deployment": "true",
-    "enable_alter_swap": "true",
-    "enable_assert_not_null": "true",
-    "enable_columnation_lgalloc": "true",
-    "enable_comment": "true",
-    "enable_compute_chunked_stack": "true",
-    "enable_connection_validation_syntax": "true",
-    "enable_copy_to_expr": "true",
-    "enable_disk_cluster_replicas": "true",
-    "enable_eager_delta_joins": "true",
-    "enable_envelope_debezium_in_subscribe": "true",
-    "enable_expressions_in_limit_syntax": "true",
-    "enable_introspection_subscribes": "true",
-    "enable_logical_compaction_window": "true",
-    "enable_multi_worker_storage_persist_sink": "true",
-    "enable_mysql_source": "true",
-    "enable_rbac_checks": "true",
-    "enable_reduce_mfp_fusion": "true",
-    "enable_refresh_every_mvs": "true",
-    "enable_cluster_schedule_refresh": "true",
-    "enable_sink_doc_on_option": "true",
-    "enable_statement_lifecycle_logging": "true",
-    "enable_table_keys": "true",
-    "enable_variadic_left_join_lowering": "true",
-    "enable_worker_core_affinity": "true",
-    "persist_batch_delete_enabled": "true",
-    "persist_fast_path_limit": "1000",
-    "persist_inline_writes_single_max_bytes": "4096",
-    "persist_inline_writes_total_max_bytes": "1048576",
-    "persist_pubsub_client_enabled": "true",
-    "persist_pubsub_push_diff_enabled": "true",
-    "persist_record_compactions": "true",
-    "persist_roundtrip_spine": "true",
-    "persist_sink_minimum_batch_updates": "128",
-    "persist_stats_audit_percent": "100",
-    "persist_txn_tables": "lazy",  # removed, but keep value for older versions
-    "persist_use_critical_since_catalog": "true",
-    "persist_use_critical_since_snapshot": "false",  # Disabled because of 0dt upgrades, TODO: reenable
-    "persist_use_critical_since_source": "false",  # Disabled because of 0dt upgrades, TODO: reenable
-    "persist_part_decode_format": "row_with_validate",
-    "statement_logging_default_sample_rate": "0.01",
-    "statement_logging_max_sample_rate": "0.01",
-    "storage_persist_sink_minimum_batch_updates": "100",
-    "storage_source_decode_fuel": "100000",
-    "timestamp_oracle": "postgres",
-    "wait_catalog_consolidation_on_startup": "true",
-    "persist_batch_record_part_format": "true",
-    "storage_use_reclock_v2": "true",
-    "persist_schema_require": "true",
-}
 
+def get_default_system_parameters(version: MzVersion | None = None) -> dict[str, Any]:
+    """For upgrade tests we only want parameters set when all environmentd /
+    clusterd processes have reached a specific version (or higher)
+    """
 
-# For upgrade tests we only want parameters set when all environmentd/clusterd
-# processes have reached a specific version (or higher)
-def version_dependent_system_parameters(version: MzVersion) -> dict[str, str]:
+    if not version:
+        version = MzVersion.parse_cargo()
+
     return {
+        # -----
+        # Unsafe functions
+        "enable_unsafe_functions": "true",
+        "enable_dangerous_functions": "true",  # former name of 'enable_unsafe_functions'
+        # -----
+        # To reduce CRDB load as we are struggling with it in CI (values based on load test environment):
+        "persist_next_listen_batch_retryer_clamp": "16s",
+        "persist_next_listen_batch_retryer_initial_backoff": "100ms",
+        "persist_next_listen_batch_retryer_fixed_sleep": "1200ms",
+        # -----
+        # Persist internals changes: advance coverage
+        "persist_enable_arrow_lgalloc_noncc_sizes": "true",
+        "persist_enable_s3_lgalloc_noncc_sizes": "true",
+        # -----
+        # Others (ordered by name)
+        "allow_real_time_recency": "true",
+        "cluster_always_use_disk": "true",
+        "compute_dataflow_max_inflight_bytes": "134217728",  # 128 MiB
+        "compute_hydration_concurrency": 2,
+        "disk_cluster_replicas_default": "true",
+        "enable_0dt_deployment": "true",
+        "enable_alter_swap": "true",
+        "enable_assert_not_null": "true",
+        "enable_columnation_lgalloc": "true",
+        "enable_comment": "true",
+        "enable_compute_chunked_stack": "true",
+        "enable_connection_validation_syntax": "true",
+        "enable_copy_to_expr": "true",
+        "enable_disk_cluster_replicas": "true",
+        "enable_eager_delta_joins": "true",
+        "enable_envelope_debezium_in_subscribe": "true",
+        "enable_expressions_in_limit_syntax": "true",
+        "enable_introspection_subscribes": "true",
+        "enable_logical_compaction_window": "true",
+        "enable_multi_worker_storage_persist_sink": "true",
+        "enable_mysql_source": "true",
+        "enable_rbac_checks": "true",
+        "enable_reduce_mfp_fusion": "true",
+        "enable_refresh_every_mvs": "true",
+        "enable_cluster_schedule_refresh": "true",
+        "enable_sink_doc_on_option": "true",
+        "enable_statement_lifecycle_logging": "true",
+        "enable_table_keys": "true",
+        "enable_variadic_left_join_lowering": "true",
+        "enable_worker_core_affinity": "true",
+        "persist_batch_delete_enabled": "true",
+        "persist_batch_record_part_format": "true",
+        "persist_fast_path_limit": "1000",
+        "persist_inline_writes_single_max_bytes": "4096",
+        "persist_inline_writes_total_max_bytes": "1048576",
+        "persist_pubsub_client_enabled": "true",
+        "persist_pubsub_push_diff_enabled": "true",
+        "persist_record_compactions": "true",
+        "persist_roundtrip_spine": "true",
         "persist_schema_register": (
             "false" if version < MzVersion.parse_mz("v0.111.0-dev") else "true"
-        )
+        ),
+        "persist_schema_require": "true",
+        "persist_sink_minimum_batch_updates": "128",
+        "persist_stats_audit_percent": "100",
+        "persist_txn_tables": "lazy",  # removed, but keep value for older versions
+        "persist_use_critical_since_catalog": "true",
+        "persist_use_critical_since_snapshot": "false",  # Disabled because of 0dt upgrades, TODO: reenable
+        "persist_use_critical_since_source": "false",  # Disabled because of 0dt upgrades, TODO: reenable
+        "persist_part_decode_format": "row_with_validate",
+        "statement_logging_default_sample_rate": "0.01",
+        "statement_logging_max_sample_rate": "0.01",
+        "storage_persist_sink_minimum_batch_updates": "100",
+        "storage_source_decode_fuel": "100000",
+        "storage_use_reclock_v2": "true",
+        "timestamp_oracle": "postgres",
+        "wait_catalog_consolidation_on_startup": "true",
+        # End of list (ordered by name)
     }
 
 

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -1379,7 +1379,7 @@ class Composition:
         mz_service: str = "materialized",
         timeout: int | None = None,
     ) -> None:
-        timeout = timeout or 300
+        timeout = timeout or 420
         print(
             f"Awaiting {mz_service} deployment status {status.value} for {timeout}s",
             end="",

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 
-from copy import copy
 from enum import Enum
 
 from materialize.mz_version import MzVersion
@@ -16,8 +15,7 @@ from materialize.mzcompose import (
     DEFAULT_CRDB_ENVIRONMENT,
     DEFAULT_MZ_ENVIRONMENT_ID,
     DEFAULT_MZ_VOLUMES,
-    DEFAULT_SYSTEM_PARAMETERS,
-    version_dependent_system_parameters,
+    get_default_system_parameters,
 )
 from materialize.mzcompose.service import (
     Service,
@@ -101,16 +99,9 @@ class Materialized(Service):
             image_version = MzVersion.parse_mz(image.split(":")[1])
 
         if system_parameter_defaults is None:
-            # Has to be copied so we later don't modify the
-            # DEFAULT_SYSTEM_PARAMETERS dictionary
-            system_parameter_defaults = copy(DEFAULT_SYSTEM_PARAMETERS)
-
-            if not system_parameter_version:
-                system_parameter_version = image_version
-            if system_parameter_version:
-                system_parameter_defaults.update(
-                    version_dependent_system_parameters(system_parameter_version)
-                )
+            system_parameter_defaults = get_default_system_parameters(
+                system_parameter_version or image_version
+            )
 
         if additional_system_parameter_defaults is not None:
             system_parameter_defaults.update(additional_system_parameter_defaults)

--- a/misc/python/materialize/mzcompose/services/sql_logic_test.py
+++ b/misc/python/materialize/mzcompose/services/sql_logic_test.py
@@ -9,7 +9,7 @@
 
 
 from materialize.mzcompose import (
-    DEFAULT_SYSTEM_PARAMETERS,
+    get_default_system_parameters,
 )
 from materialize.mzcompose.service import (
     Service,
@@ -30,7 +30,8 @@ class SqlLogicTest(Service):
         environment += [
             "MZ_SYSTEM_PARAMETER_DEFAULT="
             + ";".join(
-                f"{key}={value}" for key, value in DEFAULT_SYSTEM_PARAMETERS.items()
+                f"{key}={value}"
+                for key, value in get_default_system_parameters().items()
             )
         ]
 

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -27,6 +27,7 @@ import materialize.parallel_workload.database
 from materialize.data_ingest.data_type import NUMBER_TYPES, Text, TextTextMap
 from materialize.data_ingest.query_error import QueryError
 from materialize.data_ingest.row import Operation
+from materialize.mzcompose import get_default_system_parameters
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.materialized import (
     LEADER_STATUS_HEALTHCHECK,
@@ -1614,6 +1615,9 @@ class ZeroDowntimeDeployAction(Action):
                 ports=ports,
                 sanity_restart=self.sanity_restart,
                 deploy_generation=self.deploy_generation,
+                system_parameter_defaults=get_default_system_parameters(
+                    zero_downtime=True
+                ),
                 restart="on-failure",
                 healthcheck=LEADER_STATUS_HEALTHCHECK,
             ),

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -19,7 +19,7 @@ from collections import Counter, defaultdict
 
 import pg8000
 
-from materialize.mzcompose import DEFAULT_SYSTEM_PARAMETERS
+from materialize.mzcompose import get_default_system_parameters
 from materialize.mzcompose.composition import Composition
 from materialize.parallel_workload.action import (
     Action,
@@ -499,7 +499,7 @@ def main() -> int:
     with system_conn.cursor() as cur:
         # TODO: Currently the same as mzcompose default settings, add
         # more settings and shuffle them
-        for key, value in DEFAULT_SYSTEM_PARAMETERS.items():
+        for key, value in get_default_system_parameters().items():
             cur.execute(f"ALTER SYSTEM SET {key} = '{value}'")
     system_conn.close()
 

--- a/misc/python/materialize/zippy/backup_and_restore_actions.py
+++ b/misc/python/materialize/zippy/backup_and_restore_actions.py
@@ -31,6 +31,7 @@ class BackupAndRestore(Action):
                 external_minio=True,
                 external_cockroach=True,
                 deploy_generation=state.deploy_generation,
+                system_parameter_defaults=state.system_parameter_defaults,
                 sanity_restart=False,
                 restart="on-failure",
             )

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -21,6 +21,7 @@ from materialize.zippy.framework import (
     ActionFactory,
     Capabilities,
     Capability,
+    Mz0dtDeployBaseAction,
     State,
 )
 from materialize.zippy.minio_capabilities import MinioIsRunning
@@ -83,6 +84,7 @@ class MzStart(Action):
                 external_minio=True,
                 external_cockroach=True,
                 deploy_generation=state.deploy_generation,
+                system_parameter_defaults=state.system_parameter_defaults,
                 sanity_restart=False,
                 restart="on-failure",
                 additional_system_parameter_defaults=self.additional_system_parameter_defaults,
@@ -158,6 +160,7 @@ class MzRestart(Action):
                 external_minio=True,
                 external_cockroach=True,
                 deploy_generation=state.deploy_generation,
+                system_parameter_defaults=state.system_parameter_defaults,
                 sanity_restart=False,
                 restart="on-failure",
             )
@@ -166,7 +169,7 @@ class MzRestart(Action):
             c.up(state.mz_service)
 
 
-class Mz0dtDeploy(Action):
+class Mz0dtDeploy(Mz0dtDeployBaseAction):
     """Switches Mz to a new deployment using 0dt."""
 
     @classmethod
@@ -188,6 +191,7 @@ class Mz0dtDeploy(Action):
                 external_minio=True,
                 external_cockroach=True,
                 deploy_generation=state.deploy_generation,
+                system_parameter_defaults=state.system_parameter_defaults,
                 sanity_restart=False,
                 restart="on-failure",
                 healthcheck=LEADER_STATUS_HEALTHCHECK,

--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -20,6 +20,7 @@ from materialize.data_ingest.executor import (
 )
 from materialize.data_ingest.workload import *  # noqa: F401 F403
 from materialize.data_ingest.workload import WORKLOADS, execute_workload
+from materialize.mzcompose import get_default_system_parameters
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -52,6 +53,7 @@ SERVICES = [
         ports=["16875:6875"],
         external_minio=True,
         external_cockroach=True,
+        system_parameter_defaults=get_default_system_parameters(zero_downtime=True),
         additional_system_parameter_defaults={"enable_table_keys": "true"},
         sanity_restart=False,
     ),
@@ -60,6 +62,7 @@ SERVICES = [
         ports=["26875:6875"],
         external_minio=True,
         external_cockroach=True,
+        system_parameter_defaults=get_default_system_parameters(zero_downtime=True),
         additional_system_parameter_defaults={"enable_table_keys": "true"},
         sanity_restart=False,
     ),


### PR DESCRIPTION
Outside of 0dt tests

https://materializeinc.slack.com/archives/C01LKF361MZ/p1723047398367089

Review with https://github.com/MaterializeInc/materialize/pull/28858/files?w=1

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
