### PR TITLE
More asserts and tests and debug info around optimization notice dropping

### DIFF
--- a/src/transform/src/notice.rs
+++ b/src/transform/src/notice.rs
@@ -45,7 +45,7 @@ use enum_kinds::EnumKind;
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::GlobalId;
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// An long lived in-memory representation of a [`RawOptimizerNotice`] that is
 /// meant to be kept as part of the hydrated catalog state.
 pub struct OptimizerNotice {
@@ -121,7 +121,7 @@ impl OptimizerNotice {
     }
 }
 
-#[derive(EnumKind, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(EnumKind, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[enum_kind(ActionKind)]
 /// An action attached to an [`OptimizerNotice`]
 pub enum Action {
@@ -281,8 +281,8 @@ macro_rules! raw_optimizer_notices {
     ($($ty:ident => $name:literal,)+) => {
         paste::paste!{
             /// Notices that the optimizer wants to show to users.
-            #[derive(EnumKind, Clone, Debug, Eq, PartialEq)]
-            #[enum_kind(OptimizerNoticeKind, derive(PartialOrd, Ord))]
+            #[derive(EnumKind, Clone, Debug, Eq, PartialEq, Hash)]
+            #[enum_kind(OptimizerNoticeKind, derive(PartialOrd, Ord, Hash))]
             pub enum RawOptimizerNotice {
                 $(
                     #[doc = concat!("See [`", stringify!($ty), "`].")]

--- a/src/transform/src/notice/index_already_exists.rs
+++ b/src/transform/src/notice/index_already_exists.rs
@@ -21,7 +21,7 @@ use mz_repr::GlobalId;
 use crate::notice::{ActionKind, OptimizerNoticeApi};
 
 /// Trying to re-create an index that already exists.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct IndexAlreadyExists {
     /// The id of the identical index.
     pub index_id: GlobalId,

--- a/src/transform/src/notice/index_key_empty.rs
+++ b/src/transform/src/notice/index_key_empty.rs
@@ -27,7 +27,7 @@ use crate::notice::{ActionKind, OptimizerNoticeApi};
 ///    the orders of magnitude performance improvements that can happen with other joins when an
 ///    input arrangement exists can't happen with a cross join.
 /// Also note that skew is hard to debug, so it's good to avoid this problem in the first place.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct IndexKeyEmpty;
 
 impl OptimizerNoticeApi for IndexKeyEmpty {

--- a/src/transform/src/notice/index_too_wide_for_literal_constraints.rs
+++ b/src/transform/src/notice/index_too_wide_for_literal_constraints.rs
@@ -24,7 +24,7 @@ use crate::notice::{ActionKind, OptimizerNoticeApi};
 
 /// An index could be used for some literal constraints if the index included only a subset of its
 /// columns.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct IndexTooWideForLiteralConstraints {
     /// The id of the index.
     pub index_id: GlobalId,

--- a/test/sqllogictest/transform/notice/index_already_exists.slt
+++ b/test/sqllogictest/transform/notice/index_already_exists.slt
@@ -24,6 +24,12 @@ ALTER SYSTEM SET enable_rbac_checks TO false
 COMPLETE 0
 
 statement ok
+CREATE SCHEMA notices;
+
+statement ok
+SET SCHEMA = notices;
+
+statement ok
 CREATE TABLE t (
   a int,
   b int
@@ -37,17 +43,17 @@ CREATE INDEX t_idx1 ON t(a + 7);
 query T multiline
 EXPLAIN WITH(humanized expressions) CREATE INDEX t_idx2 ON t(a + 7);
 ----
-materialize.public.t_idx2:
+materialize.notices.t_idx2:
   ArrangeBy keys=[[(#0{a} + 7)]]
     ReadIndex on=t t_idx1=[plan root (no new arrangement)]
 
 Used Indexes:
-  - materialize.public.t_idx1 (plan root (no new arrangement), index export)
+  - materialize.notices.t_idx1 (plan root (no new arrangement), index export)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t_idx2 is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+  - Notice: Index materialize.notices.t_idx2 is identical to materialize.notices.t_idx1, which is also defined on t((a + 7)).
     Hint: Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
 
 EOF
@@ -60,17 +66,17 @@ CREATE INDEX t_idx2 ON t(a + 7);
 query T multiline
 EXPLAIN WITH(humanized expressions) INDEX t_idx2;
 ----
-materialize.public.t_idx2:
+materialize.notices.t_idx2:
   ArrangeBy keys=[[(#0{a} + 7)]]
     ReadIndex on=t t_idx1=[plan root (no new arrangement)]
 
 Used Indexes:
-  - materialize.public.t_idx1 (plan root (no new arrangement), index export)
+  - materialize.notices.t_idx1 (plan root (no new arrangement), index export)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t_idx2 is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+  - Notice: Index materialize.notices.t_idx2 is identical to materialize.notices.t_idx1, which is also defined on t((a + 7)).
     Hint: Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
 
 EOF
@@ -86,8 +92,8 @@ WHERE
   idx.name LIKE 't_idx%'
 ----
 An identical index already exists
-Index materialize.public.t_idx2 is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
-Index materialize.public.t_idx2 is identical to materialize.public.t_idx1, which is also defined on t((a + █)).
+Index materialize.notices.t_idx2 is identical to materialize.notices.t_idx1, which is also defined on t((a + 7)).
+Index materialize.notices.t_idx2 is identical to materialize.notices.t_idx1, which is also defined on t((a + █)).
 Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
 Please drop all indexes except the first index created on t((a + █)) and recreate all dependent objects.
 NULL
@@ -117,17 +123,17 @@ CREATE INDEX t_idx3 ON t(a + 7);
 query T multiline
 EXPLAIN WITH(humanized expressions) INDEX t_idx3;
 ----
-materialize.public.t_idx3:
+materialize.notices.t_idx3:
   ArrangeBy keys=[[(#0{a} + 7)]]
     ReadIndex on=t t_idx1=[plan root (no new arrangement)]
 
 Used Indexes:
-  - materialize.public.t_idx1 (plan root (no new arrangement), index export)
+  - materialize.notices.t_idx1 (plan root (no new arrangement), index export)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t_idx3 is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
+  - Notice: Index materialize.notices.t_idx3 is identical to materialize.notices.t_idx1, which is also defined on t((a + 7)).
     Hint: Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
 
 EOF
@@ -143,8 +149,8 @@ WHERE
   idx.name = 't_idx3'
 ----
 An identical index already exists
-Index materialize.public.t_idx3 is identical to materialize.public.t_idx1, which is also defined on t((a + 7)).
-Index materialize.public.t_idx3 is identical to materialize.public.t_idx1, which is also defined on t((a + █)).
+Index materialize.notices.t_idx3 is identical to materialize.notices.t_idx1, which is also defined on t((a + 7)).
+Index materialize.notices.t_idx3 is identical to materialize.notices.t_idx1, which is also defined on t((a + █)).
 Please drop all indexes except the first index created on t((a + 7)) and recreate all dependent objects.
 Please drop all indexes except the first index created on t((a + █)) and recreate all dependent objects.
 NULL
@@ -161,7 +167,7 @@ DROP INDEX t_idx1;
 query T multiline
 EXPLAIN WITH(humanized expressions) INDEX t_idx3;
 ----
-materialize.public.t_idx3:
+materialize.notices.t_idx3:
   ArrangeBy keys=[[(#0{a} + 7)]]
     ReadIndex on=t [DELETED INDEX]=[plan root (no new arrangement)]
 
@@ -183,3 +189,7 @@ FROM
 WHERE
   idx.name = 't_idx3'
 ----
+
+# This further tests `drop_plans_and_metainfos`
+statement ok
+DROP SCHEMA notices CASCADE;

--- a/test/sqllogictest/transform/notice/index_key_empty.slt
+++ b/test/sqllogictest/transform/notice/index_key_empty.slt
@@ -24,6 +24,12 @@ ALTER SYSTEM SET enable_rbac_checks TO false
 COMPLETE 0
 
 statement ok
+CREATE SCHEMA notices;
+
+statement ok
+SET SCHEMA = notices;
+
+statement ok
 CREATE TABLE t (
   a int,
   b int
@@ -37,11 +43,11 @@ CREATE INDEX t_idx_empty_key ON t();
 query T multiline
 EXPLAIN WITH(humanized expressions) INDEX t_idx_empty_key;
 ----
-materialize.public.t_idx_empty_key:
+materialize.notices.t_idx_empty_key:
   ArrangeBy keys=[[]]
-    ReadStorage materialize.public.t
+    ReadStorage materialize.notices.t
 
-Source materialize.public.t
+Source materialize.notices.t
 
 Target cluster: quickstart
 
@@ -84,3 +90,7 @@ FROM
 WHERE
   idx.name = 't_idx_empty_key'
 ----
+
+# This further tests `drop_plans_and_metainfos`
+statement ok
+DROP SCHEMA notices CASCADE;

--- a/test/sqllogictest/transform/notice/index_too_wide_for_literal_constraints.slt
+++ b/test/sqllogictest/transform/notice/index_too_wide_for_literal_constraints.slt
@@ -26,6 +26,12 @@ ALTER SYSTEM SET enable_rbac_checks TO false
 COMPLETE 0
 
 statement ok
+CREATE SCHEMA notices;
+
+statement ok
+SET SCHEMA = notices;
+
+statement ok
 CREATE TABLE t6(x int, y int, z int, w text);
 
 statement ok
@@ -39,15 +45,15 @@ WHERE x=5;
 ----
 Explained Query (fast path):
   Filter (#0{x} = 5)
-    ReadIndex on=materialize.public.t6 t6_idx_x_y=[*** full scan ***]
+    ReadIndex on=materialize.notices.t6 t6_idx_x_y=[*** full scan ***]
 
 Used Indexes:
-  - materialize.public.t6_idx_x_y (*** full scan ***)
+  - materialize.notices.t6_idx_x_y (*** full scan ***)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `x = 5`.
+  - Notice: Index materialize.notices.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `x = 5`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (x).
 
 EOF
@@ -64,17 +70,17 @@ WHERE x=5;
 ----
 Explained Query (fast path):
   Filter (#0{x} = █)
-    ReadIndex on=materialize.public.t6 t6_idx_x_y=[*** full scan ***]
+    ReadIndex on=materialize.notices.t6 t6_idx_x_y=[*** full scan ***]
 
 Used Indexes:
-  - materialize.public.t6_idx_x_y (*** full scan ***)
+  - materialize.notices.t6_idx_x_y (*** full scan ***)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `x = █`.
+  - Notice: Index materialize.notices.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `x = █`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (x).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `x = █`.
+  - Notice: Index materialize.notices.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `x = █`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (x).
 
 EOF
@@ -88,10 +94,10 @@ WHERE x=5 AND y=6;
 ----
 Explained Query (fast path):
   Project (#0{x}..=#3{w})
-    ReadIndex on=materialize.public.t6 t6_idx_x_y=[lookup value=(5, 6)]
+    ReadIndex on=materialize.notices.t6 t6_idx_x_y=[lookup value=(5, 6)]
 
 Used Indexes:
-  - materialize.public.t6_idx_x_y (lookup)
+  - materialize.notices.t6_idx_x_y (lookup)
 
 Target cluster: quickstart
 
@@ -106,10 +112,10 @@ WHERE x=5 AND y=6 AND z=7;
 ----
 Explained Query (fast path):
   Project (#0{x}..=#3{w})
-    ReadIndex on=materialize.public.t6 t6_idx_x_y_z=[lookup value=(█, █, █)]
+    ReadIndex on=materialize.notices.t6 t6_idx_x_y_z=[lookup value=(█, █, █)]
 
 Used Indexes:
-  - materialize.public.t6_idx_x_y_z (lookup)
+  - materialize.notices.t6_idx_x_y_z (lookup)
 
 Target cluster: quickstart
 
@@ -127,10 +133,10 @@ WHERE x=5;
 ----
 Explained Query (fast path):
   Project (#0{x}..=#3{w})
-    ReadIndex on=materialize.public.t6 t6_idx_x=[lookup value=(5)]
+    ReadIndex on=materialize.notices.t6 t6_idx_x=[lookup value=(5)]
 
 Used Indexes:
-  - materialize.public.t6_idx_x (lookup)
+  - materialize.notices.t6_idx_x (lookup)
 
 Target cluster: quickstart
 
@@ -145,17 +151,17 @@ WHERE y=6;
 ----
 Explained Query (fast path):
   Filter (#1{y} = 6)
-    ReadIndex on=materialize.public.t6 t6_idx_x_y=[*** full scan ***]
+    ReadIndex on=materialize.notices.t6 t6_idx_x_y=[*** full scan ***]
 
 Used Indexes:
-  - materialize.public.t6_idx_x_y (*** full scan ***)
+  - materialize.notices.t6_idx_x_y (*** full scan ***)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y = 6`.
+  - Notice: Index materialize.notices.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y = 6`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y = 6`.
+  - Notice: Index materialize.notices.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y = 6`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
 
 EOF
@@ -170,10 +176,10 @@ WHERE x=5 AND z=7;
 Explained Query (fast path):
   Project (#0{x}..=#3{w})
     Filter (#2{z} = 7)
-      ReadIndex on=materialize.public.t6 t6_idx_x=[lookup value=(5)]
+      ReadIndex on=materialize.notices.t6 t6_idx_x=[lookup value=(5)]
 
 Used Indexes:
-  - materialize.public.t6_idx_x (lookup)
+  - materialize.notices.t6_idx_x (lookup)
 
 Target cluster: quickstart
 
@@ -188,15 +194,15 @@ WHERE z=7;
 ----
 Explained Query (fast path):
   Filter (#2{z} = 7)
-    ReadIndex on=materialize.public.t6 t6_idx_x_y=[*** full scan ***]
+    ReadIndex on=materialize.notices.t6 t6_idx_x_y=[*** full scan ***]
 
 Used Indexes:
-  - materialize.public.t6_idx_x_y (*** full scan ***)
+  - materialize.notices.t6_idx_x_y (*** full scan ***)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `z = 7`.
+  - Notice: Index materialize.notices.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `z = 7`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (z).
 
 EOF
@@ -211,19 +217,19 @@ WHERE y=5;
 query T multiline
 EXPLAIN WITH(humanized expressions) MATERIALIZED VIEW mv1;
 ----
-materialize.public.mv1:
+materialize.notices.mv1:
   Filter (#1{y} = 5)
     ReadIndex on=t6 t6_idx_x_y=[*** full scan ***]
 
 Used Indexes:
-  - materialize.public.t6_idx_x_y (*** full scan ***)
+  - materialize.notices.t6_idx_x_y (*** full scan ***)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y = 5`.
+  - Notice: Index materialize.notices.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y = 5`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y = 5`.
+  - Notice: Index materialize.notices.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y = 5`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
 
 EOF
@@ -238,8 +244,8 @@ FROM
 WHERE
   mv.name = 'mv1';
 ----
-Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.public.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.public.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
-Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.public.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.public.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
 
 # Drop one of the indexes associated with the notices.
 statement ok
@@ -255,7 +261,7 @@ FROM
 WHERE
   mv.name = 'mv1';
 ----
-Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.public.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.public.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
 
 # Drop the catalog item associated with the notices.
 statement ok
@@ -285,17 +291,17 @@ WHERE y=4 OR y=8;
 ----
 Explained Query (fast path):
   Filter ((#1{y} = 4) OR (#1{y} = 8))
-    ReadIndex on=materialize.public.t6 t6_idx_x_y=[*** full scan ***]
+    ReadIndex on=materialize.notices.t6 t6_idx_x_y=[*** full scan ***]
 
 Used Indexes:
-  - materialize.public.t6_idx_x_y (*** full scan ***)
+  - materialize.notices.t6_idx_x_y (*** full scan ***)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y IN (4, 8)`.
+  - Notice: Index materialize.notices.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y IN (4, 8)`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y IN (4, 8)`.
+  - Notice: Index materialize.notices.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y IN (4, 8)`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
 
 EOF
@@ -309,17 +315,17 @@ WHERE (y=5 AND z=7) OR (y=2 AND z=3);
 ----
 Explained Query (fast path):
   Filter (((#1{y} = 2) AND (#2{z} = 3)) OR ((#1{y} = 5) AND (#2{z} = 7)))
-    ReadIndex on=materialize.public.t6 t6_idx_x_y=[*** full scan ***]
+    ReadIndex on=materialize.notices.t6 t6_idx_x_y=[*** full scan ***]
 
 Used Indexes:
-  - materialize.public.t6_idx_x_y (*** full scan ***)
+  - materialize.notices.t6_idx_x_y (*** full scan ***)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y IN (2, 5)`.
+  - Notice: Index materialize.notices.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y IN (2, 5)`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y, z).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `(y, z) IN ((2, 3), (5, 7))`.
+  - Notice: Index materialize.notices.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `(y, z) IN ((2, 3), (5, 7))`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y, z).
 
 EOF
@@ -333,15 +339,15 @@ WHERE z=9 AND w='árvíztűrő tükörfúrógép';
 ----
 Explained Query (fast path):
   Filter (#2{z} = 9) AND (#3{w} = "árvíztűrő tükörfúrógép")
-    ReadIndex on=materialize.public.t6 t6_idx_x_y=[*** full scan ***]
+    ReadIndex on=materialize.notices.t6 t6_idx_x_y=[*** full scan ***]
 
 Used Indexes:
-  - materialize.public.t6_idx_x_y (*** full scan ***)
+  - materialize.notices.t6_idx_x_y (*** full scan ***)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `z = 9`.
+  - Notice: Index materialize.notices.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `z = 9`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (z, w).
 
 EOF
@@ -372,15 +378,19 @@ Explained Query (fast path):
   Project (#4, #5, #3)
     Filter (#0{f2} = 1) AND (7 = (#2 + #2)) AND ((#2 * 2) < (#2 + 2))
       Map ((#1{f1} + #0{f2}), (#1{f1} + 1), 1, 2)
-        ReadIndex on=materialize.public.t1 t1i2=[*** full scan ***]
+        ReadIndex on=materialize.notices.t1 t1i2=[*** full scan ***]
 
 Used Indexes:
-  - materialize.public.t1i2 (*** full scan ***)
+  - materialize.notices.t1i2 (*** full scan ***)
 
 Target cluster: quickstart
 
 Notices:
-  - Notice: Index materialize.public.t1i2 on t1(f2, f1) is too wide to use for literal equalities `f2 = 1`.
+  - Notice: Index materialize.notices.t1i2 on t1(f2, f1) is too wide to use for literal equalities `f2 = 1`.
     Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (f2, ((f1 + f2) + (f1 + f2))).
 
 EOF
+
+# This further tests `drop_plans_and_metainfos`
+statement ok
+DROP SCHEMA notices CASCADE;

--- a/test/sqllogictest/transform/notice/index_too_wide_for_literal_constraints.slt
+++ b/test/sqllogictest/transform/notice/index_too_wide_for_literal_constraints.slt
@@ -234,6 +234,33 @@ Notices:
 
 EOF
 
+# Create a second, similar MV, to test the situation when two notices have the same object as their dependency.
+statement ok
+CREATE MATERIALIZED VIEW mv2 AS
+SELECT *
+FROM t6
+WHERE y=5;
+
+query T multiline
+EXPLAIN WITH(humanized expressions) MATERIALIZED VIEW mv2;
+----
+materialize.notices.mv2:
+  Filter (#1{y} = 5)
+    ReadIndex on=t6 t6_idx_x_y=[*** full scan ***]
+
+Used Indexes:
+  - materialize.notices.t6_idx_x_y (*** full scan ***)
+
+Target cluster: quickstart
+
+Notices:
+  - Notice: Index materialize.notices.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
+  - Notice: Index materialize.notices.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
+
+EOF
+
 # Verify that the same notices can be found in the catalog.
 query TTTTTTTT
 SELECT
@@ -242,16 +269,39 @@ FROM
   mz_internal.mz_notices n JOIN
   mz_catalog.mz_materialized_views mv ON(n.object_id = mv.id)
 WHERE
-  mv.name = 'mv1';
+  mv.name IN ('mv1', 'mv2');
 ----
 Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
 Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+
+statement ok
+CREATE OR REPLACE MATERIALIZED VIEW mv2 AS
+SELECT *
+FROM t6
+WHERE y=7;
+
+# The notice text should have changed.
+query TTTTTTTT
+SELECT
+  n.notice_type, n.message, n.redacted_message, n.hint, n.redacted_hint, n.action, n.redacted_action, n.action_type
+FROM
+  mz_internal.mz_notices n JOIN
+  mz_catalog.mz_materialized_views mv ON(n.object_id = mv.id)
+WHERE
+  mv.name IN ('mv1', 'mv2');
+----
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠7`.  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠7`.  Index␠materialize.notices.t6_idx_x_y_z␠on␠t6(x,␠y,␠z)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
 
 # Drop one of the indexes associated with the notices.
 statement ok
 DROP INDEX t6_idx_x_y_z;
 
-# Verify that the second notice is no longer in the catalog.
+# Verify that the associated notices are no longer in the catalog.
 query TTTTTTTT
 SELECT
   n.notice_type, n.message, n.redacted_message, n.hint, n.redacted_hint, n.action, n.redacted_action, n.action_type
@@ -259,24 +309,27 @@ FROM
   mz_internal.mz_notices n JOIN
   mz_catalog.mz_materialized_views mv ON(n.object_id = mv.id)
 WHERE
-  mv.name = 'mv1';
+  mv.name IN ('mv1', 'mv2');
+----
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠7`.  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
+
+# Drop one of the catalog items associated with the notices.
+statement ok
+DROP MATERIALIZED VIEW mv2;
+
+# Verify that one of the notices are no longer in the catalog.
+query TTTTTTTT
+SELECT
+  n.notice_type, n.message, n.redacted_message, n.hint, n.redacted_hint, n.action, n.redacted_action, n.action_type
+FROM
+  mz_internal.mz_notices n JOIN
+  mz_catalog.mz_materialized_views mv ON(n.object_id = mv.id)
+WHERE
+  mv.name IN ('mv1', 'mv2');
 ----
 Index␠too␠wide␠for␠literal␠constraints  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠5`.  Index␠materialize.notices.t6_idx_x_y␠on␠t6(x,␠y)␠is␠too␠wide␠to␠use␠for␠literal␠equalities␠`y␠=␠█`.  If␠your␠literal␠equalities␠filter␠out␠many␠rows,␠create␠an␠index␠whose␠key␠exactly␠matches␠your␠literal␠equalities:␠(y).  NULL  CREATE␠INDEX␠ON␠t6(y);  NULL  sql_statements
 
-# Drop the catalog item associated with the notices.
-statement ok
-DROP MATERIALIZED VIEW mv1;
-
-# Verify that the notices are no longer in the catalog.
-query TTTTTTTT
-SELECT
-  n.notice_type, n.message, n.redacted_message, n.hint, n.redacted_hint, n.action, n.redacted_action, n.action_type
-FROM
-  mz_internal.mz_notices n JOIN
-  mz_catalog.mz_materialized_views mv ON(n.object_id = mv.id)
-WHERE
-  mv.name = 'mv1';
-----
 
 # Re-create the index dropped above.
 statement ok


### PR DESCRIPTION
We have a bug around dropping objects with optimization notices, where some notices seem to be leaking somehow (https://github.com/MaterializeInc/materialize/issues/24884). This is turning out to be very tough to debug. This PR just adds a bunch of tests, asserts, and debug info in the critical assert's msg.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
