### PR TITLE
cloud-canary: Adapt to new version format

### DIFF
--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -15,6 +15,7 @@ import urllib.parse
 
 import pg8000
 
+from materialize.mz_version import MzVersion
 from materialize.mzcompose import (
     _wait_for_pg,
 )
@@ -32,7 +33,7 @@ REGION = "aws/us-east-1"
 ENVIRONMENT = os.getenv("ENVIRONMENT", "staging")
 USERNAME = os.getenv("NIGHTLY_CANARY_USERNAME", "infra+nightly-canary@materialize.com")
 APP_PASSWORD = os.environ["NIGHTLY_CANARY_APP_PASSWORD"]
-VERSION = "devel-" + os.environ["BUILDKITE_COMMIT"]
+VERSION = f"{MzVersion.parse_cargo()}--main.{os.environ['BUILDKITE_COMMIT']}"
 
 # The DevEx account in the Confluent Cloud is used to provide Kafka services
 KAFKA_BOOTSTRAP_SERVER = "pkc-n00kk.us-east-1.aws.confluent.cloud:9092"


### PR DESCRIPTION
Seen failing in https://buildkite.com/materialize/nightly/builds/9212#01917600-be47-4b38-9e47-99a35fe152a9

Follow-up to https://github.com/MaterializeInc/materialize/pull/29097

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
