### PR TITLE
sql: remove size column from SHOW {SOURCES | SINKS}

### DIFF
--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -60,15 +60,15 @@ with.
     <p></p>
 
     ```nofmt
-            name            |      type      | size
-    ------------------------+----------------+------
-     accounts               | subsource      | null
-     auction_house          | load-generator | null
-     auction_house_progress | progress       | null
-     auctions               | subsource      | null
-     bids                   | subsource      | null
-     organizations          | subsource      | null
-     users                  | subsource      | null
+            name            |      type
+    ------------------------+-----------------
+     accounts               | subsource
+     auction_house          | load-generator
+     auction_house_progress | progress
+     auctions               | subsource
+     bids                   | subsource
+     organizations          | subsource
+     users                  | subsource
     ```
 
     For now, you'll focus on the `auctions` and `bids` data sets. Data will

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -280,15 +280,15 @@ To display the created subsources:
 SHOW SOURCES;
 ```
 ```nofmt
-          name          |      type      |  size
-------------------------+----------------+---------
- accounts               | subsource      |
- auction_house          | load-generator | 25cc
- auction_house_progress | progress       |
- auctions               | subsource      |
- bids                   | subsource      |
- organizations          | subsource      |
- users                  | subsource      |
+          name          |      type
+------------------------+----------------
+ accounts               | subsource
+ auction_house          | load-generator
+ auction_house_progress | progress
+ auctions               | subsource
+ bids                   | subsource
+ organizations          | subsource
+ users                  | subsource
 ```
 
 To examine the simulated bids:
@@ -321,16 +321,16 @@ SHOW SOURCES;
 ```
 
 ```nofmt
-          name          |      type      | size
-------------------------+----------------+------
- clicks                 | subsource      |
- conversion_predictions | subsource      |
- coupons                | subsource      |
- customers              | subsource      |
- impressions            | subsource      |
- leads                  | subsource      |
- marketing              | load-generator | 25cc
- marketing_progress     | progress       |
+          name          |      type
+------------------------+---------------
+ clicks                 | subsource
+ conversion_predictions | subsource
+ coupons                | subsource
+ customers              | subsource
+ impressions            | subsource
+ leads                  | subsource
+ marketing              | load-generator
+ marketing_progress     | progress
 ```
 
 To find all impressions and clicks associated with a campaign over the last 30 days:
@@ -396,18 +396,18 @@ To display the created subsources:
 SHOW SOURCES;
 ```
 ```nofmt
-      name     |      type      |  size
----------------+----------------+---------
- tpch          | load-generator | 50cc
- tpch_progress | progress       |
- supplier      | subsource      |
- region        | subsource      |
- partsupp      | subsource      |
- part          | subsource      |
- orders        | subsource      |
- nation        | subsource      |
- lineitem      | subsource      |
- customer      | subsource      |
+      name     |      type
+---------------+---------------
+ tpch          | load-generator
+ tpch_progress | progress
+ supplier      | subsource
+ region        | subsource
+ partsupp      | subsource
+ part          | subsource
+ orders        | subsource
+ nation        | subsource
+ lineitem      | subsource
+ customer      | subsource
 ```
 
 To run the Pricing Summary Report Query (Q1), which reports the amount of

--- a/doc/user/content/sql/create-source/mysql.md
+++ b/doc/user/content/sql/create-source/mysql.md
@@ -142,12 +142,12 @@ When you define a source, Materialize will automatically:
     ```
 
     ```nofmt
-             name         |   type    |  size   |  cluster  |
-    ----------------------+-----------+---------+------------
-     mz_source            | mysql     |         |
-     mz_source_progress   | progress  |         |
-     table_1              | subsource |         |
-     table_2              | subsource |         |
+             name         |   type    |  cluster  |
+    ----------------------+-----------+------------
+     mz_source            | mysql     |
+     mz_source_progress   | progress  |
+     table_1              | subsource |
+     table_2              | subsource |
     ```
 
 1. Incrementally update any materialized or indexed views that depend on the

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -113,12 +113,12 @@ When you define a source, Materialize will automatically:
     ```
 
     ```nofmt
-             name         |   type    |  size
-    ----------------------+-----------+---------
-     mz_source            | postgres  | 25cc
-     mz_source_progress   | progress  |
-     table_1              | subsource |
-     table_2              | subsource |
+             name         |   type
+    ----------------------+-----------
+     mz_source            | postgres
+     mz_source_progress   | progress
+     table_1              | subsource
+     table_2              | subsource
     ```
 
     And perform an initial, snapshot-based sync of the tables in the publication

--- a/doc/user/content/sql/show-sinks.md
+++ b/doc/user/content/sql/show-sinks.md
@@ -26,16 +26,15 @@ _cluster&lowbar;name_ | The cluster to show sinks from. If omitted, sinks from a
 `SHOW SINKS`'s output is a table, with this structure:
 
 ```nofmt
-name  | type | size | cluster
-------+------+------+--------
-...   | ...  | ...  | ...
+name  | type | cluster
+------+------+--------
+...   | ...  | ...
 ```
 
 Field       | Meaning
 ------------|--------
 **name**    | The name of the sink.
 **type**    | The type of the sink: currently only `kafka` is supported.
-**size**    | The size of the sink. Null if the sink is created using the `IN CLUSTER` clause.
 **cluster** | The cluster the sink is associated with.
 
 ## Examples
@@ -44,19 +43,19 @@ Field       | Meaning
 SHOW SINKS;
 ```
 ```nofmt
-name          | type  | size    | cluster
---------------+-------+---------+--------
-my_sink       | kafka |         | c1
-my_other_sink | kafka |         | c2
+name          | type  | cluster
+--------------+-------+--------
+my_sink       | kafka | c1
+my_other_sink | kafka | c2
 ```
 
 ```mzsql
 SHOW SINKS IN CLUSTER c1;
 ```
 ```nofmt
-name    | type  | size    | cluster
---------+-------+---------+--------
-my_sink | kafka |         | c1
+name    | type  | cluster
+--------+-------+--------
+my_sink | kafka | c1
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -24,16 +24,15 @@ _cluster&lowbar;name_ | The cluster to show sources from. If omitted, sources fr
 `SHOW SOURCES`'s output is a table, with this structure:
 
 ```nofmt
-name  | type | size | cluster
-------+------+------+--------
-...   | ...  | ...  | ...
+name  | type | cluster
+------+------+--------
+...   | ...  | ...
 ```
 
 Field | Meaning
 ------|--------
 **name** | The name of the source.
 **type** | The type of the source: `kafka`, `postgres`, `load-generator`, `progress`, or `subsource`.
-**size** | The [size](/sql/create-source/#sizing-a-source) of the source. Null if the source is created using the `IN CLUSTER` clause.
 **cluster** | The cluster the source is associated with.
 
 ## Examples
@@ -42,19 +41,19 @@ Field | Meaning
 SHOW SOURCES;
 ```
 ```nofmt
-            name    | type     | size  | cluster
---------------------+----------+-------+---------
- my_kafka_source    | kafka    |       | c1
- my_postgres_source | postgres |       | c2
+            name    | type     | cluster
+--------------------+----------+---------
+ my_kafka_source    | kafka    | c1
+ my_postgres_source | postgres | c2
 ```
 
 ```mzsql
 SHOW SOURCES IN CLUSTER c2;
 ```
 ```nofmt
-name               | type     | size     | cluster
--------------------+----------+----------+--------
-my_postgres_source | postgres |          | c2
+name               | type     | cluster
+-------------------+----------+--------
+my_postgres_source | postgres | c2
 ```
 
 ## Related pages

--- a/misc/python/materialize/checks/all_checks/identifiers.py
+++ b/misc/python/materialize/checks/all_checks/identifiers.py
@@ -188,9 +188,9 @@ class Identifiers(Check):
         {dq_print(self.ident["schema"])}
 
         > SHOW SINKS FROM {dq(self.ident["schema"])};
-        {dq_print(self.ident["sink0"])} kafka 4 identifiers
-        {dq_print(self.ident["sink1"])} kafka 4 identifiers
-        {dq_print(self.ident["sink2"])} kafka 4 identifiers
+        {dq_print(self.ident["sink0"])} kafka identifiers
+        {dq_print(self.ident["sink1"])} kafka identifiers
+        {dq_print(self.ident["sink2"])} kafka identifiers
 
         > SELECT * FROM {dq(self.ident["schema"])}.{dq(self.ident["mv0"])};
         3

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -6164,7 +6164,6 @@ pub static MZ_SHOW_SOURCES: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
     sql: "SELECT
     sources.name,
     sources.type,
-    COALESCE(sources.size, clusters.size) AS size,
     clusters.name AS cluster,
     schema_id,
     cluster_id
@@ -6184,7 +6183,6 @@ pub static MZ_SHOW_SINKS: Lazy<BuiltinView> = Lazy::new(|| BuiltinView {
     sql: "SELECT
         sinks.name,
         sinks.type,
-        COALESCE(sinks.size, clusters.size) AS size,
         clusters.name AS cluster,
         schema_id,
         cluster_id

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -376,17 +376,11 @@ fn show_sources<'a>(
     }
 
     let query = format!(
-        "SELECT name, type, size, cluster
+        "SELECT name, type, cluster
         FROM mz_internal.mz_show_sources
         WHERE {where_clause}"
     );
-    ShowSelect::new(
-        scx,
-        query,
-        filter,
-        None,
-        Some(&["name", "type", "size", "cluster"]),
-    )
+    ShowSelect::new(scx, query, filter, None, Some(&["name", "type", "cluster"]))
 }
 
 fn show_subsources<'a>(
@@ -493,17 +487,11 @@ fn show_sinks<'a>(
     }
 
     let query = format!(
-        "SELECT name, type, size, cluster
+        "SELECT name, type, cluster
         FROM mz_internal.mz_show_sinks
         WHERE {where_clause}"
     );
-    ShowSelect::new(
-        scx,
-        query,
-        filter,
-        None,
-        Some(&["name", "type", "size", "cluster"]),
-    )
+    ShowSelect::new(scx, query, filter, None, Some(&["name", "type", "cluster"]))
 }
 
 fn show_types<'a>(

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -300,24 +300,24 @@ contains: CREATE SOURCE specifies DETAILS option
   );
 
 > SHOW SOURCES
-conflict_table        subsource  ${arg.default-replica-size}  cdc_cluster
-create                subsource  ${arg.default-replica-size}  cdc_cluster
-escaped_text_table    subsource  ${arg.default-replica-size}  cdc_cluster
-large_text            subsource  ${arg.default-replica-size}  cdc_cluster
-mixED_CAse            subsource  ${arg.default-replica-size}  cdc_cluster
-multipart_pk          subsource  ${arg.default-replica-size}  cdc_cluster
-mz_source             mysql      ${arg.default-replica-size}  cdc_cluster
-mz_source_progress    progress   <null> <null>
-nonpk_table           subsource  ${arg.default-replica-size}  cdc_cluster
-nulls_table           subsource  ${arg.default-replica-size}  cdc_cluster
-pk_table              subsource  ${arg.default-replica-size}  cdc_cluster
-trailing_space_nopk   subsource  ${arg.default-replica-size}  cdc_cluster
-trailing_space_pk     subsource  ${arg.default-replica-size}  cdc_cluster
-types_table           subsource  ${arg.default-replica-size}  cdc_cluster
-utf8_table            subsource  ${arg.default-replica-size}  cdc_cluster
-"\"literal_quotes\""  subsource  ${arg.default-replica-size}  cdc_cluster
-"space table"         subsource  ${arg.default-replica-size}  cdc_cluster
-таблица               subsource  ${arg.default-replica-size}  cdc_cluster
+conflict_table        subsource  cdc_cluster
+create                subsource  cdc_cluster
+escaped_text_table    subsource  cdc_cluster
+large_text            subsource  cdc_cluster
+mixED_CAse            subsource  cdc_cluster
+multipart_pk          subsource  cdc_cluster
+mz_source             mysql      cdc_cluster
+mz_source_progress    progress   <null>
+nonpk_table           subsource  cdc_cluster
+nulls_table           subsource  cdc_cluster
+pk_table              subsource  cdc_cluster
+trailing_space_nopk   subsource  cdc_cluster
+trailing_space_pk     subsource  cdc_cluster
+types_table           subsource  cdc_cluster
+utf8_table            subsource  cdc_cluster
+"\"literal_quotes\""  subsource  cdc_cluster
+"space table"         subsource  cdc_cluster
+таблица               subsource  cdc_cluster
 
 > SELECT schema_name, table_name FROM mz_internal.mz_mysql_source_tables
 public          create
@@ -709,10 +709,10 @@ contains:Reference to columns not currently being added
   );
 
 > SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
-another_enum_table      subsource ${arg.default-replica-size} cdc_cluster
-enum_source             mysql     ${arg.default-replica-size} cdc_cluster
-enum_source_progress    progress  <null> <null>
-enum_table              subsource ${arg.default-replica-size} cdc_cluster
+another_enum_table      subsource cdc_cluster
+enum_source             mysql     cdc_cluster
+enum_source_progress    progress  <null>
+enum_table              subsource cdc_cluster
 
 > SELECT * FROM enum_table
 var0
@@ -744,9 +744,9 @@ INSERT INTO pk_table VALUES (99999, 'abc');
   );
 
 > SHOW SOURCES
-another_source          mysql  ${arg.default-replica-size} cdc_cluster
-another_source_progress progress  <null> <null>
-another_table           subsource ${arg.default-replica-size} cdc_cluster
+another_source          mysql  cdc_cluster
+another_source_progress progress <null>
+another_table           subsource cdc_cluster
 
 > DROP SOURCE another_source CASCADE;
 

--- a/test/mysql-cdc/subsource-resolution-duplicates.td
+++ b/test/mysql-cdc/subsource-resolution-duplicates.td
@@ -50,9 +50,9 @@ detail: subsources referencing table: x, y
   FOR SCHEMAS (other);
 
 > SHOW sources
- mz_source          mysql     ${arg.default-replica-size} quickstart
- mz_source_progress progress  <null> <null>
- t                  subsource ${arg.default-replica-size} quickstart
+ mz_source          mysql     quickstart
+ mz_source_progress progress  <null>
+ t                  subsource quickstart
 
 $ mysql-execute name=mysql
 DROP DATABASE other;

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -316,25 +316,25 @@ detail:referenced items: public.no_replica_identity
   );
 
 > SHOW SOURCES
-array_types_table     subsource  ${arg.default-replica-size}  cdc_cluster
-conflict_table        subsource  ${arg.default-replica-size}  cdc_cluster
-create                subsource  ${arg.default-replica-size}  cdc_cluster
-escaped_text_table    subsource  ${arg.default-replica-size}  cdc_cluster
-large_text            subsource  ${arg.default-replica-size}  cdc_cluster
-multipart_pk          subsource  ${arg.default-replica-size}  cdc_cluster
-mz_source             postgres   ${arg.default-replica-size}  cdc_cluster
-mz_source_progress    progress   <null> <null>
-nonpk_table           subsource  ${arg.default-replica-size}  cdc_cluster
-nulls_table           subsource  ${arg.default-replica-size}  cdc_cluster
-pk_table              subsource  ${arg.default-replica-size}  cdc_cluster
-"space table"         subsource  ${arg.default-replica-size}  cdc_cluster
-trailing_space_nopk   subsource  ${arg.default-replica-size}  cdc_cluster
-trailing_space_pk     subsource  ${arg.default-replica-size}  cdc_cluster
-"\"literal_quotes\""  subsource  ${arg.default-replica-size}  cdc_cluster
-tstzrange_table       subsource  ${arg.default-replica-size}  cdc_cluster
-types_table           subsource  ${arg.default-replica-size}  cdc_cluster
-utf8_table            subsource  ${arg.default-replica-size}  cdc_cluster
-таблица               subsource  ${arg.default-replica-size}  cdc_cluster
+array_types_table     subsource  cdc_cluster
+conflict_table        subsource  cdc_cluster
+create                subsource  cdc_cluster
+escaped_text_table    subsource  cdc_cluster
+large_text            subsource  cdc_cluster
+multipart_pk          subsource  cdc_cluster
+mz_source             postgres   cdc_cluster
+mz_source_progress    progress   <null>
+nonpk_table           subsource  cdc_cluster
+nulls_table           subsource  cdc_cluster
+pk_table              subsource  cdc_cluster
+"space table"         subsource  cdc_cluster
+trailing_space_nopk   subsource  cdc_cluster
+trailing_space_pk     subsource  cdc_cluster
+"\"literal_quotes\""  subsource  cdc_cluster
+tstzrange_table       subsource  cdc_cluster
+types_table           subsource  cdc_cluster
+utf8_table            subsource  cdc_cluster
+таблица               subsource  cdc_cluster
 
 > SELECT schema_name, table_name FROM mz_internal.mz_postgres_source_tables
 public          create
@@ -791,10 +791,10 @@ contains:TEXT COLUMNS refers to table not currently being added
   );
 
 > SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
-another_enum_table      subsource ${arg.default-replica-size} cdc_cluster
-enum_source             postgres  ${arg.default-replica-size} cdc_cluster
-enum_source_progress    progress  <null> <null>
-enum_table              subsource ${arg.default-replica-size} cdc_cluster
+another_enum_table      subsource cdc_cluster
+enum_source             postgres  cdc_cluster
+enum_source_progress    progress  <null>
+enum_table              subsource cdc_cluster
 
 > SELECT * FROM enum_table
 var0
@@ -855,9 +855,9 @@ true
   );
 
 > SHOW SOURCES
-another_source          postgres  ${arg.default-replica-size} cdc_cluster
-another_source_progress progress  <null> <null>
-another_table           subsource ${arg.default-replica-size} cdc_cluster
+another_source          postgres  cdc_cluster
+another_source_progress progress  <null>
+another_table           subsource cdc_cluster
 
 > DROP SOURCE another_source CASCADE
 

--- a/test/pg-cdc/subsource-resolution-duplicates.td
+++ b/test/pg-cdc/subsource-resolution-duplicates.td
@@ -54,9 +54,9 @@ detail: subsources referencing table: x, y
   FOR SCHEMAS (other);
 
 > SHOW sources
- mz_source          postgres  ${arg.default-replica-size} quickstart
- mz_source_progress progress  <null> <null>
- t                  subsource ${arg.default-replica-size} quickstart
+ mz_source          postgres  quickstart
+ mz_source_progress progress  <null>
+ t                  subsource quickstart
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP SCHEMA other CASCADE;

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -516,10 +516,10 @@ statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_secrets AS SELECT name FROM (SHOW SECRETS);
 
 statement error SHOW commands are not allowed in views
-CREATE MATERIALIZED VIEW mat_sinks AS SELECT name, type, size FROM (SHOW SINKS);
+CREATE MATERIALIZED VIEW mat_sinks AS SELECT name, type FROM (SHOW SINKS);
 
 statement error SHOW commands are not allowed in views
-CREATE MATERIALIZED VIEW mat_sources AS SELECT name, type, size FROM (SHOW SOURCES);
+CREATE MATERIALIZED VIEW mat_sources AS SELECT name, type FROM (SHOW SOURCES);
 
 statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_tables AS SELECT name FROM (SHOW TABLES);

--- a/test/sqllogictest/mz_catalog_server_index_accounting.slt
+++ b/test/sqllogictest/mz_catalog_server_index_accounting.slt
@@ -484,13 +484,11 @@ mz_show_sinks  cluster
 mz_show_sinks  cluster_id
 mz_show_sinks  name
 mz_show_sinks  schema_id
-mz_show_sinks  size
 mz_show_sinks  type
 mz_show_sources  cluster
 mz_show_sources  cluster_id
 mz_show_sources  name
 mz_show_sources  schema_id
-mz_show_sources  size
 mz_show_sources  type
 mz_sink_statistics  bytes_committed
 mz_sink_statistics  bytes_staged

--- a/test/sqllogictest/source_sizing.slt
+++ b/test/sqllogictest/source_sizing.slt
@@ -27,10 +27,10 @@ u1  u3  s1_progress  progress  NULL  NULL
 u3  u3  s2_progress  progress  NULL  NULL
 
 # clusters.
-query TTTT
+query TTT
 SHOW SOURCES
 ----
-s1  load-generator  2  quickstart
-s1_progress  progress  NULL  NULL
-s2  load-generator  2  quickstart
-s2_progress  progress  NULL  NULL
+s1  load-generator  quickstart
+s1_progress  progress  NULL
+s2  load-generator  quickstart
+s2_progress  progress  NULL

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -76,7 +76,7 @@ query T multiline
 EXPLAIN SHOW SOURCES
 ----
 Explained Query (fast path):
-  Project (#1..=#4)
+  Project (#1..=#3)
     ReadIndex on=mz_internal.mz_show_sources mz_show_sources_ind=[lookup value=("u3")]
 
 Used Indexes:
@@ -163,7 +163,7 @@ query T multiline
 EXPLAIN SHOW SINKS
 ----
 Explained Query (fast path):
-  Project (#1..=#4)
+  Project (#1..=#3)
     ReadIndex on=mz_internal.mz_show_sinks mz_show_sinks_ind=[lookup value=("u3")]
 
 Used Indexes:

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -792,8 +792,8 @@ COMMIT
 simple
 SHOW SOURCES
 ----
-s,load-generator,2,quickstart
-s_progress,progress,NULL,NULL
+s,load-generator,quickstart
+s_progress,progress,NULL
 COMPLETE 2
 
 # Test a statement that doesn't work even in this mode because of ambiguous responses.

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -499,8 +499,8 @@ d2
 # Check default sources, tables, and views in mz_catalog.
 
 > SHOW SOURCES FROM mz_catalog
-name  type  size  cluster
--------------------------
+name  type  cluster
+-------------------
 
 > SHOW TABLES FROM mz_catalog
 name
@@ -561,26 +561,26 @@ mz_timezone_names
 # Check default sources, tables, and views in mz_internal.
 
 > SHOW SOURCES FROM mz_internal
-name                                           type   size  cluster
+name                                           type  cluster
 ------------------------------------------------------------------
-mz_aws_privatelink_connection_status_history source <null>  <null>
-mz_cluster_replica_frontiers                 source <null>  <null>
-mz_compute_dependencies                      source <null>  <null>
-mz_compute_error_counts_raw_unified          source <null>   <null>
-mz_compute_hydration_times                   source <null>  <null>
-mz_compute_operator_hydration_statuses_per_worker source <null> <null>
-mz_frontiers                                 source <null>  <null>
-mz_materialized_view_refreshes               source <null>  <null>
-mz_prepared_statement_history                source <null>  <null>
-mz_session_history                           source <null>  <null>
-mz_sink_statistics_raw                       source <null>  <null>
-mz_sink_status_history                       source <null>  <null>
-mz_source_statistics_raw                     source <null>  <null>
-mz_source_status_history                     source <null>  <null>
-mz_sql_text                                  source <null>  <null>
-mz_statement_execution_history               source <null>  <null>
-mz_statement_lifecycle_history               source <null>  <null>
-mz_storage_shards                            source <null>  <null>
+mz_aws_privatelink_connection_status_history source  <null>
+mz_cluster_replica_frontiers                 source  <null>
+mz_compute_dependencies                      source  <null>
+mz_compute_error_counts_raw_unified          source  <null>
+mz_compute_hydration_times                   source  <null>
+mz_compute_operator_hydration_statuses_per_worker source <null>
+mz_frontiers                                 source  <null>
+mz_materialized_view_refreshes               source  <null>
+mz_prepared_statement_history                source  <null>
+mz_session_history                           source  <null>
+mz_sink_statistics_raw                       source  <null>
+mz_sink_status_history                       source  <null>
+mz_source_statistics_raw                     source  <null>
+mz_source_status_history                     source  <null>
+mz_sql_text                                  source  <null>
+mz_statement_execution_history               source  <null>
+mz_statement_lifecycle_history               source  <null>
+mz_storage_shards                            source  <null>
 
 > SHOW TABLES FROM mz_internal
 name
@@ -669,35 +669,35 @@ pg_attribute_all_databases
 # Check default sources, tables, and views in mz_introspection.
 
 > SHOW SOURCES FROM mz_introspection
-mz_active_peeks_per_worker                   log   <null>   <null>
-mz_arrangement_batcher_allocations_raw       log   <null>   <null>
-mz_arrangement_batcher_capacity_raw          log   <null>   <null>
-mz_arrangement_batcher_records_raw           log   <null>   <null>
-mz_arrangement_batcher_size_raw              log   <null>   <null>
-mz_arrangement_batches_raw                   log   <null>   <null>
-mz_arrangement_heap_allocations_raw          log   <null>   <null>
-mz_arrangement_heap_capacity_raw             log   <null>   <null>
-mz_arrangement_heap_size_raw                 log   <null>   <null>
-mz_arrangement_records_raw                   log   <null>   <null>
-mz_arrangement_sharing_raw                   log   <null>   <null>
-mz_compute_error_counts_raw                  log   <null>   <null>
-mz_compute_exports_per_worker                log   <null>   <null>
-mz_compute_frontiers_per_worker              log   <null>   <null>
-mz_compute_hydration_times_per_worker        log   <null>   <null>
-mz_compute_import_frontiers_per_worker       log   <null>   <null>
-mz_compute_operator_durations_histogram_raw  log   <null>   <null>
-mz_dataflow_addresses_per_worker             log   <null>   <null>
-mz_dataflow_channels_per_worker              log   <null>   <null>
-mz_dataflow_operator_reachability_raw        log   <null>   <null>
-mz_dataflow_operators_per_worker             log   <null>   <null>
-mz_dataflow_shutdown_durations_histogram_raw log   <null>   <null>
-mz_message_counts_received_raw               log   <null>   <null>
-mz_message_counts_sent_raw                   log   <null>   <null>
-mz_message_batch_counts_received_raw         log   <null>   <null>
-mz_message_batch_counts_sent_raw             log   <null>   <null>
-mz_peek_durations_histogram_raw              log   <null>   <null>
-mz_scheduling_elapsed_raw                    log   <null>   <null>
-mz_scheduling_parks_histogram_raw            log   <null>   <null>
+mz_active_peeks_per_worker                   log   <null>
+mz_arrangement_batcher_allocations_raw       log   <null>
+mz_arrangement_batcher_capacity_raw          log   <null>
+mz_arrangement_batcher_records_raw           log   <null>
+mz_arrangement_batcher_size_raw              log   <null>
+mz_arrangement_batches_raw                   log   <null>
+mz_arrangement_heap_allocations_raw          log   <null>
+mz_arrangement_heap_capacity_raw             log   <null>
+mz_arrangement_heap_size_raw                 log   <null>
+mz_arrangement_records_raw                   log   <null>
+mz_arrangement_sharing_raw                   log   <null>
+mz_compute_error_counts_raw                  log   <null>
+mz_compute_exports_per_worker                log   <null>
+mz_compute_frontiers_per_worker              log   <null>
+mz_compute_hydration_times_per_worker        log   <null>
+mz_compute_import_frontiers_per_worker       log   <null>
+mz_compute_operator_durations_histogram_raw  log   <null>
+mz_dataflow_addresses_per_worker             log   <null>
+mz_dataflow_channels_per_worker              log   <null>
+mz_dataflow_operator_reachability_raw        log   <null>
+mz_dataflow_operators_per_worker             log   <null>
+mz_dataflow_shutdown_durations_histogram_raw log   <null>
+mz_message_counts_received_raw               log   <null>
+mz_message_counts_sent_raw                   log   <null>
+mz_message_batch_counts_received_raw         log   <null>
+mz_message_batch_counts_sent_raw             log   <null>
+mz_peek_durations_histogram_raw              log   <null>
+mz_scheduling_elapsed_raw                    log   <null>
+mz_scheduling_parks_histogram_raw            log   <null>
 
 > SHOW TABLES FROM mz_introspection
 

--- a/test/testdrive/distinct-arrangements.td
+++ b/test/testdrive/distinct-arrangements.td
@@ -736,9 +736,9 @@ ArrangeBy[[Column(13)]]                       1
 "ArrangeBy[[Column(1)]]"                     17
 "ArrangeBy[[Column(2)]]-errors"               9
 "ArrangeBy[[Column(2)]]"                     20
-"ArrangeBy[[Column(3)]]"                      3
-"ArrangeBy[[Column(4)]]-errors"               2
-"ArrangeBy[[Column(4)]]"                      5
+"ArrangeBy[[Column(3)]]"                      7
+"ArrangeBy[[Column(3)]]-errors"               2
+"ArrangeBy[[Column(4)]]"                      1
 "ArrangeBy[[Column(5)]]-errors"               2
 "ArrangeBy[[Column(5)]]"                      4
 "ArrangeBy[[Column(6)]]"                      1

--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -18,15 +18,15 @@ $ set-arg-default single-replica-cluster=quickstart
   FROM LOAD GENERATOR AUCTION (TICK INTERVAL '50ms') FOR ALL TABLES
 
 > SHOW SOURCES
-name          type           size                         cluster
+name          type           cluster
 -----------------------------------------------------------------
-accounts      subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
-auctions      subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
-bids          subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
-demo          load-generator ${arg.default-replica-size}  ${arg.single-replica-cluster}
-demo_progress progress       <null> <null>
-organizations subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
-users         subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
+accounts      subsource      ${arg.single-replica-cluster}
+auctions      subsource      ${arg.single-replica-cluster}
+bids          subsource      ${arg.single-replica-cluster}
+demo          load-generator ${arg.single-replica-cluster}
+demo_progress progress       <null>
+organizations subsource      ${arg.single-replica-cluster}
+users         subsource      ${arg.single-replica-cluster}
 
 > SHOW COLUMNS FROM auctions
 end_time false "timestamp with time zone"

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -124,8 +124,8 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 
 > SHOW SOURCES
-name    type   size   cluster
------------------------------
+name    type   cluster
+----------------------
 
 # [btv] uncomment if we bring back classic debezium mode
 # ! CREATE SOURCE fast_forwarded

--- a/test/testdrive/kafka-sinks.td
+++ b/test/testdrive/kafka-sinks.td
@@ -68,8 +68,8 @@ contains:Expected one of PARTITION or SNAPSHOT or VERSION
 contains:CREATE SINK...WITH (VERSION..) is not allowed
 
 > SHOW SINKS
-name               type   size  cluster
----------------------------------------
+name               type   cluster
+---------------------------------
 
 # # We should refuse to create a sink with an invalid schema registry URL.
 #
@@ -145,11 +145,11 @@ name               type   size  cluster
   ENVELOPE DEBEZIUM
 
 > SHOW SINKS
-name               type   size  cluster
+name               type   cluster
 ---------------------------------------
-snk1             kafka  ${arg.default-storage-size}  snk1_cluster
-snk2             kafka  ${arg.default-storage-size}  snk2_cluster
-snk3             kafka  ${arg.default-storage-size}  snk3_cluster
+snk1             kafka    snk1_cluster
+snk2             kafka    snk2_cluster
+snk3             kafka    snk3_cluster
 
 $ kafka-verify-data format=avro sink=materialize.public.snk1 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
@@ -309,20 +309,20 @@ contains:Expected one of PARTITION or SNAPSHOT or VERSION, found SIZE
 > SELECT bool_and(size IS NULL) FROM mz_sinks;
 true
 
-# Check that SHOW SINKS shows the size correctly
+# Check SHOW SINKS
 > SHOW SINKS
-name               type   size  cluster
+name               type      cluster
 ---------------------------------------
-cluster_c_sink        kafka  4                            c
-default_cluster_sink  kafka  ${arg.default-replica-size}  ${arg.single-replica-cluster}
-sink_with_options     kafka  ${arg.default-storage-size}  sink_with_options_cluster
-snk1                  kafka  ${arg.default-storage-size}  snk1_cluster
-snk2                  kafka  ${arg.default-storage-size}  snk2_cluster
-snk3                  kafka  ${arg.default-storage-size}  snk3_cluster
-snk4                  kafka  ${arg.default-storage-size}  snk4_cluster
-snk5                  kafka  ${arg.default-storage-size}  snk5_cluster
-snk6                  kafka  ${arg.default-storage-size}  snk6_cluster
-snk7                  kafka  ${arg.default-storage-size}  snk7_cluster
-snk8                  kafka  ${arg.default-storage-size}  snk8_cluster
-snk9                  kafka  ${arg.default-storage-size}  snk9_cluster
-snk_unsigned          kafka  ${arg.default-storage-size}  snk_unsigned_cluster
+cluster_c_sink        kafka  c
+default_cluster_sink  kafka  ${arg.single-replica-cluster}
+sink_with_options     kafka  sink_with_options_cluster
+snk1                  kafka  snk1_cluster
+snk2                  kafka  snk2_cluster
+snk3                  kafka  snk3_cluster
+snk4                  kafka  snk4_cluster
+snk5                  kafka  snk5_cluster
+snk6                  kafka  snk6_cluster
+snk7                  kafka  snk7_cluster
+snk8                  kafka  snk8_cluster
+snk9                  kafka  snk9_cluster
+snk_unsigned          kafka  snk_unsigned_cluster

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -51,13 +51,13 @@ exact:COUNTER load generators do not support SCALE FACTOR values
 "materialize.public.auction_house" "CREATE SOURCE \"materialize\".\"public\".\"auction_house\" IN CLUSTER \"${arg.single-replica-cluster}\" FROM LOAD GENERATOR AUCTION (AS OF = 300, UP TO = 301) FOR ALL TABLES EXPOSE PROGRESS AS \"materialize\".\"public\".\"auction_house_progress\""
 
 > SHOW SOURCES
-accounts                subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
-auction_house           load-generator ${arg.default-replica-size}    ${arg.single-replica-cluster}
-auction_house_progress  progress       <null> <null>
-auctions                subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
-bids                    subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
-organizations           subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
-users                   subsource      ${arg.default-replica-size}    ${arg.single-replica-cluster}
+accounts                subsource      ${arg.single-replica-cluster}
+auction_house           load-generator ${arg.single-replica-cluster}
+auction_house_progress  progress       <null>
+auctions                subsource      ${arg.single-replica-cluster}
+bids                    subsource      ${arg.single-replica-cluster}
+organizations           subsource      ${arg.single-replica-cluster}
+users                   subsource      ${arg.single-replica-cluster}
 
 > SELECT count(*) FROM bids
 255
@@ -78,13 +78,13 @@ contains:LOAD GENERATOR source validation: FOR TABLES (..) unsupported
   FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
 > SHOW SOURCES FROM another;
-accounts                subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
-auction_house           load-generator ${arg.default-replica-size}  ${arg.single-replica-cluster}
-auction_house_progress  progress       <null> <null>
-auctions                subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
-bids                    subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
-organizations           subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
-users                   subsource      ${arg.default-replica-size}  ${arg.single-replica-cluster}
+accounts                subsource      ${arg.single-replica-cluster}
+auction_house           load-generator ${arg.single-replica-cluster}
+auction_house_progress  progress       <null>
+auctions                subsource      ${arg.single-replica-cluster}
+bids                    subsource      ${arg.single-replica-cluster}
+organizations           subsource      ${arg.single-replica-cluster}
+users                   subsource      ${arg.single-replica-cluster}
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
 

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -357,12 +357,12 @@ a  b
 1  2
 
 > SHOW SOURCES
-name     type    size    cluster
+name              type    cluster
 --------------------------------
-data              kafka     ${arg.default-replica-size}   ${arg.single-replica-cluster}
-data_progress     progress  <null>                        <null>
-mat_data          kafka     ${arg.default-replica-size}   ${arg.single-replica-cluster}
-mat_data_progress progress  <null>                        <null>
+data              kafka     ${arg.single-replica-cluster}
+data_progress     progress  <null>
+mat_data          kafka     ${arg.single-replica-cluster}
+mat_data_progress progress  <null>
 
 # If there exists another index, dropping the primary index will not #
 # unmaterialize the source. This also tests creating a default index when the

--- a/test/testdrive/quickstart.td
+++ b/test/testdrive/quickstart.td
@@ -21,15 +21,15 @@
   FOR ALL TABLES
 
 > SHOW SOURCES
-name                   type           size                         cluster
+name                   type            cluster
 --------------------------------------------------------------------------
-accounts               subsource      <null>                       quickstart_tutorial
-bids                   subsource      <null>                       quickstart_tutorial
-auction_house          load-generator <null>                       quickstart_tutorial
-auction_house_progress progress       <null>                       <null>
-auctions               subsource      <null>                       quickstart_tutorial
-organizations          subsource      <null>                       quickstart_tutorial
-users                  subsource      <null>                       quickstart_tutorial
+accounts               subsource       quickstart_tutorial
+bids                   subsource       quickstart_tutorial
+auction_house          load-generator  quickstart_tutorial
+auction_house_progress progress        <null>
+auctions               subsource       quickstart_tutorial
+organizations          subsource       quickstart_tutorial
+users                  subsource       quickstart_tutorial
 
 > SELECT id, seller, item FROM auctions WHERE id = 1
 1 1824 "Best Pizza in Town"

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -194,16 +194,16 @@ renamed_sink
 
 # Source was successfully renamed
 > SHOW SOURCES;
-name               type   size                            cluster
+name               type      cluster
 -----------------------------------------------------------------
-mz_data_progress   progress  <null>                       <null>
-renamed_mz_data    kafka     ${arg.default-replica-size}  <VARIABLE_OUTPUT>
+mz_data_progress   progress  <null>
+renamed_mz_data    kafka     <VARIABLE_OUTPUT>
 
 # Sink was successfully renamed
 > SHOW SINKS
-name               type   size                            cluster
------------------------------------------------------------------
-renamed_sink       kafka  ${arg.default-replica-size}     <VARIABLE_OUTPUT>
+name               type   cluster
+---------------------------------
+renamed_sink       kafka  <VARIABLE_OUTPUT>
 
 # View was successfully renamed
 > SHOW VIEWS

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -56,8 +56,8 @@ name
 t
 
 > SHOW SOURCES;
-name    type  size  cluster
----------------------------
+name    type  cluster
+---------------------
 
 > SHOW INDEXES ON t;
 
@@ -251,8 +251,8 @@ v
 v
 
 > SHOW SOURCES;
-name    type   size   cluster
------------------------------
+name    type   cluster
+----------------------
 
 > CREATE TABLE t (a int, b text NOT NULL)
 

--- a/test/testdrive/tpch.td
+++ b/test/testdrive/tpch.td
@@ -32,24 +32,19 @@ contains: unsupported scale factor -1
   IN CLUSTER ${arg.single-replica-cluster}
   FROM LOAD GENERATOR TPCH (SCALE FACTOR .01) FOR ALL TABLES
 
-$ set-from-sql var=source-size
-SELECT size FROM (
-    SHOW SOURCES
-) WHERE name = 'gen'
-
 > SHOW SOURCES
-name           type            size             cluster
+name           type            cluster
 -------------------------------------------------------
- customer      subsource       ${source-size}   ${arg.single-replica-cluster}
- gen           load-generator  ${source-size}   ${arg.single-replica-cluster}
- gen_progress  progress        <null> <null>
- lineitem      subsource       ${source-size}   ${arg.single-replica-cluster}
- nation        subsource       ${source-size}   ${arg.single-replica-cluster}
- orders        subsource       ${source-size}   ${arg.single-replica-cluster}
- part          subsource       ${source-size}   ${arg.single-replica-cluster}
- partsupp      subsource       ${source-size}   ${arg.single-replica-cluster}
- region        subsource       ${source-size}   ${arg.single-replica-cluster}
- supplier      subsource       ${source-size}   ${arg.single-replica-cluster}
+ customer      subsource       ${arg.single-replica-cluster}
+ gen           load-generator  ${arg.single-replica-cluster}
+ gen_progress  progress        <null>
+ lineitem      subsource       ${arg.single-replica-cluster}
+ nation        subsource       ${arg.single-replica-cluster}
+ orders        subsource       ${arg.single-replica-cluster}
+ part          subsource       ${arg.single-replica-cluster}
+ partsupp      subsource       ${arg.single-replica-cluster}
+ region        subsource       ${arg.single-replica-cluster}
+ supplier      subsource       ${arg.single-replica-cluster}
 
 # SF * 150,000
 > SELECT count(*) FROM customer


### PR DESCRIPTION
Since it doesn't make much sense now that we've removed linked clusters.

This is technically a backwards compatible change, but one we've decided we're comfortable with--see 25953.

Fix #25953.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
