### PR TITLE
CODEOWNERS: s/morsapaes/docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 /bin/lint-versions                  @MaterializeInc/testing
 /ci                                 @MaterializeInc/testing
 /ci/test/lint-deps.toml             @danhhz @benesch
-/doc/user                           @morsapaes
+/doc/user                           @MaterializeInc/docs
 /doc/developer/reference/compute    @MaterializeInc/cluster
 /doc/developer/reference/storage    @MaterializeInc/cluster
 /misc/bazel                         @parkmycar


### PR DESCRIPTION
Switching ownership of `doc/user` to the Docs team (which I'm also in)!

cc @kay-kim