### PR TITLE
sql: Rename `internal` on `VarDefinition`, make feature flags always internal

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1291,28 +1291,28 @@ impl SystemVars {
             .entries()
             .map(|cfg| match cfg.default() {
                 ConfigVal::Bool(default) => {
-                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), true)
+                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), false)
                 }
                 ConfigVal::U32(default) => {
-                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), true)
+                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), false)
                 }
                 ConfigVal::Usize(default) => {
-                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), true)
+                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), false)
                 }
                 ConfigVal::OptUsize(default) => {
-                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), true)
+                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), false)
                 }
                 ConfigVal::F64(default) => {
-                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), true)
+                    VarDefinition::new_runtime(cfg.name(), *default, cfg.desc(), false)
                 }
                 ConfigVal::String(default) => {
-                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), true)
+                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), false)
                 }
                 ConfigVal::Duration(default) => {
-                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), true)
+                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), false)
                 }
                 ConfigVal::Json(default) => {
-                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), true)
+                    VarDefinition::new_runtime(cfg.name(), default.clone(), cfg.desc(), false)
                 }
             })
             .collect();

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1643,7 +1643,7 @@ macro_rules! feature_flags {
                 stringify!($name),
                 value!(bool; $value),
                 concat!("Whether ", $desc, " is allowed (Materialize)."),
-                true,
+                false,
             );
 
             pub static [<$name:upper >]: FeatureFlag = FeatureFlag {

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -659,7 +659,7 @@ pub static UNSAFE_NEW_TRANSACTION_WALL_TIME: VarDefinition = VarDefinition::new(
     value!(Option<CheckedTimestamp<DateTime<Utc>>>; None),
     "Sets the wall time for all new explicit or implicit transactions to control the value of `now()`. \
     If not set, uses the system's clock.",
-    // This needs to be false because `internal: true` things are only modifiable by the mz_system
+    // This needs to be true because `user_visible: false` things are only modifiable by the mz_system
     // and mz_support users, and we want sqllogictest to have access with its user. Because the name
     // starts with "unsafe" it still won't be visible or changeable by users unless unsafe mode is
     // enabled.
@@ -1596,12 +1596,11 @@ pub mod cluster_scheduling {
 /// availability of features.
 ///
 /// The arguments to `feature_flags!` are:
-/// - `$name`, which will be the name of the feature flag, in snake_case,
-/// - `$feature_desc`, a human-readable description of the feature,
-/// - `$value`, which if not provided, defaults to `false` and also defaults `$internal` to `true`.
-/// - `$internal`, which if not provided, defaults to `true`. Requires `$value`.
+/// - `$name`, which will be the name of the feature flag, in snake_case
+/// - `$feature_desc`, a human-readable description of the feature
+/// - `$value`, which if not provided, defaults to `false`
 ///
-/// Note that not all `ServerVar<bool>` are feature flags. Feature flags are for variables that:
+/// Note that not all `VarDefinition<bool>` are feature flags. Feature flags are for variables that:
 /// - Belong to `SystemVars`, _not_ `SessionVars`
 /// - Default to false and must be explicitly enabled, or default to `true` and can be explicitly disabled.
 ///
@@ -1627,7 +1626,7 @@ pub mod cluster_scheduling {
 /// Ensuring that all syntax-related feature flags *enable* behavior means that setting all such
 /// feature flags to `on` during catalog boot has the desired effect.
 macro_rules! feature_flags {
-    // Match `$name, $feature_desc, $value, $internal`.
+    // Match `$name, $feature_desc, $value`.
     (@inner
         // The feature flag name.
         name: $name:expr,

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -129,7 +129,7 @@ impl VarDefinition {
         }
     }
 
-    /// Create a new [`VarDefinition`] with a lazily evaluated value.
+    /// Create a new [`VarDefinition`] with a value known at runtime.
     pub fn new_runtime<V: Value>(
         name: &'static str,
         value: V,

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -30,8 +30,6 @@ emit_introspection_query_notice     on                      "Whether to print a 
 emit_plan_insights_notice           off                     "Boolean flag indicating whether to send a NOTICE with JSON-formatted plan insights before executing a SELECT statement (Materialize)."
 emit_timestamp_notice               off                     "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize)."
 emit_trace_id_notice                off                     "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize)."
-enable_alter_swap                   on                      "Whether the ALTER SWAP feature for objects is allowed (Materialize)."
-enable_comment                      on                      "Whether the COMMENT ON feature for objects is allowed (Materialize)."
 enable_rbac_checks                  on                      "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 enable_session_rbac_checks          off                     "User facing session boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 extra_float_digits                  3                       "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."


### PR DESCRIPTION
Renames the unclear field of "internal" to "user_visible", flips existing values for internal, and marks all feature flags as "user_visible: false".

### Motivation

Slack convo: https://materializeinc.slack.com/archives/C0761MZ3QD9/p1723436590306659?thread_ts=1723258258.809039&cid=C0761MZ3QD9

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
