### PR TITLE
persist: Reduce num rows in `arrow_datatype_consistent` test

### DIFF
--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -2236,7 +2236,7 @@ mod tests {
             assert_eq!(col_a.data_type(), col_b.data_type());
         }
 
-        let num_rows = 32;
+        let num_rows = 12;
         let strat = any::<RelationDesc>().prop_flat_map(|desc| {
             proptest::collection::vec(arb_source_data_for_relation_desc(&desc), num_rows)
                 .prop_map(move |datas| (desc.clone(), datas))


### PR DESCRIPTION
Reduces the number of rows generated in the test to reduce flakiness

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/29071

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
