### PR TITLE
ci: Get nightly greener (again)

### DIFF
--- a/misc/python/materialize/checks/all_checks/identifiers.py
+++ b/misc/python/materialize/checks/all_checks/identifiers.py
@@ -187,10 +187,15 @@ class Identifiers(Check):
         pg_catalog
         {dq_print(self.ident["schema"])}
 
-        > SHOW SINKS FROM {dq(self.ident["schema"])};
+        >[version>=11300] SHOW SINKS FROM {dq(self.ident["schema"])};
         {dq_print(self.ident["sink0"])} kafka identifiers
         {dq_print(self.ident["sink1"])} kafka identifiers
         {dq_print(self.ident["sink2"])} kafka identifiers
+
+        >[version<11300] SHOW SINKS FROM {dq(self.ident["schema"])};
+        {dq_print(self.ident["sink0"])} kafka 4 identifiers
+        {dq_print(self.ident["sink1"])} kafka 4 identifiers
+        {dq_print(self.ident["sink2"])} kafka 4 identifiers
 
         > SELECT * FROM {dq(self.ident["schema"])}.{dq(self.ident["mv0"])};
         3

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -2223,7 +2223,8 @@ ddl_action_list = ActionList(
         (RenameSinkAction, 10),
         (SwapSchemaAction, 10),
         (FlipFlagsAction, 2),
-        (AlterKafkaSinkFromAction, 8),
+        # TODO: Reenable when #28962 is fixed
+        # (AlterKafkaSinkFromAction, 8),
         # (TransactionIsolationAction, 1),
     ],
     autocommit=True,

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1256,12 +1256,9 @@ class FilterSubqueries(Generator):
 
             # Increase SQL timeout to 10 minutes (~5 should be enough).
             #
-            # Update: Now 15 minutes, not 10. This query appears to scale
-            # super-linear with COUNT. Here are timings for the first few
-            # multiples of 10 on a fresh staging env.
-            #
-            # 10: 200ms, 20: 375ms, 30: 1.5s, 40: 5.5s, 50: 16s, 60: 45s
-            $ set-sql-timeout duration=900s
+            # Update: Now 20 minutes, not 10. This query appears to scale
+            # super-linear with COUNT.
+            $ set-sql-timeout duration=1200s
 
             > SELECT * FROM t1 AS a1 WHERE {
                 " AND ".join(
@@ -1464,6 +1461,7 @@ class MySqlSources(Generator):
 
     @classmethod
     def body(cls) -> None:
+        print("$ set-sql-timeout duration=300s")
         print("$ postgres-execute connection=mz_system")
         print(f"ALTER SYSTEM SET max_sources = {cls.COUNT * 10};")
         print("$ postgres-execute connection=mz_system")

--- a/test/testdrive/dataflow-dependencies.td
+++ b/test/testdrive/dataflow-dependencies.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-arg-default single-replica-cluster=quickstart
+
 # Test reporting of dataflow dependencies through
 # `mz_internal.mz_compute_dependencies` and
 # `mz_internal.mz_materialization_dependencies`.
@@ -68,7 +70,9 @@ mv1_primary_idx mv1
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT)
 > CREATE CONNECTION csr_conn
   TO CONFLUENT SCHEMA REGISTRY (URL '${testdrive.schema-registry-url}')
-> CREATE SINK snk FROM mv1
+> CREATE SINK snk
+  IN CLUSTER ${arg.single-replica-cluster}
+  FROM mv1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink1-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM


### PR DESCRIPTION
Based on failures in https://buildkite.com/materialize/nightly/builds/9061

Verification: https://buildkite.com/materialize/nightly/builds/9064 (green)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
