### PR TITLE
adapter: stabilize the mz_recent_storage_usage view

### DIFF
--- a/doc/user/content/releases/v0.113.md
+++ b/doc/user/content/releases/v0.113.md
@@ -1,0 +1,7 @@
+---
+title: "Materialize v0.113"
+date: 2024-08-21
+released: false
+_build:
+  render: never
+---

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -356,6 +356,25 @@ Field       | Type                 | Meaning
 `cluster_id`| [`text`]             | The ID of the cluster maintaining the source, materialized view, index, or sink. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters). `NULL` for other object types.
 `privileges`| [`mz_aclitem array`] | The privileges belonging to the relation.
 
+### `mz_recent_storage_usage`
+
+{{< warn-if-unreleased "v0.113" >}}
+
+The `mz_recent_storage_usage` table describes the storage utilization of each
+table, source, and materialized view in the system in the most recent storage
+utilization assessment. Storage utilization assessments occur approximately
+every hour.
+
+See [`mz_storage_usage`](../mz_catalog#mz_storage_usage) for historical storage
+usage information.
+
+<!-- RELATION_SPEC mz_catalog.mz_recent_storage_usage -->
+Field                  | Type                         | Meaning
+---------------------- | ---------------------------- | -----------------------------------------------------------
+`object_id`            | [`text`]                     | The ID of the table, source, or materialized view.
+`size_bytes`           | [`uint8`]                    | The number of storage bytes used by the object in the most recent assessment.
+
+
 ### `mz_roles`
 
 The `mz_roles` table contains a row for each role in the system.

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -562,9 +562,8 @@ referenced from
 | `authenticated_user` | [`text`]                     | The name of the user for which the session was established.                                                                       |
 -->
 
+{{< if-unreleased "v0.113" >}}
 ### `mz_recent_storage_usage`
-
-{{< warn-if-unreleased "v0.111" >}}
 
 The `mz_recent_storage_usage` table describes the storage utilization of each
 table, source, and materialized view in the system in the most recent storage
@@ -574,11 +573,11 @@ every hour.
 See [`mz_storage_usage`](../mz_catalog#mz_storage_usage) for historical storage
 usage information.
 
-<!-- RELATION_SPEC mz_internal.mz_recent_storage_usage -->
 Field                  | Type                         | Meaning
 ---------------------- | ---------------------------- | -----------------------------------------------------------
 `object_id`            | [`text`]                     | The ID of the table, source, or materialized view.
 `size_bytes`           | [`uint8`]                    | The number of storage bytes used by the object in the most recent assessment.
+{{< /if-unreleased >}}
 
 ## `mz_sessions`
 

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -3302,7 +3302,7 @@ GROUP BY object_id, collection_timestamp",
 pub static MZ_RECENT_STORAGE_USAGE: Lazy<BuiltinView> = Lazy::new(|| {
     BuiltinView {
     name: "mz_recent_storage_usage",
-    schema: MZ_INTERNAL_SCHEMA,
+    schema: MZ_CATALOG_SCHEMA,
     oid: oid::VIEW_MZ_RECENT_STORAGE_USAGE_OID,
     column_defs: Some("object_id, size_bytes"),
     sql: "
@@ -3338,9 +3338,9 @@ GROUP BY object_id",
 
 pub static MZ_RECENT_STORAGE_USAGE_IND: Lazy<BuiltinIndex> = Lazy::new(|| BuiltinIndex {
     name: "mz_recent_storage_usage_ind",
-    schema: MZ_INTERNAL_SCHEMA,
+    schema: MZ_CATALOG_SCHEMA,
     oid: oid::INDEX_MZ_RECENT_STORAGE_USAGE_IND_OID,
-    sql: "IN CLUSTER mz_catalog_server ON mz_internal.mz_recent_storage_usage (object_id)",
+    sql: "IN CLUSTER mz_catalog_server ON mz_catalog.mz_recent_storage_usage (object_id)",
     is_retained_metrics_object: false,
 });
 

--- a/test/sqllogictest/autogenerated/mz_catalog.slt
+++ b/test/sqllogictest/autogenerated/mz_catalog.slt
@@ -249,6 +249,12 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 8  privileges  mz_aclitem[]
 
 query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_recent_storage_usage' ORDER BY position
+----
+1  object_id  text
+2  size_bytes  uint8
+
+query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_roles' ORDER BY position
 ----
 1  id  text
@@ -424,6 +430,7 @@ mz_materialized_views
 mz_objects
 mz_operators
 mz_pseudo_types
+mz_recent_storage_usage
 mz_relations
 mz_role_members
 mz_role_parameters

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -315,12 +315,6 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 3  table_name  text
 
 query ITT
-SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_recent_storage_usage' ORDER BY position
-----
-1  object_id  text
-2  size_bytes  uint8
-
-query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_sessions' ORDER BY position
 ----
 1  id  uuid
@@ -607,7 +601,6 @@ mz_recent_activity_log_redacted
 mz_recent_activity_log_thinned
 mz_recent_sql_text
 mz_recent_sql_text_redacted
-mz_recent_storage_usage
 mz_session_history
 mz_sessions
 mz_show_all_my_privileges

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -185,6 +185,10 @@ mz_pseudo_types
 BASE TABLE
 materialize
 mz_catalog
+mz_recent_storage_usage
+VIEW
+materialize
+mz_catalog
 mz_relations
 VIEW
 materialize
@@ -426,10 +430,6 @@ VIEW
 materialize
 mz_internal
 mz_recent_sql_text_redacted
-VIEW
-materialize
-mz_internal
-mz_recent_storage_usage
 VIEW
 materialize
 mz_internal

--- a/test/sqllogictest/mz_catalog_server_index_accounting.slt
+++ b/test/sqllogictest/mz_catalog_server_index_accounting.slt
@@ -70,7 +70,7 @@ mz_object_transitive_dependencies_ind  CREATE␠INDEX␠"mz_object_transitive_de
 mz_peek_durations_histogram_raw_s2_primary_idx  CREATE␠INDEX␠"mz_peek_durations_histogram_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_introspection"."mz_peek_durations_histogram_raw"␠("worker_id",␠"type",␠"duration_ns")
 mz_recent_activity_log_thinned_ind  CREATE␠INDEX␠"mz_recent_activity_log_thinned_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_recent_activity_log_thinned"␠("sql_hash")
 mz_recent_sql_text_ind  CREATE␠INDEX␠"mz_recent_sql_text_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_recent_sql_text"␠("sql_hash")
-mz_recent_storage_usage_ind  CREATE␠INDEX␠"mz_recent_storage_usage_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_internal"."mz_recent_storage_usage"␠("object_id")
+mz_recent_storage_usage_ind  CREATE␠INDEX␠"mz_recent_storage_usage_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_catalog"."mz_recent_storage_usage"␠("object_id")
 mz_roles_ind  CREATE␠INDEX␠"mz_roles_ind"␠IN␠CLUSTER␠[s2]␠ON␠"mz_catalog"."mz_roles"␠("id")
 mz_scheduling_elapsed_raw_s2_primary_idx  CREATE␠INDEX␠"mz_scheduling_elapsed_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_introspection"."mz_scheduling_elapsed_raw"␠("id",␠"worker_id")
 mz_scheduling_parks_histogram_raw_s2_primary_idx  CREATE␠INDEX␠"mz_scheduling_parks_histogram_raw_s2_primary_idx"␠IN␠CLUSTER␠[s2]␠ON␠"mz_introspection"."mz_scheduling_parks_histogram_raw"␠("worker_id",␠"slept_for_ns",␠"requested_ns")

--- a/test/sqllogictest/mz_recent_storage_usage.slt
+++ b/test/sqllogictest/mz_recent_storage_usage.slt
@@ -11,14 +11,14 @@ mode cockroach
 
 # Ensure that querying `mz_recent_storage_usage` by ID is a point lookup.
 query T multiline
-EXPLAIN SELECT * FROM mz_internal.mz_recent_storage_usage WHERE object_id = 'just checking explain plan; this value does not matter'
+EXPLAIN SELECT * FROM mz_recent_storage_usage WHERE object_id = 'just checking explain plan; this value does not matter'
 ----
 Explained Query (fast path):
   Project (#0, #1)
-    ReadIndex on=mz_internal.mz_recent_storage_usage mz_recent_storage_usage_ind=[lookup value=("just checking explain plan; this value does not matter")]
+    ReadIndex on=mz_catalog.mz_recent_storage_usage mz_recent_storage_usage_ind=[lookup value=("just checking explain plan; this value does not matter")]
 
 Used Indexes:
-  - mz_internal.mz_recent_storage_usage_ind (lookup)
+  - mz_catalog.mz_recent_storage_usage_ind (lookup)
 
 Target cluster: mz_catalog_server
 

--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -264,7 +264,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 <SIZE> true
 
                 > SELECT size_bytes, size_bytes BETWEEN {database_object.expected_size//3} AND {database_object.expected_size*3}
-                  FROM mz_internal.mz_recent_storage_usage
+                  FROM mz_recent_storage_usage
                   WHERE object_id = ( SELECT id FROM mz_objects WHERE name = 'obj' );
                 <SIZE> true
                 """

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -545,6 +545,7 @@ name
 -----------------------------------
 mz_objects
 mz_relations
+mz_recent_storage_usage
 mz_storage_usage
 mz_timezone_abbreviations
 mz_timezone_names
@@ -628,7 +629,6 @@ mz_recent_activity_log_thinned
 mz_recent_activity_log_redacted
 mz_recent_sql_text
 mz_recent_sql_text_redacted
-mz_recent_storage_usage
 mz_show_all_my_privileges
 mz_show_all_privileges
 mz_show_cluster_privileges


### PR DESCRIPTION
The view caused no performance issues in production, so stabilize it. The motivation for the fast stabilization is our new philosophy around stabilizing early and often so that users don't depend on mz_internal relations that can break at any time. The columns here are a subset of the already stable mz_storage_usage view, so there wasn't much to derisk besides the performance implications.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR stabilizes a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
