### PR TITLE
docs: kapa.ai config data-search-result-link-target to _self

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -87,6 +87,7 @@ toCSS | fingerprint }}
   data-modal-override-open-id="docsearch"
   data-user-analytics-fingerprint-enabled="true"
   data-modal-open-on-command-k="true"
+  data-search-result-link-target="_self"
   >
 </script>
 


### PR DESCRIPTION
Open search results in current browser tab instead of new tab