### PR TITLE
docs: make left-hand nav top-level items collapsible

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -173,15 +173,12 @@ table.inline-headings {
         padding-bottom: var(--large);
     }
 
-    &>ul>li:last-child {
-        padding-bottom: var(--milli);
-    }
-
     a {
         display: block;
         cursor: pointer;
         position: relative;
         padding: 3px 0 3px 15px;
+        margin-left: 5px;
         text-decoration: none;
         word-wrap: break-word;
         white-space: initial;
@@ -227,11 +224,11 @@ table.inline-headings {
 
     .no-children>a,
     .level-4 a {
-        border-left: 2px solid var(--divider-light);
+
 
         &:hover,
         &.active {
-            border-color: var(--highlight);
+            border-left: 2px solid  var(--highlight);
         }
     }
 
@@ -251,34 +248,35 @@ table.inline-headings {
     }
 
     li.level-1 {
-        &>div {
-            margin: 0 0 4px -2px;
-            padding: 4px 0;
-            color: var(--highlight);
+        &>a {
             font-weight: 500;
+            color: var(--highlight);
         }
 
         &>ul {
             margin-bottom: rem(1.5);
         }
+        padding: 4px 0;
+        border-bottom: 1px solid var(--gray-light);
     }
 
+    li.level-1,
     li.level-2,
     li.level-3 {
         >ul {
             display: none;
             padding-top: rem(0.5);
             margin-bottom: rem(0.625);
+            padding-left: rem(0.8);
 
             &:before,
             &:after {
                 content: "";
-                background-image: url("../images/level_three_transition.svg");
                 width: 10px;
                 height: 10px;
                 position: absolute;
-                top: 0;
-                left: -8px;
+                top: 1px;
+                left: 0px;
             }
 
             &:after {
@@ -299,6 +297,10 @@ table.inline-headings {
                 display: block;
             }
         }
+    }
+
+    li.level-1.has-children.open {
+        padding-bottom: 4px;
     }
 
     li.level-2.has-children.open {

--- a/doc/user/layouts/partials/sidebar.html
+++ b/doc/user/layouts/partials/sidebar.html
@@ -7,10 +7,13 @@
         title="cmd+K (⌘+K/⊞+K)" />
       </div>
       {{ range .Site.Menus.main.ByWeight }}
-      <li class="level-1">
-        <div class="{{if $currentPage.IsMenuCurrent "main" .}}active{{end}}">
-          {{.Name | markdownify}}
-        </div>
+      <li class="level-1 {{if .HasChildren }}has-children{{ else }}no-children{{ end }}">
+          <a {{with .URL}}href="{{.}}"{{end}} class="{{if $currentPage.IsMenuCurrent "main" .}}active{{end}}">
+            {{- if .HasChildren }}
+              {{ readFile "static/images/icon_sidebar_expander.svg" | safeHTML }}
+            {{ end }}
+            {{.Name | markdownify}}
+          </a>
 
         {{- if .HasChildren }}
         <ul>

--- a/doc/user/static/images/icon_sidebar_expander.svg
+++ b/doc/user/static/images/icon_sidebar_expander.svg
@@ -4,6 +4,6 @@
         <path d="M7 4V10" class="hidden-when-open" />
         <path d="M10 7H4" />
     </g>
-    <path d="M7 -10V0" stroke-width="2"/>
-    <path d="M7 14V24" stroke-width="2"/>
+    <path d="M7 -10V0" stroke-width="0"/>
+    <path d="M7 14V24" stroke-width="0"/>
 </svg>


### PR DESCRIPTION
- As an aside: In the future, may want to swap out the svg with something else, but for now, just incremental changes. 
- Got rid of the left hand grey border because if a nav item A is right below another nav item Z that contains children, the line can sometimes makes it A look like a child of Z.  