### PR TITLE
environmentd: enable client-side mode in Segment client

### DIFF
--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -81,6 +81,7 @@ export MZ_BOOTSTRAP_ROLE=${MZ_BOOTSTRAP_ROLE:-materialize}
 
 if [ -z "${MZ_NO_TELEMETRY:-}" ]; then
     export MZ_SEGMENT_API_KEY=${MZ_SEGMENT_API_KEY:-hMWi3sZ17KFMjn2sPWo9UJGpOQqiba4A}
+    export MZ_SEGMENT_CLIENT_SIDE=${MZ_SEGMENT_API_KEY:-true}
 fi
 
 exec environmentd "$@"

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -416,6 +416,13 @@ pub struct Args {
     /// An API key for Segment. Enables export of audit events to Segment.
     #[clap(long, env = "SEGMENT_API_KEY")]
     segment_api_key: Option<String>,
+    /// Whether the Segment client is being used on the client side
+    /// (rather than the server side).
+    ///
+    /// Enabling this causes the Segment server to record the IP address from
+    /// which the event was sent.
+    #[clap(long, env = "SEGMENT_CLIENT_SIDE")]
+    segment_client_side: bool,
     /// An SDK key for LaunchDarkly.
     ///
     /// Setting this in combination with [`Self::config_sync_loop_interval`]
@@ -967,6 +974,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 cluster_replica_sizes,
                 timestamp_oracle_url: args.timestamp_oracle_url,
                 segment_api_key: args.segment_api_key,
+                segment_client_side: args.segment_client_side,
                 launchdarkly_sdk_key: args.launchdarkly_sdk_key,
                 launchdarkly_key_map: args
                     .launchdarkly_key_map

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -125,6 +125,9 @@ pub struct Config {
     pub timestamp_oracle_url: Option<String>,
     /// An API key for Segment. Enables export of audit events to Segment.
     pub segment_api_key: Option<String>,
+    /// Whether the Segment client is being used on the client side
+    /// (rather than the server side).
+    pub segment_client_side: bool,
     /// An SDK key for LaunchDarkly. Enables system parameter synchronization
     /// with LaunchDarkly.
     pub launchdarkly_sdk_key: Option<String>,
@@ -555,7 +558,12 @@ impl Listeners {
         );
 
         // Initialize adapter.
-        let segment_client = config.segment_api_key.map(mz_segment::Client::new);
+        let segment_client = config.segment_api_key.map(|api_key| {
+            mz_segment::Client::new(mz_segment::Config {
+                api_key,
+                client_side: config.segment_client_side,
+            })
+        });
         let webhook_concurrency_limit = WebhookConcurrencyLimiter::default();
         let (adapter_handle, adapter_client) = mz_adapter::serve(mz_adapter::Config {
             connection_context: config.controller.connection_context.clone(),

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -515,6 +515,7 @@ impl Listeners {
                 storage_usage_collection_interval: config.storage_usage_collection_interval,
                 storage_usage_retention_period: config.storage_usage_retention_period,
                 segment_api_key: None,
+                segment_client_side: false,
                 egress_ips: vec![],
                 aws_account_id: None,
                 aws_privatelink_availability_zones: None,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1082,6 +1082,7 @@ impl<'a> RunnerInner<'a> {
             storage_usage_collection_interval: Duration::from_secs(3600),
             storage_usage_retention_period: None,
             segment_api_key: None,
+            segment_client_side: false,
             egress_ips: vec![],
             aws_account_id: None,
             aws_privatelink_availability_zones: None,


### PR DESCRIPTION
Segment only records IPs for events on the server if the events originate from a "client-side library" (e.g., a library that runs in the user's browser). Segment determines the origin of an event based on the `context.library.name` field. So, add an optional flag to environmentd that causes our Segment client to emulate the Analytics.js library. This flag is on by default in the evalution Docker image (materialize/materialized).

Touches #28876.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
