### PR TITLE
testdrive: Fix flaky load-generator.td test

### DIFF
--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -113,7 +113,7 @@ materialize.public.accounts "CREATE SUBSOURCE \"materialize\".\"public\".\"accou
 > SELECT count(*) FROM clock;
 1
 
-> SELECT time < now() + INTERVAL '1s', time > now() - INTERVAL '1s' FROM clock
+> SELECT time < now() + INTERVAL '5s', time > now() - INTERVAL '5s' FROM clock
 true true
 
 # Check that non-append-only `COUNTER` sources reach the proper size


### PR DESCRIPTION
Query execution can be slow in CI. Failed in https://buildkite.com/materialize/nightly/builds/9154

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
