### PR TITLE
Fix merge skew on main

### DIFF
--- a/src/balancerd/BUILD.bazel
+++ b/src/balancerd/BUILD.bazel
@@ -17,7 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_balancerd",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -50,7 +50,7 @@ rust_library(
 
 rust_test(
 	name = "mz_balancerd_lib_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate = ":mz_balancerd",
 	aliases = aliases(
 		normal = True,
@@ -115,7 +115,7 @@ rust_doc_test(
 
 rust_test(
 	name = "mz_balancerd_server_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = ["tests/server.rs"],
 	aliases = aliases(
 		normal = True,
@@ -157,7 +157,7 @@ rust_test(
 
 rust_binary(
 	name = "mz_balancerd_bin",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate_root = "src/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/catalog-debug/BUILD.bazel
+++ b/src/catalog-debug/BUILD.bazel
@@ -17,7 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_catalog_debug",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [],
 	aliases = aliases(
@@ -46,7 +46,7 @@ rust_library(
 
 rust_test(
 	name = "mz_catalog_debug_lib_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate = ":mz_catalog_debug",
 	aliases = aliases(
 		normal = True,
@@ -105,7 +105,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "mz_catalog_debug",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate_root = "src/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/clusterd/BUILD.bazel
+++ b/src/clusterd/BUILD.bazel
@@ -17,7 +17,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_doc_test",
 
 rust_library(
 	name = "mz_clusterd",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -59,7 +59,7 @@ rust_library(
 
 rust_test(
 	name = "mz_clusterd_lib_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate = ":mz_clusterd",
 	aliases = aliases(
 		normal = True,
@@ -136,7 +136,7 @@ rust_doc_test(
 
 rust_binary(
 	name = "clusterd",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate_root = "src/bin/clusterd.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/environmentd/BUILD.bazel
+++ b/src/environmentd/BUILD.bazel
@@ -18,7 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_environmentd",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = [
 		"default",
@@ -87,7 +87,7 @@ rust_library(
 
 rust_test(
 	name = "mz_environmentd_lib_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate = ":mz_environmentd",
 	aliases = aliases(
 		normal = True,
@@ -258,7 +258,7 @@ cargo_build_script(
 
 rust_test(
 	name = "mz_environmentd_auth_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = ["tests/auth.rs"],
 	aliases = aliases(
 		normal = True,
@@ -324,7 +324,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_cli_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = ["tests/cli.rs"],
 	aliases = aliases(
 		normal = True,
@@ -390,7 +390,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_pgwire_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = ["tests/pgwire.rs"],
 	aliases = aliases(
 		normal = True,
@@ -456,7 +456,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_server_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = ["tests/server.rs"],
 	aliases = aliases(
 		normal = True,
@@ -522,7 +522,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_sql_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = ["tests/sql.rs"],
 	aliases = aliases(
 		normal = True,
@@ -588,7 +588,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_timezones_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = ["tests/timezones.rs"],
 	aliases = aliases(
 		normal = True,
@@ -654,7 +654,7 @@ rust_test(
 
 rust_test(
 	name = "mz_environmentd_tracing_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = ["tests/tracing.rs"],
 	aliases = aliases(
 		normal = True,
@@ -720,7 +720,7 @@ rust_test(
 
 rust_binary(
 	name = "environmentd",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate_root = "src/bin/environmentd/main.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],

--- a/src/persist-client/BUILD.bazel
+++ b/src/persist-client/BUILD.bazel
@@ -18,7 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_persist_client",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -45,7 +45,7 @@ rust_library(
 
 rust_test(
 	name = "mz_persist_client_lib_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate = ":mz_persist_client",
 	aliases = aliases(
 		normal = True,

--- a/src/testdrive/BUILD.bazel
+++ b/src/testdrive/BUILD.bazel
@@ -18,7 +18,7 @@ load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 rust_library(
 	name = "mz_testdrive",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	srcs = glob(["src/**/*.rs"]),
 	crate_features = ["default"],
 	aliases = aliases(
@@ -56,7 +56,7 @@ rust_library(
 
 rust_test(
 	name = "mz_testdrive_lib_tests",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate = ":mz_testdrive",
 	aliases = aliases(
 		normal = True,
@@ -169,7 +169,7 @@ cargo_build_script(
 
 rust_binary(
 	name = "testdrive",
-	version = "0.114.0-dev",
+	version = "0.114.0-dev.0",
 	crate_root = "src/bin/testdrive.rs",
 	srcs = glob(["src/**/*.rs"]),
 	features = [],


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/29097
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
