### PR TITLE
ci: Switch benchmarks back to AWS for now

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -79,7 +79,9 @@ steps:
         timeout_in_minutes: 720
         parallelism: 8
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
+          queue: linux-aarch64-medium
+          # queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: feature-benchmark
@@ -92,7 +94,9 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 240
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
+          queue: linux-aarch64
+          # queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: scalability
@@ -112,7 +116,9 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 1200
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
+          queue: linux-aarch64
+          # queue: hetzner-aarch64-8cpu-16gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: scalability
@@ -136,7 +142,9 @@ steps:
         depends_on: build-aarch64
         timeout_in_minutes: 180
         agents:
-          queue: hetzner-aarch64-16cpu-32gb
+          # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
+          queue: linux-aarch64-medium
+          # queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: scalability

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -151,7 +151,9 @@ steps:
     timeout_in_minutes: 2880
     parallelism: 8
     agents:
-      queue: hetzner-aarch64-16cpu-32gb
+      # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
+      queue: linux-aarch64-medium
+      # queue: hetzner-aarch64-16cpu-32gb
     plugins:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -643,7 +643,9 @@ steps:
             ]
     coverage: skip
     agents:
-      queue: hetzner-aarch64-4cpu-8gb
+      # TODO(def-) Switch back to Hetzner? Might not have as consistent performance
+      queue: linux-aarch64-small
+      # queue: hetzner-aarch64-4cpu-8gb
 
   # Fast tests closer to the end, doesn't matter as much if they have to wait
   # for an agent

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from materialize import MZ_ROOT
 
-FEATURE_BENCHMARK_FRAMEWORK_VERSION = "1.2.0"
+FEATURE_BENCHMARK_FRAMEWORK_VERSION = "1.3.0"
 FEATURE_BENCHMARK_FRAMEWORK_HASH_FILE = Path(__file__).relative_to(MZ_ROOT)
 
 FEATURE_BENCHMARK_FRAMEWORK_DIR = Path(__file__).resolve().parent

--- a/misc/python/materialize/scalability/scalability_versioning.py
+++ b/misc/python/materialize/scalability/scalability_versioning.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from materialize import MZ_ROOT
 
-SCALABILITY_FRAMEWORK_VERSION = "1.2.0"
+SCALABILITY_FRAMEWORK_VERSION = "1.3.0"
 SCALABILITY_FRAMEWORK_HASH_FILE = Path(__file__).relative_to(MZ_ROOT)
 
 SCALABILITY_FRAMEWORK_DIR = Path(__file__).resolve().parent


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
