### PR TITLE
ci: No coredump on panic

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -56,9 +56,8 @@ cores="$HOME"/cores
 rm -rf "$cores" parallel-workload-queries.log parallel-workload-queries.log.zst
 mkdir -m 777 "$cores"
 # Max 128 characters, so don't use $PWD which will make it too long
-sudo sysctl -w kernel.core_pattern="|/usr/bin/env tee $cores/core.%E.%t"
-echo -n "Core pattern: "
-cat /proc/sys/kernel/core_pattern
+# Ignore SIGABRT
+sudo sysctl -w kernel.core_pattern="|/usr/bin/ci-filter-core.sh %s $cores/core.%E.%t"
 
 # Start dependencies under a different heading so that the main heading is less
 # noisy. But not if the service is actually a workflow, in which case it will

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -64,11 +64,7 @@ find cores -name 'core.*' | while read -r core; do
     exe=$(echo "$core" | sed -e "s/core\.\(.*\)\.[0-9]*/\1/" -e "s/.*\!//")
     # Core dumps can take a while to be written, so if extracting the info fails, try again later
     bin/ci-builder run stable gdb --batch -ex "bt full" -ex "thread apply all bt" -ex "quit" cores/"$exe" "$core" > "$core".txt || (sleep 2m; bin/ci-builder run stable gdb --batch -ex "bt full" -ex "thread apply all bt" -ex "quit" cores/"$exe" "$core" > "$core".txt || true)
-    if grep -q "Program terminated with signal SIGABRT, Aborted." "$core".txt; then
-        echo "SIGABRT found in \"$core.txt\", ignoring core file"
-    else
-        buildkite-agent artifact upload "$core".txt
-    fi
+    buildkite-agent artifact upload "$core".txt
 done
 # can be huge, clean up
 rm -rf cores


### PR DESCRIPTION
Panics in Rust cause SIGABRT, which creates coredumps If a test panic-loops this can take the entire disk space quickly

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
