### PR TITLE
lint: fix

### DIFF
--- a/bin/ci-annotate-errors
+++ b/bin/ci-annotate-errors
@@ -17,7 +17,7 @@ OUTPUT=$(exec "$(dirname "$0")"/ci-builder run stable "$(dirname "$0")"/mzcompos
 if [[ $OUTPUT == *"CalledProcessError"* ]]; then
   OUTPUT="unknown"
 else
-  # shellcheck disable=SC2181
+  # shellcheck disable=SC2181,SC2319
   if [ $? -eq 0 ]; then
     # Discard all but the last two lines, previous content can be retries when docker pull has problems
     OUTPUT=$(echo "$OUTPUT" | tail -n 2)


### PR DESCRIPTION
This is necessary locally; I don't know why it is not in CI.

Issue was:
```
In bin/ci-annotate-errors line 21:
  if [ $? -eq 0 ]; then
       ^-- SC2319 (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
```