### PR TITLE
qa notifications: Use BUILDKITE_LABEL

### DIFF
--- a/misc/python/materialize/buildkite.py
+++ b/misc/python/materialize/buildkite.py
@@ -43,7 +43,6 @@ class BuildkiteEnvVar(Enum):
     BUILDKITE_PARALLEL_JOB = auto()
     BUILDKITE_PARALLEL_JOB_COUNT = auto()
     BUILDKITE_STEP_KEY = auto()
-    BUILDKITE_STEP_LABEL = auto()
     # will be the same for sharded and retried build steps
     BUILDKITE_STEP_ID = auto()
     # assumed to be unique
@@ -211,8 +210,8 @@ def notify_qa_team_about_failure(failure: str) -> None:
     if not is_in_buildkite():
         return
 
-    step_label = get_var(BuildkiteEnvVar.BUILDKITE_STEP_LABEL)
-    message = f"{step_label}: {failure}"
+    label = get_var(BuildkiteEnvVar.BUILDKITE_LABEL)
+    message = f"{label}: {failure}"
     print(message)
     pipeline = {
         "notify": [


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
