### PR TITLE
fix merge skew on main

### DIFF
--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -205,7 +205,8 @@ mod tests {
     use mz_storage_types::instances::StorageInstanceId;
     use mz_storage_types::sinks::{
         KafkaIdStyle, KafkaSinkCompressionType, KafkaSinkConnection, KafkaSinkFormat,
-        KafkaSinkFormatType, MetadataFilled, SinkEnvelope, StorageSinkConnection, StorageSinkDesc,
+        KafkaSinkFormatType, MetadataFilled, SinkEnvelope, SinkPartitionStrategy,
+        StorageSinkConnection, StorageSinkDesc,
     };
     use mz_storage_types::sources::load_generator::LoadGenerator;
     use mz_storage_types::sources::{
@@ -335,6 +336,7 @@ mod tests {
                 progress_group_id: KafkaIdStyle::Legacy,
                 transactional_id: KafkaIdStyle::Legacy,
             }),
+            partition_strategy: SinkPartitionStrategy::V1,
             with_snapshot: Default::default(),
             version: Default::default(),
             envelope: SinkEnvelope::Upsert,


### PR DESCRIPTION
This PR fixes merge skew introduced by #26423 and #28380.

### Motivation

  * This PR fixes merge skew.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
