### PR TITLE
0dt tests: Wait 100 days and time out tests

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -123,6 +123,7 @@ def get_default_system_parameters(
         "storage_use_reclock_v2": "true",
         "timestamp_oracle": "postgres",
         "wait_catalog_consolidation_on_startup": "true",
+        "with_0dt_deployment_max_wait": "100d",  # forever, time out and fail test!
         # End of list (ordered by name)
     }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -537,8 +537,8 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         );
     }
 
-    /// Returns `true` iff all collections are hydrated on at least one
-    /// (possibly different) replica.
+    /// Returns `true` iff all (non-transient) collections are hydrated on at
+    /// least one (possibly different) replica.
     ///
     /// This also returns `true` in case this cluster does not have any
     /// replicas.
@@ -550,6 +550,12 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         let mut all_hydrated = true;
 
         for (id, _collection) in self.collections_iter() {
+            if id.is_transient() {
+                // These have no relation to dataflows running on previous
+                // deployments.
+                continue;
+            }
+
             let mut collection_hydrated = false;
             for replica_state in self.replicas.values() {
                 let collection_state = replica_state


### PR DESCRIPTION
instead of continuing with promotion when it never becomes ready

Although I would prefer a mode for testing that panics when it is not ready, allows us to retain logs and wastes fewer resources than timing out.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
