### PR TITLE
Reenable tests for #28166 and #28046

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -648,11 +648,6 @@ steps:
           composition: replica-isolation
     agents:
       queue: linux-aarch64-small
-    # TODO: #28046 (!! AllowCompaction not found for materialized view with id ['User(11)'])
-    retry:
-      automatic:
-        - exit_status: 1
-          limit: 2
 
   - id: persistence
     label: Persistence tests

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2190,8 +2190,7 @@ ddl_action_list = ActionList(
         (DropClusterAction, 2),
         (SwapClusterAction, 10),
         (CreateClusterReplicaAction, 4),
-        # TODO: Reenable when #28166 is fixed
-        # (DropClusterReplicaAction, 4),
+        (DropClusterReplicaAction, 4),
         (SetClusterAction, 1),
         (CreateWebhookSourceAction, 2),
         (DropWebhookSourceAction, 2),

--- a/src/storage-controller/src/history.rs
+++ b/src/storage-controller/src/history.rs
@@ -205,7 +205,8 @@ mod tests {
     use mz_storage_types::instances::StorageInstanceId;
     use mz_storage_types::sinks::{
         KafkaIdStyle, KafkaSinkCompressionType, KafkaSinkConnection, KafkaSinkFormat,
-        KafkaSinkFormatType, MetadataFilled, SinkEnvelope, StorageSinkConnection, StorageSinkDesc,
+        KafkaSinkFormatType, MetadataFilled, SinkEnvelope, SinkPartitionStrategy,
+        StorageSinkConnection, StorageSinkDesc,
     };
     use mz_storage_types::sources::load_generator::LoadGenerator;
     use mz_storage_types::sources::{
@@ -335,6 +336,7 @@ mod tests {
                 progress_group_id: KafkaIdStyle::Legacy,
                 transactional_id: KafkaIdStyle::Legacy,
             }),
+            partition_strategy: SinkPartitionStrategy::V1,
             with_snapshot: Default::default(),
             version: Default::default(),
             envelope: SinkEnvelope::Upsert,

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -414,10 +414,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     c.up("zookeeper", "kafka", "schema-registry", "localstack")
     for id, disruption in enumerate(selected_by_name(args.disruptions, disruptions)):
-        # TODO: Reenable when #28046 is fixed
-        if disruption.name == "restart-environmentd":
-            continue
-
         run_test(c, disruption, id)
 
 


### PR DESCRIPTION
Both closed by https://github.com/MaterializeInc/materialize/pull/28380
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
