### PR TITLE
storage/sinks/kafka: attach headers to tombstones

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -131,10 +131,6 @@ use crate::statistics::SinkStatistics;
 use crate::storage_state::StorageState;
 
 impl<G: Scope<Timestamp = Timestamp>> SinkRender<G> for KafkaSinkConnection {
-    fn uses_keys(&self) -> bool {
-        true
-    }
-
     fn get_key_indices(&self) -> Option<&[usize]> {
         self.key_desc_and_indices
             .as_ref()

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -82,8 +82,9 @@ use anyhow::{anyhow, bail, Context};
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use futures::StreamExt;
 use maplit::btreemap;
-use mz_interchange::avro::AvroEncoder;
+use mz_interchange::avro::{AvroEncoder, DiffPair};
 use mz_interchange::encode::Encode;
+use mz_interchange::envelopes::dbz_format;
 use mz_interchange::json::JsonEncoder;
 use mz_interchange::text_binary::{BinaryEncoder, TextEncoder};
 use mz_kafka_util::client::{
@@ -146,7 +147,7 @@ impl<G: Scope<Timestamp = Timestamp>> SinkRender<G> for KafkaSinkConnection {
         storage_state: &mut StorageState,
         sink: &StorageSinkDesc<MetadataFilled, Timestamp>,
         sink_id: GlobalId,
-        input: Collection<G, (Option<Row>, Option<Row>), Diff>,
+        input: Collection<G, (Option<Row>, DiffPair<Row>), Diff>,
         // TODO(benesch): errors should stream out through the sink,
         // if we figure out a protocol for that.
         _err_collection: Collection<G, DataflowError, Diff>,
@@ -1231,7 +1232,7 @@ async fn fetch_partition_count_loop<F>(
 /// Input [`Row`] updates must me compatible with the given implementor of [`Encode`].
 fn encode_collection<G: Scope>(
     name: String,
-    input: &Collection<G, (Option<Row>, Option<Row>), Diff>,
+    input: &Collection<G, (Option<Row>, DiffPair<Row>), Diff>,
     envelope: SinkEnvelope,
     connection: KafkaSinkConnection,
     storage_configuration: StorageConfiguration,
@@ -1341,11 +1342,24 @@ fn encode_collection<G: Scope>(
             // TODO(petrosagg): Make the fallible async operator safe
             *capset = CapabilitySet::new();
 
+            let mut row_buf = Row::default();
+
             while let Some(event) = input.next().await {
                 if let Event::Data(cap, rows) = event {
                     for ((key, value), time, diff) in rows {
-                        let headers = match (connection.headers_index, &value) {
-                            (Some(i), Some(v)) => encode_headers(v.iter().nth(i).unwrap()),
+
+                        let headers = match connection.headers_index {
+                            Some(i) => {
+                                // Only the upsert envelope makes it unambiguous
+                                // as to whether to use `before` or `after` to
+                                // compute the headers. The rule is simple: use
+                                // `after` if it exists (insertions and
+                                // updates), otherwise fall back to `before`
+                                // (deletions).
+                                assert!(envelope == SinkEnvelope::Upsert);
+                                let row = value.after.as_ref().or(value.before.as_ref()).expect("one of before or after must be set");
+                                encode_headers(row.iter().nth(i).unwrap())
+                            }
                             _ => vec![],
                         };
                         let (hash, key) = match key {
@@ -1357,6 +1371,13 @@ fn encode_collection<G: Scope>(
                                 (hash, Some(key_enc))
                             }
                             None => (0, None)
+                        };
+                        let value = match envelope {
+                            SinkEnvelope::Upsert => value.after,
+                            SinkEnvelope::Debezium => {
+                                dbz_format(&mut row_buf.packer(), value);
+                                Some(row_buf.clone())
+                            }
                         };
                         let value = value.map(|value| value_encoder.encode_unchecked(value));
                         let message = KafkaMessage {

--- a/test/testdrive/kafka-sink-headers.td
+++ b/test/testdrive/kafka-sink-headers.td
@@ -80,8 +80,13 @@ b         d         {"k": 5, "h": {"a": "b", "c": "d"}}
 
 > INSERT INTO text_tbl VALUES (6, '{"a" => "b", "c" => null}')
 
-$ kafka-verify-data headers=a,c format=json sink=materialize.public.text_snk key=false sort-messages=true
-b         <null>    {"k": 6, "h": {"a": "b", "c": null}}
+$ kafka-verify-data headers=a,c format=json sink=materialize.public.text_snk key=true sort-messages=true
+b         <null>    {"k": 6} {"k": 6, "h": {"a": "b", "c": null}}
+
+> DELETE FROM text_tbl WHERE k = 6
+
+$ kafka-verify-data headers=a,c format=json sink=materialize.public.text_snk key=true sort-messages=true
+b         <null>    {"k": 6}
 
 # Test successful use with `map[text => bytea]`.
 


### PR DESCRIPTION
Due to a bug in the initial implementation of the `HEADERS` option for Kafka sinks, we were not properly attaching headers to tombstones (i.e., messages with a `NULL` value).

The fix is to defer the final envelope encoding step until later in the sink pipeline, so that the code that determines what headers to apply can see the `before` value for tombstones.

This is a prerequisite to supporting custom partitioning (https://github.com/MaterializeInc/materialize/issues/28837).

### Motivation

  * This PR fixes a previously unreported recognized bug.

### Tips for reviewers

The first two commits are pure refactoring, and the third is the actual behavior change. The diff may look scarier than the change actually is, so just shout if it'd be easier if I gave y'all a verbal explainer!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
