### PR TITLE
testdrive: Fix running in cloudtest

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/redpanda.py
+++ b/misc/python/materialize/cloudtest/k8s/redpanda.py
@@ -52,6 +52,9 @@ class RedpandaDeployment(K8sDeployment):
                 "redpanda.enable_idempotence=true",
                 "--set",
                 "redpanda.auto_create_topics_enabled=true",
+                # Only require 4KB per topic partition rather than 4MiB.
+                "--set",
+                "redpanda.topic_memory_per_partition=4096",
                 "--advertise-kafka-addr",
                 f"redpanda.{namespace}:9092",
             ],


### PR DESCRIPTION
    testdrive/github-26353.td:23:1: error: Admin operation error: InvalidPartitions (Broker: Invalid number of partitions)

Seen failing in https://buildkite.com/materialize/nightly/builds/9127#01915864-3592-4b6c-9bac-1d3b68bac1b0

Follow-up to https://github.com/MaterializeInc/materialize/pull/28968

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
