### PR TITLE
output consistency: expression matcher: limit characteristics to row selection

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -43,6 +43,10 @@ from materialize.output_consistency.operation.operation import (
     match_function_by_name,
 )
 from materialize.output_consistency.query.query_template import QueryTemplate
+from materialize.output_consistency.selection.selection import (
+    ALL_ROWS_SELECTION,
+    DataRowSelection,
+)
 
 
 def matches_x_or_y(
@@ -185,6 +189,7 @@ def argument_has_any_characteristic(
     expression: Expression,
     arg_index: int,
     characteristics: set[ExpressionCharacteristics],
+    row_selection: DataRowSelection = ALL_ROWS_SELECTION,
 ) -> bool:
     if isinstance(expression, ExpressionWithArgs):
         assert arg_index < len(
@@ -195,7 +200,9 @@ def argument_has_any_characteristic(
             return False
 
         argument = expression.args[arg_index]
-        return argument.has_any_characteristic(characteristics)
+        return argument.has_any_characteristic(
+            characteristics, row_selection=row_selection
+        )
 
     return False
 

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -637,11 +637,13 @@ class PgPostExecutionInconsistencyIgnoreFilter(
                         argument_has_any_characteristic,
                         arg_index=1,
                         characteristics={ExpressionCharacteristics.NULL},
+                        row_selection=query_template.row_selection,
                     ),
                     y=partial(
                         argument_has_any_characteristic,
                         arg_index=2,
                         characteristics={ExpressionCharacteristics.NULL},
+                        row_selection=query_template.row_selection,
                     ),
                 ),
             ),


### PR DESCRIPTION
Fix to better narrow expression characteristics.