### PR TITLE
Remove the `true and` from HIR join conditions

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3632,24 +3632,7 @@ fn plan_using_constraint(
 
     both_scope = both_scope.project(&project_key);
 
-    // TODO: This should be just
-    // let on = HirScalarExpr::variadic_and(join_exprs);
-    // However, if I remove the literal true, then some plans change in weird ways
-    // (e.g., column_knowledge.slt:117 and 558)
-    // Note that before moving to variadic and, this code was
-    //         .fold(HirScalarExpr::literal_true(), |expr1, expr2| {
-    //             HirScalarExpr::CallBinary {
-    //                 func: BinaryFunc::And,
-    //                 expr1: Box::new(expr1),
-    //                 expr2: Box::new(expr2),
-    //             }
-    //         });
-    let on = HirScalarExpr::variadic_and(
-        vec![HirScalarExpr::literal_true()]
-            .into_iter()
-            .chain(join_exprs)
-            .collect(),
-    );
+    let on = HirScalarExpr::variadic_and(join_exprs);
 
     let both = left
         .join(right, on, kind)

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -31,7 +31,7 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
 ----
 Project (#0)
   Return
-    InnerJoin (true AND (#0 = #1))
+    InnerJoin (#0 = #1)
       Get l0
       Get l0
   With
@@ -69,7 +69,7 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
 ----
 Return // { arity: 1 }
   Project (#0) // { arity: 1 }
-    Filter (true AND (#0 = #1)) // { arity: 2 }
+    Filter (#0 = #1) // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
         CrossJoin // { arity: 2 }
           Get l0 // { arity: 1 }

--- a/test/sqllogictest/explain/view.slt
+++ b/test/sqllogictest/explain/view.slt
@@ -39,7 +39,7 @@ VIEW v;
 ----
 Project (#0, #1, #3)
   Filter (#1 = 100)
-    LeftOuterJoin (true AND (integer_to_bigint(#0) = #2))
+    LeftOuterJoin (integer_to_bigint(#0) = #2)
       Get materialize.public.accounts
       Get materialize.public.account_details
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -594,7 +594,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR SELECT la, l.lb, big_l.lb FROM l JOIN big_l USING (la)
 ----
 Project (#0, #1, #3)
-  InnerJoin (true AND (integer_to_bigint(#0) = #2))
+  InnerJoin (integer_to_bigint(#0) = #2)
     Get materialize.public.l
     Get materialize.public.big_l
 


### PR DESCRIPTION
This resolves an old, minor todo in join planning: The old code used to start every join condition with `true AND`. Once I tried to get rid of this when I introduced variadic AND, but this would have regressed some plans at the time, due to some weird reasons. So, at that time I only added a todo. However, now I again tried removing this `true AND`, and fortunately we are no longer seeing regressions. It seems that the lowering and/or the optimizer became more robust in the meantime.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
