### PR TITLE
ci: Decrease persist_batch_columnar_format_percent

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -99,7 +99,7 @@ def get_default_system_parameters(
         "persist_batch_columnar_format": (
             "both_v2" if version >= MzVersion.parse_mz("v0.112.0-dev") else "row"
         ),
-        "persist_batch_columnar_format_percent": "100",
+        "persist_batch_columnar_format_percent": "10",
         "persist_batch_delete_enabled": "true",
         "persist_batch_record_part_format": "true",
         "persist_fast_path_limit": "1000",


### PR DESCRIPTION
For lower disk/memory usage, especially during long-running Zippy runs that went out of disk/memory. But should also make other tests a bit zippier. See discussion in https://materializeinc.slack.com/archives/CTESPM7FU/p1724161918033919?thread_ts=1724106368.546619&cid=CTESPM7FU

Follow-up to https://github.com/MaterializeInc/materialize/pull/28914

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
