### PR TITLE
ci: Make nightly greener again

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -1535,7 +1535,9 @@ steps:
     env:
       CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      # TODO: Debezium DNS flakiness doesn't allow running on hetzner
+      # queue: hetzner-aarch64-8cpu-16gb
+      queue: linux-aarch64-medium
     plugins:
       - ./ci/plugins/cloudtest:
           args: [-m=long, test/cloudtest/test_storage_shared_fate.py]

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -765,7 +765,7 @@ class RenameSinkAction(Action):
 
 class AlterKafkaSinkFromAction(Action):
     def run(self, exe: Executor) -> bool:
-        if exe.db.scenario == Scenario.Kill:
+        if exe.db.scenario in (Scenario.Kill, Scenario.ZeroDowntimeDeploy):
             # Does not work reliably with kills, see #28870
             return False
         with exe.db.lock:


### PR DESCRIPTION
Based on failures in https://buildkite.com/materialize/nightly/builds/9049

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
