### PR TITLE
Limit compute maintenance based on elapsed time

### DIFF
--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -55,8 +55,8 @@ pub const ENABLE_CHUNKED_STACK: Config<bool> = Config::new(
 /// The interval at which the compute server performs maintenance tasks.
 pub const COMPUTE_SERVER_MAINTENANCE_INTERVAL: Config<Duration> = Config::new(
     "compute_server_maintenance_interval",
-    Duration::ZERO,
-    "The interval at which the compute server performs maintenance tasks.",
+    Duration::from_millis(10),
+    "The interval at which the compute server performs maintenance tasks. Zero enables maintenance on every iteration.",
 );
 
 /// Maximum number of in-flight bytes emitted by persist_sources feeding dataflows.

--- a/src/compute-types/src/dyncfgs.rs
+++ b/src/compute-types/src/dyncfgs.rs
@@ -52,6 +52,13 @@ pub const ENABLE_CHUNKED_STACK: Config<bool> = Config::new(
     "Enable the chunked stack implementation in compute.",
 );
 
+/// The interval at which the compute server performs maintenance tasks.
+pub const COMPUTE_SERVER_MAINTENANCE_INTERVAL: Config<Duration> = Config::new(
+    "compute_server_maintenance_interval",
+    Duration::ZERO,
+    "The interval at which the compute server performs maintenance tasks.",
+);
+
 /// Maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
 pub const DATAFLOW_MAX_INFLIGHT_BYTES: Config<Option<usize>> = Config::new(
     "compute_dataflow_max_inflight_bytes",
@@ -133,6 +140,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&ENABLE_COLUMNATION_LGALLOC)
         .add(&ENABLE_LGALLOC_EAGER_RECLAMATION)
         .add(&ENABLE_CHUNKED_STACK)
+        .add(&COMPUTE_SERVER_MAINTENANCE_INTERVAL)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES)
         .add(&DATAFLOW_MAX_INFLIGHT_BYTES_CC)
         .add(&LGALLOC_BACKGROUND_INTERVAL)

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -291,6 +291,8 @@ impl ComputeState {
         info!("using chunked stack: {chunked_stack}");
         mz_timely_util::containers::stack::use_chunked_stack(chunked_stack);
 
+        // Remember the maintenance interval locally to avoid reading it from the config set on
+        // every server iteration.
         self.server_maintenance_interval = COMPUTE_SERVER_MAINTENANCE_INTERVAL.get(config);
     }
 


### PR DESCRIPTION
Currently, the compute main loop performs maintenance whenever it loops. This can cause overhead in situations when we reasonably well know that there is no work to be done, but we still do it. This PR limits the rate at which we perform maintenance based on elapsed wall clock time. The implementation exposes a dyncfg to change the interval at runtime. Setting it to zero restores the current behavior to perform maintenance on every iteration.

In experiments, this reduces the cluster's CPU utilization to a level that I can't see much of it in perf anymore, but there's a risk I'm holding the tools wrongly.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
