### PR TITLE
feature benchmark: fix unit mismatch

### DIFF
--- a/misc/python/materialize/feature_benchmark/aggregation.py
+++ b/misc/python/materialize/feature_benchmark/aggregation.py
@@ -21,7 +21,7 @@ class Aggregation:
         self._data: list[float] = []
         self._unit: MeasurementUnit = MeasurementUnit.UNKNOWN
 
-    def append(self, measurement: Measurement) -> None:
+    def append_measurement(self, measurement: Measurement) -> None:
         assert measurement.unit != MeasurementUnit.UNKNOWN, "Unknown unit"
         self._unit = measurement.unit
         self._data.append(measurement.value)

--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -204,7 +204,7 @@ class Benchmark:
     ) -> None:
         if not self._filter or not self._filter.filter(performance_measurement):
             print(f"{i} {performance_measurement}")
-            self._performance_aggregation.append(performance_measurement)
+            self._performance_aggregation.append_measurement(performance_measurement)
 
     def _collect_message_count(self, i: int) -> None:
         messages = self._executor.Messages()
@@ -215,7 +215,7 @@ class Benchmark:
                 unit=MeasurementUnit.COUNT,
             )
             print(f"{i}: {messages_measurement}")
-            self._messages_aggregation.append(messages_measurement)
+            self._messages_aggregation.append_measurement(messages_measurement)
 
     def _collect_memory_measurement(
         self, i: int, memory_measurement_type: MeasurementType, aggregation: Aggregation
@@ -229,7 +229,7 @@ class Benchmark:
         if memory_measurement.value > 0:
             if not self._filter or not self._filter.filter(memory_measurement):
                 print(f"{i} {memory_measurement}")
-                aggregation.append(memory_measurement)
+                aggregation.append_measurement(memory_measurement)
 
 
 class Report:
@@ -238,10 +238,10 @@ class Report:
         """ 1-based cycle number. """
         self._comparisons: list[Comparator] = []
 
-    def append(self, comparison: Comparator) -> None:
+    def add_comparison(self, comparison: Comparator) -> None:
         self._comparisons.append(comparison)
 
-    def extend(self, comparisons: Iterable[Comparator]) -> None:
+    def add_comparisons(self, comparisons: Iterable[Comparator]) -> None:
         self._comparisons.extend(comparisons)
 
     def as_string(self, use_colors: bool, limit_to_scenario: str | None = None) -> str:

--- a/misc/python/materialize/feature_benchmark/benchmark_versioning.py
+++ b/misc/python/materialize/feature_benchmark/benchmark_versioning.py
@@ -19,7 +19,7 @@ FEATURE_BENCHMARK_SCENARIOS_DIR = FEATURE_BENCHMARK_FRAMEWORK_DIR / "scenarios"
 # Consider increasing the #FEATURE_BENCHMARK_FRAMEWORK_VERSION if changes are expected to impact results!
 SHA256_OF_FRAMEWORK: dict[str, str] = {}
 SHA256_OF_FRAMEWORK["*"] = (
-    "9cb5288287cd7ef5011eff15c6e99725e550eea04d07606e881f05e53d3b18e4"
+    "9e5ed3ae21972101c8cef1172ffaaab73051c192fd4ddcdc772b74eb96c1e972"
 )
 
 # Consider increasing the scenario's class #version() if changes are expected to impact results!

--- a/misc/python/materialize/feature_benchmark/comparator.py
+++ b/misc/python/materialize/feature_benchmark/comparator.py
@@ -33,6 +33,9 @@ class Comparator(Generic[T]):
     ) -> None:
         if self._unit == MeasurementUnit.UNKNOWN:
             self._unit = unit
+        elif point is None:
+            # ignore unit check
+            pass
         else:
             assert (
                 self._unit == unit

--- a/misc/python/materialize/feature_benchmark/comparator.py
+++ b/misc/python/materialize/feature_benchmark/comparator.py
@@ -28,7 +28,9 @@ class Comparator(Generic[T]):
         self._unit: MeasurementUnit = MeasurementUnit.UNKNOWN
         self.version: ScenarioVersion | None = None
 
-    def append(self, point: T, unit: MeasurementUnit, aggregation_name: str) -> None:
+    def append_point(
+        self, point: T, unit: MeasurementUnit, aggregation_name: str
+    ) -> None:
         if self._unit == MeasurementUnit.UNKNOWN:
             self._unit = unit
         else:

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -260,7 +260,7 @@ def run_one_scenario(
                 scenario_version = benchmark.create_scenario_instance().version()
                 for aggregation, comparator in zip(aggregations, comparators):
                     comparator.set_scenario_version(scenario_version)
-                    comparator.append(
+                    comparator.append_point(
                         aggregation.aggregate(),
                         aggregation.unit(),
                         aggregation.name(),
@@ -514,7 +514,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             if len(comparators) == 0:
                 continue
 
-            report.extend(comparators)
+            report.add_comparisons(comparators)
 
             # Do not retry the scenario if no regressions
             if _shall_retry_scenario(scenario, comparators, cycle_index):


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/commit/2bc6b7a0fe52251e4eb5dc012fc34853561068a8 should finally fix

```
builtins.AssertionError: Mix of units in FastPathLimit: # and ? in MinAggregation
```

observed again in https://buildkite.com/materialize/nightly/builds/9158#01916237-8d5e-438b-b4fb-2ba86df51a1a.