### PR TITLE
dyncfg: Add parse functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4875,6 +4875,7 @@ dependencies = [
 name = "mz-dyncfg"
 version = "0.0.0"
 dependencies = [
+ "humantime",
  "mz-build-tools",
  "mz-ore",
  "mz-proto",

--- a/src/dyncfg/Cargo.toml
+++ b/src/dyncfg/Cargo.toml
@@ -11,10 +11,11 @@ publish = false
 workspace = true
 
 [dependencies]
+humantime = "2.1.0"
 mz-ore = { path = "../ore", default-features = false, features = ["proptest", "test"] }
 mz-proto = { path = "../proto" }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.99"


### PR DESCRIPTION
This commit adds the functionality for a `Config` struct to parse a string into the correct `ConfigVal`. One potential use case for this feature, and the motivation of this commit, is to pass in default values for a `ConfigSet` via CLI arguments.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
