### PR TITLE
cluster: use async channel to return activators

### DIFF
--- a/src/cluster/src/types.rs
+++ b/src/cluster/src/types.rs
@@ -36,7 +36,7 @@ pub trait AsRunnableWorker<C, R> {
         client_rx: crossbeam_channel::Receiver<(
             crossbeam_channel::Receiver<C>,
             tokio::sync::mpsc::UnboundedSender<R>,
-            crossbeam_channel::Sender<Self::Activatable>,
+            tokio::sync::mpsc::UnboundedSender<Self::Activatable>,
         )>,
         persist_clients: Arc<PersistClientCache>,
         txns_ctx: TxnsContext,

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -97,7 +97,7 @@ pub fn serve(
     Ok((timely_container, client_builder))
 }
 
-type ActivatorSender = crossbeam_channel::Sender<SyncActivator>;
+type ActivatorSender = mpsc::UnboundedSender<SyncActivator>;
 
 /// Endpoint used by workers to receive compute commands.
 struct CommandReceiver {

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -100,7 +100,7 @@ impl mz_cluster::types::AsRunnableWorker<StorageCommand, StorageResponse> for Co
         client_rx: crossbeam_channel::Receiver<(
             crossbeam_channel::Receiver<StorageCommand>,
             tokio::sync::mpsc::UnboundedSender<StorageResponse>,
-            crossbeam_channel::Sender<std::thread::Thread>,
+            tokio::sync::mpsc::UnboundedSender<std::thread::Thread>,
         )>,
         persist_clients: Arc<PersistClientCache>,
         txns_ctx: TxnsContext,

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -135,7 +135,7 @@ pub struct Worker<'w, A: Allocate> {
     pub client_rx: crossbeam_channel::Receiver<(
         CommandReceiver,
         ResponseSender,
-        crossbeam_channel::Sender<std::thread::Thread>,
+        mpsc::UnboundedSender<std::thread::Thread>,
     )>,
     /// The state associated with collection ingress and egress.
     pub storage_state: StorageState,
@@ -148,7 +148,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
         client_rx: crossbeam_channel::Receiver<(
             CommandReceiver,
             ResponseSender,
-            crossbeam_channel::Sender<std::thread::Thread>,
+            mpsc::UnboundedSender<std::thread::Thread>,
         )>,
         metrics: StorageMetrics,
         now: NowFn,


### PR DESCRIPTION
Previously, the channel through which cluster workers would return dataflow activators to the tokio tasks managing client connections was a sync channel. When the connection tasks called `recv` on them, that call would synchronously block, stalling the current thread and even the entire tokio runtime if it was single-threaded.

The fix is to use an async channel instead.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
