### PR TITLE
ci: Real fix for `no such service: default`

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -63,7 +63,13 @@ cat /proc/sys/kernel/core_pattern
 # Start dependencies under a different heading so that the main heading is less
 # noisy. But not if the service is actually a workflow, in which case it will
 # do its own dependency management.
-if ! mzcompose --mz-quiet list-workflows | grep -q "$service"; then
+
+# Don't use `grep -q`! It will stop the `grep` process before mzcompose might
+# be finished, thus mzcompose can fail with `write /dev/stdout: broken pipe`.
+# Since we have `pipefail` set in this script, this would lead to a failure and
+# we would attempt to bring up the workflow, which will fail with `no such
+# service: default`.
+if ! mzcompose --mz-quiet list-workflows | grep "$service" > /dev/null; then
     ci_collapsed_heading ":docker: Starting dependencies"
     mzcompose up -d --scale "$service=0" "$service"
 fi

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -323,7 +323,6 @@ class Composition:
             file = TemporaryFile(mode="w")
             os.set_inheritable(file.fileno(), True)
             yaml.dump(self.compose, file)
-            file.flush()
             self.files[thread_id] = file
 
         cmd = [


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/29041

Verified that this is the cause by adding a sleep:
 ```diff
diff --git a/misc/python/materialize/cli/mzcompose.py b/misc/python/materialize/cli/mzcompose.py
index 3a2f5dbb81..a9cf23cc04 100644
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -24,6 +24,7 @@ from __future__ import annotations

 import argparse
 import inspect
+import time
 import json
 import os
 import shlex
@@ -319,6 +320,7 @@ class ListWorkflowsCommand(Command):
         composition = load_composition(args)
         for name in sorted(composition.workflows):
             print(name)
+            time.sleep(10)
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
