### PR TITLE
parallel-workload: More logging to figure out #28983

### DIFF
--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -93,6 +93,8 @@ ERROR_RE = re.compile(
     | possibly\ invalid\ operation\ specification
     # for miri test summary
     | (FAIL|TIMEOUT)\s+\[\s*\d+\.\d+s\]
+    # parallel-workload
+    | worker_.*\ still\ running: [\s\S]* Threads\ have\ not\ stopped\ within\ 5\ minutes,\ exiting\ hard
     )
     .* $
     """,

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -80,10 +80,10 @@ class Executor:
     def commit(self, http: Http = Http.RANDOM) -> None:
         self.insert_table = None
         try:
-            self.log("commit")
             if self.use_ws and http != Http.NO:
                 self.execute("commit")
             else:
+                self.log("commit")
                 self.cur._c.commit()
         except QueryError:
             raise
@@ -95,10 +95,10 @@ class Executor:
     def rollback(self, http: Http = Http.RANDOM) -> None:
         self.insert_table = None
         try:
-            self.log("rollback")
             if self.use_ws and http != Http.NO:
                 self.execute("rollback")
             else:
+                self.log("rollback")
                 self.cur._c.rollback()
         except QueryError:
             raise
@@ -117,7 +117,7 @@ class Executor:
         self.last_log = msg
 
         with lock:
-            print(f"[{thread_name}] {msg}", file=logging)
+            print(f"[{thread_name}][{self.mz_service}] {msg}", file=logging)
             logging.flush()
 
     def execute(

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -353,12 +353,14 @@ def run(
     else:
         for worker, thread in zip(workers, threads):
             if thread.is_alive():
-                print(f"{thread.name} still running: {worker.exe.last_log}")
-        print("Threads have not stopped within 5 minutes, exiting hard")
+                print(
+                    f"{thread.name} still running ({worker.exe.mz_service}): {worker.exe.last_log}"
+                )
         print_stats(num_queries, workers, num_threads)
         if num_threads >= 50:
             # Under high load some queries can't finish quickly, especially UPDATE/DELETE
             os._exit(0)
+        print("Threads have not stopped within 5 minutes, exiting hard")
         os._exit(1)
 
     try:


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
