### PR TITLE
Update netio dns error to be more informative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5601,6 +5601,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "stacker",
+ "thiserror",
  "tokio",
  "tokio-native-tls",
  "tokio-openssl",

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -58,6 +58,7 @@ tokio = { version = "1.38.0", features = [
   "time",
 ], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
+thiserror = "1.0.37"
 tracing-capture = { version = "0.1.0", optional = true }
 # TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
 # The `tracing-log` feature here is load-bearing: While our busiest-logging dependency (`rdkafka`) is now hooked-up

--- a/src/ore/src/netio.rs
+++ b/src/ore/src/netio.rs
@@ -22,7 +22,7 @@ mod read_exact;
 mod socket;
 
 pub use crate::netio::async_ready::AsyncReady;
-pub use crate::netio::dns::resolve_address;
+pub use crate::netio::dns::{resolve_address, DnsResolutionError};
 pub use crate::netio::framed::{FrameTooBig, MAX_FRAME_SIZE};
 pub use crate::netio::read_exact::{read_exact_or_eof, ReadExactOrEof};
 pub use crate::netio::socket::{Listener, SocketAddr, SocketAddrType, Stream, UnixSocketAddr};

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -995,6 +995,8 @@ pub enum ContextCreationError {
     #[error(transparent)]
     KafkaError(#[from] KafkaError),
     #[error(transparent)]
+    Dns(#[from] mz_ore::netio::DnsResolutionError),
+    #[error(transparent)]
     Other(#[from] anyhow::Error),
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -1042,6 +1044,9 @@ where
                 ContextCreationError::Io(e) => {
                     ContextCreationError::Other(anyhow!(anyhow!(e).context(msg)))
                 }
+                ContextCreationError::Dns(e) => {
+                    ContextCreationError::Other(anyhow!(e).context(msg))
+                }
             }
         })
     }
@@ -1069,6 +1074,8 @@ pub enum CsrConnectError {
     NativeTls(#[from] native_tls::Error),
     #[error(transparent)]
     Openssl(#[from] openssl::error::ErrorStack),
+    #[error(transparent)]
+    Dns(#[from] mz_ore::netio::DnsResolutionError),
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error(transparent)]

--- a/test/mysql-cdc/mysql-cdc.td
+++ b/test/mysql-cdc/mysql-cdc.td
@@ -228,7 +228,7 @@ ALTER SYSTEM SET storage_enforce_external_addresses = true
     USER root,
     PASSWORD SECRET mysqlpass
   )
-contains:address is not global
+contains:Address resolved to a private IP
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET storage_enforce_external_addresses = false

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -236,7 +236,7 @@ ALTER SYSTEM SET storage_enforce_external_addresses = true
     USER postgres,
     PASSWORD SECRET pgpass
   )
-contains:address is not global
+contains:Address resolved to a private IP
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET storage_enforce_external_addresses = false

--- a/test/ssh-connection/ssh-connections.td
+++ b/test/ssh-connection/ssh-connections.td
@@ -141,7 +141,7 @@ contains:failed to
   );
 
 ! VALIDATE CONNECTION local;
-contains:address is not global
+contains:Address resolved to a private IP
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET storage_enforce_external_addresses = false

--- a/test/testdrive/connection-create-external.td
+++ b/test/testdrive/connection-create-external.td
@@ -68,7 +68,7 @@ $ kafka-ingest format=avro topic=csr_test key-format=avro key-schema=${keyschema
 ! CREATE CONNECTION csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
   ) WITH (VALIDATE = true);
-contains:address is not global
+contains:Address resolved to a private IP
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET storage_enforce_external_addresses = false


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Unfortunately there doesn't seem to be a way to add a `hint()` method to this error enum that would actually be used anywhere, since each of the `Connection` implementations that use this convert all errors to an `anyhow::Error` and hide the underlying type behind that opaque type. I tried to make the display message as informative as possible.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
