### PR TITLE
CI: Switch further tests to Hetzner

### DIFF
--- a/ci/cleanup/pipeline.template.yml
+++ b/ci/cleanup/pipeline.template.yml
@@ -9,6 +9,9 @@
 
 # Cleans up CI resources that occasionally leak.
 
+# Doesn't hurt to run late
+priority: -50
+
 steps:
   - command: bin/ci-builder run stable bin/pyactivate -m ci.cleanup.aws
     timeout_in_minutes: 10

--- a/ci/deploy/pipeline.template.yml
+++ b/ci/deploy/pipeline.template.yml
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Deploys are fast, do them quickly
+priority: 30
+
 steps:
   - command: bin/ci-builder run nightly ci/deploy/devsite.sh
     branches: main

--- a/ci/deploy_mz/pipeline.template.yml
+++ b/ci/deploy_mz/pipeline.template.yml
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Deploys are fast, do them quickly
+priority: 30
+
 steps:
   - command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz.version
     timeout_in_minutes: 30

--- a/ci/deploy_mz_lsp_server/pipeline.template.yml
+++ b/ci/deploy_mz_lsp_server/pipeline.template.yml
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Deploys are fast, do them quickly
+priority: 30
+
 steps:
   - command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz_lsp_server.version
     timeout_in_minutes: 30

--- a/ci/deploy_website/pipeline.template.yml
+++ b/ci/deploy_website/pipeline.template.yml
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Deploys are fast, do them quickly
+priority: 30
+
 steps:
   - command: bin/ci-builder run nightly ci/deploy_website/website.sh
     branches: main

--- a/ci/license/pipeline.template.yml
+++ b/ci/license/pipeline.template.yml
@@ -7,9 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Very fast
+priority: 70
+
 steps:
   - label: Bump change date
     timeout_in_minutes: 10
     command: ci/license/bump-change-date.sh
     agents:
-      queue: linux-x86_64
+      queue: linux-x86_64-small

--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -53,7 +53,7 @@ from .deploy.deploy_util import rust_version
 # trying to capture that.)
 CI_GLUE_GLOBS = ["bin", "ci"]
 
-DEFAULT_AGENT = "linux-aarch64-small"
+DEFAULT_AGENT = "hetzner-aarch64-4cpu-8gb"
 
 
 def steps(pipeline: Any) -> Iterator[dict[str, Any]]:

--- a/ci/mkpipeline.sh
+++ b/ci/mkpipeline.sh
@@ -45,7 +45,7 @@ steps:
   - wait
   - label: mkpipeline
     command: bin/ci-builder run stable bin/pyactivate -m ci.mkpipeline $pipeline $@
-    priority: 2
+    priority: 100
     agents:
       queue: linux-aarch64-small
 EOF

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -291,7 +291,7 @@ steps:
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
           # queue: hetzner-aarch64-8cpu-16gb
           queue: linux-aarch64-medium
         plugins:
@@ -855,7 +855,7 @@ steps:
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
-          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
           # queue: hetzner-aarch64-8cpu-16gb
           queue: linux-aarch64-medium
         plugins:
@@ -878,7 +878,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
           # queue: hetzner-aarch64-8cpu-16gb
           queue: linux-aarch64
         inputs:
@@ -904,7 +904,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
           # queue: hetzner-aarch64-8cpu-16gb
           queue: linux-aarch64
         inputs:
@@ -930,7 +930,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
           # queue: hetzner-aarch64-8cpu-16gb
           queue: linux-aarch64
         inputs:
@@ -956,7 +956,7 @@ steps:
             - exit_status: 255
               limit: 2
         agents:
-          # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+          # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
           # queue: hetzner-aarch64-8cpu-16gb
           queue: linux-aarch64
         inputs:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Default priority, just set to be explicit
+priority: 0
+
 steps:
   - group: Builds
     key: builds
@@ -18,7 +21,7 @@ steps:
           - "*"
         depends_on: []
         timeout_in_minutes: 60
-        priority: 1
+        priority: 50
         agents:
           queue: builder-linux-x86_64
 

--- a/ci/qa-canary/pipeline.template.yml
+++ b/ci/qa-canary/pipeline.template.yml
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+priority: 40
+
 steps:
   - id: build-aarch64
     label: Build aarch64

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Runs long, but can block a release
+priority: 40
+
 steps:
   - group: Builds
     key: builds

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -24,7 +24,6 @@ steps:
         # sure we use the exact same version for testing here as was tagged and
         # will be released, and don't build our own version just for the tests.
         if: build.source == "ui" || build.source == "schedule" || build.source == "api"
-      # TODO(def-) Get rid of this for PRs once we don't have any x86-64 tests remaining
       - id: build-x86_64
         label: Build x86_64
         command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
@@ -43,7 +42,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -56,7 +55,7 @@ steps:
       # 48h
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -67,7 +66,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -76,20 +75,20 @@ steps:
     - id: zippy-mysql-cdc-large
       label: "Large Zippy MySqlCdc"
       depends_on: build-aarch64
-      timeout_in_minutes: 2880
+      timeout_in_minutes: 1440
       agents:
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
-            args: [--scenario=MySqlCdcLarge, --actions=200000]
+            args: [--scenario=MySqlCdcLarge, --actions=100000, --max-execution-time=4h]
 
     - id: zippy-cluster-replicas-long
       label: "Longer Zippy ClusterReplicas"
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -101,7 +100,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -110,20 +109,21 @@ steps:
     - id: zippy-debezium-postgres-long
       label: "Longer Zippy Debezium Postgres"
       depends_on: build-aarch64
-      timeout_in_minutes: 2880
+      timeout_in_minutes: 1440
       agents:
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
-            args: [--scenario=DebeziumPostgres, --actions=1000000]
+            # Runs into upload size limits of Buildkite
+            args: [--scenario=DebeziumPostgres, --actions=500000, --max-execution-time=4h]
 
     - id: zippy-backup-and-restore-large
       label: "Large-scale backup+restore"
       depends_on: build-aarch64
       timeout_in_minutes: 2880
       agents:
-        queue: linux-aarch64
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
@@ -133,13 +133,14 @@ steps:
     - id: zippy-kafka-parallel-insert
       label: "Longer Zippy Kafka Parallel Insert"
       depends_on: build-aarch64
-      timeout_in_minutes: 2880
+      timeout_in_minutes: 1440
       agents:
-        queue: linux-aarch64-medium
+        queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
-            args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=100000, --max-execution-time=8h]
+            # TODO(def-) Increase number of actions when #24250 is fixed
+            args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=50000, --max-execution-time=4h]
 
   - id: feature-benchmark-scale-plus-one
     label: "Feature benchmark against 'common-ancestor' with --scale=+1 %N"
@@ -147,7 +148,7 @@ steps:
     timeout_in_minutes: 2880
     parallelism: 8
     agents:
-      queue: linux-aarch64-medium
+      queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark
@@ -161,7 +162,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 120
       agents:
-        queue: linux-aarch64
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
@@ -173,7 +174,7 @@ steps:
       depends_on: build-aarch64
       timeout_in_minutes: 120
       agents:
-        queue: linux-aarch64
+        queue: hetzner-aarch64-8cpu-16gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: sqlsmith
@@ -211,7 +212,7 @@ steps:
         timeout_in_minutes: 30
         agents:
           # no matching manifest of MySQL 5.7.x for linux/arm64/v8 in the manifest list entries
-          queue: linux-x86_64-small
+          queue: hetzner-x86-64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
@@ -221,7 +222,7 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 30
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc
@@ -240,6 +241,8 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=15.6" ]
         agents:
+          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-small
       - id: pg-cdc-14_11
         label: "Postgres CDC w/ 14.11"
@@ -251,6 +254,8 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=14.11" ]
         agents:
+          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-small
       - id: pg-cdc-13_14
         label: "Postgres CDC w/ 13.14"
@@ -262,6 +267,8 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=13.14" ]
         agents:
+          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-small
       - id: pg-cdc-12_18
         label: "Postgres CDC w/ 12.18"
@@ -273,6 +280,8 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=12.18" ]
         agents:
+          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-small
       - id: pg-cdc-11_22
         label: "Postgres CDC w/ 11.22"
@@ -284,4 +293,6 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=11.22" ]
         agents:
+          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-small

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -244,9 +244,7 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=15.6" ]
         agents:
-          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
-          # queue: hetzner-aarch64-4cpu-8gb
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
       - id: pg-cdc-14_11
         label: "Postgres CDC w/ 14.11"
         depends_on: build-aarch64
@@ -257,9 +255,7 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=14.11" ]
         agents:
-          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
-          # queue: hetzner-aarch64-4cpu-8gb
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
       - id: pg-cdc-13_14
         label: "Postgres CDC w/ 13.14"
         depends_on: build-aarch64
@@ -270,9 +266,7 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=13.14" ]
         agents:
-          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
-          # queue: hetzner-aarch64-4cpu-8gb
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
       - id: pg-cdc-12_18
         label: "Postgres CDC w/ 12.18"
         depends_on: build-aarch64
@@ -283,9 +277,7 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=12.18" ]
         agents:
-          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
-          # queue: hetzner-aarch64-4cpu-8gb
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
       - id: pg-cdc-11_22
         label: "Postgres CDC w/ 11.22"
         depends_on: build-aarch64
@@ -296,6 +288,4 @@ steps:
               composition: pg-cdc
               args: [ "--pg-version=11.22" ]
         agents:
-          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
-          # queue: hetzner-aarch64-4cpu-8gb
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb

--- a/ci/security/pipeline.template.yml
+++ b/ci/security/pipeline.template.yml
@@ -9,6 +9,9 @@
 
 # Checks for security advisories in the Rust crate dependency graph.
 
+# Very fast
+priority: 80
+
 steps:
   - command: bin/ci-builder run stable cargo deny check advisories
     timeout_in_minutes: 20

--- a/ci/security/pipeline.template.yml
+++ b/ci/security/pipeline.template.yml
@@ -13,4 +13,4 @@ steps:
   - command: bin/ci-builder run stable cargo deny check advisories
     timeout_in_minutes: 20
     agents:
-      queue: linux-aarch64
+      queue: hetzner-aarch64-8cpu-16gb

--- a/ci/slt/pipeline.template.yml
+++ b/ci/slt/pipeline.template.yml
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Only checked async by QA
+priority: -40
+
 steps:
   - id: build-aarch64
     label: Build aarch64

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -419,8 +419,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc
         agents:
-          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
-          # queue: hetzner-aarch64-4cpu-8gb
+          queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-small
         # the mzbuild postgres version will be used, which depends on the Dockerfile specification
 

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -21,6 +21,9 @@ env:
   # build jobs to "default" which will use all cores.
   CARGO_BUILD_JOBS: "default"
 
+# When resources are constrained, run early since this might be blocking a PR from merging
+priority: 20
+
 steps:
   - group: Builds
     key: builds
@@ -32,7 +35,7 @@ steps:
           - "*"
         depends_on: []
         timeout_in_minutes: 60
-        priority: 1
+        priority: 50
         agents:
           queue: builder-linux-x86_64
 
@@ -42,7 +45,7 @@ steps:
         inputs:
           - "*"
         depends_on: []
-        priority: 1
+        priority: 50
         timeout_in_minutes: 60
         agents:
           queue: builder-linux-aarch64

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -25,7 +25,6 @@ steps:
   - group: Builds
     key: builds
     steps:
-      # TODO(def-) Get rid of this for PRs once we don't have any x86-64 tests remaining
       - id: build-x86_64
         label: Build x86_64
         command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
@@ -98,7 +97,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         if: "build.pull_request.id != null"
         coverage: skip
         sanitizer: skip
@@ -133,7 +132,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 10
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
         coverage: skip
         sanitizer: skip
 
@@ -182,7 +181,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 30
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
         coverage: skip
         sanitizer: skip
 
@@ -195,7 +194,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 20
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
         coverage: skip
         sanitizer: skip
 
@@ -214,7 +213,7 @@ steps:
         timeout_in_minutes: 30
         agents:
           # hugo: command not found
-          queue: linux-x86_64-small
+          queue: hetzner-x86-64-4cpu-8gb
         coverage: skip
         sanitizer: skip
 
@@ -239,7 +238,7 @@ steps:
         depends_on: []
         timeout_in_minutes: 15
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
         coverage: skip
         sanitizer: skip
 
@@ -264,6 +263,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cargo-test
     agents:
+      # Because of scratch-aws-access
       queue: builder-linux-aarch64
 
   - id: testdrive
@@ -273,11 +273,10 @@ steps:
     inputs: [test/testdrive]
     parallelism: 8
     plugins:
-      - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
     agents:
-      queue: linux-aarch64
+      queue: hetzner-aarch64-8cpu-16gb
 
   - id: cluster-tests
     label: Cluster tests %N
@@ -289,7 +288,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cluster
     agents:
-      queue: linux-aarch64
+      queue: hetzner-aarch64-8cpu-16gb
 
   - id: sqllogictest-fast
     label: Fast SQL logic tests %N
@@ -302,7 +301,7 @@ steps:
           composition: sqllogictest
           run: fast-tests
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: restarts
     label: Restart test
@@ -312,7 +311,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: restart
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: legacy-upgrade
     label: Legacy upgrade tests (last version from docs)
@@ -323,7 +322,7 @@ steps:
           composition: legacy-upgrade
           args: ["--versions-source=docs"]
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
 
   - group: "Debezium tests"
     key: debezium-tests
@@ -338,7 +337,7 @@ steps:
               composition: debezium
               run: postgres
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: debezium-sql-server
         label: Debezium SQL Server tests
@@ -351,7 +350,7 @@ steps:
               run: sql-server
         agents:
           # too slow to run emulated on aarch64, SQL Server's docker image is not yet available for aarch64 natively yet: https://github.com/microsoft/mssql-docker/issues/802
-          queue: linux-x86_64-small
+          queue: hetzner-x86-64-4cpu-8gb
 
       - id: debezium-mysql
         label: Debezium MySQL tests
@@ -363,7 +362,7 @@ steps:
               composition: debezium
               run: mysql
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
   - group: "MySQL tests"
     key: mysql-tests
@@ -379,19 +378,20 @@ steps:
               composition: mysql-cdc
               args: ["--mysql-version=8.4.0"]
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: mysql-cdc-resumption
         label: MySQL CDC resumption tests %N
         parallelism: 2
         depends_on: build-aarch64
-        timeout_in_minutes: 30
+        timeout_in_minutes: 35
         inputs: [test/mysql-cdc-resumption]
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc-resumption
         agents:
-          queue: linux-aarch64-small
+          # Runs too slow otherwise, can't parallelize further
+          queue: hetzner-aarch64-8cpu-16gb
 
       - id: mysql-rtr
         label: MySQL RTR tests
@@ -402,7 +402,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: mysql-rtr
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
   - group: "Postgres tests"
     key: postgres-tests
@@ -416,6 +416,8 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc
         agents:
+          # TODO(def-): Expected 0 replication slot(s) but found 2 slot(s)
+          # queue: hetzner-aarch64-4cpu-8gb
           queue: linux-aarch64-small
         # the mzbuild postgres version will be used, which depends on the Dockerfile specification
 
@@ -429,7 +431,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-cdc-resumption
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: pg-rtr
         label: Postgres RTR tests
@@ -440,7 +442,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: pg-rtr
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
   - group: "Connection tests"
     key: connection-tests
@@ -454,7 +456,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: ssh-connection
         agents:
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
 
       - id: fivetran-destination-tests
         label: Fivetran Destination tests
@@ -465,7 +467,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: fivetran-destination
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
   - group: "Copy to S3 tests"
     key: copy-to-s3-tests
@@ -480,7 +482,7 @@ steps:
               composition: copy-to-s3
               run: ci
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
   - group: "Kafka tests"
     key: kafka-tests
@@ -493,7 +495,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-resumption
         agents:
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
 
       - id: kafka-auth
         label: Kafka auth test
@@ -504,7 +506,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-auth
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: kafka-exactly-once
         label: Kafka exactly-once tests
@@ -514,7 +516,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-exactly-once
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
       - id: kafka-rtr
         label: Kafka RTR tests
@@ -526,7 +528,7 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: kafka-rtr
         agents:
-          queue: linux-aarch64-small
+          queue: hetzner-aarch64-4cpu-8gb
 
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
@@ -534,7 +536,7 @@ steps:
     inputs: [misc/python/materialize/zippy]
     timeout_in_minutes: 30
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
@@ -550,7 +552,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 6
         agents:
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -567,7 +569,7 @@ steps:
         timeout_in_minutes: 45
         parallelism: 4
         agents:
-          queue: linux-aarch64
+          queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
@@ -592,10 +594,11 @@ steps:
               --exitfirst,
               -m,
               "not long and not node_recovery",
-              --aws-region=us-east-1,
               test/cloudtest/,
             ]
     agents:
+      # TODO(def-): Debezium DNS flakiness doesn't allow running on hetzner
+      # queue: hetzner-aarch64-8cpu-16gb
       queue: linux-aarch64
     sanitizer: skip
 
@@ -605,7 +608,7 @@ steps:
     parallelism: 2
     timeout_in_minutes: 30
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: source-sink-errors
@@ -615,7 +618,7 @@ steps:
     depends_on: build-aarch64
     timeout_in_minutes: 30
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: backup-restore
@@ -634,7 +637,7 @@ steps:
             ]
     coverage: skip
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
 
   # Fast tests closer to the end, doesn't matter as much if they have to wait
   # for an agent
@@ -647,7 +650,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: replica-isolation
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: persistence
     label: Persistence tests
@@ -657,7 +660,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: persistence
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: cluster-isolation
     label: Cluster isolation test
@@ -668,7 +671,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cluster-isolation
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: chbench-demo
     label: chbench smoke test
@@ -680,7 +683,7 @@ steps:
           args: [--run-seconds=10, --wait]
     timeout_in_minutes: 30
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: metabase-demo
     label: Metabase smoke test
@@ -691,7 +694,7 @@ steps:
           composition: metabase
     agents:
       # too slow to run emulated on aarch64, Metabase'ss docker image is not yet available for aarch64 natively yet: https://github.com/metabase/metabase/issues/13119
-      queue: linux-x86_64-small
+      queue: hetzner-x86-64-4cpu-8gb
 
   - id: dbt-materialize
     label: dbt-materialize tests
@@ -701,14 +704,14 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: dbt-materialize
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: storage-usage
     label: "Storage Usage Table Test"
     depends_on: build-aarch64
     timeout_in_minutes: 30
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: storage-usage
@@ -722,6 +725,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: tracing
     agents:
+      # Requires BUILDKITE_SENTRY_DSN
       queue: linux-aarch64-small
 
   - id: 0dt
@@ -732,7 +736,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: 0dt
     agents:
-      queue: linux-aarch64
+      queue: hetzner-aarch64-8cpu-16gb
 
   - id: skip-version-upgrade
     label: "Skip Version Upgrade"
@@ -743,7 +747,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: skip-version-upgrade
     agents:
-      queue: linux-aarch64-small
+      queue: hetzner-aarch64-4cpu-8gb
 
   - id: deploy-website
     label: Deploy website
@@ -844,7 +848,7 @@ steps:
     inputs: ["*"]
     priority: 1
     agents:
-      queue: linux-aarch64-medium
+      queue: hetzner-aarch64-16cpu-32gb
     coverage: only
 
   - wait: ~

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -179,9 +179,7 @@ def workflow_silent_connection_drop(
             ],
         ),
     ):
-        c.kill("postgres")
-        c.rm("postgres", destroy_volumes=True)
-        c.up("materialized", "postgres")
+        c.up("postgres")
 
         pg_conn = pg8000.connect(
             host="localhost",
@@ -191,6 +189,8 @@ def workflow_silent_connection_drop(
         )
 
         _verify_exactly_n_replication_slots_exist(pg_conn, n=0)
+
+        c.up("materialized")
 
         c.run_testdrive_files(
             "--no-reset",
@@ -308,9 +308,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     else:
         # Otherwise we are running all workflows
         for name in c.workflows:
-            # clear postgres to avoid issues with special arguments conflicting with existing state
+            # clear postgres and materialized to avoid issues with special arguments conflicting with existing state
             c.kill("postgres")
             c.rm("postgres")
+            c.kill("materialized")
+            c.rm("materialized")
 
             if name == "default":
                 continue


### PR DESCRIPTION
This reverts commit 1ab980f411006c99df669b1f6cdc80fc1849911b.

Verification runs:
https://buildkite.com/materialize/security/builds/1278
https://buildkite.com/materialize/release-qualification/builds/568 & https://buildkite.com/materialize/release-qualification/builds/569
https://buildkite.com/materialize/test/builds/87931 & https://buildkite.com/materialize/test/builds/87944 & https://buildkite.com/materialize/test/builds/87955 & https://buildkite.com/materialize/test/builds/87980 & https://buildkite.com/materialize/test/builds/88051 & https://buildkite.com/materialize/test/builds/88077

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
