### PR TITLE
ci: Fix services.log sorting

### DIFF
--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -26,7 +26,12 @@ if [ -f services.log ]; then
     # Don't capture log lines we received already
     time=$(date +%s -r services.log)
 fi
-run logs --no-color --since "$time" >> services.log
+run logs --no-color --timestamps --since "$time" >> services.log
+# Sort services.log and remove the timestamps we added to prevent having duplicate timestamps in output. For reference:
+# https://github.com/moby/moby/issues/33673
+# https://github.com/moby/moby/issues/31706
+sort -k 1 < services.log | sed -E "s/ \| [0-9]{4}-[01][0-9]-[0-3][0-9]T[0-2][0-9]\:[0-5][0-9]:[0-6][0-9]\.[0-9]{9}Z / \| /" > services-sorted.log
+mv services-sorted.log services.log
 # shellcheck disable=SC2024
 sudo journalctl --merge --since "$(cat step_start_timestamp)" > journalctl-merge.log
 netstat -ant > netstat-ant.log

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -1039,7 +1039,13 @@ class Composition:
         time = os.path.getmtime(path) if os.path.isfile(path) else 0
         with open(path, "a") as f:
             self.invoke(
-                "logs", "--no-color", "--since", str(time), *services, capture=f
+                "logs",
+                "--no-color",
+                "--timestamps",
+                "--since",
+                str(time),
+                *services,
+                capture=f,
             )
 
     def down(


### PR DESCRIPTION
Docker Compose is strange here, restore order

If this doesn't work, the cleaner solution is to use a proper logging driver: https://docs.docker.com/engine/logging/configure/

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
