### PR TITLE
adapter: use controller `ReadHold`s everywhere

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3291,6 +3291,11 @@ impl Coordinator {
         // to serialize an object if the keys aren't strings, so `Debug` formatting the values
         // prevents a future unrelated change from silently breaking this method.
 
+        let global_timelines: BTreeMap<_, _> = self
+            .global_timelines
+            .iter()
+            .map(|(timeline, state)| (timeline.to_string(), format!("{state:?}")))
+            .collect();
         let active_conns: BTreeMap<_, _> = self
             .active_conns
             .iter()
@@ -3324,6 +3329,10 @@ impl Coordinator {
             .collect();
 
         let map = serde_json::Map::from_iter([
+            (
+                "global_timelines".to_string(),
+                serde_json::to_value(global_timelines)?,
+            ),
             (
                 "active_conns".to_string(),
                 serde_json::to_value(active_conns)?,

--- a/src/adapter/src/coord/consistency.rs
+++ b/src/adapter/src/coord/consistency.rs
@@ -23,8 +23,8 @@ use serde::Serialize;
 pub struct CoordinatorInconsistencies {
     /// Inconsistencies found in the catalog.
     catalog_inconsistencies: Box<CatalogInconsistencies>,
-    /// Inconsistencies found in read capabilities.
-    read_capabilities: Vec<ReadCapabilitiesInconsistency>,
+    /// Inconsistencies found in read holds.
+    read_holds: Vec<ReadHoldsInconsistency>,
     /// Inconsistencies found with our map of active webhooks.
     active_webhooks: Vec<ActiveWebhookInconsistency>,
     /// Inconsistencies found with our map of cluster statuses.
@@ -34,7 +34,7 @@ pub struct CoordinatorInconsistencies {
 impl CoordinatorInconsistencies {
     pub fn is_empty(&self) -> bool {
         self.catalog_inconsistencies.is_empty()
-            && self.read_capabilities.is_empty()
+            && self.read_holds.is_empty()
             && self.active_webhooks.is_empty()
             && self.cluster_statuses.is_empty()
     }
@@ -50,8 +50,8 @@ impl Coordinator {
             inconsistencies.catalog_inconsistencies = catalog_inconsistencies;
         }
 
-        if let Err(read_capabilities) = self.check_read_capabilities() {
-            inconsistencies.read_capabilities = read_capabilities;
+        if let Err(read_holds) = self.check_read_holds() {
+            inconsistencies.read_holds = read_holds;
         }
 
         if let Err(active_webhooks) = self.check_active_webhooks() {
@@ -71,34 +71,37 @@ impl Coordinator {
 
     /// # Invariants:
     ///
-    /// * Read capabilities should reference known objects.
+    /// * Read holds should reference known objects.
     ///
-    fn check_read_capabilities(&self) -> Result<(), Vec<ReadCapabilitiesInconsistency>> {
-        let mut read_capabilities_inconsistencies = Vec::new();
-        for (gid, _) in &self.storage_read_capabilities {
-            if self.catalog().try_get_entry(gid).is_none() {
-                read_capabilities_inconsistencies
-                    .push(ReadCapabilitiesInconsistency::Storage(gid.clone()));
+    fn check_read_holds(&self) -> Result<(), Vec<ReadHoldsInconsistency>> {
+        let mut inconsistencies = Vec::new();
+
+        for timeline in self.global_timelines.values() {
+            for id in timeline.read_holds.storage_ids() {
+                if self.catalog().try_get_entry(&id).is_none() {
+                    inconsistencies.push(ReadHoldsInconsistency::Storage(id));
+                }
             }
-        }
-        for (gid, _) in &self.compute_read_capabilities {
-            if !gid.is_transient() && self.catalog().try_get_entry(gid).is_none() {
-                read_capabilities_inconsistencies
-                    .push(ReadCapabilitiesInconsistency::Compute(gid.clone()));
-            }
-        }
-        for (conn_id, _) in &self.txn_read_holds {
-            if !self.active_conns.contains_key(conn_id) {
-                read_capabilities_inconsistencies.push(ReadCapabilitiesInconsistency::Transaction(
-                    conn_id.unhandled(),
-                ));
+            for (cluster_id, id) in timeline.read_holds.compute_ids() {
+                if self.catalog().try_get_cluster(cluster_id).is_none() {
+                    inconsistencies.push(ReadHoldsInconsistency::Cluster(cluster_id));
+                }
+                if !id.is_transient() && self.catalog().try_get_entry(&id).is_none() {
+                    inconsistencies.push(ReadHoldsInconsistency::Compute(id));
+                }
             }
         }
 
-        if read_capabilities_inconsistencies.is_empty() {
+        for conn_id in self.txn_read_holds.keys() {
+            if !self.active_conns.contains_key(conn_id) {
+                inconsistencies.push(ReadHoldsInconsistency::Transaction(conn_id.unhandled()));
+            }
+        }
+
+        if inconsistencies.is_empty() {
             Ok(())
         } else {
-            Err(read_capabilities_inconsistencies)
+            Err(inconsistencies)
         }
     }
 
@@ -184,9 +187,10 @@ impl Coordinator {
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
-enum ReadCapabilitiesInconsistency {
+enum ReadHoldsInconsistency {
     Storage(GlobalId),
     Compute(GlobalId),
+    Cluster(ClusterId),
     Transaction(ConnectionIdType),
 }
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -108,10 +108,6 @@ impl Coordinator {
                 Message::AdvanceTimelines => {
                     self.advance_timelines().await;
                 }
-                Message::DropReadHolds(dropped_read_holds) => {
-                    tracing::debug!(?dropped_read_holds, "releasing dropped read holds!");
-                    self.release_read_holds(dropped_read_holds);
-                }
                 Message::ClusterEvent(event) => self.message_cluster_event(event).await,
                 Message::CancelPendingPeeks { conn_id } => {
                     self.cancel_pending_peeks(&conn_id);

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -22,155 +22,31 @@
 
 use std::collections::{btree_map, hash_map, BTreeMap, BTreeSet, HashMap};
 use std::fmt::Debug;
-use std::hash::Hash;
 
 use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
-use mz_adapter_types::compaction::{CompactionWindow, ReadCapability};
+use mz_adapter_types::compaction::CompactionWindow;
 use mz_compute_types::ComputeInstanceId;
 use mz_ore::instrument;
 use mz_repr::{GlobalId, Timestamp};
 use mz_sql::session::metadata::SessionMetadata;
 use mz_storage_types::read_holds::ReadHold;
 use mz_storage_types::read_policy::ReadPolicy;
-use serde::Serialize;
 use timely::progress::Antichain;
 use timely::progress::Timestamp as TimelyTimestamp;
 
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timeline::{TimelineContext, TimelineState};
-use crate::coord::Coordinator;
 use crate::session::Session;
 use crate::util::ResultExt;
 
-/// For each timeline, we hold one [TimelineReadHolds] as the root read holds
-/// for that timeline. Even if there are no other [ReadHolds] , it acts as a
-/// backstop that makes sure that collections remain readable at the read
-/// timestamp (according to the timestamp oracle) of that timeline.
+/// Read holds kept to ensure a set of collections remains readable at some
+/// time.
 ///
-/// When creating a collection in a timeline, it is added to the one
-/// [TimelineReadHolds] of that timeline and when a collection is dropped it is
-/// removed.
-///
-/// A [TimelineReadHolds] is never released, it is only dropped when the
-/// corresponding timeline is dropped, which only happens when all collections
-/// in it have been dropped. We only add collections, remove collections, and
-/// downgrade (update, yes!) the read holds.
-#[derive(Debug, Serialize)]
-pub struct TimelineReadHolds<T> {
-    pub holds: HashMap<Antichain<T>, CollectionIdBundle>,
-}
-
-impl<T: Eq + Hash + Ord> TimelineReadHolds<T> {
-    /// Return empty `ReadHolds`.
-    pub fn new() -> Self {
-        TimelineReadHolds {
-            holds: HashMap::new(),
-        }
-    }
-
-    /// Returns whether the [TimelineReadHolds] is empty.
-    pub fn is_empty(&self) -> bool {
-        self.holds.is_empty()
-    }
-
-    /// Returns an iterator over all times at which a read hold exists.
-    pub fn times(&self) -> impl Iterator<Item = &Antichain<T>> {
-        self.holds.keys()
-    }
-
-    /// Return a `CollectionIdBundle` containing all the IDs in the
-    /// [TimelineReadHolds].
-    pub fn id_bundle(&self) -> CollectionIdBundle {
-        self.holds
-            .values()
-            .fold(CollectionIdBundle::default(), |mut accum, id_bundle| {
-                accum.extend(id_bundle);
-                accum
-            })
-    }
-
-    /// Returns an iterator over all storage ids and the time at which their read hold exists.
-    #[allow(unused)]
-    pub fn storage_ids(&self) -> impl Iterator<Item = (&Antichain<T>, &GlobalId)> {
-        self.holds
-            .iter()
-            .flat_map(|(time, id_bundle)| std::iter::repeat(time).zip(id_bundle.storage_ids.iter()))
-    }
-
-    /// Returns an iterator over all compute ids by compute instance and the time at which their
-    /// read hold exists.
-    pub fn compute_ids(
-        &self,
-    ) -> impl Iterator<
-        Item = (
-            &ComputeInstanceId,
-            impl Iterator<Item = (&Antichain<T>, &GlobalId)>,
-        ),
-    > {
-        let compute_instances: BTreeSet<_> = self
-            .holds
-            .iter()
-            .flat_map(|(_, id_bundle)| id_bundle.compute_ids.keys())
-            .collect();
-
-        compute_instances.into_iter().map(|compute_instance| {
-            let inner_iter = self
-                .holds
-                .iter()
-                .filter_map(|(time, id_bundle)| {
-                    id_bundle
-                        .compute_ids
-                        .get(compute_instance)
-                        .map(|ids| std::iter::repeat(time).zip(ids.iter()))
-                })
-                .flatten();
-            (compute_instance, inner_iter)
-        })
-    }
-
-    /// Extends a [TimelineReadHolds] with the contents of another
-    /// [TimelineReadHolds].
-    ///
-    /// Asserts that the newly added read holds don't coincide with any of the existing read holds in self.
-    pub fn extend_with_new(&mut self, mut other: TimelineReadHolds<T>) {
-        for (time, other_id_bundle) in other.holds.drain() {
-            let self_id_bundle = self.holds.entry(time).or_default();
-            assert!(
-                self_id_bundle.intersection(&other_id_bundle).is_empty(),
-                "extend_with_new encountered duplicate read holds",
-            );
-            self_id_bundle.extend(&other_id_bundle);
-        }
-    }
-
-    /// If the read hold contains a storage ID equal to `id`, removes it from the read hold and
-    /// drops it.
-    pub fn remove_storage_id(&mut self, id: &GlobalId) {
-        for (_, id_bundle) in &mut self.holds {
-            id_bundle.storage_ids.remove(id);
-        }
-        self.holds.retain(|_, id_bundle| !id_bundle.is_empty());
-    }
-
-    /// If the read hold contains a compute ID equal to `id` in `compute_instance`, removes it from
-    /// the read hold and drops it.
-    pub fn remove_compute_id(&mut self, compute_instance: &ComputeInstanceId, id: &GlobalId) {
-        for (_, id_bundle) in &mut self.holds {
-            if let Some(compute_ids) = id_bundle.compute_ids.get_mut(compute_instance) {
-                compute_ids.remove(id);
-                if compute_ids.is_empty() {
-                    id_bundle.compute_ids.remove(compute_instance);
-                }
-            }
-        }
-        self.holds.retain(|_, id_bundle| !id_bundle.is_empty());
-    }
-}
-
-/// [ReadHolds] are used for short-lived read holds. For example, when
-/// processing peeks or rendering dataflows. These are never downgraded but they
-/// _are_ released automatically when being dropped.
+/// This is a collection of [`ReadHold`] objects, which act as tokens ensuring
+/// that read frontiers cannot advance past the held time as long as they exist.
+/// Dropping a [`ReadHolds`] also drops the [`ReadHold`] tokens within and
+/// relinquishes the associated read capabilities.
 #[derive(Debug)]
 pub struct ReadHolds<T: TimelyTimestamp> {
     pub storage_holds: HashMap<GlobalId, ReadHold<T>>,
@@ -186,18 +62,51 @@ impl<T: TimelyTimestamp> ReadHolds<T> {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.storage_holds.is_empty() && self.compute_holds.is_empty()
+    }
+
+    /// Return the IDs of the contained storage collections.
+    pub fn storage_ids(&self) -> impl Iterator<Item = GlobalId> + '_ {
+        self.storage_holds.keys().copied()
+    }
+
+    /// Return the IDs of the contained compute collections.
+    pub fn compute_ids(&self) -> impl Iterator<Item = (ComputeInstanceId, GlobalId)> + '_ {
+        self.compute_holds.keys().copied()
+    }
+
     /// Return a `CollectionIdBundle` containing all the IDs in the
     /// [ReadHolds].
     pub fn id_bundle(&self) -> CollectionIdBundle {
         let mut res = CollectionIdBundle::default();
-        for id in self.storage_holds.keys() {
-            res.storage_ids.insert(*id);
+        for id in self.storage_ids() {
+            res.storage_ids.insert(id);
         }
-        for (instance_id, id) in self.compute_holds.keys() {
-            res.compute_ids.entry(*instance_id).or_default().insert(*id);
+        for (instance_id, id) in self.compute_ids() {
+            res.compute_ids.entry(instance_id).or_default().insert(id);
         }
 
         res
+    }
+
+    /// Downgrade the contained [`ReadHold`]s to the given time.
+    pub fn downgrade(&mut self, time: T) {
+        let frontier = Antichain::from_elem(time);
+        for hold in self.storage_holds.values_mut() {
+            let _ = hold.try_downgrade(frontier.clone());
+        }
+        for hold in self.compute_holds.values_mut() {
+            let _ = hold.try_downgrade(frontier.clone());
+        }
+    }
+
+    pub fn remove_storage_collection(&mut self, id: GlobalId) {
+        self.storage_holds.remove(&id);
+    }
+
+    pub fn remove_compute_collection(&mut self, instance_id: ComputeInstanceId, id: GlobalId) {
+        self.compute_holds.remove(&(instance_id, id));
     }
 }
 
@@ -238,7 +147,8 @@ impl<T: TimelyTimestamp + Lattice> ReadHolds<T> {
         since
     }
 
-    pub fn merge(&mut self, other: Self) {
+    /// Merge the read holds in `other` into the contained read holds.
+    fn merge(&mut self, other: Self) {
         for (id, other_hold) in other.storage_holds {
             match self.storage_holds.entry(id) {
                 hash_map::Entry::Occupied(mut o) => {
@@ -258,6 +168,24 @@ impl<T: TimelyTimestamp + Lattice> ReadHolds<T> {
                     v.insert(other_hold);
                 }
             }
+        }
+    }
+
+    /// Extend the contained read holds with those in `other`.
+    ///
+    ///
+    /// # Panics
+    ///
+    /// In contrast to [`ReadHolds::merge`], this method expects the collection
+    /// IDs in `self` and `other` to be distinct and panics otherwise.
+    fn extend(&mut self, other: Self) {
+        for (id, other_hold) in other.storage_holds {
+            let prev = self.storage_holds.insert(id, other_hold);
+            assert!(prev.is_none(), "duplicate storage read hold: {id}");
+        }
+        for (id, other_hold) in other.compute_holds {
+            let prev = self.compute_holds.insert(id, other_hold);
+            assert!(prev.is_none(), "duplicate compute read hold: {id:?}");
         }
     }
 }
@@ -323,322 +251,40 @@ impl crate::coord::Coordinator {
         id_bundle: &CollectionIdBundle,
         compaction_window: CompactionWindow,
     ) {
-        // When initializing read policies we acquire a hold from STORAGE. We
-        // have to keep those until we install our read policy all the way at
-        // the end.
-        let mut stashed_storage_holds = Vec::new();
-
-        // Creates a `ReadHolds` struct that contains a read hold for each id in
-        // `id_bundle`. The time of each read holds is at `time`, if possible
-        // otherwise it is at the lowest possible time, meaning the implied
-        // capability of the collection.
-        //
-        // This does not apply the read holds in STORAGE or COMPUTE. The code
-        // below applies those, after ensuring that read capabilities exist.
-        let mut initialize_read_holds = |coord: &mut Coordinator,
-                                         time: mz_repr::Timestamp,
-                                         id_bundle: &CollectionIdBundle|
-         -> TimelineReadHolds<mz_repr::Timestamp> {
-            let mut read_holds = TimelineReadHolds::new();
-            let time = Antichain::from_elem(time);
-
-            for id in id_bundle.storage_ids.iter() {
-                // Figure out at what since we can hold for this collection. We
-                // will use that for the initial policy that we're installing
-                // below.
-                let storage_hold = coord
-                    .controller
-                    .storage
-                    .acquire_read_hold(*id)
-                    .expect("collection does not exist");
-
-                let time = time.join(storage_hold.since());
-                read_holds
-                    .holds
-                    .entry(time)
-                    .or_default()
-                    .storage_ids
-                    .insert(*id);
-
-                // Stash the hold until we update/initialize the policy below.
-                stashed_storage_holds.push(storage_hold);
-            }
-            for (compute_instance, compute_ids) in id_bundle.compute_ids.iter() {
-                for id in compute_ids.iter() {
-                    let collection = coord
-                        .controller
-                        .compute
-                        .collection(*compute_instance, *id)
-                        .expect("collection does not exist");
-                    let read_frontier = collection.read_capability().clone();
-                    let time = time.join(&read_frontier);
-                    read_holds
-                        .holds
-                        .entry(time)
-                        .or_default()
-                        .compute_ids
-                        .entry(*compute_instance)
-                        .or_default()
-                        .insert(*id);
-                }
-            }
-
-            read_holds
-        };
-
-        let mut compute_policy_updates: BTreeMap<ComputeInstanceId, Vec<_>> = BTreeMap::new();
-        let mut storage_policy_updates = Vec::new();
-        let mut id_bundles: HashMap<_, CollectionIdBundle> = HashMap::new();
-
-        // Update the Coordinator's timeline read hold state and organize all id bundles by time.
+        // Install read holds in the Coordinator's timeline state.
         for (timeline_context, id_bundle) in self.partition_ids_by_timeline_context(id_bundle) {
-            match timeline_context {
-                TimelineContext::TimelineDependent(timeline) => {
-                    let TimelineState { oracle, .. } = self.ensure_timeline_state(&timeline).await;
-                    let read_ts = oracle.read_ts().await;
-                    let new_read_holds = initialize_read_holds(self, read_ts, &id_bundle);
-                    let TimelineState { read_holds, .. } =
-                        self.ensure_timeline_state(&timeline).await;
-                    for (time, id_bundle) in &new_read_holds.holds {
-                        id_bundles
-                            .entry(Some(time.clone()))
-                            .or_default()
-                            .extend(id_bundle);
-                    }
-                    read_holds.extend_with_new(new_read_holds);
-                }
-                TimelineContext::TimestampIndependent | TimelineContext::TimestampDependent => {
-                    id_bundles.entry(None).or_default().extend(&id_bundle);
-                }
+            if let TimelineContext::TimelineDependent(timeline) = timeline_context {
+                let TimelineState { oracle, .. } = self.ensure_timeline_state(&timeline).await;
+                let read_ts = oracle.read_ts().await;
+
+                let mut new_read_holds = self.acquire_read_holds(&id_bundle);
+                new_read_holds.downgrade(read_ts);
+
+                let TimelineState { read_holds, .. } = self.ensure_timeline_state(&timeline).await;
+                read_holds.extend(new_read_holds);
             }
         }
 
-        // Create read capabilities for all objects.
-        for (time, id_bundle) in id_bundles {
-            for (compute_instance, compute_ids) in id_bundle.compute_ids {
-                for id in compute_ids {
-                    let read_capability = self.ensure_compute_capability(
-                        &compute_instance,
-                        &id,
-                        Some(compaction_window.clone()),
-                    );
-                    if let Some(time) = &time {
-                        read_capability
-                            .holds
-                            .update_iter(time.iter().map(|t| (*t, 1)));
-                    }
-                    compute_policy_updates
-                        .entry(compute_instance)
-                        .or_default()
-                        .push((id, self.compute_read_capabilities[&id].policy()));
-                }
-            }
+        // Install read policies.
+        let read_policy = ReadPolicy::from(compaction_window);
 
-            for id in id_bundle.storage_ids {
-                let read_capability =
-                    self.ensure_storage_capability(&id, Some(compaction_window.clone()));
-                if let Some(time) = &time {
-                    read_capability
-                        .holds
-                        .update_iter(time.iter().map(|t| (*t, 1)));
-                }
-                storage_policy_updates.push((id, self.storage_read_capabilities[&id].policy()));
-            }
-        }
+        let storage_policies = id_bundle
+            .storage_ids
+            .iter()
+            .map(|id| (*id, read_policy.clone()))
+            .collect();
+        self.controller.storage.set_read_policy(storage_policies);
 
-        // Apply read capabilities.
-        for (compute_instance, compute_policy_updates) in compute_policy_updates {
+        for (instance_id, collection_ids) in &id_bundle.compute_ids {
+            let compute_policies = collection_ids
+                .iter()
+                .map(|id| (*id, read_policy.clone()))
+                .collect();
             self.controller
                 .compute
-                .set_read_policy(compute_instance, compute_policy_updates)
-                .unwrap_or_terminate("cannot fail to set read policy");
+                .set_read_policy(*instance_id, compute_policies)
+                .expect("cannot fail to set read policy");
         }
-        self.controller
-            .storage
-            .set_read_policy(storage_policy_updates);
-
-        // Now that we installed our read policy updates we can relinquish holds
-        // that we used to determine and hold collection sinces.
-        drop(stashed_storage_holds);
-    }
-
-    /// Attempt to update the timestamp of the read holds on the indicated collections from the
-    /// indicated times within `read_holds` to `new_time`.
-    pub(super) fn update_timeline_read_holds(
-        &mut self,
-        read_holds: &mut TimelineReadHolds<mz_repr::Timestamp>,
-        new_time: mz_repr::Timestamp,
-    ) {
-        // After this, read_holds.holds is initialized to an empty HashMap.
-        let old_holds = std::mem::take(&mut read_holds.holds);
-
-        let mut storage_policy_changes = Vec::new();
-        let mut compute_policy_changes: BTreeMap<_, Vec<_>> = BTreeMap::new();
-        let new_time = Antichain::from_elem(new_time);
-
-        for (old_time, id_bundle) in old_holds {
-            let new_time = old_time.join(&new_time);
-            if old_time != new_time {
-                read_holds
-                    .holds
-                    .entry(new_time.clone())
-                    .or_default()
-                    .extend(&id_bundle);
-                for id in id_bundle.storage_ids {
-                    // NOTE: We don't verify that the new frontier is beyond the
-                    // old frontier. The timeline read hold for storage
-                    // collections is largely advisory, and "real" read holds
-                    // that we acquire via `acquire_read_hold` go directly to
-                    // STORAGE to acquire read holds at the earliest legal time.
-
-                    let read_needs = self
-                        .storage_read_capabilities
-                        .get_mut(&id)
-                        .expect("id does not exist");
-
-                    read_needs
-                        .holds
-                        .update_iter(new_time.iter().map(|t| (*t, 1)));
-                    read_needs
-                        .holds
-                        .update_iter(old_time.iter().map(|t| (*t, -1)));
-
-                    storage_policy_changes.push((id, read_needs.policy()));
-                }
-
-                for (compute_instance, compute_ids) in id_bundle.compute_ids {
-                    for id in compute_ids {
-                        let collection = self
-                            .controller
-                            .compute
-                            .collection(compute_instance, id)
-                            .expect("id does not exist");
-                        assert!(collection.read_capability().le(&new_time.borrow()),
-                                "Compute collection {:?} (instance {:?}) has read frontier {:?} not less-equal new time {:?}; old time: {:?}",
-                                id,
-                                compute_instance,
-                                collection.read_capability(),
-                                new_time,
-                                old_time,
-                        );
-                        let read_needs = self
-                            .compute_read_capabilities
-                            .get_mut(&id)
-                            .expect("id does not exist");
-                        read_needs
-                            .holds
-                            .update_iter(new_time.iter().map(|t| (*t, 1)));
-                        read_needs
-                            .holds
-                            .update_iter(old_time.iter().map(|t| (*t, -1)));
-                        compute_policy_changes
-                            .entry(compute_instance)
-                            .or_default()
-                            .push((id, read_needs.policy()));
-                    }
-                }
-            } else {
-                read_holds
-                    .holds
-                    .entry(old_time)
-                    .or_default()
-                    .extend(&id_bundle);
-            }
-        }
-
-        // Update STORAGE read policies.
-        self.controller
-            .storage
-            .set_read_policy(storage_policy_changes);
-
-        // Update COMPUTE read policies
-        for (compute_instance, compute_policy_changes) in compute_policy_changes {
-            self.controller
-                .compute
-                .set_read_policy(compute_instance, compute_policy_changes)
-                .unwrap_or_terminate("cannot fail to set read policy");
-        }
-    }
-
-    /// If there is not capability for the given object, initialize one at the
-    /// earliest possible since. Return the capability.
-    //
-    /// When a `compaction_window` is given, this is installed as the policy of
-    /// the collection, regardless if a capability existed before or not.
-    fn ensure_compute_capability(
-        &mut self,
-        instance_id: &ComputeInstanceId,
-        id: &GlobalId,
-        compaction_window: Option<CompactionWindow>,
-    ) -> &mut ReadCapability<mz_repr::Timestamp> {
-        let entry = self
-            .compute_read_capabilities
-            .entry(*id)
-            .and_modify(|capability| {
-                // If we explicitly got a compaction window, override any existing
-                // one.
-                if let Some(compaction_window) = compaction_window {
-                    capability.base_policy = compaction_window.into();
-                }
-            })
-            .or_insert_with(|| {
-                let policy: ReadPolicy<Timestamp> = match compaction_window {
-                    Some(compaction_window) => compaction_window.into(),
-                    None => {
-                        // We didn't get an initial policy, so set the current
-                        // since as a static policy.
-                        let collection = self
-                            .controller
-                            .compute
-                            .collection(*instance_id, *id)
-                            .expect("collection does not exist");
-                        let read_frontier = collection.read_capability().clone();
-                        ReadPolicy::ValidFrom(read_frontier)
-                    }
-                };
-
-                ReadCapability::from(policy)
-            });
-
-        entry
-    }
-
-    /// If there is not capability for the given object, initialize one at the
-    /// earliest possible since. Return the capability.
-    ///
-    /// When a `compaction_window` is given, this is installed as the policy of
-    /// the collection, regardless if a capability existed before or not.
-    fn ensure_storage_capability(
-        &mut self,
-        id: &GlobalId,
-        compaction_window: Option<CompactionWindow>,
-    ) -> &mut ReadCapability<mz_repr::Timestamp> {
-        let entry = self
-            .storage_read_capabilities
-            .entry(*id)
-            .and_modify(|capability| {
-                // If we explicitly got a compaction window, override any existing
-                // one.
-                if let Some(compaction_window) = compaction_window {
-                    capability.base_policy = compaction_window.into();
-                }
-            })
-            .or_insert_with(|| {
-                let policy: ReadPolicy<Timestamp> = match compaction_window {
-                    Some(compaction_window) => compaction_window.into(),
-                    None => {
-                        // We didn't get an initial policy, so put in place the
-                        // most conservative policy in order to not accidentally
-                        // give a very lax policy to STORAGE. This will get
-                        // updated once the "real" policies are put in place.
-                        ReadPolicy::ValidFrom(Antichain::from_elem(mz_repr::Timestamp::MIN))
-                    }
-                };
-
-                ReadCapability::from(policy)
-            });
-
-        entry
     }
 
     pub(crate) fn update_storage_base_read_policies(

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2906,7 +2906,7 @@ impl Coordinator {
                 CatalogItem::Index(index) => Some(index.cluster_id),
                 CatalogItem::Source(_) => {
                     let read_policies = coord.catalog().source_read_policies(plan.id);
-                    coord.update_storage_base_read_policies(read_policies);
+                    coord.update_storage_read_policies(read_policies);
                     return;
                 }
                 CatalogItem::Log(_)
@@ -2919,10 +2919,10 @@ impl Coordinator {
             };
             match cluster {
                 Some(cluster) => {
-                    coord.update_compute_base_read_policy(cluster, plan.id, plan.window.into());
+                    coord.update_compute_read_policy(cluster, plan.id, plan.window.into());
                 }
                 None => {
-                    coord.update_storage_base_read_policies(vec![(plan.id, plan.window.into())]);
+                    coord.update_storage_read_policies(vec![(plan.id, plan.window.into())]);
                 }
             }
         })

--- a/src/adapter/src/coord/sequencer/inner/create_index.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_index.rs
@@ -507,7 +507,7 @@ impl Coordinator {
                 // point compute will have put in its own read holds.
                 drop(read_holds);
 
-                coord.update_compute_base_read_policy(
+                coord.update_compute_read_policy(
                     cluster_id,
                     exported_index_id,
                     compaction_window.unwrap_or_default().into(),

--- a/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_materialized_view.rs
@@ -382,7 +382,7 @@ impl Coordinator {
                 let ids = self
                     .index_oracle(*cluster_id)
                     .sufficient_collections(resolved_ids.0.iter());
-                if !ids.difference(&read_holds.inner.id_bundle()).is_empty() {
+                if !ids.difference(&read_holds.id_bundle()).is_empty() {
                     return Err(AdapterError::ChangedPlan(
                         "the set of possible inputs changed during the creation of the \
                          materialized view"

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -544,8 +544,7 @@ impl Coordinator {
     /// Determines the timestamp for a query, acquires read holds that ensure the
     /// query remains executable at that time, and returns those.
     ///
-    /// The caller is responsible for eventually dropping those read holds using
-    /// [Coordinator::release_read_holds]!
+    /// The caller is responsible for eventually dropping those read holds.
     #[mz_ore::instrument(level = "debug")]
     pub(crate) fn determine_timestamp(
         &mut self,

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -62,7 +62,6 @@ pub use crate::command::{ExecuteResponse, ExecuteResponseKind, RowsFuture, Start
 pub use crate::coord::id_bundle::CollectionIdBundle;
 pub use crate::coord::peek::PeekResponseUnary;
 pub use crate::coord::read_policy::ReadHolds;
-pub use crate::coord::read_policy::ReadHoldsInner;
 pub use crate::coord::timeline::TimelineContext;
 pub use crate::coord::timestamp_selection::{
     TimestampContext, TimestampExplanation, TimestampProvider,

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -25,7 +25,6 @@ use mz_sql_parser::ast::TransactionIsolationLevel;
 use mz_storage_types::read_holds::ReadHold;
 use mz_storage_types::sources::Timeline;
 use serde::{Deserialize, Serialize};
-use timely::progress::frontier::MutableAntichain;
 use timely::progress::Antichain;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -126,21 +125,25 @@ impl TimestampProvider for Frontiers {
     fn acquire_read_holds(&mut self, id_bundle: &CollectionIdBundle) -> ReadHolds<Timestamp> {
         let mut read_holds = ReadHolds::new();
 
+        let mock_read_hold = |id, frontier| {
+            let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+            ReadHold::new(id, frontier, tx)
+        };
+
         for (instance_id, ids) in id_bundle.compute_ids.iter() {
             for id in ids.iter() {
                 let frontiers = self.compute.get(&(*instance_id, *id)).unwrap();
                 read_holds.compute_holds.insert(
                     (*instance_id, *id),
-                    MutableAntichain::from(frontiers.read.to_owned()),
+                    mock_read_hold(*id, frontiers.read.clone()),
                 );
             }
         }
         for id in id_bundle.storage_ids.iter() {
             let frontiers = self.storage.get(id).unwrap();
-
-            let (dummy_tx, _dummy_rx) = tokio::sync::mpsc::unbounded_channel();
-            let mock_storage_hold = ReadHold::new(*id, frontiers.read.to_owned(), dummy_tx);
-            read_holds.storage_holds.insert(*id, mock_storage_hold);
+            read_holds
+                .storage_holds
+                .insert(*id, mock_read_hold(*id, frontiers.read.clone()));
         }
 
         read_holds

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -144,8 +144,7 @@ impl TimestampProvider for Frontiers {
             read_holds.storage_holds.insert(*id, mock_storage_hold);
         }
 
-        let (dummy_tx, _dummy_rx) = tokio::sync::mpsc::unbounded_channel();
-        ReadHolds::new(read_holds, dummy_tx)
+        ReadHolds::new(read_holds)
     }
 
     fn catalog_state(&self) -> &CatalogState {

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -15,7 +15,6 @@ use async_trait::async_trait;
 use mz_adapter::catalog::CatalogState;
 use mz_adapter::session::Session;
 use mz_adapter::ReadHolds;
-use mz_adapter::ReadHoldsInner;
 use mz_adapter::{CollectionIdBundle, TimelineContext, TimestampProvider};
 use mz_compute_types::ComputeInstanceId;
 use mz_expr::MirScalarExpr;
@@ -125,7 +124,7 @@ impl TimestampProvider for Frontiers {
     }
 
     fn acquire_read_holds(&mut self, id_bundle: &CollectionIdBundle) -> ReadHolds<Timestamp> {
-        let mut read_holds = ReadHoldsInner::new();
+        let mut read_holds = ReadHolds::new();
 
         for (instance_id, ids) in id_bundle.compute_ids.iter() {
             for id in ids.iter() {
@@ -144,7 +143,7 @@ impl TimestampProvider for Frontiers {
             read_holds.storage_holds.insert(*id, mock_storage_hold);
         }
 
-        ReadHolds::new(read_holds)
+        read_holds
     }
 
     fn catalog_state(&self) -> &CatalogState {

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -816,12 +816,12 @@ where
 
     /// Acquires a [`ReadHold`] for the identified compute collection.
     pub fn acquire_read_hold(
-        &self,
+        &mut self,
         instance_id: ComputeInstanceId,
         collection_id: GlobalId,
     ) -> Result<ReadHold<T>, CollectionUpdateError> {
         let hold = self
-            .instance(instance_id)?
+            .instance_mut(instance_id)?
             .acquire_read_hold(collection_id)?;
         Ok(hold)
     }
@@ -956,9 +956,10 @@ pub struct CollectionState<T: Timestamp> {
     /// This accumulation contains the capabilities held by all [`ReadHold`]s given out for the
     /// collection, including `implied_read_hold` and `warmup_read_hold`.
     ///
-    /// NOTE: This field may only be modified by [`Instance::apply_read_hold_changes`]. Nobody else
-    /// should modify read capabilities directly. Instead, collection users should manage read
-    /// holds through [`ReadHold`] objects acquired through [`Instance::acquire_read_hold`].
+    /// NOTE: This field may only be modified by [`Instance::apply_read_hold_changes`] and
+    /// [`Instance::acquire_read_hold`]. Nobody else should modify read capabilities directly.
+    /// Instead, collection users should manage read holds through [`ReadHold`] objects acquired
+    /// through [`Instance::acquire_read_hold`].
     ///
     /// TODO(teskje): Restructure the code to enforce the above in the type system.
     read_capabilities: MutableAntichain<T>,


### PR DESCRIPTION
This PR moves the coordinator to use `ReadHold`s for taking read holds on storage/compute collections everywhere. This removes the need for separate read capability tracking that duplicates the logic already present in the controller, thus greatly simplifying the coordinator code dealing with read holds.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I've split the PR into digestible commits, recommend reviewing those separately!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
