### PR TITLE
parallel-workload: Don't alter sink based on webhook source

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -794,7 +794,10 @@ class AlterKafkaSinkFromAction(Action):
                 objs = [
                     o
                     for o in exe.db.db_objects_without_views()
-                    if len(o.columns) >= len(old_object.columns)
+                    # Webhook sources can include all headers, then we don't know the exact columns
+                    if not isinstance(old_object, WebhookSource)
+                    and not isinstance(o, WebhookSource)
+                    and len(o.columns) >= len(old_object.columns)
                     and [c.data_type for c in o.columns[: len(old_object.columns)]]
                     == [c.data_type for c in old_object.columns]
                 ]


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/9023#0191330b-b56a-42d1-817d-bb76a81a9124

Verification: lhttps://buildkite.com/materialize/nightly/builds/9035

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
