### PR TITLE
ci: No pruning, switch x86-64 back to AWS

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -47,10 +47,6 @@ fi
 ci_collapsed_heading ":docker: Purging all existing docker containers and volumes, regardless of origin"
 docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes
 rm -f services.log
-ci_collapsed_heading ":docker: Pruning less recently used docker images to save disk space"
-for r in $(docker images --format "{{.Repository}}" | sort -u); do
-  docker rmi "$(docker images -q --filter reference="$r" | tail -n+3)" || true
-done
 
 ci_collapsed_heading ":docker: Rebuilding non-mzbuild containers"
 mzcompose --mz-quiet build

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -215,7 +215,9 @@ steps:
         timeout_in_minutes: 30
         agents:
           # no matching manifest of MySQL 5.7.x for linux/arm64/v8 in the manifest list entries
-          queue: hetzner-x86-64-4cpu-8gb
+          # TODO(def-) Switch back to Hetzner when we have increased server limit
+          queue: linux-x86_64-small
+          # queue: hetzner-x86-64-4cpu-8gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: mysql-cdc

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -216,7 +216,9 @@ steps:
         timeout_in_minutes: 30
         agents:
           # hugo: command not found
-          queue: hetzner-x86-64-4cpu-8gb
+          # TODO(def-) Switch back to Hetzner when we have increased server limit
+          queue: linux-x86_64-small
+          # queue: hetzner-x86-64-4cpu-8gb
         coverage: skip
         sanitizer: skip
 
@@ -355,7 +357,9 @@ steps:
               run: sql-server
         agents:
           # too slow to run emulated on aarch64, SQL Server's docker image is not yet available for aarch64 natively yet: https://github.com/microsoft/mssql-docker/issues/802
-          queue: hetzner-x86-64-4cpu-8gb
+          # TODO(def-) Switch back to Hetzner when we have increased server limit
+          queue: linux-x86_64-small
+          # queue: hetzner-x86-64-4cpu-8gb
 
       - id: debezium-mysql
         label: Debezium MySQL tests
@@ -696,7 +700,9 @@ steps:
           composition: metabase
     agents:
       # too slow to run emulated on aarch64, Metabase'ss docker image is not yet available for aarch64 natively yet: https://github.com/metabase/metabase/issues/13119
-      queue: hetzner-x86-64-4cpu-8gb
+      # TODO(def-) Switch back to Hetzner when we have increased server limit
+      queue: linux-x86_64-small
+      # queue: hetzner-x86-64-4cpu-8gb
 
   - id: dbt-materialize
     label: dbt-materialize tests


### PR DESCRIPTION
Currently resource-constrained on Hetzner and these jobs often take a long time since there are so few of them, so chance of having an agent is low.

We have better pruning with https://github.com/MaterializeInc/i2/pull/2094 now

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
