### PR TITLE
ci: Lower priority on main branch compared to PRs

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -271,10 +271,16 @@ def prioritize_pipeline(pipeline: Any) -> None:
     """Prioritize builds against main or release branches"""
 
     tag = os.environ["BUILDKITE_TAG"]
+    branch = os.environ["BUILDKITE_BRANCH"]
     priority = None
 
+    # Release results are time sensitive
     if tag.startswith("v"):
         priority = 10
+
+    # main branch is less time sensitive than results on PRs
+    if branch == "main":
+        priority = -10
 
     def visit(config: Any) -> None:
         config["priority"] = config.get("priority", 0) + priority

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -291,7 +291,9 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cluster
     agents:
-      queue: hetzner-aarch64-8cpu-16gb
+      # TODO(def-): Investigate timeout in `SELECT * from remote1`
+      # queue: hetzner-aarch64-8cpu-16gb
+      queue: linux-aarch64
 
   - id: sqllogictest-fast
     label: Fast SQL logic tests %N


### PR DESCRIPTION
To increase developer velocity when all agents are busy

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
