### PR TITLE
tests: Mark v0.113.1 as a bad release

### DIFF
--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -48,6 +48,7 @@ INVALID_VERSIONS = {
     MzVersion.parse_mz("v0.92.0"),  # incompatible for upgrades
     MzVersion.parse_mz("v0.93.0"),  # accidental release
     MzVersion.parse_mz("v0.99.1"),  # incompatible for upgrades
+    MzVersion.parse_mz("v0.113.1"),  # incompatible for upgrades
 }
 
 _SKIP_IMAGE_CHECK_BELOW_THIS_VERSION = MzVersion.parse_mz("v0.77.0")


### PR DESCRIPTION
Otherwise breaks 0d tests because of new restart behavior

Since https://github.com/MaterializeInc/materialize/pull/29025 did not make it into v0.113.1, but is in v0.113.0 and v0.113.2

See https://materializeinc.slack.com/archives/C01LKF361MZ/p1723843931523169

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
