### PR TITLE
[persist] Store run-level metadata in hollow batches, including order

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1017,6 +1017,7 @@ class FlipFlagsAction(Action):
             "100",
         ]
         self.flags_with_values["persist_batch_record_part_format"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["persist_batch_record_run_meta"] = BOOLEAN_FLAG_VALUES
         self.flags_with_values["persist_part_decode_format"] = [
             "row_with_validate",
             "arrow",

--- a/src/persist-client/build.rs
+++ b/src/persist-client/build.rs
@@ -32,6 +32,10 @@ fn main() {
             "#[derive(serde::Deserialize)]",
         )
         .type_attribute(
+            ".mz_persist_client.internal.state.ProtoRunMeta",
+            "#[derive(serde::Deserialize)]",
+        )
+        .type_attribute(
             ".mz_persist_client.internal.state.ProtoU64Description",
             "#[derive(serde::Deserialize)]",
         )

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -704,7 +704,7 @@ where
             self.blob,
             shard_metrics,
             self.version,
-            HollowBatch::new(desc, parts, self.num_updates, self.runs),
+            HollowBatch::new(desc, parts, self.num_updates, self.runs, vec![]),
         );
 
         Ok(batch)

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -331,6 +331,7 @@ pub fn all_dyncfgs(configs: ConfigSet) -> ConfigSet {
         .add(&crate::batch::INLINE_WRITES_SINGLE_MAX_BYTES)
         .add(&crate::batch::ENCODING_ENABLE_DICTIONARY)
         .add(&crate::batch::ENCODING_COMPRESSION_FORMAT)
+        .add(&crate::batch::RECORD_RUN_META)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
         .add(&crate::cfg::CONSENSUS_CONNECTION_POOL_TTL)
         .add(&crate::cfg::CRDB_CONNECT_TIMEOUT)

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -532,7 +532,7 @@ pub async fn shard_stats(blob_uri: &str) -> anyhow::Result<()> {
             if b.is_empty() {
                 empty_batches += 1;
             }
-            for run in b.runs() {
+            for (_meta, run) in b.runs() {
                 let largest_part = run
                     .iter()
                     .map(|p| p.encoded_size_bytes())

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -547,6 +547,7 @@ where
                 parts: all_parts,
                 runs: all_runs,
                 len,
+                run_meta: vec![],
             },
         })
     }

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -117,6 +117,7 @@ impl<'a> DirectiveArgs<'a> {
                 })
                 .collect(),
             runs: vec![],
+            run_meta: vec![],
         }
     }
 

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -98,11 +98,9 @@ impl<'a> DirectiveArgs<'a> {
         let (desc, len, keys) = (parts[0], parts[1], &parts[2..]);
         let desc = Self::parse_desc(desc);
         let len = len.parse().expect("invalid len");
-        HollowBatch {
+        HollowBatch::new_run(
             desc,
-            len,
-            parts: keys
-                .iter()
+            keys.iter()
                 .map(|x| {
                     BatchPart::Hollow(HollowBatchPart {
                         key: PartialBatchKey((*x).to_owned()),
@@ -116,9 +114,8 @@ impl<'a> DirectiveArgs<'a> {
                     })
                 })
                 .collect(),
-            runs: vec![],
-            run_meta: vec![],
-        }
+            len,
+        )
     }
 
     #[track_caller]

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1726,7 +1726,7 @@ mod tests {
 
     #[mz_ore::test]
     fn hollow_batch_migration_keys() {
-        let x = HollowBatch::new(
+        let x = HollowBatch::new_run(
             Description::new(
                 Antichain::from_elem(1u64),
                 Antichain::from_elem(2u64),
@@ -1743,8 +1743,6 @@ mod tests {
                 schema_id: None,
             })],
             4,
-            vec![],
-            vec![],
         );
         let mut old = x.into_proto();
         // Old ProtoHollowBatch had keys instead of parts.

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1744,6 +1744,7 @@ mod tests {
             })],
             4,
             vec![],
+            vec![],
         );
         let mut old = x.into_proto();
         // Old ProtoHollowBatch had keys instead of parts.

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1800,7 +1800,7 @@ pub mod datadriven {
             }
         }
         if !s.is_empty() {
-            for (idx, run) in batch.runs().enumerate() {
+            for (idx, (_meta, run)) in batch.runs().enumerate() {
                 write!(s, "<run {idx}>\n");
                 for part in run {
                     let part_idx = batch
@@ -2024,7 +2024,7 @@ pub mod datadriven {
                 batch.desc.lower().elements(),
                 batch.desc.upper().elements()
             );
-            for (run, parts) in batch.runs().enumerate() {
+            for (run, (_meta, parts)) in batch.runs().enumerate() {
                 writeln!(result, "<run {run}>");
                 for (part_id, part) in parts.into_iter().enumerate() {
                     writeln!(result, "<part {part_id}>");

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -57,11 +57,30 @@ message ProtoInlineBatchPart {
     mz_persist.gen.persist.ProtoColumnarRecords updates = 3;
 }
 
+enum ProtoRunOrder {
+    // The ordering of the data is not available; it can only be determined heuristically
+    // once the part is fetched by inspecting the batch description.
+    UNKNOWN = 0;
+    // No particular order.
+    UNORDERED = 1;
+    // Ordered by the codec-encoded bytes of the key, value, and timestamp.
+    CODEC = 2;
+    // Ordered by the structured encoding of the key, value, and timestamp.
+    STRUCTURED = 3;
+}
+
+// Data that should be common across all parts in a run.
+message ProtoRunMeta {
+    ProtoRunOrder order = 1;
+    optional uint64 schema_id = 2;
+}
+
 message ProtoHollowBatch {
     ProtoU64Description desc = 1;
     repeated ProtoHollowBatchPart parts = 4;
     uint64 len = 3;
     repeated uint64 runs = 5;
+    repeated ProtoRunMeta run_meta = 6;
 
     repeated string deprecated_keys = 2;
 }

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -539,6 +539,17 @@ impl<T> HollowBatch<T> {
         }
     }
 
+    /// Construct a batch of a single run.
+    pub(crate) fn new_run(desc: Description<T>, parts: Vec<BatchPart<T>>, len: usize) -> Self {
+        Self {
+            desc,
+            len,
+            parts,
+            runs: vec![],
+            run_meta: vec![],
+        }
+    }
+
     /// An empty hollow batch, representing no updates over the given desc.
     pub(crate) fn empty(desc: Description<T>) -> Self {
         Self {
@@ -2323,7 +2334,7 @@ pub(crate) mod tests {
         keys: &[&str],
         len: usize,
     ) -> HollowBatch<T> {
-        HollowBatch::new(
+        HollowBatch::new_run(
             Description::new(
                 Antichain::from_elem(lower),
                 Antichain::from_elem(upper),
@@ -2344,8 +2355,6 @@ pub(crate) mod tests {
                 })
                 .collect(),
             len,
-            vec![],
-            vec![],
         )
     }
 

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -1343,7 +1343,7 @@ mod tests {
                                 .into_iter()
                                 .flat_map(|p| p.batch.parts.clone())
                                 .collect();
-                            let output = HollowBatch::new(req.desc, parts, len, vec![], vec![]);
+                            let output = HollowBatch::new_run(req.desc, parts, len);
                             leader
                                 .collections
                                 .trace
@@ -1384,7 +1384,7 @@ mod tests {
     #[mz_ore::test]
     fn regression_15493_sniff_insert() {
         fn hb(lower: u64, upper: u64, len: usize) -> HollowBatch<u64> {
-            HollowBatch::new(
+            HollowBatch::new_run(
                 Description::new(
                     Antichain::from_elem(lower),
                     Antichain::from_elem(upper),
@@ -1392,8 +1392,6 @@ mod tests {
                 ),
                 Vec::new(),
                 len,
-                Vec::new(),
-                Vec::new(),
             )
         }
 
@@ -1494,7 +1492,7 @@ mod tests {
                     Antichain::from_elem(*upper),
                     Antichain::from_elem(*since),
                 );
-                HollowBatch::new(desc, Vec::new(), *len, Vec::new(), Vec::new())
+                HollowBatch::new_run(desc, Vec::new(), *len)
             }
             let replacement = batch(&replacement);
             let batches = spine.iter().map(batch).collect::<Vec<_>>();

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -1343,7 +1343,7 @@ mod tests {
                                 .into_iter()
                                 .flat_map(|p| p.batch.parts.clone())
                                 .collect();
-                            let output = HollowBatch::new(req.desc, parts, len, vec![]);
+                            let output = HollowBatch::new(req.desc, parts, len, vec![], vec![]);
                             leader
                                 .collections
                                 .trace
@@ -1392,6 +1392,7 @@ mod tests {
                 ),
                 Vec::new(),
                 len,
+                Vec::new(),
                 Vec::new(),
             )
         }
@@ -1493,7 +1494,7 @@ mod tests {
                     Antichain::from_elem(*upper),
                     Antichain::from_elem(*since),
                 );
-                HollowBatch::new(desc, Vec::new(), *len, Vec::new())
+                HollowBatch::new(desc, Vec::new(), *len, Vec::new(), Vec::new())
             }
             let replacement = batch(&replacement);
             let batches = spine.iter().map(batch).collect::<Vec<_>>();

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -1532,7 +1532,7 @@ mod tests {
         testcase(
             (2, 4, 0, 100),
             &[(0, 3, 0, 1), (3, 4, 0, 0)],
-            Err("overlapping batch was unexpectedly non-empty: HollowBatch { desc: ([0], [3], [0]), parts: [], len: 1, runs: [] }")
+            Err("overlapping batch was unexpectedly non-empty: HollowBatch { desc: ([0], [3], [0]), parts: [], len: 1, runs: [], run_meta: [] }")
         );
 
         // Split batch at replacement lower (untouched batch before the split one)
@@ -1560,7 +1560,7 @@ mod tests {
         testcase(
             (0, 2, 0, 100),
             &[(0, 1, 0, 0), (1, 4, 0, 1)],
-            Err("overlapping batch was unexpectedly non-empty: HollowBatch { desc: ([1], [4], [0]), parts: [], len: 1, runs: [] }")
+            Err("overlapping batch was unexpectedly non-empty: HollowBatch { desc: ([1], [4], [0]), parts: [], len: 1, runs: [], run_meta: [] }")
         );
 
         // Split batch at replacement upper (untouched batch after the split one)

--- a/src/persist-client/src/internal/state_serde.json
+++ b/src/persist-client/src/internal/state_serde.json
@@ -488,19 +488,25 @@
       "part_runs": [
         [
           {
-            "type": "Inline",
-            "updates": {
-              "desc": null,
-              "index": 0,
-              "updates[len]": 0
-            },
-            "ts_rewrite": {
-              "elements": [
-                245054358183071630
-              ]
-            },
-            "schema_id": "h9875232680843580888"
-          }
+            "order": null,
+            "schema": null
+          },
+          [
+            {
+              "type": "Inline",
+              "updates": {
+                "desc": null,
+                "index": 0,
+                "updates[len]": 0
+              },
+              "ts_rewrite": {
+                "elements": [
+                  245054358183071630
+                ]
+              },
+              "schema_id": "h9875232680843580888"
+            }
+          ]
         ]
       ]
     },
@@ -531,29 +537,35 @@
       "part_runs": [
         [
           {
-            "type": "Inline",
-            "updates": {
-              "desc": null,
-              "index": 0,
-              "updates[len]": 0
-            },
-            "ts_rewrite": null,
-            "schema_id": "h9518259874590116324"
+            "order": null,
+            "schema": null
           },
-          {
-            "type": "Inline",
-            "updates": {
-              "desc": null,
-              "index": 0,
-              "updates[len]": 0
+          [
+            {
+              "type": "Inline",
+              "updates": {
+                "desc": null,
+                "index": 0,
+                "updates[len]": 0
+              },
+              "ts_rewrite": null,
+              "schema_id": "h9518259874590116324"
             },
-            "ts_rewrite": {
-              "elements": [
-                17071391453325819086
-              ]
-            },
-            "schema_id": null
-          }
+            {
+              "type": "Inline",
+              "updates": {
+                "desc": null,
+                "index": 0,
+                "updates[len]": 0
+              },
+              "ts_rewrite": {
+                "elements": [
+                  17071391453325819086
+                ]
+              },
+              "schema_id": null
+            }
+          ]
         ]
       ]
     },
@@ -571,29 +583,35 @@
       "part_runs": [
         [
           {
-            "type": "Inline",
-            "updates": {
-              "desc": null,
-              "index": 0,
-              "updates[len]": 0
-            },
-            "ts_rewrite": {
-              "elements": [
-                15961028640594888816
-              ]
-            },
-            "schema_id": null
+            "order": null,
+            "schema": null
           },
-          {
-            "type": "Inline",
-            "updates": {
-              "desc": null,
-              "index": 0,
-              "updates[len]": 0
+          [
+            {
+              "type": "Inline",
+              "updates": {
+                "desc": null,
+                "index": 0,
+                "updates[len]": 0
+              },
+              "ts_rewrite": {
+                "elements": [
+                  15961028640594888816
+                ]
+              },
+              "schema_id": null
             },
-            "ts_rewrite": null,
-            "schema_id": null
-          }
+            {
+              "type": "Inline",
+              "updates": {
+                "desc": null,
+                "index": 0,
+                "updates[len]": 0
+              },
+              "ts_rewrite": null,
+              "schema_id": null
+            }
+          ]
         ]
       ]
     },
@@ -611,64 +629,70 @@
       "part_runs": [
         [
           {
-            "type": "Inline",
-            "updates": {
-              "desc": null,
-              "index": 0,
-              "updates[len]": 0
-            },
-            "ts_rewrite": {
-              "elements": [
-                1990182459289640688
-              ]
-            },
-            "schema_id": null
+            "order": null,
+            "schema": null
           },
-          {
-            "type": "Hollow",
-            "key": "?%ꞰOↁὖௗ𐨕-Ο{Ѩ%🕴{ßȺ:f🂱𑜾2f",
-            "encoded_size_bytes": 12336862283325747769,
-            "key_lower": "1b015efdf7021bcdb7d7b3094da7cca0278bb399cfa9ee82a0eea6c90cfa20a7bcbfd9b60b4c87d65cf28bbb51d48dec",
-            "stats": {
-              "len": 9216362869167982641,
-              "cols": {
-                "*=<.~\\d+": {
-                  "len": 5879932233594401360,
-                  "ଁ)𖾛🕴$𝔻n`nય:⼖୴ဂ|ꧠA%🩩ോ勺[𝼧𑍧`": {
-                    "lower": false,
-                    "upper": true
-                  },
-                  "🕴ዅ/໖": {
-                    "len": 17168192427257351185,
-                    "<`�/୕𐾃=🡐Ѩ¥𑊊qᦆ\"k𲀭¥ନ{ȺW<u": {
-                      "G𑊅\"૾𐽺ࢼ𐓹h:": {
-                        "len": 1,
-                        "stats": {
-                          "lower": false,
-                          "upper": true
+          [
+            {
+              "type": "Inline",
+              "updates": {
+                "desc": null,
+                "index": 0,
+                "updates[len]": 0
+              },
+              "ts_rewrite": {
+                "elements": [
+                  1990182459289640688
+                ]
+              },
+              "schema_id": null
+            },
+            {
+              "type": "Hollow",
+              "key": "?%ꞰOↁὖௗ𐨕-Ο{Ѩ%🕴{ßȺ:f🂱𑜾2f",
+              "encoded_size_bytes": 12336862283325747769,
+              "key_lower": "1b015efdf7021bcdb7d7b3094da7cca0278bb399cfa9ee82a0eea6c90cfa20a7bcbfd9b60b4c87d65cf28bbb51d48dec",
+              "stats": {
+                "len": 9216362869167982641,
+                "cols": {
+                  "*=<.~\\d+": {
+                    "len": 5879932233594401360,
+                    "ଁ)𖾛🕴$𝔻n`nય:⼖୴ဂ|ꧠA%🩩ോ勺[𝼧𑍧`": {
+                      "lower": false,
+                      "upper": true
+                    },
+                    "🕴ዅ/໖": {
+                      "len": 17168192427257351185,
+                      "<`�/୕𐾃=🡐Ѩ¥𑊊qᦆ\"k𲀭¥ନ{ȺW<u": {
+                        "G𑊅\"૾𐽺ࢼ𐓹h:": {
+                          "len": 1,
+                          "stats": {
+                            "lower": false,
+                            "upper": true
+                          }
+                        },
+                        "h/Ò?'Ã🝘5¯\\𐆠/𝒢==%𑙤Ѩ\\ᬑ": {
+                          "len": 1,
+                          "stats": "json_mixed"
                         }
-                      },
-                      "h/Ò?'Ã🝘5¯\\𐆠/𝒢==%𑙤Ѩ\\ᬑ": {
-                        "len": 1,
-                        "stats": "json_mixed"
                       }
                     }
-                  }
-                },
-                "Ⱥ૪b0": {
-                  "len": 5197454066737604612,
-                  "$G್𞺧:$᳒\\o\"🕴3\"Lꠊ๚𐬪¼:?ச?ᝥ&𐾽)Î𖿰>?𑊤𔖘": {
-                    "lower": "'xlㄑ🕴 D𐦇Ul",
-                    "upper": "ቄȺû"
+                  },
+                  "Ⱥ૪b0": {
+                    "len": 5197454066737604612,
+                    "$G್𞺧:$᳒\\o\"🕴3\"Lꠊ๚𐬪¼:?ச?ᝥ&𐾽)Î𖿰>?𑊤𔖘": {
+                      "lower": "'xlㄑ🕴 D𐦇Ul",
+                      "upper": "ቄȺû"
+                    }
                   }
                 }
-              }
-            },
-            "ts_rewrite": null,
-            "diffs_sum": -946081707879001155,
-            "format": null,
-            "schema_id": "h2260404778546976278"
-          }
+              },
+              "ts_rewrite": null,
+              "diffs_sum": -946081707879001155,
+              "format": null,
+              "schema_id": "h2260404778546976278"
+            }
+          ]
         ]
       ]
     }

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -307,7 +307,7 @@ impl<T: Timestamp + Lattice> Trace<T> {
 
                 // Empty legacy batches are not deterministic: different nodes may split them up
                 // in different ways. For now, we rearrange them such to match the spine data.
-                if batch.parts.is_empty() && batch.runs.is_empty() && batch.len == 0 {
+                if batch.parts.is_empty() && batch.run_splits.is_empty() && batch.len == 0 {
                     let mut new_upper = batch.desc.upper().clone();
 
                     // While our current batch is too small, and there's another empty batch
@@ -713,7 +713,7 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
     pub fn is_compact(&self) -> bool {
         // This definition is extremely likely to change, but for now, we consider a batch
         // "compact" if it has at most one hollow batch with at most one run.
-        self.parts.len() <= 1 && self.parts.iter().all(|p| p.batch.runs.is_empty())
+        self.parts.len() <= 1 && self.parts.iter().all(|p| p.batch.run_splits.is_empty())
     }
 
     pub fn is_merging(&self) -> bool {

--- a/src/persist-client/src/internals_bench.rs
+++ b/src/persist-client/src/internals_bench.rs
@@ -37,7 +37,7 @@ pub fn trace_push_batch_one_iter(num_batches: usize) {
         // Other, much better handled, workloads include all empty or all
         // non-empty.
         let len = if ts == 0 { 1 } else { 0 };
-        let _ = trace.push_batch(HollowBatch::new(
+        let _ = trace.push_batch(HollowBatch::new_run(
             Description::new(
                 Antichain::from_elem(ts),
                 Antichain::from_elem(ts + 1),
@@ -45,8 +45,6 @@ pub fn trace_push_batch_one_iter(num_batches: usize) {
             ),
             vec![],
             len,
-            vec![],
-            vec![],
         ));
     }
     black_box(trace);

--- a/src/persist-client/src/internals_bench.rs
+++ b/src/persist-client/src/internals_bench.rs
@@ -46,6 +46,7 @@ pub fn trace_push_batch_one_iter(num_batches: usize) {
             vec![],
             len,
             vec![],
+            vec![],
         ));
     }
     black_box(trace);

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1004,7 +1004,7 @@ where
 
         let lease = self.lease_seqno();
         for batch in batches {
-            for run in batch.runs() {
+            for (_meta, run) in batch.runs() {
                 consolidator.enqueue_run(
                     &batch.desc,
                     run.into_iter()

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -485,15 +485,19 @@ where
             let any_batch_rewrite = batches
                 .iter()
                 .any(|x| x.batch.parts.iter().any(|x| x.ts_rewrite().is_some()));
-            let (mut parts, mut num_updates, mut runs) = (vec![], 0, vec![]);
+            let (mut parts, mut num_updates, mut runs, mut run_metas) = (vec![], 0, vec![], vec![]);
             for batch in batches.iter() {
                 let () = validate_truncate_batch(&batch.batch, &desc, any_batch_rewrite)?;
-                for run in batch.batch.runs() {
+                for (run_meta, run) in batch.batch.runs() {
+                    if run.is_empty() {
+                        continue;
+                    }
                     // Mark the boundary if this is not the first run in the batch.
                     let start_index = parts.len();
                     if start_index != 0 {
                         runs.push(start_index);
                     }
+                    run_metas.push(run_meta);
                     parts.extend_from_slice(run);
                 }
                 num_updates += batch.batch.len;
@@ -503,7 +507,7 @@ where
             let res = self
                 .machine
                 .compare_and_append(
-                    &HollowBatch::new(desc.clone(), parts, num_updates, runs),
+                    &HollowBatch::new(desc.clone(), parts, num_updates, runs, run_metas),
                     &self.writer_id,
                     &self.debug_state,
                     heartbeat_timestamp,

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -102,6 +102,12 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                     x
                 },
                 {
+                    // Write the format of a Part in State.
+                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
+                    x.add_dynamic("persist_batch_record_run_meta", ::mz_dyncfg::ConfigVal::Bool(true));
+                    x
+                },
+                {
                     let mut x = ::mz_dyncfg::ConfigUpdates::default();
                     x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
                     x.add_dynamic("persist_part_decode_format", ::mz_dyncfg::ConfigVal::String("arrow".into()));

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -20,6 +20,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::num::{NonNeg, NonNegError};
 use num::Signed;
 use proptest::prelude::Strategy;
+use prost::UnknownEnumValue;
 use uuid::Uuid;
 
 #[cfg(feature = "chrono")]
@@ -106,6 +107,12 @@ impl From<NonNegError> for TryFromProtoError {
 impl From<CharTryFromError> for TryFromProtoError {
     fn from(error: CharTryFromError) -> Self {
         TryFromProtoError::CharTryFromError(error)
+    }
+}
+
+impl From<UnknownEnumValue> for TryFromProtoError {
+    fn from(UnknownEnumValue(n): UnknownEnumValue) -> Self {
+        TryFromProtoError::UnknownEnumVariant(format!("value {n}"))
     }
 }
 

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -193,7 +193,7 @@ def workflow_inspect_shard(c: Composition) -> None:
         part
         for batch in json_dict["batches"]
         for part_run in batch["part_runs"]
-        for part in part_run
+        for part in part_run[1]
     ]
     non_empty_part = next(part for part in parts if part["encoded_size_bytes"] > 0)
     cols = non_empty_part["stats"]["cols"]["ok"]


### PR DESCRIPTION
### Motivation

We'd like to store the ordering metadata for #23942.

This is logically a run-level thing, and we've hit a couple cases recently where we similarly wanted run-level metadata; this gives us a way to store that. I've added the schema id for now, since that may also be relevant to my work soon, but we can imagine migrating a few other things there.

### Tips for reviewer

Nightlies: https://buildkite.com/materialize/nightly/builds/9221

Pulled out of my larger ordering PR in the hopes of landing for this week's release; let me know if you'd like any additional context.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
