### PR TITLE
ci: Bump priority for agents with multiple queues

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -520,7 +520,7 @@ steps:
       - id: checks-restart-cockroach
         label: "Checks + restart Cockroach"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           # A larger instance is needed due to frequent OOMs, same in all other platform-checks
           queue: hetzner-aarch64-16cpu-32gb
@@ -532,7 +532,7 @@ steps:
       - id: checks-restart-entire-mz
         label: "Checks + restart of the entire Mz"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -543,7 +543,7 @@ steps:
       - id: checks-backup-restore-before-manipulate
         label: "Checks backup + restore between the two manipulate()"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -554,7 +554,7 @@ steps:
       - id: checks-backup-restore-after-manipulate
         label: "Checks backup + restore after manipulate()"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -565,7 +565,7 @@ steps:
       - id: checks-backup-multi
         label: "Checks + multiple backups/restores"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -576,7 +576,7 @@ steps:
       - id: checks-backup-rollback
         label: "Checks + backup + rollback to previous"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -588,7 +588,7 @@ steps:
         label: "Checks parallel + DROP/CREATE replica"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -600,7 +600,7 @@ steps:
         label: "Checks parallel + restart compute clusterd"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -612,7 +612,7 @@ steps:
         label: "Checks parallel + restart of the entire Mz"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -624,7 +624,7 @@ steps:
         label: "Checks parallel + restart of environmentd & storage clusterd"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -636,7 +636,7 @@ steps:
         label: "Checks parallel + kill storage clusterd"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -648,7 +648,7 @@ steps:
         label: "Checks parallel + restart Redpanda & Debezium"
         depends_on: build-aarch64
         skip: "Affected by #23882"
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -659,7 +659,7 @@ steps:
       - id: checks-upgrade-entire-mz
         label: "Checks upgrade, whole-Mz restart"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -670,7 +670,7 @@ steps:
       - id: checks-preflight-check-continue
         label: "Checks preflight-check and continue upgrade"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -681,7 +681,7 @@ steps:
       - id: checks-preflight-check-rollback
         label: "Checks preflight-check and roll back upgrade"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -692,7 +692,7 @@ steps:
       - id: checks-upgrade-entire-mz-two-versions
         label: "Checks upgrade across two versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -703,7 +703,7 @@ steps:
       - id: checks-upgrade-entire-mz-four-versions
         label: "Checks upgrade across four versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -714,7 +714,7 @@ steps:
       - id: checks-upgrade-clusterd-compute-first
         label: "Platform checks upgrade, restarting compute clusterd first"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -725,7 +725,7 @@ steps:
       - id: checks-upgrade-clusterd-compute-last
         label: "Platform checks upgrade, restarting compute clusterd last"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -736,7 +736,7 @@ steps:
       - id: checks-kill-clusterd-storage
         label: "Checks + kill storage clusterd"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -747,7 +747,7 @@ steps:
       - id: checks-restart-source-postgres
         label: "Checks + restart source Postgres"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -758,7 +758,7 @@ steps:
       - id: checks-restart-clusterd-compute
         label: "Checks + restart clusterd compute"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           queue: hetzner-aarch64-16cpu-32gb
         plugins:
@@ -769,7 +769,7 @@ steps:
       - id: checks-drop-create-default-replica
         label: "Checks + DROP/CREATE replica"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           # Seems to require more memory on aarch64
           queue: hetzner-aarch64-16cpu-32gb
@@ -781,7 +781,7 @@ steps:
       - id: checks-0dt-restart-entire-mz
         label: "Checks 0dt restart of the entire Mz"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -793,7 +793,7 @@ steps:
       - id: checks-0dt-restart-entire-mz-forced-migrations
         label: "Checks 0dt restart of the entire Mz with forced migrations"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -805,7 +805,7 @@ steps:
       - id: checks-0dt-upgrade-entire-mz
         label: "Checks 0dt upgrade, whole-Mz restart"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -817,7 +817,7 @@ steps:
       - id: checks-0dt-upgrade-entire-mz-two-versions
         label: "Checks 0dt upgrade across two versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -829,7 +829,7 @@ steps:
       - id: checks-0dt-upgrade-entire-mz-four-versions
         label: "Checks 0dt upgrade across four versions"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         agents:
           # TODO(def-): Switch back to hetzner
           queue: linux-aarch64-large
@@ -841,7 +841,7 @@ steps:
       - id: cloudtest-upgrade
         label: "Platform checks upgrade in Cloudtest/K8s"
         depends_on: build-aarch64
-        timeout_in_minutes: 120
+        timeout_in_minutes: 180
         env:
           CLOUDTEST_CLUSTER_DEFINITION_FILE: "misc/kind/cluster.yaml"
         agents:
@@ -1315,7 +1315,7 @@ steps:
   - id: pubsub-disruption
     label: "PubSub disruption"
     depends_on: build-aarch64
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     agents:
       queue: hetzner-aarch64-8cpu-16gb
     plugins:
@@ -1356,7 +1356,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1368,7 +1368,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1380,7 +1380,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1406,7 +1406,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1418,7 +1418,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1431,7 +1431,7 @@ steps:
         timeout_in_minutes: 90
         skip: "TODO(def-): Reenable when #2392 is fixed"
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1443,7 +1443,7 @@ steps:
         artifact_paths: [parallel-workload-queries.log.zst]
         timeout_in_minutes: 90
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
@@ -1456,7 +1456,7 @@ steps:
         timeout_in_minutes: 90
         skip: "TODO(def-): Properly stop all db actions during backup & restore"
         agents:
-          queue: hetzner-aarch64-8cpu-16gb
+          queue: hetzner-aarch64-16cpu-32gb
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -301,7 +301,7 @@ steps:
     label: Fast SQL logic tests %N
     depends_on: build-aarch64
     timeout_in_minutes: 30
-    parallelism: 2
+    parallelism: 3
     inputs: [test/sqllogictest]
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
Makes https://github.com/MaterializeInc/i2/pull/2103 more efficient

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
