### PR TITLE
mzbuild: Also use run_with_retries

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -56,7 +56,7 @@ def annotate_buildkite_with_tags(arch: Arch, deps: mzbuild.DependencySet) -> Non
 
 
 def maybe_upload_debuginfo(
-    repo: mzbuild.Repository, built_images: set[ResolvedImage], max_tries: int = 3
+    repo: mzbuild.Repository, built_images: set[ResolvedImage]
 ) -> None:
     """Uploads debuginfo to `DEBUGINFO_S3_BUCKET` and Polar Signals if any
     DEBUGINFO_BINS were built."""

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -28,7 +28,6 @@ import shutil
 import stat
 import subprocess
 import sys
-import time
 from collections import OrderedDict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from functools import cache
@@ -652,28 +651,18 @@ class ResolvedImage:
         ]
         spawn.runv(cmd, stdin=f, stdout=sys.stderr.buffer)
 
-    def try_pull(self, max_retries: int) -> bool:
+    def try_pull(self, max_duration: int) -> bool:
         """Download the image if it does not exist locally. Returns whether it was found."""
         ui.header(f"Acquiring {self.spec()}")
         if not self.acquired:
-            for retry in range(1, max_retries + 1):
-                try:
-                    spawn.runv(
-                        ["docker", "pull", self.spec()],
-                        stdout=sys.stderr.buffer,
-                    )
-                    self.acquired = True
-                except subprocess.CalledProcessError:
-                    if retry < max_retries:
-                        # There seems to be no good way to tell what error
-                        # happened based on error code
-                        # (https://github.com/docker/cli/issues/538) and we
-                        # want to print output directly to terminal.
-                        print("Retrying ...")
-                        time.sleep(1)
-                        continue
-                    else:
-                        break
+            spawn.run_with_retries(
+                lambda: spawn.runv(
+                    ["docker", "pull", self.spec()],
+                    stdout=sys.stderr.buffer,
+                ),
+                max_duration,
+            )
+            self.acquired = True
         return self.acquired
 
     def is_published_if_necessary(self) -> bool:
@@ -820,20 +809,19 @@ class DependencySet:
             pre_image_prep[cls] = pre_image.prepare_batch(instances)
         return pre_image_prep
 
-    def acquire(self, max_retries: int | None = None) -> None:
+    def acquire(self, max_duration: int | None = None) -> None:
         """Download or build all of the images in the dependency set that do not
         already exist locally.
 
         Args:
-            max_retries: Number of retries on failure.
+            max_duration: Max sleeping time for retries on failure.
         """
 
         # Only retry in CI runs since we struggle with flaky docker pulls there
-        if not max_retries:
-            max_retries = 3 if ui.env_is_truthy("CI") else 1
-        assert max_retries > 0
+        if not max_duration:
+            max_duration = 60 if ui.env_is_truthy("CI") else 0
 
-        deps_to_build = [dep for dep in self if not dep.try_pull(max_retries)]
+        deps_to_build = [dep for dep in self if not dep.try_pull(max_duration)]
         prep = self._prepare_batch(deps_to_build)
         for dep in deps_to_build:
             dep.build(prep)

--- a/misc/python/materialize/spawn.py
+++ b/misc/python/materialize/spawn.py
@@ -150,7 +150,7 @@ T = TypeVar("T")  # Generic type variable
 def run_with_retries(fn: Callable[[], T], max_duration: int = 60) -> T:
     """Retry a function until it doesn't raise a `CalledProcessError`, uses
     exponential backoff until `max_duration` is reached."""
-    for retry in range(math.ceil(math.log2(max_duration))):
+    for retry in range(math.ceil(math.log2(max(max_duration, 1)))):
         try:
             return fn()
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
