### PR TITLE
Expand `EquivalenceClasses`'s handling of predicates

### DIFF
--- a/src/expr/src/scalar.rs
+++ b/src/expr/src/scalar.rs
@@ -720,8 +720,8 @@ impl MirScalarExpr {
     /// use mz_repr::{ColumnType, Datum, ScalarType};
     ///
     /// let expr_0 = MirScalarExpr::Column(0);
-    /// let expr_t = MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool);
-    /// let expr_f = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
+    /// let expr_t = MirScalarExpr::literal_true();
+    /// let expr_f = MirScalarExpr::literal_false();
     ///
     /// let mut test =
     /// expr_t

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1884,7 +1884,7 @@ fn apply_scalar_subquery(
                     (0..inner_arity).collect::<Vec<_>>(),
                     vec![mz_expr::AggregateExpr {
                         func: mz_expr::AggregateFunc::Count,
-                        expr: MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool),
+                        expr: MirScalarExpr::literal_true(),
                         distinct: false,
                     }],
                     None,

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -805,7 +805,7 @@ fn optimize(
                     if matches!(&knowledge, DatumKnowledge::Lit { .. }) {
                         e.reduce(column_types);
                     } else if func == &UnaryFunc::IsNull(func::IsNull) && !knowledge.nullable() {
-                        *e = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
+                        *e = MirScalarExpr::literal_false();
                     };
                     DatumKnowledge::from(&*e)
                 }

--- a/src/transform/src/equivalence_propagation.rs
+++ b/src/transform/src/equivalence_propagation.rs
@@ -31,7 +31,6 @@
 use std::collections::BTreeMap;
 
 use mz_expr::{Id, MirRelationExpr, MirScalarExpr};
-use mz_repr::Datum;
 
 use crate::analysis::equivalences::{EquivalenceClasses, Equivalences};
 use crate::analysis::{Arity, DerivedView, RelationType};
@@ -264,12 +263,10 @@ impl EquivalencePropagation {
                     for expr in predicates.iter_mut() {
                         input_equivalences.reduce_expr(expr);
                     }
+
                     // Incorporate `predicates` into `outer_equivalences`.
                     let mut class = predicates.clone();
-                    class.push(MirScalarExpr::literal_ok(
-                        Datum::True,
-                        mz_repr::ScalarType::Bool,
-                    ));
+                    class.push(MirScalarExpr::literal_true());
                     outer_equivalences.classes.push(class);
                     outer_equivalences.minimize(input_types);
                     self.apply(

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -15,7 +15,7 @@
 // TODO(frank): evaluate for redundancy with `column_knowledge`, or vice-versa.
 
 use mz_expr::{func, AggregateExpr, AggregateFunc, MirRelationExpr, MirScalarExpr, UnaryFunc};
-use mz_repr::{Datum, RelationType, ScalarType};
+use mz_repr::RelationType;
 
 use crate::{TransformCtx, TransformError};
 
@@ -124,7 +124,7 @@ fn scalar_nonnullable(expr: &mut MirScalarExpr, metadata: &RelationType) {
         {
             if let MirScalarExpr::Column(c) = &**expr {
                 if !metadata.column_types[*c].nullable {
-                    *e = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
+                    *e = MirScalarExpr::literal_false();
                 }
             }
         }
@@ -137,7 +137,7 @@ fn aggregate_nonnullable(expr: &mut AggregateExpr, metadata: &RelationType) {
     // count(true).
     if let (AggregateFunc::Count, MirScalarExpr::Column(c)) = (&expr.func, &expr.expr) {
         if !metadata.column_types[*c].nullable && !expr.distinct {
-            expr.expr = MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool);
+            expr.expr = MirScalarExpr::literal_true();
         }
     }
 }

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -53,7 +53,7 @@
 //! let predicate0 = MirScalarExpr::column(0);
 //! let predicate1 = MirScalarExpr::column(1);
 //! let predicate01 = MirScalarExpr::column(0).call_binary(MirScalarExpr::column(2), BinaryFunc::AddInt64);
-//! let predicate012 = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
+//! let predicate012 = MirScalarExpr::literal_false();
 //!
 //! let mut expr = join.filter(
 //!    vec![
@@ -92,7 +92,7 @@ use mz_expr::{
 };
 use mz_ore::soft_assert_eq_no_log;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
-use mz_repr::{ColumnType, Datum, ScalarType};
+use mz_repr::ColumnType;
 
 use crate::{TransformCtx, TransformError};
 
@@ -323,10 +323,7 @@ impl PredicatePushdown {
                                             && aggregates[0].func == AggregateFunc::Any
                                         {
                                             push_down.push(aggregates[0].expr.clone());
-                                            aggregates[0].expr = MirScalarExpr::literal_ok(
-                                                Datum::True,
-                                                ScalarType::Bool,
-                                            );
+                                            aggregates[0].expr = MirScalarExpr::literal_true();
                                         } else {
                                             retain.push(predicate);
                                         }

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -3588,7 +3588,7 @@ Explained Query:
             implementation
               %1[#0]UKA » %0:l0[#1]K
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+              Filter (#0{id}) IS NOT NULL // { arity: 3 }
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
@@ -3609,7 +3609,7 @@ Explained Query:
                   implementation
                     %1:pathq19[#0]KA » %0:l0[#1]K
                   ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                    Filter (#0{id}) IS NOT NULL // { arity: 3 }
                       Get l0 // { arity: 3 }
                   ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                     ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
@@ -3713,10 +3713,10 @@ Explained Query:
             implementation
               %0:l0[#1]K » %1:l1[#1]K
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+              Filter (#0{id}) IS NOT NULL // { arity: 3 }
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+              Filter (#0{id}) IS NOT NULL // { arity: 3 }
                 Get l1 // { arity: 3 }
     cte l1 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
@@ -3733,7 +3733,7 @@ Explained Query:
                     %1 » %0:l1[×] » %2:pathq19[#0]KA
                     %2:pathq19 » %0:l1[#1]K » %1[×]
                   ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                    Filter (#0{id}) IS NOT NULL // { arity: 3 }
                       Get l1 // { arity: 3 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     Union // { arity: 1 }
@@ -3764,7 +3764,7 @@ Explained Query:
                     %1 » %0:l0[×] » %2:pathq19[#0]KA
                     %2:pathq19 » %0:l0[#1]K » %1[×]
                   ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                    Filter (#0{id}) IS NOT NULL // { arity: 3 }
                       Get l0 // { arity: 3 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     Union // { arity: 1 }

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -3880,7 +3880,7 @@ Explained Query:
                 %1[#0]UK » %0:l7[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#2{id}) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
+                  Filter (#1{id}) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
                     Get l7 // { arity: 6 }
               ArrangeBy keys=[[#0{max}]] // { arity: 1 }
                 Filter (#0{max}) IS NOT NULL // { arity: 1 }
@@ -3946,11 +3946,11 @@ Explained Query:
                 %0:l3[#0]Kef » %1:l3[#0]Kef
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                  Filter (#0 = false) AND (#1) IS NOT NULL // { arity: 5 }
                     Get l3 // { arity: 5 }
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                  Filter (#0 = true) AND (#1) IS NOT NULL // { arity: 5 }
                     Get l3 // { arity: 5 }
       cte l3 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
@@ -3965,7 +3965,7 @@ Explained Query:
                       ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
                     ArrangeBy keys=[[#2]] // { arity: 4 }
                       Project (#0..=#3) // { arity: 4 }
-                        Filter (#2) IS NOT NULL // { arity: 5 }
+                        Filter (#1) IS NOT NULL // { arity: 5 }
                           Get l0 // { arity: 5 }
               Project (#0..=#3, #9) // { arity: 5 }
                 Map ((#4 OR #8)) // { arity: 10 }
@@ -3997,12 +3997,12 @@ Explained Query:
             implementation
               %1[#0..=#2]UKKKA » %0:l1[#0..=#2]UKKK
             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
+              Filter (#1) IS NOT NULL // { arity: 3 }
                 Get l1 // { arity: 3 }
             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Distinct project=[#0..=#2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
-                  Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
+                  Filter (#1) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
       cte l1 =
         Distinct project=[#0..=#2] // { arity: 3 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -3887,7 +3887,7 @@ Explained Query:
                 %1[#0]UK » %0:l7[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#2{id}) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
+                  Filter (#1{id}) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
                     Get l7 // { arity: 6 }
               ArrangeBy keys=[[#0{max}]] // { arity: 1 }
                 Filter (#0{max}) IS NOT NULL // { arity: 1 }
@@ -3953,11 +3953,11 @@ Explained Query:
                 %0:l3[#0]Kef » %1:l3[#0]Kef
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                  Filter (#0 = false) AND (#1) IS NOT NULL // { arity: 5 }
                     Get l3 // { arity: 5 }
               ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
+                  Filter (#0 = true) AND (#1) IS NOT NULL // { arity: 5 }
                     Get l3 // { arity: 5 }
       cte l3 =
         TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
@@ -3972,7 +3972,7 @@ Explained Query:
                       ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
                     ArrangeBy keys=[[#2]] // { arity: 4 }
                       Project (#0..=#3) // { arity: 4 }
-                        Filter (#2) IS NOT NULL // { arity: 5 }
+                        Filter (#1) IS NOT NULL // { arity: 5 }
                           Get l0 // { arity: 5 }
               Project (#0..=#3, #9) // { arity: 5 }
                 Map ((#4 OR #8)) // { arity: 10 }
@@ -4004,12 +4004,12 @@ Explained Query:
             implementation
               %1[#0..=#2]UKKKA » %0:l1[#0..=#2]UKKK
             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
+              Filter (#1) IS NOT NULL // { arity: 3 }
                 Get l1 // { arity: 3 }
             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Distinct project=[#0..=#2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
-                  Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
+                  Filter (#1) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
       cte l1 =
         Distinct project=[#0..=#2] // { arity: 3 }

--- a/test/sqllogictest/ldbc_bi_eager.slt
+++ b/test/sqllogictest/ldbc_bi_eager.slt
@@ -3595,7 +3595,7 @@ Explained Query:
             implementation
               %1[#0]UKA » %0:l0[#1]K
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+              Filter (#0{id}) IS NOT NULL // { arity: 3 }
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Distinct project=[#0{id}] // { arity: 1 }
@@ -3616,7 +3616,7 @@ Explained Query:
                   implementation
                     %1:pathq19[#0]KA » %0:l0[#1]K
                   ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                    Filter (#0{id}) IS NOT NULL // { arity: 3 }
                       Get l0 // { arity: 3 }
                   ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                     ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
@@ -3720,10 +3720,10 @@ Explained Query:
             implementation
               %0:l0[#1]K » %1:l1[#1]K
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+              Filter (#0{id}) IS NOT NULL // { arity: 3 }
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[#1{id}]] // { arity: 3 }
-              Filter (#1{id}) IS NOT NULL // { arity: 3 }
+              Filter (#0{id}) IS NOT NULL // { arity: 3 }
                 Get l1 // { arity: 3 }
     cte l1 =
       TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
@@ -3740,7 +3740,7 @@ Explained Query:
                     %1 » %0:l1[×] » %2:pathq19[#0]KA
                     %2:pathq19 » %0:l1[#1]K » %1[×]
                   ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                    Filter (#0{id}) IS NOT NULL // { arity: 3 }
                       Get l1 // { arity: 3 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     Union // { arity: 1 }
@@ -3771,7 +3771,7 @@ Explained Query:
                     %1 » %0:l0[×] » %2:pathq19[#0]KA
                     %2:pathq19 » %0:l0[#1]K » %1[×]
                   ArrangeBy keys=[[], [#1{id}]] // { arity: 3 }
-                    Filter (#1{id}) IS NOT NULL // { arity: 3 }
+                    Filter (#0{id}) IS NOT NULL // { arity: 3 }
                       Get l0 // { arity: 3 }
                   ArrangeBy keys=[[]] // { arity: 1 }
                     Union // { arity: 1 }

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -280,25 +280,24 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Filter (#2 >= 0) // { arity: 3 }
-    Reduce group_by=[#0] aggregates=[sum(#0), max(#0)] // { arity: 3 }
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t2 // { arity: 2 }
+  Reduce group_by=[#0] aggregates=[sum(#0), max(#0)] // { arity: 3 }
+    Project (#0) // { arity: 1 }
+      Join on=(#0 = #1) type=differential // { arity: 2 }
+        implementation
+          %0:t1[#0]Kif » %1:t2[#0]Kiif
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#0 >= 0) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#0 >= 0) // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
-  filter=((#0) IS NOT NULL)
+  filter=((#0 >= 0))
 Source materialize.public.t2
-  filter=((#0) IS NOT NULL)
+  filter=((#0 >= 0))
 
 Target cluster: quickstart
 
@@ -309,25 +308,25 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0 and sum(t2.f1) >= 0;
 ----
 Explained Query:
-  Filter (#1 >= 0) AND (#2 >= 0) // { arity: 3 }
+  Filter (#1 >= 0) // { arity: 3 }
     Reduce group_by=[#0] aggregates=[sum(#0), max(#0)] // { arity: 3 }
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %0:t1[#0]K » %1:t2[#0]K
+            %0:t1[#0]Kif » %1:t2[#0]Kiif
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
+              Filter (#0 >= 0) // { arity: 2 }
                 ReadStorage materialize.public.t1 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
+              Filter (#0 >= 0) // { arity: 2 }
                 ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
-  filter=((#0) IS NOT NULL)
+  filter=((#0 >= 0))
 Source materialize.public.t2
-  filter=((#0) IS NOT NULL)
+  filter=((#0 >= 0))
 
 Target cluster: quickstart
 
@@ -387,24 +386,23 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f1 + t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Filter (#2 >= 0) // { arity: 3 }
-    Reduce group_by=[#0] aggregates=[sum((#0 + #1)), max(#0)] // { arity: 3 }
-      Project (#0, #2) // { arity: 2 }
-        Join on=(#0 = #1) type=differential // { arity: 3 }
-          implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
+  Reduce group_by=[#0] aggregates=[sum((#0 + #1)), max(#0)] // { arity: 3 }
+    Project (#0, #2) // { arity: 2 }
+      Join on=(#0 = #1) type=differential // { arity: 3 }
+        implementation
+          %0:t1[#0]Kif » %1:t2[#0]Kiif
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#0 >= 0) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Filter (#0 >= 0) // { arity: 2 }
+            ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
-  filter=((#0) IS NOT NULL)
+  filter=((#0 >= 0))
 Source materialize.public.t2
-  filter=((#0) IS NOT NULL)
+  filter=((#0 >= 0))
 
 Target cluster: quickstart
 
@@ -415,25 +413,24 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t1.f1 + t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Filter (#2 >= 0) // { arity: 3 }
-    Reduce group_by=[#0] aggregates=[sum((#0 + #0)), max(#0)] // { arity: 3 }
-      Project (#0) // { arity: 1 }
-        Join on=(#0 = #1) type=differential // { arity: 2 }
-          implementation
-            %0:t1[#0]K » %1:t2[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Project (#0) // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 2 }
-                ReadStorage materialize.public.t2 // { arity: 2 }
+  Reduce group_by=[#0] aggregates=[sum((#0 + #0)), max(#0)] // { arity: 3 }
+    Project (#0) // { arity: 1 }
+      Join on=(#0 = #1) type=differential // { arity: 2 }
+        implementation
+          %0:t1[#0]Kif » %1:t2[#0]Kiif
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#0 >= 0) // { arity: 2 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#0 >= 0) // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
-  filter=((#0) IS NOT NULL)
+  filter=((#0 >= 0))
 Source materialize.public.t2
-  filter=((#0) IS NOT NULL)
+  filter=((#0 >= 0))
 
 Target cluster: quickstart
 

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -344,11 +344,13 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(1 = (#0 / #2)) type=differential // { arity: 4 }
       implementation
-        %0:foo[×] » %1:bar[×]
+        %0:foo[×]enf » %1:bar[×]enf
       ArrangeBy keys=[[]] // { arity: 2 }
-        ReadIndex on=foo foo_idx=[*** full scan ***] // { arity: 2 }
+        Filter (false = (#0) IS NULL) // { arity: 2 }
+          ReadIndex on=foo foo_idx=[*** full scan ***] // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 2 }
-        ReadIndex on=bar bar_idx2=[*** full scan ***] // { arity: 2 }
+        Filter (false = (#0) IS NULL) // { arity: 2 }
+          ReadIndex on=bar bar_idx2=[*** full scan ***] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.foo_idx (*** full scan ***)
@@ -377,11 +379,13 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(-1 = (#3 - #1) = (#0 / #2)) type=differential // { arity: 4 }
       implementation
-        %0:foo[×] » %1:bar[×]
+        %0:foo[×]enf » %1:bar[×]enf
       ArrangeBy keys=[[]] // { arity: 2 }
-        ReadIndex on=foo foo_idx=[*** full scan ***] // { arity: 2 }
+        Filter (false = (#0) IS NULL) AND (false = (#1) IS NULL) // { arity: 2 }
+          ReadIndex on=foo foo_idx=[*** full scan ***] // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 2 }
-        ReadIndex on=bar bar_idx2=[*** full scan ***] // { arity: 2 }
+        Filter (false = (#0) IS NULL) AND (false = (#1) IS NULL) // { arity: 2 }
+          ReadIndex on=bar bar_idx2=[*** full scan ***] // { arity: 2 }
 
 Used Indexes:
   - materialize.public.foo_idx (*** full scan ***)


### PR DESCRIPTION
`EquivalenceClasses` tracks which expressions must be equivalent (in the Rust-not-SQL sense). Some expressions must be equivalent to the literal true, and these are what we think of as "predicates". Some others must be equivalent to the literal false, and .. idk what we call these. But both of these cases can be expanded out to further decompose expressions, as well as fish up some "implications", primarily the non-nullability requirement of expressions.

In effecting this change, the termination conditions for `EquivalenceClasses::minimize` were made less clever, and just check whether the classes have changed (we have to keep a second copy for our defensive test afterwards, anyhow).

Incidentally, and largely unrelatedly, various `MirScalarExpr::literal_ok(Datum::{True, False}, ...)` were replaced with `literal_true()` and `literal_false()` helper functions.

1. `2aadef`: expands predicate handling, including a more sophisticated `union` implementation that better tracks predicates in common as well as column non-nullability.
2. `724ee6`: Introduces non-nullability expansion of predicates. This will evenutally be moved out of `minimize_once`, because it "inflates" the set of predicates without a corresponding reduction elsewhere, which led to non-termination in some cases.
3. `917197`: extracts non-nullability of columns into a helper method, from three locations with identical logic.
4. `7873f0`: moves around the non-nullability checks and corrects some convergence issues (not running enough). In response to diagnosing moments where `Equivalences` failed to find column non-nullability that `typ()` found.
5. `bc761e`: introduces `self.tidy` in some load bearing moments that were resulting in defective minimization.

As a bonus, `59e28b` claims to `Update tests` but seems to have attached an improvement to `Reduce` logic, wherein we surface equivalences for `MIN/MAX/ANY/ALL` aggregations. 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
