### PR TITLE
Improve error message for json source decoding failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6713,6 +6713,7 @@ dependencies = [
  "differential-dataflow",
  "fail",
  "futures",
+ "hex",
  "insta",
  "itertools 0.10.5",
  "mysql_async",

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -26,6 +26,7 @@ columnation = { git = "https://github.com/frankmcsherry/columnation" }
 dec = "0.4.8"
 derivative = "2.2.0"
 differential-dataflow = "0.12.0"
+hex = "0.4.3"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 itertools = { version = "0.10.5" }

--- a/src/storage/src/decode.rs
+++ b/src/storage/src/decode.rs
@@ -223,12 +223,7 @@ impl PreDelimitedFormat {
                 let j = mz_repr::adt::jsonb::Jsonb::from_slice(bytes).map_err(|e| {
                     DecodeErrorKind::Bytes(format!(
                         "Failed to decode JSON: {}",
-                        // See if we can output the string that failed to be converted to JSON.
-                        match std::str::from_utf8(bytes) {
-                            Ok(str) => str.to_string(),
-                            // Otherwise produce the nominally helpful error.
-                            Err(_) => e.display_with_causes().to_string(),
-                        }
+                        e.display_with_causes(),
                     ))
                 })?;
                 Ok(Some(j.into_row()))

--- a/test/testdrive/avro-decode-mismatched-columns.td
+++ b/test/testdrive/avro-decode-mismatched-columns.td
@@ -55,7 +55,7 @@ $ kafka-ingest format=avro topic=decode-1to2-default schema=${1column} timestamp
   ENVELOPE NONE
 
 ! SELECT * FROM decode_1to2_default
-contains:Text: avro deserialization error: unable to decode row : IO error: UnexpectedEof
+contains:Decode error: avro deserialization error: unable to decode row : IO error: UnexpectedEof
 
 #
 # 2 columns -> 1 column

--- a/test/testdrive/avro-decode.td
+++ b/test/testdrive/avro-decode.td
@@ -217,7 +217,7 @@ garbage
   FORMAT AVRO USING SCHEMA '${reader-schema}'
 
 ! SELECT f2 FROM avro_corrupted_values
-contains:Decode error: Text: avro deserialization error: wrong Confluent-style avro serialization magic: expected 0, got 1
+contains:Decode error: avro deserialization error: wrong Confluent-style avro serialization magic: expected 0, got 103 (original text: garbage, original bytes: "67617262616765")
 
 # Test decoding of corrupted messages without magic byte
 $ kafka-create-topic topic=avro-corrupted-values2

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -664,8 +664,8 @@ ALTER SYSTEM SET enable_envelope_upsert_inline_errors = true
 # though for other types (e.g. avro) the value columns should be present and flattened.
 
 > SELECT key, data, error::text FROM value_decode_error ORDER BY key
-val1 <null> "(\"Bytes: Failed to decode JSON: {\"\"a\"\":,\"\"c\"\":\"\"d\"\"} (original bytes: [7b, 22, 61, 22, 3a, 2c, 22, 63, 22, 3a, 22, 64, 22, 7d])\")"
-val2 <null> "(\"Bytes: Failed to decode JSON: [1,2, (original bytes: [5b, 31, 2c, 32, 2c])\")"
+val1 <null> "(\"Failed to decode JSON: expected value at line 1 column 6 (original text: {\"\"a\"\":,\"\"c\"\":\"\"d\"\"}, original bytes: \"\"7b2261223a2c2263223a2264227d\"\")\")"
+val2 <null> "(\"Failed to decode JSON: EOF while parsing a value at line 1 column 5 (original text: [1,2,, original bytes: \"\"5b312c322c\"\")\")"
 
 # replace the bad values with good ones
 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=inline-value-errors-1
@@ -724,6 +724,6 @@ $ kafka-ingest format=bytes key-format=avro key-schema=${keyschema} topic=inline
 {"key": "birdmore"} "notvalidavro"
 
 > SELECT key, f1, f2, decode_error::text from value_decode_error_avro ORDER BY key
-birdmore      <null>   <null>    "(\"Text: avro deserialization error: wrong Confluent-style avro serialization magic: expected 0, got 32 (original bytes: [20, 22, 6e, 6f, 74, 76, 61, 6c, 69, 64, 61, 76, 72, 6f, 22])\")"
+birdmore      <null>   <null>    "(\"avro deserialization error: wrong Confluent-style avro serialization magic: expected 0, got 32 (original text:  \"\"notvalidavro\"\", original bytes: \"\"20226e6f7476616c69646176726f22\"\")\")"
 fish          fish     1000      <null>
 mammal1       moose    1         <null>

--- a/test/testdrive/protobuf-corrupted.td
+++ b/test/testdrive/protobuf-corrupted.td
@@ -38,7 +38,7 @@ garbage
   FORMAT PROTOBUF MESSAGE '.OneInt' USING SCHEMA '${simple-schema}'
 
 ! SELECT * FROM total_garbage
-contains:Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type value: 7
+contains:Decode error: protobuf deserialization error: failed to decode Protobuf message: invalid wire type value: 7 (original text: garbage, original bytes: "67617262616765")
 
 $ kafka-create-topic topic=wrong-message
 
@@ -51,4 +51,4 @@ $ kafka-ingest topic=wrong-message format=protobuf descriptor-file=simple.pb mes
   FORMAT PROTOBUF MESSAGE '.OneString' USING SCHEMA '${simple-schema}'
 
 ! SELECT * FROM wrong_message
-contains:Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type: Varint (expected LengthDelimited)
+contains:Decode error: protobuf deserialization error: failed to decode Protobuf message: invalid wire type: Varint (expected LengthDelimited)

--- a/test/testdrive/protobuf-evolution.td
+++ b/test/testdrive/protobuf-evolution.td
@@ -135,4 +135,4 @@ $ kafka-ingest topic=evolution format=protobuf descriptor-file=evolution.pb mess
 {"wrong": "i'm not an int!"}
 
 ! SELECT * FROM evolution
-contains:Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type: LengthDelimited (expected Varint)
+contains:Decode error: protobuf deserialization error: failed to decode Protobuf message: invalid wire type: LengthDelimited (expected Varint)

--- a/test/testdrive/protobuf-import.td
+++ b/test/testdrive/protobuf-import.td
@@ -124,4 +124,4 @@ $ kafka-ingest topic=import-csr format=protobuf descriptor-file=import.pb messag
 {"importee1": {"b": false}, "importee2": {"ts": "1970-01-01T00:20:34.000005678Z"}}
 
 ! SELECT importee1::text, importee2::text FROM import_csr
-contains:Decode error: Text: protobuf deserialization error: unsupported Confluent-style protobuf message descriptor id: expected 0, but found: 123. See https://github.com/MaterializeInc/materialize/issues/9250
+contains:Decode error: protobuf deserialization error: unsupported Confluent-style protobuf message descriptor id: expected 0, but found: 123. See https://github.com/MaterializeInc/materialize/issues/9250

--- a/test/testdrive/source-format-json.td
+++ b/test/testdrive/source-format-json.td
@@ -55,7 +55,7 @@ $ kafka-ingest format=bytes topic=data
 "{\"a\":\"b\",\"c\":\"d\"}"
 
 $ kafka-ingest format=bytes topic=data
-hello
+{ "@timestamp":"2015-06-03T22:20:44.000Z", "latitude":39.613658, "longitude":4.9E-324, "location":[-86.106653,39.613658] }
 
 !SELECT * FROM data
-exact:Decode error: Bytes: Failed to decode JSON: hello (original bytes: [68, 65, 6c, 6c, 6f])
+exact:Decode error: Failed to decode JSON: "4.9E-324" is out of range for type numeric: exceeds maximum precision 39 at line 1 column 85 (original text: { "@timestamp":"2015-06-03T22:20:44.000Z", "latitude":39.613658, "longitude":4.9E-324, "location":[-86.106653,39.613658] }, original bytes: "7b20224074696d657374616d70223a22323031352d30362d30335432323a32303a34342e3030305a222c20226c61746974756465223a33392e3631333635382c20226c6f6e676974756465223a342e39452d3332342c20226c6f636174696f6e223a5b2d38362e3130363635332c33392e3631333635385d207d")


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Our previous error message would include the string that failed to decode but hide the actual error message.

We also probably can get rid of the `DecodeErrorKind` enum at some point, since there is no functional difference in `DecodeErrorKind::Bytes` and `DecodeErrorKind::Text` anywhere I can see

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
