### PR TITLE
Revert "ci: Reenable Cloudtest on Hetzner"

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -277,7 +277,9 @@ steps:
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # queue: hetzner-aarch64-8cpu-16gb
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/cloudtest:
               args: [-m=long, test/cloudtest/test_full_testdrive.py]
@@ -839,7 +841,9 @@ steps:
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # queue: hetzner-aarch64-8cpu-16gb
+          queue: linux-aarch64-medium
         plugins:
           - ./ci/plugins/cloudtest:
               args: [-m=long, test/cloudtest/test_upgrade.py]
@@ -860,7 +864,9 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # queue: hetzner-aarch64-8cpu-16gb
+          queue: linux-aarch64
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -884,7 +890,9 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # queue: hetzner-aarch64-8cpu-16gb
+          queue: linux-aarch64
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -908,7 +916,9 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # queue: hetzner-aarch64-8cpu-16gb
+          queue: linux-aarch64
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest
@@ -932,7 +942,9 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # queue: hetzner-aarch64-8cpu-16gb
+          queue: linux-aarch64
         inputs:
           - test/cloudtest
           - misc/python/materialize/cloudtest


### PR DESCRIPTION
This reverts commit 09afd4c3a1bf3e7d2955d1a917d8e721cfe16ed2.

Has apparantely not worked, I am currently out of ideas. What I tried:
- Switch from Ubuntu to Fedora
- Disable systemd-resolved
- Set DNS servers manually
- Pass in systemd-resolved resolv.conf via kind

Maybe someone will have another idea: https://materializeinc.slack.com/archives/C01LKF361MZ/p1723140526811439

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
