### PR TITLE
compute: min/max/avg wallclock lag

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -441,7 +441,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
     ///
     /// This method is invoked by `ComputeController::maintain`, which we expect to be called once
     /// per second during normal operation.
-    fn refresh_state_metrics(&self) {
+    fn refresh_state_metrics(&mut self) {
         let unscheduled_collections_count =
             self.collections.values().filter(|c| !c.scheduled).count();
 
@@ -467,11 +467,11 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
         self.refresh_wallclock_lag_metric();
     }
 
-    /// Refresh the `wallclock_lag_seconds` metric with the current lag values.
-    fn refresh_wallclock_lag_metric(&self) {
-        for replica in self.replicas.values() {
-            for collection in replica.collections.values() {
-                let Some(metrics) = &collection.metrics else {
+    /// Refresh the `wallclock_lag_*_seconds` metrics with the current lag values.
+    fn refresh_wallclock_lag_metric(&mut self) {
+        for replica in self.replicas.values_mut() {
+            for collection in replica.collections.values_mut() {
+                let Some(metrics) = &mut collection.metrics else {
                     continue;
                 };
 
@@ -479,7 +479,7 @@ impl<T: ComputeControllerTimestamp> Instance<T> {
                     Some(ts) => (self.wallclock_lag)(ts),
                     None => Duration::ZERO,
                 };
-                metrics.wallclock_lag_seconds.observe(lag.as_secs_f64());
+                metrics.observe_wallclock_lag(lag);
             }
         }
     }


### PR DESCRIPTION
This PR replaces the experimental `mz_dataflow_wallclock_lag_metric` with three alternative experimental metrics that expose per-minute min/max/avg aggregations of observed wallclock lag.

The assumption is that these aggregations are more useful than a low-res histogram because (a) they allow us to see precise maximum values, rather than ranges and (b) they provide insight into lag values above 30s. We lose the ability to inspect sub-minute lag distribution, but this ability didn't turn out to be particularly useful for judging cluster health.

### Motivation

  * This PR adds a known-desirable feature.

Part of #28097 

This is an attempt of validating the min/max/avg format before we consider exposing it to users.

### Tips for reviewer

I decided to have three metrics, rather than a single one with an `aggregation = {min,max,avg}` label, because I think the alternative could be a footgun for people that don't know that the metric is really three metrics rolled into one.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
