### PR TITLE
storage/adapter: Remove subsource statement option migration

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -11,7 +11,6 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use futures::future::BoxFuture;
 use mz_adapter_types::dyncfgs::DEFAULT_SINK_PARTITION_STRATEGY;
-use mz_catalog::durable::Item;
 use mz_catalog::memory::objects::{StateDiff, StateUpdate};
 use mz_catalog::{durable::Transaction, memory::objects::StateUpdateKind};
 use mz_dyncfg::ConfigSet;
@@ -19,11 +18,9 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::now::NowFn;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::ast::display::AstDisplay;
-use mz_sql::ast::visit_mut::VisitMut;
 use mz_sql::ast::{
     CreateSinkConnection, CreateSinkOption, CreateSinkOptionName, CreateSinkStatement,
-    CreateSourceStatement, KafkaSinkConfigOption, KafkaSinkConfigOptionName, UnresolvedItemName,
-    Value, WithOptionValue,
+    KafkaSinkConfigOption, KafkaSinkConfigOptionName, Value, WithOptionValue,
 };
 use mz_sql_parser::ast::{Raw, Statement};
 use mz_storage_types::connections::ConnectionContext;
@@ -39,25 +36,13 @@ where
         &'a mut Transaction<'_>,
         GlobalId,
         &'a mut Statement<Raw>,
-        &'a Vec<(Item, Statement<Raw>)>,
     ) -> BoxFuture<'a, Result<(), anyhow::Error>>,
 {
     let mut updated_items = BTreeMap::new();
-    let items_with_statements = tx
-        .get_items()
-        .map(|item| {
-            let stmt = mz_sql::parse::parse(&item.create_sql)?.into_element().ast;
-            Ok((item, stmt))
-        })
-        .collect::<Result<Vec<_>, anyhow::Error>>()?;
 
-    // Clone this vec to be referenced within the closure if needed
-    // TODO(roshan): Remove this once the `ast_rewrite_create_subsource_options` migration is
-    // removed.
-    let items_with_statements_ref = items_with_statements.clone();
-
-    for (mut item, mut stmt) in items_with_statements {
-        f(tx, item.id, &mut stmt, &items_with_statements_ref).await?;
+    for mut item in tx.get_items() {
+        let mut stmt = mz_sql::parse::parse(&item.create_sql)?.into_element().ast;
+        f(tx, item.id, &mut stmt).await?;
 
         item.create_sql = stmt.to_ast_string_stable();
 
@@ -113,7 +98,7 @@ pub(crate) async fn migrate(
         catalog_version
     );
 
-    rewrite_ast_items(tx, |_tx, _id, stmt, all_items_and_statements| {
+    rewrite_ast_items(tx, |_tx, _id, stmt| {
         let catalog_version = catalog_version.clone();
         let configs = state.system_config().dyncfgs().clone();
         Box::pin(async move {
@@ -126,7 +111,6 @@ pub(crate) async fn migrate(
             // Migration functions may also take `tx` as input to stage
             // arbitrary changes to the catalog.
             ast_rewrite_create_sink_partition_strategy(&configs, stmt)?;
-            ast_rewrite_create_subsource_options(stmt, all_items_and_statements)?;
             if catalog_version < Version::parse("0.112.0-dev").expect("known to be valid") {
                 ast_rewrite_create_sink_default_compression(stmt)?;
             }
@@ -195,322 +179,6 @@ pub(crate) async fn migrate(
 //
 // Please include the adapter team on any code reviews that add or edit
 // migrations.
-
-/// Copies options from relevant `CREATE SOURCE` statements to any relevant `CREATE SUBSOURCE`
-/// statements. This preps for the eventual removal of these options from the `CREATE SOURCE`
-/// statement.
-fn ast_rewrite_create_subsource_options(
-    stmt: &mut Statement<Raw>,
-    all_items_and_statements: &Vec<(Item, Statement<Raw>)>,
-) -> Result<(), anyhow::Error> {
-    use mz_sql::ast::{
-        CreateSourceConnection, CreateSubsourceOption, CreateSubsourceOptionName,
-        CreateSubsourceStatement, MySqlConfigOptionName, PgConfigOptionName, RawItemName, Value,
-        WithOptionValue,
-    };
-    use mz_storage_types::sources::mysql::{
-        ProtoMySqlSourceDetails, ProtoMySqlSourceExportStatementDetails,
-    };
-    use mz_storage_types::sources::postgres::{
-        ProtoPostgresSourceExportStatementDetails, ProtoPostgresSourcePublicationDetails,
-    };
-    use mz_storage_types::sources::proto_source_export_statement_details;
-    use mz_storage_types::sources::ProtoSourceExportStatementDetails;
-    use prost::Message;
-
-    // Since subsources have named-only references to their `of_source` and some have the
-    // global_id of their source, we first generate mapping from all source names and ids to their
-    // statements.
-    let source_name_to_stmt: BTreeMap<_, _> = all_items_and_statements
-        .iter()
-        .filter_map(|(_, statement)| match statement {
-            Statement::CreateSource(stmt) => Some((stmt.name.clone(), stmt)),
-            _ => None,
-        })
-        .collect();
-    let source_id_to_stmt: BTreeMap<_, _> = all_items_and_statements
-        .iter()
-        .filter_map(|(item, statement)| match statement {
-            Statement::CreateSource(stmt) => Some((item.id, stmt)),
-            _ => None,
-        })
-        .collect();
-
-    struct Rewriter<'a> {
-        source_name_to_stmt: BTreeMap<UnresolvedItemName, &'a CreateSourceStatement<Raw>>,
-        source_id_to_stmt: BTreeMap<GlobalId, &'a CreateSourceStatement<Raw>>,
-    }
-
-    impl<'ast> VisitMut<'ast, Raw> for Rewriter<'_> {
-        fn visit_create_subsource_statement_mut(
-            &mut self,
-            node: &'ast mut CreateSubsourceStatement<Raw>,
-        ) {
-            match &node.of_source {
-                // Not a source export subsource
-                None => (),
-                Some(source) => {
-                    let details = node
-                        .with_options
-                        .iter()
-                        .find(|o| o.name == CreateSubsourceOptionName::Details);
-                    if details.is_some() {
-                        // this subsource has already had its details written, so it's either new or was already
-                        // migrated
-                        return;
-                    }
-                    info!("migrate: populating subsource details: {:?}", node);
-
-                    let external_reference = node
-                        .with_options
-                        .iter()
-                        .find(|o| o.name == CreateSubsourceOptionName::ExternalReference)
-                        .expect("subsources must have external reference");
-                    // For mysql subsources the `external_reference` only contains the schema and table name
-                    // and for postgres sources the `external_reference` does include the database name but
-                    // when matching to the `deprecated_tables` vec in `details` below there is no database
-                    // name on the `ProtoPostgresTableDesc` structs. Since all tables in a given postgres
-                    // publication must belong to the same database it doesn't matter anyways.
-                    let (external_schema, external_table) = match &external_reference.value {
-                        Some(WithOptionValue::UnresolvedItemName(name)) => {
-                            let name_len = name.0.len();
-                            (
-                                name.0[name_len - 2].clone().into_string(),
-                                name.0[name_len - 1].clone().into_string(),
-                            )
-                        }
-                        _ => unreachable!("external reference must be an unresolved item name"),
-                    };
-
-                    let source_statement = match &source {
-                        RawItemName::Name(name) => self
-                            .source_name_to_stmt
-                            .get(name)
-                            .expect("source must exist"),
-                        RawItemName::Id(id, _) => {
-                            let gid = id
-                                .parse()
-                                .expect("RawItenName::Id must be uncorrupted GlobalId");
-                            self.source_id_to_stmt.get(&gid).expect("source must exist")
-                        }
-                    };
-                    match &source_statement.connection {
-                        CreateSourceConnection::Postgres {
-                            connection: _,
-                            options,
-                        } => {
-                            // Copy the PostgresTableDesc from the top-level source publication details proto
-                            // into the subsource details proto.
-                            let details = options
-                                .iter()
-                                .find(|o| o.name == PgConfigOptionName::Details)
-                                .expect("Sources must have details");
-                            let details_val = match &details.value {
-                                Some(WithOptionValue::Value(Value::String(details))) => details,
-                                _ => unreachable!("Source details' value must be a string"),
-                            };
-                            let details = hex::decode(details_val)
-                                .expect("Source details must be a hex-encoded string");
-                            let details = ProtoPostgresSourcePublicationDetails::decode(&*details)
-                                .expect("Source details must be a hex-encoded protobuf");
-                            let table = details
-                                .deprecated_tables
-                                .iter()
-                                .find(|t| {
-                                    t.namespace == external_schema && t.name == external_table
-                                })
-                                .expect("subsource table must be in source details");
-                            let subsource_details = ProtoSourceExportStatementDetails {
-                                kind: Some(proto_source_export_statement_details::Kind::Postgres(
-                                    ProtoPostgresSourceExportStatementDetails {
-                                        table: Some(table.clone()),
-                                    },
-                                )),
-                            };
-                            node.with_options.push(CreateSubsourceOption {
-                                name: CreateSubsourceOptionName::Details,
-                                value: Some(WithOptionValue::Value(Value::String(hex::encode(
-                                    subsource_details.encode_to_vec(),
-                                )))),
-                            });
-
-                            // Copy the relevant Text Columns from the top-level source option into the subsource option
-                            let text_columns = options
-                                .iter()
-                                .find(|o| o.name == PgConfigOptionName::TextColumns);
-                            if let Some(text_columns) = text_columns {
-                                let table_text_columns = self.columns_for_table(
-                                    &external_schema,
-                                    &external_table,
-                                    &text_columns.value,
-                                );
-                                if table_text_columns.len() > 0 {
-                                    node.with_options.push(CreateSubsourceOption {
-                                        name: CreateSubsourceOptionName::TextColumns,
-                                        value: Some(WithOptionValue::Sequence(table_text_columns)),
-                                    });
-                                }
-                            }
-                        }
-                        CreateSourceConnection::MySql {
-                            connection: _,
-                            options,
-                        } => {
-                            let details = options
-                                .iter()
-                                .find(|o| o.name == MySqlConfigOptionName::Details)
-                                .expect("Sources must have details");
-
-                            let details_val = match &details.value {
-                                Some(WithOptionValue::Value(Value::String(details))) => details,
-                                _ => unreachable!("Source details' value must be a string"),
-                            };
-
-                            let details = hex::decode(details_val)
-                                .expect("Source details must be a hex-encoded string");
-                            let details = ProtoMySqlSourceDetails::decode(&*details)
-                                .expect("Source details must be a hex-encoded protobuf");
-
-                            let (table_idx, table) = details
-                                .deprecated_tables
-                                .iter()
-                                .enumerate()
-                                .find(|(_, t)| {
-                                    t.schema_name == external_schema && t.name == external_table
-                                })
-                                .expect("subsource table must be in source details");
-                            // Handle the 2 versions of the initial_gtid_set fields in the top-level source details
-                            let initial_gtid_set = if details.deprecated_initial_gtid_set.len() == 1
-                            {
-                                details.deprecated_initial_gtid_set[0].clone()
-                            } else if details.deprecated_initial_gtid_set.len()
-                                == details.deprecated_tables.len()
-                            {
-                                details.deprecated_initial_gtid_set[table_idx].clone()
-                            } else if details.deprecated_legacy_initial_gtid_set.len() > 0 {
-                                details.deprecated_legacy_initial_gtid_set.clone()
-                            } else {
-                                unreachable!("invalid initial GTID set(s) in source details")
-                            };
-
-                            let subsource_details = ProtoSourceExportStatementDetails {
-                                kind: Some(proto_source_export_statement_details::Kind::Mysql(
-                                    ProtoMySqlSourceExportStatementDetails {
-                                        table: Some(table.clone()),
-                                        initial_gtid_set,
-                                    },
-                                )),
-                            };
-                            node.with_options.push(CreateSubsourceOption {
-                                name: CreateSubsourceOptionName::Details,
-                                value: Some(WithOptionValue::Value(Value::String(hex::encode(
-                                    subsource_details.encode_to_vec(),
-                                )))),
-                            });
-
-                            // Copy the relevant Text Columns from the top-level source option into the subsource option
-                            let text_columns = options
-                                .iter()
-                                .find(|o| o.name == MySqlConfigOptionName::TextColumns);
-                            if let Some(text_columns) = text_columns {
-                                let table_text_columns = self.columns_for_table(
-                                    &external_schema,
-                                    &external_table,
-                                    &text_columns.value,
-                                );
-                                if table_text_columns.len() > 0 {
-                                    node.with_options.push(CreateSubsourceOption {
-                                        name: CreateSubsourceOptionName::TextColumns,
-                                        value: Some(WithOptionValue::Sequence(table_text_columns)),
-                                    });
-                                }
-                            }
-                            // Copy the relevant Ignore Columns from the top-level source option into the subsource option
-                            let ignore_columns = options
-                                .iter()
-                                .find(|o| o.name == MySqlConfigOptionName::IgnoreColumns);
-                            if let Some(ignore_columns) = ignore_columns {
-                                let table_ignore_columns = self.columns_for_table(
-                                    &external_schema,
-                                    &external_table,
-                                    &ignore_columns.value,
-                                );
-                                if table_ignore_columns.len() > 0 {
-                                    node.with_options.push(CreateSubsourceOption {
-                                        name: CreateSubsourceOptionName::IgnoreColumns,
-                                        value: Some(WithOptionValue::Sequence(
-                                            table_ignore_columns,
-                                        )),
-                                    });
-                                }
-                            }
-                        }
-                        CreateSourceConnection::LoadGenerator { .. } => {
-                            // Load generator sources don't have any information we need to copy
-                            // to the subsource, so we just create an empty details for the subsource
-                            // which is used as a stub to ensure conformity with other source-export subsources
-                            let subsource_details = ProtoSourceExportStatementDetails {
-                                kind: Some(
-                                    proto_source_export_statement_details::Kind::Loadgen(()),
-                                ),
-                            };
-                            node.with_options.push(CreateSubsourceOption {
-                                name: CreateSubsourceOptionName::Details,
-                                value: Some(WithOptionValue::Value(Value::String(hex::encode(
-                                    subsource_details.encode_to_vec(),
-                                )))),
-                            });
-                        }
-                        _ => unreachable!("unexpected source type for existing subsource"),
-                    };
-                    info!("migrated subsource: {:?}", node);
-                }
-            }
-        }
-    }
-
-    impl Rewriter<'_> {
-        fn columns_for_table(
-            &self,
-            external_schema: &str,
-            external_table: &str,
-            all_columns: &Option<WithOptionValue<Raw>>,
-        ) -> Vec<WithOptionValue<Raw>> {
-            let all_table_columns = match all_columns {
-                Some(WithOptionValue::Sequence(columns)) => {
-                    columns.into_iter().map(|column| match column {
-                        WithOptionValue::UnresolvedItemName(name) => name,
-                        _ => unreachable!("text columns must be UnresolvedItemName"),
-                    })
-                }
-                _ => {
-                    unreachable!("Source columns value must be a sequence")
-                }
-            };
-
-            all_table_columns
-                .filter_map(|name| {
-                    // source text columns are an UnresolvedItemName with (schema, table, column) tuples
-                    // and we only need to copy the column name for the subsource option
-                    if name.0[0].clone().into_string() == external_schema
-                        && name.0[1].clone().into_string() == external_table
-                    {
-                        Some(WithOptionValue::Ident(name.0[2].clone()))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        }
-    }
-    Rewriter {
-        source_name_to_stmt,
-        source_id_to_stmt,
-    }
-    .visit_statement_mut(stmt);
-
-    Ok(())
-}
 
 fn ast_rewrite_create_sink_partition_strategy(
     configs: &ConfigSet,

--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -23,15 +23,7 @@ message ProtoMySqlSourceConnection {
 }
 
 message ProtoMySqlSourceDetails {
-    // These fields marked 'deprecated_' are kept around to migrate old sources since
-    // this message is serialized as proto in the catalog.
-    repeated mz_mysql_util.ProtoMySqlTableDesc deprecated_tables = 1;
-    // This was changed from a string to a repeated string in order to support
-    // separate GTID sets for each table. If this field contains a single element,
-    // or the `legacy_initial_gtid_set` field is populated, it
-    // is the initial GTID set for all tables.
-    string deprecated_legacy_initial_gtid_set = 2;
-    repeated string deprecated_initial_gtid_set = 3;
+    reserved 1, 2, 3;
 }
 
 message ProtoMySqlSourceExportDetails {

--- a/src/storage-types/src/sources/mysql.rs
+++ b/src/storage-types/src/sources/mysql.rs
@@ -206,11 +206,7 @@ pub struct MySqlSourceDetails {}
 
 impl RustType<ProtoMySqlSourceDetails> for MySqlSourceDetails {
     fn into_proto(&self) -> ProtoMySqlSourceDetails {
-        ProtoMySqlSourceDetails {
-            deprecated_tables: vec![],
-            deprecated_initial_gtid_set: vec![],
-            deprecated_legacy_initial_gtid_set: "".to_string(),
-        }
+        ProtoMySqlSourceDetails {}
     }
 
     fn from_proto(_proto: ProtoMySqlSourceDetails) -> Result<Self, TryFromProtoError> {

--- a/src/storage-types/src/sources/postgres.proto
+++ b/src/storage-types/src/sources/postgres.proto
@@ -38,9 +38,7 @@ message ProtoPostgresSourceConnection {
 }
 
 message ProtoPostgresSourcePublicationDetails {
-    // This field is deprecated, but kept around to migrate old sources since this
-    // field is serialized as proto in the catalog.
-    repeated mz_postgres_util.desc.ProtoPostgresTableDesc deprecated_tables = 1;
+    reserved 1;
 
     string slot = 2;
     optional uint64 timeline_id = 3;

--- a/src/storage-types/src/sources/postgres.rs
+++ b/src/storage-types/src/sources/postgres.rs
@@ -302,7 +302,6 @@ pub struct PostgresSourcePublicationDetails {
 impl RustType<ProtoPostgresSourcePublicationDetails> for PostgresSourcePublicationDetails {
     fn into_proto(&self) -> ProtoPostgresSourcePublicationDetails {
         ProtoPostgresSourcePublicationDetails {
-            deprecated_tables: vec![],
             slot: self.slot.clone(),
             timeline_id: self.timeline_id.clone(),
             database: self.database.clone(),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Removes the migration introduced in #28491 now that it's been applied

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
