### PR TITLE
skip version upgrade test: Consider released flag

### DIFF
--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -114,7 +114,7 @@ def get_all_and_latest_two_minor_mz_versions(
     use_versions_from_docs: bool,
 ) -> tuple[list[MzVersion], list[MzVersion]]:
     if use_versions_from_docs:
-        version_list = VersionsFromDocs()
+        version_list = VersionsFromDocs(respect_released_tag=False)
         all_versions = version_list.all_versions()
         tested_versions = version_list.minor_versions()[-2:]
     else:

--- a/test/skip-version-upgrade/mzcompose.py
+++ b/test/skip-version-upgrade/mzcompose.py
@@ -42,7 +42,9 @@ def workflow_test_version_skips(c: Composition) -> None:
 
     # If the current version is `v0.X.0-dev`, two_minor_releases_before will be `v0.X-2.Y`.
     # where Y is the most recent patch version of the minor version.
-    last_two_minor_releases = get_minor_mz_versions_listed_in_docs()[-2:]
+    last_two_minor_releases = get_minor_mz_versions_listed_in_docs(
+        respect_released_tag=True
+    )[-2:]
     two_minor_releases_before = last_two_minor_releases[-2]
     one_minor_release_before = last_two_minor_releases[-1]
 


### PR DESCRIPTION
Noticed by @sdht0 in https://materializeinc.slack.com/archives/CTESPM7FU/p1723491877661829?thread_ts=1723471217.547279&cid=CTESPM7FU
Fallout from https://github.com/MaterializeInc/materialize/pull/28860 (where I only considered the legacy upgrade test)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
