### PR TITLE
materialized: add telemetry to Docker image

### DIFF
--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -12,6 +12,17 @@
 set -euo pipefail
 
 cat <<EOF >/dev/stderr
+Thank you for trying Materialize! We are interested in any and all feedback you
+have, which may be able to improve both our software and your queries!
+
+Please reach out at:
+
+  Web: https://materialize.com
+  GitHub issues: https://github.com/MaterializeInc/materialize/issues
+  Slack: https://www.materialize.com/s/chat
+  Email: support@materialize.com
+  Twitter: @MaterializeInc
+
 ********************************* WARNING ********************************
 
 You *should not* run production deployments using this Docker image.
@@ -67,5 +78,9 @@ export MZ_ORCHESTRATOR=${MZ_ORCHESTRATOR:-process}
 export MZ_ORCHESTRATOR_PROCESS_SECRETS_DIRECTORY=${MZ_ORCHESTRATOR_PROCESS_SECRETS_DIRECTORY:-/mzdata/secrets}
 export MZ_ORCHESTRATOR_PROCESS_SCRATCH_DIRECTORY=${MZ_ORCHESTRATOR_PROCESS_SCRATCH_DIRECTORY:-/scratch}
 export MZ_BOOTSTRAP_ROLE=${MZ_BOOTSTRAP_ROLE:-materialize}
+
+if [ -z "${MZ_NO_TELEMETRY:-}" ]; then
+    export MZ_SEGMENT_API_KEY=${MZ_SEGMENT_API_KEY:-hMWi3sZ17KFMjn2sPWo9UJGpOQqiba4A}
+fi
 
 exec environmentd "$@"

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -69,6 +69,7 @@ class Materialized(Service):
         }
 
         environment = [
+            "MZ_NO_TELEMETRY=1",
             f"MZ_SOFT_ASSERTIONS={int(soft_assertions)}",
             # The following settings can not be baked in the default image, as they
             # are enabled for testing purposes only


### PR DESCRIPTION
Since we're bringing this back as a supported method for trying Materialize. The idea here is to have a Segment key in the Docker image that we use by default.

Touches https://github.com/MaterializeInc/materialize/issues/28876.

@def-: anywhere else I should disable telemetry so that CI doesn't generate a bunch of noise?
@matthelm: this is going to flow into a new database in Snowflake called `self_hosted`. Schema matches `cloud_production`, but the cloud provider is `docker` and the cloud region is `container`. 

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
