### PR TITLE
[persist] Allow stats collection on already-written arrays

### DIFF
--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -890,7 +890,7 @@ where
             // To be defensive, create an empty batch and inspect the resulting
             // data type (as opposed to something like allowing the `Schema2` to
             // declare the DataType).
-            let (array, _stats) = Schema2::encoder(schema).expect("valid schema").finish();
+            let array = Schema2::encoder(schema).expect("valid schema").finish();
             let proto = Array::data_type(&array).into_proto();
             prost::Message::encode_to_vec(&proto).into()
         }

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -152,7 +152,6 @@ impl ColumnDecoder<()> for UnitColumnar {
 
 impl ColumnEncoder<()> for UnitColumnar {
     type FinishedColumn = NullArray;
-    type FinishedStats = NoneStats;
 
     fn append(&mut self, _val: &()) {
         self.len += 1;
@@ -162,8 +161,8 @@ impl ColumnEncoder<()> for UnitColumnar {
         self.len += 1;
     }
 
-    fn finish(self) -> (Self::FinishedColumn, Self::FinishedStats) {
-        (NullArray::new(self.len), NoneStats)
+    fn finish(self) -> Self::FinishedColumn {
+        NullArray::new(self.len)
     }
 }
 
@@ -252,7 +251,6 @@ pub struct SimpleColumnarEncoder<T: SimpleColumnarData>(T::ArrowBuilder);
 
 impl<T: SimpleColumnarData> ColumnEncoder<T> for SimpleColumnarEncoder<T> {
     type FinishedColumn = T::ArrowColumn;
-    type FinishedStats = NoneStats;
 
     fn append(&mut self, val: &T) {
         T::push(val, &mut self.0);
@@ -260,7 +258,7 @@ impl<T: SimpleColumnarData> ColumnEncoder<T> for SimpleColumnarEncoder<T> {
     fn append_null(&mut self) {
         T::push_null(&mut self.0)
     }
-    fn finish(mut self) -> (Self::FinishedColumn, Self::FinishedStats) {
+    fn finish(mut self) -> Self::FinishedColumn {
         let array = ArrayBuilder::finish(&mut self.0);
         let array = array
             .as_any()
@@ -268,7 +266,7 @@ impl<T: SimpleColumnarData> ColumnEncoder<T> for SimpleColumnarEncoder<T> {
             .expect("created using StringBuilder")
             .clone();
 
-        (array, NoneStats)
+        array
     }
 }
 
@@ -1333,7 +1331,6 @@ pub struct TodoColumnarEncoder<T>(PhantomData<T>);
 
 impl<T> ColumnEncoder<T> for TodoColumnarEncoder<T> {
     type FinishedColumn = StructArray;
-    type FinishedStats = NoneStats;
 
     fn append(&mut self, _val: &T) {
         panic!("TODO")
@@ -1343,7 +1340,7 @@ impl<T> ColumnEncoder<T> for TodoColumnarEncoder<T> {
         panic!("TODO")
     }
 
-    fn finish(self) -> (Self::FinishedColumn, Self::FinishedStats) {
+    fn finish(self) -> Self::FinishedColumn {
         panic!("TODO")
     }
 }

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -36,7 +36,9 @@ use crate::dyn_col::DynColumnMut;
 use crate::dyn_struct::{
     ColumnsMut, ColumnsRef, DynStruct, DynStructCfg, DynStructCol, DynStructMut, DynStructRef,
 };
-use crate::stats::{BytesStats, NoneStats, OptionStats, PrimitiveStats, StatsFn, StructStats};
+use crate::stats::{
+    BytesStats, ColumnarStats, NoneStats, OptionStats, PrimitiveStats, StatsFn, StructStats,
+};
 use crate::{Codec, Codec64, Opaque, ShardId};
 
 /// An implementation of [Schema] for [()].
@@ -141,6 +143,10 @@ impl ColumnDecoder<()> for UnitColumnar {
         } else {
             panic!("index out of bounds, idx: {idx}, len: {}", self.len);
         }
+    }
+
+    fn stats(&self) -> ColumnarStats {
+        ColumnarStats::NONE
     }
 }
 
@@ -283,6 +289,10 @@ impl<T: SimpleColumnarData> ColumnDecoder<T> for SimpleColumnarDecoder<T> {
     }
     fn is_null(&self, idx: usize) -> bool {
         self.0.is_null(idx)
+    }
+
+    fn stats(&self) -> ColumnarStats {
+        ColumnarStats::NONE
     }
 }
 
@@ -1348,6 +1358,10 @@ impl<T> ColumnDecoder<T> for TodoColumnarDecoder<T> {
     }
 
     fn is_null(&self, _idx: usize) -> bool {
+        panic!("TODO")
+    }
+
+    fn stats(&self) -> ColumnarStats {
         panic!("TODO")
     }
 }

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -299,6 +299,11 @@ pub trait ColumnDecoder<T> {
 
     /// Returns if the value at `idx` is null.
     fn is_null(&self, idx: usize) -> bool;
+
+    /// Returns statistics for the column. This structure is defined by Persist,
+    /// but the contents are determined by the client; Persist will preserve them
+    /// in the part metadata and make them available to readers.
+    fn stats(&self) -> ColumnarStats;
 }
 
 /// An encoder for values of a fixed schema

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -21,7 +21,7 @@ use crate::columnar::sealed::{ColumnMut, ColumnRef};
 use crate::columnar::{ColumnEncoder, PartEncoder, Schema, Schema2};
 use crate::dyn_col::DynColumnRef;
 use crate::dyn_struct::{ColumnsRef, DynStructCfg, DynStructCol, DynStructMut, ValidityRef};
-use crate::stats::{ColumnarStats, DynStats, StructStats};
+use crate::stats::StructStats;
 use crate::Codec64;
 
 /// A structured columnar representation of one blob's worth of data.
@@ -337,12 +337,8 @@ impl<K, KS: Schema<K>, V, VS: Schema<V>> PartBuilder<K, KS, V, VS> {
 pub struct Part2 {
     /// The 'k' values from a Part, generally `SourceData`.
     pub key: Arc<dyn Array>,
-    /// Statistics for the `key` values.
-    pub key_stats: ColumnarStats,
     /// The 'v' values from a Part, generally `()`.
     pub val: Arc<dyn Array>,
-    /// Statistics for the `val` values.
-    pub val_stats: ColumnarStats,
     /// The `ts` values from a Part.
     pub time: ScalarBuffer<i64>,
     /// The `diff` values from a Part.
@@ -390,16 +386,14 @@ impl<K, KS: Schema2<K>, V, VS: Schema2<V>> PartBuilder2<K, KS, V, VS> {
             diff,
         } = self;
 
-        let (key_col, key_stats) = key.finish();
-        let (val_col, val_stats) = val.finish();
+        let key_col = key.finish();
+        let val_col = val.finish();
         let time = ScalarBuffer::from(time);
         let diff = ScalarBuffer::from(diff);
 
         Part2 {
             key: Arc::new(key_col),
-            key_stats: key_stats.into_columnar_stats(),
             val: Arc::new(val_col),
-            val_stats: val_stats.into_columnar_stats(),
             time,
             diff,
         }

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -54,6 +54,11 @@ pub struct ColumnarStats {
 }
 
 impl ColumnarStats {
+    pub const NONE: Self = ColumnarStats {
+        nulls: None,
+        values: ColumnStatKinds::None,
+    };
+
     /// Downcast this instasnce of [`ColumnarStats`] into `T::Stats`, if the
     /// inner type is a `T::Stats`.
     pub fn downcast<T: Data>(&self) -> Option<T::Stats> {

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -478,7 +478,7 @@ fn bench_json(c: &mut Criterion) {
                 std::hint::black_box(&mut builder).push(&row, &(), 1, 1);
             }
             let part = builder.finish();
-            std::hint::black_box((part.key, part.key_stats));
+            std::hint::black_box(part.key);
         });
     });
 
@@ -559,7 +559,7 @@ fn bench_string(c: &mut Criterion) {
                 std::hint::black_box(&mut builder).push(&row, &(), 1, 1);
             }
             let part = builder.finish();
-            std::hint::black_box((part.key, part.key_stats));
+            std::hint::black_box(part.key);
         });
     });
 

--- a/src/repr/src/stats2.rs
+++ b/src/repr/src/stats2.rs
@@ -241,10 +241,7 @@ pub struct NumericStatsBuilder {
     upper: OrderedDecimal<Numeric>,
 }
 
-impl ColumnarStatsBuilder<OrderedDecimal<Numeric>> for NumericStatsBuilder {
-    type ArrowColumn = BinaryArray;
-    type FinishedStats = BytesStats;
-
+impl NumericStatsBuilder {
     fn new() -> Self
     where
         Self: Sized,
@@ -254,6 +251,16 @@ impl ColumnarStatsBuilder<OrderedDecimal<Numeric>> for NumericStatsBuilder {
             upper: OrderedDecimal(-Numeric::infinity()),
         }
     }
+
+    fn include(&mut self, val: OrderedDecimal<Numeric>) {
+        self.lower = val.min(self.lower);
+        self.upper = val.max(self.upper);
+    }
+}
+
+impl ColumnarStatsBuilder<OrderedDecimal<Numeric>> for NumericStatsBuilder {
+    type ArrowColumn = BinaryArray;
+    type FinishedStats = BytesStats;
 
     fn from_column(col: &Self::ArrowColumn) -> Self
     where
@@ -273,11 +280,6 @@ impl ColumnarStatsBuilder<OrderedDecimal<Numeric>> for NumericStatsBuilder {
             builder.include(OrderedDecimal(val));
         }
         builder
-    }
-
-    fn include(&mut self, val: OrderedDecimal<Numeric>) {
-        self.lower = val.min(self.lower);
-        self.upper = val.max(self.upper);
     }
 
     fn finish(self) -> Self::FinishedStats
@@ -302,16 +304,6 @@ pub struct NaiveTimeStatsBuilder {
 impl ColumnarStatsBuilder<NaiveTime> for NaiveTimeStatsBuilder {
     type ArrowColumn = FixedSizeBinaryArray;
     type FinishedStats = BytesStats;
-
-    fn new() -> Self
-    where
-        Self: Sized,
-    {
-        NaiveTimeStatsBuilder {
-            lower: NaiveTime::default(),
-            upper: NaiveTime::default(),
-        }
-    }
 
     fn from_column(col: &Self::ArrowColumn) -> Self
     where
@@ -344,11 +336,6 @@ impl ColumnarStatsBuilder<NaiveTime> for NaiveTimeStatsBuilder {
         NaiveTimeStatsBuilder { lower, upper }
     }
 
-    fn include(&mut self, val: NaiveTime) {
-        self.lower = val.min(self.lower);
-        self.upper = val.max(self.upper);
-    }
-
     fn finish(self) -> Self::FinishedStats
     where
         Self::FinishedStats: Sized,
@@ -371,16 +358,6 @@ pub struct NaiveDateTimeStatsBuilder {
 impl ColumnarStatsBuilder<NaiveDateTime> for NaiveDateTimeStatsBuilder {
     type ArrowColumn = FixedSizeBinaryArray;
     type FinishedStats = BytesStats;
-
-    fn new() -> Self
-    where
-        Self: Sized,
-    {
-        NaiveDateTimeStatsBuilder {
-            lower: NaiveDateTime::default(),
-            upper: NaiveDateTime::default(),
-        }
-    }
 
     fn from_column(col: &Self::ArrowColumn) -> Self
     where
@@ -413,11 +390,6 @@ impl ColumnarStatsBuilder<NaiveDateTime> for NaiveDateTimeStatsBuilder {
         NaiveDateTimeStatsBuilder { lower, upper }
     }
 
-    fn include(&mut self, val: NaiveDateTime) {
-        self.lower = val.min(self.lower);
-        self.upper = val.max(self.upper);
-    }
-
     fn finish(self) -> Self::FinishedStats
     where
         Self::FinishedStats: Sized,
@@ -444,16 +416,6 @@ pub struct IntervalStatsBuilder {
 impl ColumnarStatsBuilder<Interval> for IntervalStatsBuilder {
     type ArrowColumn = FixedSizeBinaryArray;
     type FinishedStats = BytesStats;
-
-    fn new() -> Self
-    where
-        Self: Sized,
-    {
-        IntervalStatsBuilder {
-            lower: Interval::default(),
-            upper: Interval::default(),
-        }
-    }
 
     fn from_column(col: &Self::ArrowColumn) -> Self
     where
@@ -486,11 +448,6 @@ impl ColumnarStatsBuilder<Interval> for IntervalStatsBuilder {
         IntervalStatsBuilder { lower, upper }
     }
 
-    fn include(&mut self, val: Interval) {
-        self.lower = val.min(self.lower);
-        self.upper = val.max(self.upper);
-    }
-
     fn finish(self) -> Self::FinishedStats
     where
         Self::FinishedStats: Sized,
@@ -514,16 +471,6 @@ impl ColumnarStatsBuilder<Uuid> for UuidStatsBuilder {
     type ArrowColumn = FixedSizeBinaryArray;
     type FinishedStats = BytesStats;
 
-    fn new() -> Self
-    where
-        Self: Sized,
-    {
-        UuidStatsBuilder {
-            lower: Uuid::default(),
-            upper: Uuid::default(),
-        }
-    }
-
     fn from_column(col: &Self::ArrowColumn) -> Self
     where
         Self: Sized,
@@ -545,11 +492,6 @@ impl ColumnarStatsBuilder<Uuid> for UuidStatsBuilder {
             .unwrap_or_default();
 
         UuidStatsBuilder { lower, upper }
-    }
-
-    fn include(&mut self, val: Uuid) {
-        self.lower = val.min(self.lower);
-        self.upper = val.max(self.upper);
     }
 
     fn finish(self) -> Self::FinishedStats


### PR DESCRIPTION
- Clean up some now-unused incremental stats building methods.
- Add a new `stats()` method to `ColumnDecoder`, which calculates stats for already-written data. This is a more-or-less copy-and-paste of the encode-time stats.
- Switch batch write to use this new method. (This is particularly useful in the case of compaction, where we might never otherwise re-encode the user types.)
- Remove the now-unneeded encode-type stats. (This is optional, but nice to tidy up.)

### Motivation

For #24830: this allows us to collect stats without having to do a full decode-and-re-encode, which has been a big significant CPU burn in the past few months. (Though we'll still need to pay that cost until I land the structured-data support in compaction.)

### Tips for reviewer

Maybe it's surprising to put this as a method on `ColumnDecoder`? This was mostly for convenience - creating a decoder already does pretty much all the downcasting etc. that we'd want for stats - but I think you could make an argument for it from principles also. Let me know if that doesn't seem right!

This is a fair bit of code movement, but not _pure_ code movement, which is always a little tricky. I feel like we have pretty good test coverage here, but feel free to suggest more useful tests!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
