### PR TITLE
ci: Bump some timeouts in nightly

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -49,7 +49,7 @@ steps:
         label: Unused dependencies
         command: bin/ci-builder run nightly bin/unused-deps
         depends_on: []
-        timeout_in_minutes: 30
+        timeout_in_minutes: 45
         agents:
           queue: hetzner-aarch64-8cpu-16gb
         sanitizer: skip
@@ -87,7 +87,7 @@ steps:
       - id: scalability-benchmark-dml-dql
         label: "Scalability benchmark (read & write) against merge base or 'latest'"
         depends_on: build-aarch64
-        timeout_in_minutes: 180
+        timeout_in_minutes: 240
         agents:
           queue: hetzner-aarch64-8cpu-16gb
         plugins:
@@ -1233,7 +1233,7 @@ steps:
       - id: rqg-db3-joins
         label: "RQG dbt3-joins workload"
         depends_on: build-aarch64
-        timeout_in_minutes: 45
+        timeout_in_minutes: 60
         agents:
           # Runs into timeout/OoM on small agents
           queue: hetzner-aarch64-16cpu-32gb
@@ -1544,7 +1544,7 @@ steps:
   - id: txn-wal-fencing
     label: Txn-wal fencing
     depends_on: build-aarch64
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     plugins:
       - ./ci/plugins/mzcompose:
           composition: txn-wal-fencing


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/9034
Not sure yet if there is a regression in the product, seems suspicious. Checking
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
