### PR TITLE
bazel: Fix mz_version

### DIFF
--- a/misc/bazel/cargo-gazelle/BUILD.bazel
+++ b/misc/bazel/cargo-gazelle/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "cargo_gazelle",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "cargo_gazelle_lib_tests",
+	version = "0.0.0",
 	crate = ":cargo_gazelle",
 	aliases = aliases(
 		normal = True,
@@ -67,6 +69,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "main",
+	version = "0.0.0",
 	crate_root = "src/bin/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/misc/bazel/cargo-gazelle/src/targets.rs
+++ b/misc/bazel/cargo-gazelle/src/targets.rs
@@ -52,6 +52,7 @@ impl<T: RustTarget> RustTarget for Option<T> {
 #[derive(Debug)]
 pub struct RustLibrary {
     name: Field<QuotedString>,
+    version: Field<QuotedString>,
     is_proc_macro: bool,
     features: Field<List<QuotedString>>,
     aliases: Field<Aliases>,
@@ -157,6 +158,7 @@ impl RustLibrary {
 
         Ok(Some(RustLibrary {
             name: Field::new("name", name),
+            version: Field::new("version", metadata.version().to_string().into()),
             is_proc_macro: metadata.is_proc_macro(),
             features: Field::new("crate_features", features),
             aliases: Field::new("aliases", Aliases::default().normal().proc_macro()),
@@ -187,6 +189,7 @@ impl ToBazelDefinition for RustLibrary {
             let mut w = w.indent();
 
             self.name.format(&mut w)?;
+            self.version.format(&mut w)?;
 
             writeln!(w, r#"srcs = glob(["src/**/*.rs"]),"#)?;
 
@@ -218,6 +221,7 @@ impl ToBazelDefinition for RustLibrary {
 #[derive(Debug)]
 pub struct RustBinary {
     name: Field<QuotedString>,
+    version: Field<QuotedString>,
     crate_root: Field<QuotedString>,
     features: Field<List<QuotedString>>,
     aliases: Field<Aliases>,
@@ -333,6 +337,7 @@ impl RustBinary {
 
         Ok(Some(RustBinary {
             name: Field::new("name", target_name),
+            version: Field::new("version", metadata.version().to_string().into()),
             crate_root: Field::new("crate_root", binary_path),
             features: Field::new("features", List::empty()),
             aliases: Field::new("aliases", Aliases::default().normal().proc_macro()),
@@ -356,6 +361,7 @@ impl ToBazelDefinition for RustBinary {
             let mut w = w.indent();
 
             self.name.format(&mut w)?;
+            self.version.format(&mut w)?;
             self.crate_root.format(&mut w)?;
 
             writeln!(w, r#"srcs = glob(["src/**/*.rs"]),"#)?;
@@ -380,6 +386,7 @@ impl ToBazelDefinition for RustBinary {
 #[derive(Debug)]
 pub struct RustTest {
     name: Field<QuotedString>,
+    version: Field<QuotedString>,
     kind: RustTestKind,
     aliases: Field<Aliases>,
     deps: Field<List<QuotedString>>,
@@ -475,6 +482,7 @@ impl RustTest {
 
         Ok(Some(RustTest {
             name: Field::new("name", name),
+            version: Field::new("version", metadata.version().to_string().into()),
             kind,
             aliases: Field::new("aliases", aliases),
             deps: Field::new("deps", deps),
@@ -545,6 +553,7 @@ impl ToBazelDefinition for RustTest {
             let mut w = w.indent();
 
             self.name.format(&mut w)?;
+            self.version.format(&mut w)?;
             self.kind.format(&mut w)?;
             self.aliases.format(&mut w)?;
             self.deps.format(&mut w)?;

--- a/src/adapter-types/BUILD.bazel
+++ b/src/adapter-types/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_adapter_types",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_adapter_types_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_adapter_types",
 	aliases = aliases(
 		normal = True,

--- a/src/adapter/BUILD.bazel
+++ b/src/adapter/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_adapter",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -73,6 +74,7 @@ rust_library(
 
 rust_test(
 	name = "mz_adapter_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_adapter",
 	aliases = aliases(
 		normal = True,
@@ -187,6 +189,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_adapter_parameters_tests",
+	version = "0.0.0",
 	srcs = ["tests/parameters.rs"],
 	aliases = aliases(
 		normal = True,
@@ -253,6 +256,7 @@ rust_test(
 
 rust_test(
 	name = "mz_adapter_sql_tests",
+	version = "0.0.0",
 	srcs = ["tests/sql.rs"],
 	aliases = aliases(
 		normal = True,
@@ -319,6 +323,7 @@ rust_test(
 
 rust_test(
 	name = "mz_adapter_timestamp_selection_tests",
+	version = "0.0.0",
 	srcs = ["tests/timestamp_selection.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/alloc-default/BUILD.bazel
+++ b/src/alloc-default/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_alloc_default",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_alloc_default_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_alloc_default",
 	aliases = aliases(
 		normal = True,

--- a/src/alloc/BUILD.bazel
+++ b/src/alloc/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_alloc",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"] + select({
 		"@//misc/bazel/platforms:linux_arm": [
@@ -49,6 +50,7 @@ rust_library(
 
 rust_test(
 	name = "mz_alloc_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_alloc",
 	aliases = aliases(
 		normal = True,

--- a/src/arrow-util/BUILD.bazel
+++ b/src/arrow-util/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_arrow_util",
+	version = "0.1.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_arrow_util_lib_tests",
+	version = "0.1.0",
 	crate = ":mz_arrow_util",
 	aliases = aliases(
 		normal = True,

--- a/src/audit-log/BUILD.bazel
+++ b/src/audit-log/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_audit_log",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_audit_log_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_audit_log",
 	aliases = aliases(
 		normal = True,

--- a/src/avro/BUILD.bazel
+++ b/src/avro/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_avro",
+	version = "0.7.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"byteorder",
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_avro_lib_tests",
+	version = "0.7.0",
 	crate = ":mz_avro",
 	aliases = aliases(
 		normal = True,
@@ -72,6 +74,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_avro_io_tests",
+	version = "0.7.0",
 	srcs = ["tests/io.rs"],
 	aliases = aliases(
 		normal = True,
@@ -100,6 +103,7 @@ rust_test(
 
 rust_test(
 	name = "mz_avro_schema_tests",
+	version = "0.7.0",
 	srcs = ["tests/schema.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/aws-secrets-controller/BUILD.bazel
+++ b/src/aws-secrets-controller/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_aws_secrets_controller",
+	version = "0.1.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -37,6 +38,7 @@ rust_library(
 
 rust_test(
 	name = "mz_aws_secrets_controller_lib_tests",
+	version = "0.1.0",
 	crate = ":mz_aws_secrets_controller",
 	aliases = aliases(
 		normal = True,

--- a/src/aws-util/BUILD.bazel
+++ b/src/aws-util/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_aws_util",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"aws-sdk-s3",
@@ -37,6 +38,7 @@ rust_library(
 
 rust_test(
 	name = "mz_aws_util_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_aws_util",
 	aliases = aliases(
 		normal = True,

--- a/src/balancerd/BUILD.bazel
+++ b/src/balancerd/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_balancerd",
+	version = "0.114.0-dev",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -49,6 +50,7 @@ rust_library(
 
 rust_test(
 	name = "mz_balancerd_lib_tests",
+	version = "0.114.0-dev",
 	crate = ":mz_balancerd",
 	aliases = aliases(
 		normal = True,
@@ -113,6 +115,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_balancerd_server_tests",
+	version = "0.114.0-dev",
 	srcs = ["tests/server.rs"],
 	aliases = aliases(
 		normal = True,
@@ -154,6 +157,7 @@ rust_test(
 
 rust_binary(
 	name = "mz_balancerd_bin",
+	version = "0.114.0-dev",
 	crate_root = "src/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/build-info/BUILD.bazel
+++ b/src/build-info/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_build_info",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -37,6 +38,7 @@ rust_library(
 
 rust_test(
 	name = "mz_build_info_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_build_info",
 	aliases = aliases(
 		normal = True,

--- a/src/build-tools/BUILD.bazel
+++ b/src/build-tools/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_build_tools",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -39,6 +40,7 @@ rust_library(
 
 rust_test(
 	name = "mz_build_tools_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_build_tools",
 	aliases = aliases(
 		normal = True,

--- a/src/catalog-debug/BUILD.bazel
+++ b/src/catalog-debug/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_catalog_debug",
+	version = "0.114.0-dev",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -45,6 +46,7 @@ rust_library(
 
 rust_test(
 	name = "mz_catalog_debug_lib_tests",
+	version = "0.114.0-dev",
 	crate = ":mz_catalog_debug",
 	aliases = aliases(
 		normal = True,
@@ -103,6 +105,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "mz_catalog_debug",
+	version = "0.114.0-dev",
 	crate_root = "src/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/catalog/BUILD.bazel
+++ b/src/catalog/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_catalog",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -58,6 +59,7 @@ rust_library(
 
 rust_test(
 	name = "mz_catalog_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_catalog",
 	aliases = aliases(
 		normal = True,
@@ -182,6 +184,7 @@ cargo_build_script(
 
 rust_test(
 	name = "mz_catalog_debug_tests",
+	version = "0.0.0",
 	srcs = ["tests/debug.rs"],
 	aliases = aliases(
 		normal = True,
@@ -232,6 +235,7 @@ rust_test(
 
 rust_test(
 	name = "mz_catalog_open_tests",
+	version = "0.0.0",
 	srcs = ["tests/open.rs"],
 	aliases = aliases(
 		normal = True,
@@ -282,6 +286,7 @@ rust_test(
 
 rust_test(
 	name = "mz_catalog_read-write_tests",
+	version = "0.0.0",
 	srcs = ["tests/read-write.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/ccsr/BUILD.bazel
+++ b/src/ccsr/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_ccsr",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_ccsr_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_ccsr",
 	aliases = aliases(
 		normal = True,
@@ -73,6 +75,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_ccsr_client_tests",
+	version = "0.0.0",
 	srcs = ["tests/client.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/cloud-api/BUILD.bazel
+++ b/src/cloud-api/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_cloud_api",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_cloud_api_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_cloud_api",
 	aliases = aliases(
 		normal = True,

--- a/src/cloud-resources/BUILD.bazel
+++ b/src/cloud-resources/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_cloud_resources",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_cloud_resources_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_cloud_resources",
 	aliases = aliases(
 		normal = True,

--- a/src/cluster-client/BUILD.bazel
+++ b/src/cluster-client/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_cluster_client",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_cluster_client_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_cluster_client",
 	aliases = aliases(
 		normal = True,

--- a/src/cluster/BUILD.bazel
+++ b/src/cluster/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_cluster",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -43,6 +44,7 @@ rust_library(
 
 rust_test(
 	name = "mz_cluster_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_cluster",
 	aliases = aliases(
 		normal = True,

--- a/src/clusterd/BUILD.bazel
+++ b/src/clusterd/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_clusterd",
+	version = "0.114.0-dev",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -58,6 +59,7 @@ rust_library(
 
 rust_test(
 	name = "mz_clusterd_lib_tests",
+	version = "0.114.0-dev",
 	crate = ":mz_clusterd",
 	aliases = aliases(
 		normal = True,
@@ -134,6 +136,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "clusterd",
+	version = "0.114.0-dev",
 	crate_root = "src/bin/clusterd.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/compute-client/BUILD.bazel
+++ b/src/compute-client/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_compute_client",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -54,6 +55,7 @@ rust_library(
 
 rust_test(
 	name = "mz_compute_client_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_compute_client",
 	aliases = aliases(
 		normal = True,

--- a/src/compute-types/BUILD.bazel
+++ b/src/compute-types/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_compute_types",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -42,6 +43,7 @@ rust_library(
 
 rust_test(
 	name = "mz_compute_types_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_compute_types",
 	aliases = aliases(
 		normal = True,

--- a/src/compute/BUILD.bazel
+++ b/src/compute/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_compute",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -51,6 +52,7 @@ rust_library(
 
 rust_test(
 	name = "mz_compute_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_compute",
 	aliases = aliases(
 		normal = True,

--- a/src/controller-types/BUILD.bazel
+++ b/src/controller-types/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_controller_types",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -37,6 +38,7 @@ rust_library(
 
 rust_test(
 	name = "mz_controller_types_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_controller_types",
 	aliases = aliases(
 		normal = True,

--- a/src/controller/BUILD.bazel
+++ b/src/controller/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_controller",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -50,6 +51,7 @@ rust_library(
 
 rust_test(
 	name = "mz_controller_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_controller",
 	aliases = aliases(
 		normal = True,

--- a/src/dyncfg-launchdarkly/BUILD.bazel
+++ b/src/dyncfg-launchdarkly/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_dyncfg_launchdarkly",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -37,6 +38,7 @@ rust_library(
 
 rust_test(
 	name = "mz_dyncfg_launchdarkly_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_dyncfg_launchdarkly",
 	aliases = aliases(
 		normal = True,

--- a/src/dyncfg/BUILD.bazel
+++ b/src/dyncfg/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_dyncfg",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_dyncfg_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_dyncfg",
 	aliases = aliases(
 		normal = True,

--- a/src/dyncfgs/BUILD.bazel
+++ b/src/dyncfgs/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_dyncfgs",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -41,6 +42,7 @@ rust_library(
 
 rust_test(
 	name = "mz_dyncfgs_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_dyncfgs",
 	aliases = aliases(
 		normal = True,

--- a/src/environmentd/BUILD.bazel
+++ b/src/environmentd/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_environmentd",
+	version = "0.114.0-dev",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -86,6 +87,7 @@ rust_library(
 
 rust_test(
 	name = "mz_environmentd_lib_tests",
+	version = "0.114.0-dev",
 	crate = ":mz_environmentd",
 	aliases = aliases(
 		normal = True,
@@ -256,6 +258,7 @@ cargo_build_script(
 
 rust_test(
 	name = "mz_environmentd_auth_tests",
+	version = "0.114.0-dev",
 	srcs = ["tests/auth.rs"],
 	aliases = aliases(
 		normal = True,
@@ -321,6 +324,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_cli_tests",
+	version = "0.114.0-dev",
 	srcs = ["tests/cli.rs"],
 	aliases = aliases(
 		normal = True,
@@ -386,6 +390,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_pgwire_tests",
+	version = "0.114.0-dev",
 	srcs = ["tests/pgwire.rs"],
 	aliases = aliases(
 		normal = True,
@@ -451,6 +456,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_server_tests",
+	version = "0.114.0-dev",
 	srcs = ["tests/server.rs"],
 	aliases = aliases(
 		normal = True,
@@ -516,6 +522,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_sql_tests",
+	version = "0.114.0-dev",
 	srcs = ["tests/sql.rs"],
 	aliases = aliases(
 		normal = True,
@@ -581,6 +588,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_timezones_tests",
+	version = "0.114.0-dev",
 	srcs = ["tests/timezones.rs"],
 	aliases = aliases(
 		normal = True,
@@ -646,6 +654,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_tracing_tests",
+	version = "0.114.0-dev",
 	srcs = ["tests/tracing.rs"],
 	aliases = aliases(
 		normal = True,
@@ -711,6 +720,7 @@ rust_test(
 
 rust_binary(
 	name = "environmentd",
+	version = "0.114.0-dev",
 	crate_root = "src/bin/environmentd/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/expr-parser/BUILD.bazel
+++ b/src/expr-parser/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_expr_parser",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -37,6 +38,7 @@ rust_library(
 
 rust_test(
 	name = "mz_expr_parser_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_expr_parser",
 	aliases = aliases(
 		normal = True,
@@ -79,6 +81,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_expr_parser_test_mir_parser_tests",
+	version = "0.0.0",
 	srcs = ["tests/test_mir_parser.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/expr-test-util/BUILD.bazel
+++ b/src/expr-test-util/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_expr_test_util",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -39,6 +40,7 @@ rust_library(
 
 rust_test(
 	name = "mz_expr_test_util_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_expr_test_util",
 	aliases = aliases(
 		normal = True,
@@ -85,6 +87,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_expr_test_util_test_runner_tests",
+	version = "0.0.0",
 	srcs = ["tests/test_runner.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/expr/BUILD.bazel
+++ b/src/expr/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_expr",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -46,6 +47,7 @@ rust_library(
 
 rust_test(
 	name = "mz_expr_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_expr",
 	aliases = aliases(
 		normal = True,
@@ -149,6 +151,7 @@ cargo_build_script(
 
 rust_test(
 	name = "mz_expr_test_runner_tests",
+	version = "0.0.0",
 	srcs = ["tests/test_runner.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/fivetran-destination/BUILD.bazel
+++ b/src/fivetran-destination/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_fivetran_destination",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -39,6 +40,7 @@ rust_library(
 
 rust_test(
 	name = "mz_fivetran_destination_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_fivetran_destination",
 	aliases = aliases(
 		normal = True,
@@ -104,6 +106,7 @@ cargo_build_script(
 
 rust_binary(
 	name = "mz_fivetran_destination_bin",
+	version = "0.0.0",
 	crate_root = "src/bin/mz-fivetran-destination.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/frontegg-auth/BUILD.bazel
+++ b/src/frontegg-auth/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_frontegg_auth",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_frontegg_auth_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_frontegg_auth",
 	aliases = aliases(
 		normal = True,

--- a/src/frontegg-client/BUILD.bazel
+++ b/src/frontegg-client/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_frontegg_client",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_frontegg_client_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_frontegg_client",
 	aliases = aliases(
 		normal = True,

--- a/src/frontegg-mock/BUILD.bazel
+++ b/src/frontegg-mock/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_frontegg_mock",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_frontegg_mock_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_frontegg_mock",
 	aliases = aliases(
 		normal = True,
@@ -76,6 +78,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "mz_frontegg_mock_bin",
+	version = "0.0.0",
 	crate_root = "src/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/http-util/BUILD.bazel
+++ b/src/http-util/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_http_util",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_http_util_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_http_util",
 	aliases = aliases(
 		normal = True,

--- a/src/interchange/BUILD.bazel
+++ b/src/interchange/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_interchange",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -41,6 +42,7 @@ rust_library(
 
 rust_test(
 	name = "mz_interchange_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_interchange",
 	aliases = aliases(
 		normal = True,
@@ -117,6 +119,7 @@ cargo_build_script(
 
 rust_binary(
 	name = "avro_decode",
+	version = "0.0.0",
 	crate_root = "src/bin/avro-decode.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/kafka-util/BUILD.bazel
+++ b/src/kafka-util/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_kafka_util",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_kafka_util_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_kafka_util",
 	aliases = aliases(
 		normal = True,
@@ -82,6 +84,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "kgen",
+	version = "0.0.0",
 	crate_root = "src/bin/kgen.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/lowertest-derive/BUILD.bazel
+++ b/src/lowertest-derive/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_proc_macro", "rust_test", "rust_doc_tes
 
 rust_proc_macro(
 	name = "mz_lowertest_derive",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_proc_macro(
 
 rust_test(
 	name = "mz_lowertest_derive_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_lowertest_derive",
 	aliases = aliases(
 		normal = True,

--- a/src/lowertest/BUILD.bazel
+++ b/src/lowertest/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_lowertest",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_lowertest_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_lowertest",
 	aliases = aliases(
 		normal = True,
@@ -67,6 +69,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_lowertest_test_runner_tests",
+	version = "0.0.0",
 	srcs = ["tests/test_runner.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/lsp-server/BUILD.bazel
+++ b/src/lsp-server/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_lsp_server",
+	version = "0.3.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -39,6 +40,7 @@ rust_library(
 
 rust_test(
 	name = "mz_lsp_server_lib_tests",
+	version = "0.3.0",
 	crate = ":mz_lsp_server",
 	aliases = aliases(
 		normal = True,
@@ -85,6 +87,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_lsp_server_test_tests",
+	version = "0.3.0",
 	srcs = ["tests/test.rs"],
 	aliases = aliases(
 		normal = True,
@@ -117,6 +120,7 @@ rust_test(
 
 rust_binary(
 	name = "mz_lsp_server_bin",
+	version = "0.3.0",
 	crate_root = "src/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/metabase/BUILD.bazel
+++ b/src/metabase/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_metabase",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_metabase_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_metabase",
 	aliases = aliases(
 		normal = True,

--- a/src/metrics/BUILD.bazel
+++ b/src/metrics/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_metrics",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_metrics_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_metrics",
 	aliases = aliases(
 		normal = True,

--- a/src/mysql-util/BUILD.bazel
+++ b/src/mysql-util/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_mysql_util",
+	version = "0.1.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -41,6 +42,7 @@ rust_library(
 
 rust_test(
 	name = "mz_mysql_util_lib_tests",
+	version = "0.1.0",
 	crate = ":mz_mysql_util",
 	aliases = aliases(
 		normal = True,

--- a/src/mz/BUILD.bazel
+++ b/src/mz/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz",
+	version = "0.3.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -39,6 +40,7 @@ rust_library(
 
 rust_test(
 	name = "mz_lib_tests",
+	version = "0.3.0",
 	crate = ":mz",
 	aliases = aliases(
 		normal = True,
@@ -85,6 +87,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_local_tests",
+	version = "0.3.0",
 	srcs = ["tests/local.rs"],
 	aliases = aliases(
 		normal = True,
@@ -117,6 +120,7 @@ rust_test(
 
 rust_binary(
 	name = "mz_bin",
+	version = "0.3.0",
 	crate_root = "src/bin/mz/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/npm/BUILD.bazel
+++ b/src/npm/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_npm",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_npm_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_npm",
 	aliases = aliases(
 		normal = True,

--- a/src/orchestrator-kubernetes/BUILD.bazel
+++ b/src/orchestrator-kubernetes/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_orchestrator_kubernetes",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -39,6 +40,7 @@ rust_library(
 
 rust_test(
 	name = "mz_orchestrator_kubernetes_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_orchestrator_kubernetes",
 	aliases = aliases(
 		normal = True,

--- a/src/orchestrator-process/BUILD.bazel
+++ b/src/orchestrator-process/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_orchestrator_process",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_orchestrator_process_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_orchestrator_process",
 	aliases = aliases(
 		normal = True,

--- a/src/orchestrator-tracing/BUILD.bazel
+++ b/src/orchestrator-tracing/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_orchestrator_tracing",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"capture",
@@ -47,6 +48,7 @@ rust_library(
 
 rust_test(
 	name = "mz_orchestrator_tracing_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_orchestrator_tracing",
 	aliases = aliases(
 		normal = True,

--- a/src/orchestrator/BUILD.bazel
+++ b/src/orchestrator/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_orchestrator",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_orchestrator_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_orchestrator",
 	aliases = aliases(
 		normal = True,

--- a/src/ore-proc/BUILD.bazel
+++ b/src/ore-proc/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_proc_macro", "rust_test", "rust_doc_tes
 
 rust_proc_macro(
 	name = "mz_ore_proc",
+	version = "0.1.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_proc_macro(
 
 rust_test(
 	name = "mz_ore_proc_lib_tests",
+	version = "0.1.0",
 	crate = ":mz_ore_proc",
 	aliases = aliases(
 		normal = True,
@@ -67,6 +69,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_ore_proc_instrument_tests",
+	version = "0.1.0",
 	srcs = ["tests/instrument.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/ore/BUILD.bazel
+++ b/src/ore/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_ore",
+	version = "0.1.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"anyhow",
@@ -89,6 +90,7 @@ rust_library(
 
 rust_test(
 	name = "mz_ore_lib_tests",
+	version = "0.1.0",
 	crate = ":mz_ore",
 	aliases = aliases(
 		normal = True,
@@ -123,6 +125,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_ore_future_tests",
+	version = "0.1.0",
 	srcs = ["tests/future.rs"],
 	aliases = aliases(
 		normal = True,
@@ -148,6 +151,7 @@ rust_test(
 
 rust_test(
 	name = "mz_ore_panic_tests",
+	version = "0.1.0",
 	srcs = ["tests/panic.rs"],
 	aliases = aliases(
 		normal = True,
@@ -173,6 +177,7 @@ rust_test(
 
 rust_test(
 	name = "mz_ore_task_tests",
+	version = "0.1.0",
 	srcs = ["tests/task.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/persist-cli/BUILD.bazel
+++ b/src/persist-cli/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "persistcli",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -46,6 +47,7 @@ rust_library(
 
 rust_test(
 	name = "persistcli_lib_tests",
+	version = "0.0.0",
 	crate = ":persistcli",
 	aliases = aliases(
 		normal = True,
@@ -100,6 +102,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "persistcli",
+	version = "0.0.0",
 	crate_root = "src/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/persist-client/BUILD.bazel
+++ b/src/persist-client/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_persist_client",
+	version = "0.114.0-dev",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -44,6 +45,7 @@ rust_library(
 
 rust_test(
 	name = "mz_persist_client_lib_tests",
+	version = "0.114.0-dev",
 	crate = ":mz_persist_client",
 	aliases = aliases(
 		normal = True,

--- a/src/persist-proc/BUILD.bazel
+++ b/src/persist-proc/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_proc_macro", "rust_test", "rust_doc_tes
 
 rust_proc_macro(
 	name = "mz_persist_proc",
+	version = "0.1.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_proc_macro(
 
 rust_test(
 	name = "mz_persist_proc_lib_tests",
+	version = "0.1.0",
 	crate = ":mz_persist_proc",
 	aliases = aliases(
 		normal = True,

--- a/src/persist-types/BUILD.bazel
+++ b/src/persist-types/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_persist_types",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_persist_types_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_persist_types",
 	aliases = aliases(
 		normal = True,

--- a/src/persist/BUILD.bazel
+++ b/src/persist/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_persist",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -42,6 +43,7 @@ rust_library(
 
 rust_test(
 	name = "mz_persist_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_persist",
 	aliases = aliases(
 		normal = True,

--- a/src/pgcopy/BUILD.bazel
+++ b/src/pgcopy/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_pgcopy",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -40,6 +41,7 @@ rust_library(
 
 rust_test(
 	name = "mz_pgcopy_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_pgcopy",
 	aliases = aliases(
 		normal = True,

--- a/src/pgrepr-consts/BUILD.bazel
+++ b/src/pgrepr-consts/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_pgrepr_consts",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_pgrepr_consts_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_pgrepr_consts",
 	aliases = aliases(
 		normal = True,

--- a/src/pgrepr/BUILD.bazel
+++ b/src/pgrepr/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_pgrepr",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_pgrepr_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_pgrepr",
 	aliases = aliases(
 		normal = True,

--- a/src/pgtest/BUILD.bazel
+++ b/src/pgtest/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_pgtest",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_pgtest_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_pgtest",
 	aliases = aliases(
 		normal = True,
@@ -67,6 +69,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "mz_pgtest_bin",
+	version = "0.0.0",
 	crate_root = "src/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/pgtz/BUILD.bazel
+++ b/src/pgtz/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_pgtz",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -39,6 +40,7 @@ rust_library(
 
 rust_test(
 	name = "mz_pgtz_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_pgtz",
 	aliases = aliases(
 		normal = True,

--- a/src/pgwire-common/BUILD.bazel
+++ b/src/pgwire-common/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_pgwire_common",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_pgwire_common_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_pgwire_common",
 	aliases = aliases(
 		normal = True,

--- a/src/pgwire/BUILD.bazel
+++ b/src/pgwire/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_pgwire",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -45,6 +46,7 @@ rust_library(
 
 rust_test(
 	name = "mz_pgwire_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_pgwire",
 	aliases = aliases(
 		normal = True,

--- a/src/postgres-client/BUILD.bazel
+++ b/src/postgres-client/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_postgres_client",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_postgres_client_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_postgres_client",
 	aliases = aliases(
 		normal = True,

--- a/src/postgres-util/BUILD.bazel
+++ b/src/postgres-util/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_postgres_util",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -56,6 +57,7 @@ rust_library(
 
 rust_test(
 	name = "mz_postgres_util_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_postgres_util",
 	aliases = aliases(
 		normal = True,

--- a/src/prof-http/BUILD.bazel
+++ b/src/prof-http/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_prof_http",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"] + select({
 		"@//misc/bazel/platforms:linux_arm": [
@@ -53,6 +54,7 @@ rust_library(
 
 rust_test(
 	name = "mz_prof_http_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_prof_http",
 	aliases = aliases(
 		normal = True,
@@ -121,6 +123,7 @@ cargo_build_script(
 
 rust_binary(
 	name = "fgviz",
+	version = "0.0.0",
 	crate_root = "src/bin/fgviz.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/prof/BUILD.bazel
+++ b/src/prof/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_prof",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"] + select({
 		"@//misc/bazel/platforms:linux_arm": [
@@ -49,6 +50,7 @@ rust_library(
 
 rust_test(
 	name = "mz_prof_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_prof",
 	aliases = aliases(
 		normal = True,

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_proto",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"chrono",
@@ -42,6 +43,7 @@ rust_library(
 
 rust_test(
 	name = "mz_proto_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_proto",
 	aliases = aliases(
 		normal = True,

--- a/src/regexp/BUILD.bazel
+++ b/src/regexp/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_regexp",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_regexp_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_regexp",
 	aliases = aliases(
 		normal = True,

--- a/src/repr-test-util/BUILD.bazel
+++ b/src/repr-test-util/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_repr_test_util",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -37,6 +38,7 @@ rust_library(
 
 rust_test(
 	name = "mz_repr_test_util_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_repr_test_util",
 	aliases = aliases(
 		normal = True,
@@ -79,6 +81,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_repr_test_util_test_runner_tests",
+	version = "0.0.0",
 	srcs = ["tests/test_runner.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/repr/BUILD.bazel
+++ b/src/repr/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_repr",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -46,6 +47,7 @@ rust_library(
 
 rust_test(
 	name = "mz_repr_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_repr",
 	aliases = aliases(
 		normal = True,
@@ -150,6 +152,7 @@ cargo_build_script(
 
 rust_test(
 	name = "mz_repr_strconv_tests",
+	version = "0.0.0",
 	srcs = ["tests/strconv.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/rocksdb-types/BUILD.bazel
+++ b/src/rocksdb-types/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_rocksdb_types",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_rocksdb_types_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_rocksdb_types",
 	aliases = aliases(
 		normal = True,

--- a/src/rocksdb/BUILD.bazel
+++ b/src/rocksdb/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_rocksdb",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -37,6 +38,7 @@ rust_library(
 
 rust_test(
 	name = "mz_rocksdb_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_rocksdb",
 	aliases = aliases(
 		normal = True,
@@ -79,6 +81,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_rocksdb_basic_tests",
+	version = "0.0.0",
 	srcs = ["tests/basic.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/s3-datagen/BUILD.bazel
+++ b/src/s3-datagen/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_s_3_datagen",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_s_3_datagen_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_s_3_datagen",
 	aliases = aliases(
 		normal = True,
@@ -76,6 +78,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "mz_s_3_datagen",
+	version = "0.0.0",
 	crate_root = "src/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/secrets/BUILD.bazel
+++ b/src/secrets/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_secrets",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_secrets_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_secrets",
 	aliases = aliases(
 		normal = True,

--- a/src/segment/BUILD.bazel
+++ b/src/segment/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_segment",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_segment_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_segment",
 	aliases = aliases(
 		normal = True,

--- a/src/server-core/BUILD.bazel
+++ b/src/server-core/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_server_core",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_server_core_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_server_core",
 	aliases = aliases(
 		normal = True,

--- a/src/service/BUILD.bazel
+++ b/src/service/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_service",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -44,6 +45,7 @@ rust_library(
 
 rust_test(
 	name = "mz_service_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_service",
 	aliases = aliases(
 		normal = True,

--- a/src/sql-lexer/BUILD.bazel
+++ b/src/sql-lexer/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_sql_lexer",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -37,6 +38,7 @@ rust_library(
 
 rust_test(
 	name = "mz_sql_lexer_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_sql_lexer",
 	aliases = aliases(
 		normal = True,
@@ -89,6 +91,7 @@ cargo_build_script(
 
 rust_test(
 	name = "mz_sql_lexer_lexer_tests",
+	version = "0.0.0",
 	srcs = ["tests/lexer.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/sql-parser/BUILD.bazel
+++ b/src/sql-parser/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_sql_parser",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"datadriven",
@@ -43,6 +44,7 @@ rust_library(
 
 rust_test(
 	name = "mz_sql_parser_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_sql_parser",
 	aliases = aliases(
 		normal = True,
@@ -107,6 +109,7 @@ cargo_build_script(
 
 rust_test(
 	name = "mz_sql_parser_sqlparser_common_tests",
+	version = "0.0.0",
 	srcs = ["tests/sqlparser_common.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/sql-pretty/BUILD.bazel
+++ b/src/sql-pretty/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_sql_pretty",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_sql_pretty_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_sql_pretty",
 	aliases = aliases(
 		normal = True,
@@ -73,6 +75,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_sql_pretty_parser_tests",
+	version = "0.0.0",
 	srcs = ["tests/parser.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/sql/BUILD.bazel
+++ b/src/sql/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_sql",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -64,6 +65,7 @@ rust_library(
 
 rust_test(
 	name = "mz_sql_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_sql",
 	aliases = aliases(
 		normal = True,

--- a/src/sqllogictest/BUILD.bazel
+++ b/src/sqllogictest/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_sqllogictest",
+	version = "0.0.1",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -54,6 +55,7 @@ rust_library(
 
 rust_test(
 	name = "mz_sqllogictest_lib_tests",
+	version = "0.0.1",
 	crate = ":mz_sqllogictest",
 	aliases = aliases(
 		normal = True,
@@ -130,6 +132,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_sqllogictest_parser_tests",
+	version = "0.0.1",
 	srcs = ["tests/parser.rs"],
 	aliases = aliases(
 		normal = True,
@@ -177,6 +180,7 @@ rust_test(
 
 rust_binary(
 	name = "sqllogictest",
+	version = "0.0.1",
 	crate_root = "src/bin/sqllogictest.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/ssh-util/BUILD.bazel
+++ b/src/ssh-util/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_ssh_util",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_ssh_util_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_ssh_util",
 	aliases = aliases(
 		normal = True,

--- a/src/storage-client/BUILD.bazel
+++ b/src/storage-client/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_storage_client",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -50,6 +51,7 @@ rust_library(
 
 rust_test(
 	name = "mz_storage_client_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_storage_client",
 	aliases = aliases(
 		normal = True,

--- a/src/storage-controller/BUILD.bazel
+++ b/src/storage-controller/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_storage_controller",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -48,6 +49,7 @@ rust_library(
 
 rust_test(
 	name = "mz_storage_controller_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_storage_controller",
 	aliases = aliases(
 		normal = True,

--- a/src/storage-operators/BUILD.bazel
+++ b/src/storage-operators/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_storage_operators",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -46,6 +47,7 @@ rust_library(
 
 rust_test(
 	name = "mz_storage_operators_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_storage_operators",
 	aliases = aliases(
 		normal = True,

--- a/src/storage-types/BUILD.bazel
+++ b/src/storage-types/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_storage_types",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -58,6 +59,7 @@ rust_library(
 
 rust_test(
 	name = "mz_storage_types_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_storage_types",
 	aliases = aliases(
 		normal = True,

--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_storage",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -63,6 +64,7 @@ rust_library(
 
 rust_test(
 	name = "mz_storage_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_storage",
 	aliases = aliases(
 		normal = True,

--- a/src/testdrive/BUILD.bazel
+++ b/src/testdrive/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_testdrive",
+	version = "0.114.0-dev",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -55,6 +56,7 @@ rust_library(
 
 rust_test(
 	name = "mz_testdrive_lib_tests",
+	version = "0.114.0-dev",
 	crate = ":mz_testdrive",
 	aliases = aliases(
 		normal = True,
@@ -167,6 +169,7 @@ cargo_build_script(
 
 rust_binary(
 	name = "testdrive",
+	version = "0.114.0-dev",
 	crate_root = "src/bin/testdrive.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/timely-util/BUILD.bazel
+++ b/src/timely-util/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_timely_util",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_timely_util_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_timely_util",
 	aliases = aliases(
 		normal = True,

--- a/src/timestamp-oracle/BUILD.bazel
+++ b/src/timestamp-oracle/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_timestamp_oracle",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -39,6 +40,7 @@ rust_library(
 
 rust_test(
 	name = "mz_timestamp_oracle_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_timestamp_oracle",
 	aliases = aliases(
 		normal = True,

--- a/src/tls-util/BUILD.bazel
+++ b/src/tls-util/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_tls_util",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_tls_util_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_tls_util",
 	aliases = aliases(
 		normal = True,

--- a/src/tracing/BUILD.bazel
+++ b/src/tracing/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_tracing",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_tracing_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_tracing",
 	aliases = aliases(
 		normal = True,

--- a/src/transform/BUILD.bazel
+++ b/src/transform/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_transform",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -38,6 +39,7 @@ rust_library(
 
 rust_test(
 	name = "mz_transform_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_transform",
 	aliases = aliases(
 		normal = True,
@@ -88,6 +90,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_transform_test_runner_tests",
+	version = "0.0.0",
 	srcs = ["tests/test_runner.rs"],
 	aliases = aliases(
 		normal = True,
@@ -122,6 +125,7 @@ rust_test(
 
 rust_test(
 	name = "mz_transform_test_transforms_tests",
+	version = "0.0.0",
 	srcs = ["tests/test_transforms.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/txn-wal/BUILD.bazel
+++ b/src/txn-wal/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_txn_wal",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -41,6 +42,7 @@ rust_library(
 
 rust_test(
 	name = "mz_txn_wal_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_txn_wal",
 	aliases = aliases(
 		normal = True,

--- a/src/walkabout/BUILD.bazel
+++ b/src/walkabout/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_walkabout",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -33,6 +34,7 @@ rust_library(
 
 rust_test(
 	name = "mz_walkabout_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_walkabout",
 	aliases = aliases(
 		normal = True,
@@ -67,6 +69,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_walkabout_walkabout_tests",
+	version = "0.0.0",
 	srcs = ["tests/walkabout.rs"],
 	aliases = aliases(
 		normal = True,

--- a/src/workspace-hack/BUILD.bazel
+++ b/src/workspace-hack/BUILD.bazel
@@ -18,6 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "workspace_hack",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -34,6 +35,7 @@ rust_library(
 
 rust_test(
 	name = "workspace_hack_lib_tests",
+	version = "0.0.0",
 	crate = ":workspace_hack",
 	aliases = aliases(
 		normal = True,

--- a/test/metabase/smoketest/BUILD.bazel
+++ b/test/metabase/smoketest/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_metabase_smoketest",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_metabase_smoketest_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_metabase_smoketest",
 	aliases = aliases(
 		normal = True,
@@ -76,6 +78,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "metabase_smoketest",
+	version = "0.0.0",
 	crate_root = "src/bin/metabase-smoketest.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/test/test-util/BUILD.bazel
+++ b/test/test-util/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test")
 
 rust_library(
 	name = "mz_test_util",
+	version = "0.0.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -36,6 +37,7 @@ rust_library(
 
 rust_test(
 	name = "mz_test_util_lib_tests",
+	version = "0.0.0",
 	crate = ":mz_test_util",
 	aliases = aliases(
 		normal = True,


### PR DESCRIPTION
This PR sets the `version` field in our generated `rust_library`, `rust_binary`, and `rust_test` Bazel targets which previously was just using the default of "0.0.0".

### Motivation

Fixes the `mz_version` number reported by versions of Materialize built with Bazel.

### Tips for reviewer

This PR is split into two commits:

1. Changes to `cargo-gazelle` to set the `version` field.
2. Changes to `BUILD.bazel` files after running `bin/bazel gen`

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
