### PR TITLE
[persist] Fix nullability in DatumColumnEncoder

### DIFF
--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -80,7 +80,7 @@ struct DatumEncoder {
 }
 
 impl DatumEncoder {
-    fn push<'e, 'd>(&'e mut self, datum: Datum<'d>) -> Result<(), anyhow::Error> {
+    fn push(&mut self, datum: Datum) {
         assert!(
             !datum.is_null() || self.nullable,
             "tried pushing Null into non-nullable column"
@@ -90,8 +90,6 @@ impl DatumEncoder {
         if datum.is_null() {
             self.none_stats += 1;
         }
-
-        Ok(())
     }
 
     fn push_invalid(&mut self) {
@@ -1268,7 +1266,7 @@ impl ColumnEncoder<Row> for RowColumnarEncoder {
     fn append(&mut self, val: &Row) {
         let mut num_datums = 0;
         for (datum, encoder) in val.iter().zip(self.encoders.iter_mut()) {
-            encoder.push(datum).expect("failed to push datum");
+            encoder.push(datum);
             num_datums += 1;
         }
         assert_eq!(

--- a/src/repr/src/row/encoding2.rs
+++ b/src/repr/src/row/encoding2.rs
@@ -1925,8 +1925,8 @@ mod tests {
             "a",
             ScalarType::Record {
                 fields: vec![
-                    (ColumnName::from("foo"), ScalarType::Int64.nullable(true)),
-                    (ColumnName::from("bar"), ScalarType::String.nullable(false)),
+                    (ColumnName::from("foo"), ScalarType::Int64.nullable(false)),
+                    (ColumnName::from("bar"), ScalarType::String.nullable(true)),
                     (
                         ColumnName::from("baz"),
                         ScalarType::List {


### PR DESCRIPTION
Currently, we set the `nullability` of the field in a struct array based on whether / not the array contains any nulls. This means that two arrays generated by the same encoder may not have the same type, which limits our ability to eg. concatenate / consolidate them together later. (And concretely, this causes problems for the new consolidation code, which calls `interleave`, which expects all arrays to have the same type.)

Two ideas for fixes in separate commits:
- Third commit: we could just say every column is nullable. AFAICT this is fine and causes no problems. 
- Last commit: we could thread the nullability info from the RelationDesc through to the individual field.

Either seems basically fine to me, but I suspect the last commit is slightly more in line with the rest of our approach.

### Motivation

Addresses Zippy failures in such tests as: https://buildkite.com/materialize/nightly/builds/9038

### Tips for reviewer

Separately, we've presumably already encoded data with the bad nullability information in Staging. Will discuss what to do there with the team and follow up separately.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
