### PR TITLE
release: add scripts for automatic weekly release cuts

### DIFF
--- a/bin/cut-release
+++ b/bin/cut-release
@@ -9,6 +9,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# cut-release -- cuts a new Materialize version and pushes it to the Materialize repo.
+# cut-release -- cuts a new release and pushes the tag to the upstream
+# Materialize repository.
 
-exec "$(dirname "$0")"/pyactivate -m materialize.cut-release "$@"
+exec "$(dirname "$0")"/pyactivate -m materialize.release.cut_release "$@"

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -350,7 +350,7 @@ def create_branch(name: str) -> None:
     spawn.runv(["git", "checkout", "-b", name])
 
 
-def checkout(rev: str, branch: str | None = None) -> None:
+def checkout(rev: str) -> None:
     """Git checkout the rev"""
     spawn.runv(["git", "checkout", rev])
 

--- a/misc/python/materialize/release/cut_release.py
+++ b/misc/python/materialize/release/cut_release.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-"""Cut a new release and push it to the Materialize repo"""
+"""Cut a new release and push the tag to the upstream Materialize repository."""
 
 import argparse
 import sys


### PR DESCRIPTION
Add a script to the repository that automatically kicks off a new minor
release series by:

  1. Tagging the .0 release.
  2. Bumping the version on main to the next development version.