### PR TITLE
platform-checks: Add 0dt restart scenario with forced migrations

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -815,6 +815,18 @@ steps:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeRestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-0dt-restart-entire-mz-forced-migrations
+        label: "Checks 0dt restart of the entire Mz with forced migrations"
+        depends_on: build-aarch64
+        timeout_in_minutes: 120
+        agents:
+          # TODO(def-): Switch back to hetzner
+          queue: linux-aarch64-large
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=ZeroDowntimeRestartEntireMzForcedMigrations, "--seed=$BUILDKITE_JOB_ID"]
+
       - id: checks-0dt-upgrade-entire-mz
         label: "Checks 0dt upgrade, whole-Mz restart"
         depends_on: build-aarch64

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -44,6 +44,7 @@ class StartMz(MzcomposeAction):
         healthcheck: list[str] | None = None,
         deploy_generation: int | None = None,
         restart: str | None = None,
+        force_migrations: str | None = None,
     ) -> None:
         if healthcheck is None:
             healthcheck = ["CMD", "curl", "-f", "localhost:6878/api/readyz"]
@@ -57,6 +58,7 @@ class StartMz(MzcomposeAction):
         self.platform = platform
         self.deploy_generation = deploy_generation
         self.restart = restart
+        self.force_migrations = force_migrations
 
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
@@ -78,6 +80,7 @@ class StartMz(MzcomposeAction):
             healthcheck=self.healthcheck,
             deploy_generation=self.deploy_generation,
             restart=self.restart,
+            force_migrations=self.force_migrations,
         )
 
         # Don't fail since we are careful to explicitly kill and collect logs

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -67,6 +67,7 @@ def start_mz_read_only(
     tag: MzVersion | None = None,
     system_parameter_defaults: dict[str, str] | None = None,
     system_parameter_version: MzVersion | None = None,
+    force_migrations: str | None = None,
 ) -> StartMz:
     return StartMz(
         scenario,
@@ -77,6 +78,7 @@ def start_mz_read_only(
         restart="unless-stopped",
         system_parameter_defaults=system_parameter_defaults,
         system_parameter_version=system_parameter_version,
+        force_migrations=force_migrations,
     )
 
 

--- a/misc/python/materialize/checks/scenarios_zero_downtime.py
+++ b/misc/python/materialize/checks/scenarios_zero_downtime.py
@@ -70,6 +70,47 @@ class ZeroDowntimeRestartEntireMz(Scenario):
         ]
 
 
+class ZeroDowntimeRestartEntireMzForcedMigrations(Scenario):
+    def actions(self) -> list[Action]:
+        system_parameter_defaults = get_default_system_parameters(zero_downtime=True)
+        return [
+            StartMz(
+                self,
+                mz_service="mz_1",
+                system_parameter_defaults=system_parameter_defaults,
+            ),
+            Initialize(self, mz_service="mz_1"),
+            start_mz_read_only(
+                self,
+                deploy_generation=1,
+                mz_service="mz_2",
+                system_parameter_defaults=system_parameter_defaults,
+                force_migrations="all",
+            ),
+            Manipulate(self, phase=1, mz_service="mz_1"),
+            *wait_ready_and_promote("mz_2"),
+            start_mz_read_only(
+                self,
+                deploy_generation=2,
+                mz_service="mz_3",
+                system_parameter_defaults=system_parameter_defaults,
+                force_migrations="all",
+            ),
+            Manipulate(self, phase=2, mz_service="mz_2"),
+            *wait_ready_and_promote("mz_3"),
+            start_mz_read_only(
+                self,
+                deploy_generation=3,
+                mz_service="mz_4",
+                system_parameter_defaults=system_parameter_defaults,
+                force_migrations="all",
+            ),
+            Validate(self, mz_service="mz_3"),
+            *wait_ready_and_promote("mz_4"),
+            Validate(self, mz_service="mz_4"),
+        ]
+
+
 class ZeroDowntimeUpgradeEntireMz(Scenario):
     """0dt upgrade of the entire Mz instance from the last released version."""
 


### PR DESCRIPTION
Useful in general, might help with #29015

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
