### PR TITLE
compute: replace dependants of replaced dataflows

### DIFF
--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -299,10 +299,17 @@ impl<P, S, T> DataflowDescription<P, S, T> {
 
     /// Identifiers of imported objects (indexes and sources).
     pub fn import_ids(&self) -> impl Iterator<Item = GlobalId> + Clone + '_ {
-        self.index_imports
-            .keys()
-            .chain(self.source_imports.keys())
-            .copied()
+        self.imported_index_ids().chain(self.imported_source_ids())
+    }
+
+    /// Identifiers of imported indexes.
+    pub fn imported_index_ids(&self) -> impl Iterator<Item = GlobalId> + Clone + '_ {
+        self.index_imports.keys().copied()
+    }
+
+    /// Identifiers of imported sources.
+    pub fn imported_source_ids(&self) -> impl Iterator<Item = GlobalId> + Clone + '_ {
+        self.source_imports.keys().copied()
     }
 
     /// Identifiers of exported objects (indexes and sinks).

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -180,6 +180,7 @@ impl ComputeMetrics {
         compatible: bool,
         uncompacted: bool,
         subscribe_free: bool,
+        dependencies_retained: bool,
     ) {
         let worker = worker_id.to_string();
 
@@ -194,6 +195,10 @@ impl ComputeMetrics {
         } else if !subscribe_free {
             self.reconciliation_replaced_dataflows_count_total
                 .with_label_values(&[&worker, "subscribe"])
+                .inc();
+        } else if !dependencies_retained {
+            self.reconciliation_replaced_dataflows_count_total
+                .with_label_values(&[&worker, "dependency"])
                 .inc();
         } else {
             self.reconciliation_reused_dataflows_count_total


### PR DESCRIPTION
This PR fixes a bug in compute reconciliation, which would reuse dataflows even when dataflows they were reading from had been replaced. This behavior was undesirable because the reused dataflows would keep discarded dataflows alive, and the installed dataflows wouldn't match the ones requested by the controller anymore.

To fix this we tweak the reconciliation logic to also replace dataflows that depend on replaced dataflows.

### Motivation

  * This PR fixes a recognized bug.

Fixes #28961 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
