### PR TITLE
persist: add imperfect metric tracing unindexed persist_source reads

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -538,6 +538,7 @@ impl MetricsVecs {
             snapshot: self.read_metrics("snapshot"),
             batch_fetcher: self.read_metrics("batch_fetcher"),
             compaction: self.read_metrics("compaction"),
+            unindexed: self.read_metrics("unindexed"),
         }
     }
 
@@ -677,6 +678,7 @@ pub struct BatchPartReadMetrics {
     pub(crate) snapshot: ReadMetrics,
     pub(crate) batch_fetcher: ReadMetrics,
     pub(crate) compaction: ReadMetrics,
+    pub(crate) unindexed: ReadMetrics,
 }
 
 #[derive(Debug, Clone)]

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -393,6 +393,7 @@ impl PersistClient {
         shard_id: ShardId,
         key_schema: Arc<K::Schema>,
         val_schema: Arc<V::Schema>,
+        is_transient: bool,
         diagnostics: Diagnostics,
     ) -> BatchFetcher<K, V, T, D>
     where
@@ -432,6 +433,7 @@ impl PersistClient {
             shard_metrics,
             shard_id,
             schemas,
+            is_transient,
             _phantom: PhantomData,
         };
 
@@ -1092,6 +1094,7 @@ mod tests {
                     shard_id1,
                     Default::default(),
                     Default::default(),
+                    false,
                     Diagnostics::for_tests(),
                 )
                 .await;

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1363,6 +1363,7 @@ mod tests {
                 shard_id,
                 Default::default(),
                 Default::default(),
+                false,
                 Diagnostics::for_tests(),
             )
             .await;


### PR DESCRIPTION
I've continually put off on typing this PR up because I've been letting perfect be the enemy of the good. I'd really love to totally rework the BatchPartFetchMetrics, but in the meantime, what I have here plus prominent display in the persist dash would have led us to immediately diagnose at least 3 issues that otherwise took much longer to sus out.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
