### PR TITLE
compute: use `ReadHold` in the controller

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -955,6 +955,12 @@ pub struct CollectionState<T: Timestamp> {
     ///
     /// This accumulation contains the capabilities held by all [`ReadHold`]s given out for the
     /// collection, including `implied_read_hold` and `warmup_read_hold`.
+    ///
+    /// NOTE: This field may only be modified by [`Instance::apply_read_hold_changes`]. Nobody else
+    /// should modify read capabilities directly. Instead, collection users should manage read
+    /// holds through [`ReadHold`] objects acquired through [`Instance::acquire_read_hold`].
+    ///
+    /// TODO(teskje): Restructure the code to enforce the above in the type system.
     read_capabilities: MutableAntichain<T>,
     /// A read hold maintaining the implicit capability of the collection.
     ///

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -50,6 +50,7 @@ use mz_repr::refresh_schedule::RefreshSchedule;
 use mz_repr::{Datum, Diff, GlobalId, Row, TimestampManipulation};
 use mz_storage_client::controller::{IntrospectionType, StorageController, StorageWriteOp};
 use mz_storage_client::storage_collections::StorageCollections;
+use mz_storage_types::read_holds::ReadHold;
 use mz_storage_types::read_policy::ReadPolicy;
 use prometheus::proto::LabelPair;
 use serde::{Deserialize, Serialize};
@@ -814,6 +815,18 @@ where
     ) -> Result<(), ReadPolicyError> {
         self.instance_mut(instance_id)?.set_read_policy(policies)?;
         Ok(())
+    }
+
+    /// Acquires a [`ReadHold`] for the identified compute collection.
+    pub fn acquire_read_hold(
+        &mut self,
+        instance_id: ComputeInstanceId,
+        collection_id: GlobalId,
+    ) -> Result<ReadHold<T>, CollectionUpdateError> {
+        let hold = self
+            .instance_mut(instance_id)?
+            .acquire_read_hold(collection_id)?;
+        Ok(hold)
     }
 
     #[mz_ore::instrument(level = "debug")]

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -147,7 +147,7 @@ enum Readiness<T> {
 }
 
 /// A client that maintains soft state and validates commands, in addition to forwarding them.
-pub struct Controller<T = mz_repr::Timestamp> {
+pub struct Controller<T: Timestamp = mz_repr::Timestamp> {
     pub storage: Box<dyn StorageController<Timestamp = T>>,
     pub storage_collections: Arc<dyn StorageCollections<Timestamp = T> + Send + Sync>,
     pub compute: ComputeController<T>,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -49,7 +49,7 @@ use mz_storage_types::sources::{
 };
 use serde::{Deserialize, Serialize};
 use timely::progress::Timestamp as TimelyTimestamp;
-use timely::progress::{Antichain, ChangeBatch, Timestamp};
+use timely::progress::{Antichain, Timestamp};
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, oneshot};
 
@@ -665,12 +665,6 @@ pub trait StorageController: Debug {
 
         Ok(hold)
     }
-
-    /// Applies `updates` and sends any appropriate compaction command.
-    fn update_read_capabilities(
-        &mut self,
-        updates: &mut BTreeMap<GlobalId, ChangeBatch<Self::Timestamp>>,
-    );
 
     /// Waits until the controller is ready to process a response.
     ///

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -296,15 +296,6 @@ pub trait StorageCollections: Debug {
         &self,
         desired_holds: Vec<GlobalId>,
     ) -> Result<Vec<ReadHold<Self::Timestamp>>, ReadHoldError>;
-
-    /// Applies `updates` and sends any appropriate compaction command.
-    ///
-    /// This is a legacy interface that should _not_ be used! It is only used by
-    /// the compute controller.
-    fn update_read_capabilities(
-        &self,
-        updates: &mut BTreeMap<GlobalId, ChangeBatch<Self::Timestamp>>,
-    );
 }
 
 /// Frontiers of the collection identified by `id`.
@@ -1937,19 +1928,6 @@ where
         trace!(?desired_holds, ?acquired_holds, "acquire_read_holds");
 
         Ok(acquired_holds)
-    }
-
-    fn update_read_capabilities(
-        &self,
-        updates: &mut BTreeMap<GlobalId, ChangeBatch<Self::Timestamp>>,
-    ) {
-        let mut collections = self.collections.lock().expect("lock poisoned");
-
-        StorageCollectionsImpl::update_read_capabilities_inner(
-            &self.cmd_tx,
-            &mut collections,
-            updates,
-        );
     }
 }
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1741,14 +1741,6 @@ where
         self.storage_collections.acquire_read_holds(desired_holds)
     }
 
-    #[instrument(level = "debug", fields(updates))]
-    fn update_read_capabilities(
-        &mut self,
-        updates: &mut BTreeMap<GlobalId, ChangeBatch<Self::Timestamp>>,
-    ) {
-        self.storage_collections.update_read_capabilities(updates);
-    }
-
     async fn ready(&mut self) {
         if self.pending_compaction_commands.len() > 0 {
             return;


### PR DESCRIPTION
The PR moves the compute controller from manually manipulating collection's `read_capabilities` to using `ReadHold` objects instead. The result of this is significantly simplified code, since the various places that maintain read holds are now immediately recognizable by grepping for uses of the `ReadHold` type, and downgrading a read hold is now a single method call, rather than a multi-line `ChangeSet` application. Another benefit is now that parts that need to keep read holds are no longer tightly coupled to the `Instance` state, as they don't need access to `Instance::update_read_capabilities` anymore. This, for example, opens up the opportunity to attempt to factor out the replication logic in a follow up.

Another cool thing is that for debugging frontier issues, we can now use the coordinator's dump endpoint (`<internal-http-port>/api/coordinator/dump`, which also dumps the compute controller state) to see which read holds the compute controller is holding for what purposes, on which collections, for which times.

### Motivation

  * This PR adds a known-desirable feature.

Closes #24266

### Tips for reviewer

This PR is much more digestible when reviewed commit by commit. I added a couple comments to clarify some of the changes too.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
