### PR TITLE
Mark v0.112.2 as released in the docs

### DIFF
--- a/doc/user/content/releases/v0.112.md
+++ b/doc/user/content/releases/v0.112.md
@@ -1,7 +1,8 @@
 ---
 title: "Materialize v0.112"
 date: 2024-08-14
-released: false
+released: true
+patch: 2
 _build:
   render: never
 ---


### PR DESCRIPTION
While we don't publish release notes anymore, for the time being, we still need a file in `doc/user/content/releases/` for each release that identifies the release date, patch no, and what date it was released. This file already exists for `v0.112`, so I just need to update that it's been released and the patch no.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
