### PR TITLE
version consistency: normalize table function error messages

### DIFF
--- a/misc/python/materialize/version_consistency/validation/version_consistency_error_message_normalizer.py
+++ b/misc/python/materialize/version_consistency/validation/version_consistency_error_message_normalizer.py
@@ -14,11 +14,16 @@ from materialize.output_consistency.validation.error_message_normalizer import (
 )
 
 FUNCTION_ID_SUFFIX_PATTERN = re.compile(r" \(function \[s\d+ AS pg_catalog\.\w+\]\)")
+# Example: column "table_func_8ab9ea9d-340c-45c2-967d-65118d6c979b" does not exist
+TABLE_FUNC_PATTERN = re.compile(r"column \"table_func_[a-f0-9-]+\"")
 
 
 class VersionConsistencyErrorMessageNormalizer(ErrorMessageNormalizer):
     def normalize(self, error_message: str) -> str:
         error_message = super().normalize(error_message)
         error_message = re.sub(FUNCTION_ID_SUFFIX_PATTERN, "", error_message)
+        error_message = re.sub(
+            TABLE_FUNC_PATTERN, 'column "table_func_x"', error_message
+        )
 
         return error_message


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightly/builds/9154#01915d87-fc42-4e36-b85d-a7c6d6c8b760:

```
ValidationErrorType.ERROR_MISMATCH: Error message differs.
Expression: pow(log(generate_subscripts(multi_dim_text_array_two_elem, int2_max), uint4_max), list_length(list_agg(uint4_one)))
  Value 1 (Constant folding v0.114.0-dev (e488dfc57)): 'column "table_func_f93e2875-e70a-42d3-9701-474f28806339" does not exist' (type: <class 'str'>)
  Value 2 (Constant folding v0.113.2 (e9f403526)): 'column "table_func_8ab9ea9d-340c-45c2-967d-65118d6c979b" does not exist' (type: <class 'str'>)
```