### PR TITLE
tests: Ignore multiple images for same commit hash

### DIFF
--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -191,8 +191,8 @@ def _select_image_name_from_candidates(
         raise RuntimeError(f"No image found for commit hash {commit_hash}")
 
     if len(image_name_candidates) > 1:
-        raise RuntimeError(
-            f"Multiple images found for commit hash {commit_hash}: {image_name_candidates}"
+        print(
+            f"Multiple images found for commit hash {commit_hash}: {image_name_candidates}, picking first"
         )
 
     return image_name_candidates[0]


### PR DESCRIPTION
Can happen when the same commit hash is built on main and in a PR

Seen in https://buildkite.com/materialize/test/builds/88880#019176bc-ff7d-45b8-80d7-ca0b7b29eeef

Related to https://github.com/MaterializeInc/materialize/pull/29097

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
