### PR TITLE
output consistency: minor extensions as preparation for join support

### DIFF
--- a/misc/python/materialize/output_consistency/data_type/data_type_with_values.py
+++ b/misc/python/materialize/output_consistency/data_type/data_type_with_values.py
@@ -22,7 +22,7 @@ class DataTypeWithValues:
         """Creates a new instance and prefills the values with a NULL value"""
         self.data_type = data_type
         self.null_value = self._create_raw_value(
-            "NULL", "NULL", {ExpressionCharacteristics.NULL}
+            "NULL", "NULL", {ExpressionCharacteristics.NULL}, is_null_value=True
         )
         # values (and implicitly a column for each value for horizontal storage)
         self.raw_values: list[DataValue] = [self.null_value]
@@ -32,8 +32,15 @@ class DataTypeWithValues:
         value: str,
         column_name: str,
         characteristics: set[ExpressionCharacteristics],
+        is_null_value: bool = False,
     ) -> DataValue:
-        return DataValue(value, self.data_type, column_name, characteristics)
+        return DataValue(
+            value,
+            self.data_type,
+            column_name,
+            characteristics,
+            is_null_value=is_null_value,
+        )
 
     def add_raw_value(
         self,

--- a/misc/python/materialize/output_consistency/data_value/data_value.py
+++ b/misc/python/materialize/output_consistency/data_value/data_value.py
@@ -32,6 +32,7 @@ class DataValue(LeafExpression):
         data_type: DataType,
         value_identifier: str,
         characteristics: set[ExpressionCharacteristics],
+        is_null_value: bool,
         is_pg_compatible: bool = True,
     ):
         column_name = (
@@ -46,6 +47,7 @@ class DataValue(LeafExpression):
             False,
         )
         self.value = value
+        self.is_null_value = is_null_value
         self.is_pg_compatible = is_pg_compatible
 
     def resolve_return_type_spec(self) -> ReturnTypeSpec:

--- a/misc/python/materialize/output_consistency/expression/constant_expression.py
+++ b/misc/python/materialize/output_consistency/expression/constant_expression.py
@@ -1,0 +1,67 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from __future__ import annotations
+
+from materialize.output_consistency.data_type.data_type import DataType
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.execution.sql_dialect_adjuster import (
+    SqlDialectAdjuster,
+)
+from materialize.output_consistency.execution.value_storage_layout import (
+    ValueStorageLayout,
+)
+from materialize.output_consistency.expression.expression import LeafExpression
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
+from materialize.output_consistency.operation.return_type_spec import ReturnTypeSpec
+from materialize.output_consistency.selection.selection import (
+    DataRowSelection,
+)
+
+
+class ConstantExpression(LeafExpression):
+
+    def __init__(
+        self,
+        value: str,
+        data_type: DataType,
+        characteristics: set[ExpressionCharacteristics] = set(),
+        is_aggregate: bool = False,
+    ):
+        column_name = "<none>"
+        super().__init__(
+            column_name,
+            data_type,
+            characteristics,
+            ValueStorageLayout.ANY,
+            is_aggregate,
+            False,
+        )
+        self.value = value
+
+    def resolve_return_type_spec(self) -> ReturnTypeSpec:
+        return self.data_type.resolve_return_type_spec(self.own_characteristics)
+
+    def resolve_return_type_category(self) -> DataTypeCategory:
+        return self.data_type.category
+
+    def to_sql_as_value(self, sql_adjuster: SqlDialectAdjuster) -> str:
+        return self.data_type.value_to_sql(self.value, sql_adjuster)
+
+    def recursively_collect_involved_characteristics(
+        self, row_selection: DataRowSelection
+    ) -> set[ExpressionCharacteristics]:
+        return self.own_characteristics
+
+    def collect_vertical_table_indices(self) -> set[int]:
+        return set()
+
+    def __str__(self) -> str:
+        return f"ConstantExpression (value={self.value}, type={self.data_type})"

--- a/misc/python/materialize/output_consistency/generators/expression_generator.py
+++ b/misc/python/materialize/output_consistency/generators/expression_generator.py
@@ -166,12 +166,12 @@ class ExpressionGenerator:
             return operation.return_type_spec.type_category == DataTypeCategory.BOOLEAN
 
         boolean_operation = self.pick_random_operation(use_aggregation, accept_op)
-        expression, _ = self.generate_expression(
+        expression, _ = self.generate_expression_for_operation(
             boolean_operation, storage_layout, nesting_level
         )
         return expression
 
-    def generate_expression(
+    def generate_expression_for_operation(
         self,
         operation: DbOperationOrFunction,
         storage_layout: ValueStorageLayout | None = None,
@@ -399,7 +399,7 @@ class ExpressionGenerator:
             suitable_operations, weights
         )
 
-        nested_expression, _ = self.generate_expression(
+        nested_expression, _ = self.generate_expression_for_operation(
             operation, storage_layout, nesting_level
         )
 

--- a/misc/python/materialize/output_consistency/generators/expression_generator.py
+++ b/misc/python/materialize/output_consistency/generators/expression_generator.py
@@ -30,6 +30,9 @@ from materialize.output_consistency.expression.expression import (
 from materialize.output_consistency.expression.expression_with_args import (
     ExpressionWithArgs,
 )
+from materialize.output_consistency.input_data.operations.equality_operations_provider import (
+    EQUALS_OPERATION,
+)
 from materialize.output_consistency.input_data.params.same_operation_param import (
     SameOperationParam,
 )
@@ -198,6 +201,15 @@ class ExpressionGenerator:
         expression = ExpressionWithArgs(operation, args, is_aggregate, is_expect_error)
 
         return expression, number_of_args
+
+    def generate_equals_expression(
+        self, arg1: Expression, arg2: Expression
+    ) -> ExpressionWithArgs:
+        operation = EQUALS_OPERATION
+        args = [arg1, arg2]
+        is_aggregate = self._contains_aggregate_arg(args)
+        is_expect_error = operation.is_expected_to_cause_db_error(args)
+        return ExpressionWithArgs(operation, args, is_aggregate, is_expect_error)
 
     def generate_leaf_expression(
         self,

--- a/misc/python/materialize/output_consistency/generators/expression_generator.py
+++ b/misc/python/materialize/output_consistency/generators/expression_generator.py
@@ -199,6 +199,27 @@ class ExpressionGenerator:
 
         return expression, number_of_args
 
+    def generate_leaf_expression(
+        self,
+        storage_layout: ValueStorageLayout,
+        types_with_values: list[DataTypeWithValues],
+    ) -> LeafExpression:
+        assert len(types_with_values) > 0, "No suitable types with values"
+
+        type_with_values = self.randomized_picker.random_type_with_values(
+            types_with_values
+        )
+
+        if storage_layout == ValueStorageLayout.VERTICAL:
+            return type_with_values.create_vertical_storage_column()
+        elif storage_layout == ValueStorageLayout.HORIZONTAL:
+            if len(type_with_values.raw_values) == 0:
+                raise NoSuitableExpressionFound("No value in type")
+
+            return self.randomized_picker.random_value(type_with_values.raw_values)
+        else:
+            raise RuntimeError(f"Unsupported storage layout: {storage_layout}")
+
     def _select_storage_layout(
         self, operation: DbOperationOrFunction
     ) -> ValueStorageLayout:
@@ -326,19 +347,7 @@ class ExpressionGenerator:
         if len(suitable_types_with_values) == 0:
             raise NoSuitableExpressionFound("No suitable type")
 
-        type_with_values = self.randomized_picker.random_type_with_values(
-            suitable_types_with_values
-        )
-
-        if storage_layout == ValueStorageLayout.VERTICAL:
-            return type_with_values.create_vertical_storage_column()
-        elif storage_layout == ValueStorageLayout.HORIZONTAL:
-            if len(type_with_values.raw_values) == 0:
-                raise NoSuitableExpressionFound("No value in type")
-
-            return self.randomized_picker.random_value(type_with_values.raw_values)
-        else:
-            raise RuntimeError(f"Unsupported storage layout: {storage_layout}")
+        return self.generate_leaf_expression(storage_layout, suitable_types_with_values)
 
     def _generate_complex_arg_for_param(
         self,

--- a/misc/python/materialize/output_consistency/input_data/constants/constant_expressions.py
+++ b/misc/python/materialize/output_consistency/input_data/constants/constant_expressions.py
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from materialize.output_consistency.data_type.data_type import DataType
+from materialize.output_consistency.expression.constant_expression import (
+    ConstantExpression,
+)
+from materialize.output_consistency.input_data.types.boolean_type_provider import (
+    BOOLEAN_DATA_TYPE,
+)
+
+TRUE_EXPRESSION = ConstantExpression("TRUE", BOOLEAN_DATA_TYPE)
+FALSE_EXPRESSION = ConstantExpression("FALSE", BOOLEAN_DATA_TYPE)
+
+
+def create_null_expression(data_type: DataType) -> ConstantExpression:
+    return ConstantExpression("NULL", data_type)

--- a/misc/python/materialize/output_consistency/input_data/operations/equality_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/equality_operations_provider.py
@@ -24,14 +24,14 @@ EQUALITY_OPERATION_TYPES: list[DbOperationOrFunction] = []
 TAG_EQUALITY = "equality"
 TAG_EQUALITY_ORDERING = "equality-order"
 
-EQUALITY_OPERATION_TYPES.append(
-    DbOperation(
-        "$ = $",
-        [AnyOperationParam(), AnyLikeOtherOperationParam(0)],
-        BooleanReturnTypeSpec(),
-        tags={TAG_EQUALITY},
-    )
+EQUALS_OPERATION = DbOperation(
+    "$ = $",
+    [AnyOperationParam(), AnyLikeOtherOperationParam(0)],
+    BooleanReturnTypeSpec(),
+    tags={TAG_EQUALITY},
 )
+
+EQUALITY_OPERATION_TYPES.append(EQUALS_OPERATION)
 
 EQUALITY_OPERATION_TYPES.append(
     DbOperation(

--- a/misc/python/materialize/output_consistency/output_consistency_test.py
+++ b/misc/python/materialize/output_consistency/output_consistency_test.py
@@ -183,7 +183,7 @@ class OutputConsistencyTest:
             config, randomized_picker, input_data
         )
         query_generator = QueryGenerator(
-            config, randomized_picker, input_data, ignore_filter
+            config, randomized_picker, input_data, expression_generator, ignore_filter
         )
         output_comparator = self.create_result_comparator(ignore_filter)
 

--- a/misc/python/materialize/output_consistency/query/query_template.py
+++ b/misc/python/materialize/output_consistency/query/query_template.py
@@ -62,12 +62,6 @@ class QueryTemplate:
         self.custom_order_expressions = custom_order_expressions
         self.disable_error_message_validation = not self.__can_compare_error_messages()
 
-    def add_select_expression(self, expression: Expression) -> None:
-        self.select_expressions.append(expression)
-
-    def add_multiple_select_expressions(self, expressions: list[Expression]) -> None:
-        self.select_expressions.extend(expressions)
-
     def to_sql(
         self,
         strategy: EvaluationStrategy,

--- a/misc/python/materialize/output_consistency/runner/test_runner.py
+++ b/misc/python/materialize/output_consistency/runner/test_runner.py
@@ -123,8 +123,8 @@ class ConsistencyTestRunner:
                 expression_count, time_guard
             )
 
-            expression, number_of_args = self.expression_generator.generate_expression(
-                operation
+            expression, number_of_args = (
+                self.expression_generator.generate_expression_for_operation(operation)
             )
             test_summary.accept_expression_generation_statistics(
                 operation, expression, number_of_args

--- a/misc/python/materialize/output_consistency/runner/test_runner.py
+++ b/misc/python/materialize/output_consistency/runner/test_runner.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from materialize.output_consistency.common import probability
 from materialize.output_consistency.common.configuration import (
     ConsistencyTestConfiguration,
 )
@@ -29,7 +28,6 @@ from materialize.output_consistency.input_data.test_input_data import (
     ConsistencyTestInputData,
 )
 from materialize.output_consistency.output.output_printer import OutputPrinter
-from materialize.output_consistency.query.query_template import QueryTemplate
 from materialize.output_consistency.runner.time_guard import TimeGuard
 from materialize.output_consistency.selection.randomized_picker import RandomizedPicker
 from materialize.output_consistency.status.test_summary import (
@@ -170,7 +168,7 @@ class ConsistencyTestRunner:
 
         for query in queries:
             if ENABLE_ADDING_WHERE_CONDITIONS:
-                self._add_random_where_condition(query)
+                self.query_generator.add_random_where_condition_to_query(query)
             success = self.execution_manager.execute_query(query, test_summary)
 
             if not success and self.config.fail_fast:
@@ -185,26 +183,6 @@ class ConsistencyTestRunner:
                 return False
 
         return False
-
-    def _add_random_where_condition(self, query: QueryTemplate) -> None:
-        if not self.randomized_picker.random_boolean(
-            probability.GENERATE_WHERE_EXPRESSION
-        ):
-            return
-
-        where_expression = self.expression_generator.generate_boolean_expression(
-            False, query.storage_layout
-        )
-
-        if where_expression is None:
-            return
-
-        ignore_verdict = self.ignore_filter.shall_ignore_expression(
-            where_expression, query.row_selection
-        )
-
-        if not ignore_verdict.ignore:
-            query.where_expression = where_expression
 
     def _shall_abort(self, iteration_count: int, time_guard: TimeGuard) -> bool:
         if (


### PR DESCRIPTION
This is a preparation for the join support to avoid that the other PR gets too large.

### Commits
034e9dfb96 output consistency: expressions: add ConstantExpression
0789670391 output consistency: expressions: add TRUE, FALSE, and NULL
c35ac964fa output consistency: operations: extract equality operation
caff6f8463 output consistency: expression generator: add generate_leaf_expression
220b9194e0 output consistency: expression generator: add generate_equals_expression
25fab112e8 output consistency: expression generator: rename method
ec51ed884d output consistency: expression generator: add variants
c0e11fac16 output consistency: query: move where condition creation
287733bcd9 output consistency: query: remove unused code
7ed4de1c8d output consistency: data value: mark NULL value

