### PR TITLE
ci: Reenable Cloudtest on Hetzner

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -277,9 +277,7 @@ steps:
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          # TODO: #25108 flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64-medium
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/cloudtest:
               args: [-m=long, test/cloudtest/test_full_testdrive.py]
@@ -309,7 +307,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: limits
               run: main
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
 
       - id: limits-instance-size
         label: "Instance size limits"
@@ -841,9 +839,7 @@ steps:
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          # TODO: #25108 flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64-medium
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/cloudtest:
               args: [-m=long, test/cloudtest/test_upgrade.py]
@@ -864,9 +860,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO: #25108 flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -890,9 +884,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO: #25108 flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -916,9 +908,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO: #25108 flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -942,9 +932,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO: #25108 flakiness doesn't allow running on hetzner
-          # queue: hetzner-aarch64-8cpu-16gb
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -1221,8 +1209,8 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 45
         agents:
-          # Runs into timeout on small agents
-          queue: hetzner-aarch64-8cpu-16gb
+          # Runs into timeout/OoM on small agents
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: rqg

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -149,6 +149,7 @@ IGNORE_RE = re.compile(
     | skip-version-upgrade-materialized.* \| .* incompatible\ persist\ version\ \d+\.\d+\.\d+(-dev)?,\ current:\ \d+\.\d+\.\d+(-dev)?,\ make\ sure\ to\ upgrade\ the\ catalog\ one\ version\ at\ a\ time
     # For 0dt upgrades
     | halting\ process:\ (unable\ to\ confirm\ leadership|fenced\ out\ old\ deployment;\ rebooting\ as\ leader|this\ deployment\ has\ been\ fenced\ out)
+    | zippy-materialized.* \| .* halting\ process:\ Server\ started\ with\ requested\ generation
     # Don't care for ssh problems
     | fatal:\ userauth_pubkey
     )

--- a/misc/python/materialize/cloudtest/k8s/debezium.py
+++ b/misc/python/materialize/cloudtest/k8s/debezium.py
@@ -36,7 +36,9 @@ class DebeziumDeployment(K8sDeployment):
         ports = [V1ContainerPort(container_port=8083, name="debezium")]
 
         env = [
-            V1EnvVar(name="BOOTSTRAP_SERVERS", value="redpanda:9092"),
+            V1EnvVar(
+                name="BOOTSTRAP_SERVERS", value=f"redpanda.{redpanda_namespace}:9092"
+            ),
             V1EnvVar(name="CONFIG_STORAGE_TOPIC", value="connect_configs"),
             V1EnvVar(name="OFFSET_STORAGE_TOPIC", value="connect_offsets"),
             V1EnvVar(name="STATUS_STORAGE_TOPIC", value="connect_statuses"),

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -19,7 +19,6 @@ from materialize.mzcompose.services.zookeeper import Zookeeper
 REDPANDA_VERSIONS = ["v22.3.25", "v23.1.21", "v23.2.29", "v23.3.18", "v24.1.9"]
 
 CONFLUENT_PLATFORM_VERSIONS = [
-    "6.2.15",
     "7.0.14",
     "7.1.12",
     "7.2.10",
@@ -61,12 +60,10 @@ def workflow_default(c: Composition) -> None:
 
     for confluent_version in CONFLUENT_PLATFORM_VERSIONS:
         print(f"--- Testing Confluent Platform {confluent_version}")
-        # No arm64 images available for Confluent Platform versions 6.*
-        platform = "linux/amd64" if confluent_version.startswith("6.") else None
         with c.override(
-            Zookeeper(tag=confluent_version, platform=platform),
-            Kafka(tag=confluent_version, platform=platform),
-            SchemaRegistry(tag=confluent_version, platform=platform),
+            Zookeeper(tag=confluent_version),
+            Kafka(tag=confluent_version),
+            SchemaRegistry(tag=confluent_version),
         ):
             c.down(destroy_volumes=True)
             c.up("zookeeper", "kafka", "schema-registry", "materialized")


### PR DESCRIPTION
Seems to be green now with https://github.com/MaterializeInc/i2/pull/2065
Doing another round of reruns in https://buildkite.com/materialize/nightly/builds/9009#_

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
