### PR TITLE
sql: add support for `YUGABYTE` connections and sources

### DIFF
--- a/src/postgres-util/BUILD.bazel
+++ b/src/postgres-util/BUILD.bazel
@@ -104,7 +104,10 @@ rust_doc_test(
 
 filegroup(
 	name = "all_protos",
-	srcs = ["src/desc.proto"],
+	srcs = [
+		"src/desc.proto",
+		"src/tunnel.proto",
+	],
 )
 
 cargo_build_script(

--- a/src/postgres-util/build.rs
+++ b/src/postgres-util/build.rs
@@ -11,6 +11,7 @@ use std::env;
 
 fn main() {
     env::set_var("PROTOC", mz_build_tools::protoc());
+    std::env::set_var("PROTOC_INCLUDE", mz_build_tools::protoc_include());
 
     let mut config = prost_build::Config::new();
     config.btree_map(["."]);
@@ -22,6 +23,13 @@ fn main() {
         // is to re-run if any file in the crate changes; that's still a bit too
         // broad, but it's better.
         .emit_rerun_if_changed(false)
-        .compile_with_config(config, &["postgres-util/src/desc.proto"], &[".."])
+        .compile_with_config(
+            config,
+            &[
+                "postgres-util/src/desc.proto",
+                "postgres-util/src/tunnel.proto",
+            ],
+            &[".."],
+        )
         .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -25,7 +25,7 @@ pub use schemas::{get_schemas, publication_info};
 #[cfg(feature = "tunnel")]
 pub mod tunnel;
 #[cfg(feature = "tunnel")]
-pub use tunnel::{Config, TunnelConfig, DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT};
+pub use tunnel::{Client, Config, TunnelConfig, DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT};
 
 pub mod query;
 pub use query::simple_query_opt;

--- a/src/postgres-util/src/tunnel.proto
+++ b/src/postgres-util/src/tunnel.proto
@@ -1,0 +1,21 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package mz_postgres_util.tunnel;
+
+message ProtoPostgresFlavor {
+    oneof kind {
+        google.protobuf.Empty vanilla = 1;
+        google.protobuf.Empty yugabyte = 2;
+    }
+}

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -482,5 +482,6 @@ Workload
 Write
 Year
 Years
+Yugabyte
 Zone
 Zones

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -845,6 +845,7 @@ pub enum CreateConnectionType {
     Postgres,
     Ssh,
     MySql,
+    Yugabyte,
 }
 
 impl AstDisplay for CreateConnectionType {
@@ -870,6 +871,9 @@ impl AstDisplay for CreateConnectionType {
             }
             Self::MySql => {
                 f.write_str("MYSQL");
+            }
+            Self::Yugabyte => {
+                f.write_str("YUGABYTE");
             }
         }
     }
@@ -1139,6 +1143,10 @@ pub enum CreateSourceConnection<T: AstInfo> {
         connection: T::ItemName,
         options: Vec<PgConfigOption<T>>,
     },
+    Yugabyte {
+        connection: T::ItemName,
+        options: Vec<PgConfigOption<T>>,
+    },
     MySql {
         connection: T::ItemName,
         options: Vec<MySqlConfigOption<T>>,
@@ -1169,6 +1177,18 @@ impl<T: AstInfo> AstDisplay for CreateSourceConnection<T> {
                 options,
             } => {
                 f.write_str("POSTGRES CONNECTION ");
+                f.write_node(connection);
+                if !options.is_empty() {
+                    f.write_str(" (");
+                    f.write_node(&display::comma_separated(options));
+                    f.write_str(")");
+                }
+            }
+            CreateSourceConnection::Yugabyte {
+                connection,
+                options,
+            } => {
+                f.write_str("YUGABYTE CONNECTION ");
                 f.write_node(connection);
                 if !options.is_empty() {
                     f.write_str(" (");

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -485,6 +485,13 @@ CREATE CONNECTION pgconn TO POSTGRES (HOST = foo, PORT = 1234, SSL CERTIFICATE A
 CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: Host, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("foo")]))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, ConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("tun")])))) }, ConnectionOption { name: Database, value: Some(Value(String("db"))) }, ConnectionOption { name: Password, value: Some(Value(String("pw"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }, ConnectionOption { name: SslMode, value: Some(Value(String("mode"))) }, ConnectionOption { name: User, value: Some(Value(String("postgres"))) }], with_options: [] })
 
 parse-statement
+CREATE CONNECTION yugabyteconn FOR YUGABYTE HOST foo, PORT 1234, SSL CERTIFICATE AUTHORITY 'foo', SSH TUNNEL tun, DATABASE 'db', PASSWORD 'pw', SSL CERTIFICATE 'cert', SSL KEY 'key', SSL MODE 'mode', USER 'postgres'
+----
+CREATE CONNECTION yugabyteconn TO YUGABYTE (HOST = foo, PORT = 1234, SSL CERTIFICATE AUTHORITY = 'foo', SSH TUNNEL = tun, DATABASE = 'db', PASSWORD = 'pw', SSL CERTIFICATE = 'cert', SSL KEY = 'key', SSL MODE = 'mode', USER = 'postgres')
+=>
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("yugabyteconn")]), connection_type: Yugabyte, if_not_exists: false, values: [ConnectionOption { name: Host, value: Some(UnresolvedItemName(UnresolvedItemName([Ident("foo")]))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, ConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("tun")])))) }, ConnectionOption { name: Database, value: Some(Value(String("db"))) }, ConnectionOption { name: Password, value: Some(Value(String("pw"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }, ConnectionOption { name: SslMode, value: Some(Value(String("mode"))) }, ConnectionOption { name: User, value: Some(Value(String("postgres"))) }], with_options: [] })
+
+parse-statement
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234)
 ----
 CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1234)
@@ -560,6 +567,13 @@ CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red');
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red')
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Postgres { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
+
+parse-statement
+CREATE SOURCE psychic FROM YUGABYTE CONNECTION pgconn (PUBLICATION 'red');
+----
+CREATE SOURCE psychic FROM YUGABYTE CONNECTION pgconn (PUBLICATION = 'red')
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("psychic")]), in_cluster: None, col_names: [], connection: Yugabyte { connection: Name(UnresolvedItemName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], external_references: None, progress_subsource: None })
 
 parse-statement
 CREATE SUBSOURCE mz_subsource (c int) OF SOURCE public.foo.mz_source WITH (EXTERNAL REFERENCE = public.foo.bar, IGNORE COLUMNS (bar), TEXT COLUMNS (baz, foobar), DETAILS = 'details');

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -799,6 +799,10 @@ pub fn plan_create_source(
         CreateSourceConnection::Postgres {
             connection,
             options,
+        }
+        | CreateSourceConnection::Yugabyte {
+            connection,
+            options,
         } => {
             let connection_item = scx.get_item_by_resolved_name(connection)?;
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -961,7 +961,8 @@ fn humanize_sql_for_show_create(
                 .collect();
 
             match &mut stmt.connection {
-                CreateSourceConnection::Postgres { options, .. } => {
+                CreateSourceConnection::Postgres { options, .. }
+                | CreateSourceConnection::Yugabyte { options, .. } => {
                     options.retain_mut(|o| {
                         match o.name {
                             // Dropping a subsource does not remove any `TEXT

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -599,7 +599,7 @@ async fn purify_create_source(
         CreateSourceConnection::Kafka { .. } => {
             &mz_storage_types::sources::kafka::KAFKA_PROGRESS_DESC
         }
-        CreateSourceConnection::Postgres { .. } => {
+        CreateSourceConnection::Postgres { .. } | CreateSourceConnection::Yugabyte { .. } => {
             &mz_storage_types::sources::postgres::PG_PROGRESS_DESC
         }
         CreateSourceConnection::MySql { .. } => {
@@ -723,6 +723,10 @@ async fn purify_create_source(
             }
         }
         CreateSourceConnection::Postgres {
+            connection,
+            options,
+        }
+        | CreateSourceConnection::Yugabyte {
             connection,
             options,
         } => {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -2073,6 +2073,12 @@ feature_flags!(
         default: false,
         enable_for_item_parsing: true,
     },
+    {
+        name: enable_yugabyte_connection,
+        desc: "Create a YUGABYTE connection",
+        default: false,
+        enable_for_item_parsing: false,
+    },
 );
 
 impl From<&super::SystemVars> for OptimizerFeatures {

--- a/src/storage-types/build.rs
+++ b/src/storage-types/build.rs
@@ -41,6 +41,7 @@ fn main() {
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
         .extern_path(".mz_orchestrator", "::mz_orchestrator")
         .extern_path(".mz_pgcopy.copy", "::mz_pgcopy")
+        .extern_path(".mz_postgres_util.tunnel", "::mz_postgres_util::tunnel")
         .extern_path(".mz_proto", "::mz_proto")
         .extern_path(".mz_repr.relation_and_scalar", "::mz_repr")
         .extern_path(".mz_repr.row", "::mz_repr")

--- a/src/storage-types/src/connections.proto
+++ b/src/storage-types/src/connections.proto
@@ -13,6 +13,7 @@ import "google/protobuf/empty.proto";
 
 import "repr/src/global_id.proto";
 import "repr/src/url.proto";
+import "postgres-util/src/tunnel.proto";
 import "proto/src/tokio_postgres.proto";
 import "storage-types/src/errors.proto";
 import "storage-types/src/connections/string_or_secret.proto";
@@ -85,6 +86,7 @@ message ProtoPostgresConnection {
     string_or_secret.ProtoStringOrSecret tls_root_cert = 7;
     ProtoTlsIdentity tls_identity = 8;
     ProtoTunnel tunnel = 12;
+    mz_postgres_util.tunnel.ProtoPostgresFlavor flavor = 13;
 }
 
 message ProtoTunnel {

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -14,7 +14,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, bail, Context};
 use itertools::Itertools;
 use mz_ccsr::tls::{Certificate, Identity};
 use mz_cloud_resources::{vpc_endpoint_host, AwsExternalIdPrefix, CloudResourceReader};
@@ -27,6 +27,7 @@ use mz_ore::error::ErrorExt;
 use mz_ore::future::{InTask, OreFutureExt};
 use mz_ore::netio::resolve_address;
 use mz_ore::num::NonNeg;
+use mz_postgres_util::tunnel::PostgresFlavor;
 use mz_proto::tokio_postgres::any_ssl_mode;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::url::any_url;
@@ -1318,6 +1319,9 @@ pub struct PostgresConnection<C: ConnectionAccess = InlinedConnection> {
     pub tls_root_cert: Option<StringOrSecret>,
     /// An optional TLS client certificate for authentication.
     pub tls_identity: Option<TlsIdentity>,
+    /// The kind of postgres server we are connecting to. This can be vanilla, for a normal
+    /// postgres server or some other system that is pg compatible, like Yugabyte, Aurora, etc.
+    pub flavor: PostgresFlavor,
 }
 
 impl<R: ConnectionResolver> IntoInlineConnection<PostgresConnection, R>
@@ -1334,6 +1338,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<PostgresConnection, R>
             tls_mode,
             tls_root_cert,
             tls_identity,
+            flavor,
         } = self;
 
         PostgresConnection {
@@ -1346,6 +1351,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<PostgresConnection, R>
             tls_mode,
             tls_root_cert,
             tls_identity,
+            flavor,
         }
     }
 }
@@ -1508,12 +1514,18 @@ impl PostgresConnection<InlinedConnection> {
                 InTask::No,
             )
             .await?;
-        config
+        let client = config
             .connect(
                 "connection validation",
                 &storage_configuration.connection_context.ssh_tunnel_manager,
             )
             .await?;
+        use PostgresFlavor::*;
+        match (client.server_flavor(), &self.flavor) {
+            (Vanilla, Yugabyte) => bail!("Expected to find PostgreSQL server, found Yugabyte."),
+            (Yugabyte, Vanilla) => bail!("Expected to find Yugabyte server, found PostgreSQL."),
+            (Vanilla, Vanilla) | (Yugabyte, Yugabyte) => {}
+        }
         Ok(())
     }
 }
@@ -1522,6 +1534,7 @@ impl<C: ConnectionAccess> AlterCompatible for PostgresConnection<C> {
     fn alter_compatible(&self, id: GlobalId, other: &Self) -> Result<(), AlterError> {
         let PostgresConnection {
             tunnel,
+            flavor,
             // All non-tunnel options may change arbitrarily
             host: _,
             port: _,
@@ -1533,7 +1546,10 @@ impl<C: ConnectionAccess> AlterCompatible for PostgresConnection<C> {
             tls_identity: _,
         } = self;
 
-        let compatibility_checks = [(tunnel.alter_compatible(id, &other.tunnel).is_ok(), "tunnel")];
+        let compatibility_checks = [
+            (tunnel.alter_compatible(id, &other.tunnel).is_ok(), "tunnel"),
+            (flavor == &other.flavor, "flavor"),
+        ];
 
         for (compatible, field) in compatibility_checks {
             if !compatible {
@@ -1562,6 +1578,7 @@ impl RustType<ProtoPostgresConnection> for PostgresConnection {
             tls_root_cert: self.tls_root_cert.into_proto(),
             tls_identity: self.tls_identity.into_proto(),
             tunnel: Some(self.tunnel.into_proto()),
+            flavor: Some(self.flavor.into_proto()),
         }
     }
 
@@ -1582,6 +1599,9 @@ impl RustType<ProtoPostgresConnection> for PostgresConnection {
                 .into_rust_if_some("ProtoPostgresConnection::tls_mode")?,
             tls_root_cert: proto.tls_root_cert.into_rust()?,
             tls_identity: proto.tls_identity.into_rust()?,
+            flavor: proto
+                .flavor
+                .into_rust_if_some("ProtoPostgresConnection::flavor")?,
         })
     }
 }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -88,7 +88,7 @@ use itertools::Itertools as _;
 use mz_expr::{EvalError, MirScalarExpr};
 use mz_ore::error::ErrorExt;
 use mz_postgres_util::desc::PostgresTableDesc;
-use mz_postgres_util::{simple_query_opt, PostgresError};
+use mz_postgres_util::{simple_query_opt, Client, PostgresError};
 use mz_repr::{Datum, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_types::errors::{DataflowError, SourceError, SourceErrorDetails};
@@ -103,7 +103,6 @@ use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 use tokio_postgres::error::SqlState;
 use tokio_postgres::types::PgLsn;
-use tokio_postgres::Client;
 
 use crate::healthcheck::{HealthStatusMessage, HealthStatusUpdate, StatusNamespace};
 use crate::source::types::{ProgressStatisticsUpdate, SourceRender, StackedCollection};

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -85,7 +85,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::HashSet;
 use mz_ore::future::InTask;
 use mz_postgres_util::desc::PostgresTableDesc;
-use mz_postgres_util::simple_query_opt;
+use mz_postgres_util::{simple_query_opt, Client};
 use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_ssh_util::tunnel_manager::SshTunnelManager;
@@ -113,7 +113,6 @@ use timely::progress::Antichain;
 use tokio_postgres::error::SqlState;
 use tokio_postgres::replication::LogicalReplicationStream;
 use tokio_postgres::types::PgLsn;
-use tokio_postgres::Client;
 use tracing::{error, trace};
 
 use crate::metrics::source::postgres::PgSourceMetrics;

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -144,7 +144,7 @@ use futures::{StreamExt as _, TryStreamExt};
 use mz_expr::MirScalarExpr;
 use mz_ore::future::InTask;
 use mz_postgres_util::desc::PostgresTableDesc;
-use mz_postgres_util::{simple_query_opt, PostgresError};
+use mz_postgres_util::{simple_query_opt, Client, PostgresError};
 use mz_repr::{Datum, DatumVec, GlobalId, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
 use mz_storage_types::errors::DataflowError;
@@ -160,7 +160,6 @@ use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, ConnectLoop,
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp};
 use tokio_postgres::types::{Oid, PgLsn};
-use tokio_postgres::Client;
 use tracing::{error, trace};
 
 use crate::metrics::source::postgres::PgSnapshotMetrics;


### PR DESCRIPTION
Beyond the syntax level changes the underlying source machinery remains identical. The connection gained a `flavor` field that is used to track whether we should expect a PostgreSQL or Yugabyte server on the other side and is meant to be used by the actual operator to modify its behavior accordingly.
    
The new syntax is guarded by a feature flag that we can enable for everyone once all the pieces are in place.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
