### PR TITLE
catalog: Clean up state update docs and name

### DIFF
--- a/src/catalog/src/durable/objects/serialization.rs
+++ b/src/catalog/src/durable/objects/serialization.rs
@@ -39,7 +39,7 @@ use std::time::Duration;
 use crate::durable::objects::serialization::proto::{
     cluster_schedule, ClusterScheduleRefreshOptions, Empty,
 };
-use crate::durable::objects::state_update::StateUpdateKindRaw;
+use crate::durable::objects::state_update::StateUpdateKindJson;
 use crate::durable::objects::{
     AuditLogKey, ClusterIntrospectionSourceIndexKey, ClusterIntrospectionSourceIndexValue,
     ClusterKey, ClusterReplicaKey, ClusterReplicaValue, ClusterValue, CommentKey, CommentValue,
@@ -58,16 +58,16 @@ pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/objects.rs"));
 }
 
-impl From<proto::StateUpdateKind> for StateUpdateKindRaw {
+impl From<proto::StateUpdateKind> for StateUpdateKindJson {
     fn from(value: proto::StateUpdateKind) -> Self {
-        StateUpdateKindRaw::from_serde(&value)
+        StateUpdateKindJson::from_serde(&value)
     }
 }
 
-impl TryFrom<StateUpdateKindRaw> for proto::StateUpdateKind {
+impl TryFrom<StateUpdateKindJson> for proto::StateUpdateKind {
     type Error = String;
 
-    fn try_from(value: StateUpdateKindRaw) -> Result<Self, Self::Error> {
+    fn try_from(value: StateUpdateKindJson) -> Result<Self, Self::Error> {
         value.try_to_serde::<Self>().map_err(|err| err.to_string())
     }
 }

--- a/src/catalog/src/durable/upgrade/tests.rs
+++ b/src/catalog/src/durable/upgrade/tests.rs
@@ -16,7 +16,7 @@ use std::io::Write;
 use mz_persist_types::Codec;
 use mz_storage_types::sources::SourceData;
 
-use crate::durable::objects::state_update::StateUpdateKindRaw;
+use crate::durable::objects::state_update::StateUpdateKindJson;
 use crate::durable::upgrade::AllVersionsStateUpdateKind;
 
 static PROTO_DIRECTORY: Lazy<String> =
@@ -66,7 +66,7 @@ fn test_proto_serialization_stability() {
             .lines()
             .map(|s| base64::decode_config(s, base64_config).expect("valid base64"))
             .map(|b| SourceData::decode(&b, &relation_desc).expect("valid proto"))
-            .map(StateUpdateKindRaw::from)
+            .map(StateUpdateKindJson::from)
             .map(|raw| {
                 AllVersionsStateUpdateKind::try_from_raw(&snapshot_file, raw)
                     .expect("valid version and raw")


### PR DESCRIPTION
This commit cleans up the catalog state update naming and documentation in an attempt to make it more understandable.

### Motivation
This PR refactors existing code.

### Tips for reviewer
This is all renaming and adding docs, no logic has changed.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
