### PR TITLE
frontegg-mock: additional api token endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4385,6 +4385,7 @@ dependencies = [
  "axum",
  "bytes",
  "bytesize",
+ "chrono",
  "clap",
  "domain",
  "futures",

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1.68"
 axum = "0.7.5"
 bytes = "1.3.0"
 bytesize = "1.1.0"
+chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
 domain = { version = "0.9.3", default-features = false, features = ["resolv"] }
 futures = "0.3.25"

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -15,6 +15,7 @@ use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::Utc;
 use futures::StreamExt;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use mz_balancerd::{BalancerConfig, BalancerService, FronteggResolver, Resolver, BUILD_INFO};
@@ -54,6 +55,8 @@ async fn test_balancer() {
     let initial_api_tokens = vec![ApiToken {
         client_id: client_id.clone(),
         secret: secret.clone(),
+        description: None,
+        created_at: Utc::now(),
     }];
     let roles = Vec::new();
     let users = BTreeMap::from([(

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use chrono::Utc;
 use headers::Authorization;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
@@ -436,6 +437,8 @@ async fn test_auth_expiry() {
     let initial_api_tokens = vec![ApiToken {
         client_id: client_id.clone(),
         secret: secret.clone(),
+        description: None,
+        created_at: Utc::now(),
     }];
     let roles = Vec::new();
     let users = BTreeMap::from([(
@@ -557,6 +560,8 @@ async fn test_auth_base_require_tls_frontegg() {
     let initial_api_tokens = vec![ApiToken {
         client_id: client_id.clone(),
         secret: secret.clone(),
+        description: None,
+        created_at: Utc::now(),
     }];
     let system_password = Uuid::new_v4().to_string();
     let system_client_id = Uuid::new_v4();
@@ -564,6 +569,8 @@ async fn test_auth_base_require_tls_frontegg() {
     let system_initial_api_tokens = vec![ApiToken {
         client_id: system_client_id.clone(),
         secret: system_secret.clone(),
+        description: None,
+        created_at: Utc::now(),
     }];
     let service_user_client_id = Uuid::new_v4();
     let service_user_secret = Uuid::new_v4();
@@ -604,6 +611,8 @@ async fn test_auth_base_require_tls_frontegg() {
             ApiToken {
                 client_id: service_user_client_id.clone(),
                 secret: service_user_secret.clone(),
+                description: None,
+                created_at: Utc::now(),
             },
             TenantApiTokenConfig {
                 tenant_id,
@@ -611,12 +620,17 @@ async fn test_auth_base_require_tls_frontegg() {
                 metadata: Some(ClaimMetadata {
                     user: Some("svc".into()),
                 }),
+                description: None,
+                created_at: Utc::now(),
+                created_by_user_id: client_id,
             },
         ),
         (
             ApiToken {
                 client_id: service_system_user_client_id.clone(),
                 secret: service_system_user_secret.clone(),
+                description: None,
+                created_at: Utc::now(),
             },
             TenantApiTokenConfig {
                 tenant_id,
@@ -624,6 +638,9 @@ async fn test_auth_base_require_tls_frontegg() {
                 metadata: Some(ClaimMetadata {
                     user: Some("mz_system".into()),
                 }),
+                description: None,
+                created_at: Utc::now(),
+                created_by_user_id: client_id,
             },
         ),
     ]);
@@ -1556,6 +1573,7 @@ async fn test_auth_admin_non_superuser() {
 
     let frontegg_user = "user@_.com";
     let admin_frontegg_user = "admin@_.com";
+    let created_at = Utc::now();
 
     let admin_role = "mzadmin";
 
@@ -1567,7 +1585,12 @@ async fn test_auth_admin_non_superuser() {
                 email: frontegg_user.to_string(),
                 password,
                 tenant_id,
-                initial_api_tokens: vec![ApiToken { client_id, secret }],
+                initial_api_tokens: vec![ApiToken {
+                    client_id,
+                    secret,
+                    description: None,
+                    created_at,
+                }],
                 roles: Vec::new(),
                 auth_provider: None,
                 verified: None,
@@ -1584,6 +1607,8 @@ async fn test_auth_admin_non_superuser() {
                 initial_api_tokens: vec![ApiToken {
                     client_id: admin_client_id,
                     secret: admin_secret,
+                    description: None,
+                    created_at: Utc::now(),
                 }],
                 roles: vec![admin_role.to_string()],
                 auth_provider: None,
@@ -1693,6 +1718,7 @@ async fn test_auth_admin_superuser() {
 
     let frontegg_user = "user@_.com";
     let admin_frontegg_user = "admin@_.com";
+    let created_at = Utc::now();
 
     let admin_role = "mzadmin";
 
@@ -1704,7 +1730,12 @@ async fn test_auth_admin_superuser() {
                 email: frontegg_user.to_string(),
                 password,
                 tenant_id,
-                initial_api_tokens: vec![ApiToken { client_id, secret }],
+                initial_api_tokens: vec![ApiToken {
+                    client_id,
+                    secret,
+                    description: None,
+                    created_at,
+                }],
                 roles: Vec::new(),
                 auth_provider: None,
                 verified: None,
@@ -1721,6 +1752,8 @@ async fn test_auth_admin_superuser() {
                 initial_api_tokens: vec![ApiToken {
                     client_id: admin_client_id,
                     secret: admin_secret,
+                    description: None,
+                    created_at: Utc::now(),
                 }],
                 roles: vec![admin_role.to_string()],
                 auth_provider: None,
@@ -1830,6 +1863,7 @@ async fn test_auth_admin_superuser_revoked() {
 
     let frontegg_user = "user@_.com";
     let admin_frontegg_user = "admin@_.com";
+    let created_at = Utc::now();
 
     let admin_role = "mzadmin";
 
@@ -1841,7 +1875,12 @@ async fn test_auth_admin_superuser_revoked() {
                 email: frontegg_user.to_string(),
                 password,
                 tenant_id,
-                initial_api_tokens: vec![ApiToken { client_id, secret }],
+                initial_api_tokens: vec![ApiToken {
+                    client_id,
+                    secret,
+                    description: None,
+                    created_at,
+                }],
                 roles: Vec::new(),
                 auth_provider: None,
                 verified: None,
@@ -1858,6 +1897,8 @@ async fn test_auth_admin_superuser_revoked() {
                 initial_api_tokens: vec![ApiToken {
                     client_id: admin_client_id,
                     secret: admin_secret,
+                    description: None,
+                    created_at: Utc::now(),
                 }],
                 roles: vec![admin_role.to_string()],
                 auth_provider: None,
@@ -1976,6 +2017,7 @@ async fn test_auth_deduplication() {
     let password = Uuid::new_v4().to_string();
     let client_id = Uuid::new_v4();
     let secret = Uuid::new_v4();
+    let created_at = Utc::now();
 
     let frontegg_user = "user@_.com";
 
@@ -1986,7 +2028,12 @@ async fn test_auth_deduplication() {
             email: frontegg_user.to_string(),
             password,
             tenant_id,
-            initial_api_tokens: vec![ApiToken { client_id, secret }],
+            initial_api_tokens: vec![ApiToken {
+                client_id,
+                secret,
+                description: None,
+                created_at,
+            }],
             roles: Vec::new(),
             auth_provider: None,
             verified: None,
@@ -2142,6 +2189,7 @@ async fn test_refresh_task_metrics() {
     let password = Uuid::new_v4().to_string();
     let client_id = Uuid::new_v4();
     let secret = Uuid::new_v4();
+    let created_at = Utc::now();
 
     let frontegg_user = "user@_.com";
 
@@ -2152,7 +2200,12 @@ async fn test_refresh_task_metrics() {
             email: frontegg_user.to_string(),
             password,
             tenant_id,
-            initial_api_tokens: vec![ApiToken { client_id, secret }],
+            initial_api_tokens: vec![ApiToken {
+                client_id,
+                secret,
+                description: None,
+                created_at,
+            }],
             roles: Vec::new(),
             auth_provider: None,
             verified: None,
@@ -2275,6 +2328,7 @@ async fn test_superuser_can_alter_cluster() {
     let admin_password = Uuid::new_v4().to_string();
     let admin_client_id = Uuid::new_v4();
     let admin_secret = Uuid::new_v4();
+    let created_at = Utc::now();
 
     let frontegg_user = "user@_.com";
     let admin_frontegg_user = "admin@_.com";
@@ -2289,7 +2343,12 @@ async fn test_superuser_can_alter_cluster() {
                 email: frontegg_user.to_string(),
                 password,
                 tenant_id,
-                initial_api_tokens: vec![ApiToken { client_id, secret }],
+                initial_api_tokens: vec![ApiToken {
+                    client_id,
+                    secret,
+                    description: None,
+                    created_at,
+                }],
                 roles: Vec::new(),
                 auth_provider: None,
                 verified: None,
@@ -2306,6 +2365,8 @@ async fn test_superuser_can_alter_cluster() {
                 initial_api_tokens: vec![ApiToken {
                     client_id: admin_client_id,
                     secret: admin_secret,
+                    description: None,
+                    created_at: Utc::now(),
                 }],
                 roles: vec![admin_role.to_string()],
                 auth_provider: None,
@@ -2415,6 +2476,7 @@ async fn test_refresh_dropped_session() {
     let password = Uuid::new_v4().to_string();
     let client_id = Uuid::new_v4();
     let secret = Uuid::new_v4();
+    let created_at = Utc::now();
 
     let frontegg_user = "user@_.com";
 
@@ -2425,7 +2487,12 @@ async fn test_refresh_dropped_session() {
             email: frontegg_user.to_string(),
             password,
             tenant_id,
-            initial_api_tokens: vec![ApiToken { client_id, secret }],
+            initial_api_tokens: vec![ApiToken {
+                client_id,
+                secret,
+                description: None,
+                created_at,
+            }],
             roles: Vec::new(),
             auth_provider: None,
             verified: None,
@@ -2579,13 +2646,19 @@ async fn test_refresh_dropped_session_lru() {
         let password = Uuid::new_v4().to_string();
         let client_id = Uuid::new_v4();
         let secret = Uuid::new_v4();
+        let created_at = Utc::now();
 
         let user = UserConfig {
             id: Uuid::new_v4(),
             email: email.to_string(),
             password,
             tenant_id,
-            initial_api_tokens: vec![ApiToken { client_id, secret }],
+            initial_api_tokens: vec![ApiToken {
+                client_id,
+                secret,
+                description: None,
+                created_at,
+            }],
             roles: Vec::new(),
             auth_provider: None,
             verified: None,
@@ -2771,6 +2844,7 @@ async fn test_transient_auth_failures() {
     let password = Uuid::new_v4().to_string();
     let client_id = Uuid::new_v4();
     let secret = Uuid::new_v4();
+    let created_at = Utc::now();
 
     let frontegg_user = "user@_.com";
 
@@ -2781,7 +2855,12 @@ async fn test_transient_auth_failures() {
             email: frontegg_user.to_string(),
             password,
             tenant_id,
-            initial_api_tokens: vec![ApiToken { client_id, secret }],
+            initial_api_tokens: vec![ApiToken {
+                client_id,
+                secret,
+                description: None,
+                created_at,
+            }],
             roles: Vec::new(),
             auth_provider: None,
             verified: None,
@@ -2889,6 +2968,7 @@ async fn test_transient_auth_failure_on_refresh() {
     let password = Uuid::new_v4().to_string();
     let client_id = Uuid::new_v4();
     let secret = Uuid::new_v4();
+    let created_at = Utc::now();
 
     let frontegg_user = "user@_.com";
 
@@ -2899,7 +2979,12 @@ async fn test_transient_auth_failure_on_refresh() {
             email: frontegg_user.to_string(),
             password,
             tenant_id,
-            initial_api_tokens: vec![ApiToken { client_id, secret }],
+            initial_api_tokens: vec![ApiToken {
+                client_id,
+                secret,
+                description: None,
+                created_at,
+            }],
             roles: Vec::new(),
             auth_provider: None,
             verified: None,

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -4350,6 +4350,8 @@ async fn test_cert_reloading() {
     let initial_api_tokens = vec![ApiToken {
         client_id: client_id.clone(),
         secret: secret.clone(),
+        description: None,
+        created_at: Utc::now(),
     }];
     let roles = Vec::new();
     let users = BTreeMap::from([(

--- a/src/frontegg-mock/src/lib.rs
+++ b/src/frontegg-mock/src/lib.rs
@@ -640,7 +640,7 @@ async fn handle_list_tenant_api_tokens(
         .iter()
         .map(|(api_token, config)| TenantApiTokenResponse {
             client_id: api_token.client_id,
-            description: config.description.clone(),
+            description: api_token.description.clone().unwrap(),
             secret: api_token.secret,
             created_by_user_id: config.created_by_user_id,
             metadata: config.metadata.clone(),
@@ -674,7 +674,7 @@ async fn handle_create_tenant_api_token(
         tenant_id: claims.tenant_id,
         metadata: request.metadata.clone(),
         roles: request.role_ids.clone(),
-        description: request.description.clone(),
+        description: Some(request.description.clone()),
         created_by_user_id: claims.sub,
         created_at: new_token.created_at,
     };
@@ -1650,7 +1650,7 @@ pub struct TenantApiTokenConfig {
     pub tenant_id: Uuid,
     pub metadata: Option<ClaimMetadata>,
     pub roles: Vec<String>,
-    pub description: String,
+    pub description: Option<String>,
     pub created_by_user_id: Uuid,
     pub created_at: DateTime<Utc>,
 }

--- a/src/frontegg-mock/src/lib.rs
+++ b/src/frontegg-mock/src/lib.rs
@@ -48,6 +48,9 @@ const GROUP_PATH_WITH_SLASH: &str = "/frontegg/identity/resources/groups/v1/:id/
 const MEMBERS_PATH: &str = "/frontegg/team/resources/members/v1";
 const USERS_ME_PATH: &str = "/identity/resources/users/v2/me";
 const USERS_API_TOKENS_PATH: &str = "/identity/resources/users/api-tokens/v1";
+const USER_API_TOKENS_PATH: &str = "/identity/resources/users/api-tokens/v1/:id";
+const TENANT_API_TOKENS_PATH: &str = "/identity/resources/tenants/api-tokens/v1";
+const TENANT_API_TOKEN_PATH: &str = "/identity/resources/tenants/api-tokens/v1/:id";
 const USER_PATH: &str = "/identity/resources/users/v1/:id";
 const USER_CREATE_PATH: &str = "/identity/resources/users/v2";
 const USERS_V3_PATH: &str = "/identity/resources/users/v3";
@@ -162,7 +165,19 @@ impl FronteggMockServer {
             .route(AUTH_USER_PATH, post(handle_post_auth_user))
             .route(AUTH_API_TOKEN_REFRESH_PATH, post(handle_post_token_refresh))
             .route(USERS_ME_PATH, get(handle_get_user_profile))
-            .route(USERS_API_TOKENS_PATH, post(handle_post_user_api_token))
+            .route(
+                USERS_API_TOKENS_PATH,
+                get(handle_list_user_api_tokens).post(handle_post_user_api_token),
+            )
+            .route(USER_API_TOKENS_PATH, delete(handle_delete_user_api_token))
+            .route(
+                TENANT_API_TOKENS_PATH,
+                get(handle_list_tenant_api_tokens).post(handle_create_tenant_api_token),
+            )
+            .route(
+                TENANT_API_TOKEN_PATH,
+                delete(handle_delete_tenant_api_token),
+            )
             .route(USER_PATH, get(handle_get_user).delete(handle_delete_user))
             .route(USER_CREATE_PATH, post(handle_create_user))
             .route(USERS_V3_PATH, get(handle_get_users_v3))
@@ -527,7 +542,7 @@ async fn handle_get_user_profile<'a>(
 async fn handle_post_user_api_token<'a>(
     State(context): State<Arc<Context>>,
     TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
-) -> Result<Json<ApiToken>, StatusCode> {
+) -> Result<(StatusCode, Json<ApiToken>), StatusCode> {
     let claims: Claims = match decode_access_token(&context, authorization.token()) {
         Ok(TokenData { claims, .. }) => claims,
         Err(_) => return Err(StatusCode::UNAUTHORIZED),
@@ -538,7 +553,161 @@ async fn handle_post_user_api_token<'a>(
         secret: Uuid::new_v4(),
     };
     tokens.insert(new_token.clone(), claims.email.unwrap());
-    Ok(Json(new_token))
+    Ok((StatusCode::CREATED, Json(new_token)))
+}
+
+// https://docs.frontegg.com/reference/userapitokensv1controller_getapitokens
+async fn handle_list_user_api_tokens(
+    State(context): State<Arc<Context>>,
+    TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
+) -> Result<Json<Vec<UserApiTokenResponse>>, StatusCode> {
+    let claims = match decode_access_token(&context, authorization.token()) {
+        Ok(TokenData { claims, .. }) => claims,
+        Err(_) => return Err(StatusCode::UNAUTHORIZED),
+    };
+
+    let user_api_tokens = context.user_api_tokens.lock().unwrap();
+    let tokens: Vec<UserApiTokenResponse> = user_api_tokens
+        .iter()
+        .filter(|(_, email)| *email == claims.email.as_ref().unwrap())
+        .map(|(token, _)| UserApiTokenResponse {
+            client_id: token.client_id.to_string(),
+            description: "User API Token".to_string(),
+            created_at: Utc::now(),
+            secret: token.secret.to_string(),
+        })
+        .collect();
+
+    Ok(Json(tokens))
+}
+
+// https://docs.frontegg.com/reference/userapitokensv1controller_deleteapitoken
+async fn handle_delete_user_api_token(
+    State(context): State<Arc<Context>>,
+    TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
+    Path(token_id): Path<Uuid>,
+) -> StatusCode {
+    let claims = match decode_access_token(&context, authorization.token()) {
+        Ok(TokenData { claims, .. }) => claims,
+        Err(_) => return StatusCode::UNAUTHORIZED,
+    };
+
+    let mut user_api_tokens = context.user_api_tokens.lock().unwrap();
+
+    let removed = user_api_tokens
+        .iter()
+        .find(|(token, email)| {
+            token.client_id == token_id && *email == claims.email.as_ref().unwrap()
+        })
+        .map(|(token, _)| token.clone());
+
+    if let Some(token_to_remove) = removed {
+        user_api_tokens.remove(&token_to_remove);
+        StatusCode::OK
+    } else {
+        StatusCode::NOT_FOUND
+    }
+}
+
+// https://docs.frontegg.com/reference/tenantapitokensv1controller_gettenantsapitokens
+async fn handle_list_tenant_api_tokens(
+    State(context): State<Arc<Context>>,
+    TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
+) -> Result<Json<Vec<TenantApiTokenResponse>>, StatusCode> {
+    let _claims = match decode_access_token(&context, authorization.token()) {
+        Ok(TokenData { claims, .. }) => claims,
+        Err(_) => return Err(StatusCode::UNAUTHORIZED),
+    };
+
+    let tenant_api_tokens = context.tenant_api_tokens.lock().unwrap();
+    let tokens: Vec<TenantApiTokenResponse> = tenant_api_tokens
+        .iter()
+        .map(|(api_token, config)| TenantApiTokenResponse {
+            client_id: api_token.client_id,
+            description: "".to_string(),
+            secret: api_token.secret,
+            created_by_user_id: Uuid::nil(),
+            metadata: config
+                .metadata
+                .as_ref()
+                .and_then(|m| m.user.clone().map(serde_json::Value::String)),
+            created_at: Utc::now(),
+            role_ids: config.roles.clone(),
+        })
+        .collect();
+
+    Ok(Json(tokens))
+}
+
+// https://docs.frontegg.com/reference/tenantapitokensv1controller_createtenantapitoken
+async fn handle_create_tenant_api_token(
+    State(context): State<Arc<Context>>,
+    TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
+    Json(request): Json<CreateTenantApiTokenRequest>,
+) -> Result<(StatusCode, Json<TenantApiTokenResponse>), StatusCode> {
+    let claims = match decode_access_token(&context, authorization.token()) {
+        Ok(TokenData { claims, .. }) => claims,
+        Err(_) => return Err(StatusCode::UNAUTHORIZED),
+    };
+
+    let new_token = ApiToken {
+        client_id: Uuid::new_v4(),
+        secret: Uuid::new_v4(),
+    };
+
+    let config = TenantApiTokenConfig {
+        tenant_id: claims.tenant_id,
+        metadata: request.metadata.as_ref().and_then(|m| {
+            if let serde_json::Value::String(s) = m {
+                Some(ClaimMetadata {
+                    user: Some(s.clone()),
+                })
+            } else {
+                None
+            }
+        }),
+        roles: request.role_ids.clone(),
+    };
+
+    let mut tenant_api_tokens = context.tenant_api_tokens.lock().unwrap();
+    tenant_api_tokens.insert(new_token.clone(), config);
+
+    let response = TenantApiTokenResponse {
+        client_id: new_token.client_id,
+        description: request.description,
+        secret: new_token.secret,
+        created_by_user_id: claims.sub,
+        metadata: request.metadata,
+        created_at: Utc::now(),
+        role_ids: request.role_ids,
+    };
+
+    Ok((StatusCode::CREATED, Json(response)))
+}
+
+// https://docs.frontegg.com/reference/tenantapitokensv1controller_deletetenantapitoken
+async fn handle_delete_tenant_api_token(
+    State(context): State<Arc<Context>>,
+    TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
+    Path(token_id): Path<Uuid>,
+) -> StatusCode {
+    let _claims = match decode_access_token(&context, authorization.token()) {
+        Ok(TokenData { claims, .. }) => claims,
+        Err(_) => return StatusCode::UNAUTHORIZED,
+    };
+
+    let mut tenant_api_tokens = context.tenant_api_tokens.lock().unwrap();
+    if tenant_api_tokens
+        .remove(&ApiToken {
+            client_id: token_id,
+            secret: Uuid::nil(),
+        })
+        .is_some()
+    {
+        StatusCode::OK
+    } else {
+        StatusCode::NOT_FOUND
+    }
 }
 
 // https://docs.frontegg.com/reference/userscontrollerv2_getuserbyid
@@ -1425,6 +1594,45 @@ pub struct ApiToken {
     #[serde(alias = "client_id")]
     pub client_id: Uuid,
     pub secret: Uuid,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct UserApiTokenResponse {
+    #[serde(rename = "clientId")]
+    pub client_id: String,
+    pub description: String,
+    #[serde(rename = "created_at")]
+    pub created_at: DateTime<Utc>,
+    pub secret: String,
+}
+
+#[derive(Deserialize)]
+pub struct UserApiTokenRequest {
+    pub description: String,
+}
+
+
+#[derive(Serialize, Deserialize)]
+struct CreateTenantApiTokenRequest {
+    description: String,
+    metadata: Option<serde_json::Value>,
+    #[serde(rename = "roleIds")]
+    role_ids: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct TenantApiTokenResponse {
+    #[serde(rename = "clientId")]
+    client_id: Uuid,
+    description: String,
+    secret: Uuid,
+    #[serde(rename = "createdByUserId")]
+    created_by_user_id: Uuid,
+    metadata: Option<serde_json::Value>,
+    #[serde(rename = "createdAt")]
+    created_at: DateTime<Utc>,
+    #[serde(rename = "roleIds")]
+    role_ids: Vec<String>,
 }
 
 pub struct TenantApiTokenConfig {

--- a/src/frontegg-mock/src/lib.rs
+++ b/src/frontegg-mock/src/lib.rs
@@ -557,7 +557,7 @@ async fn handle_post_user_api_token<'a>(
     let new_token = ApiToken {
         client_id: Uuid::new_v4(),
         secret: Uuid::new_v4(),
-        description: Some(request.description.clone()),
+        description: request.description.clone(),
         created_at: Utc::now(),
     };
     tokens.insert(new_token.clone(), claims.email.unwrap());
@@ -640,7 +640,7 @@ async fn handle_list_tenant_api_tokens(
         .iter()
         .map(|(api_token, config)| TenantApiTokenResponse {
             client_id: api_token.client_id,
-            description: api_token.description.clone().unwrap(),
+            description: api_token.description.clone().unwrap_or_default(),
             secret: api_token.secret,
             created_by_user_id: config.created_by_user_id,
             metadata: config.metadata.clone(),
@@ -1634,7 +1634,7 @@ pub struct UserApiTokenResponse {
 
 #[derive(Deserialize)]
 pub struct UserApiTokenRequest {
-    pub description: String,
+    pub description: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
### Motivation

Transferring over the last batch of endpoints from the Golang Frontegg mock service as per the discussion here: https://github.com/MaterializeInc/terraform-provider-materialize/issues/461

```
 /identity/resources/users/api-tokens/v1" (GET)
 /identity/resources/users/api-tokens/v1/{id}" (DELETE)
 /identity/resources/tenants/api-tokens/v1" (GET, POST)
 /identity/resources/tenants/api-tokens/v1/{id}" (DELETE)
```