### PR TITLE
ci: Delete unnecessary testdrive run

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -259,20 +259,6 @@ steps:
               composition: testdrive
               args: [--default-size=8]
 
-      - id: testdrive-structured-persist-validate
-        label: ":racing_car: testdrive with Structured Persist (Row + Validate)"
-        depends_on: build-aarch64
-        timeout_in_minutes: 180
-        agents:
-          queue: hetzner-aarch64-16cpu-32gb
-        plugins:
-          - ./ci/plugins/mzcompose:
-              composition: testdrive
-              args: [
-                --system-param=persist_part_decode_format=row_with_validate,
-                --system-param=persist_batch_columnar_format=both_v2,
-              ]
-
       - id: testdrive-structured-persist-arrow
         label: ":racing_car: testdrive with Structured Persist (Only Structured)"
         depends_on: build-aarch64


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/pull/28914 enabled structured data in Persist for all of CI, so this special Nightly run is no longer needed.

### Motivation

Remove unnecessary test

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
