### PR TITLE
docs: enable cmd+k for kapa widget

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -86,6 +86,7 @@ toCSS | fingerprint }}
   data-search-mode-enabled="true"
   data-modal-override-open-id="docsearch"
   data-user-analytics-fingerprint-enabled="true"
+  data-modal-open-on-command-k="true"
   >
 </script>
 


### PR DESCRIPTION
Enable `cmd+k` for opening the modal.