### PR TITLE
docs: Update Materialize definition

### DIFF
--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -9,14 +9,9 @@ weight: 1
 
 # Materialize documentation
 
-Materialize is the Operational Data Warehouse that delivers the speed of
-streaming with the ease of a data warehouse.
-
-Using SQL and common tools in the wider data ecosystem, Materialize allows you
-to build real-time automation, engaging customer experiences, and interactive
-data products that drive value for your business while **reducing the cost of
-data freshness**.
-
+Materialize is the Cloud Operational Data Store that delivers the speed of
+streaming with the ease of a data warehouse. With Materialize, organizations can
+use SQL to transform, deliver, and act on fast-changing data.
 
 {{< callout primary_url="https://materialize.com/register/?utm_campaign=General&utm_source=documentation" primary_text="Get Started">}}
 

--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -9,9 +9,8 @@ weight: 1
 
 # Materialize documentation
 
-Materialize is the Cloud Operational Data Store that delivers the speed of
-streaming with the ease of a data warehouse. With Materialize, organizations can
-use SQL to transform, deliver, and act on fast-changing data.
+Materialize is the Cloud Operational Data Store that lets you use SQL to
+transform, deliver, and act on fast-changing data.
 
 {{< callout primary_url="https://materialize.com/register/?utm_campaign=General&utm_source=documentation" primary_text="Get Started">}}
 

--- a/doc/user/content/get-started/_index.md
+++ b/doc/user/content/get-started/_index.md
@@ -15,8 +15,9 @@ Materialize is the Cloud Operational Data Store that delivers the speed of
 streaming with the ease of a data warehouse. With Materialize, organizations can
 use SQL to transform, deliver, and act on fast-changing data.
 
-To keeps results up-to-date as new data arrives, Materialize incrementally updates results as it ingests data rather than recalculating results
-from scratch.
+To keeps results up-to-date as new data arrives, Materialize incrementally
+updates results as it ingests data rather than recalculating results from
+scratch.
 
 {{< callout primary_url="https://materialize.com/register/?utm_campaign=General&utm_source=documentation" primary_text="Get Started">}}
 

--- a/doc/user/content/get-started/_index.md
+++ b/doc/user/content/get-started/_index.md
@@ -11,14 +11,12 @@ menu:
     weight: 5
 ---
 
-Materialize is the Operational Data Warehouse that delivers the speed of
+Materialize is the Cloud Operational Data Store that delivers the speed of
 streaming with the ease of a data warehouse. With Materialize, organizations can
-operate on real-time data just by using SQL.
+use SQL to transform, deliver, and act on fast-changing data.
 
-If you need to speed up queries that run frequently, or trigger actions as
-soon as events happen, Materialize is a good fit. Rather than recalculate
-results from scratch, or serve stale cached results, Materialize continually
-ingests data and keeps results up-to-date as new data arrives.
+To keeps results up-to-date as new data arrives, Materialize incrementally updates results as it ingests data rather than recalculating results
+from scratch.
 
 {{< callout primary_url="https://materialize.com/register/?utm_campaign=General&utm_source=documentation" primary_text="Get Started">}}
 

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -18,7 +18,7 @@ use SQL to transform, deliver, and act on fast-changing data.
 
 This quickstart will get you up and running in a few minutes and with no
 dependencies, so you can experience the superpowers of an operational data
-warehouse first-hand:
+store first-hand:
 
 * **Interactivity**: get immediate responses from indexed warehouse relations and derived results.
 

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -12,10 +12,13 @@ aliases:
   - /install/
 ---
 
-Materialize is the Operational Data Warehouse that delivers the speed of
-streaming with the ease of a data warehouse. This quickstart will get you up and
-running in a few minutes and with no dependencies, so you can experience the
-superpowers of an operational data warehouse first-hand:
+Materialize is the Cloud Operational Data Store that delivers the speed of
+streaming with the ease of a data warehouse. With Materialize, organizations can
+use SQL to transform, deliver, and act on fast-changing data.
+
+This quickstart will get you up and running in a few minutes and with no
+dependencies, so you can experience the superpowers of an operational data
+warehouse first-hand:
 
 * **Interactivity**: get immediate responses from indexed warehouse relations and derived results.
 


### PR DESCRIPTION
Changed Operational Data Warehouse to the Cloud Operational Data Store and copied blurb from homepage to be aligned.  Emily will get back to me if there is a preferred sentence, but figured I'd have the PR ready. 