### PR TITLE
adapter,compute: improved dataflow as-of bootstrapping

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -72,9 +72,11 @@ use mz_adapter_types::dyncfgs::{
     ENABLE_0DT_CAUGHT_UP_CHECK, WITH_0DT_CAUGHT_UP_CHECK_ALLOWED_LAG,
     WITH_0DT_DEPLOYMENT_HYDRATION_CHECK_INTERVAL,
 };
+use mz_compute_client::as_of_selection;
 use mz_ore::channel::trigger;
 use mz_sql::names::{ResolvedIds, SchemaSpecifier};
 use mz_sql::session::user::User;
+use mz_storage_types::read_holds::ReadHold;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
@@ -154,7 +156,6 @@ use mz_transform::dataflow::DataflowMetainfo;
 use opentelemetry::trace::TraceContextExt;
 use serde::Serialize;
 use timely::progress::{Antichain, Timestamp as _};
-use timely::PartialOrder;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch, OwnedMutexGuard};
@@ -182,15 +183,13 @@ use crate::error::AdapterError;
 use crate::explain::insights::PlanInsightsContext;
 use crate::explain::optimizer_trace::{DispatchGuard, OptimizerTrace};
 use crate::metrics::Metrics;
-use crate::optimize::dataflows::{
-    dataflow_import_id_bundle, ComputeInstanceSnapshot, DataflowBuilder,
-};
+use crate::optimize::dataflows::{ComputeInstanceSnapshot, DataflowBuilder};
 use crate::optimize::{self, Optimize, OptimizerConfig};
 use crate::session::{EndTransactionAction, Session};
 use crate::statement_logging::{StatementEndedExecutionReason, StatementLifecycleEvent};
 use crate::util::{ClientTransmitter, CompletedClientTransmitter, ResultExt};
 use crate::webhook::{WebhookAppenderInvalidator, WebhookConcurrencyLimiter};
-use crate::{flags, AdapterNotice, ReadHolds, TimestampProvider};
+use crate::{flags, AdapterNotice, ReadHolds};
 
 use self::statement_logging::{StatementLogging, StatementLoggingId};
 
@@ -1852,20 +1851,25 @@ impl Coordinator {
             optimize_dataflows_start.elapsed()
         );
 
+        // Select dataflow as-ofs. This step relies on the storage collections created by
+        // `bootstrap_storage_collections` and the dataflow plans created by
+        // `bootstrap_dataflow_plans`.
+        let bootstrap_as_ofs_start = Instant::now();
+        info!("startup: coordinator init: bootstrap: dataflow as-of bootstrapping beginning");
+        let dataflow_read_holds = self.bootstrap_dataflow_as_ofs().await;
+        info!(
+            "startup: coordinator init: bootstrap: dataflow as-of bootstrapping complete in {:?}",
+            bootstrap_as_ofs_start.elapsed()
+        );
+
         let postamble_start = Instant::now();
         info!("startup: coordinator init: bootstrap: postamble beginning");
-
-        // Discover storage constrains on compute dataflows. Needed for as-of selection below.
-        // These steps rely on the dataflow plans created by `bootstrap_dataflow_plans`.
-        let mut dataflow_storage_constraints = self.collect_dataflow_storage_constraints();
 
         let logs: BTreeSet<_> = BUILTINS::logs()
             .map(|log| self.catalog().resolve_builtin_log(log))
             .collect();
 
         let mut privatelink_connections = BTreeMap::new();
-
-        let local_read_ts_for_index_bootstrapping = self.get_local_read_ts().await;
 
         for entry in &entries {
             // TODO(#26794): we should move this invariant into `CatalogEntry`.
@@ -1944,41 +1948,11 @@ impl Coordinator {
                             .or_insert_with(BTreeSet::new)
                             .insert(entry.id());
                     } else {
-                        let mut df_desc = self
+                        let df_desc = self
                             .catalog()
                             .try_get_physical_plan(&entry.id())
                             .expect("added in `bootstrap_dataflow_plans`")
                             .clone();
-
-                        // Timestamp selection
-                        let storage_constraints = dataflow_storage_constraints
-                            .remove(&entry.id())
-                            .expect("all dataflow storage constraints were collected");
-
-                        let compaction_window = if idx.is_retained_metrics_object {
-                            let retention =
-                                self.catalog().state().system_config().metrics_retention();
-                            match u64::try_from(retention.as_millis()) {
-                                Ok(d) => CompactionWindow::Duration(Timestamp::new(d)),
-                                Err(_) => {
-                                    tracing::error!(
-                                        "absurd metrics retention duration: {retention:?}"
-                                    );
-                                    CompactionWindow::DisableCompaction
-                                }
-                            }
-                        } else {
-                            idx.custom_logical_compaction_window.unwrap_or_default()
-                        };
-
-                        let (as_of, read_holds) = self.bootstrap_dataflow_as_of(
-                            &df_desc,
-                            idx.cluster_id,
-                            storage_constraints,
-                            compaction_window,
-                            local_read_ts_for_index_bootstrapping,
-                        );
-                        df_desc.set_as_of(as_of);
 
                         let df_meta = self
                             .catalog()
@@ -2006,10 +1980,6 @@ impl Coordinator {
                             .compute
                             .create_dataflow(idx.cluster_id, df_desc)
                             .unwrap_or_terminate("cannot fail to create dataflows");
-
-                        // Drop read holds after the dataflow has been shipped, at which
-                        // point compute will have put in its own read holds.
-                        drop(read_holds);
                     }
                 }
                 CatalogItem::View(_) => (),
@@ -2026,19 +1996,6 @@ impl Coordinator {
                         .expect("added in `bootstrap_dataflow_plans`")
                         .clone();
 
-                    // Timestamp selection
-                    let storage_constraints = dataflow_storage_constraints
-                        .remove(&entry.id())
-                        .expect("all dataflow storage constraints were collected");
-
-                    let (as_of, read_holds) = self.bootstrap_dataflow_as_of(
-                        &df_desc,
-                        mview.cluster_id,
-                        storage_constraints,
-                        mview.custom_logical_compaction_window.unwrap_or_default(),
-                        local_read_ts_for_index_bootstrapping,
-                    );
-                    df_desc.set_as_of(as_of);
                     if let Some(initial_as_of) = mview.initial_as_of.clone() {
                         df_desc.set_initial_as_of(initial_as_of);
                     }
@@ -2068,10 +2025,6 @@ impl Coordinator {
                     }
 
                     self.ship_dataflow(df_desc, mview.cluster_id).await;
-
-                    // Drop read holds after the dataflow has been shipped, at which
-                    // point compute will have put in its own read holds.
-                    drop(read_holds);
                 }
                 CatalogItem::Sink(sink) => {
                     let id = entry.id();
@@ -2118,8 +2071,9 @@ impl Coordinator {
             }
         }
 
-        // Having installed all entries, creating all constraints, we can now relax read policies.
-        //
+        // Having installed all entries, creating all constraints, we can now drop read holds and
+        // relax read policies.
+        drop(dataflow_read_holds);
         // TODO -- Improve `initialize_read_policies` API so we can avoid calling this in a loop.
         for (cw, policies) in policies_to_set {
             self.initialize_read_policies(&policies, cw).await;
@@ -2647,279 +2601,45 @@ impl Coordinator {
         Ok(())
     }
 
-    /// Collects for each compute dataflow (index, MV) the storage collections that constrain
-    /// timestamp selection.
+    /// Selects for each compute dataflow an as-of suitable for bootstrapping it.
     ///
-    /// The returned information is required during coordinator bootstrap for index and MV as-of
-    /// selection, to ensure that selected as-ofs satisfy these constraints.
+    /// Returns a set of [`ReadHold`]s that ensures the read frontiers of involved collections stay
+    /// in place and that must not be dropped before all compute dataflows have been created with
+    /// the compute controller.
     ///
-    /// This method expects all dataflow plans to be available, so it must run after
+    /// This method expects all storage collections and dataflow plans to be available, so it must
+    /// run after [`Coordinator::bootstrap_storage_collections`] and
     /// [`Coordinator::bootstrap_dataflow_plans`].
-    fn collect_dataflow_storage_constraints(&self) -> BTreeMap<GlobalId, StorageConstraints> {
-        let is_storage_collection =
-            |id: &GlobalId| self.controller.storage.check_exists(*id).is_ok();
-
-        // Collect index imports and direct storage constraints for all dataflows.
-        let mut index_imports: BTreeMap<_, Vec<_>> = Default::default();
-        let mut constraints: BTreeMap<_, StorageConstraints> = Default::default();
-        let catalog = self.catalog();
-        for entry in catalog.entries() {
+    async fn bootstrap_dataflow_as_ofs(&mut self) -> BTreeMap<GlobalId, ReadHold<Timestamp>> {
+        let mut catalog_ids = Vec::new();
+        let mut dataflows = Vec::new();
+        let mut read_policies = BTreeMap::new();
+        for entry in self.catalog.entries() {
             let id = entry.id();
-            if let Some(plan) = catalog.try_get_physical_plan(&id) {
-                let index_import_ids = plan.index_imports.keys().copied().collect();
-                let storage_import_ids = plan.source_imports.keys().copied().collect();
-                let sink_export_ids = plan.sink_exports.keys().copied();
-                let storage_export_ids = sink_export_ids.filter(is_storage_collection).collect();
+            if let Some(plan) = self.catalog.try_get_physical_plan(&id) {
+                catalog_ids.push(id);
+                dataflows.push(plan.clone());
 
-                index_imports.insert(id, index_import_ids);
-                constraints.insert(
-                    id,
-                    StorageConstraints {
-                        dependencies: storage_import_ids,
-                        dependants: storage_export_ids,
-                    },
-                );
-            }
+                if let Some(compaction_window) = entry.item().initial_logical_compaction_window() {
+                    read_policies.insert(id, compaction_window.into());
+                }
+            };
         }
 
-        // Collect transitive constraints through indexes.
-        //
-        // Objects with larger IDs tend to depend on objects with smaller IDs. We don't want to
-        // rely on that being true, but we can use it to be more efficient. We do so by having two
-        // fixpoint loops. The first iterates forwards through the index dependencies to propagate
-        // `dependencies` constraints, the seconds iterates backwards through the index
-        // dependencies to propagate `dependants` constraints.
-
-        fn fixpoint(mut step: impl FnMut(&mut bool)) {
-            loop {
-                let mut changed = false;
-                step(&mut changed);
-                if !changed {
-                    break;
-                }
-            }
-        }
-
-        fixpoint(|changed| {
-            for (id, idx_deps) in index_imports.iter() {
-                let transitive_deps: Vec<_> = idx_deps
-                    .iter()
-                    .flat_map(|dep_id| constraints[dep_id].dependencies.iter().copied())
-                    .collect();
-                let entry = constraints.get_mut(id).expect("inserted above");
-                for dep_id in transitive_deps {
-                    *changed |= entry.dependencies.insert(dep_id);
-                }
-            }
-        });
-        fixpoint(|changed| {
-            for (id, idx_deps) in index_imports.iter().rev() {
-                let transitive_depts = constraints[id].dependants.clone();
-                if transitive_depts.is_empty() {
-                    continue;
-                }
-                for dep_id in idx_deps {
-                    let entry = constraints.get_mut(dep_id).expect("inserted above");
-                    for dept_id in &transitive_depts {
-                        *changed |= entry.dependants.insert(*dept_id);
-                    }
-                }
-            }
-        });
-
-        constraints
-    }
-
-    /// Returns an `as_of` suitable for bootstrapping the given index or materialized view
-    /// dataflow, along with a [ReadHolds] that ensures the sinces of involved collections
-    /// stay in place.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the given dataflow exports neither an index nor a materialized view.
-    fn bootstrap_dataflow_as_of(
-        &mut self,
-        dataflow: &DataflowDescription<Plan>,
-        cluster_id: ComputeInstanceId,
-        storage_constraints: StorageConstraints,
-        compaction_window: CompactionWindow,
-        local_read_ts: Timestamp,
-    ) -> (Antichain<Timestamp>, ReadHolds<Timestamp>) {
-        // Supporting multi-export dataflows is not impossible but complicates the logic, so we
-        // punt on it until we actually want to create such dataflows.
-        assert!(
-            dataflow.export_ids().count() <= 1,
-            "multi-export dataflows not supported"
+        let read_ts = self.get_local_read_ts().await;
+        let read_holds = as_of_selection::run(
+            &mut dataflows,
+            &read_policies,
+            &*self.controller.storage_collections,
+            read_ts,
         );
 
-        // All inputs must be readable at the chosen `as_of`, so it must be at least the join of
-        // the `since`s of all dependencies.
-        let direct_dependencies = dataflow_import_id_bundle(dataflow, cluster_id);
-
-        // We're putting in place read holds, to prevent the since of
-        // dependencies moving along concurrently, pulling the rug from under
-        // us!
-        let read_holds = self.acquire_read_holds(&direct_dependencies);
-
-        let min_as_of = self.least_valid_read(&read_holds);
-
-        // We must not select an `as_of` that is beyond any times that have not yet been written to
-        // downstream storage collections (i.e., materialized views). If we would, we might skip
-        // times in the output of these storage collections, violating correctness. So our chosen
-        // `as_of` must be at most the meet of the `upper`s of all dependent storage collections.
-        //
-        // An exception are storage collections that have an `upper` that's less than their `since`
-        // (most likely because they have not yet produced their snapshot). For these collections
-        // we only need to provide output starting from their `since`s, so these serve as upper
-        // bounds for our `as_of`.
-        let mut max_as_of = Antichain::new();
-        let dependent_frontiers =
-            self.storage_frontiers(storage_constraints.dependants.iter().cloned().collect());
-        for (_id, since, upper) in dependent_frontiers {
-            max_as_of.meet_assign(&since.join(&upper));
+        let catalog = self.catalog_mut();
+        for (id, plan) in catalog_ids.into_iter().zip(dataflows) {
+            catalog.set_physical_plan(id, plan);
         }
 
-        // For compute reconciliation to recognize that an existing dataflow can be reused, we want
-        // to advance the `as_of` far enough that it is beyond the `as_of`s of all dataflows that
-        // might still be installed on replicas, but ideally not much farther as that would prevent
-        // dataflow warmup.
-        //
-        // The compute controller maintains warmup capabilities for each dataflow, at the meet of
-        // the greatest available read frontiers (i.e. `upper.step_back()`) of all dataflow inputs.
-        // Dataflows installed on replicas are thus prevented from compacting beyond these warmup
-        // frontiers, so if we can reconstruct them, we know that reconciliation will succeed. Note
-        // that to reconstruct a warmup frontier, we must only take into account the frontiers of
-        // (transitive) storage dependencies: The frontiers of index dependencies can regress
-        // across restarts, so we'd risk ending up with a warmup frontier that is too early to
-        // ensure successful reconciliation.
-        //
-        // Note that choosing the warmup frontier only based on storage dependencies means that the
-        // dataflow might have to wait for indexes in between to catch up to this frontier, if
-        // their `as_of` is selected earlier.
-        let storage_dependencies = storage_constraints.dependencies_bundle();
-        let warmup_frontier = self.greatest_available_read(&storage_dependencies);
-
-        // Apply additional constraints based on whether this dataflow exports an index or a
-        // materialized view.
-        let write_frontier;
-        let candidate_as_of = if dataflow.exported_index_ids().next().is_some() {
-            // Index dataflow.
-
-            write_frontier = self.least_valid_write(&storage_dependencies);
-            if let Some(ts) = write_frontier.as_option() {
-                // If the index has a compaction window configured, we should hold back the `as_of`
-                // to ensure this window is queryable after the index was created. Doing so should
-                // not break compute reconciliation because the compute controller should have
-                // prevented replicas from compacting their installed dataflows into the compaction
-                // window.
-                let max_compaction_frontier = Antichain::from_elem(compaction_window.lag_from(*ts));
-                soft_assert_or_log!(
-                    !max_compaction_frontier.is_empty(),
-                    "`max_compaction_frontier` unexpectedly empty",
-                );
-                // We hold back the `as_of` to near the current time. This is needed for indexes on
-                // REFRESH MVs, because otherwise the `as_of` would be near the next refresh time,
-                // making the index unreadable until then.
-                //
-                // This is fine for Compute reconciliation, because Adapter was keeping a read hold
-                // on indexes before the restart at the Oracle read ts (see `advance_timelines`),
-                // and the Oracle read ts can't go backwards between restarts.
-                max_compaction_frontier.meet(&Antichain::from_elem(local_read_ts))
-            } else {
-                // The write frontier is empty. This can happen for constant collections, and for
-                // an index on a REFRESH MV that is past its last refresh. Installing an index with
-                // an empty frontier is not useful since that index would not be readable, so we
-                // bail using the minimum frontier instead. This is something we could refine in
-                // the future.
-                min_as_of.clone()
-            }
-        } else if let Some(sink_id) = dataflow.persist_sink_ids().next() {
-            // Materialized view dataflow.
-
-            let (since, upper) = self
-                .controller
-                .storage
-                .collection_frontiers(sink_id)
-                .expect("collection does not exist");
-
-            // Materialized view dataflows are only depended on by their target storage collection,
-            // so `write_frontier` should never be greater than `max_as_of`.
-            soft_assert_or_log!(
-                PartialOrder::less_equal(&upper, &max_as_of),
-                "`write_frontier` unexpectedly greater than `max_as_of`; \
-                materialized view {sink_id}, max_as_of {max_as_of:?}, since {since:?}, upper {upper:?}",
-            );
-
-            write_frontier = upper;
-
-            // If the target storage collection of a materialized view is already sealed, there is
-            // no need to install a dataflow in the first place.
-            if write_frontier.is_empty() {
-                Antichain::new()
-            } else {
-                warmup_frontier.clone()
-            }
-        } else {
-            // Neither an index nor a materialized view dataflow.
-            panic!("bootstrapping only supports indexes and materialized views");
-        };
-
-        let as_of = if self.controller.read_only() {
-            // Choose something that is most likely to make dependent dataflows
-            // hydrate. But this will likely make it so that reconciliation
-            // cannot re-use already-running dataflows.
-            //
-            // The latter is fine, though, because in read-only mode we're
-            // likely bringing up new cluster processes anyways.
-            //
-            // NOTE: This is working around a quirk in how we normally select
-            // as_ofs for dataflows: we don't take dependent dataflows into
-            // account when bounding the as_of, so it can happen that we end up
-            // in a situation where a downstream dataflow cannot hydrate even
-            // though it's transitive storage collection dependencies would have
-            // the data at the as_of that is required. This is a band-aid
-            // solution until we have
-            // https://github.com/MaterializeInc/materialize/issues/28440
-            min_as_of.clone()
-        } else if PartialOrder::less_equal(&min_as_of, &max_as_of) {
-            // Determine the `as_of` by bounding the candidate from below and above by the
-            // correctness constraints `min_as_of` and `max_as_of`, respectively.
-            candidate_as_of.join(&min_as_of).meet(&max_as_of)
-        } else {
-            // This should not happen. If we get here that means we _will_ skip times in some of
-            // the dependent storage collections, which is a correctness bug. However, skipping
-            // times is probably preferable to panicking and thus making the entire environment
-            // unavailable. So we chose to handle this case gracefully and only log an error,
-            // unless soft-asserts are enabled, and continue with the `min_as_of` to make us skip
-            // as few times as possible.
-            mz_ore::soft_panic_or_log!(
-                "error bootstrapping dataflow `as_of`: \
-                 `min_as_of` {:?} greater than `max_as_of` {:?} \
-                 (import_ids={}, export_ids={}, storage_constraints={:?})",
-                min_as_of.elements(),
-                max_as_of.elements(),
-                dataflow.display_import_ids(),
-                dataflow.display_export_ids(),
-                storage_constraints,
-            );
-            min_as_of.clone()
-        };
-
-        tracing::info!(
-            export_ids = %dataflow.display_export_ids(),
-            %cluster_id,
-            as_of = ?as_of.elements(),
-            min_as_of = ?min_as_of.elements(),
-            max_as_of = ?max_as_of.elements(),
-            warmup_frontier = ?warmup_frontier.elements(),
-            ?local_read_ts,
-            write_frontier = ?write_frontier.elements(),
-            ?compaction_window,
-            ?storage_constraints,
-            "bootstrapping dataflow `as_of`",
-        );
-
-        (as_of, read_holds)
+        read_holds
     }
 
     /// Serves the coordinator, receiving commands from users over `cmd_rx`
@@ -4206,27 +3926,6 @@ pub async fn load_remote_system_parameters(
         }
     } else {
         Ok(None)
-    }
-}
-
-/// The set of storage collections that constrain bootstrap timestamp selection for a given
-/// dataflow.
-///
-/// The set of constraints includes both dependencies and dependants, which constrain the valid
-/// timestamps from below and above, respectively. It includes transitive dependencies/dependants
-/// through indexes, but not through other storage collections.
-#[derive(Debug, Default)]
-struct StorageConstraints {
-    dependencies: BTreeSet<GlobalId>,
-    dependants: BTreeSet<GlobalId>,
-}
-
-impl StorageConstraints {
-    fn dependencies_bundle(&self) -> CollectionIdBundle {
-        CollectionIdBundle {
-            storage_ids: self.dependencies.clone(),
-            compute_ids: Default::default(),
-        }
     }
 }
 

--- a/src/compute-client/src/as_of_selection.rs
+++ b/src/compute-client/src/as_of_selection.rs
@@ -1,0 +1,530 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Support for selecting as-ofs of compute dataflows during system initialization.
+//!
+//! The functionality implemented here is invoked by the coordinator during its bootstrap process.
+//! Ideally, it would be part of the controller and transparent to the coordinator, but that's
+//! difficult to reconcile with the current controller API. For now, we still make the coordinator
+//! worry about as-of selection but keep the implementation in a compute crate because it really is
+//! a compute implementation concern.
+//!
+//! The as-of selection process takes a list of `DataflowDescription`s, determines compatible
+//! as-ofs for the compute collections they export, and augments the `DataflowDescription`s with
+//! these as-ofs.
+//!
+//! For each compute collection, the as-of selection process keeps an `AsOfBounds` instance that
+//! tracks a lower and an upper bound for the as-of the collection may get assigned. Throughout the
+//! process, a collection's `AsOfBounds` get repeatedly refined, by increasing the lower bound and
+//! decreasing the upper bound. The final upper bound is then used for the collection as-of. Using
+//! the upper bound maximizes the chances of compute reconciliation being effective, and minimizes
+//! the amount of historical data that must be read from the dataflow sources.
+//!
+//! Refinement of `AsOfBounds` is performed by applying `Constraint`s to collections. A
+//! `Constraint` specifies which bound should be refined to which frontier. A `Constraint` may be
+//! "hard" or "soft", which determines how failure to apply it is handled. Failing to apply a hard
+//! constraint is treated as an error, failing to apply a soft constraint is not. If a constraint
+//! fails to apply, the respective `AsOfBounds` are refined as much as possible (to a single
+//! frontier) and marked as "sealed". Subsequent constraint applications against the sealed bounds
+//! are no-ops. This is done to avoid log noise from repeated constraint application failures.
+//!
+//! Note that failing to apply a hard constraint does not abort the as-of selection process for the
+//! affected collection. Instead the failure is handled gracefully by logging an error and
+//! assigning the collection a best-effort as-of. This is done, rather than panicking or returning
+//! an error and letting the coordinator panic, to ensure the availability of the system. Ideally,
+//! we would instead mark the affected dataflow as failed/poisoned, but such a mechanism doesn't
+//! currently exist.
+//!
+//! The as-of selection process applies constraints in order of importance, because once a
+//! constraint application fails, the respective `AsOfBounds` are sealed and later applications
+//! won't have any effect. This means hard constraints must be applied before soft constraints, and
+//! more desirable soft constraints should be applied before less desirable ones.
+//!
+//! # `AsOfBounds` Invariants
+//!
+//! Correctness requires two invariants of `AsOfBounds` of dependent collections:
+//!
+//!  (1) The lower bound of a collection is >= the lower bound of each of its inputs.
+//!  (2) The upper bound of a collection is >= the upper bound of each of its inputs.
+//!
+//! Each step of the as-of selection process needs to ensure that these invariants are upheld once
+//! it completes. The expectation is that each step (a) performs local changes to either the
+//! `lower` _or_ the `upper` bounds of some collections and (b) invokes the appropriate
+//! `propagate_bounds_*` method to restore the invariant broken by (a).
+//!
+//! For steps that behave as described in (a), we can prove that (b) will always succeed in
+//! applying the bounds propagation constraints:
+//!
+//!     Let `A` and `B` be any pair of collections where `A` is an input of `B`.
+//!     Before (a), both invariants are upheld, i.e. `A.lower <= B.lower` and `A.upper <= B.upper`.
+//!
+//!     Case 1: (a) increases `A.lower` and/or `B.lower` to `A.lower'` and `B.lower'`
+//!         Invariant (1) might be broken, need to prove that it can be restored.
+//!         Case 1.a: `A.lower' <= B.lower'`
+//!             Invariant (1) is still upheld without propagation.
+//!         Case 1.b: `A.lower' > B.lower'`
+//!             A collection's lower bound can only be increased up to its upper bound.
+//!             Therefore, and from invariant (2): `A.lower' <= A.upper <= B.upper`
+//!             Therefore, propagation can set `B.lower' = A.lower'`, restoring invariant (1).
+//!     Case 2: (a) decreases `A.upper` and/or `B.upper`
+//!         Invariant (2) might be broken, need to prove that it can be restored.
+//!         The proof is equivalent to Case 1.
+//!
+//! Because the bounds propagation is guaranteed to succeed, provided each step of the as-of
+//! selection process only modifies either lower or upper bounds, the `propagate_bounds_*` methods
+//! always apply hard constraints, even when they are invoked during a soft-constraint step.
+//! Failing to apply a constraint while propagating bounds is a bug.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::rc::Rc;
+
+use differential_dataflow::lattice::Lattice;
+use mz_compute_types::dataflows::DataflowDescription;
+use mz_compute_types::plan::Plan;
+use mz_ore::collections::CollectionExt;
+use mz_ore::soft_panic_or_log;
+use mz_repr::GlobalId;
+use mz_storage_client::storage_collections::StorageCollections;
+use mz_storage_types::read_holds::ReadHold;
+use timely::progress::{Antichain, Timestamp};
+use timely::PartialOrder;
+use tracing::{info, warn};
+
+/// Runs as-of selection for the given dataflows.
+///
+/// Assigns the selected as-of to the provided dataflow descriptions and returns a set of
+/// `ReadHold`s that must not be dropped nor downgraded until the dataflows have been installed
+/// with the compute controller.
+pub fn run<T: Timestamp + Lattice>(
+    dataflows: &mut [DataflowDescription<Plan<T>, (), T>],
+    storage_collections: &dyn StorageCollections<Timestamp = T>,
+) -> BTreeMap<GlobalId, ReadHold<T>> {
+    // Get read holds for the storage inputs of the dataflows.
+    // This ensures that storage frontiers don't advance past the selected as-ofs.
+    let mut storage_read_holds = BTreeMap::new();
+    for dataflow in &*dataflows {
+        for id in dataflow.source_imports.keys() {
+            if !storage_read_holds.contains_key(id) {
+                let read_hold = storage_collections
+                    .acquire_read_holds(vec![*id])
+                    .expect("storage collection exists")
+                    .into_element();
+                storage_read_holds.insert(*id, read_hold);
+            }
+        }
+    }
+
+    let ctx = Context::new(dataflows, storage_collections);
+
+    // Apply hard constraints from upstream and downstream storage collections.
+    ctx.apply_upstream_storage_constraints(&storage_read_holds);
+    ctx.apply_downstream_storage_constraints();
+
+    // At this point all collections have as-of bounds that reflect what is required for
+    // correctness. The current state isn't very usable though. In particular, most of the upper
+    // bounds are likely to be the empty frontier, so if we'd select as-ofs on this basis, the
+    // resulting dataflows would never hydrate. Instead we'll apply a number of soft constraints to
+    // end up in a better place.
+
+    // TODO: soft constraints
+
+    // Apply the derived as-of bounds to the dataflows.
+    for dataflow in dataflows {
+        // `AsOfBounds` are shared between the exports of a dataflow, so looking at just the first
+        // export is sufficient.
+        let first_export = dataflow.export_ids().next();
+        let as_of = first_export.map_or(Antichain::new(), |id| ctx.best_as_of(id));
+        dataflow.as_of = Some(as_of);
+    }
+
+    storage_read_holds
+}
+
+/// Bounds for possible as-of values of a dataflow.
+#[derive(Debug)]
+struct AsOfBounds<T> {
+    lower: Antichain<T>,
+    upper: Antichain<T>,
+    /// Whether these bounds can still change.
+    sealed: bool,
+}
+
+impl<T: Clone> AsOfBounds<T> {
+    /// Creates an `AsOfBounds` that only allows the given `frontier`.
+    fn single(frontier: Antichain<T>) -> Self {
+        Self {
+            lower: frontier.clone(),
+            upper: frontier,
+            sealed: false,
+        }
+    }
+
+    /// Get the bound of the given type.
+    fn get(&self, type_: BoundType) -> &Antichain<T> {
+        match type_ {
+            BoundType::Lower => &self.lower,
+            BoundType::Upper => &self.upper,
+        }
+    }
+}
+
+impl<T: Timestamp> Default for AsOfBounds<T> {
+    fn default() -> Self {
+        Self {
+            lower: Antichain::from_elem(T::minimum()),
+            upper: Antichain::new(),
+            sealed: false,
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Display for AsOfBounds<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{:?} .. {:?}]",
+            self.lower.elements(),
+            self.upper.elements()
+        )
+    }
+}
+
+/// Types of bounds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BoundType {
+    Lower,
+    Upper,
+}
+
+impl fmt::Display for BoundType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Lower => f.write_str("lower"),
+            Self::Upper => f.write_str("upper"),
+        }
+    }
+}
+
+/// Types of constraints.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConstraintType {
+    /// Hard constraints are applied to enforce correctness properties, and failing to apply them is
+    /// an error.
+    Hard,
+    /// Soft constraints are applied to improve performance or UX, and failing to apply them is
+    /// undesirable but not an error.
+    Soft,
+}
+
+/// A constraint that can be applied to the `AsOfBounds` of a collection.
+#[derive(Debug)]
+struct Constraint<'a, T> {
+    type_: ConstraintType,
+    /// Which bound this constraint applies to.
+    bound_type: BoundType,
+    /// The frontier by which the bound should be constrained.
+    frontier: &'a Antichain<T>,
+    /// A short description of the reason for applying this constraint.
+    ///
+    /// Used only for logging.
+    reason: &'a str,
+}
+
+impl<T: Timestamp> Constraint<'_, T> {
+    /// Applies this constraint to the given bounds.
+    ///
+    /// Returns a bool indicating whether the given bounds were changed as a result.
+    ///
+    /// Applying a constraint can fail, if the constraint frontier is incompatible with the
+    /// existing bounds. In this case, the constraint still gets partially applied by moving one of
+    /// the bounds up/down to the other, depending on the `bound_type`.
+    ///
+    /// Applying a constraint to sealed bounds is a no-op.
+    fn apply(&self, bounds: &mut AsOfBounds<T>) -> Result<bool, bool> {
+        if bounds.sealed {
+            return Ok(false);
+        }
+
+        match self.bound_type {
+            BoundType::Lower => {
+                if PartialOrder::less_than(&bounds.upper, self.frontier) {
+                    bounds.sealed = true;
+                    if PartialOrder::less_than(&bounds.lower, &bounds.upper) {
+                        bounds.lower.clone_from(&bounds.upper);
+                        Err(true)
+                    } else {
+                        Err(false)
+                    }
+                } else if PartialOrder::less_equal(self.frontier, &bounds.lower) {
+                    Ok(false)
+                } else {
+                    bounds.lower.clone_from(self.frontier);
+                    Ok(true)
+                }
+            }
+            BoundType::Upper => {
+                if PartialOrder::less_than(self.frontier, &bounds.lower) {
+                    bounds.sealed = true;
+                    if PartialOrder::less_than(&bounds.lower, &bounds.upper) {
+                        bounds.upper.clone_from(&bounds.lower);
+                        Err(true)
+                    } else {
+                        Err(false)
+                    }
+                } else if PartialOrder::less_equal(&bounds.upper, self.frontier) {
+                    Ok(false)
+                } else {
+                    bounds.upper.clone_from(self.frontier);
+                    Ok(true)
+                }
+            }
+        }
+    }
+}
+
+/// State tracked for a compute collection during as-of selection.
+struct Collection<T> {
+    storage_inputs: Vec<GlobalId>,
+    compute_inputs: Vec<GlobalId>,
+    /// The currently known as-of bounds.
+    ///
+    /// Shared between collections exported by the same dataflow.
+    bounds: Rc<RefCell<AsOfBounds<T>>>,
+}
+
+/// The as-of selection context.
+struct Context<'a, T> {
+    collections: BTreeMap<GlobalId, Collection<T>>,
+    storage_collections: &'a dyn StorageCollections<Timestamp = T>,
+}
+
+impl<'a, T: Timestamp + Lattice> Context<'a, T> {
+    /// Initializes an as-of selection context for the given `dataflows`.
+    fn new(
+        dataflows: &[DataflowDescription<Plan<T>, (), T>],
+        storage_collections: &'a dyn StorageCollections<Timestamp = T>,
+    ) -> Self {
+        // Construct initial collection state for each dataflow export. Dataflows might have their
+        // as-ofs already fixed, which we need to take into account when constructing `AsOfBounds`.
+        let mut collections = BTreeMap::new();
+        for dataflow in dataflows {
+            let storage_inputs: Vec<_> = dataflow.source_imports.keys().copied().collect();
+            let compute_inputs: Vec<_> = dataflow.index_imports.keys().copied().collect();
+
+            let bounds = match dataflow.as_of.clone() {
+                Some(frontier) => AsOfBounds::single(frontier),
+                None => AsOfBounds::default(),
+            };
+            let bounds = Rc::new(RefCell::new(bounds));
+
+            for id in dataflow.export_ids() {
+                let collection = Collection {
+                    storage_inputs: storage_inputs.clone(),
+                    compute_inputs: compute_inputs.clone(),
+                    bounds: Rc::clone(&bounds),
+                };
+                collections.insert(id, collection);
+            }
+        }
+
+        Self {
+            collections,
+            storage_collections,
+        }
+    }
+
+    /// Returns the state of the identified collection.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the identified collection doesn't exist.
+    fn expect_collection(&self, id: GlobalId) -> &Collection<T> {
+        self.collections
+            .get(&id)
+            .unwrap_or_else(|| panic!("collection missing: {id}"))
+    }
+
+    /// Applies the given as-of constraint to the identified collection.
+    ///
+    /// Returns whether the collection's as-of bounds where changed as a result.
+    fn apply_constraint(&self, id: GlobalId, constraint: Constraint<T>) -> bool {
+        let collection = self.expect_collection(id);
+        let mut bounds = collection.bounds.borrow_mut();
+        match constraint.apply(&mut bounds) {
+            Ok(changed) => {
+                if changed {
+                    info!(%id, %bounds, reason = %constraint.reason, "applied as-of constraint");
+                }
+                changed
+            }
+            Err(changed) => {
+                match constraint.type_ {
+                    ConstraintType::Hard => {
+                        soft_panic_or_log!(
+                            "failed to apply hard as-of constraint \
+                             (id={id}, bounds={bounds}, constraint={constraint:?})"
+                        );
+                    }
+                    ConstraintType::Soft => {
+                        warn!(%id, %bounds, ?constraint, "failed to apply soft as-of constraint");
+                    }
+                }
+                changed
+            }
+        }
+    }
+
+    /// Apply as-of constraints imposed by the frontiers of upstream storage collections.
+    ///
+    /// A collection's as-of _must_ be >= the read frontier of each of its (transitive) storage
+    /// inputs.
+    ///
+    /// Failing to apply this constraint to a collection is an error. The affected dataflow will
+    /// not be able to hydrate successfully.
+    fn apply_upstream_storage_constraints(
+        &self,
+        storage_read_holds: &BTreeMap<GlobalId, ReadHold<T>>,
+    ) {
+        // Apply direct constraints from storage inputs.
+        for (id, collection) in &self.collections {
+            for input_id in &collection.storage_inputs {
+                let read_hold = &storage_read_holds[input_id];
+                let constraint = Constraint {
+                    type_: ConstraintType::Hard,
+                    bound_type: BoundType::Lower,
+                    frontier: read_hold.since(),
+                    reason: &format!("storage input {input_id} read frontier"),
+                };
+                self.apply_constraint(*id, constraint);
+            }
+        }
+
+        // Propagate constraints downstream, restoring `AsOfBounds` invariant (1).
+        self.propagate_bounds_downstream(BoundType::Lower);
+    }
+
+    /// Apply as-of constraints imposed by the frontiers of downstream storage collections.
+    ///
+    /// A collection's as-of _must_ be <= the join of the read frontier and the write frontier of
+    /// the storage collection it exports to, if any.
+    ///
+    /// We need to consider the read frontier in addition to the write frontier because storage
+    /// collections are commonly initialyzed with a write frontier of `[0]`, even when they start
+    /// producing output at some later time. The read frontier is always initialized to the first
+    /// time the collection will produce valid output for, so it constrains the times that need to
+    /// be produced by dependencies of newly initialized storage collections.
+    ///
+    /// Failing to apply this constraint to a collection is an error. The storage collection it
+    /// exports to will have times visible to readers skipped in its output, violating correctness.
+    fn apply_downstream_storage_constraints(&self) {
+        // Apply direct constraints from storage exports.
+        for id in self.collections.keys() {
+            let Ok(frontiers) = self.storage_collections.collection_frontiers(*id) else {
+                continue;
+            };
+            let upper = frontiers.read_capabilities.join(&frontiers.write_frontier);
+            let constraint = Constraint {
+                type_: ConstraintType::Hard,
+                bound_type: BoundType::Upper,
+                frontier: &upper,
+                reason: &format!("storage export {id} write frontier"),
+            };
+            self.apply_constraint(*id, constraint);
+        }
+
+        // Propagate constraints upstream, restoring `AsOfBounds` invariant (2).
+        self.propagate_bounds_upstream(BoundType::Upper);
+    }
+
+    /// Propagate as-of bounds through the dependency graph, in downstream direction.
+    fn propagate_bounds_downstream(&self, bound_type: BoundType) {
+        // We don't want to rely on a correspondence between `GlobalId` order and dependency order,
+        // so we use a fixpoint loop here.
+        fixpoint(|changed| {
+            self.propagate_bounds_downstream_inner(bound_type, changed);
+
+            // Propagating `upper` bounds downstream might break `AsOfBounds` invariant (2), so we
+            // need to restore it.
+            if bound_type == BoundType::Upper {
+                self.propagate_bounds_upstream_inner(BoundType::Upper, changed);
+            }
+        });
+    }
+
+    fn propagate_bounds_downstream_inner(&self, bound_type: BoundType, changed: &mut bool) {
+        for (id, collection) in &self.collections {
+            for input_id in &collection.compute_inputs {
+                let input_collection = self.expect_collection(*input_id);
+                let bounds = input_collection.bounds.borrow();
+                let constraint = Constraint {
+                    type_: ConstraintType::Hard,
+                    bound_type,
+                    frontier: bounds.get(bound_type),
+                    reason: &format!("upstream {input_id} {bound_type} as-of bound"),
+                };
+                *changed |= self.apply_constraint(*id, constraint);
+            }
+        }
+    }
+
+    /// Propagate as-of bounds through the dependency graph, in upstream direction.
+    fn propagate_bounds_upstream(&self, bound_type: BoundType) {
+        // We don't want to rely on a correspondence between `GlobalId` order and dependency order,
+        // so we use a fixpoint loop here.
+        fixpoint(|changed| {
+            self.propagate_bounds_upstream_inner(bound_type, changed);
+
+            // Propagating `lower` bounds upstream might break `AsOfBounds` invariant (1), so we
+            // need to restore it.
+            if bound_type == BoundType::Lower {
+                self.propagate_bounds_downstream_inner(BoundType::Lower, changed);
+            }
+        });
+    }
+
+    fn propagate_bounds_upstream_inner(&self, bound_type: BoundType, changed: &mut bool) {
+        for (id, collection) in self.collections.iter().rev() {
+            let bounds = collection.bounds.borrow();
+            for input_id in &collection.compute_inputs {
+                let constraint = Constraint {
+                    type_: ConstraintType::Hard,
+                    bound_type,
+                    frontier: bounds.get(bound_type),
+                    reason: &format!("downstream {id} {bound_type} as-of bound"),
+                };
+                *changed |= self.apply_constraint(*input_id, constraint);
+            }
+        }
+    }
+
+    /// Selects the "best" as-of for the identified collection, based on its currently known
+    /// bounds.
+    ///
+    /// We simply use the upper bound here, to maximize the chances of compute reconciliation
+    /// succeeding. Choosing the latest possible as-of also minimizes the amount of work the
+    /// dataflow has to spend processing historical data from its sources.
+    fn best_as_of(&self, id: GlobalId) -> Antichain<T> {
+        let collection = self.expect_collection(id);
+        let bounds = collection.bounds.borrow();
+        bounds.upper.clone()
+    }
+}
+
+/// Runs `step` in a loop until it stops reporting changes.
+fn fixpoint(mut step: impl FnMut(&mut bool)) {
+    loop {
+        let mut changed = false;
+        step(&mut changed);
+        if !changed {
+            break;
+        }
+    }
+}

--- a/src/compute-client/src/lib.rs
+++ b/src/compute-client/src/lib.rs
@@ -11,6 +11,7 @@
 
 //! The public API for the compute layer.
 
+pub mod as_of_selection;
 pub mod controller;
 pub mod logging;
 pub mod metrics;


### PR DESCRIPTION
This PR is a refactor of the as-of bootstrapping process. Currently that logic resides in the coordinator and is split between two methods, `collect_dataflow_storage_constraints` and `bootstrap_dataflow_as_of`, and has some issues:

* It's hard to follow because as-of constraints apply in both directions (downstream and upstream) but `bootstrap_dataflow_as_of` only receives dataflows one at a time, in dependency order. `collect_dataflow_storage_constraints` exists to work around this limitation, supplying information about downstream constraints.
* It is not always able to select as-ofs at which the respective dataflows can hydrate immediately (#28440). This follows directly from the limited insight in constraints imposed by downstream objects and is an issue for 0dt.
* It's implemented in adapter code, even though the cluster team is the de-facto owner of the logic.

This PR tries to address all of these concerns by:

* Moving the as-of selection process into a cluster crate, specifically `mz-compute-client`.
* Supplying the as-of selection process with the full set of dependent dataflows, rather than one at a time.
* Changing the as-of selection process to be more explicit about (a) the current lower and upper bounds for the as-of of each compute collection and (b) the constraints applied to these bounds.

The hope is that the result is more readable and easier to change than what we had before.

### Motivation

  * This PR fixes a recognized bug.

Fixes #28440 

### Tips for reviewer

I had considered making bootstrap as-of selection transparent to adapter by moving it into the controller and running it on `initialization_complete`. That approach ran into issues because adapter wants to take read holds before calling `initialization_complete` and we can't provide them when we don't know the as-ofs yet. This is fixable (e.g. by changing adapter to take read holds later) but it's not clear if the added complexity is worth it.

The new as-of selection process should be mostly equivalent in the outcome to the old one, even though its implementation looks considerably different. The only functional change should be that we do a better job of propagating constraints between dependent dataflows now. In particular, the "warmup" constraint is now effective in ensuring that all collections can immediately hydrate (provided the storage frontiers allow that), whereas it couldn't always ensure that before.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
