### PR TITLE
feature-benchmark: Ignore messages regression in many scenarios

### DIFF
--- a/misc/python/materialize/version_ancestor_overrides.py
+++ b/misc/python/materialize/version_ancestor_overrides.py
@@ -31,6 +31,24 @@ def get_ancestor_overrides_for_performance_regressions(
     # Commits must be ordered descending by their date.
     min_ancestor_mz_version_per_commit = dict()
 
+    if scenario_class_name in (
+        "SmallClusters",
+        "AccumulateReductions",
+        "CreateIndex",
+        "ManySmallUpdates",
+        "FastPathOrderByLimit",
+        "FastPathFilterIndex",
+        "ParallelIngestion",
+        "SubscribeParallelTableWithIndex",
+        "DeltaJoinMaintained",
+        "Update",
+        "Retraction",
+    ):
+        # PR#28307 (Render regions for object build and let bindings) increases messages
+        min_ancestor_mz_version_per_commit[
+            "ffcafa5b5c3e83845a868cf6103048c045b4f155"
+        ] = MzVersion.parse_mz("v0.113.0")
+
     if "OptbenchTPCH" in scenario_class_name:
         # PR#28664 (Introduce MirScalarExpr::reduce_safely) increases wallclock
         min_ancestor_mz_version_per_commit[


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightly/builds/9034#_

@frankmcsherry is this expected?
```
ffcafa5b5c3e83845a868cf6103048c045b4f155 is the first bad commit
commit ffcafa5b5c3e83845a868cf6103048c045b4f155
Author: Frank McSherry <fmcsherry@me.com>
Date:   Fri Aug 9 13:05:14 2024 -0400

    Render regions for object build and let bindings (#28307)

    Add rendering regions around dataflow "objects to build" as well as both
    `Let` ~and `LetRec`~ values and bodies. NB: No `LetRec`: Rust gets
    angry.

    The intended outcome is that it becomes easier to map dataflow operator
    addresses back to LIR/MIR fragments by way of their CTE identifiers.
    Prior to this PR, all were in one scope and were undifferentiated, which
    meant one needed to understand the union of all CTEs rather than just
    one at a time.

    cc: @sthm

    ### Motivation

    <!--
    Which of the following best describes the motivation behind this PR?

      * This PR fixes a recognized bug.

        [Ensure issue is linked somewhere.]

      * This PR adds a known-desirable feature.

        [Ensure issue is linked somewhere.]

      * This PR fixes a previously unreported bug.

        [Describe the bug in detail, as if you were filing a bug report.]

      * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
    for its inclusion in Materialize, as if you were writing the original
         feature specification.]

       * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
    -->

    ### Tips for reviewer

    <!--
    Leave some tips for your reviewer, like:

        * The diff is much smaller if viewed with whitespace hidden.
        * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a
    skim.

    Delete this section if no tips.
    -->

    ### Checklist

    - [ ] This PR has adequate test coverage / QA involvement has been duly
    considered. ([trigger-ci for additional test/nightly
    runs](https://trigger-ci.dev.materialize.com/))
    - [ ] This PR has an associated up-to-date [design
    doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md),
    is a design doc
    ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)),
    or is sufficiently small to not require a design.
      <!-- Reference the design in the description. -->
    - [ ] If this PR evolves [an existing `$T ⇔ Proto$T`
    mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md)
    (possibly in a backwards-incompatible way), then it is tagged with a
    `T-proto` label.
    - [ ] If this PR will require changes to cloud orchestration or tests,
    there is a companion cloud PR to account for those changes that is
    tagged with the release-blocker label
    ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
    <!-- Ask in #team-cloud on Slack if you need help preparing the cloud
    PR. -->
    - [ ] This PR includes the following [user-facing behavior
    changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
    - <!-- Add release notes here or explicitly state that there are no
    user-facing behavior changes. -->

 src/compute-types/src/plan/flat_plan.rs | 14 ++++++++
 src/compute/src/render.rs               | 57 ++++++++++++++++++++++-----------
 src/compute/src/render/context.rs       | 32 ++++++++++++++++++
 3 files changed, 84 insertions(+), 19 deletions(-)
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
