### PR TITLE
adapter/migrations: Fix previous migration bug on Postgres subsources with text-columns

### DIFF
--- a/test/legacy-upgrade/create-in-v0.108.0-sources.td
+++ b/test/legacy-upgrade/create-in-v0.108.0-sources.td
@@ -59,16 +59,16 @@ ALTER USER postgres WITH replication;
 DROP PUBLICATION IF EXISTS mz_source_1;
 CREATE PUBLICATION mz_source_1 FOR ALL TABLES;
 CREATE TYPE an_enum AS ENUM ('var0', 'var1');
-CREATE TABLE public_1.table_a (pk INTEGER PRIMARY KEY, f2 TEXT, f3 an_enum);
-INSERT INTO public_1.table_a VALUES (1, 'one', 'var0');
+CREATE TABLE public_1.table_a (pk INTEGER PRIMARY KEY, f2 TEXT, f3 an_enum, f4 NUMERIC(50));
+INSERT INTO public_1.table_a VALUES (1, 'one', 'var0', 500.0);
 ALTER TABLE public_1.table_a REPLICA IDENTITY FULL;
-INSERT INTO public_1.table_a VALUES (2, 'two', 'var1');
+INSERT INTO public_1.table_a VALUES (2, 'two', 'var1', 1000.0);
 
 
 > CREATE SOURCE "mz_source"
   FROM POSTGRES CONNECTION pg (
     PUBLICATION 'mz_source_1',
-    TEXT COLUMNS [public_1.table_f.f2]
+    TEXT COLUMNS [public_1.table_f.f2, public_1.table_f.f4]
   )
   FOR TABLES (public_1.table_a);
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

There was a subtle bug in the migration in `v0.111` and `v0.112` that made an incorrect assumption about the format of the 'text columns' `UnresolvedItemName` stored on each Postgres `CREATE SOURCE` statement, such that we never ended up copying the relevant 'text columns' for Postgres sources to each `CREATE SUBSOURCE` statement:
https://github.com/MaterializeInc/materialize/blob/a8ac55c46319446b404ba12761f90992a226500d/src/adapter/src/catalog/migrate.rs#L491-L503

For postgres sources, the `UnresolvedItemName` is actually (database, schema, table, column).

This PR reintroduces a very similar migration that only applies to Postgres `CREATE SUBSOURCE` statements to fix the issue by copying the relevant text columns from the top-level source, again. Luckily we kept the text columns option on the `CREATE SOURCE` statements around temporarily and hadn't yet removed it. The bug does not exist for MySQL subsources since those followed the convention made in that assumption.

The original PR that introduced the issue was https://github.com/MaterializeInc/materialize/pull/28493

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
