### PR TITLE
change ready status to "online/offline"

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -191,8 +191,8 @@ of each process in each cluster replica in the system.
 |--------------|------------------------------|---------------------------------------------------------------------------------------------------------|
 | `replica_id` | [`text`]                     | Materialize's unique ID for the cluster replica.                                                        |
 | `process_id` | [`uint8`]                    | The ID of the process within the cluster replica.                                                       |
-| `status`     | [`text`]                     | The status of the cluster replica: `ready` or `not-ready`.                                              |
-| `reason`     | [`text`]                     | If the cluster replica is in a `not-ready` state, the reason (if available). For example, `oom-killed`. |
+| `status`     | [`text`]                     | The status of the cluster replica: `online` or `offline`.                                               |
+| `reason`     | [`text`]                     | If the cluster replica is in a `offline` state, the reason (if available). For example, `oom-killed`.   |
 | `updated_at` | [`timestamp with time zone`] | The time at which the status was last updated.                                                          |
 
 ## `mz_cluster_replica_utilization`

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -14,6 +14,7 @@ documentation][user-docs].
 
 [user-docs]: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/mzbuild.md
 """
+
 import argparse
 import copy
 import importlib
@@ -937,11 +938,11 @@ class Composition:
             JOIN mz_cluster_replicas
             ON mz_internal.mz_cluster_replica_statuses.replica_id = mz_cluster_replicas.id
             JOIN mz_clusters ON mz_cluster_replicas.cluster_id = mz_clusters.id
-            WHERE status NOT IN ('ready', 'not-ready')
+            WHERE status NOT IN ('online', 'offline')
             """
         )
         for cluster_name, replica_name, status, reason in results:
-            return f"Cluster replica {cluster_name}.{replica_name} is expected to be ready/not-ready, but is {status}, reason: {reason}"
+            return f"Cluster replica {cluster_name}.{replica_name} is expected to be online/offline, but is {status}, reason: {reason}"
 
         return None
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -436,10 +436,10 @@ impl CatalogState {
     ) -> BuiltinTableUpdate<&'static BuiltinTable> {
         let status = event.status.as_kebab_case_str();
 
-        let not_ready_reason = match event.status {
-            ClusterStatus::Ready => None,
-            ClusterStatus::NotReady(None) => None,
-            ClusterStatus::NotReady(Some(reason)) => Some(reason.to_string()),
+        let offline_reason = match event.status {
+            ClusterStatus::Online => None,
+            ClusterStatus::Offline(None) => None,
+            ClusterStatus::Offline(Some(reason)) => Some(reason.to_string()),
         };
 
         BuiltinTableUpdate {
@@ -448,7 +448,7 @@ impl CatalogState {
                 Datum::String(&replica_id.to_string()),
                 Datum::UInt64(process_id),
                 Datum::String(status),
-                Datum::from(not_ready_reason.as_deref()),
+                Datum::from(offline_reason.as_deref()),
                 Datum::TimestampTz(event.time.try_into().expect("must fit")),
             ]),
             diff,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1398,7 +1398,7 @@ impl ClusterReplicaStatuses {
         let process_statuses = (0..num_processes)
             .map(|process_id| {
                 let status = ClusterReplicaProcessStatus {
-                    status: ClusterStatus::NotReady(None),
+                    status: ClusterStatus::Offline(None),
                     time: time.clone(),
                 };
                 (u64::cast_from(process_id), status)
@@ -1475,19 +1475,19 @@ impl ClusterReplicaStatuses {
     ) -> ClusterStatus {
         process_status
             .values()
-            .fold(ClusterStatus::Ready, |s, p| match (s, p.status) {
-                (ClusterStatus::Ready, ClusterStatus::Ready) => ClusterStatus::Ready,
+            .fold(ClusterStatus::Online, |s, p| match (s, p.status) {
+                (ClusterStatus::Online, ClusterStatus::Online) => ClusterStatus::Online,
                 (x, y) => {
                     let reason_x = match x {
-                        ClusterStatus::NotReady(reason) => reason,
-                        ClusterStatus::Ready => None,
+                        ClusterStatus::Offline(reason) => reason,
+                        ClusterStatus::Online => None,
                     };
                     let reason_y = match y {
-                        ClusterStatus::NotReady(reason) => reason,
-                        ClusterStatus::Ready => None,
+                        ClusterStatus::Offline(reason) => reason,
+                        ClusterStatus::Online => None,
                     };
                     // Arbitrarily pick the first known not-ready reason.
-                    ClusterStatus::NotReady(reason_x.or(reason_y))
+                    ClusterStatus::Offline(reason_x.or(reason_y))
                 }
             })
     }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -706,8 +706,8 @@ impl Coordinator {
                 "status": event.status.as_kebab_case_str(),
             });
             match event.status {
-                ClusterStatus::Ready => (),
-                ClusterStatus::NotReady(reason) => {
+                ClusterStatus::Online => (),
+                ClusterStatus::Offline(reason) => {
                     let properties = match &mut properties {
                         serde_json::Value::Object(map) => map,
                         _ => unreachable!(),

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use mz_controller::clusters::ClusterStatus;
-use mz_orchestrator::{NotReadyReason, ServiceStatus};
+use mz_orchestrator::{OfflineReason, ServiceStatus};
 use mz_ore::str::{separated, StrExt};
 use mz_pgwire_common::{ErrorResponse, Severity};
 use mz_repr::adt::mz_acl_item::AclMode;
@@ -231,9 +231,9 @@ impl AdapterNotice {
             AdapterNotice::DroppedActiveCluster { name: _ } => Some("Choose a new active cluster by executing SET CLUSTER = <name>.".into()),
             AdapterNotice::ClusterReplicaStatusChanged { status, .. } => {
                 match status {
-                    ServiceStatus::NotReady(None) => Some("The cluster replica may be restarting or going offline.".into()),
-                    ServiceStatus::NotReady(Some(NotReadyReason::OomKilled)) => Some("The cluster replica may have run out of memory and been killed.".into()),
-                    ServiceStatus::Ready => None,
+                    ServiceStatus::Offline(None) => Some("The cluster replica may be restarting or going offline.".into()),
+                    ServiceStatus::Offline(Some(OfflineReason::OomKilled)) => Some("The cluster replica may have run out of memory and been killed.".into()),
+                    ServiceStatus::Online => None,
                 }
             },
             AdapterNotice::RbacUserDisabled => Some("To enable RBAC globally run `ALTER SYSTEM SET enable_rbac_checks TO TRUE` as a superuser. TO enable RBAC for just this session run `SET enable_session_rbac_checks TO TRUE`.".into()),

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -42,7 +42,7 @@ use mz_cloud_resources::crd::vpc_endpoint::v1::VpcEndpoint;
 use mz_cloud_resources::AwsExternalIdPrefix;
 use mz_orchestrator::{
     scheduling_config::*, DiskLimit, LabelSelectionLogic, LabelSelector as MzLabelSelector,
-    NamespacedOrchestrator, NotReadyReason, Orchestrator, Service, ServiceConfig, ServiceEvent,
+    NamespacedOrchestrator, OfflineReason, Orchestrator, Service, ServiceConfig, ServiceEvent,
     ServiceProcessMetrics, ServiceStatus,
 };
 use mz_ore::retry::Retry;
@@ -1229,9 +1229,9 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 .unwrap_or((false, None));
 
             let status = if pod_ready {
-                ServiceStatus::Ready
+                ServiceStatus::Online
             } else {
-                ServiceStatus::NotReady(oomed.then_some(NotReadyReason::OomKilled))
+                ServiceStatus::Offline(oomed.then_some(OfflineReason::OomKilled))
             };
             let time = if let Some(time) = last_probe_time {
                 time.0

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -1120,8 +1120,8 @@ enum ProcessStatus {
 impl From<ProcessStatus> for ServiceStatus {
     fn from(status: ProcessStatus) -> ServiceStatus {
         match status {
-            ProcessStatus::NotReady => ServiceStatus::NotReady(None),
-            ProcessStatus::Ready { .. } => ServiceStatus::Ready,
+            ProcessStatus::NotReady => ServiceStatus::Offline(None),
+            ProcessStatus::Ready { .. } => ServiceStatus::Online,
         }
     }
 }

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -97,14 +97,14 @@ pub struct ServiceEvent {
 
 /// Why the service is not ready, if known
 #[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq)]
-pub enum NotReadyReason {
+pub enum OfflineReason {
     OomKilled,
 }
 
-impl fmt::Display for NotReadyReason {
+impl fmt::Display for OfflineReason {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            NotReadyReason::OomKilled => f.write_str("oom-killed"),
+            OfflineReason::OomKilled => f.write_str("oom-killed"),
         }
     }
 }
@@ -113,19 +113,19 @@ impl fmt::Display for NotReadyReason {
 #[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq)]
 pub enum ServiceStatus {
     /// Service is ready to accept requests.
-    Ready,
+    Online,
     /// Service is not ready to accept requests.
     /// The inner element is `None` if the reason
     /// is unknown
-    NotReady(Option<NotReadyReason>),
+    Offline(Option<OfflineReason>),
 }
 
 impl ServiceStatus {
     /// Returns the service status as a kebab-case string.
     pub fn as_kebab_case_str(&self) -> &'static str {
         match self {
-            ServiceStatus::Ready => "ready",
-            ServiceStatus::NotReady(_) => "not-ready",
+            ServiceStatus::Online => "online",
+            ServiceStatus::Offline(_) => "offline",
         }
     }
 }

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -72,7 +72,7 @@ def test_oom_clusterd(mz: MaterializeApplication) -> None:
                 for _, diff, status, reason in cur.fetchall():
                     if diff < 1:
                         continue
-                    if status == "not-ready" and reason == "oom-killed":
+                    if status == "offline" and reason == "oom-killed":
                         return
 
     # Once we create an index on this view in a cluster limited to 2Gb, it is practically guaranteed to OOM
@@ -161,7 +161,7 @@ def test_crash_clusterd(mz: MaterializeApplication) -> None:
     assert podcount > 0
 
     # Wait for expected notices on all connections.
-    msg = b'cluster replica quickstart.r1 changed status to "not-ready"'
+    msg = b'cluster replica quickstart.r1 changed status to "offline"'
     assert_notice(c_select, msg)
     assert_notice(c_subscribe, msg)
     assert_notice(c_copy, msg)

--- a/test/ldbc-bi/q04.sql
+++ b/test/ldbc-bi/q04.sql
@@ -116,27 +116,27 @@
 -- Time: 791.930 ms
 -- CREATE INDEX
 -- Time: 349.982 ms
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "not-ready" at 2023-07-20 18:17:02.072258+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "offline" at 2023-07-20 18:17:02.072258+00
 -- HINT:  The cluster replica may be restarting or going offline.
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "ready" at 2023-07-20 18:17:07.113753+00
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "not-ready" at 2023-07-20 22:19:42.544537+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "online" at 2023-07-20 18:17:07.113753+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "offline" at 2023-07-20 22:19:42.544537+00
 -- HINT:  The cluster replica may be restarting or going offline.
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "ready" at 2023-07-20 22:19:47.566627+00
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "not-ready" at 2023-07-21 01:54:04.832211+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "online" at 2023-07-20 22:19:47.566627+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "offline" at 2023-07-21 01:54:04.832211+00
 -- HINT:  The cluster replica may be restarting or going offline.
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "ready" at 2023-07-21 01:54:09.850194+00
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "not-ready" at 2023-07-21 05:49:35.058072+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "online" at 2023-07-21 01:54:09.850194+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "offline" at 2023-07-21 05:49:35.058072+00
 -- HINT:  The cluster replica may be restarting or going offline.
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "ready" at 2023-07-21 05:49:40.109144+00
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "not-ready" at 2023-07-21 08:42:54.897804+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "online" at 2023-07-21 05:49:40.109144+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "offline" at 2023-07-21 08:42:54.897804+00
 -- HINT:  The cluster replica may be restarting or going offline.
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "ready" at 2023-07-21 08:42:59.928996+00
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "not-ready" at 2023-07-21 12:02:54.517557+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "online" at 2023-07-21 08:42:59.928996+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "offline" at 2023-07-21 12:02:54.517557+00
 -- HINT:  The cluster replica may be restarting or going offline.
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "ready" at 2023-07-21 12:02:59.559505+00
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "not-ready" at 2023-07-21 13:30:02.559734+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "online" at 2023-07-21 12:02:59.559505+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "offline" at 2023-07-21 13:30:02.559734+00
 -- HINT:  The cluster replica may be restarting or going offline.
--- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "ready" at 2023-07-21 13:30:07.566586+00
+-- psql:q04.sql:63: NOTICE:  cluster replica default.r1 changed status to "online" at 2023-07-21 13:30:07.566586+00
 -- ^CCancel request sent
 -- psql:q04.sql:63: ERROR:  canceling statement due to user request
 -- Time: 93951684.641 ms (1 d 02:05:51.685)

--- a/test/sqllogictest/mz_catalog_server_index_accounting.slt
+++ b/test/sqllogictest/mz_catalog_server_index_accounting.slt
@@ -182,6 +182,9 @@ mz_audit_events  object_type
 mz_audit_events  occurred_at
 mz_audit_events  user
 mz_base_types  id
+mz_cluster_replica_frontiers  object_id
+mz_cluster_replica_frontiers  replica_id
+mz_cluster_replica_frontiers  write_frontier
 mz_cluster_replica_history  cluster_name
 mz_cluster_replica_history  created_at
 mz_cluster_replica_history  credits_per_hour
@@ -247,6 +250,13 @@ mz_compute_exports_per_worker  worker_id
 mz_compute_frontiers_per_worker  export_id
 mz_compute_frontiers_per_worker  time
 mz_compute_frontiers_per_worker  worker_id
+mz_compute_hydration_statuses  hydrated
+mz_compute_hydration_statuses  hydration_time
+mz_compute_hydration_statuses  object_id
+mz_compute_hydration_statuses  replica_id
+mz_compute_hydration_times  object_id
+mz_compute_hydration_times  replica_id
+mz_compute_hydration_times  time_ns
 mz_compute_hydration_times_per_worker  export_id
 mz_compute_hydration_times_per_worker  time_ns
 mz_compute_hydration_times_per_worker  worker_id
@@ -302,6 +312,9 @@ mz_functions  return_type_id
 mz_functions  returns_set
 mz_functions  schema_id
 mz_functions  variadic_argument_type_id
+mz_hydration_statuses  hydrated
+mz_hydration_statuses  object_id
+mz_hydration_statuses  replica_id
 mz_index_columns  index_id
 mz_index_columns  index_position
 mz_index_columns  nullable

--- a/test/testdrive/distinct-arrangements.td
+++ b/test/testdrive/distinct-arrangements.td
@@ -726,14 +726,15 @@ ReduceMinsMaxes
 "ArrangeBy[[Column(0), Column(1), Column(2), Column(3), Column(4), Column(5)]]-errors" 1
 "ArrangeBy[[Column(0), Column(1), Column(2), Column(3), Column(4)]]" 1
 "ArrangeBy[[Column(0), Column(1), Column(2), Column(3), Column(4)]]-errors" 1
-"ArrangeBy[[Column(0), Column(2)]]"           2
+"ArrangeBy[[Column(0), Column(1)]]"           1
+"ArrangeBy[[Column(0), Column(2)]]"           3
 "ArrangeBy[[Column(1), Column(2)]]"           1
 "ArrangeBy[[Column(0)]]-errors"              26
-"ArrangeBy[[Column(0)]]"                     81
+"ArrangeBy[[Column(0)]]"                     90
 "ArrangeBy[[Column(1), Column(3)]]"           1
 "ArrangeBy[[Column(1)]]-errors"               6
 ArrangeBy[[Column(13)]]                       1
-"ArrangeBy[[Column(1)]]"                     17
+"ArrangeBy[[Column(1)]]"                     19
 "ArrangeBy[[Column(2)]]-errors"               9
 "ArrangeBy[[Column(2)]]"                     20
 "ArrangeBy[[Column(3)]]"                      3
@@ -747,18 +748,18 @@ ArrangeBy[[Column(13)]]                       1
 "ArrangeBy[[Column(20)]]-errors"              1
 "ArrangeBy[[If { cond: CallUnary { func: IsNull(IsNull), expr: Column(2) }, then: Literal(Ok(Row{[Null]}), ColumnType { scalar_type: String, nullable: true }), els: Column(1) }]]" 1
 "ArrangeBy[[]]"                               10
-"Arranged DistinctBy"                         22
+"Arranged DistinctBy"                         24
 "Arranged MinsMaxesHierarchical input"        14
 "Arranged ReduceInaccumulable"                1
-"Arranged TopK input"                        16
+"Arranged TopK input"                        24
 "Distinct recursive err"                      1
-"DistinctBy"                                  22
-"DistinctByErrorCheck"                        22
+"DistinctBy"                                  24
+"DistinctByErrorCheck"                        24
 "ReduceAccumulable"                           9
 "ReduceCollation Errors"                      1
 "ReduceCollation"                             1
 "Reduced Fallibly MinsMaxesHierarchical"     14
-"Reduced TopK input"                         16
+"Reduced TopK input"                         24
 "ReduceInaccumulable Error Check"             1
 "ReduceInaccumulable"                         1
 "ReduceMinsMaxes"                             2


### PR DESCRIPTION
### Motivation

        moves ready/not-ready to online/offline
        in order to avoid conflation with a future
        hydration status ready status

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
