### PR TITLE
expr: optimize `to_char` for static format

### DIFF
--- a/src/expr/BUILD.bazel
+++ b/src/expr/BUILD.bazel
@@ -112,6 +112,7 @@ filegroup(
 		"src/relation.proto",
 		"src/relation/func.proto",
 		"src/scalar.proto",
+		"src/scalar/func/format.proto",
 		"src/scalar/like_pattern.proto",
 		"//src/pgtz:all_protos",
 		"//src/proto:all_protos",

--- a/src/expr/build.rs
+++ b/src/expr/build.rs
@@ -37,6 +37,7 @@ fn main() {
                 "expr/src/relation.proto",
                 "expr/src/relation/func.proto",
                 "expr/src/scalar.proto",
+                "expr/src/scalar/func/format.proto",
                 "expr/src/scalar/like_pattern.proto",
             ],
             &[".."],

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -14,6 +14,7 @@ syntax = "proto3";
 import "google/protobuf/empty.proto";
 
 import "expr/src/scalar/like_pattern.proto";
+import "expr/src/scalar/func/format.proto";
 
 import "pgtz/src/timezone.proto";
 import "proto/src/chrono.proto";
@@ -126,6 +127,10 @@ message ProtoUnaryFunc {
     message ProtoCastRecord1ToRecord2 {
         mz_repr.relation_and_scalar.ProtoScalarType return_ty = 1;
         repeated ProtoMirScalarExpr cast_exprs = 2;
+    }
+    message ProtoToCharTimestamp {
+        string format_string = 1;
+        mz_expr.scalar.func.format.ProtoDateTimeFormat format = 2;
     }
     reserved 5, 6, 15, 104, 111, 115, 212, 306, 313;
     oneof kind {
@@ -451,6 +456,8 @@ message ProtoUnaryFunc {
         google.protobuf.Empty kafka_murmur2_string = 328;
         google.protobuf.Empty seahash_bytes = 329;
         google.protobuf.Empty seahash_string = 330;
+        ProtoToCharTimestamp to_char_timestamp = 331;
+        ProtoToCharTimestamp to_char_timestamp_tz = 332;
     }
 }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -69,7 +69,7 @@ use crate::{like_pattern, EvalError, MirScalarExpr};
 #[macro_use]
 mod macros;
 mod encoding;
-mod format;
+pub(crate) mod format;
 pub(crate) mod impls;
 
 pub use impls::*;
@@ -4790,6 +4790,8 @@ derive_unary!(
     TimezoneTimestampTz,
     TimezoneTime,
     ToTimestamp,
+    ToCharTimestamp,
+    ToCharTimestampTz,
     JustifyDays,
     JustifyHours,
     JustifyInterval,
@@ -5590,6 +5592,14 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                 wall_time: Some(func.wall_time.into_proto()),
             }),
             UnaryFunc::ToTimestamp(_) => ToTimestamp(()),
+            UnaryFunc::ToCharTimestamp(func) => ToCharTimestamp(ProtoToCharTimestamp {
+                format_string: func.format_string.into_proto(),
+                format: Some(func.format.into_proto()),
+            }),
+            UnaryFunc::ToCharTimestampTz(func) => ToCharTimestampTz(ProtoToCharTimestamp {
+                format_string: func.format_string.into_proto(),
+                format: Some(func.format.into_proto()),
+            }),
             UnaryFunc::JustifyDays(_) => JustifyDays(()),
             UnaryFunc::JustifyHours(_) => JustifyHours(()),
             UnaryFunc::JustifyInterval(_) => JustifyInterval(()),
@@ -6069,6 +6079,20 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                 }
                 .into()),
                 ToTimestamp(()) => Ok(impls::ToTimestamp.into()),
+                ToCharTimestamp(func) => Ok(impls::ToCharTimestamp {
+                    format_string: func.format_string,
+                    format: func
+                        .format
+                        .into_rust_if_some("ProtoToCharTimestamp::format")?,
+                }
+                .into()),
+                ToCharTimestampTz(func) => Ok(impls::ToCharTimestampTz {
+                    format_string: func.format_string,
+                    format: func
+                        .format
+                        .into_rust_if_some("ProtoToCharTimestamp::format")?,
+                }
+                .into()),
                 JustifyDays(()) => Ok(impls::JustifyDays.into()),
                 JustifyHours(()) => Ok(impls::JustifyHours.into()),
                 JustifyInterval(()) => Ok(impls::JustifyInterval.into()),

--- a/src/expr/src/scalar/func/format.proto
+++ b/src/expr/src/scalar/func/format.proto
@@ -1,0 +1,98 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package mz_expr.scalar.func.format;
+
+message ProtoDateTimeFormat { repeated ProtoDateTimeFormatNode nodes = 1; }
+
+message ProtoDateTimeFormatNode {
+  message ProtoField {
+    ProtoDateTimeField field = 1;
+    bool fill = 2;
+    ProtoOrdinalMode ordinal = 3;
+  }
+
+  oneof kind {
+    ProtoField field = 1;
+    uint32 literal = 2;
+  }
+}
+
+message ProtoDateTimeField {
+  message ProtoIndicator {
+    bool dots = 1;
+    bool caps = 2;
+  }
+
+  message ProtoName {
+    bool abbrev = 1;
+    ProtoWordCaps caps = 2;
+  }
+
+  message ProtoDayName {}
+
+  oneof kind {
+    google.protobuf.Empty hour12 = 1;
+    google.protobuf.Empty hour24 = 2;
+    google.protobuf.Empty minute = 3;
+    google.protobuf.Empty second = 4;
+    google.protobuf.Empty millisecond = 5;
+    google.protobuf.Empty microsecond = 6;
+    google.protobuf.Empty seconds_past_midnight = 7;
+    ProtoIndicator meridiem = 8;
+    google.protobuf.Empty year1 = 9;
+    google.protobuf.Empty year2 = 10;
+    google.protobuf.Empty year3 = 11;
+    bool year4 = 12;
+    google.protobuf.Empty iso_year1 = 13;
+    google.protobuf.Empty iso_year2 = 14;
+    google.protobuf.Empty iso_year3 = 15;
+    google.protobuf.Empty iso_year4 = 16;
+    ProtoIndicator era = 17;
+    ProtoName month_name = 18;
+    google.protobuf.Empty month_of_year = 19;
+    ProtoName day_name = 20;
+    google.protobuf.Empty day_of_week = 21;
+    google.protobuf.Empty iso_day_of_week = 22;
+    google.protobuf.Empty day_of_month = 23;
+    google.protobuf.Empty day_of_year = 24;
+    google.protobuf.Empty iso_day_of_year = 25;
+    google.protobuf.Empty week_of_month = 26;
+    google.protobuf.Empty week_of_year = 27;
+    google.protobuf.Empty iso_week_of_year = 28;
+    google.protobuf.Empty century = 29;
+    google.protobuf.Empty julian_day = 30;
+    google.protobuf.Empty quarter = 31;
+    bool month_in_roman_numerals = 32;
+    bool timezone = 33;
+    google.protobuf.Empty timezone_hours = 34;
+    google.protobuf.Empty timezone_minutes = 35;
+    google.protobuf.Empty timezone_offset = 36;
+  }
+}
+
+message ProtoWordCaps {
+  oneof kind {
+    google.protobuf.Empty all_caps = 1;
+    google.protobuf.Empty first_caps = 2;
+    google.protobuf.Empty no_caps = 3;
+  }
+}
+
+message ProtoOrdinalMode {
+  oneof kind {
+    google.protobuf.Empty none = 1;
+    google.protobuf.Empty lower = 2;
+    google.protobuf.Empty upper = 3;
+  }
+}

--- a/src/expr/src/scalar/func/format.rs
+++ b/src/expr/src/scalar/func/format.rs
@@ -17,10 +17,15 @@ use std::fmt;
 
 use aho_corasick::AhoCorasickBuilder;
 use enum_iterator::Sequence;
+use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use serde::{Deserialize, Serialize};
 
 use crate::scalar::func::TimestampLike;
+
+include!(concat!(env!("OUT_DIR"), "/mz_expr.scalar.func.format.rs"));
 
 /// The raw tokens that can appear in a format string. Many of these tokens
 /// overlap, in which case the longest matching token should be selected.
@@ -403,7 +408,9 @@ impl DateTimeToken {
 }
 
 /// Specifies the ordinal suffix that should be attached to numeric fields.
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(
+    Debug, Eq, PartialEq, PartialOrd, Ord, Copy, Clone, Hash, Serialize, Deserialize, MzReflect,
+)]
 enum OrdinalMode {
     /// No ordinal suffix.
     None,
@@ -440,9 +447,38 @@ impl OrdinalMode {
     }
 }
 
+impl RustType<ProtoOrdinalMode> for OrdinalMode {
+    fn into_proto(&self) -> ProtoOrdinalMode {
+        use proto_ordinal_mode::*;
+
+        let kind = match self {
+            Self::None => Kind::None(()),
+            Self::Lower => Kind::Lower(()),
+            Self::Upper => Kind::Upper(()),
+        };
+        ProtoOrdinalMode { kind: Some(kind) }
+    }
+
+    fn from_proto(proto: ProtoOrdinalMode) -> Result<Self, TryFromProtoError> {
+        use proto_ordinal_mode::*;
+
+        let kind = proto
+            .kind
+            .ok_or_else(|| TryFromProtoError::missing_field("ProtoOrdinalMode::kind"))?;
+        let x = match kind {
+            Kind::None(()) => Self::None,
+            Kind::Lower(()) => Self::Lower,
+            Kind::Upper(()) => Self::Upper,
+        };
+        Ok(x)
+    }
+}
+
 /// Specifies the capitalization of a word.
 #[allow(clippy::enum_variant_names)] // Having "Caps" in the variant names is clarifying.
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(
+    Debug, Eq, PartialEq, PartialOrd, Ord, Copy, Clone, Hash, Serialize, Deserialize, MzReflect,
+)]
 enum WordCaps {
     /// All of the letters should be capitalized.
     AllCaps,
@@ -452,11 +488,38 @@ enum WordCaps {
     NoCaps,
 }
 
+impl RustType<ProtoWordCaps> for WordCaps {
+    fn into_proto(&self) -> ProtoWordCaps {
+        use proto_word_caps::*;
+
+        let kind = match self {
+            Self::AllCaps => Kind::AllCaps(()),
+            Self::FirstCaps => Kind::FirstCaps(()),
+            Self::NoCaps => Kind::NoCaps(()),
+        };
+        ProtoWordCaps { kind: Some(kind) }
+    }
+
+    fn from_proto(proto: ProtoWordCaps) -> Result<Self, TryFromProtoError> {
+        use proto_word_caps::*;
+
+        let kind = proto
+            .kind
+            .ok_or_else(|| TryFromProtoError::missing_field("ProtoWordCaps::kind"))?;
+        let x = match kind {
+            Kind::AllCaps(()) => Self::AllCaps,
+            Kind::FirstCaps(()) => Self::FirstCaps,
+            Kind::NoCaps(()) => Self::NoCaps,
+        };
+        Ok(x)
+    }
+}
+
 /// A date-time field.
 ///
 /// The variants are largely self-evident, but are described in detail in the
 /// PostgreSQL documentation if necessary.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize, MzReflect)]
 enum DateTimeField {
     Hour12,
     Hour24,
@@ -496,8 +559,131 @@ enum DateTimeField {
     TimezoneOffset,
 }
 
+impl RustType<ProtoDateTimeField> for DateTimeField {
+    fn into_proto(&self) -> ProtoDateTimeField {
+        use proto_date_time_field::*;
+
+        let kind = match self {
+            Self::Hour12 => Kind::Hour12(()),
+            Self::Hour24 => Kind::Hour24(()),
+            Self::Minute => Kind::Minute(()),
+            Self::Second => Kind::Second(()),
+            Self::Millisecond => Kind::Millisecond(()),
+            Self::Microsecond => Kind::Microsecond(()),
+            Self::SecondsPastMidnight => Kind::SecondsPastMidnight(()),
+            Self::Meridiem { dots, caps } => Kind::Meridiem(ProtoIndicator {
+                dots: dots.into_proto(),
+                caps: caps.into_proto(),
+            }),
+            Self::Year1 => Kind::Year1(()),
+            Self::Year2 => Kind::Year2(()),
+            Self::Year3 => Kind::Year3(()),
+            Self::Year4 { separator } => Kind::Year4(separator.into_proto()),
+            Self::IsoYear1 => Kind::IsoYear1(()),
+            Self::IsoYear2 => Kind::IsoYear2(()),
+            Self::IsoYear3 => Kind::IsoYear3(()),
+            Self::IsoYear4 => Kind::IsoYear4(()),
+            Self::Era { dots, caps } => Kind::Era(ProtoIndicator {
+                dots: dots.into_proto(),
+                caps: caps.into_proto(),
+            }),
+            Self::MonthName { abbrev, caps } => Kind::MonthName(ProtoName {
+                abbrev: abbrev.into_proto(),
+                caps: Some(caps.into_proto()),
+            }),
+            Self::MonthOfYear => Kind::MonthOfYear(()),
+            Self::DayName { abbrev, caps } => Kind::DayName(ProtoName {
+                abbrev: abbrev.into_proto(),
+                caps: Some(caps.into_proto()),
+            }),
+            Self::DayOfWeek => Kind::DayOfWeek(()),
+            Self::IsoDayOfWeek => Kind::IsoDayOfWeek(()),
+            Self::DayOfMonth => Kind::DayOfMonth(()),
+            Self::DayOfYear => Kind::DayOfYear(()),
+            Self::IsoDayOfYear => Kind::IsoDayOfYear(()),
+            Self::WeekOfMonth => Kind::WeekOfMonth(()),
+            Self::WeekOfYear => Kind::WeekOfYear(()),
+            Self::IsoWeekOfYear => Kind::IsoWeekOfYear(()),
+            Self::Century => Kind::Century(()),
+            Self::JulianDay => Kind::JulianDay(()),
+            Self::Quarter => Kind::Quarter(()),
+            Self::MonthInRomanNumerals { caps } => Kind::MonthInRomanNumerals(caps.into_proto()),
+            Self::Timezone { caps } => Kind::Timezone(caps.into_proto()),
+            Self::TimezoneHours => Kind::TimezoneHours(()),
+            Self::TimezoneMinutes => Kind::TimezoneMinutes(()),
+            Self::TimezoneOffset => Kind::TimezoneOffset(()),
+        };
+        ProtoDateTimeField { kind: Some(kind) }
+    }
+
+    fn from_proto(proto: ProtoDateTimeField) -> Result<Self, TryFromProtoError> {
+        use proto_date_time_field::*;
+
+        let kind = proto
+            .kind
+            .ok_or_else(|| TryFromProtoError::missing_field("ProtoDateTimeField::kind"))?;
+        let x = match kind {
+            Kind::Hour12(()) => Self::Hour12,
+            Kind::Hour24(()) => Self::Hour24,
+            Kind::Minute(()) => Self::Minute,
+            Kind::Second(()) => Self::Second,
+            Kind::Millisecond(()) => Self::Millisecond,
+            Kind::Microsecond(()) => Self::Microsecond,
+            Kind::SecondsPastMidnight(()) => Self::SecondsPastMidnight,
+            Kind::Meridiem(x) => Self::Meridiem {
+                dots: x.dots.into_rust()?,
+                caps: x.caps.into_rust()?,
+            },
+            Kind::Year1(()) => Self::Year1,
+            Kind::Year2(()) => Self::Year2,
+            Kind::Year3(()) => Self::Year3,
+            Kind::Year4(x) => Self::Year4 {
+                separator: x.into_rust()?,
+            },
+            Kind::IsoYear1(()) => Self::IsoYear1,
+            Kind::IsoYear2(()) => Self::IsoYear2,
+            Kind::IsoYear3(()) => Self::IsoYear3,
+            Kind::IsoYear4(()) => Self::IsoYear4,
+            Kind::Era(x) => Self::Era {
+                dots: x.dots.into_rust()?,
+                caps: x.caps.into_rust()?,
+            },
+            Kind::MonthName(x) => Self::MonthName {
+                abbrev: x.abbrev.into_rust()?,
+                caps: x.caps.into_rust_if_some("ProtoName::caps")?,
+            },
+            Kind::MonthOfYear(()) => Self::MonthOfYear,
+            Kind::DayName(x) => Self::DayName {
+                abbrev: x.abbrev.into_rust()?,
+                caps: x.caps.into_rust_if_some("ProtoName::caps")?,
+            },
+            Kind::DayOfWeek(()) => Self::DayOfWeek,
+            Kind::IsoDayOfWeek(()) => Self::IsoDayOfWeek,
+            Kind::DayOfMonth(()) => Self::DayOfMonth,
+            Kind::DayOfYear(()) => Self::DayOfYear,
+            Kind::IsoDayOfYear(()) => Self::IsoDayOfYear,
+            Kind::WeekOfMonth(()) => Self::WeekOfMonth,
+            Kind::WeekOfYear(()) => Self::WeekOfYear,
+            Kind::IsoWeekOfYear(()) => Self::IsoWeekOfYear,
+            Kind::Century(()) => Self::Century,
+            Kind::JulianDay(()) => Self::JulianDay,
+            Kind::Quarter(()) => Self::Quarter,
+            Kind::MonthInRomanNumerals(x) => Self::MonthInRomanNumerals {
+                caps: x.into_rust()?,
+            },
+            Kind::Timezone(x) => Self::Timezone {
+                caps: x.into_rust()?,
+            },
+            Kind::TimezoneHours(()) => Self::TimezoneHours,
+            Kind::TimezoneMinutes(()) => Self::TimezoneMinutes,
+            Kind::TimezoneOffset(()) => Self::TimezoneOffset,
+        };
+        Ok(x)
+    }
+}
+
 /// An element of a date-time format string.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, MzReflect)]
 enum DateTimeFormatNode {
     /// A field whose value will be computed from the input timestamp.
     Field {
@@ -513,6 +699,43 @@ enum DateTimeFormatNode {
     },
     /// A literal character.
     Literal(char),
+}
+
+impl RustType<ProtoDateTimeFormatNode> for DateTimeFormatNode {
+    fn into_proto(&self) -> ProtoDateTimeFormatNode {
+        use proto_date_time_format_node::*;
+
+        let kind = match self {
+            Self::Field {
+                field,
+                fill,
+                ordinal,
+            } => Kind::Field(ProtoField {
+                field: Some(field.into_proto()),
+                fill: fill.into_proto(),
+                ordinal: Some(ordinal.into_proto()),
+            }),
+            Self::Literal(c) => Kind::Literal(c.into_proto()),
+        };
+        ProtoDateTimeFormatNode { kind: Some(kind) }
+    }
+
+    fn from_proto(proto: ProtoDateTimeFormatNode) -> Result<Self, TryFromProtoError> {
+        use proto_date_time_format_node::*;
+
+        let kind = proto
+            .kind
+            .ok_or_else(|| TryFromProtoError::missing_field("ProtoDateTimeFormatNode::kind"))?;
+        let x = match kind {
+            Kind::Field(x) => Self::Field {
+                field: x.field.into_rust_if_some("ProtoField::field")?,
+                fill: x.fill.into_rust()?,
+                ordinal: x.ordinal.into_rust_if_some("ProtoField::ordinal")?,
+            },
+            Kind::Literal(x) => Self::Literal(x.into_rust()?),
+        };
+        Ok(x)
+    }
 }
 
 const WEEKDAYS_ALL_CAPS: [&str; 7] = [
@@ -792,6 +1015,7 @@ impl DateTimeFormatNode {
 }
 
 /// A compiled date-time format string.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, MzReflect)]
 pub struct DateTimeFormat(Vec<DateTimeFormatNode>);
 
 impl DateTimeFormat {
@@ -885,5 +1109,22 @@ impl DateTimeFormat {
                 .expect("rendering to string cannot fail");
         }
         out
+    }
+}
+
+impl RustType<ProtoDateTimeFormat> for DateTimeFormat {
+    fn into_proto(&self) -> ProtoDateTimeFormat {
+        ProtoDateTimeFormat {
+            nodes: self.0.iter().map(RustType::into_proto).collect(),
+        }
+    }
+
+    fn from_proto(proto: ProtoDateTimeFormat) -> Result<Self, TryFromProtoError> {
+        let nodes = proto
+            .nodes
+            .into_iter()
+            .map(RustType::from_proto)
+            .collect::<Result<_, _>>()?;
+        Ok(Self(nodes))
     }
 }

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -24,6 +24,7 @@ use mz_repr::{strconv, ColumnType, ScalarType};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
+use crate::scalar::func::format::DateTimeFormat;
 use crate::scalar::func::{EagerUnaryFunc, TimestampLike};
 use crate::EvalError;
 
@@ -719,5 +720,55 @@ impl<'a> EagerUnaryFunc<'a> for TimezoneTimestampTz {
 impl fmt::Display for TimezoneTimestampTz {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "timezone_{}_tstz", self.0)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, MzReflect)]
+pub struct ToCharTimestamp {
+    pub format_string: String,
+    pub format: DateTimeFormat,
+}
+
+impl<'a> EagerUnaryFunc<'a> for ToCharTimestamp {
+    type Input = CheckedTimestamp<NaiveDateTime>;
+    type Output = String;
+
+    fn call(&self, input: CheckedTimestamp<NaiveDateTime>) -> String {
+        self.format.render(&*input)
+    }
+
+    fn output_type(&self, input: ColumnType) -> ColumnType {
+        ScalarType::String.nullable(input.nullable)
+    }
+}
+
+impl fmt::Display for ToCharTimestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "tocharts[{}]", self.format_string)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, MzReflect)]
+pub struct ToCharTimestampTz {
+    pub format_string: String,
+    pub format: DateTimeFormat,
+}
+
+impl<'a> EagerUnaryFunc<'a> for ToCharTimestampTz {
+    type Input = CheckedTimestamp<DateTime<Utc>>;
+    type Output = String;
+
+    fn call(&self, input: CheckedTimestamp<DateTime<Utc>>) -> String {
+        self.format.render(&*input)
+    }
+
+    fn output_type(&self, input: ColumnType) -> ColumnType {
+        ScalarType::String.nullable(input.nullable)
+    }
+}
+
+impl fmt::Display for ToCharTimestampTz {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "tochartstz[{}]", self.format_string)
     }
 }

--- a/test/sqllogictest/timestamp.slt
+++ b/test/sqllogictest/timestamp.slt
@@ -13,9 +13,6 @@ ALTER SYSTEM SET enable_binary_date_bin = true
 ----
 COMPLETE 0
 
-# Tests adapted from Postgresql
-# https://github.com/postgres/postgres/blob/master/src/test/regress/sql/timestamp.sql
-
 # case 1: AD dates, origin < input
 query TTT
 SELECT
@@ -292,3 +289,158 @@ ORDER BY 1;
 103
 2021-01-01 01:15:00+00
 61
+
+statement ok
+DROP TABLE t;
+
+### to_char
+
+statement ok
+CREATE TABLE t (ts timestamp)
+
+statement ok
+INSERT INTO t VALUES
+  ('1997-01-01 00:00:00'),
+  ('2021-02-09 01:07:12'),
+  ('2024-03-21 12:09:23'),
+  ('2060-12-31 23:59:59.999999')
+
+query T rowsort
+SELECT to_char(ts, 'DAY Day day DY Dy dy MONTH Month month RM MON Mon mon') FROM t
+----
+FRIDAY    Friday    friday    FRI Fri fri DECEMBER  December  december  XII  DEC Dec dec
+THURSDAY  Thursday  thursday  THU Thu thu MARCH     March     march     III  MAR Mar mar
+TUESDAY   Tuesday   tuesday   TUE Tue tue FEBRUARY  February  february  II   FEB Feb feb
+WEDNESDAY Wednesday wednesday WED Wed wed JANUARY   January   january   I    JAN Jan jan
+
+query T rowsort
+SELECT to_char(ts, 'FMDAY FMDay FMday FMMONTH FMMonth FMmonth FMRM') FROM t
+----
+FRIDAY Friday friday DECEMBER December december XII
+THURSDAY Thursday thursday MARCH March march III
+TUESDAY Tuesday tuesday FEBRUARY February february II
+WEDNESDAY Wednesday wednesday JANUARY January january I
+
+query T rowsort
+SELECT to_char(ts, 'Y,YYY YYYY YYY YY Y CC Q MM WW DDD DD D J') FROM t
+----
+1,997 1997 997 97 7 20 1 01 01 001 01 4 2450450
+2,021 2021 021 21 1 21 1 02 06 040 09 3 2459255
+2,024 2024 024 24 4 21 1 03 12 081 21 5 2460391
+2,060 2060 060 60 0 21 4 12 53 366 31 6 2473825
+
+query T rowsort
+SELECT to_char(ts, 'FMY,YYY FMYYYY FMYYY FMYY FMY FMCC FMQ FMMM FMWW FMDDD FMDD FMD FMJ') FROM t
+----
+1,997 1997 997 97 7 20 1 1 1 1 1 4 2450450
+2,021 2021 21 21 1 21 1 2 6 40 9 3 2459255
+2,024 2024 24 24 4 21 1 3 12 81 21 5 2460391
+2,060 2060 60 60 0 21 4 12 53 366 31 6 2473825
+
+query T rowsort
+SELECT to_char(ts, 'HH HH12 HH24 MI SS SSSS') FROM t
+----
+01 01 01 07 12 4032
+11 11 23 59 59 86399
+12 12 00 00 00 0
+12 12 12 09 23 43763
+
+query T rowsort
+SELECT to_char(ts, '"HH:MI:SS is" HH:MI:SS "\"text between quote marks\""') FROM t
+----
+HH:MI:SS is 01:07:12 "text between quote marks"
+HH:MI:SS is 11:59:59 "text between quote marks"
+HH:MI:SS is 12:00:00 "text between quote marks"
+HH:MI:SS is 12:09:23 "text between quote marks"
+
+query T rowsort
+SELECT to_char(ts, 'HH24--text--MI--text--SS') FROM t
+----
+00--text--00--text--00
+01--text--07--text--12
+12--text--09--text--23
+23--text--59--text--59
+
+query T rowsort
+SELECT to_char(ts, 'YYYYTH YYYYth Jth') FROM t
+----
+1997TH 1997th 2450450th
+2021ST 2021st 2459255th
+2024TH 2024th 2460391st
+2060TH 2060th 2473825th
+
+query T rowsort
+SELECT to_char(ts, 'YYYY A.D. YYYY a.d. YYYY bc HH:MI:SS P.M. HH:MI:SS p.m. HH:MI:SS pm') FROM t
+----
+1997 A.D. 1997 a.d. 1997 ad 12:00:00 A.M. 12:00:00 a.m. 12:00:00 am
+2021 A.D. 2021 a.d. 2021 ad 01:07:12 A.M. 01:07:12 a.m. 01:07:12 am
+2024 A.D. 2024 a.d. 2024 ad 12:09:23 P.M. 12:09:23 p.m. 12:09:23 pm
+2060 A.D. 2060 a.d. 2060 ad 11:59:59 P.M. 11:59:59 p.m. 11:59:59 pm
+
+query T rowsort
+SELECT to_char(ts, 'IYYY IYY IY I IW IDDD ID') FROM t
+----
+1997 997 97 7 01 003 3
+2021 021 21 1 06 037 2
+2024 024 24 4 12 081 4
+2060 060 60 0 53 369 5
+
+query T rowsort
+SELECT to_char(ts, 'FMIYYY FMIYY FMIY FMI FMIW FMIDDD FMID') FROM t
+----
+1997 997 97 7 1 3 3
+2021 21 21 1 6 37 2
+2024 24 24 4 12 81 4
+2060 60 60 0 53 369 5
+
+query T
+SELECT to_char(ts, 'FF1 FF2 FF3 FF4 FF5 FF6  ff1 ff2 ff3 ff4 ff5 ff6  MS US') FROM (
+    VALUES
+        ('2018-11-02 12:34:56'::timestamp),
+        ('2018-11-02 12:34:56.78'),
+        ('2018-11-02 12:34:56.78901'),
+        ('2018-11-02 12:34:56.78901234')
+    ) d(ts)
+----
+FF1 FF2 FF3 FF4 FF5 FF6  ff1 ff2 ff3 ff4 ff5 ff6  000 000000
+FF1 FF2 FF3 FF4 FF5 FF6  ff1 ff2 ff3 ff4 ff5 ff6  780 780000
+FF1 FF2 FF3 FF4 FF5 FF6  ff1 ff2 ff3 ff4 ff5 ff6  789 789010
+FF1 FF2 FF3 FF4 FF5 FF6  ff1 ff2 ff3 ff4 ff5 ff6  789 789012
+
+# Verify that the format string gets precompiled.
+query T multiline
+EXPLAIN SELECT to_char(ts, 'HH:MI:SS') FROM t
+----
+Explained Query:
+  Project (#1)
+    Map (tocharts[HH:MI:SS](#0))
+      ReadStorage materialize.public.t
+
+Source materialize.public.t
+
+Target cluster: quickstart
+
+EOF
+
+# Verify handling of NULL arguments.
+
+statement ok
+INSERT INTO t VALUES (NULL)
+
+query T rowsort
+SELECT to_char(ts, 'HH:MI:SS') FROM t
+----
+01:07:12
+11:59:59
+12:00:00
+12:09:23
+NULL
+
+query T
+SELECT to_char(ts, NULL) FROM t
+----
+NULL
+NULL
+NULL
+NULL
+NULL

--- a/test/sqllogictest/timestamptz.slt
+++ b/test/sqllogictest/timestamptz.slt
@@ -13,9 +13,6 @@ ALTER SYSTEM SET enable_binary_date_bin = true
 ----
 COMPLETE 0
 
-# Tests adapted from Postgresql
-# https://github.com/postgres/postgres/blob/master/src/test/regress/sql/timestamptz.sql
-
 # case 1: AD dates, origin < input
 query TTT
 SELECT
@@ -195,3 +192,155 @@ true
 
 query error timestamp out of range
 select timezone('1 day'::interval, '1-12-31'::timestamptz+'262141 years'::interval)
+
+### to_char
+
+statement ok
+CREATE TABLE t (ts timestamp with time zone)
+
+statement ok
+INSERT INTO t VALUES
+  ('1997-01-01 00:00:00 GMT'),
+  ('2021-02-09 01:07:12 UTC'),
+  ('2024-03-21 12:09:23 +0000'),
+  ('2060-12-31 23:59:59.999999 -0800')
+
+query T rowsort
+SELECT to_char(ts, 'DAY Day day DY Dy dy MONTH Month month RM MON Mon mon') FROM t
+----
+SATURDAY  Saturday  saturday  SAT Sat sat JANUARY   January   january   I    JAN Jan jan
+THURSDAY  Thursday  thursday  THU Thu thu MARCH     March     march     III  MAR Mar mar
+TUESDAY   Tuesday   tuesday   TUE Tue tue FEBRUARY  February  february  II   FEB Feb feb
+WEDNESDAY Wednesday wednesday WED Wed wed JANUARY   January   january   I    JAN Jan jan
+
+query T rowsort
+SELECT to_char(ts, 'FMDAY FMDay FMday FMMONTH FMMonth FMmonth FMRM') FROM t
+----
+SATURDAY Saturday saturday JANUARY January january I
+THURSDAY Thursday thursday MARCH March march III
+TUESDAY Tuesday tuesday FEBRUARY February february II
+WEDNESDAY Wednesday wednesday JANUARY January january I
+
+query T rowsort
+SELECT to_char(ts, 'Y,YYY YYYY YYY YY Y CC Q MM WW DDD DD D J') FROM t
+----
+1,997 1997 997 97 7 20 1 01 01 001 01 4 2450450
+2,021 2021 021 21 1 21 1 02 06 040 09 3 2459255
+2,024 2024 024 24 4 21 1 03 12 081 21 5 2460391
+2,061 2061 061 61 1 21 1 01 01 001 01 7 2473826
+
+query T rowsort
+SELECT to_char(ts, 'FMY,YYY FMYYYY FMYYY FMYY FMY FMCC FMQ FMMM FMWW FMDDD FMDD FMD FMJ') FROM t
+----
+1,997 1997 997 97 7 20 1 1 1 1 1 4 2450450
+2,021 2021 21 21 1 21 1 2 6 40 9 3 2459255
+2,024 2024 24 24 4 21 1 3 12 81 21 5 2460391
+2,061 2061 61 61 1 21 1 1 1 1 1 7 2473826
+
+query T rowsort
+SELECT to_char(ts, 'HH HH12 HH24 MI SS SSSS') FROM t
+----
+01 01 01 07 12 4032
+07 07 07 59 59 28799
+12 12 00 00 00 0
+12 12 12 09 23 43763
+
+query T rowsort
+SELECT to_char(ts, '"HH:MI:SS is" HH:MI:SS "\"text between quote marks\""') FROM t
+----
+HH:MI:SS is 01:07:12 "text between quote marks"
+HH:MI:SS is 07:59:59 "text between quote marks"
+HH:MI:SS is 12:00:00 "text between quote marks"
+HH:MI:SS is 12:09:23 "text between quote marks"
+
+query T rowsort
+SELECT to_char(ts, 'HH24--text--MI--text--SS') FROM t
+----
+00--text--00--text--00
+01--text--07--text--12
+07--text--59--text--59
+12--text--09--text--23
+
+query T rowsort
+SELECT to_char(ts, 'YYYYTH YYYYth Jth') FROM t
+----
+1997TH 1997th 2450450th
+2021ST 2021st 2459255th
+2024TH 2024th 2460391st
+2061ST 2061st 2473826th
+
+query T rowsort
+SELECT to_char(ts, 'YYYY A.D. YYYY a.d. YYYY bc HH:MI:SS P.M. HH:MI:SS p.m. HH:MI:SS pm') FROM t
+----
+1997 A.D. 1997 a.d. 1997 ad 12:00:00 A.M. 12:00:00 a.m. 12:00:00 am
+2021 A.D. 2021 a.d. 2021 ad 01:07:12 A.M. 01:07:12 a.m. 01:07:12 am
+2024 A.D. 2024 a.d. 2024 ad 12:09:23 P.M. 12:09:23 p.m. 12:09:23 pm
+2061 A.D. 2061 a.d. 2061 ad 07:59:59 A.M. 07:59:59 a.m. 07:59:59 am
+
+query T rowsort
+SELECT to_char(ts, 'IYYY IYY IY I IW IDDD ID') FROM t
+----
+1997 997 97 7 01 003 3
+2021 021 21 1 06 037 2
+2024 024 24 4 12 081 4
+2060 060 60 0 53 370 6
+
+query T rowsort
+SELECT to_char(ts, 'FMIYYY FMIYY FMIY FMI FMIW FMIDDD FMID') FROM t
+----
+1997 997 97 7 1 3 3
+2021 21 21 1 6 37 2
+2024 24 24 4 12 81 4
+2060 60 60 0 53 370 6
+
+query T
+SELECT to_char(ts, 'FF1 FF2 FF3 FF4 FF5 FF6  ff1 ff2 ff3 ff4 ff5 ff6  MS US') FROM (
+    VALUES
+        ('2018-11-02 12:34:56'::timestamp),
+        ('2018-11-02 12:34:56.78'),
+        ('2018-11-02 12:34:56.78901'),
+        ('2018-11-02 12:34:56.78901234')
+    ) d(ts)
+----
+FF1 FF2 FF3 FF4 FF5 FF6  ff1 ff2 ff3 ff4 ff5 ff6  000 000000
+FF1 FF2 FF3 FF4 FF5 FF6  ff1 ff2 ff3 ff4 ff5 ff6  780 780000
+FF1 FF2 FF3 FF4 FF5 FF6  ff1 ff2 ff3 ff4 ff5 ff6  789 789010
+FF1 FF2 FF3 FF4 FF5 FF6  ff1 ff2 ff3 ff4 ff5 ff6  789 789012
+
+# Verify that the format string gets precompiled.
+query T multiline
+EXPLAIN SELECT to_char(ts, 'HH:MI:SS') FROM t
+----
+Explained Query:
+  Project (#1)
+    Map (tochartstz[HH:MI:SS](#0))
+      ReadStorage materialize.public.t
+
+Source materialize.public.t
+
+Target cluster: quickstart
+
+EOF
+
+# Verify handling of NULL arguments.
+
+statement ok
+INSERT INTO t VALUES (NULL)
+
+query T rowsort
+SELECT to_char(ts, 'HH:MI:SS') FROM t
+----
+01:07:12
+07:59:59
+12:00:00
+12:09:23
+NULL
+
+query T
+SELECT to_char(ts, NULL) FROM t
+----
+NULL
+NULL
+NULL
+NULL
+NULL


### PR DESCRIPTION
This PR introduces unary `ToCharTimestamp` and `ToCharTimestampTz` variants that differ from their binary counterparts in that they have the format string already precompiled into a `DateTimeFormat`. This lets us skip the per-datum compilation in cases where the format string is statically known.

### Motivation

  * This PR adds a known-desirable feature.

Closes #29068 

### Tips for reviewer

I'm pretty unfamiliar with the code I touched here. Definitely check my work!

Most of the diff is adding protobuf support for `DateTimeFormat`.

Should we do more to test this? AFAICT most/all of the `to_char` uses in tests already supply a static format, so it seems that test coverage should already be good for this change.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
