### PR TITLE
adapter,pgwire: use conn UUID as session UUID; display in welcome message

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -252,6 +252,7 @@ impl Client {
   Cluster: {}
   Database: {}
   {}
+  Session UUID: {}
 
 Issue a SQL query to get started. Need help?
   View documentation: https://materialize.com/s/docs
@@ -270,6 +271,7 @@ Issue a SQL query to get started. Need help?
                         schemas.iter().map(|id| id.to_string()).join(", ")
                     ),
                 },
+                session.uuid(),
             )));
         }
 
@@ -356,6 +358,7 @@ Issue a SQL query to get started. Need help?
         let conn_id = self.new_conn_id()?;
         let session = self.new_session(SessionConfig {
             conn_id,
+            uuid: Uuid::new_v4(),
             user: SUPPORT_USER.name.clone(),
             external_metadata_rx: None,
         });

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeMap;
 
 use mz_sql::session::user::SYSTEM_USER;
 use tracing::{error, info};
+use uuid::Uuid;
 
 use crate::config::SynchronizedParameters;
 use crate::session::SessionConfig;
@@ -29,6 +30,7 @@ impl SystemParameterBackend {
         let conn_id = client.new_conn_id()?;
         let session = client.new_session(SessionConfig {
             conn_id,
+            uuid: Uuid::new_v4(),
             user: SYSTEM_USER.name.clone(),
             external_metadata_rx: None,
         });

--- a/src/adapter/src/coord/validity.rs
+++ b/src/adapter/src/coord/validity.rs
@@ -182,6 +182,7 @@ mod tests {
     use mz_repr::{GlobalId, Timestamp};
     use mz_sql::catalog::RoleAttributes;
     use mz_sql::session::metadata::SessionMetadata;
+    use uuid::Uuid;
 
     use crate::catalog::{Catalog, Op};
     use crate::coord::validity::PlanValidity;
@@ -217,6 +218,7 @@ mod tests {
                 &mz_build_info::DUMMY_BUILD_INFO,
                 SessionConfig {
                     conn_id,
+                    uuid: Uuid::new_v4(),
                     user,
                     external_metadata_rx: None,
                 },

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -172,7 +172,14 @@ impl SessionMetadata for SessionMeta {
 #[derive(Debug, Clone)]
 pub struct SessionConfig {
     /// The connection ID for the session.
+    ///
+    /// May be reused after the session terminates.
     pub conn_id: ConnectionId,
+    /// A universally unique identifier for the session, across all processes,
+    /// region, and all time.
+    ///
+    /// Must not be reused, even after the session terminates.
+    pub uuid: Uuid,
     /// The name of the user associated with the session.
     pub user: String,
     /// An optional receiver that the session will periodically check for
@@ -254,6 +261,7 @@ impl<T: TimestampManipulation> Session<T> {
             &DUMMY_BUILD_INFO,
             SessionConfig {
                 conn_id: DUMMY_CONNECTION_ID,
+                uuid: Uuid::new_v4(),
                 user: SYSTEM_USER.name.clone(),
                 external_metadata_rx: None,
             },
@@ -267,6 +275,7 @@ impl<T: TimestampManipulation> Session<T> {
         build_info: &'static BuildInfo,
         SessionConfig {
             conn_id,
+            uuid,
             user,
             mut external_metadata_rx,
         }: SessionConfig,
@@ -286,7 +295,7 @@ impl<T: TimestampManipulation> Session<T> {
         }
         Session {
             conn_id,
-            uuid: Uuid::new_v4(),
+            uuid,
             transaction: TransactionStatus::Default,
             pcx: None,
             metrics,

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -673,7 +673,7 @@ impl mz_server_core::Server for PgwireBalancer {
         let outer_metrics = self.metrics.clone();
         let cancellation_resolver = self.cancellation_resolver.clone();
         let conn_uuid = Uuid::new_v4();
-        conn.uuid_handle().set(Some(conn_uuid));
+        conn.uuid_handle().set(conn_uuid);
         Box::pin(async move {
             // TODO: Try to merge this with pgwire/server.rs to avoid the duplication. May not be
             // worth it.

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -61,6 +61,7 @@ use tower::limit::GlobalConcurrencyLimitLayer;
 use tower::{Service, ServiceBuilder};
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tracing::{error, warn};
+use uuid::Uuid;
 
 use crate::deployment::state::DeploymentStateHandle;
 use crate::http::sql::SqlError;
@@ -482,6 +483,7 @@ impl AuthedClient {
         let conn_id = adapter_client.new_conn_id()?;
         let mut session = adapter_client.new_session(SessionConfig {
             conn_id,
+            uuid: Uuid::new_v4(),
             user: user.name,
             external_metadata_rx: user.external_metadata_rx,
         });

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -51,6 +51,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time::{self};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, debug_span, warn, Instrument};
+use uuid::Uuid;
 
 use crate::codec::FramedConn;
 use crate::message::{self, BackendMessage};
@@ -83,6 +84,8 @@ pub struct RunParams<'a, A> {
     pub adapter_client: mz_adapter::Client,
     /// The connection to the client.
     pub conn: &'a mut FramedConn<A>,
+    /// The universally unique identifier for the connection.
+    pub conn_uuid: Uuid,
     /// The protocol version that the client provided in the startup message.
     pub version: i32,
     /// The parameters that the client provided in the startup message.
@@ -111,6 +114,7 @@ pub async fn run<'a, A>(
         tls_mode,
         adapter_client,
         conn,
+        conn_uuid,
         version,
         mut params,
         frontegg,
@@ -182,6 +186,7 @@ where
                 // canonical.
                 let session = adapter_client.new_session(SessionConfig {
                     conn_id: conn.conn_id().clone(),
+                    uuid: conn_uuid,
                     user: auth_session.user().into(),
                     external_metadata_rx: Some(auth_session.external_metadata_rx()),
                 });
@@ -201,6 +206,7 @@ where
     } else {
         let session = adapter_client.new_session(SessionConfig {
             conn_id: conn.conn_id().clone(),
+            uuid: conn_uuid,
             user,
             external_metadata_rx: None,
         });

--- a/src/server-core/src/lib.rs
+++ b/src/server-core/src/lib.rs
@@ -124,8 +124,8 @@ impl ConnectionUuidHandle {
     }
 
     /// Sets the UUID for this connection.
-    pub fn set(&self, conn_uuid: Option<Uuid>) {
-        *self.0.lock().expect("lock poisoned") = conn_uuid;
+    pub fn set(&self, conn_uuid: Uuid) {
+        *self.0.lock().expect("lock poisoned") = Some(conn_uuid);
     }
 
     /// Returns a displayble that renders a possibly missing connection UUID.


### PR DESCRIPTION
Use the connection UUID added in 3b42b8ec3, which tracks connections across balancerd and environmentd processes, as the session UUID. Then show the session UUID in the welcome message.

This will make it easier to correlate particular connections with their environmentd and balancerd logs.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR works towards fixing a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
