### PR TITLE
[persist] Temporarily switch back to the non-chunked iter in compaction

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -727,30 +727,16 @@ where
         let mut val_vec = vec![];
         loop {
             let fetch_start = Instant::now();
-            let Some(updates) = consolidator
-                .next_chunk(cfg.compaction_yield_after_n_updates)
-                .await?
-            else {
+            let Some(updates) = consolidator.next().await? else {
                 break;
             };
             timings.part_fetching += fetch_start.elapsed();
-            // We now have a full set of consolidated columnar data here, but no way to push it
-            // into the batch builder yet. Instead, iterate over the codec records and push those
-            // in directly.
-            for ((k, v), t, d) in updates.records().iter() {
+            for ((k, v), t, d) in updates.take(cfg.compaction_yield_after_n_updates) {
                 key_vec.clear();
                 key_vec.extend_from_slice(k);
                 val_vec.clear();
                 val_vec.extend_from_slice(v);
-                batch
-                    .add(
-                        &real_schemas,
-                        &key_vec,
-                        &val_vec,
-                        &T::decode(t),
-                        &D::decode(d),
-                    )
-                    .await?;
+                batch.add(&real_schemas, &key_vec, &val_vec, &t, &d).await?;
             }
             tokio::task::yield_now().await;
         }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -555,6 +555,7 @@ where
     /// Wait until data is available, then return an iterator over the next
     /// consolidated chunk of output. If this method returns `None`, that all the data has been
     /// exhausted and the full consolidated dataset has been returned.
+    #[allow(dead_code)]
     pub(crate) async fn next_chunk(
         &mut self,
         max_len: usize,


### PR DESCRIPTION
We're getting input data with heterogenous array types, and arrow::compute::interleave can't handle it! Switch back to the old version until we've got a migration story.

### Motivation

Avoids a bug with interleaving arrays of different types - see https://github.com/MaterializeInc/materialize/pull/28914. This should help unblock running with structured data in CI.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
