### PR TITLE
Pass github user env vars into the ci-builder

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -236,6 +236,11 @@ case "$cmd" in
             --env COCKROACH_URL
             # For ci-closed-issues-detect
             --env GITHUB_CI_ISSUE_REFERENCE_CHECKER_TOKEN
+            # For auto_cut_release
+            --env GIT_AUTHOR_EMAIL
+            --env GIT_AUTHOR_NAME
+            --env GIT_COMMITTER_EMAIL
+            --env GIT_COMMITTER_NAME
         )
 
         if [[ $detach_container == "true" ]]; then

--- a/misc/python/materialize/release/auto_cut_release.py
+++ b/misc/python/materialize/release/auto_cut_release.py
@@ -11,13 +11,13 @@
 
 import os
 import sys
-from pathlib import Path
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from materialize import MZ_ROOT, git, spawn
 from materialize.mz_version import MzVersion
 
-version_file_text = """---
+VERSION_FILE_TEXT = """---
 title: "Materialize $VERSION"
 date: $DATE
 released: false
@@ -72,7 +72,7 @@ def main():
         MZ_ROOT / "doc" / "user" / "content" / "releases" / f"{next_version_final}.md"
     )
     if not next_version_doc_file.exists():
-        text = version_file_text.replace("$VERSION", str(next_version_final)).replace(
+        text = VERSION_FILE_TEXT.replace("$VERSION", str(next_version_final)).replace(
             "$DATE", next_thursday.strftime("%Y-%m-%d")
         )
         next_version_doc_file.write_text(text)


### PR DESCRIPTION
To make the misc/python/materialize/release/auto_cut_release.py script work - needed to push up commits.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
