### PR TITLE
storage/sources: Implement purification for CREATE TABLE .. FROM SOURCE statements

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -1007,7 +1007,10 @@ impl Coordinator {
         // coordinator thread.
         if !matches!(
             stmt,
-            Statement::CreateSource(_) | Statement::AlterSource(_) | Statement::CreateSink(_)
+            Statement::CreateSource(_)
+                | Statement::AlterSource(_)
+                | Statement::CreateSink(_)
+                | Statement::CreateTableFromSource(_)
         ) {
             return false;
         }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -556,11 +556,15 @@ impl Coordinator {
                 .await
             }
             o @ (PurifiedStatement::PurifiedAlterSource { .. }
-            | PurifiedStatement::PurifiedCreateSink(..)) => {
+            | PurifiedStatement::PurifiedCreateSink(..)
+            | PurifiedStatement::PurifiedCreateTableFromSource { .. }) => {
                 // Unify these into a `Statement`.
                 let stmt = match o {
                     PurifiedStatement::PurifiedAlterSource { alter_source_stmt } => {
                         Statement::AlterSource(alter_source_stmt)
+                    }
+                    PurifiedStatement::PurifiedCreateTableFromSource { stmt } => {
+                        Statement::CreateTableFromSource(stmt)
                     }
                     PurifiedStatement::PurifiedCreateSink(stmt) => Statement::CreateSink(stmt),
                     PurifiedStatement::PurifiedCreateSource { .. }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1506,16 +1506,62 @@ pub struct TableOption<T: AstInfo> {
 }
 impl_display_for_with_option!(TableOption);
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TableFromSourceOptionName {
+    /// Columns whose types you want to unconditionally format as text
+    TextColumns,
+    /// Columns you want to ignore when ingesting data
+    IgnoreColumns,
+    /// Hex-encoded protobuf of a `ProtoSourceExportStatementDetails`
+    /// message, which includes details necessary for planning this
+    /// table as a Source Export
+    Details,
+}
+
+impl AstDisplay for TableFromSourceOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str(match self {
+            TableFromSourceOptionName::TextColumns => "TEXT COLUMNS",
+            TableFromSourceOptionName::IgnoreColumns => "IGNORE COLUMNS",
+            TableFromSourceOptionName::Details => "DETAILS",
+        })
+    }
+}
+impl_display!(TableFromSourceOptionName);
+
+impl WithOptionName for TableFromSourceOptionName {
+    /// # WARNING
+    ///
+    /// Whenever implementing this trait consider very carefully whether or not
+    /// this value could contain sensitive user data. If you're uncertain, err
+    /// on the conservative side and return `true`.
+    fn redact_value(&self) -> bool {
+        match self {
+            TableFromSourceOptionName::Details
+            | TableFromSourceOptionName::TextColumns
+            | TableFromSourceOptionName::IgnoreColumns => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TableFromSourceOption<T: AstInfo> {
+    pub name: TableFromSourceOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+impl_display_for_with_option!(TableFromSourceOption);
+
 /// `CREATE TABLE .. FROM SOURCE`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateTableFromSourceStatement<T: AstInfo> {
     /// Table name
     pub name: UnresolvedItemName,
-    /// Optional set of columns to include
-    pub columns: Vec<Ident>,
+    pub columns: Vec<ColumnDef<T>>,
+    pub constraints: Vec<TableConstraint<T>>,
     pub if_not_exists: bool,
-    pub source: T::ItemName,
+    pub source: UnresolvedItemName,
     pub external_reference: UnresolvedItemName,
+    pub with_options: Vec<TableFromSourceOption<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for CreateTableFromSourceStatement<T> {
@@ -1523,19 +1569,25 @@ impl<T: AstInfo> AstDisplay for CreateTableFromSourceStatement<T> {
         let Self {
             name,
             columns,
+            constraints,
             source,
             external_reference,
             if_not_exists,
+            with_options,
         } = self;
         f.write_str("CREATE TABLE ");
         if *if_not_exists {
             f.write_str("IF NOT EXISTS ");
         }
         f.write_node(name);
-        if !columns.is_empty() {
+        if !columns.is_empty() || !constraints.is_empty() {
             f.write_str(" (");
 
             f.write_node(&display::comma_separated(columns));
+            if !constraints.is_empty() {
+                f.write_str(", ");
+                f.write_node(&display::comma_separated(constraints));
+            }
             f.write_str(")");
         }
         f.write_str(" FROM SOURCE ");
@@ -1543,6 +1595,12 @@ impl<T: AstInfo> AstDisplay for CreateTableFromSourceStatement<T> {
         f.write_str(" (REFERENCE = ");
         f.write_node(external_reference);
         f.write_str(")");
+
+        if !with_options.is_empty() {
+            f.write_str(" WITH (");
+            f.write_node(&display::comma_separated(with_options));
+            f.write_str(")");
+        }
     }
 }
 impl_display_t!(CreateTableFromSourceStatement);

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1559,7 +1559,7 @@ pub struct CreateTableFromSourceStatement<T: AstInfo> {
     pub columns: Vec<ColumnDef<T>>,
     pub constraints: Vec<TableConstraint<T>>,
     pub if_not_exists: bool,
-    pub source: UnresolvedItemName,
+    pub source: T::ItemName,
     pub external_reference: UnresolvedItemName,
     pub with_options: Vec<TableFromSourceOption<T>>,
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4388,7 +4388,7 @@ impl<'a> Parser<'a> {
 
         self.expect_keywords(&[FROM, SOURCE])?;
 
-        let source = self.parse_item_name()?;
+        let source = self.parse_raw_name()?;
         self.expect_token(&Token::LParen)?;
         self.expect_keyword(REFERENCE)?;
         let _ = self.consume_token(&Token::Eq);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4382,33 +4382,74 @@ impl<'a> Parser<'a> {
         self.expect_keyword(TABLE)?;
         let if_not_exists = self.parse_if_not_exists()?;
         let table_name = self.parse_item_name()?;
-        // parse optional column name list
-        let columns = if self.consume_token(&Token::LParen) {
-            let cols = self.parse_comma_separated(Parser::parse_identifier)?;
-            self.expect_token(&Token::RParen)?;
-            cols
-        } else {
-            vec![]
-        };
+        // Columns are not specified by users, but are populated in this
+        // statement after purification, so Optional is used.
+        let (columns, constraints) = self.parse_columns(Optional)?;
 
         self.expect_keywords(&[FROM, SOURCE])?;
 
-        let source = self.parse_raw_name()?;
+        let source = self.parse_item_name()?;
         self.expect_token(&Token::LParen)?;
         self.expect_keyword(REFERENCE)?;
         let _ = self.consume_token(&Token::Eq);
         let external_reference = self.parse_item_name()?;
         self.expect_token(&Token::RParen)?;
 
+        let with_options = if self.parse_keyword(WITH) {
+            self.expect_token(&Token::LParen)?;
+            let options = self.parse_comma_separated(Parser::parse_table_from_source_option)?;
+            self.expect_token(&Token::RParen)?;
+            options
+        } else {
+            vec![]
+        };
+
         Ok(Statement::CreateTableFromSource(
             CreateTableFromSourceStatement {
                 name: table_name,
                 columns,
+                constraints,
                 if_not_exists,
                 source,
                 external_reference,
+                with_options,
             },
         ))
+    }
+
+    fn parse_table_from_source_option(
+        &mut self,
+    ) -> Result<TableFromSourceOption<Raw>, ParserError> {
+        let option = match self.expect_one_of_keywords(&[TEXT, IGNORE, DETAILS])? {
+            ref keyword @ (TEXT | IGNORE) => {
+                self.expect_keyword(COLUMNS)?;
+
+                let _ = self.consume_token(&Token::Eq);
+
+                let value = self
+                    .parse_option_sequence(Parser::parse_identifier)?
+                    .map(|inner| {
+                        WithOptionValue::Sequence(
+                            inner.into_iter().map(WithOptionValue::Ident).collect_vec(),
+                        )
+                    });
+
+                TableFromSourceOption {
+                    name: match *keyword {
+                        TEXT => TableFromSourceOptionName::TextColumns,
+                        IGNORE => TableFromSourceOptionName::IgnoreColumns,
+                        _ => unreachable!(),
+                    },
+                    value,
+                }
+            }
+            DETAILS => TableFromSourceOption {
+                name: TableFromSourceOptionName::Details,
+                value: self.parse_optional_option_value()?,
+            },
+            _ => unreachable!(),
+        };
+        Ok(option)
     }
 
     fn parse_columns(

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -253,7 +253,7 @@ CREATE TABLE t (c int4, d int4) FROM SOURCE foo (REFERENCE bar)
 ----
 CREATE TABLE t (c int4, d int4) FROM SOURCE foo (REFERENCE = bar)
 =>
-CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("d"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, source: UnresolvedItemName([Ident("foo")]), external_reference: UnresolvedItemName([Ident("bar")]), with_options: [] })
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("d"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: UnresolvedItemName([Ident("bar")]), with_options: [] })
 
 parse-statement
 CREATE TABLE t (c, d) FROM SOURCE foo (REFERENCE bar)
@@ -274,7 +274,7 @@ CREATE TABLE t FROM SOURCE foo (REFERENCE = baz)
 ----
 CREATE TABLE t FROM SOURCE foo (REFERENCE = baz)
 =>
-CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: [], constraints: [], if_not_exists: false, source: UnresolvedItemName([Ident("foo")]), external_reference: UnresolvedItemName([Ident("baz")]), with_options: [] })
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: [], constraints: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: UnresolvedItemName([Ident("baz")]), with_options: [] })
 
 parse-statement
 CREATE DATABASE IF EXISTS foo

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -251,16 +251,16 @@ CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("t")]), colum
 parse-statement
 CREATE TABLE t (c int4, d int4) FROM SOURCE foo (REFERENCE bar)
 ----
-error: Expected right parenthesis, found identifier "int4"
-CREATE TABLE t (c int4, d int4) FROM SOURCE foo (REFERENCE bar)
-                  ^
+CREATE TABLE t (c int4, d int4) FROM SOURCE foo (REFERENCE = bar)
+=>
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("d"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, source: UnresolvedItemName([Ident("foo")]), external_reference: UnresolvedItemName([Ident("bar")]), with_options: [] })
 
 parse-statement
 CREATE TABLE t (c, d) FROM SOURCE foo (REFERENCE bar)
 ----
-CREATE TABLE t (c, d) FROM SOURCE foo (REFERENCE = bar)
-=>
-CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: [Ident("c"), Ident("d")], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: UnresolvedItemName([Ident("bar")]) })
+error: Expected a data type name, found comma
+CREATE TABLE t (c, d) FROM SOURCE foo (REFERENCE bar)
+                 ^
 
 parse-statement
 CREATE TABLE t FROM SOURCE foo
@@ -274,7 +274,7 @@ CREATE TABLE t FROM SOURCE foo (REFERENCE = baz)
 ----
 CREATE TABLE t FROM SOURCE foo (REFERENCE = baz)
 =>
-CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: [], if_not_exists: false, source: Name(UnresolvedItemName([Ident("foo")])), external_reference: UnresolvedItemName([Ident("baz")]) })
+CreateTableFromSource(CreateTableFromSourceStatement { name: UnresolvedItemName([Ident("t")]), columns: [], constraints: [], if_not_exists: false, source: UnresolvedItemName([Ident("foo")]), external_reference: UnresolvedItemName([Ident("baz")]), with_options: [] })
 
 parse-statement
 CREATE DATABASE IF EXISTS foo

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -24,11 +24,11 @@ use mz_ccsr::{Client, GetByIdError, GetBySubjectError, Schema as CcsrSchema};
 use mz_controller_types::ClusterId;
 use mz_kafka_util::client::MzClientContext;
 use mz_mysql_util::MySqlTableDesc;
-use mz_ore::assert_none;
 use mz_ore::error::ErrorExt;
 use mz_ore::future::InTask;
 use mz_ore::iter::IteratorExt;
 use mz_ore::str::StrExt;
+use mz_ore::{assert_none, soft_panic_or_log};
 use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::replication::WalLevel;
 use mz_proto::RustType;
@@ -40,18 +40,20 @@ use mz_sql_parser::ast::{
     AlterSourceAction, AlterSourceAddSubsourceOptionName, AlterSourceStatement, AvroDocOn,
     ColumnName, CreateMaterializedViewStatement, CreateSinkConnection, CreateSinkOption,
     CreateSinkOptionName, CreateSinkStatement, CreateSubsourceOption, CreateSubsourceOptionName,
-    CsrConfigOption, CsrConfigOptionName, CsrConnection, CsrSeedAvro, CsrSeedProtobuf,
-    CsrSeedProtobufSchema, DeferredItemName, DocOnIdentifier, DocOnSchema, Expr, Function,
-    FunctionArgs, Ident, KafkaSourceConfigOption, KafkaSourceConfigOptionName, LoadGenerator,
-    LoadGeneratorOption, LoadGeneratorOptionName, MaterializedViewOption,
-    MaterializedViewOptionName, MySqlConfigOption, MySqlConfigOptionName, PgConfigOption,
-    PgConfigOptionName, RawItemName, ReaderSchemaSelectionStrategy, RefreshAtOptionValue,
-    RefreshEveryOptionValue, RefreshOptionValue, SourceEnvelope, Statement, UnresolvedItemName,
+    CreateTableFromSourceStatement, CsrConfigOption, CsrConfigOptionName, CsrConnection,
+    CsrSeedAvro, CsrSeedProtobuf, CsrSeedProtobufSchema, DeferredItemName, DocOnIdentifier,
+    DocOnSchema, Expr, Function, FunctionArgs, Ident, KafkaSourceConfigOption,
+    KafkaSourceConfigOptionName, LoadGenerator, LoadGeneratorOption, LoadGeneratorOptionName,
+    MaterializedViewOption, MaterializedViewOptionName, MySqlConfigOption, MySqlConfigOptionName,
+    PgConfigOption, PgConfigOptionName, RawItemName, ReaderSchemaSelectionStrategy,
+    RefreshAtOptionValue, RefreshEveryOptionValue, RefreshOptionValue, SourceEnvelope, Statement,
+    TableFromSourceOption, TableFromSourceOptionName, UnresolvedItemName,
 };
 use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::connections::Connection;
 use mz_storage_types::errors::ContextCreationError;
+use mz_storage_types::sources::load_generator::LOAD_GENERATOR_DATABASE_NAME;
 use mz_storage_types::sources::mysql::MySqlSourceDetails;
 use mz_storage_types::sources::postgres::PostgresSourcePublicationDetails;
 use mz_storage_types::sources::{
@@ -97,7 +99,7 @@ pub(crate) struct RequestedSourceExport<'a, T> {
 
 /// Generates appropriate source exports for a set of external references to export from a source.
 fn source_export_gen<'a, T: ExternalCatalogReference>(
-    selected_references: &mut Vec<ExternalReferenceExport>,
+    selected_references: &'a [ExternalReferenceExport],
     resolver: &SourceReferenceResolver,
     references: &'a [T],
     canonical_width: usize,
@@ -190,11 +192,11 @@ fn validate_source_export_names<T>(
         })?;
     }
 
-    // TODO: Remove this when supporting source-fed tables which can ingest the same external
-    // reference.
-
-    // We technically could allow multiple subsources to ingest the same upstream table, but
-    // it is almost certainly an error on the user's end.
+    // We disallow subsource statements from referencing the same upstream table, but we allow
+    // `CREATE TABLE .. FROM SOURCE` statements to do so. Since `CREATE TABLE .. FROM SOURCE`
+    // purification will only provide 1 `requested_source_export`, we can leave this here without
+    // needing to differentiate between the two types of statements.
+    // TODO(roshan): Remove this when auto-generated subsources are deprecated.
     if let Some(name) = requested_source_exports
         .iter()
         .map(|export| &export.external_reference)
@@ -242,6 +244,9 @@ pub enum PurifiedStatement {
         subsources: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
     },
     PurifiedCreateSink(CreateSinkStatement<Aug>),
+    PurifiedCreateTableFromSource {
+        stmt: CreateTableFromSourceStatement<Aug>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -302,6 +307,10 @@ pub async fn purify_statement(
                 cluster_id,
             )
         }
+        Statement::CreateTableFromSource(stmt) => (
+            purify_create_table_from_source(catalog, stmt, storage_configuration).await,
+            None,
+        ),
         o => unreachable!("{:?} does not need to be purified", o),
     }
 }
@@ -1203,8 +1212,6 @@ async fn purify_alter_source(
                 )
             }
 
-            let mut references = Some(ExternalReferences::SubsetTables(external_references));
-
             let postgres::PurifiedSourceExports {
                 source_exports: subsources,
                 normalized_text_columns,
@@ -1213,7 +1220,7 @@ async fn purify_alter_source(
                 &config,
                 &pg_source_connection.publication,
                 pg_connection,
-                &mut references,
+                &Some(ExternalReferences::SubsetTables(external_references)),
                 text_columns,
                 &unresolved_source_name,
             )
@@ -1245,8 +1252,6 @@ async fn purify_alter_source(
                 )
                 .await?;
 
-            let mut references = Some(ExternalReferences::SubsetTables(external_references));
-
             // Retrieve the current @gtid_executed value of the server to mark as the effective
             // initial snapshot point for these subsources.
             let initial_gtid_set =
@@ -1258,11 +1263,11 @@ async fn purify_alter_source(
                 normalized_ignore_columns,
             } = mysql::purify_source_exports(
                 &mut conn,
-                &mut references,
+                &Some(ExternalReferences::SubsetTables(external_references)),
                 text_columns,
                 ignore_columns,
                 &unresolved_source_name,
-                initial_gtid_set.clone(),
+                initial_gtid_set,
             )
             .await?;
             requested_subsource_map.extend(subsources);
@@ -1290,6 +1295,340 @@ async fn purify_alter_source(
         options,
         subsources: requested_subsource_map,
     })
+}
+
+async fn purify_create_table_from_source(
+    catalog: impl SessionCatalog,
+    mut stmt: CreateTableFromSourceStatement<Aug>,
+    storage_configuration: &StorageConfiguration,
+) -> Result<PurifiedStatement, PlanError> {
+    let scx = StatementContext::new(None, &catalog);
+    let CreateTableFromSourceStatement {
+        name: _,
+        columns,
+        constraints,
+        source: unresolved_source_name,
+        if_not_exists: _,
+        external_reference,
+        with_options,
+    } = &mut stmt;
+
+    // Columns and constraints cannot be specified by the user but will be populated below.
+    if !columns.is_empty() {
+        sql_bail!("CREATE TABLE .. FROM SOURCE column definitions cannot be specified directly");
+    }
+    if !constraints.is_empty() {
+        sql_bail!(
+            "CREATE TABLE .. FROM SOURCE constraint definitions cannot be specified directly"
+        );
+    }
+
+    // Get the source item
+    let item = match scx.resolve_item(RawItemName::Name(unresolved_source_name.clone())) {
+        Ok(item) => item,
+        Err(e) => return Err(e),
+    };
+
+    // Ensure it's an ingestion-based and alterable source.
+    let desc = match item.source_desc()? {
+        Some(desc) => desc.clone().into_inline_connection(scx.catalog),
+        None => {
+            sql_bail!("cannot ALTER this type of source")
+        }
+    };
+    let source_name = item.name();
+    let connection_name = desc.connection.name();
+
+    let crate::plan::statement::ddl::TableFromSourceOptionExtracted {
+        text_columns,
+        ignore_columns,
+        details,
+        seen: _,
+    } = with_options.clone().try_into()?;
+    assert_none!(details, "details cannot be explicitly set");
+
+    // Our text column values are unqualified (just column names), but the purification methods below
+    // expect to match the fully-qualified names against the full set of tables in upstream, so we
+    // need to qualify them using the external reference first.
+    let qualified_text_columns = text_columns
+        .iter()
+        .map(|col| {
+            UnresolvedItemName(
+                external_reference
+                    .0
+                    .iter()
+                    .chain_one(col)
+                    .map(|i| i.clone())
+                    .collect(),
+            )
+        })
+        .collect_vec();
+    let qualified_ignore_columns = ignore_columns
+        .iter()
+        .map(|col| {
+            UnresolvedItemName(
+                external_reference
+                    .0
+                    .iter()
+                    .chain_one(col)
+                    .map(|i| i.clone())
+                    .collect(),
+            )
+        })
+        .collect_vec();
+
+    // The requested external reference for this table which will be resolved below to a
+    // fully-qualified / normalized reference for each source type.
+    let requested_reference = ExternalReferenceExport {
+        reference: external_reference.clone(),
+        alias: None,
+    };
+
+    // Run purification work specific to each source type: resolve the external reference to
+    // a fully qualified name and obtain the appropriate details for the source-export statement
+    // NOTE that each source type has its own rules for how to resolve the external reference,
+    // and each source-type's fully-qualified external reference may be different. In Postgres
+    // a 3-layer reference is used (database, schema, table), whereas in MySQL only a 2-layer
+    // is used (schema, table), since databases == schemas. For load generator sources
+    // the reference is (schema, table) where schema defines the type of load-generator.
+    // When kafka is implemented, likely just the topic-name will be used.
+    let purified_export = match desc.connection {
+        GenericSourceConnection::Postgres(pg_source_connection) => {
+            // Get PostgresConnection for generating subsources.
+            let pg_connection = &pg_source_connection.connection;
+
+            let config = pg_connection
+                .config(
+                    &storage_configuration.connection_context.secrets_reader,
+                    storage_configuration,
+                    InTask::No,
+                )
+                .await?;
+
+            let client = config
+                .connect(
+                    "postgres_purification",
+                    &storage_configuration.connection_context.ssh_tunnel_manager,
+                )
+                .await?;
+
+            let available_replication_slots =
+                mz_postgres_util::available_replication_slots(&client).await?;
+
+            // We need 1 additional replication slot for the snapshots
+            if available_replication_slots < 1 {
+                Err(PgSourcePurificationError::InsufficientReplicationSlotsAvailable { count: 1 })?;
+            }
+
+            // TODO(roshan): Add support for PG sources to allow this
+            if !ignore_columns.is_empty() {
+                sql_bail!(
+                    "{} is a {} source, which does not support IGNORE COLUMNS.",
+                    scx.catalog.minimal_qualification(source_name),
+                    connection_name
+                )
+            }
+
+            let postgres::PurifiedSourceExports {
+                source_exports,
+                // This `normalized_text_columns` is not relevant for us and is only returned for
+                // `CREATE SOURCE` statements that automatically generate subsources, and will be
+                // removed with that functionality in the future.
+                normalized_text_columns: _,
+            } = postgres::purify_source_exports(
+                &client,
+                &config,
+                &pg_source_connection.publication,
+                pg_connection,
+                &Some(ExternalReferences::SubsetTables(vec![requested_reference])),
+                qualified_text_columns,
+                unresolved_source_name,
+            )
+            .await?;
+            // There should be exactly one source_export returned for this statement
+            let (_, purified_export) = source_exports.into_iter().next().unwrap();
+            purified_export
+        }
+        GenericSourceConnection::MySql(mysql_source_connection) => {
+            let mysql_connection = &mysql_source_connection.connection;
+            let config = mysql_connection
+                .config(
+                    &storage_configuration.connection_context.secrets_reader,
+                    storage_configuration,
+                    InTask::No,
+                )
+                .await?;
+
+            let mut conn = config
+                .connect(
+                    "mysql purification",
+                    &storage_configuration.connection_context.ssh_tunnel_manager,
+                )
+                .await?;
+
+            // Retrieve the current @gtid_executed value of the server to mark as the effective
+            // initial snapshot point for these subsources.
+            let initial_gtid_set =
+                mz_mysql_util::query_sys_var(&mut conn, "global.gtid_executed").await?;
+
+            let mysql::PurifiedSourceExports {
+                source_exports,
+                // `normalized_text/ignore_columns` is not relevant for us and is only returned for
+                // `CREATE SOURCE` statements that automatically generate subsources, and will be
+                // removed with that functionality in the future.
+                normalized_text_columns: _,
+                normalized_ignore_columns: _,
+            } = mysql::purify_source_exports(
+                &mut conn,
+                &Some(ExternalReferences::SubsetTables(vec![requested_reference])),
+                qualified_text_columns,
+                qualified_ignore_columns,
+                unresolved_source_name,
+                initial_gtid_set,
+            )
+            .await?;
+            // There should be exactly one source_export returned for this statement
+            let (_, purified_export) = source_exports.into_iter().next().unwrap();
+            purified_export
+        }
+        GenericSourceConnection::LoadGenerator(load_gen_connection) => {
+            let mut views = load_gen_connection.load_generator.views();
+            // Resolve the desired view reference to a `schema_name.view_name` reference
+            let resolver = SourceReferenceResolver::new(
+                LOAD_GENERATOR_DATABASE_NAME,
+                &views
+                    .iter()
+                    .map(|(view_name, _)| {
+                        (load_gen_connection.load_generator.schema_name(), *view_name)
+                    })
+                    .collect_vec(),
+            )?;
+            let (qualified_reference, view_idx) = resolver.resolve(&external_reference.0, 2)?;
+
+            let desired_view_desc = views.swap_remove(view_idx).1;
+            PurifiedSourceExport {
+                external_reference: qualified_reference,
+                details: PurifiedExportDetails::LoadGenerator {
+                    table: desired_view_desc,
+                },
+            }
+        }
+        // TODO(roshan): Add support for kafka sources
+        _ => sql_bail!(
+            "{} is a {} source, which does not support CREATE TABLE .. FROM SOURCE.",
+            scx.catalog.minimal_qualification(source_name),
+            connection_name,
+        ),
+    };
+
+    // Update the external reference in the statement to the resolved fully-qualified
+    // external reference
+    *external_reference = purified_export.external_reference.clone();
+
+    // Update options in the statement using the purified export details
+    match &purified_export.details {
+        PurifiedExportDetails::Postgres { .. } => {
+            let mut unsupported_cols = vec![];
+            let (gen_columns, gen_constraints, gen_text_columns, gen_details, _) =
+                postgres::generate_source_export_statement_values(
+                    &scx,
+                    purified_export,
+                    &mut unsupported_cols,
+                )?;
+            if !unsupported_cols.is_empty() {
+                unsupported_cols.sort();
+                Err(PgSourcePurificationError::UnrecognizedTypes {
+                    cols: unsupported_cols,
+                })?;
+            }
+
+            if let Some(text_cols_option) = with_options
+                .iter_mut()
+                .find(|option| option.name == TableFromSourceOptionName::TextColumns)
+            {
+                if let Some(gen_text_columns) = gen_text_columns {
+                    text_cols_option.value = Some(WithOptionValue::Sequence(gen_text_columns));
+                } else {
+                    soft_panic_or_log!(
+                        "text_columns should be Some if text_cols_option is present"
+                    );
+                }
+            }
+            *columns = gen_columns;
+            *constraints = gen_constraints;
+            with_options.push(TableFromSourceOption {
+                name: TableFromSourceOptionName::Details,
+                value: Some(WithOptionValue::Value(Value::String(hex::encode(
+                    gen_details.into_proto().encode_to_vec(),
+                )))),
+            })
+        }
+        PurifiedExportDetails::MySql { .. } => {
+            let (
+                gen_columns,
+                gen_constraints,
+                gen_text_columns,
+                gen_ignore_columns,
+                gen_details,
+                _,
+            ) = mysql::generate_source_export_statement_values(&scx, purified_export)?;
+
+            if let Some(text_cols_option) = with_options
+                .iter_mut()
+                .find(|option| option.name == TableFromSourceOptionName::TextColumns)
+            {
+                if let Some(gen_text_columns) = gen_text_columns {
+                    text_cols_option.value = Some(WithOptionValue::Sequence(gen_text_columns));
+                } else {
+                    soft_panic_or_log!(
+                        "text_columns should be Some if text_cols_option is present"
+                    );
+                }
+            }
+            if let Some(ignore_cols_option) = with_options
+                .iter_mut()
+                .find(|option| option.name == TableFromSourceOptionName::IgnoreColumns)
+            {
+                if let Some(gen_ignore_columns) = gen_ignore_columns {
+                    ignore_cols_option.value = Some(WithOptionValue::Sequence(gen_ignore_columns));
+                } else {
+                    soft_panic_or_log!(
+                        "text_columns should be Some if ignore_cols_option is present"
+                    );
+                }
+            }
+            *columns = gen_columns;
+            *constraints = gen_constraints;
+            with_options.push(TableFromSourceOption {
+                name: TableFromSourceOptionName::Details,
+                value: Some(WithOptionValue::Value(Value::String(hex::encode(
+                    gen_details.into_proto().encode_to_vec(),
+                )))),
+            })
+        }
+        PurifiedExportDetails::LoadGenerator { .. } => {
+            let desc = match purified_export.details {
+                PurifiedExportDetails::LoadGenerator { table } => table,
+                _ => unreachable!("purified export details must be load generator"),
+            };
+
+            let (gen_columns, gen_constraints) = scx.relation_desc_into_table_defs(&desc)?;
+            let details = SourceExportStatementDetails::LoadGenerator;
+            *columns = gen_columns;
+            *constraints = gen_constraints;
+            with_options.push(TableFromSourceOption {
+                name: TableFromSourceOptionName::Details,
+                value: Some(WithOptionValue::Value(Value::String(hex::encode(
+                    details.into_proto().encode_to_vec(),
+                )))),
+            })
+        }
+        PurifiedExportDetails::Kafka { .. } => {
+            sql_bail!("Kafka sources do not yet support CREATE TABLE .. FROM SOURCE")
+        }
+    };
+
+    Ok(PurifiedStatement::PurifiedCreateTableFromSource { stmt })
 }
 
 async fn purify_source_format(

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -1530,12 +1530,17 @@ async fn purify_create_table_from_source(
     match &purified_export.details {
         PurifiedExportDetails::Postgres { .. } => {
             let mut unsupported_cols = vec![];
-            let (gen_columns, gen_constraints, gen_text_columns, gen_details, _) =
-                postgres::generate_source_export_statement_values(
-                    &scx,
-                    purified_export,
-                    &mut unsupported_cols,
-                )?;
+            let postgres::PostgresExportStatementValues {
+                columns: gen_columns,
+                constraints: gen_constraints,
+                text_columns: gen_text_columns,
+                details: gen_details,
+                external_reference: _,
+            } = postgres::generate_source_export_statement_values(
+                &scx,
+                purified_export,
+                &mut unsupported_cols,
+            )?;
             if !unsupported_cols.is_empty() {
                 unsupported_cols.sort();
                 Err(PgSourcePurificationError::UnrecognizedTypes {
@@ -1565,14 +1570,14 @@ async fn purify_create_table_from_source(
             })
         }
         PurifiedExportDetails::MySql { .. } => {
-            let (
-                gen_columns,
-                gen_constraints,
-                gen_text_columns,
-                gen_ignore_columns,
-                gen_details,
-                _,
-            ) = mysql::generate_source_export_statement_values(&scx, purified_export)?;
+            let mysql::MySqlExportStatementValues {
+                columns: gen_columns,
+                constraints: gen_constraints,
+                text_columns: gen_text_columns,
+                ignore_columns: gen_ignore_columns,
+                details: gen_details,
+                external_reference: _,
+            } = mysql::generate_source_export_statement_values(&scx, purified_export)?;
 
             if let Some(text_cols_option) = with_options
                 .iter_mut()

--- a/src/sql/src/pure/postgres.rs
+++ b/src/sql/src/pure/postgres.rs
@@ -19,7 +19,7 @@ use mz_repr::{ColumnType, RelationType, ScalarType};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
     ColumnDef, CreateSubsourceOption, CreateSubsourceOptionName, CreateSubsourceStatement,
-    ExternalReferences, Ident, UnresolvedItemName, Value, WithOptionValue,
+    ExternalReferences, Ident, TableConstraint, UnresolvedItemName, Value, WithOptionValue,
 };
 use mz_storage_types::connections::PostgresConnection;
 use mz_storage_types::sources::postgres::CastType;
@@ -147,97 +147,13 @@ pub fn generate_create_subsource_statements(
     let mut subsources = Vec::with_capacity(requested_subsources.len());
 
     for (subsource_name, purified_export) in requested_subsources {
-        let (text_columns, table) = match purified_export.details {
-            PurifiedExportDetails::Postgres {
-                text_columns,
-                table,
-            } => (text_columns, table),
-            _ => unreachable!("purified export details must be postgres"),
-        };
-
-        let text_column_set = text_columns
-            .as_ref()
-            .map(|v| BTreeSet::from_iter(v.iter().map(Ident::as_str)));
-
-        // Figure out the schema of the subsource
-        let mut columns = vec![];
-        for c in table.columns.iter() {
-            let name = Ident::new(c.name.clone())?;
-
-            let ty = match text_column_set {
-                Some(ref names) if names.contains(c.name.as_str()) => mz_pgrepr::Type::Text,
-                _ => match mz_pgrepr::Type::from_oid_and_typmod(c.type_oid, c.type_mod) {
-                    Ok(t) => t,
-                    Err(_) => {
-                        let mut full_name = purified_export.external_reference.0.clone();
-                        full_name.push(name);
-                        unsupported_cols.push((
-                            UnresolvedItemName(full_name).to_ast_string(),
-                            mz_repr::adt::system::Oid(c.type_oid),
-                        ));
-                        continue;
-                    }
-                },
-            };
-
-            let data_type = scx.resolve_type(ty)?;
-            let mut options = vec![];
-
-            if !c.nullable {
-                options.push(mz_sql_parser::ast::ColumnOptionDef {
-                    name: None,
-                    option: mz_sql_parser::ast::ColumnOption::NotNull,
-                });
-            }
-
-            columns.push(ColumnDef {
-                name,
-                data_type,
-                collation: None,
-                options,
-            });
-        }
-
-        let mut constraints = vec![];
-        for key in table.keys.clone() {
-            let mut key_columns = vec![];
-
-            for col_num in key.cols {
-                let ident = Ident::new(
-                    table
-                        .columns
-                        .iter()
-                        .find(|col| col.col_num == col_num)
-                        .expect("key exists as column")
-                        .name
-                        .clone(),
-                )?;
-                key_columns.push(ident);
-            }
-
-            let constraint = mz_sql_parser::ast::TableConstraint::Unique {
-                name: Some(Ident::new(key.name)?),
-                columns: key_columns,
-                is_primary: key.is_primary,
-                nulls_not_distinct: key.nulls_not_distinct,
-            };
-
-            // We take the first constraint available to be the primary key.
-            if key.is_primary {
-                constraints.insert(0, constraint);
-            } else {
-                constraints.push(constraint);
-            }
-        }
-
-        let details = SourceExportStatementDetails::Postgres { table };
+        let (columns, constraints, text_columns, details, external_reference) =
+            generate_source_export_statement_values(scx, purified_export, &mut unsupported_cols)?;
 
         let mut with_options = vec![
             CreateSubsourceOption {
                 name: CreateSubsourceOptionName::ExternalReference,
-                value: Some(WithOptionValue::UnresolvedItemName(
-                    purified_export.external_reference,
-                )),
+                value: Some(WithOptionValue::UnresolvedItemName(external_reference)),
             },
             CreateSubsourceOption {
                 name: CreateSubsourceOptionName::Details,
@@ -250,12 +166,7 @@ pub fn generate_create_subsource_statements(
         if let Some(text_columns) = text_columns {
             with_options.push(CreateSubsourceOption {
                 name: CreateSubsourceOptionName::TextColumns,
-                value: Some(WithOptionValue::Sequence(
-                    text_columns
-                        .into_iter()
-                        .map(WithOptionValue::Ident::<Aug>)
-                        .collect::<Vec<_>>(),
-                )),
+                value: Some(WithOptionValue::Sequence(text_columns)),
             });
         }
 
@@ -291,6 +202,121 @@ pub fn generate_create_subsource_statements(
     Ok(subsources)
 }
 
+pub(super) fn generate_source_export_statement_values(
+    scx: &StatementContext,
+    purified_export: PurifiedSourceExport,
+    unsupported_cols: &mut Vec<(String, mz_repr::adt::system::Oid)>,
+) -> Result<
+    (
+        Vec<ColumnDef<Aug>>,
+        Vec<TableConstraint<Aug>>,
+        Option<Vec<WithOptionValue<Aug>>>,
+        SourceExportStatementDetails,
+        UnresolvedItemName,
+    ),
+    PlanError,
+> {
+    let (text_columns, table) = match purified_export.details {
+        PurifiedExportDetails::Postgres {
+            text_columns,
+            table,
+        } => (text_columns, table),
+        _ => unreachable!("purified export details must be postgres"),
+    };
+
+    let text_column_set = text_columns
+        .as_ref()
+        .map(|v| BTreeSet::from_iter(v.iter().map(Ident::as_str)));
+
+    // Figure out the schema of the subsource
+    let mut columns = vec![];
+    for c in table.columns.iter() {
+        let name = Ident::new(c.name.clone())?;
+
+        let ty = match text_column_set {
+            Some(ref names) if names.contains(c.name.as_str()) => mz_pgrepr::Type::Text,
+            _ => match mz_pgrepr::Type::from_oid_and_typmod(c.type_oid, c.type_mod) {
+                Ok(t) => t,
+                Err(_) => {
+                    let mut full_name = purified_export.external_reference.0.clone();
+                    full_name.push(name);
+                    unsupported_cols.push((
+                        UnresolvedItemName(full_name).to_ast_string(),
+                        mz_repr::adt::system::Oid(c.type_oid),
+                    ));
+                    continue;
+                }
+            },
+        };
+
+        let data_type = scx.resolve_type(ty)?;
+        let mut options = vec![];
+
+        if !c.nullable {
+            options.push(mz_sql_parser::ast::ColumnOptionDef {
+                name: None,
+                option: mz_sql_parser::ast::ColumnOption::NotNull,
+            });
+        }
+
+        columns.push(ColumnDef {
+            name,
+            data_type,
+            collation: None,
+            options,
+        });
+    }
+
+    let mut constraints = vec![];
+    for key in table.keys.clone() {
+        let mut key_columns = vec![];
+
+        for col_num in key.cols {
+            let ident = Ident::new(
+                table
+                    .columns
+                    .iter()
+                    .find(|col| col.col_num == col_num)
+                    .expect("key exists as column")
+                    .name
+                    .clone(),
+            )?;
+            key_columns.push(ident);
+        }
+
+        let constraint = mz_sql_parser::ast::TableConstraint::Unique {
+            name: Some(Ident::new(key.name)?),
+            columns: key_columns,
+            is_primary: key.is_primary,
+            nulls_not_distinct: key.nulls_not_distinct,
+        };
+
+        // We take the first constraint available to be the primary key.
+        if key.is_primary {
+            constraints.insert(0, constraint);
+        } else {
+            constraints.push(constraint);
+        }
+    }
+    let details = SourceExportStatementDetails::Postgres { table };
+
+    let text_columns = text_columns.map(|mut columns| {
+        columns.sort();
+        columns
+            .into_iter()
+            .map(WithOptionValue::Ident::<Aug>)
+            .collect()
+    });
+
+    Ok((
+        columns,
+        constraints,
+        text_columns,
+        details,
+        purified_export.external_reference,
+    ))
+}
+
 pub(super) struct PurifiedSourceExports {
     pub(super) source_exports: BTreeMap<UnresolvedItemName, PurifiedSourceExport>,
     // NOTE(roshan): The text columns are already part of their
@@ -310,7 +336,7 @@ pub(super) async fn purify_source_exports(
     config: &mz_postgres_util::Config,
     publication: &str,
     connection: &PostgresConnection,
-    external_references: &mut Option<ExternalReferences>,
+    external_references: &Option<ExternalReferences>,
     mut text_columns: Vec<UnresolvedItemName>,
     unresolved_source_name: &UnresolvedItemName,
 ) -> Result<PurifiedSourceExports, PlanError> {
@@ -327,7 +353,7 @@ pub(super) async fn purify_source_exports(
 
     let mut validated_references = vec![];
     match external_references
-        .as_mut()
+        .as_ref()
         .ok_or(PgSourcePurificationError::RequiresExternalReferences)?
     {
         ExternalReferences::All => {
@@ -404,7 +430,7 @@ pub(super) async fn purify_source_exports(
     // source-fed tables to that source later.
     if validated_references.is_empty() {
         sql_bail!(
-            "[internal error]: Postgres source must ingest at least one table, but {} matched none",
+            "[internal error]: Postgres reference {} did not match any tables",
             external_references.as_ref().unwrap().to_ast_string()
         );
     }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1178,8 +1178,8 @@ impl RustType<ProtoSourceExportDetails> for SourceExportDetails {
 }
 
 /// Details necessary to store in the `Details` option of a source export
-/// statement (currently only `CREATE SUBSOURCE` statements), to generate the
-/// appropriate `SourceExportDetails` struct during planning.
+/// statement (`CREATE SUBSOURCE` and `CREATE TABLE .. FROM SOURCE` statements),
+/// to generate the appropriate `SourceExportDetails` struct during planning.
 /// NOTE that this is serialized as proto to the catalog, so any changes here
 /// must be backwards compatible or will require a migration.
 /// We only support `CREATE SUBSOURCE` statements for Postgres and MySQL

--- a/src/storage-types/src/sources/mysql.proto
+++ b/src/storage-types/src/sources/mysql.proto
@@ -33,8 +33,8 @@ message ProtoMySqlSourceExportDetails {
     repeated string ignore_columns = 4;
 }
 
-// NOTE: this message is encoded and stored as part of a source export
-// statement option (currently only `CREATE SUBSOURCE` statements)
+// NOTE: this message is encoded and stored as part of source export
+// statement options
 // Be extra careful about changes, ensuring that all changes are backwards compatible
 message ProtoMySqlSourceExportStatementDetails {
     mz_mysql_util.ProtoMySqlTableDesc table = 1;

--- a/src/storage-types/src/sources/postgres.proto
+++ b/src/storage-types/src/sources/postgres.proto
@@ -50,8 +50,8 @@ message ProtoPostgresSourceExportDetails {
     repeated ProtoPostgresColumnCast column_casts = 2;
 }
 
-// NOTE: this message is encoded and stored as part of a source export
-// statement option (currently only `CREATE SUBSOURCE` statements)
+// NOTE: this message is encoded and stored as part of source export
+// statement options
 // Be extra careful about changes, ensuring that all changes are backwards compatible
 message ProtoPostgresSourceExportStatementDetails {
     mz_postgres_util.desc.ProtoPostgresTableDesc table = 1;

--- a/test/testdrive/source-tables.td
+++ b/test/testdrive/source-tables.td
@@ -1,0 +1,18 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-arg-default default-replica-size=1
+$ set-arg-default single-replica-cluster=quickstart
+
+> CREATE SOURCE auction_house
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
+
+! CREATE TABLE bids2 FROM SOURCE auction_house (REFERENCE "auction"."bids");
+contains: not yet supported


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.
Fixes https://github.com/MaterializeInc/materialize/issues/28942

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Best reviewed commit-by-commit, since the second commit is just refactoring existing subsource purification code so it can be reused.

Since planning is still not implemented for these statements (will be in the [next PR](https://github.com/MaterializeInc/materialize/pull/28954)) I'm not able to add any tests here. So this temporarily adds a chunk of uncovered code as a tradeoff for smaller review sizes, but feel free to push back if you disagree.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
