### PR TITLE
postgres consistency: adjust ignores

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/operations/generic_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/generic_operations_provider.py
@@ -6,7 +6,9 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
 from materialize.output_consistency.input_data.params.any_operation_param import (
     AnyLikeOtherOperationParam,
     AnyOperationParam,
@@ -41,6 +43,7 @@ IS_NULL_OPERATION = DbOperation(
     [AnyOperationParam()],
     BooleanReturnTypeSpec(),
 )
+IS_NULL_OPERATION.added_characteristics.add(ExpressionCharacteristics.NULL)
 GENERIC_OPERATION_TYPES.append(IS_NULL_OPERATION)
 
 GENERIC_OPERATION_TYPES.append(

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -206,6 +206,14 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("#28193: bpchar in jsonb aggregation without spaces")
 
+        if expression.matches(
+            partial(matches_any_expression_arg, arg_matcher=is_table_function),
+            True,
+        ) and expression.has_any_characteristic({ExpressionCharacteristics.NULL}):
+            return YesIgnore(
+                "#28806: table functions: combination with operations with NULL"
+            )
+
         return super()._matches_problematic_operation_or_function_invocation(
             expression, operation, all_involved_characteristics
         )
@@ -330,14 +338,6 @@ class PgPreExecutionInconsistencyIgnoreFilter(
                 True,
             ):
                 return YesIgnore("Consequence of #25723: decimal 0s are not shown")
-
-        if expression.matches(
-            partial(matches_any_expression_arg, arg_matcher=is_table_function),
-            True,
-        ) and expression.has_any_characteristic({ExpressionCharacteristics.NULL}):
-            return YesIgnore(
-                "#28806: table functions: combination with operations with NULL"
-            )
 
         return NoIgnore()
 

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -27,11 +27,12 @@ from materialize.output_consistency.validation.result_comparator import ResultCo
 # * 2038-01-19 03:14:18
 # * 2038-01-19 03:14:18.123
 # * 2038-01-19 03:14:18.123+00
+# * 2038-01-19 03:14:18.123+00 BC
 # * 2038-01-19 03:14:18+00
 # * 2038-01-19 03:14:18-03:00
 # * 2038-01-19T03:14:18+00 (when used in JSONB)
 TIMESTAMP_PATTERN = re.compile(
-    r"^\d{4,}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d+(:\d+)?)?$"
+    r"^\d{4,}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d+(:\d+)?)?( (BC|AC))?$"
 )
 
 # Examples:
@@ -137,9 +138,11 @@ class PostgresResultComparator(ResultComparator):
         return TIMESTAMP_PATTERN.match(value) is not None
 
     def is_timestamp_equal(self, value1: str, value2: str) -> bool:
+        # try to match any of these
         last_second_and_milliseconds_regex = r"(\d\.\d+)"
         last_second_before_timezone_regex = r"(?<=:\d)(\d)(?=\+)"
         last_second_at_the_end_regex = r"(?<=:\d)(\d$)"
+
         last_second_and_milliseconds_pattern = re.compile(
             f"{last_second_and_milliseconds_regex}|{last_second_before_timezone_regex}|{last_second_at_the_end_regex}"
         )


### PR DESCRIPTION
This addresses issues observed in https://buildkite.com/materialize/nightly/builds/9127#01915864-3615-4762-9fbd-d1037caeac05.

### Commits
5065533482 output consistency: operations: improve definition
bf8c2efd94 postgres consistency: move ignore to also apply to operations
014277cbe9 postgres consistency: result comparator: extend timestamp pattern
