### PR TITLE
Remove release note bullet point from the PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,5 +54,3 @@ Delete this section if no tips.
 - [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
 - [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
   <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
-- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
-  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->


### PR DESCRIPTION
Since we're no longer publishing release notes, this step is no longer required.