### PR TITLE
storage: relax since check in read-only mode

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -696,9 +696,18 @@ where
                 // We don't care about the dependency since when the write
                 // frontier is empty. In that case, no-one can write down any
                 // more updates.
+                //
+                // In read-only mode (or potentially other situations, when we
+                // allow concurrently running coordinator-like processes) it can
+                // happen that a collection is dropped and hence it's since is
+                // advanced to `[]` while we are trying to "create" that
+                // collection. For now, we allow that state in this here assert.
+                // In the future, we might have to relax this even furhter and
+                // not restrict the relaxation to read-only mode.
                 mz_ore::soft_assert_or_log!(
                     write_frontier.elements() == &[T::minimum()]
                         || write_frontier.is_empty()
+                        || (dependency_since.is_empty() && self.read_only)
                         || PartialOrder::less_than(&dependency_since, write_frontier),
                     "dependency since has advanced past dependent ({id}) upper \n
                             dependent ({id}): upper {:?} \n
@@ -3649,6 +3658,19 @@ where
                 Err(StorageError::IdentifierInvalid(id))?
             }
         };
+
+        let ingestion_state = match &collection.extra_state {
+            CollectionStateExtra::Ingestion(ingestion_state) => ingestion_state,
+            CollectionStateExtra::None => {
+                tracing::warn!("missing ingestion state for ingestion {}", id);
+                Err(StorageError::IdentifierInvalid(id))?
+            }
+        };
+
+        if ingestion_state.read_capabilities.frontier().is_empty() {
+            tracing::info!("not running ingestion {id} because its since is empty");
+            return Ok(());
+        }
 
         // Enrich all of the exports with their metadata
         let mut source_exports = BTreeMap::new();


### PR DESCRIPTION
Fixes MaterializeInc/database-issues#8425

With this change, we might now get panics in other places where we make assumptions about sinces/uppers that don't hold in read-only mode or when there are concurrent coordinator-like processes.

cc @benesch & @def-: As mentioned in MaterializeInc/database-issues#8425, this fixes the panic but we might discover new ones.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
