### PR TITLE
dbt-materialize: fix `dbt seed` command

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,21 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Fix a bug in the `materialize__drop_relation` macro that prevented using the
+  [`--full-refresh` flag](https://docs.getdbt.com/reference/resource-configs/full_refresh)
+  (or the `full_refresh` configuration) with `dbt seed`.
+
+* Fix a bug that would prevent `dbt seed` from succeeding on subsequent runs
+  without a valid default cluster. It's important to note that this scenario
+  will still fail if no cluster is specified for the target in
+  `profiles.yml` _and_ the default cluster for the user is invalid
+  (or intentionally set to `mz_catalog_server`, which cannot query user data).
+
+* Produce an error message when attempting to use the [`grants` configuration](https://docs.getdbt.com/reference/resource-configs/grants),
+  which is not supported in the adapter. This configuration will be supported in
+  the future (see [#20244](https://github.com/MaterializeInc/materialize/issues/20244)).
+
 ## 1.8.4 - 2024-08-07
 
 * Include the dbt version in the `application_name` connection parameter [#28813](https://github.com/MaterializeInc/materialize/pull/28813).

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -16,6 +16,13 @@
   which is not supported in the adapter. This configuration will be supported in
   the future (see [#20244](https://github.com/MaterializeInc/materialize/issues/20244)).
 
+* Stop hardcoding `quickstart` as the default cluster to fall back to when no
+  cluster is specified. When no cluster is specified, either in `profiles.yml`
+  or as a configuration, we should default to the default cluster configured
+  for the connected dbt user (or, the active cluster for the connection). This
+  will still fail if the defalt cluster for the connected user is invalid or
+  set to `mz_catalog_server` (which cannot be modified).
+
 ## 1.8.4 - 2024-08-07
 
 * Include the dbt version in the `application_name` connection parameter [#28813](https://github.com/MaterializeInc/materialize/pull/28813).

--- a/misc/dbt-materialize/dbt/adapters/materialize/connections.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/connections.py
@@ -72,7 +72,17 @@ psycopg2.connect = connect
 
 @dataclass
 class MaterializeCredentials(PostgresCredentials):
-    cluster: Optional[str] = "quickstart"
+    # NOTE(morsapaes) The cluster parameter defined in `profiles.yml` is not
+    # picked up in the connection string, but is picked up wherever we fall
+    # back to `target.cluster`. When no cluster is specified, either in
+    # `profiles.yml` or as a configuration, we should default to the default
+    # cluster configured for the connected dbt user (or, the active cluster for
+    # the connection). This is strictly better than hardcoding `quickstart` as
+    # the `target.cluster`, which might not exist and leads to all sorts of
+    # annoying errors. This will still fail if the defalt cluster for the
+    # connected user is invalid or set to `mz_catalog_server` (which cannot be
+    # modified).
+    cluster: Optional[str] = None
     application_name: Optional[str] = f"dbt-materialize v{__version__}"
 
     @property

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -325,7 +325,7 @@ class MaterializeAdapter(PostgresAdapter, SQLAdapter):
     @available
     def generate_final_cluster_name(
         self, cluster_name: str, force_deploy_suffix: bool = False
-    ) -> str:
+    ) -> Optional[str]:
         cluster_name = self.execute_macro(
             "generate_cluster_name",
             kwargs={"custom_cluster_name": cluster_name},

--- a/misc/dbt-materialize/dbt/adapters/materialize/relation.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/relation.py
@@ -62,3 +62,11 @@ class MaterializeRelation(PostgresRelation):
             MaterializeRelationType.MaterializedView,
             MaterializeRelationType.MaterializedViewLegacy,
         ]
+
+    @property
+    def is_source(self) -> bool:
+        return self.type == MaterializeRelationType.Source
+
+    @property
+    def is_sink(self) -> bool:
+        return self.type == MaterializeRelationType.Sink

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -161,10 +161,12 @@
   -- Materialize does not support the TRUNCATE command, so we work around that
   -- by using an unqualified DELETE. DELETE requires a scan of the relation, so
   -- it needs a valid cluster to run against. This is expected to fail if no
-  -- cluster is specified for the target in profiles.yml _and_ the default
+  -- cluster is specified for the target in `profiles.yml` _and_ the default
   -- cluster for the user is invalid (or intentionally set to
   -- mz_catalog_server, which cannot query user data).
-  {% do run_query(set_cluster(target.cluster)) -%}
+  {% if target.cluster -%}
+    {% do run_query(set_cluster(generate_cluster_name(target.cluster))) -%}
+  {%- endif %}
   {% call statement('truncate_relation') -%}
     delete from {{ relation }}
   {%- endcall %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -212,6 +212,16 @@
   {% endif %}
 {% endmacro %}
 
+{% macro materialize__apply_grants(relation, grant_config, should_revoke) -%}
+  {{ exceptions.raise_compiler_error(
+        """
+        dbt-materialize does not implement the grants configuration.
+
+        If this feature is important to you, please reach out!
+        """
+    )}}
+{% endmacro %}
+
 {% macro materialize__get_refresh_interval_sql(relation, refresh_interval_dict) -%}
   {%- set refresh_interval = adapter.parse_refresh_interval(refresh_interval_dict) -%}
     {% if refresh_interval.at -%}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -143,6 +143,12 @@
       drop source if exists {{ relation }} cascade
     {% elif relation.type == 'index' %}
       drop index if exists {{ relation }}
+    -- Tables are not supported as a materialization type in dbt-materialize,
+    -- but seeds are materialized as tables. This is needed to enable full
+    -- refreshes for seeds.
+    -- See: https://github.com/dbt-labs/dbt-adapters/blob/main/dbt/include/global_project/macros/materializations/seeds/helpers.sql
+    {% elif relation.type == 'table' %}
+      drop table if exists {{ relation }}
     {% endif %}
   {%- endcall %}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/seed.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/seed.sql
@@ -1,0 +1,79 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{% materialization seed, adapter='materialize' %}
+
+  {%- set identifier = model['alias'] -%}
+  {%- set full_refresh_mode = (should_full_refresh()) -%}
+
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+
+  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}
+  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
+  {%- set exists_as_materialized_view = (old_relation is not none and old_relation.is_materialized_view) -%}
+  {%- set exists_as_source = (old_relation is not none and old_relation.is_source) -%}
+  {%- set exists_as_sink = (old_relation is not none and old_relation.is_sink) -%}
+
+  {%- set grant_config = config.get('grants') -%}
+  {%- set agate_table = load_agate_table() -%}
+  -- grab current tables grants config for comparison later on
+
+  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  -- build model
+  {% set create_table_sql = "" %}
+  {% if exists_as_view or exists_as_materialized_view or exists_as_source or exists_as_sink %}
+    {{ exceptions.raise_compiler_error("Cannot seed to '{}', it is a '{}'".format(old_relation.render(),old_relation.type)) }}
+  {% elif exists_as_table %}
+    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}
+  {% else %}
+    {% set create_table_sql = create_csv_table(model, agate_table) %}
+  {% endif %}
+
+  {% set code = 'CREATE' if full_refresh_mode else 'INSERT' %}
+  {% set rows_affected = (agate_table.rows | length) %}
+  {% set sql = load_csv_rows(model, agate_table) %}
+
+  {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}
+    {{ get_csv_sql(create_table_sql, sql) }};
+  {% endcall %}
+
+  {% set target_relation = this.incorporate(type='table') %}
+
+  {% set should_revoke = should_revoke(old_relation, full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {% if full_refresh_mode or not exists_as_table %}
+    {% do create_indexes(target_relation) %}
+  {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  -- `COMMIT` happens here
+  {{ adapter.commit() }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}
+

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
@@ -69,13 +69,12 @@
   {% set fail_calc = config.get('fail_calc') %}
   {% set warn_if = config.get('warn_if') %}
   {% set error_if = config.get('error_if') %}
-  --Tests compile to ad-hoc queries, which need a cluster to run against. If no
-  --cluster is configured for data tests, use the target cluster from
-  --profiles.yml.
-  {% set cluster = config.get('cluster') %}
-  {% if cluster == none %}
-    {% set cluster = target.cluster %}
-  {% endif %}
+  -- Tests compile to ad-hoc queries, which need a cluster to run against. If no
+  -- cluster is configured for data tests, use the target cluster from
+  -- `profiles.yml`. If none exists, fall back to the default cluster
+  -- configured for the connected user.
+  -- See: misc/dbt-materialize/dbt/adapters/materialize/connections.py
+  {%- set cluster = adapter.generate_final_cluster_name(config.get('cluster', target.cluster)) %}
 
   {% call statement('main', fetch_result=True) -%}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
@@ -14,9 +14,11 @@
 -- limitations under the License.
 
 {% macro generate_deploy_cluster_name(custom_cluster_name) -%}
-    {{ custom_cluster_name }}_dbt_deploy
+        {{ custom_cluster_name }}_dbt_deploy
 {%- endmacro %}
 
 {% macro generate_cluster_name(custom_cluster_name) -%}
-    {{ custom_cluster_name }}
+    {% if custom_cluster_name -%}
+        {{ custom_cluster_name }}
+    {%- endif %}
 {%- endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
@@ -18,7 +18,11 @@
 {%- endmacro %}
 
 {% macro generate_cluster_name(custom_cluster_name) -%}
-    {% if custom_cluster_name -%}
+{% macro generate_cluster_name(custom_cluster_name) -%}
+    {% if var('deploy', false) and not custom_cluster_name -%}
+        {{ exceptions.raise_compiler_error("When the 'deploy' variable is set, you must specify a valid target cluster in 'profiles.yml', or via the 'cluster' configuration") }}
+    {% elif custom_cluster_name -%}
         {{ custom_cluster_name }}
     {%- endif %}
+{%- endmacro %}
 {%- endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/utils/generate_cluster_name.sql
@@ -18,11 +18,9 @@
 {%- endmacro %}
 
 {% macro generate_cluster_name(custom_cluster_name) -%}
-{% macro generate_cluster_name(custom_cluster_name) -%}
     {% if var('deploy', false) and not custom_cluster_name -%}
         {{ exceptions.raise_compiler_error("When the 'deploy' variable is set, you must specify a valid target cluster in 'profiles.yml', or via the 'cluster' configuration") }}
     {% elif custom_cluster_name -%}
         {{ custom_cluster_name }}
     {%- endif %}
-{%- endmacro %}
 {%- endmacro %}

--- a/misc/dbt-materialize/tests/adapter/test_deploy.py
+++ b/misc/dbt-materialize/tests/adapter/test_deploy.py
@@ -271,6 +271,19 @@ class TestPermissionValidation:
 
 class TestRunWithDeploy:
     @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        return {
+            "type": "materialize",
+            "threads": 1,
+            "host": "{{ env_var('DBT_HOST', 'localhost') }}",
+            "user": "materialize",
+            "pass": "password",
+            "database": "materialize",
+            "port": "{{ env_var('DBT_PORT', 6875) }}",
+            "cluster": "quickstart",
+        }
+
+    @pytest.fixture(scope="class")
     def project_config_update(self):
         return {
             "vars": {
@@ -660,6 +673,19 @@ class TestLagTolerance:
 
 
 class TestEndToEndDeployment:
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        return {
+            "type": "materialize",
+            "threads": 1,
+            "host": "{{ env_var('DBT_HOST', 'localhost') }}",
+            "user": "materialize",
+            "pass": "password",
+            "database": "materialize",
+            "port": "{{ env_var('DBT_PORT', 6875) }}",
+            "cluster": "quickstart",
+        }
+
     @pytest.fixture(scope="class")
     def models(self):
         return {


### PR DESCRIPTION
Seeds are broken in `dbt-materialize` in a couple of different ways:

* **Repeated runs:** when a user runs `dbt seed` for a non-existent object, the command succeeds, but on subsequent runs, the command might fail if the default cluster for the connecting user is either an invalid cluster or `mz_catalog_server` (from which it isn't possible to query user data). Under the hood, the adapter runs a `DELETE FROM` operation against the table ([source]()), which requires a valid cluster.
* **Full refreshes:** when a user runs `dbt seed` with the [`--full-refresh` flag](https://docs.getdbt.com/reference/resource-configs/full_refresh) (or the `full_refresh` configuration), dbt will try to drop the existing relation [(source)](https://github.com/dbt-labs/dbt-adapters/blob/f1987d4313cc94bac9906963dff1337ee0bffbc6/dbt/include/global_project/macros/materializations/seeds/helpers.sql#L35). Because we don't support `table` as a materialization type, we never added a condition for tables in the `drop_relation` macro, which causes the adapter to fail with `can't execute an empty query`.
* **Grants:** `apply_grants` ([source]()) tries to run multiple commands in a transaction block, which isn't supported in Materialize (but can be worked around, as described [here](https://github.com/MaterializeInc/materialize/pull/21878#issuecomment-1762172572)). Surfacing an error for now, and linking to #20244.

Fixes #28927.