### PR TITLE
balancer: Add tracing dynamic config parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,6 +4401,7 @@ dependencies = [
  "mz-ore",
  "mz-pgwire-common",
  "mz-server-core",
+ "mz-tracing",
  "num_cpus",
  "openssl",
  "postgres",
@@ -4414,6 +4415,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "workspace-hack",
 ]

--- a/src/balancerd/BUILD.bazel
+++ b/src/balancerd/BUILD.bazel
@@ -38,6 +38,7 @@ rust_library(
 		"//src/ore:mz_ore",
 		"//src/pgwire-common:mz_pgwire_common",
 		"//src/server-core:mz_server_core",
+		"//src/tracing:mz_tracing",
 	] + all_crate_deps(normal = True),
 	proc_macro_deps = [] + all_crate_deps(proc_macro = True),
 	compile_data = [],
@@ -69,6 +70,7 @@ rust_test(
 		"//src/ore:mz_ore",
 		"//src/pgwire-common:mz_pgwire_common",
 		"//src/server-core:mz_server_core",
+		"//src/tracing:mz_tracing",
 	] + all_crate_deps(
 		normal = True,
 		normal_dev = True,
@@ -102,6 +104,7 @@ rust_doc_test(
 		"//src/ore:mz_ore",
 		"//src/pgwire-common:mz_pgwire_common",
 		"//src/server-core:mz_server_core",
+		"//src/tracing:mz_tracing",
 	] + all_crate_deps(
 		normal = True,
 		normal_dev = True,
@@ -132,6 +135,7 @@ rust_test(
 		"//src/ore:mz_ore",
 		"//src/pgwire-common:mz_pgwire_common",
 		"//src/server-core:mz_server_core",
+		"//src/tracing:mz_tracing",
 	] + all_crate_deps(
 		normal = True,
 		normal_dev = True,
@@ -170,6 +174,7 @@ rust_binary(
 		"//src/ore:mz_ore",
 		"//src/pgwire-common:mz_pgwire_common",
 		"//src/server-core:mz_server_core",
+		"//src/tracing:mz_tracing",
 	] + all_crate_deps(normal = True),
 	proc_macro_deps = [] + all_crate_deps(proc_macro = True),
 	compile_data = [],

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -34,6 +34,7 @@ mz-http-util = { path = "../http-util" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-ore = { path = "../ore", default-features = false }
 mz-server-core = { path = "../server-core" }
+mz-tracing = { path = "../tracing" }
 mz-pgwire-common = { path = "../pgwire-common" }
 num_cpus = "1.14.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
@@ -45,6 +46,7 @@ tokio-postgres = { version = "0.7.8" }
 tokio-util = { version = "0.7.4", features = ["codec"] }
 tower = "0.4.13"
 tracing = "0.1.37"
+tracing-subscriber = "0.3.16"
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/balancerd/src/dyncfgs.rs
+++ b/src/balancerd/src/dyncfgs.rs
@@ -9,12 +9,18 @@
 
 //! Dyncfgs used by the balancer.
 
+use std::str::FromStr;
 use std::time::Duration;
 
-use mz_dyncfg::{Config, ConfigSet};
+use mz_dyncfg::{Config, ConfigSet, ConfigUpdates};
+use mz_tracing::params::TracingParameters;
+use mz_tracing::{CloneableEnvFilter, SerializableDirective};
+use tracing_subscriber::filter::Directive;
 
 // The defaults here must be set to an appropriate value in case LaunchDarkly is down because we
 // continue startup even in that case.
+//
+// All configuration names should be prefixed with "balancerd_" to avoid name collisions.
 
 /// Duration to wait after SIGTERM for outstanding connections to complete.
 pub const SIGTERM_WAIT: Config<Duration> = Config::new(
@@ -23,7 +29,113 @@ pub const SIGTERM_WAIT: Config<Duration> = Config::new(
     "Duration to wait after SIGTERM for outstanding connections to complete.",
 );
 
+/// Sets the filter to apply to stderr logging.
+pub const LOGGING_FILTER: Config<&str> = Config::new(
+    "balancerd_log_filter",
+    "info",
+    "Sets the filter to apply to stderr logging.",
+);
+
+/// Sets the filter to apply to OpenTelemetry-backed distributed tracing.
+pub const OPENTELEMETRY_FILTER: Config<&str> = Config::new(
+    "balancerd_opentelemetry_filter",
+    "info",
+    "Sets the filter to apply to OpenTelemetry-backed distributed tracing.",
+);
+
+/// Sets additional default directives to apply to stderr logging.
+/// These apply to all variations of `log_filter`. Directives other than
+/// `module=off` are likely incorrect. Comma separated list.
+pub const LOGGING_FILTER_DEFAULTS: Config<fn() -> String> = Config::new(
+    "balancerd_log_filter_defaults",
+    || mz_ore::tracing::LOGGING_DEFAULTS_STR.join(","),
+    "Sets additional default directives to apply to stderr logging. \
+    These apply to all variations of `log_filter`. Directives other than \
+    `module=off` are likely incorrect. Comma separated list.",
+);
+
+/// Sets additional default directives to apply to OpenTelemetry-backed
+/// distributed tracing.
+/// These apply to all variations of `opentelemetry_filter`. Directives other than
+/// `module=off` are likely incorrect. Comma separated list.
+pub const OPENTELEMETRY_FILTER_DEFAULTS: Config<fn() -> String> = Config::new(
+    "balancerd_opentelemetry_filter_defaults",
+    || mz_ore::tracing::OPENTELEMETRY_DEFAULTS_STR.join(","),
+    "Sets additional default directives to apply to OpenTelemetry-backed \
+    distributed tracing. \
+    These apply to all variations of `opentelemetry_filter`. Directives other than \
+    `module=off` are likely incorrect. Comma separated list.",
+);
+
+/// Sets additional default directives to apply to sentry logging. \
+/// These apply on top of a default `info` directive. Directives other than \
+/// `module=off` are likely incorrect. Comma separated list.
+pub const SENTRY_FILTERS: Config<fn() -> String> = Config::new(
+    "balancerd_sentry_filters",
+    || mz_ore::tracing::SENTRY_DEFAULTS_STR.join(","),
+    "Sets additional default directives to apply to sentry logging. \
+    These apply on top of a default `info` directive. Directives other than \
+    `module=off` are likely incorrect. Comma separated list.",
+);
+
 /// Adds the full set of all balancer `Config`s.
 pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
-    configs.add(&SIGTERM_WAIT)
+    configs
+        .add(&SIGTERM_WAIT)
+        .add(&LOGGING_FILTER)
+        .add(&OPENTELEMETRY_FILTER)
+        .add(&LOGGING_FILTER_DEFAULTS)
+        .add(&OPENTELEMETRY_FILTER_DEFAULTS)
+        .add(&SENTRY_FILTERS)
+}
+
+/// Get all dynamic tracing config parameters from this [`ConfigSet`].
+pub fn tracing_config(configs: &ConfigSet) -> Result<TracingParameters, String> {
+    fn to_serializable_directives(
+        config: &Config<fn() -> String>,
+        configs: &ConfigSet,
+    ) -> Result<Vec<SerializableDirective>, String> {
+        let directives = config.get(configs);
+        let directives: Vec<_> = directives
+            .split(',')
+            .map(|directive| Directive::from_str(directive))
+            .collect::<Result<_, _>>()
+            .map_err(|e| e.to_string())?;
+        Ok(directives.into_iter().map(|d| d.into()).collect())
+    }
+
+    let log_filter = LOGGING_FILTER.get(configs);
+    let log_filter = CloneableEnvFilter::from_str(&log_filter).map_err(|e| e.to_string())?;
+
+    let opentelemetry_filter = OPENTELEMETRY_FILTER.get(configs);
+    let opentelemetry_filter =
+        CloneableEnvFilter::from_str(&opentelemetry_filter).map_err(|e| e.to_string())?;
+
+    let log_filter_defaults = to_serializable_directives(&LOGGING_FILTER_DEFAULTS, configs)?;
+
+    let opentelemetry_filter_defaults =
+        to_serializable_directives(&OPENTELEMETRY_FILTER_DEFAULTS, configs)?;
+
+    let sentry_filters = to_serializable_directives(&SENTRY_FILTERS, configs)?;
+
+    Ok(TracingParameters {
+        log_filter: Some(log_filter),
+        opentelemetry_filter: Some(opentelemetry_filter),
+        log_filter_defaults,
+        opentelemetry_filter_defaults,
+        sentry_filters,
+    })
+}
+
+/// Returns true if `updates` contains an update to a tracing config, false otherwise.
+pub fn has_tracing_config_update(updates: &ConfigUpdates) -> bool {
+    [
+        LOGGING_FILTER.name(),
+        OPENTELEMETRY_FILTER.name(),
+        LOGGING_FILTER_DEFAULTS.name(),
+        OPENTELEMETRY_FILTER_DEFAULTS.name(),
+        SENTRY_FILTERS.name(),
+    ]
+    .into_iter()
+    .any(|name| updates.updates.contains_key(name))
 }

--- a/src/balancerd/src/dyncfgs.rs
+++ b/src/balancerd/src/dyncfgs.rs
@@ -98,7 +98,7 @@ pub fn tracing_config(configs: &ConfigSet) -> Result<TracingParameters, String> 
         let directives = config.get(configs);
         let directives: Vec<_> = directives
             .split(',')
-            .map(|directive| Directive::from_str(directive))
+            .map(Directive::from_str)
             .collect::<Result<_, _>>()
             .map_err(|e| e.to_string())?;
         Ok(directives.into_iter().map(|d| d.into()).collect())

--- a/src/balancerd/src/main.rs
+++ b/src/balancerd/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
         .expect("Failed building the Runtime");
 
     let metrics_registry = MetricsRegistry::new();
-    let (_, _tracing_guard) = runtime
+    let (tracing_handle, _tracing_guard) = runtime
         .block_on(args.tracing.configure_tracing(
             StaticTracingConfig {
                 service_name: "balancerd",
@@ -62,7 +62,9 @@ fn main() {
 
     let root_span = info_span!("balancer");
     let res = match args.command {
-        Command::Service(args) => runtime.block_on(crate::service::run(args).instrument(root_span)),
+        Command::Service(args) => {
+            runtime.block_on(crate::service::run(args, tracing_handle).instrument(root_span))
+        }
     };
 
     if let Err(err) = res {

--- a/src/balancerd/src/service.rs
+++ b/src/balancerd/src/service.rs
@@ -21,6 +21,7 @@ use mz_frontegg_auth::{
     DEFAULT_REFRESH_DROP_LRU_CACHE_SIZE,
 };
 use mz_ore::metrics::MetricsRegistry;
+use mz_ore::tracing::TracingHandle;
 use mz_server_core::TlsCliArgs;
 use tracing::warn;
 
@@ -116,7 +117,7 @@ pub struct Args {
     cloud_provider_region: Option<String>,
 }
 
-pub async fn run(args: Args) -> Result<(), anyhow::Error> {
+pub async fn run(args: Args, tracing_handle: TracingHandle) -> Result<(), anyhow::Error> {
     let metrics_registry = MetricsRegistry::new();
     let resolver = match (args.static_resolver_addr, args.frontegg_resolver_template) {
         (None, Some(addr_template)) => {
@@ -183,6 +184,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         args.config_sync_loop_interval,
         args.cloud_provider,
         args.cloud_provider_region,
+        tracing_handle,
     );
     let service = BalancerService::new(config).await?;
     service.serve().await?;

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -29,6 +29,7 @@ use mz_ore::id_gen::{conn_id_org_uuid, org_id_conn_bits};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::retry::Retry;
+use mz_ore::tracing::TracingHandle;
 use mz_ore::{assert_contains, assert_err, assert_ok, task};
 use mz_server_core::TlsCertConfig;
 use openssl::ssl::{SslConnectorBuilder, SslVerifyMode};
@@ -187,6 +188,7 @@ async fn test_balancer() {
             None,
             None,
             None,
+            TracingHandle::disabled(),
         );
         let balancer_server = BalancerService::new(balancer_cfg).await.unwrap();
         let balancer_pgwire_listen = balancer_server.pgwire.0.local_addr();

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -271,28 +271,38 @@ impl std::fmt::Debug for TracingGuard {
 ///
 /// Note: folks should feel free to add more crates here if we find more
 /// with long lived Spans.
+pub const LOGGING_DEFAULTS_STR: [&str; 1] = ["kube_client::client::builder=off"];
+/// Same as [`LOGGING_DEFAULTS_STR`], but structured as [`Directive`]s.
 pub static LOGGING_DEFAULTS: Lazy<Vec<Directive>> = Lazy::new(|| {
-    vec![Directive::from_str("kube_client::client::builder=off").expect("valid directive")]
+    LOGGING_DEFAULTS_STR
+        .into_iter()
+        .map(|directive| Directive::from_str(directive).expect("valid directive"))
+        .collect()
 });
 /// By default we turn off tracing from the following crates, because they
 /// have long-lived Spans, which OpenTelemetry does not handle well.
 ///
 /// Note: folks should feel free to add more crates here if we find more
 /// with long lived Spans.
+pub const OPENTELEMETRY_DEFAULTS_STR: [&str; 2] = ["h2=off", "hyper=off"];
+/// Same as [`OPENTELEMETRY_DEFAULTS_STR`], but structured as [`Directive`]s.
 pub static OPENTELEMETRY_DEFAULTS: Lazy<Vec<Directive>> = Lazy::new(|| {
-    vec![
-        Directive::from_str("h2=off").expect("valid directive"),
-        Directive::from_str("hyper=off").expect("valid directive"),
-    ]
+    OPENTELEMETRY_DEFAULTS_STR
+        .into_iter()
+        .map(|directive| Directive::from_str(directive).expect("valid directive"))
+        .collect()
 });
 
 /// By default we turn off tracing from the following crates, because they
 /// have error spans which are noisy.
+pub const SENTRY_DEFAULTS_STR: [&str; 2] =
+    ["kube_client::client::builder=off", "mysql_async::conn=off"];
+/// Same as [`SENTRY_DEFAULTS_STR`], but structured as [`Directive`]s.
 pub static SENTRY_DEFAULTS: Lazy<Vec<Directive>> = Lazy::new(|| {
-    vec![
-        Directive::from_str("kube_client::client::builder=off").expect("valid directive"),
-        Directive::from_str("mysql_async::conn=off").expect("valid directive"),
-    ]
+    SENTRY_DEFAULTS_STR
+        .into_iter()
+        .map(|directive| Directive::from_str(directive).expect("valid directive"))
+        .collect()
 });
 
 /// The [`GLOBAL_SUBSCRIBER`] type.


### PR DESCRIPTION
This commit adds dynamic configuration parameters to balancerd that can
control tracing.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
