### PR TITLE
cloudtest: Disable test_replica_metrics and reduce parallelism

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -584,7 +584,7 @@ steps:
   - id: cloudtest
     label: Cloudtest %N
     depends_on: build-aarch64
-    parallelism: 8
+    parallelism: 6
     timeout_in_minutes: 40
     inputs:
       - test/cloudtest

--- a/test/cloudtest/test_metrics.py
+++ b/test/cloudtest/test_metrics.py
@@ -9,9 +9,12 @@
 
 from textwrap import dedent
 
+import pytest
+
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 
 
+@pytest.mark.skip(reason="Fails occasionally, see #29171")
 def test_replica_metrics(mz: MaterializeApplication) -> None:
     mz.testdrive.run(
         input=dedent(


### PR DESCRIPTION
Since we run with faster CI machines now

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
