### PR TITLE
WIP: Can we run CI tests without ci-builder?

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -14,7 +14,7 @@ set -euo pipefail
 . misc/shlib/shlib.bash
 
 mzcompose() {
-    stdbuf --output=L --error=L bin/ci-builder run stable bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
+    stdbuf --output=L --error=L bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
 
 faketty() {
@@ -91,7 +91,7 @@ if is_truthy "${CI_HEAP_PROFILES:-}"; then
         sleep 5
         # faketty because otherwise docker will complain about not being inside
         # of a TTY when run in a background job
-        faketty bin/ci-builder run stable bin/ci-upload-heap-profiles "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
+        faketty bin/ci-upload-heap-profiles "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION"
     done
     ) &
 fi

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -14,7 +14,7 @@ set -euo pipefail
 . misc/shlib/shlib.bash
 
 run() {
-    bin/ci-builder run stable bin/mzcompose --mz-quiet --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
+    bin/mzcompose --mz-quiet --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
 
 echo "Collecting logs"
@@ -47,10 +47,10 @@ mv "$HOME"/cores .
 
 if find cores -name 'core.*' | grep -q .; then
     # Best effort attempt to fetch interesting executables to get backtrace of core files
-    bin/ci-builder run stable cp /mnt/build/debug/clusterd cores/ || true
-    bin/ci-builder run stable cp /mnt/build/debug/environmentd cores/ || true
-    bin/ci-builder run stable cp /mnt/build/debug/mz-balancerd cores/balancerd || true
-    bin/ci-builder run stable cp /mnt/build/debug/sqllogictest cores/ || true
+    cp /mnt/build/debug/clusterd cores/ || true
+    cp /mnt/build/debug/environmentd cores/ || true
+    cp /mnt/build/debug/mz-balancerd cores/balancerd || true
+    cp /mnt/build/debug/sqllogictest cores/ || true
     run cp sqllogictest:/usr/local/bin/sqllogictest cores/ || true
     run cp sqllogictest:/usr/local/bin/clusterd cores/ || true
     run cp materialized:/usr/local/bin/environmentd cores/ || true
@@ -74,7 +74,7 @@ done
 rm -rf cores
 
 echo "Compressing parallel-workload-queries.log"
-bin/ci-builder run stable zstd --rm parallel-workload-queries.log || true
+zstd --rm parallel-workload-queries.log || true
 
 echo "Uploading log artifacts"
 mapfile -t artifacts < <(printf "run.log\nservices.log\njournalctl-merge.log\nnetstat-ant.log\nnetstat-panelot.log\nps-aux.log\ndocker-ps-a.log\ndocker-inspect.log\n"; find . -name 'junit_*.xml')
@@ -84,7 +84,7 @@ unset CI_EXTRA_ARGS # We don't want extra args for the annotation
 CI_ANNOTATE_ERRORS_RESULT=0
 # We have to upload artifacts before ci-annotate-errors, so that the annotations can link to the artifacts
 buildkite-agent artifact upload "$artifacts_str"
-bin/ci-builder run stable bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
+bin/ci-annotate-errors "${artifacts[@]}" > ci-annotate-errors.log || CI_ANNOTATE_ERRORS_RESULT=$?
 buildkite-agent artifact upload "ci-annotate-errors.log"
 
 if [ ! -s services.log ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Long single-node Maelstrom coverage of persist" ] && [ "$BUILDKITE_LABEL" != "Maelstrom coverage of txn-wal" ] && [ "$BUILDKITE_LABEL" != "Mz E2E Test" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version for DFR)" ] && [ "$BUILDKITE_LABEL" != "Output consistency (version for CTF)" ] && [ "$BUILDKITE_LABEL" != "QA Canary Environment Base Load" ]; then

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -22,7 +22,7 @@ fi
 ci_unimportant_heading ":docker: Cleaning up after mzcompose"
 
 run() {
-    bin/ci-builder run stable bin/mzcompose --mz-quiet --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
+    bin/mzcompose --mz-quiet --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
 
 # docker-compose kill may fail attempting to kill containers


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
