### PR TITLE
test: upgrade to Redpanda v24.2.2

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/redpanda.py
+++ b/misc/python/materialize/cloudtest/k8s/redpanda.py
@@ -31,7 +31,7 @@ class RedpandaDeployment(K8sDeployment):
         super().__init__(namespace)
         container = V1Container(
             name="redpanda",
-            image="vectorized/redpanda:v24.1.9",
+            image="vectorized/redpanda:v24.2.2",
             command=[
                 "/usr/bin/rpk",
                 "redpanda",

--- a/misc/python/materialize/mzcompose/services/redpanda.py
+++ b/misc/python/materialize/mzcompose/services/redpanda.py
@@ -18,7 +18,7 @@ class Redpanda(Service):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v24.1.9",
+        version: str = "v24.2.2",
         auto_create_topics: bool = False,
         image: str | None = None,
         aliases: list[str] | None = None,

--- a/misc/python/materialize/mzcompose/services/redpanda.py
+++ b/misc/python/materialize/mzcompose/services/redpanda.py
@@ -13,12 +13,14 @@ from materialize.mzcompose.service import (
     ServiceConfig,
 )
 
+REDPANDA_VERSION = "v24.2.2"
+
 
 class Redpanda(Service):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v24.2.2",
+        version: str = REDPANDA_VERSION,
         auto_create_topics: bool = False,
         image: str | None = None,
         aliases: list[str] | None = None,

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -11,12 +11,19 @@ from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.localstack import Localstack
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.redpanda import Redpanda
+from materialize.mzcompose.services.redpanda import REDPANDA_VERSION, Redpanda
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
 
-REDPANDA_VERSIONS = ["v22.3.25", "v23.1.21", "v23.2.29", "v23.3.18", "v24.1.9"]
+REDPANDA_VERSIONS = [
+    "v22.3.25",
+    "v23.1.21",
+    "v23.2.29",
+    "v23.3.18",
+    "v24.1.9",
+    REDPANDA_VERSION,
+]
 
 CONFLUENT_PLATFORM_VERSIONS = [
     "7.0.14",

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -89,11 +89,6 @@ def workflow_sink_networking(c: Composition, parser: WorkflowArgumentParser) -> 
 
 def workflow_sink_kafka_restart(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parse_args(parser)
-    if args.redpanda:
-        print(
-            "Test disabled with Redpanda, TODO: Enable when incidents-and-escalations#33 is fixed"
-        )
-        return
 
     # Sleeping for 5s before the transaction commits virtually guarantees that
     # there will be an open transaction when the Kafka/Redpanda service is


### PR DESCRIPTION
Redpanda v24.2 includes a fix that allows our sinks to restart after a Redpanda broker failure without waiting out the full transaction timeout (often 10m+).

For details about the original issue and the fix in Redpanda, see:

  * redpanda-data/redpanda#19889
  * MaterializeInc/incidents-and-escalations#33

Fix MaterializeInc/incidents-and-escalations#33.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
