### PR TITLE
orchestrator-tracing: warn people off of startup-log-filter arg

### DIFF
--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -54,7 +54,14 @@ use opentelemetry_sdk::resource::Resource;
 #[derive(Derivative, Clone, clap::Parser)]
 #[derivative(Debug)]
 pub struct TracingCliArgs {
-    /// Which tracing events to log to stderr.
+    /// Which tracing events to log to stderr during startup, before the
+    /// real log filter is synced from LaunchDarkly.
+    ///
+    /// WARNING: you probably don't want to set this for `environmentd`. This
+    /// parameter only controls logging for the brief moment before the log
+    /// filter is synced from LaunchDarkly. You probably instead want to pass
+    /// `--system-parameter-default=log_filter=<filter>`, which will set the
+    /// default log filter to use unless overridden by the LaunchDarkly sync.
     ///
     /// This value is a comma-separated list of filter directives. Each filter
     /// directive has the following format:


### PR DESCRIPTION
It's almost never what you want. What you want instead if `--system-parameter-default=log_filter=<filter>`.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR improves documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
