### PR TITLE
Fix join fusion when there are only constant singleton inputs

### DIFF
--- a/src/transform/tests/testdata/join-implementation
+++ b/src/transform/tests/testdata/join-implementation
@@ -34,22 +34,22 @@ opt
 (join [(get x)] [[#0 #1 #2]])
 ----
 Project (#0..=#2)
-  Filter ((#5 AND #7 AND (#6 OR (#3 AND #4))) OR ((#0) IS NULL AND ((#3 AND (#4 OR (#5 AND #6))) OR (#4 AND #6 AND #7))))
-    Map ((#1) IS NULL, (#2) IS NULL, (#0 = #2), (#1 = #2), (#0 = #1))
+  Filter ((#4 AND #5) OR ((#0) IS NULL AND ((#3 AND #5) OR ((#1) IS NULL AND (#3 OR #4)))))
+    Map ((#2) IS NULL, (#0 = #2), (#0 = #1))
       Get x
 
 opt
 (join [(get x)] [[#0 #2 #1 #2]])
 ----
 Project (#0..=#2)
-  Filter ((#5 AND #7 AND (#6 OR (#3 AND #4))) OR ((#0) IS NULL AND ((#3 AND (#4 OR (#5 AND #6))) OR (#4 AND #6 AND #7))))
-    Map ((#1) IS NULL, (#2) IS NULL, (#0 = #2), (#1 = #2), (#0 = #1))
+  Filter ((#4 AND #5) OR ((#0) IS NULL AND ((#3 AND #5) OR ((#1) IS NULL AND (#3 OR #4)))))
+    Map ((#2) IS NULL, (#0 = #2), (#0 = #1))
       Get x
 
 opt
 (join [(get x)] [[#0 #1 5]])
 ----
-Filter (#0 = 5) AND (#1 = 5)
+Filter (#0 = 5) AND (#0 = #1)
   Get x
 
 opt

--- a/test/sqllogictest/github-28174-29110.slt
+++ b/test/sqllogictest/github-28174-29110.slt
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Regression test for #28174.
+# Regression test for #28174 and #29110.
 
 # The setup is based on https://github.com/MaterializeInc/RQG/blob/main/conf/mz/simple.sql
 
@@ -127,6 +127,7 @@ CREATE MATERIALIZED VIEW pk2 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t2 WHERE f1
 statement ok
 CREATE MATERIALIZED VIEW pk3 AS SELECT DISTINCT ON (f1) f1 , f2 FROM t3 WHERE f1 IS NOT NULL AND f2 IS NOT NULL;
 
+# #28174
 query RRRIR
 SELECT (a1.f1) AS c1, (a2.f1) AS c2, (a1.f2) AS c3, (count(a1.f2)) AS agg1, (max(a1.f1 + a1.f1)) AS agg2
 FROM
@@ -277,4 +278,22 @@ NULL
 4.571
 NULL
 0
+NULL
+
+# #29110
+query RR
+SELECT
+    a1.f1 AS c3,
+    a1.f2
+FROM
+    (SELECT 1 AS f1, 2 AS f2) AS a1
+RIGHT JOIN (
+    SELECT avg(a2.f2) AS f1, min(a1.f2) AS f2
+    FROM pk2 AS a1
+    LEFT JOIN pk2 AS a2 USING(f1)
+    WHERE a2.f1 IS NULL
+) AS a2
+ON (NULLIF (a1.f2, a2.f2) = a1.f1 + a2.f2);
+----
+NULL
 NULL


### PR DESCRIPTION
This fixes the correctness issue https://github.com/MaterializeInc/materialize/issues/29110

Additionally to fixing the `inputs.len() == 0` case, it also improves the `inputs.len() == 1` case. This one didn't have a bug, but we can do more there.

Note that if equivalences is empty, then the added `.filter` call won't actually add a `Filter`, so there can't be any optimizer regression due to an extra `Filter` appearing.

I've put the test into an existing slt, where the setup is the same as for this one.

See an example showing how this actually looks in a real plan [here](https://github.com/MaterializeInc/materialize/issues/29110#issuecomment-2296818981).

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/29110

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
