### PR TITLE
adapter: Log pgwire connection start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4407,6 +4407,7 @@ dependencies = [
  "prometheus",
  "reqwest",
  "semver",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-openssl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6209,6 +6209,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "uuid",
  "workspace-hack",
 ]
 

--- a/src/adapter-types/src/dyncfgs.rs
+++ b/src/adapter-types/src/dyncfgs.rs
@@ -84,6 +84,13 @@ pub const DEFAULT_SINK_PARTITION_STRATEGY: Config<&str> = Config::new(
     "The default sink partitioning strategy for an environment. It defaults to 'v0'.",
 );
 
+/// Whether to log the status of pgwire connections.
+pub const LOG_PGWIRE_CONNECTION_STATUS: Config<bool> = Config::new(
+    "log_pgwire_connection_status",
+    false,
+    "Whether to log the status of pgwire connections.",
+);
+
 /// Adds the full set of all compute `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
     configs
@@ -97,4 +104,5 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_INTROSPECTION_SUBSCRIBES)
         .add(&PLAN_INSIGHTS_NOTICE_FAST_PATH_CLUSTERS_OPTIMIZE_DURATION)
         .add(&DEFAULT_SINK_PARTITION_STRATEGY)
+        .add(&LOG_PGWIRE_CONNECTION_STATUS)
 }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -23,6 +23,7 @@ use itertools::Itertools;
 use mz_adapter_types::connection::{ConnectionId, ConnectionIdType};
 use mz_build_info::BuildInfo;
 use mz_compute_types::ComputeInstanceId;
+use mz_dyncfg::ConfigSet;
 use mz_ore::channel::OneshotReceiverExt;
 use mz_ore::collections::CollectionExt;
 use mz_ore::id_gen::{org_id_conn_bits, IdAllocator, IdAllocatorInnerBitSet, MAX_ORG_ID};
@@ -105,6 +106,7 @@ pub struct Client {
     metrics: Metrics,
     environment_id: EnvironmentId,
     segment_client: Option<mz_segment::Client>,
+    configs: ConfigSet,
 }
 
 impl Client {
@@ -115,6 +117,7 @@ impl Client {
         now: NowFn,
         environment_id: EnvironmentId,
         segment_client: Option<mz_segment::Client>,
+        configs: ConfigSet,
     ) -> Client {
         // Connection ids are 32 bits and have 3 parts.
         // 1. MSB bit is always 0 because these are interpreted as an i32, and it is possible some
@@ -132,6 +135,7 @@ impl Client {
             metrics,
             environment_id,
             segment_client,
+            configs,
         }
     }
 
@@ -389,6 +393,11 @@ Issue a SQL query to get started. Need help?
     /// The current time according to the [`Client`].
     pub fn now(&self) -> DateTime<Utc> {
         to_datetime((self.now)())
+    }
+
+    /// Returns the dynamic configurations associated with the adapter layer.
+    pub fn configs(&self) -> &ConfigSet {
+        &self.configs
     }
 
     /// Get a metadata and a channel that can be used to append to a webhook source.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3826,6 +3826,8 @@ pub fn serve(
             pg_timestamp_oracle_params.apply(config);
         }
 
+        let dyncfgs = catalog.system_config().dyncfgs().clone();
+
         let coord_thread_start = Instant::now();
         info!("startup: coordinator init: start coordinator thread beginning");
         let parent_span = tracing::Span::current();
@@ -3958,6 +3960,7 @@ pub fn serve(
                     now,
                     environment_id,
                     segment_client_clone,
+                    dyncfgs,
                 );
                 Ok((handle, client))
             }

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -39,6 +39,7 @@ num_cpus = "1.14.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
 prometheus = { version = "0.13.3", default-features = false }
 semver = "1.0.16"
+serde_json = "1.0.89"
 tokio = { version = "1.38.0", default-features = false }
 tokio-openssl = "0.6.3"
 tokio-postgres = { version = "0.7.8" }

--- a/src/balancerd/src/codec.rs
+++ b/src/balancerd/src/codec.rs
@@ -20,6 +20,7 @@ use mz_pgwire_common::{
 };
 use tokio::io::{self, AsyncRead, AsyncWrite, Interest, Ready};
 use tokio_util::codec::{Decoder, Encoder, Framed};
+use uuid::Uuid;
 
 /// Internal representation of a backend [message].
 ///
@@ -38,6 +39,7 @@ impl From<ErrorResponse> for BackendMessage {
 
 /// A connection that manages the encoding and decoding of pgwire frames.
 pub struct FramedConn<A> {
+    pub uuid: Uuid,
     inner: sink::Buffer<Framed<Conn<A>, Codec>, BackendMessage>,
 }
 
@@ -50,11 +52,9 @@ where
     /// The underlying connection, `inner`, is expected to be something like a
     /// TCP stream. Anything that implements [`AsyncRead`] and [`AsyncWrite`]
     /// will do.
-    ///
-    /// The supplied `conn_id` is used to identify the connection in logging
-    /// messages.
     pub fn new(inner: Conn<A>) -> FramedConn<A> {
         FramedConn {
+            uuid: Uuid::new_v4(),
             inner: Framed::new(inner, Codec::new()).buffer(32),
         }
     }

--- a/src/balancerd/src/dyncfgs.rs
+++ b/src/balancerd/src/dyncfgs.rs
@@ -23,7 +23,16 @@ pub const SIGTERM_WAIT: Config<Duration> = Config::new(
     "Duration to wait after SIGTERM for outstanding connections to complete.",
 );
 
+/// Whether to log the status of pgwire connections.
+pub const LOG_PGWIRE_CONNECTION_STATUS: Config<bool> = Config::new(
+    "balancerd_log_pgwire_connection_status",
+    false,
+    "Whether to log the status of pgwire connections.",
+);
+
 /// Adds the full set of all balancer `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
-    configs.add(&SIGTERM_WAIT)
+    configs
+        .add(&SIGTERM_WAIT)
+        .add(&LOG_PGWIRE_CONNECTION_STATUS)
 }

--- a/src/balancerd/src/service.rs
+++ b/src/balancerd/src/service.rs
@@ -20,6 +20,7 @@ use mz_frontegg_auth::{
     Authenticator, AuthenticatorConfig, DEFAULT_REFRESH_DROP_FACTOR,
     DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
 };
+use mz_ore::cli::KeyValueArg;
 use mz_ore::metrics::MetricsRegistry;
 use mz_server_core::TlsCliArgs;
 use tracing::warn;
@@ -107,6 +108,10 @@ pub struct Args {
         parse(try_from_str = humantime::parse_duration),
     )]
     config_sync_loop_interval: Option<Duration>,
+    /// A list of NAME=VALUE pairs used to override static defaults
+    /// for configuration parameters.
+    #[clap(long, env = "CONFIG_DEFAULT", multiple = true, value_delimiter = ';')]
+    config_default: Vec<KeyValueArg<String, String>>,
 
     /// The cloud provider where the balancer is running.
     #[clap(long, env = "CLOUD_PROVIDER")]
@@ -181,6 +186,10 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         args.launchdarkly_sdk_key,
         args.config_sync_timeout,
         args.config_sync_loop_interval,
+        args.config_default
+            .into_iter()
+            .map(|kv| (kv.key, kv.value))
+            .collect(),
         args.cloud_provider,
         args.cloud_provider_region,
     );

--- a/src/dyncfg/src/lib.rs
+++ b/src/dyncfg/src/lib.rs
@@ -221,6 +221,11 @@ impl ConfigSet {
     pub fn entries(&self) -> impl Iterator<Item = &ConfigEntry> {
         self.configs.values()
     }
+
+    /// Returns the config with `name` registered to this set, if one exists.
+    pub fn entry(&self, name: &str) -> Option<&ConfigEntry> {
+        self.configs.get(name)
+    }
 }
 
 /// An entry for a config in a [ConfigSet].

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -508,7 +508,7 @@ pub struct Args {
         default_value = "1"
     )]
     bootstrap_builtin_support_cluster_replica_size: String,
-    /// An list of NAME=VALUE pairs used to override static defaults
+    /// A list of NAME=VALUE pairs used to override static defaults
     /// for system parameters.
     #[clap(
         long,

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1535,7 +1535,6 @@ fn test_default_cluster_sizes() {
 }
 
 #[mz_ore::test]
-#[ignore] // TODO: Reenable when #22998 is fixed
 fn test_max_request_size() {
     let statement = "SELECT $1::text";
     let statement_size = statement.bytes().count();

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -26,7 +26,6 @@ use mz_adapter::{
     verify_datum_desc, AdapterError, AdapterNotice, ExecuteContextExtra, ExecuteResponse,
     PeekResponseUnary, RowsFuture,
 };
-use mz_adapter_types::dyncfgs::LOG_PGWIRE_CONNECTION_STATUS;
 use mz_frontegg_auth::Authenticator as FronteggAuthentication;
 use mz_ore::cast::CastFrom;
 use mz_ore::netio::AsyncReady;
@@ -37,7 +36,7 @@ use mz_pgwire_common::{ErrorResponse, Format, FrontendMessage, Severity, VERSION
 use mz_repr::{
     Datum, GlobalId, RelationDesc, RelationType, RowArena, RowIterator, RowRef, ScalarType,
 };
-use mz_server_core::{TlsMode, CONN_UUID_KEY};
+use mz_server_core::TlsMode;
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{CopyDirection, CopyStatement, FetchDirection, Ident, Raw, Statement};
 use mz_sql::parse::StatementParseResult;
@@ -51,7 +50,7 @@ use tokio::select;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time::{self};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{debug, debug_span, info, warn, Instrument};
+use tracing::{debug, debug_span, warn, Instrument};
 
 use crate::codec::FramedConn;
 use crate::message::{self, BackendMessage};
@@ -132,8 +131,6 @@ where
     }
 
     let user = params.remove("user").unwrap_or_else(String::new);
-    let conn_uuid = params.remove(CONN_UUID_KEY);
-    let log_connection_status = LOG_PGWIRE_CONNECTION_STATUS.get(adapter_client.configs());
 
     if internal {
         // The internal server can only be used to connect to the internal users.
@@ -287,12 +284,6 @@ where
         adapter_client,
         txn_needs_commit: false,
     };
-
-    if let Some(conn_uuid) = conn_uuid {
-        if log_connection_status {
-            info!(%conn_uuid, "starting new pgwire connection in adapter");
-        }
-    }
 
     select! {
         r = machine.run() => {

--- a/src/server-core/Cargo.toml
+++ b/src/server-core/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.25"
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 tokio = "1.38.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
+uuid = { version = "1.7.0", features = ["v4"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1112,7 +1112,7 @@ pub struct SystemVars {
 
     active_connection_count: Arc<Mutex<ConnectionCounter>>,
     /// NB: This is intentionally disconnected from the one that is plumbed around to persist and
-    /// the controllers. This is so we can explictly control and reason about when changes to config
+    /// the controllers. This is so we can explicitly control and reason about when changes to config
     /// values are propagated to the rest of the system.
     dyncfgs: ConfigSet,
 }


### PR DESCRIPTION
This commit assigns all pgwire connections a unique UUID and logs when that connection starts in the balancer and adapter. This will help us debug broken connections. The next step is to log when the connection is severed, where it was severed and why.

This commit also plumbs dyncfg `ConfigSet`s around so that we can dynamically turn the logging on and off.

Works towards resolving incidents-and-escalations/#92

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
