### PR TITLE
bump k8s-openapi feature to v1_29 and kind nodes to v1.29.7

### DIFF
--- a/misc/kind/cluster-node-recovery-test.yaml
+++ b/misc/kind/cluster-node-recovery-test.yaml
@@ -22,7 +22,7 @@ kubeadmConfigPatches:
         "service-node-port-range": "32000-32063"
 nodes:
   - role: control-plane
-    image: kindest/node:v1.28.9
+    image: kindest/node:v1.29.7
     extraPortMappings:
       - containerPort: 32000
         hostPort: 32000

--- a/misc/kind/cluster.yaml
+++ b/misc/kind/cluster.yaml
@@ -22,7 +22,7 @@ kubeadmConfigPatches:
         "service-node-port-range": "32000-32063"
 nodes:
   - role: control-plane
-    image: kindest/node:v1.28.9
+    image: kindest/node:v1.29.7
     extraPortMappings:
       - containerPort: 32000
         hostPort: 32000

--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.68"
-k8s-openapi = { version = "0.22.0", features = ["schemars", "v1_28"] }
+k8s-openapi = { version = "0.22.0", features = ["schemars", "v1_29"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "derive", "openssl-tls", "ws"] }
 chrono = { version = "0.4.35", default-features = false }
 futures = "0.3.25"

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -22,7 +22,7 @@ mz-orchestrator = { path = "../orchestrator" }
 mz-ore = { path = "../ore", features = ["async"]  }
 mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }
-k8s-openapi = { version = "0.22.0", features = ["v1_28"] }
+k8s-openapi = { version = "0.22.0", features = ["v1_29"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "runtime", "ws"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -28,7 +28,8 @@ use k8s_openapi::api::core::v1::{
     PersistentVolumeClaimTemplate, Pod, PodAffinity, PodAffinityTerm, PodAntiAffinity,
     PodSecurityContext, PodSpec, PodTemplateSpec, PreferredSchedulingTerm, ResourceRequirements,
     SeccompProfile, Secret, SecurityContext, Service as K8sService, ServicePort, ServiceSpec,
-    Toleration, TopologySpreadConstraint, Volume, VolumeMount, WeightedPodAffinityTerm,
+    Toleration, TopologySpreadConstraint, Volume, VolumeMount, VolumeResourceRequirements,
+    WeightedPodAffinityTerm,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement};
@@ -944,7 +945,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                                 storage_class_name: Some(
                                     ephemeral_volume_storage_class.to_string(),
                                 ),
-                                resources: Some(ResourceRequirements {
+                                resources: Some(VolumeResourceRequirements {
                                     requests: Some(BTreeMap::from([(
                                         "storage".to_string(),
                                         Quantity(
@@ -982,7 +983,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 },
                 spec: Some(PersistentVolumeClaimSpec {
                     access_modes: Some(vec!["ReadWriteOnce".to_string()]),
-                    resources: Some(ResourceRequirements {
+                    resources: Some(VolumeResourceRequirements {
                         requests: Some(BTreeMap::from([(
                             "storage".to_string(),
                             Quantity("10Gi".to_string()),

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -60,7 +60,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 hyper = { version = "0.14.27", features = ["client", "http1", "http2", "stream", "tcp"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 insta = { version = "1.33.0", features = ["json"] }
-k8s-openapi = { version = "0.22.0", default-features = false, features = ["schemars", "v1_28"] }
+k8s-openapi = { version = "0.22.0", default-features = false, features = ["schemars", "v1_29"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
 kube-client = { version = "0.92.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
 kube-core = { version = "0.92.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }
@@ -187,7 +187,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 hyper = { version = "0.14.27", features = ["client", "http1", "http2", "stream", "tcp"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 insta = { version = "1.33.0", features = ["json"] }
-k8s-openapi = { version = "0.22.0", default-features = false, features = ["schemars", "v1_28"] }
+k8s-openapi = { version = "0.22.0", default-features = false, features = ["schemars", "v1_29"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "derive", "openssl-tls", "runtime", "ws"] }
 kube-client = { version = "0.92.1", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
 kube-core = { version = "0.92.1", default-features = false, features = ["jsonpatch", "schema", "ws"] }


### PR DESCRIPTION
Bumps k8s-openapi feature to v1_29 and kind nodes to v1.29.7.

### Motivation

Update to match our production clusters.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  Not a release blocker, but we will also follow up with bumping this in cloud.
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
  No user-facing behavior changes.
