### PR TITLE
ci: Smaller Zippy in release qualification

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -55,14 +55,15 @@ steps:
     - id: zippy-dataflows-large
       label: "Large Zippy w/ complex dataflows"
       depends_on: build-aarch64
-      # 48h
-      timeout_in_minutes: 2880
+      # 24h
+      timeout_in_minutes: 1440
       agents:
         queue: hetzner-aarch64-16cpu-32gb
       plugins:
         - ./ci/plugins/mzcompose:
             composition: zippy
-            args: [--scenario=DataflowsLarge, --actions=35000]
+            # OoM and out of disk
+            args: [--scenario=DataflowsLarge, --actions=15000]
 
     - id: zippy-pg-cdc-large
       label: "Large Zippy PostgresCdc"


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/release-qualification/builds/574#01915cd4-d7a1-433c-a7c2-b40b78911cfc

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
