### PR TITLE
python docs: Switch to pdoc

### DIFF
--- a/bin/pydoc
+++ b/bin/pydoc
@@ -12,7 +12,8 @@
 # pydoc -- generates docs for python API
 
 exec "$(dirname "$0")"/pyactivate -Werror -Wignore::DeprecationWarning -m pdoc \
-    --html --force \
-    -c 'git_link_template="https://github.com/MaterializeInc/materialize/blob/{commit}/{path}#L{start_line}-L{end_line}"' \
     -o target/pydoc \
-    misc/python/materialize "$@"
+    --logo "https://private-user-images.githubusercontent.com/23521087/267212323-39270ecb-7ac4-4829-b98b-c5b5699a16b8.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjM3MjM3NTcsIm5iZiI6MTcyMzcyMzQ1NywicGF0aCI6Ii8yMzUyMTA4Ny8yNjcyMTIzMjMtMzkyNzBlY2ItN2FjNC00ODI5LWI5OGItYzViNTY5OWExNmI4LnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODE1VDEyMDQxN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTNhY2Y1OTBkYzA5YzM1ZTI5MDRmNTExOWE0Y2E4NDhmNmJkODQ5ODFkZWFiZDA3MWVkOTFhNThkMzk3YTRlZmMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.FmOX-kdzxqsUatq2v_KFOVtQ8PPKmXm9EQY0wPkRQzI" \
+    --logo-link "https://materialize.com/" \
+    --favicon "view-source:https://materialize.com/favicon-32x32.png" \
+    misc.python.materialize "$@"

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -32,7 +32,7 @@ pandas==2.1.2
 pandas-stubs==2.1.1.230928
 parameterized==0.8.1
 paramiko==3.4.0
-pdoc3==0.10.0
+pdoc==14.6.0
 pg8000==1.30.3
 prettytable==3.10.2
 psutil==5.9.4

--- a/misc/python/materialize/__init__.py
+++ b/misc/python/materialize/__init__.py
@@ -9,7 +9,7 @@
 
 """Package `materialize` is the top-level Python package for Materialize, Inc.
 
-While the primary product, [materialized], is written in Rust, various demos and
+While the primary product, [materialized][], is written in Rust, various demos and
 build tools are written in Python. This package enables the sharing of code
 between those scripts.
 

--- a/misc/python/materialize/cargo.py
+++ b/misc/python/materialize/cargo.py
@@ -9,7 +9,7 @@
 
 """A pure Python metadata parser for Cargo, Rust's package manager.
 
-See the [Cargo] documentation for details. Only the features that are presently
+See the [Cargo][] documentation for details. Only the features that are presently
 necessary to support this repository are implemented.
 
 [Cargo]: https://doc.rust-lang.org/cargo/


### PR DESCRIPTION
pdoc3 has broken parsing for multiple of our (valid) Python files. While checking how to fix that I found out that the there is a pdoc project as well, which works better and is less controversial: https://github.com/mitmproxy/pdoc?tab=readme-ov-file#pdoc-vs-pdoc3

Before:
![Screenshot 2024-08-15 at 14 24 57](https://github.com/user-attachments/assets/b1c546ee-eaf5-4965-bb69-a864dbbaaa78)
After:
![Screenshot 2024-08-15 at 14 25 14](https://github.com/user-attachments/assets/92943ac8-49b9-468d-85f6-ec06f75a2d0b)
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
