### PR TITLE
ci: tag non-release Docker images with prerelease version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "mz-balancerd"
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4514,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "mz-catalog-debug"
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "mz-clusterd"
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -5688,7 +5688,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.4",
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "mz-testdrive"
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/ci/deploy/docker.py
+++ b/ci/deploy/docker.py
@@ -10,7 +10,7 @@
 import os
 from pathlib import Path
 
-from materialize import git, mzbuild
+from materialize import ci_util, git, mzbuild
 from materialize.mz_version import MzVersion
 from materialize.rustc_flags import Sanitizer
 from materialize.version_list import get_all_mz_versions
@@ -50,8 +50,11 @@ def main() -> None:
         if version == latest_version:
             mzbuild.publish_multiarch_images("latest", deps)
     else:
+        mz_version = ci_util.get_mz_version()
         mzbuild.publish_multiarch_images("unstable", deps)
-        mzbuild.publish_multiarch_images(f'unstable-{git.rev_parse("HEAD")}', deps)
+        mzbuild.publish_multiarch_images(
+            f'v{mz_version}+main.g{git.rev_parse("HEAD")}', deps
+        )
 
         # Sync image descriptions to Docker Hub. The image descriptions are the
         # same across architectures, so we arbitrarily choose the first

--- a/ci/deploy/docker.py
+++ b/ci/deploy/docker.py
@@ -52,8 +52,10 @@ def main() -> None:
     else:
         mz_version = ci_util.get_mz_version()
         mzbuild.publish_multiarch_images("unstable", deps)
+        # Ideally we'd use SemVer metadata (e.g., `v1.0.0+metadata`), but `+`
+        # is not a valid character in Docker tags, so we use `--` instead.
         mzbuild.publish_multiarch_images(
-            f'v{mz_version}+main.g{git.rev_parse("HEAD")}', deps
+            f'v{mz_version}--main.g{git.rev_parse("HEAD")}', deps
         )
 
         # Sync image descriptions to Docker Hub. The image descriptions are the

--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -43,12 +43,16 @@ def generate_version(
 ) -> NpmPackageVersion:
     node_version = str(crate_version)
     is_development = False
-    if crate_version.prerelease == "dev":
+    if crate_version.prerelease:
         if build_identifier is None:
             raise ValueError(
                 "a build identifier must be provided for prerelease builds"
             )
-        node_version = str(crate_version.replace(prerelease=f"dev.{build_identifier}"))
+        node_version = str(
+            crate_version.replace(
+                prerelease=f"{crate_version.prerelease}.{build_identifier}"
+            )
+        )
         is_development = True
     else:
         buildkite_tag = os.environ.get("BUILDKITE_TAG")

--- a/ci/test/dev_tag.py
+++ b/ci/test/dev_tag.py
@@ -31,7 +31,11 @@ def main() -> None:
         repo.resolve_dependencies(image for image in repo if image.publish)
         for repo in repos
     ]
-    mzbuild.publish_multiarch_images(f'v{mz_version}+pr.g{git.rev_parse("HEAD")}', deps)
+    # Ideally we'd use SemVer metadata (e.g., `v1.0.0+metadata`), but `+` is not
+    # a valid character in Docker tags, so we use `--` instead.
+    mzbuild.publish_multiarch_images(
+        f'v{mz_version}--pr.g{git.rev_parse("HEAD")}', deps
+    )
 
 
 if __name__ == "__main__":

--- a/ci/test/dev_tag.py
+++ b/ci/test/dev_tag.py
@@ -11,12 +11,13 @@
 
 from pathlib import Path
 
-from materialize import git, mzbuild
+from materialize import ci_util, git, mzbuild
 from materialize.rustc_flags import Sanitizer
 from materialize.xcompile import Arch
 
 
 def main() -> None:
+    mz_version = ci_util.get_mz_version()
     repos = [
         mzbuild.Repository(
             Path("."), Arch.X86_64, coverage=False, sanitizer=Sanitizer.none
@@ -30,7 +31,7 @@ def main() -> None:
         repo.resolve_dependencies(image for image in repo if image.publish)
         for repo in repos
     ]
-    mzbuild.publish_multiarch_images(f'devel-{git.rev_parse("HEAD")}', deps)
+    mzbuild.publish_multiarch_images(f'v{mz_version}+pr.g{git.rev_parse("HEAD")}', deps)
 
 
 if __name__ == "__main__":

--- a/doc/user/content/releases/v0.111.md
+++ b/doc/user/content/releases/v0.111.md
@@ -2,7 +2,7 @@
 title: "Materialize v0.111"
 date: 2024-08-07
 released: true
-patch: 3
+patch: 4
 _build:
   render: never
 ---

--- a/misc/python/materialize/ci_util/__init__.py
+++ b/misc/python/materialize/ci_util/__init__.py
@@ -14,8 +14,9 @@ from pathlib import Path
 from typing import Any
 
 import requests
+from semver.version import VersionInfo
 
-from materialize import buildkite, ui
+from materialize import MZ_ROOT, buildkite, cargo, ui
 
 
 def junit_report_filename(suite: str) -> Path:
@@ -109,3 +110,11 @@ def get_artifacts() -> Any:
         return []
 
     return res.json()
+
+
+def get_mz_version(workspace: cargo.Workspace | None = None) -> VersionInfo:
+    """Get the current Materialize version from Cargo.toml."""
+
+    if not workspace:
+        workspace = cargo.Workspace(MZ_ROOT)
+    return VersionInfo.parse(workspace.crates["mz-environmentd"].version_string)

--- a/misc/python/materialize/cli/ci_annotate_errors.py
+++ b/misc/python/materialize/cli/ci_annotate_errors.py
@@ -150,7 +150,7 @@ IGNORE_RE = re.compile(
     | platform-checks-.* \| .* received\ persist\ state\ from\ the\ future
     | cannot\ load\ unknown\ system\ parameter\ from\ catalog\ storage(\ to\ set\ (default|configured)\ parameter)?
     # For tests we purposely trigger this error
-    | skip-version-upgrade-materialized.* \| .* incompatible\ persist\ version\ \d+\.\d+\.\d+(-dev)?,\ current:\ \d+\.\d+\.\d+(-dev)?,\ make\ sure\ to\ upgrade\ the\ catalog\ one\ version\ forward\ at\ a\ time
+    | skip-version-upgrade-materialized.* \| .* incompatible\ persist\ version\ \d+\.\d+\.\d+(-dev)?,\ current:\ \d+\.\d+\.\d+(-dev\.\d+)?,\ make\ sure\ to\ upgrade\ the\ catalog\ one\ version\ forward\ at\ a\ time
     # For 0dt upgrades
     | halting\ process:\ (unable\ to\ confirm\ leadership|fenced\ out\ old\ deployment;\ rebooting\ as\ leader|this\ deployment\ has\ been\ fenced\ out)
     | zippy-materialized.* \| .* halting\ process:\ Server\ started\ with\ requested\ generation

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -19,14 +19,14 @@ from materialize.mz_version import MzVersion
 CACHED_IMAGE_NAME_BY_COMMIT_HASH: dict[str, str] = dict()
 EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK: dict[str, bool] = dict()
 
-IMAGE_TAG_OF_DEV_VERSION_METADATA_SEPARATOR = "+"
+IMAGE_TAG_OF_DEV_VERSION_METADATA_SEPARATOR = "--"
 LATEST_IMAGE_TAG = "latest"
 LEGACY_IMAGE_TAG_COMMIT_PREFIX = "devel-"
 
 # Examples:
 # * v0.114.0
 # * v0.114.0-dev
-# * v0.114.0-dev.0+pr.g3d565dd11ba1224a41beb6a584215d99e6b3c576
+# * v0.114.0-dev.0--pr.g3d565dd11ba1224a41beb6a584215d99e6b3c576
 VERSION_IN_IMAGE_TAG_PATTERN = re.compile(r"^(v\d+\.\d+\.\d+(-dev)?)")
 
 

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -20,6 +20,7 @@ CACHED_IMAGE_NAME_BY_COMMIT_HASH: dict[str, str] = dict()
 EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK: dict[str, bool] = dict()
 
 IMAGE_TAG_OF_DEV_VERSION_METADATA_SEPARATOR = "+"
+LATEST_IMAGE_TAG = "latest"
 LEGACY_IMAGE_TAG_COMMIT_PREFIX = "devel-"
 
 # Examples:
@@ -112,6 +113,7 @@ def is_image_tag_of_release_version(image_tag: str) -> bool:
     return (
         IMAGE_TAG_OF_DEV_VERSION_METADATA_SEPARATOR not in image_tag
         and not image_tag.startswith(LEGACY_IMAGE_TAG_COMMIT_PREFIX)
+        and image_tag != LATEST_IMAGE_TAG
     )
 
 

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -8,27 +8,38 @@
 # by the Apache License, Version 2.0.
 
 """Docker utilities."""
+import re
 import subprocess
+import time
 
 import requests
 
 from materialize.mz_version import MzVersion
 
+CACHED_IMAGE_NAME_BY_COMMIT_HASH: dict[str, str] = dict()
 EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK: dict[str, bool] = dict()
-IMAGE_TAG_OF_VERSION_PREFIX = "v"
-# XXX TODO
-IMAGE_TAG_OF_COMMIT_PREFIX = "devel-"
+
+IMAGE_TAG_OF_DEV_VERSION_METADATA_SEPARATOR = "+"
+
+# Examples:
+# * v0.114.0
+# * v0.114.0-dev
+# * v0.114.0-dev.0+pr.g3d565dd11ba1224a41beb6a584215d99e6b3c576
+VERSION_IN_IMAGE_TAG_PATTERN = re.compile(r"^(v\d+\.\d+\.\d+(-dev)?)")
 
 
 def image_of_release_version_exists(version: MzVersion) -> bool:
-    return mz_image_tag_exists(release_version_to_image_tag(version))
+    if version.is_dev_version():
+        raise ValueError(f"Version {version} is a dev version, not a release version")
+
+    return _mz_image_tag_exists(release_version_to_image_tag(version))
 
 
 def image_of_commit_exists(commit_hash: str) -> bool:
-    return mz_image_tag_exists(commit_to_image_tag(commit_hash))
+    return _mz_image_tag_exists(commit_to_image_tag(commit_hash))
 
 
-def mz_image_tag_exists(image_tag: str) -> bool:
+def _mz_image_tag_exists(image_tag: str) -> bool:
     image_name = f"materialize/materialized:{image_tag}"
 
     if image_name in EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK:
@@ -89,7 +100,7 @@ def mz_image_tag_exists(image_tag: str) -> bool:
 
 
 def commit_to_image_tag(commit_hash: str) -> str:
-    return f"{IMAGE_TAG_OF_COMMIT_PREFIX}{commit_hash}"
+    return _resolve_image_name_by_commit_hash(commit_hash)
 
 
 def release_version_to_image_tag(version: MzVersion) -> str:
@@ -97,23 +108,77 @@ def release_version_to_image_tag(version: MzVersion) -> str:
 
 
 def is_image_tag_of_release_version(image_tag: str) -> bool:
-    return image_tag.startswith(IMAGE_TAG_OF_VERSION_PREFIX)
+    return IMAGE_TAG_OF_DEV_VERSION_METADATA_SEPARATOR not in image_tag
 
 
 def is_image_tag_of_commit(image_tag: str) -> bool:
-    return image_tag.startswith(IMAGE_TAG_OF_COMMIT_PREFIX)
+    return IMAGE_TAG_OF_DEV_VERSION_METADATA_SEPARATOR in image_tag
 
 
 def get_version_from_image_tag(image_tag: str) -> str:
-    assert image_tag.startswith(IMAGE_TAG_OF_VERSION_PREFIX)
-    # image tag is equal to the version
-    return image_tag
+    match = VERSION_IN_IMAGE_TAG_PATTERN.match(image_tag)
+    assert match is not None, f"Invalid image tag: {image_tag}"
+
+    return match.group(1)
 
 
 def get_mz_version_from_image_tag(image_tag: str) -> MzVersion:
     return MzVersion.parse_mz(get_version_from_image_tag(image_tag))
 
 
-def get_commit_from_image_tag(image_tag: str) -> str:
-    assert image_tag.startswith(IMAGE_TAG_OF_COMMIT_PREFIX)
-    return image_tag.removeprefix(IMAGE_TAG_OF_COMMIT_PREFIX)
+def _resolve_image_name_by_commit_hash(commit_hash: str) -> str:
+    if commit_hash in CACHED_IMAGE_NAME_BY_COMMIT_HASH.keys():
+        return CACHED_IMAGE_NAME_BY_COMMIT_HASH[commit_hash]
+
+    image_name_candidates = _search_docker_hub_for_image_name(search_value=commit_hash)
+    image_name = _select_image_name_from_candidates(image_name_candidates, commit_hash)
+
+    CACHED_IMAGE_NAME_BY_COMMIT_HASH[commit_hash] = image_name
+    EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK[image_name] = True
+
+    return image_name
+
+
+def _search_docker_hub_for_image_name(
+    search_value: str, remaining_retries: int = 1
+) -> list[str]:
+    try:
+        json_response = requests.get(
+            f"https://hub.docker.com/v2/repositories/materialize/materialized/tags?name={search_value}"
+        ).json()
+    except (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.JSONDecodeError,
+    ) as _:
+        print("Searching Docker Hub for image name failed, retrying in 5 seconds")
+        time.sleep(5)
+        if remaining_retries > 0:
+            return _search_docker_hub_for_image_name(
+                search_value, remaining_retries - 1
+            )
+
+        raise
+
+    json_results = json_response.get("results")
+
+    image_names = []
+
+    for entry in json_results:
+        image_name = entry.get("name")
+        image_names.append(image_name)
+
+    return image_names
+
+
+def _select_image_name_from_candidates(
+    image_name_candidates: list[str], commit_hash: str
+) -> str:
+    if len(image_name_candidates) == 0:
+        raise RuntimeError(f"No image found for commit hash {commit_hash}")
+
+    if len(image_name_candidates) > 1:
+        raise RuntimeError(
+            f"Multiple images found for commit hash {commit_hash}: {image_name_candidates}"
+        )
+
+    return image_name_candidates[0]

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -21,7 +21,7 @@ IMAGE_TAG_OF_COMMIT_PREFIX = "devel-"
 
 
 def image_of_release_version_exists(version: MzVersion) -> bool:
-    return mz_image_tag_exists(version_to_image_tag(version))
+    return mz_image_tag_exists(release_version_to_image_tag(version))
 
 
 def image_of_commit_exists(commit_hash: str) -> bool:
@@ -92,11 +92,11 @@ def commit_to_image_tag(commit_hash: str) -> str:
     return f"{IMAGE_TAG_OF_COMMIT_PREFIX}{commit_hash}"
 
 
-def version_to_image_tag(version: MzVersion) -> str:
+def release_version_to_image_tag(version: MzVersion) -> str:
     return str(version)
 
 
-def is_image_tag_of_version(image_tag: str) -> bool:
+def is_image_tag_of_release_version(image_tag: str) -> bool:
     return image_tag.startswith(IMAGE_TAG_OF_VERSION_PREFIX)
 
 

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -16,6 +16,7 @@ from materialize.mz_version import MzVersion
 
 EXISTENCE_OF_IMAGE_NAMES_FROM_EARLIER_CHECK: dict[str, bool] = dict()
 IMAGE_TAG_OF_VERSION_PREFIX = "v"
+# XXX TODO
 IMAGE_TAG_OF_COMMIT_PREFIX = "devel-"
 
 

--- a/misc/python/materialize/mz_version.py
+++ b/misc/python/materialize/mz_version.py
@@ -86,6 +86,9 @@ class TypedVersionBase(Version):
     def __str__(self) -> str:
         return f"{self.get_prefix()}{self.str_without_prefix()}"
 
+    def is_dev_version(self) -> bool:
+        return self.prerelease is not None
+
 
 class MzVersion(TypedVersionBase):
     """Version of Materialize, can be parsed from version string, SQL, cargo"""

--- a/misc/python/materialize/mz_version.py
+++ b/misc/python/materialize/mz_version.py
@@ -48,7 +48,7 @@ class TypedVersionBase(Version):
 
     @classmethod
     def parse(cls: type[T], version: str, drop_dev_suffix: bool = False) -> T:
-        """Parses a version string with prefix, for example: v0.45.0-dev (f01773cb1)"""
+        """Parses a version string with prefix, for example: v0.45.0-dev (f01773cb1) or v0.115.0-dev.0"""
         expected_prefix = cls.get_prefix()
         if not version.startswith(expected_prefix):
             raise ValueError(
@@ -62,7 +62,7 @@ class TypedVersionBase(Version):
             # Hash ignored
 
         if drop_dev_suffix:
-            version = version.replace("-dev", "")
+            version, _, _ = version.partition("-dev")
 
         return super().parse(version)
 
@@ -99,7 +99,7 @@ class MzVersion(TypedVersionBase):
 
     @classmethod
     def parse_mz(cls: type[T], version: str, drop_dev_suffix: bool = False) -> T:
-        """Parses a version string with prefix, for example: v0.45.0-dev (f01773cb1)"""
+        """Parses a version string with prefix, for example: v0.45.0-dev (f01773cb1) or v0.115.0-dev.0"""
         return cls.parse(version=version, drop_dev_suffix=drop_dev_suffix)
 
     @classmethod

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -10,6 +10,7 @@
 
 from enum import Enum
 
+from materialize import docker
 from materialize.mz_version import MzVersion
 from materialize.mzcompose import (
     DEFAULT_CRDB_ENVIRONMENT,
@@ -96,8 +97,10 @@ class Materialized(Service):
         image_version = None
         if not image:
             image_version = MzVersion.parse_cargo()
-        elif "latest" not in image and "devel" not in image and "unstable" not in image:
-            image_version = MzVersion.parse_mz(image.split(":")[1])
+        elif ":" in image:
+            image_version_str = image.split(":")[1]
+            if docker.is_image_tag_of_release_version(image_version_str):
+                image_version = MzVersion.parse_mz(image_version_str)
 
         if system_parameter_defaults is None:
             system_parameter_defaults = get_default_system_parameters(

--- a/misc/python/materialize/release/auto_cut_release.py
+++ b/misc/python/materialize/release/auto_cut_release.py
@@ -31,7 +31,7 @@ def main():
     remote = git.get_remote()
     latest_version = git.get_latest_version(version_type=MzVersion)
     release_version = latest_version.bump_minor()
-    next_version = MzVersion.parse_mz(f"{release_version.bump_minor()}-dev")
+    next_version = MzVersion.parse_mz(f"{release_version.bump_minor()}-dev.0")
 
     print("Pulling latest main...")
     spawn.runv(["git", "pull", remote, "main"])
@@ -54,7 +54,7 @@ def main():
     print(f"Bumping version on main to {next_version}...")
     spawn.runv([MZ_ROOT / "bin" / "bump-version", str(next_version)])
 
-    next_version_final = str(next_version).removesuffix(".0-dev")
+    next_version_final = str(next_version).removesuffix(".0-dev.0")
     print(f"Creating {next_version_final}.md in the docs")
     today = datetime.today()
     next_thursday = today + timedelta(days=((3 - today.weekday()) % 7 or 7))

--- a/misc/python/materialize/scalability/regression_assessment.py
+++ b/misc/python/materialize/scalability/regression_assessment.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from materialize.docker import (
     get_mz_version_from_image_tag,
-    is_image_tag_of_version,
+    is_image_tag_of_release_version,
 )
 from materialize.mz_version import MzVersion
 from materialize.mzcompose.test_result import TestFailureDetails
@@ -111,9 +111,9 @@ class RegressionAssessment:
 
     def _endpoint_references_release_version(self, endpoint: Endpoint) -> bool:
         target = endpoint.resolved_target()
-        return is_image_tag_of_version(target) and MzVersion.is_valid_version_string(
+        return is_image_tag_of_release_version(
             target
-        )
+        ) and MzVersion.is_valid_version_string(target)
 
     def to_failure_details(self) -> list[TestFailureDetails]:
         failure_details = []

--- a/misc/python/materialize/scalability/scalability_versioning.py
+++ b/misc/python/materialize/scalability/scalability_versioning.py
@@ -19,7 +19,7 @@ SCALABILITY_WORKLOADS_DIR = SCALABILITY_FRAMEWORK_DIR / "workloads"
 # Consider increasing the #SCALABILITY_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {}
 SHA256_OF_FRAMEWORK["*"] = (
-    "bdc636367da82cafe005dd8e4bfe2b2d38028f723f9cb80e8ccf031a22272b5b"
+    "3e5257ef1ee3158b7a08a3e2dd0511886e104d3b286c7172ce8024111775b982"
 )
 
 # Consider increasing the workload's class #version() if changes are expected to impact results!

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -20,7 +20,7 @@ from materialize import build_context, buildkite, docker, git
 from materialize.docker import (
     commit_to_image_tag,
     image_of_commit_exists,
-    version_to_image_tag,
+    release_version_to_image_tag,
 )
 from materialize.git import get_version_tags
 from materialize.mz_version import MzVersion
@@ -88,7 +88,7 @@ def _create_ancestor_image_resolution(
 
 def _manual_ancestor_specification_to_image_tag(ancestor_spec: str) -> str:
     if MzVersion.is_valid_version_string(ancestor_spec):
-        return version_to_image_tag(MzVersion.parse_mz(ancestor_spec))
+        return release_version_to_image_tag(MzVersion.parse_mz(ancestor_spec))
     else:
         return commit_to_image_tag(ancestor_spec)
 
@@ -144,7 +144,7 @@ class AncestorImageResolutionBase:
             )
 
         return (
-            version_to_image_tag(previous_release_version),
+            release_version_to_image_tag(previous_release_version),
             f"{context_prefix} {tagged_release_version}",
         )
 
@@ -170,7 +170,7 @@ class AncestorImageResolutionBase:
             )
 
         return (
-            version_to_image_tag(previous_published_version),
+            release_version_to_image_tag(previous_published_version),
             context,
         )
 
@@ -187,7 +187,7 @@ class AncestorImageResolutionBase:
             )
         else:
             return (
-                version_to_image_tag(get_latest_published_version()),
+                release_version_to_image_tag(get_latest_published_version()),
                 context_when_falling_back_to_latest,
             )
 

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-balancerd"
 description = "Balancer service."
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-catalog-debug"
 description = "Durable metadata storage debug tool."
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/catalog/src/durable/persist/tests.rs
+++ b/src/catalog/src/durable/persist/tests.rs
@@ -25,6 +25,8 @@ use crate::durable::{
 async fn test_upgrade_shard() {
     let first_version = semver::Version::parse("0.10.0").expect("failed to parse version");
     let second_version = semver::Version::parse("0.11.0").expect("failed to parse version");
+    let second_dev_version =
+        semver::Version::parse("0.11.0-dev.0").expect("failed to parse version");
     let third_version = semver::Version::parse("0.12.0").expect("failed to parse version");
     let organization_id = Uuid::new_v4();
     let deploy_generation = 0;
@@ -83,6 +85,19 @@ async fn test_upgrade_shard() {
         ),
         "Unexpected error: {err:?}"
     );
+
+    persist_cache.cfg.build_version = second_dev_version.clone();
+    let persist_client = persist_cache
+        .open(PersistLocation::new_in_mem())
+        .await
+        .expect("in-mem location is valid");
+    test_persist_backed_catalog_state_with_version(
+        persist_client.clone(),
+        organization_id.clone(),
+        second_dev_version.clone(),
+    )
+    .await
+    .expect("failed to create persist catalog");
 
     persist_cache.cfg.build_version = second_version.clone();
     let persist_client = persist_cache

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-clusterd"
 description = "Materialize's cluster server."
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-testdrive"
 description = "Integration test driver for Materialize."
-version = "0.114.0-dev"
+version = "0.114.0-dev.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -15,7 +15,7 @@ import uuid
 from textwrap import dedent
 
 from materialize import buildkite
-from materialize.docker import is_image_tag_of_version
+from materialize.docker import is_image_tag_of_release_version
 from materialize.feature_benchmark.benchmark_versioning import (
     FEATURE_BENCHMARK_FRAMEWORK_VERSION,
 )
@@ -675,9 +675,9 @@ def _is_regression_justified(
 def _tag_references_release_version(image_tag: str | None) -> bool:
     if image_tag is None:
         return False
-    return is_image_tag_of_version(image_tag) and MzVersion.is_valid_version_string(
+    return is_image_tag_of_release_version(
         image_tag
-    )
+    ) and MzVersion.is_valid_version_string(image_tag)
 
 
 def _regressions_to_failure_details(

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -13,7 +13,7 @@
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_rbac_checks = true;
 
-$ set-regex match="cluster1|^quickstart$|v\d+\.\d+\.\d+(-[a-z0-9]+)? \([a-f0-9]{9}\)" replacement=<VARIES>
+$ set-regex match="cluster1|^quickstart$|v\d+\.\d+\.\d+(-[a-z0-9]+)?(\.\d+)? \([a-f0-9]{9}\)" replacement=<VARIES>
 
 > SHOW ALL
 allowed_cluster_replica_sizes       ""                      "The allowed sizes when creating a new cluster replica (Materialize)."


### PR DESCRIPTION
Historically, we've tagged Docker images for PRs and builds directly from main, respectively, like so:

     devel-3d565dd11ba1224a41beb6a584215d99e6b3c576
     unstable-3d565dd11ba1224a41beb6a584215d99e6b3c576

This makes it impossible for our cloud infrastructure to do version compatibility checks based on Docker tags alone.

This commit changes our prerelease tagging scheme to the following:

    v0.114.0-dev.0--pr.g3d565dd11ba1224a41beb6a584215d99e6b3c576
    v0.114.0-dev.0--main.g3d565dd11ba1224a41beb6a584215d99e6b3c576

The tags now include a SemVer version (v0.114.0-dev.0 in this case), followed by build metadata indicating whether the image was generated by a build for a PR or for main and the specific commit hash used for the build. We use `--` to separate the build metadata rather than the SemVer-standard `+` character because `+` is not a valid character in Docker tags.

When we make breaking changes to environmentd's interface, we can bump the prerelease version (e.g., v0.114.0-dev.1), so that our cloud infrastructure can have precise version checks, like:

    if version.meets_minimum_version("v0.114.0-dev.1") { ... }

Touches MaterializeInc/cloud#9939.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR improves the release process.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
