### PR TITLE
[do not merge] Arrow ord bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219d05930b81663fd3b32e3bde8ce5bff3c4d23052a99f11a8fa50a3b47b2658"
+checksum = "05048a8932648b63f21c37d88b552ccc8a65afb6dfe9fc9f30ce79174c2e7a85"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0272150200c07a86a390be651abdd320a2d12e84535f0837566ca87ecd8f95e0"
+checksum = "1d8a57966e43bfe9a3277984a14c24ec617ad874e4c0e1d2a1b083a39cfbf22c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8010572cf8c745e242d1b632bd97bd6d4f40fefed5ed1290a8f433abaa686fea"
+checksum = "16f4a9468c882dc66862cef4e1fd8423d47e67972377d85d80e022786427768c"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0a2432f0cba5692bf4cb757469c66791394bac9ec7ce63c1afe74744c37b27"
+checksum = "c975484888fc95ec4a632cdc98be39c085b1bb518531b0c80c5d462063e5daa1"
 dependencies = [
  "bytes",
  "half 2.4.1",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc10cd7995e83505cc290df9384d6e5412b207b79ce6bdff89a10505ed2cba"
+checksum = "da26719e76b81d8bc3faad1d4dbdc1bcc10d14704e63dc17fc9f3e7e1e567c8e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2742ac1f6650696ab08c88f6dd3f0eb68ce10f8c253958a18c943a68cd04aec5"
+checksum = "dd9d6f18c65ef7a2573ab498c374d8ae364b4a4edf67105357491c031f716ca5"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ea853130f7e78b9b9d178cb4cd01dee0f78e64d96c2949dc0a915d6d9e19d"
+checksum = "e786e1cdd952205d9a8afc69397b317cfbb6e0095e445c69cda7e8da5c1eeb0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e6b61e3dc468f503181dccc2fc705bdcc5f2f146755fa5b56d0a6c5943f412"
+checksum = "42745f86b1ab99ef96d1c0bcf49180848a64fe2c7a7a0d945bc64fa2b21ba9bc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848ee52bb92eb459b811fb471175ea3afcf620157674c8794f539838920f9228"
+checksum = "4cd09a518c602a55bd406bcc291a967b284cfa7a63edfbf8b897ea4748aad23c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -244,20 +244,19 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "half 2.4.1",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
 name = "arrow-schema"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d9483aaabe910c4781153ae1b6ae0393f72d9ef757d38d09d450070cf2e528"
+checksum = "9e972cd1ff4a4ccd22f86d3e53e835c2ed92e0eea6a3e8eadb72b4f1ac802cf8"
 
 [[package]]
 name = "arrow-select"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849524fa70e0e3c5ab58394c770cb8f514d0122d20de08475f7b472ed8075830"
+checksum = "600bae05d43483d216fb3494f8c32fdbefd8aa4e1de237e790dbb3d9f44690a3"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -269,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9373cb5a021aee58863498c37eb484998ef13377f69989c6c5ccfbd258236cdb"
+checksum = "f0dc1985b67cb45f6606a248ac2b4a288849f196bab8c657ea5589f47cdd55e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2407,9 +2406,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "24.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "8add37afff2d4ffa83bc748a70b4b1370984f6980768554182424ef71447c35f"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version",
@@ -5519,6 +5518,7 @@ dependencies = [
  "anyhow",
  "arrayvec 0.7.4",
  "arrow",
+ "arrow-row",
  "async-stream",
  "async-trait",
  "bytes",
@@ -5876,6 +5876,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arrow",
+ "arrow-row",
  "bitflags 1.3.2",
  "bytes",
  "cfg-if",
@@ -7335,9 +7336,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "096795d4f47f65fd3ee1ec5a98b77ab26d602f2cc785b0e4be5443add17ecc32"
+checksum = "e977b9066b4d3b03555c22bdc442f3fadebd96a39111249113087d0edb2691cd"
 dependencies = [
  "ahash",
  "arrow-array",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
-arrow = { version = "51.0.0", default-features = false }
+arrow = { version = "52.2.0", default-features = false }
 async-trait = "0.1.68"
 bytes = "1.3.0"
 bytesize = "1.1.0"

--- a/src/arrow-util/Cargo.toml
+++ b/src/arrow-util/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
-arrow = { version = "51.0.0", default-features = false }
+arrow = { version = "52.2.0", default-features = false }
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 mz-repr = { path = "../repr" }
 mz-ore = { path = "../ore" }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = { version = "1.0.66", optional = true }
 async-trait = { version = "0.1.68", optional = true }
 bytes = { version = "1.3.0", optional = true }
 chrono = { version = "0.4.35", default-features = false, features = [
-  "std",
+    "std",
 ], optional = true }
 clap = { version = "3.2.24", features = ["env"], optional = true }
 compact_bytes = { version = "0.1.2", optional = true }
@@ -38,12 +38,12 @@ num = "0.4.0"
 once_cell = "1.16.0"
 # The vendored feature is transitively depended upon by tokio-openssl.
 openssl = { version = "0.10.48", features = ["vendored"], optional = true }
-parquet = { version = "51.0.0", optional = true, default-features = false }
+parquet = { version = "52.2.0", optional = true, default-features = false }
 paste = "1.0.11"
 pin-project = "1.0.12"
 prometheus = { version = "0.13.3", default-features = false, optional = true }
 proptest = { version = "1.0.0", default-features = false, features = [
-  "std",
+    "std",
 ], optional = true }
 rand = { version = "0.8.5", optional = true }
 smallvec = { version = "1.10.0", optional = true }
@@ -51,11 +51,11 @@ stacker = { version = "0.1.15", optional = true }
 sentry = { version = "0.29.1", optional = true, features = ["debug-images"] }
 serde = { version = "1.0.152", features = ["derive"] }
 tokio = { version = "1.38.0", features = [
-  "io-util",
-  "net",
-  "rt-multi-thread",
-  "sync",
-  "time",
+    "io-util",
+    "net",
+    "rt-multi-thread",
+    "sync",
+    "time",
 ], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
 tracing-capture = { version = "0.1.0", optional = true }
@@ -66,10 +66,10 @@ tracing-capture = { version = "0.1.0", optional = true }
 # Note that this feature is distinct from `tracing`'s `log` feature, which has `tracing` macros emit `log` records if
 # there is no global `tracing` subscriber.
 tracing-subscriber = { version = "0.3.16", default-features = false, features = [
-  "env-filter",
-  "fmt",
-  "json",
-  "tracing-log",
+    "env-filter",
+    "fmt",
+    "json",
+    "tracing-log",
 ], optional = true }
 uuid = { version = "1.7.0", optional = true }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
@@ -87,7 +87,7 @@ hyper-tls = { version = "0.5.0", optional = true }
 opentelemetry = { version = "0.21.0", features = ["trace"], optional = true }
 opentelemetry-otlp = { version = "0.14.0", optional = true }
 opentelemetry_sdk = { version = "0.21.2", features = [
-  "rt-tokio",
+    "rt-tokio",
 ], optional = true }
 console-subscriber = { version = "0.1.10", optional = true }
 sentry-tracing = { version = "0.29.1", optional = true }
@@ -107,38 +107,38 @@ tracing-subscriber = "0.3.16"
 [features]
 default = ["tokio-console", "workspace-hack", "mz-ore-proc/workspace-hack"]
 async = [
-  "async-trait",
-  "futures",
-  "metrics",
-  "openssl",
-  "tokio-openssl",
-  "tokio",
-  "tracing",
+    "async-trait",
+    "futures",
+    "metrics",
+    "openssl",
+    "tokio-openssl",
+    "tokio",
+    "tracing",
 ]
 bytes_ = ["bytes", "compact_bytes", "smallvec", "smallvec/const_generics", "region", "tracing_"]
 network = ["async", "bytes", "hyper", "smallvec", "tonic", "tracing"]
 process = ["libc"]
 region = ["lgalloc"]
 tracing_ = [
-  "anyhow",
-  "atty",
-  "tracing",
-  "tracing-subscriber",
-  "tracing-subscriber/ansi",
-  "tracing-opentelemetry",
-  "tokio-native-tls",
-  "native-tls",
-  "http",
-  "hyper",
-  "hyper-tls",
-  "metrics",
-  "opentelemetry",
-  "opentelemetry-otlp",
-  "opentelemetry_sdk",
-  "tonic",
-  "sentry",
-  "sentry-tracing",
-  "yansi",
+    "anyhow",
+    "atty",
+    "tracing",
+    "tracing-subscriber",
+    "tracing-subscriber/ansi",
+    "tracing-opentelemetry",
+    "tokio-native-tls",
+    "native-tls",
+    "http",
+    "hyper",
+    "hyper-tls",
+    "metrics",
+    "opentelemetry",
+    "opentelemetry-otlp",
+    "opentelemetry_sdk",
+    "tonic",
+    "sentry",
+    "sentry-tracing",
+    "yansi",
 ]
 tokio-console = ["console-subscriber", "tokio", "tokio/tracing", "network"]
 cli = ["clap"]

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -18,7 +18,7 @@ bench = false
 
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-arrow = { version = "51.0.0", default-features = false }
+arrow = { version = "52.2.0", default-features = false }
 async-trait = "0.1.68"
 axum = { version = "0.6.20" }
 bytes = { version = "1.3.0", features = ["serde"] }

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -30,7 +30,8 @@ harness = false
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 arrayvec = "0.7.4"
-arrow = { version = "51.0.0", default-features = false }
+arrow = { version = "52.2.0", default-features = false }
+arrow-row = { version = "52.2.0", default-features = false }
 async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytes = { version = "1.3.0", features = ["serde"] }

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -13,15 +13,15 @@ workspace = true
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-arrow = { version = "51.0.0", default-features = false }
+arrow = { version = "52.2.0", default-features = false }
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 hex = "0.4.3"
 mz-ore = { path = "../ore", features = ["metrics", "test"], default-features = false }
 mz-proto = { path = "../proto", default-features = false }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow"] }
+parquet = { version = "52.2.0", default-features = false, features = ["arrow"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -23,12 +23,12 @@ bench = false
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-arrow = { version = "51.0.0", default-features = false }
+arrow = { version = "52.2.0", default-features = false }
 async-trait = "0.1.68"
 async-stream = "0.3.3"
 aws-config = { version = "1.2.0", default-features = false }
 aws-credential-types = { version = "1.1.1", features = ["hardcoded-credentials"] }
-aws-sdk-s3 = { version = "1.23.0", default-features = false, features = ["rt-tokio"]  }
+aws-sdk-s3 = { version = "1.23.0", default-features = false, features = ["rt-tokio"] }
 aws-types = "1.1.1"
 base64 = "0.13.1"
 bytes = "1.3.0"
@@ -46,11 +46,11 @@ mz-postgres-client = { path = "../postgres-client" }
 mz-proto = { path = "../proto" }
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow"] }
+parquet = { version = "52.2.0", default-features = false, features = ["arrow"] }
 postgres-openssl = { version = "0.5.0" }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -27,7 +27,8 @@ harness = false
 
 [dependencies]
 anyhow = "1.0.66"
-arrow = { version = "51.0.0", default-features = false }
+arrow = { version = "52.2.0", default-features = false }
+arrow-row = { version = "52.2.0", default-features = false }
 bitflags = "1.3.2"
 bytes = "1.3.0"
 cfg-if = "1.0.0"

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
-arrow = { version = "51.0.0", default-features = false }
+arrow = { version = "52.2.0", default-features = false }
 async-stream = "0.3.3"
 aws-types = "1.1.1"
 bytesize = "1.1.0"
@@ -30,7 +30,7 @@ mz-repr = { path = "../repr" }
 mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 mz-txn-wal = { path = "../txn-wal" }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
+parquet = { version = "52.2.0", default-features = false, features = ["arrow", "snap"] }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 sentry = { version = "0.29.1" }

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -15,7 +15,7 @@ harness = false
 
 [dependencies]
 anyhow = "1.0.66"
-arrow = { version = "51.0.0", default-features = false }
+arrow = { version = "52.2.0", default-features = false }
 async-trait = "0.1.68"
 aws-config = { version = "1.2.0", default-features = false, features = ["sso"] }
 aws-credential-types = { version = "1.1.1", features = ["hardcoded-credentials"] }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -18,7 +18,7 @@ aws-config = { version = "1.2.0", default-features = false }
 aws-credential-types = { version = "1.1.1", features = ["hardcoded-credentials"] }
 aws-sdk-sts = { version = "1.7.0", default-features = false, features = ["rt-tokio"] }
 aws-types = "1.1.1"
-arrow = { version = "51.0.0", default-features = false }
+arrow = { version = "52.2.0", default-features = false }
 byteorder = "1.4.3"
 bytes = "1.3.0"
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
@@ -54,7 +54,7 @@ mz-sql = { path = "../sql" }
 mz-sql-parser = { path = "../sql-parser" }
 mz-storage-types = { path = "../storage-types" }
 mz-tls-util = { path = "../tls-util" }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow"] }
+parquet = { version = "52.2.0", default-features = false, features = ["arrow"] }
 postgres_array = { version = "0.11.0" }
 postgres-protocol = { version = "0.6.5" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -82,7 +82,7 @@ num-traits = { version = "0.2.15", features = ["i128", "libm"] }
 openssl = { version = "0.10.64", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
+parquet = { version = "52.2.0", default-features = false, features = ["arrow", "snap"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
@@ -206,7 +206,7 @@ num-traits = { version = "0.2.15", features = ["i128", "libm"] }
 openssl = { version = "0.10.64", features = ["vendored"] }
 ordered-float = { version = "4.2.0", features = ["serde"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
-parquet = { version = "51.0.0", default-features = false, features = ["arrow", "snap"] }
+parquet = { version = "52.2.0", default-features = false, features = ["arrow", "snap"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }


### PR DESCRIPTION
### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

```
sort_structured2_repr   time:   [35.707 ms 35.768 ms 35.836 ms]
                        change: [-2.5479% -1.9692% -1.4942%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

sort_structured2_lexsort
                        time:   [14.201 ms 14.239 ms 14.280 ms]
                        change: [-5.4958% -4.4009% -3.4494%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  12 (12.00%) high mild
  1 (1.00%) high severe

sort_structured2_arrayord
                        time:   [21.337 ms 21.375 ms 21.418 ms]
                        change: [-11.070% -8.9658% -7.1060%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe

sort_structured2_row    time:   [12.369 ms 12.392 ms 12.417 ms]
                        change: [-5.8678% -4.9708% -4.1489%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) high mild
  12 (12.00%) high severe

sort_structured2_merge_repr
                        time:   [7.6495 ms 7.6661 ms 7.6848 ms]
                        change: [-2.8954% -2.2056% -1.5748%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe

sort_structured2_merge_dyncmp
                        time:   [3.0179 ms 3.0260 ms 3.0344 ms]
                        change: [-5.7680% -4.7886% -3.8694%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

sort_structured2_merge_arrayord
                        time:   [3.2991 ms 3.3083 ms 3.3183 ms]
                        change: [-4.0291% -3.4845% -2.9241%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

sort_structured2_merge_row
                        time:   [3.9468 ms 3.9541 ms 3.9618 ms]
                        change: [-4.8853% -3.3091% -2.1023%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

sort_structured2_interleave_repr
                        time:   [6.3214 ms 6.3341 ms 6.3479 ms]
                        change: [-3.7488% -3.0854% -2.5127%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

sort_structured2_interleave_arrow
                        time:   [2.5916 ms 2.5966 ms 2.6022 ms]
                        change: [-4.1028% -2.8619% -1.8303%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

sort_structured2_interleave_row
                        time:   [3.3270 ms 3.3392 ms 3.3521 ms]
                        change: [-4.4999% -3.6566% -2.8815%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
