### PR TITLE
persist: remove schema reg dyncfgs

### DIFF
--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -75,8 +75,6 @@ impl Transactor {
             mz_txn_wal::all_dyncfgs(client.dyncfgs().clone()),
             Arc::new(TxnMetrics::new(&MetricsRegistry::new())),
             txns_id,
-            Arc::new(StringSchema),
-            Arc::new(UnitSchema),
         )
         .await;
         oracle.apply_write(init_ts.into()).await;

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -362,8 +362,6 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::read::READER_LEASE_DURATION)
         .add(&crate::rpc::PUBSUB_CLIENT_ENABLED)
         .add(&crate::rpc::PUBSUB_PUSH_DIFF_ENABLED)
-        .add(&crate::schema::SCHEMA_REGISTER)
-        .add(&crate::schema::SCHEMA_REQUIRE)
         .add(&crate::stats::STATS_AUDIT_PERCENT)
         .add(&crate::stats::STATS_BUDGET_BYTES)
         .add(&crate::stats::STATS_COLLECTION_ENABLED)

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -43,7 +43,7 @@ use crate::internal::state_versions::StateVersions;
 use crate::metrics::Metrics;
 use crate::read::{LeasedReaderId, ReadHandle, READER_LEASE_DURATION};
 use crate::rpc::PubSubSender;
-use crate::schema::{SchemaId, SCHEMA_REGISTER, SCHEMA_REQUIRE};
+use crate::schema::SchemaId;
 use crate::write::{WriteHandle, WriterId};
 
 pub mod async_runtime;
@@ -545,24 +545,17 @@ impl PersistClient {
         // `PersistClient::compare_and_append_schema(current_schema_id,
         // next_schema)`. Presumably this would then be passed in to open_writer
         // instead of us implicitly registering it here.
-        let schema_id = if SCHEMA_REGISTER.get(&self.cfg) {
-            // NB: The overwhelming common case is that this schema is already
-            // registered. In this case, the cmd breaks early and nothing is
-            // written to (or read from) CRDB.
-            let (schema, maintenance) = machine.register_schema(&*key_schema, &*val_schema).await;
-            maintenance.start_performing(&machine, &gc);
-            if SCHEMA_REQUIRE.get(&self.cfg) {
-                soft_assert_or_log!(
-                    schema.is_some(),
-                    "unable to register schemas {:?} {:?}",
-                    key_schema,
-                    val_schema,
-                );
-            }
-            schema
-        } else {
-            None
-        };
+        // NB: The overwhelming common case is that this schema is already
+        // registered. In this case, the cmd breaks early and nothing is
+        // written to (or read from) CRDB.
+        let (schema_id, maintenance) = machine.register_schema(&*key_schema, &*val_schema).await;
+        maintenance.start_performing(&machine, &gc);
+        soft_assert_or_log!(
+            schema_id.is_some(),
+            "unable to register schemas {:?} {:?}",
+            key_schema,
+            val_schema,
+        );
 
         let writer_id = WriterId::new();
         let schemas = Schemas {

--- a/src/persist-client/src/schema.rs
+++ b/src/persist-client/src/schema.rs
@@ -11,7 +11,6 @@
 
 use std::str::FromStr;
 
-use mz_dyncfg::Config;
 use mz_ore::cast::CastFrom;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -46,18 +45,6 @@ impl TryFrom<String> for SchemaId {
         Ok(SchemaId(usize::cast_from(schema_id)))
     }
 }
-
-pub(crate) const SCHEMA_REGISTER: Config<bool> = Config::new(
-    "persist_schema_register",
-    true,
-    "register schemas with the shard when opening a read or write handle",
-);
-
-pub(crate) const SCHEMA_REQUIRE: Config<bool> = Config::new(
-    "persist_schema_require",
-    true,
-    "error if schema registration is unsuccessful when opening a read or write handle",
-);
 
 #[cfg(test)]
 mod tests {

--- a/src/persist-client/tests/machine/regression_listen_compaction
+++ b/src/persist-client/tests/machine/regression_listen_compaction
@@ -11,12 +11,6 @@
 # Listen would emit a batch, then the batch would get compacted, then the Listen
 # would emit the entire merged batch, which double emitted the first batch.
 
-# Enable schema registry so the seqnos are stable
-dyncfg
-persist_schema_register true
-----
-ok
-
 # Write a batch and emit it from a Listen
 write-batch output=b0 lower=0 upper=2
 one 1 1

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -103,12 +103,6 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                 },
                 {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
-                    x.add_dynamic("persist_schema_register", ::mz_dyncfg::ConfigVal::Bool(true));
-                    x.add_dynamic("persist_schema_require", ::mz_dyncfg::ConfigVal::Bool(true));
-                    x
-                },
-                {
-                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
                     x.add_dynamic("persist_part_decode_format", ::mz_dyncfg::ConfigVal::String("arrow".into()));
                     x

--- a/src/storage-client/src/storage_collections.rs
+++ b/src/storage-client/src/storage_collections.rs
@@ -450,8 +450,6 @@ where
                 txns_client.dyncfgs().clone(),
                 Arc::clone(&txns_metrics),
                 txns_id,
-                Arc::new(RelationDesc::empty()),
-                Arc::new(UnitSchema),
             )
             .await;
 

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2421,8 +2421,6 @@ where
                 txns_client.dyncfgs().clone(),
                 Arc::clone(&txns_metrics),
                 txns_id,
-                Arc::new(RelationDesc::empty()),
-                Arc::new(UnitSchema),
             )
             .await;
             persist_handles::PersistTableWriteWorker::new_txns(txns)

--- a/src/txn-wal/src/lib.rs
+++ b/src/txn-wal/src/lib.rs
@@ -127,7 +127,7 @@
 //! // Open a txn shard, initializing it if necessary.
 //! let txns_id = ShardId::new();
 //! let mut txns = TxnsHandle::<String, (), u64, i64>::open(
-//!     0u64, client.clone(), dyncfgs, metrics, txns_id, StringSchema.into(), UnitSchema.into()
+//!     0u64, client.clone(), dyncfgs, metrics, txns_id
 //! ).await;
 //!
 //! // Register data shards to the txn set.


### PR DESCRIPTION
As of the release currently being qualified, these are on for all of staging and prod and we don't intend to turn them off. Use the new knowledge to clean up a TODO in txn_wal and remove a sus `RelationDesc::empty()`.


### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
