### PR TITLE
cargo security: Ignore abomonation being unsound

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -224,6 +224,8 @@ ignore = [
     "RUSTSEC-2021-0145",
     # Consider `encoding_rs` instead of `encoding` (unmaintained)
     "RUSTSEC-2021-0153",
+    # abomonation transmutes &T to and from &[u8] without sufficient constraints
+    "RUSTSEC-2021-0120",
 ]
 
 # Must be manually kept in sync with about.toml.


### PR DESCRIPTION
This is extremely scary to me, why can we not fix it in abomonation?! https://rustsec.org/advisories/RUSTSEC-2021-0120

> This transmute is at the core of the abomonation crates. It's so easy to use it to violate alignment requirements that no test in the crate's test suite passes under miri. The use of this transmute in serialization/deserialization also incorrectly assumes that the layout of a repr(Rust) type is stable.

I feel like this could be causing some of the mystery segfaults we keep seeing in CI, for example https://github.com/MaterializeInc/materialize/issues/24644

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
