### PR TITLE
ci: Clean up target(|-xcompile) directories after cancelation

### DIFF
--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -17,6 +17,11 @@ run() {
     bin/ci-builder run stable bin/mzcompose --mz-quiet --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
 
+if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq -1 ]; then
+  echo "Job was canceled, cleaning target directories to prevent corrupted incremental state"
+  rm -rf target target-xcompile
+fi
+
 echo "Collecting logs"
 # Run before potential "run down" in coverage
 docker ps --all --quiet | xargs --no-run-if-empty docker inspect > docker-inspect.log


### PR DESCRIPTION
It is easy to get build directories into a corrupted state by canceling builds at the right time, debugged in https://materializeinc.slack.com/archives/C01LKF361MZ/p1724318419682379

Lighter-weight version of https://github.com/MaterializeInc/i2/pull/2120

This only works for the linting steps, the actual build steps are not using mzcompose, so I still prefer the i2 change.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
