### PR TITLE
catalog: Add cluster_id to mz_object_fully_qualifed_names

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -414,28 +414,29 @@ all database objects in the system.
 The `mz_object_fully_qualified_names` view enriches the [`mz_catalog.mz_objects`](/sql/system-catalog/mz_catalog/#mz_objects) view with namespace information.
 
 <!-- RELATION_SPEC mz_internal.mz_object_fully_qualified_names -->
-| Field          | Type       | Meaning                                                                                                                                        |
-| ---------------|------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`           | [`text`]   | Materialize's unique ID for the object.                                                                                                        |
-| `name`         | [`text`]   | The name of the object.                                                                                                                        |
-| `object_type`  | [`text`]   | The type of the object: one of `table`, `source`, `view`, `materialized view`, `sink`, `index`, `connection`, `secret`, `type`, or `function`. |
-| `schema_id`    | [`text`]   | The ID of the schema to which the object belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).                |
-| `schema_name`  | [`text`]   | The name of the schema to which the object belongs. Corresponds to [`mz_schemas.name`](/sql/system-catalog/mz_catalog/#mz_schemas).            |
-| `database_id`  | [`text`]   | The ID of the database to which the object belongs. Corresponds to [`mz_databases.id`](/sql/system-catalog/mz_catalog/#mz_schemas).             |
-| `database_name`| [`text`]   | The name of the database to which the object belongs. Corresponds to [`mz_databases.name`](/sql/system-catalog/mz_catalog/#mz_databases).      |
+| Field           | Type         | Meaning                                                                                                                                                                                         |
+| --------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------                                                |
+| `id`            | [`text`]     | Materialize's unique ID for the object.                                                                                                                                                         |
+| `name`          | [`text`]     | The name of the object.                                                                                                                                                                         |
+| `object_type`   | [`text`]     | The type of the object: one of `table`, `source`, `view`, `materialized view`, `sink`, `index`, `connection`, `secret`, `type`, or `function`.                                                  |
+| `schema_id`     | [`text`]     | The ID of the schema to which the object belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).                                                                 |
+| `schema_name`   | [`text`]     | The name of the schema to which the object belongs. Corresponds to [`mz_schemas.name`](/sql/system-catalog/mz_catalog/#mz_schemas).                                                             |
+| `database_id`   | [`text`]     | The ID of the database to which the object belongs. Corresponds to [`mz_databases.id`](/sql/system-catalog/mz_catalog/#mz_schemas).                                                             |
+| `database_name` | [`text`]     | The name of the database to which the object belongs. Corresponds to [`mz_databases.name`](/sql/system-catalog/mz_catalog/#mz_databases).                                                       |
+| `cluster_id`    | [`text`]     | The ID of the cluster maintaining the source, materialized view, index, or sink. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters). `NULL` for other object types. |
 
 ## `mz_object_lifetimes`
 
 The `mz_object_lifetimes` view enriches the [`mz_catalog.mz_objects`](/sql/system-catalog/mz_catalog/#mz_objects) view with information about the last lifetime event that occurred for each object in the system.
 
 <!-- RELATION_SPEC mz_internal.mz_object_lifetimes -->
-| Field          | Type                         | Meaning                                          |
-| ---------------|------------------------------|------------------------------------------------- |
-| `id`           | [`text`]                     | Materialize's unique ID for the object.          |
-| `previous_id`  | [`text`]                     | The object's previous ID, if one exists.          |
-| `object_type`  | [`text`]                     | The type of the object: one of `table`, `source`, `view`, `materialized view`, `sink`, `index`, `connection`, `secret`, `type`, or `function`.                                                                              |
-| `event_type`   | [`text`]                     | The lifetime event, either `create` or `drop`.   |
-| `occurred_at`  | [`timestamp with time zone`] | Wall-clock timestamp of when the event occurred. |
+| Field           | Type                           | Meaning                                                                                                                                        |
+| --------------- | ------------------------------ | -------------------------------------------------                                                                                              |
+| `id`            | [`text`]                       | Materialize's unique ID for the object.                                                                                                        |
+| `previous_id`   | [`text`]                       | The object's previous ID, if one exists.                                                                                                       |
+| `object_type`   | [`text`]                       | The type of the object: one of `table`, `source`, `view`, `materialized view`, `sink`, `index`, `connection`, `secret`, `type`, or `function`. |
+| `event_type`    | [`text`]                       | The lifetime event, either `create` or `drop`.                                                                                                 |
+| `occurred_at`   | [`timestamp with time zone`]   | Wall-clock timestamp of when the event occurred.                                                                                               |
 
 ## `mz_object_transitive_dependencies`
 

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -3412,7 +3412,9 @@ pub static MZ_OBJECT_FULLY_QUALIFIED_NAMES: Lazy<BuiltinView> = Lazy::new(|| Bui
     name: "mz_object_fully_qualified_names",
     schema: MZ_INTERNAL_SCHEMA,
     oid: oid::VIEW_MZ_OBJECT_FULLY_QUALIFIED_NAMES_OID,
-    column_defs: Some("id, name, object_type, schema_id, schema_name, database_id, database_name"),
+    column_defs: Some(
+        "id, name, object_type, schema_id, schema_name, database_id, database_name, cluster_id",
+    ),
     sql: "
     SELECT o.id,
         o.name,
@@ -3420,7 +3422,8 @@ pub static MZ_OBJECT_FULLY_QUALIFIED_NAMES: Lazy<BuiltinView> = Lazy::new(|| Bui
         sc.id as schema_id,
         sc.name as schema_name,
         db.id as database_id,
-        db.name as database_name
+        db.name as database_name,
+        o.cluster_id
     FROM mz_catalog.mz_objects o
     INNER JOIN mz_catalog.mz_schemas sc ON sc.id = o.schema_id
     -- LEFT JOIN accounts for objects in the ambient database.

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -250,6 +250,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 5  schema_name  text
 6  database_id  text
 7  database_name  text
+8  cluster_id  text
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_object_lifetimes' ORDER BY position


### PR DESCRIPTION
I recently added cluster_id to `mz_objects`, it would also be useful in `mz_object_fully_qualifed_names`.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
