### PR TITLE
pydoc: Don't leak environment variables

### DIFF
--- a/bin/pydoc
+++ b/bin/pydoc
@@ -11,7 +11,9 @@
 #
 # pydoc -- generates docs for python API
 
-exec "$(dirname "$0")"/pyactivate -Werror -Wignore::DeprecationWarning -m pdoc \
+# Only allow the $PATH environment variable to prevent leaking any secrets through Python globals
+exec env -i PATH="$PATH" \
+    "$(dirname "$0")"/pyactivate -Werror -Wignore::DeprecationWarning -m pdoc \
     -o target/pydoc \
     --logo "https://private-user-images.githubusercontent.com/23521087/267212323-39270ecb-7ac4-4829-b98b-c5b5699a16b8.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjM3MjM3NTcsIm5iZiI6MTcyMzcyMzQ1NywicGF0aCI6Ii8yMzUyMTA4Ny8yNjcyMTIzMjMtMzkyNzBlY2ItN2FjNC00ODI5LWI5OGItYzViNTY5OWExNmI4LnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODE1VDEyMDQxN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTNhY2Y1OTBkYzA5YzM1ZTI5MDRmNTExOWE0Y2E4NDhmNmJkODQ5ODFkZWFiZDA3MWVkOTFhNThkMzk3YTRlZmMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.FmOX-kdzxqsUatq2v_KFOVtQ8PPKmXm9EQY0wPkRQzI" \
     --logo-link "https://materialize.com/" \


### PR DESCRIPTION
Failed: https://buildkite.com/materialize/deploy/builds/15531#0191566a-3c8a-486f-8f69-f39e2b2a8666

> RuntimeWarning: The default value of misc.python.materialize.mzcompose.DEFAULT_CLOUD_REGION matches the $AWS_DEFAULT_REGION environment variable. To prevent accidental leakage of secrets, the default value is not displayed. Disable this behavior by setting PDOC_DISPLAY_ENV_VARS=1 as an environment variable.

In this case harmless, since it's just us-east-1, but we might accidentally leak other variables, so that was a good call by pdoc!

Follow-up to https://github.com/MaterializeInc/materialize/pull/29021

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
