### PR TITLE
coordinator: Dequeue batches of messages

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -113,7 +113,7 @@ use mz_controller::ControllerConfig;
 use mz_controller_types::{ClusterId, ReplicaId, WatchSetId};
 use mz_expr::{MapFilterProject, OptimizedMirRelationExpr};
 use mz_orchestrator::ServiceProcessMetrics;
-use mz_ore::cast::CastFrom;
+use mz_ore::cast::{CastFrom, CastLossy};
 use mz_ore::future::TimeoutError;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
@@ -2970,25 +2970,33 @@ impl Coordinator {
                 .system_config()
                 .coord_slow_message_warn_threshold();
 
+            const MESSAGE_BATCH: usize = 64;
+            let mut messages = Vec::with_capacity(MESSAGE_BATCH);
+            let mut cmd_messages = Vec::with_capacity(MESSAGE_BATCH);
+
+            let message_batch = self.metrics
+                .message_batch
+                .with_label_values(&[]);
+
             loop {
                 // Before adding a branch to this select loop, please ensure that the branch is
                 // cancellation safe and add a comment explaining why. You can refer here for more
                 // info: https://docs.rs/tokio/latest/tokio/macro.select.html#cancellation-safety
-                let msg = select! {
+                select! {
                     // Order matters here. Some correctness properties rely on us processing
                     // internal commands before processing external commands.
                     biased;
 
                     // `recv()` on `UnboundedReceiver` is cancel-safe:
                     // https://docs.rs/tokio/1.8.0/tokio/sync/mpsc/struct.UnboundedReceiver.html#cancel-safety
-                    Some(m) = internal_cmd_rx.recv() => m,
+                    _ = internal_cmd_rx.recv_many(&mut messages, MESSAGE_BATCH) => {},
                     // `next()` on any stream is cancel-safe:
                     // https://docs.rs/tokio-stream/0.1.9/tokio_stream/trait.StreamExt.html#cancel-safety
-                    Some(event) = cluster_events.next() => Message::ClusterEvent(event),
+                    Some(event) = cluster_events.next() => messages.push(Message::ClusterEvent(event)),
                     // See [`mz_controller::Controller::Controller::ready`] for notes
                     // on why this is cancel-safe.
                     () = self.controller.ready() => {
-                        Message::ControllerReady
+                        messages.push(Message::ControllerReady);
                     }
                     // See [`appends::GroupCommitWaiter`] for notes on why this is cancel safe.
                     permit = group_commit_rx.ready() => {
@@ -3011,15 +3019,15 @@ impl Coordinator {
                                 span
                             }
                         };
-                        Message::GroupCommitInitiate(span, Some(permit))
+                        messages.push(Message::GroupCommitInitiate(span, Some(permit)));
                     },
                     // `recv()` on `UnboundedReceiver` is cancellation safe:
                     // https://docs.rs/tokio/1.8.0/tokio/sync/mpsc/struct.UnboundedReceiver.html#cancel-safety
-                    m = cmd_rx.recv() => match m {
-                        None => break,
-                        Some((otel_ctx, m)) => {
-                            Message::Command(otel_ctx, m)
-
+                    count = cmd_rx.recv_many(&mut cmd_messages, MESSAGE_BATCH) => {
+                        if count == 0 {
+                            break;
+                        } else {
+                            messages.extend(cmd_messages.drain(..).map(|(otel_ctx, cmd)| Message::Command(otel_ctx, cmd)));
                         }
                     },
                     // `recv()` on `UnboundedReceiver` is cancellation safe:
@@ -3036,7 +3044,7 @@ impl Coordinator {
                                 "connections can not have multiple concurrent reads, prev: {prev:?}"
                             )
                         }
-                        Message::LinearizeReads
+                        messages.push(Message::LinearizeReads);
                     }
                     // `tick()` on `Interval` is cancel-safe:
                     // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
@@ -3047,12 +3055,12 @@ impl Coordinator {
                         }
                         let span = info_span!(parent: None, "coord::advance_timelines_interval");
                         span.follows_from(Span::current());
-                        Message::GroupCommitInitiate(span, None)
+                        messages.push(Message::GroupCommitInitiate(span, None));
                     },
                     // `tick()` on `Interval` is cancel-safe:
                     // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
                     _ = self.check_cluster_scheduling_policies_interval.tick() => {
-                        Message::CheckSchedulingPolicies
+                        messages.push(Message::CheckSchedulingPolicies);
                     },
 
                     // `tick()` on `Interval` is cancel-safe:
@@ -3080,55 +3088,59 @@ impl Coordinator {
                     }
                 };
 
-                // All message processing functions trace. Start a parent span
-                // for them to make it easy to find slow messages.
-                let msg_kind = msg.kind();
-                let span = span!(
-                    target: "mz_adapter::coord::handle_message_loop",
-                    Level::INFO,
-                    "coord::handle_message",
-                    kind = msg_kind
-                );
-                let otel_context = span.context().span().span_context().clone();
+                message_batch.observe(f64::cast_lossy(messages.len()));
 
-                // Record the last kind of message in case we get stuck. For
-                // execute commands, we additionally stash the user's SQL,
-                // statement, so we can log it in case we get stuck.
-                *last_message.lock().expect("poisoned") = LastMessage {
-                    kind: msg_kind,
-                    stmt: match &msg {
-                        Message::Command(
-                            _,
-                            Command::Execute {
-                                portal_name,
-                                session,
-                                ..
-                            },
-                        ) => session
-                            .get_portal_unverified(portal_name)
-                            .and_then(|p| p.stmt.as_ref().map(Arc::clone)),
-                        _ => None,
-                    },
-                };
-
-                let start = Instant::now();
-                self.handle_message(span, msg).await;
-                let duration = start.elapsed();
-
-                self.metrics
-                    .message_handling
-                    .with_label_values(&[msg_kind])
-                    .observe(duration.as_secs_f64());
-
-                // If something is _really_ slow, print a trace id for debugging, if OTEL is enabled.
-                if duration > warn_threshold {
-                    let trace_id = otel_context.is_valid().then(|| otel_context.trace_id());
-                    tracing::error!(
-                        ?msg_kind,
-                        ?trace_id,
-                        ?duration,
-                        "very slow coordinator message"
+                for msg in messages.drain(..) {
+                    // All message processing functions trace. Start a parent span
+                    // for them to make it easy to find slow messages.
+                    let msg_kind = msg.kind();
+                    let span = span!(
+                        target: "mz_adapter::coord::handle_message_loop",
+                        Level::INFO,
+                        "coord::handle_message",
+                        kind = msg_kind
                     );
+                    let otel_context = span.context().span().span_context().clone();
+
+                    // Record the last kind of message in case we get stuck. For
+                    // execute commands, we additionally stash the user's SQL,
+                    // statement, so we can log it in case we get stuck.
+                    *last_message.lock().expect("poisoned") = LastMessage {
+                        kind: msg_kind,
+                        stmt: match &msg {
+                            Message::Command(
+                                _,
+                                Command::Execute {
+                                    portal_name,
+                                    session,
+                                    ..
+                                },
+                            ) => session
+                                .get_portal_unverified(portal_name)
+                                .and_then(|p| p.stmt.as_ref().map(Arc::clone)),
+                            _ => None,
+                        },
+                    };
+
+                    let start = Instant::now();
+                    self.handle_message(span, msg).await;
+                    let duration = start.elapsed();
+
+                    self.metrics
+                        .message_handling
+                        .with_label_values(&[msg_kind])
+                        .observe(duration.as_secs_f64());
+
+                    // If something is _really_ slow, print a trace id for debugging, if OTEL is enabled.
+                    if duration > warn_threshold {
+                        let trace_id = otel_context.is_valid().then(|| otel_context.trace_id());
+                        tracing::error!(
+                            ?msg_kind,
+                            ?trace_id,
+                            ?duration,
+                            "very slow coordinator message"
+                        );
+                    }
                 }
             }
             // Try and cleanup as a best effort. There may be some async tasks out there holding a

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -447,11 +447,9 @@ impl Coordinator {
         // ordering of advancing timelines and user transactions. Updating read holds are only to
         // allow compaction and free some memory. Non-realtime timelines can only be written to by
         // upstream sources, which we don't provide ordering guarantees for with respect to user
-        // transactions. We send the `AdvanceTimelines` message here out of convenience, because we
+        // transactions. We advance the timelines here out of convenience, because we
         // know at least the real-time timeline will have a read hold that can be updated.
-        self.internal_cmd_tx
-            .send(Message::AdvanceTimelines)
-            .expect("sending to self.internal_cmd_tx cannot fail");
+        self.advance_timelines().await;
     }
 
     /// Submit a write to be executed during the next group commit and trigger a group commit.

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -79,7 +79,7 @@ impl Coordinator {
     /// BOXED FUTURE: As of Nov 2023 the returned Future from this function was 58KB. This would
     /// get stored on the stack which is bad for runtime performance, and blow up our stack usage.
     /// Because of that we purposefully move this Future onto the heap (i.e. Box it).
-    pub(crate) fn handle_command<'a>(&'a mut self, mut cmd: Command) -> LocalBoxFuture<'a, ()> {
+    pub(crate) fn handle_command(&mut self, mut cmd: Command) -> LocalBoxFuture<()> {
         async move {
             if let Some(session) = cmd.session_mut() {
                 session.apply_external_metadata_updates();

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4504,6 +4504,10 @@ impl Coordinator {
         session: &Session,
         notices: &Vec<RawOptimizerNotice>,
     ) {
+        // `for_session` below is expensive, so return early if there's nothing to do.
+        if notices.is_empty() {
+            return;
+        }
         let humanizer = self.catalog.for_session(session);
         let system_vars = self.catalog.system_config();
         for notice in notices {

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -32,6 +32,7 @@ pub struct Metrics {
     pub time_to_first_row_seconds: HistogramVec,
     pub statement_logging_unsampled_bytes: IntCounterVec,
     pub statement_logging_actual_bytes: IntCounterVec,
+    pub message_batch: HistogramVec,
     pub message_handling: HistogramVec,
     pub optimization_notices: IntCounterVec,
     pub append_table_duration_seconds: HistogramVec,
@@ -119,6 +120,11 @@ impl Metrics {
             statement_logging_actual_bytes: registry.register(metric!(
                 name: "mz_statement_logging_actual_bytes",
                 help: "The total amount of SQL text that was logged by statement logging.",
+            )),
+            message_batch: registry.register(metric!(
+                name: "mz_coordinator_message_batch_size",
+                help: "Message batch size handled by the coordinator.",
+                buckets: vec![0., 1., 2., 3., 4., 6., 8., 12., 16., 24., 32., 48., 64.],
             )),
             message_handling: registry.register(metric!(
                 name: "mz_slow_message_handling",


### PR DESCRIPTION
Dequeues batches of messages at a time when possible to amortize the cost
of calling into select. Not all components are able to provide batches of
messages, specifically the controller-ready response is message-at-a-time.

Workload: (The exact view definition is pretty irrelevant, just a leftover from a previous experiment.)
```
duration = 120s

[setup]
query=create materialized view if not exists test2 as select generate_series as x from generate_series(1, 100)
query=create view if not exists tempview1 as select * from test2 where x % 2 = 1
query=create default index on tempview1

[teardown]
query=drop materialized view test2 cascade

[loadtest]
query=select * from tempview1
concurrency=128
start=5s
```

Before:
```
2024/08/15 13:33:23 loadtest: 167229 transactions (1453.389 TPS), latency 87.544447ms±329.584µs; 8361450 rows (72669.429 RPS), 167229 queries (1453.389 QPS); 0 aborts (0.000%), latency 0s±0s
Transactions:
  8.388608ms -  16.777216ms [     1]: ▏
 16.777216ms -  33.554432ms [     0]:
 33.554432ms -  67.108864ms [ 92177]: ██████████████████████████████████████████████████
 67.108864ms - 134.217728ms [ 49124]: ██████████████████████████▋
134.217728ms - 268.435456ms [ 23421]: ████████████▋
268.435456ms - 536.870912ms [  2375]: █▎
536.870912ms - 1.073741824s [   131]: ▏
2024/08/15 13:33:23 Performing teardown
```

After:
```
2024/08/16 10:20:30 loadtest: 230644 transactions (2004.556 TPS), latency 63.369413ms±183.222µs; 11532200 rows (100227.795 RPS), 230644 queries (2004.556 QPS); 0 aborts (0.000%), latency 0s±0s
Transactions:
 16.777216ms -  33.554432ms [   669]: ▏
 33.554432ms -  67.108864ms [161896]: ██████████████████████████████████████████████████
 67.108864ms - 134.217728ms [ 58666]: ██████████████████
134.217728ms - 268.435456ms [  8837]: ██▋
268.435456ms - 536.870912ms [   576]: ▏
2024/08/16 10:20:30 Performing teardown
```

In support of #28720.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
