### PR TITLE
Add client_address to session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,6 +4376,7 @@ dependencies = [
  "openssl",
  "postgres",
  "prometheus",
+ "proxy-header",
  "reqwest",
  "semver",
  "tempfile",
@@ -6168,6 +6169,7 @@ dependencies = [
  "mz-dyncfg",
  "mz-ore",
  "openssl",
+ "proxy-header",
  "scopeguard",
  "socket2 0.5.7",
  "tokio",
@@ -8118,6 +8120,12 @@ checksum = "e1ed294a835b0f30810e13616b1cd34943c6d1e84a8f3b0dcfe466d256c3e7e7"
 dependencies = [
  "thiserror",
 ]
+
+[[package]]
+name = "proxy-header"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1493f63ddddfba840c3169e997c2905d09538ace72d64e84af6324c6e0e065"
 
 [[package]]
 name = "psm"

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -33,7 +33,8 @@ pandas-stubs==2.1.1.230928
 parameterized==0.8.1
 paramiko==3.4.0
 pdoc==14.6.0
-pg8000==1.30.3
+# We can revert back to standard pg800 versions once https://github.com/tlocke/pg8000/pull/161 merges
+pg8000 @ git+https://github.com/benesch/pg8000@0e7d1fbe02bd47958f9cf0cf132d6d08fbcca18e
 prettytable==3.11.0
 psutil==5.9.4
 psycopg==3.1.12

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -632,12 +632,13 @@ Field                  | Type                         | Meaning
 The `mz_sessions` table contains a row for each active session in the system.
 
 <!-- RELATION_SPEC mz_internal.mz_sessions -->
-| Field           | Type                           | Meaning                                                                                                                   |
-| --------------- | ------------------------------ | --------                                                                                                                  |
-| `id`            | [`uuid`]                       | The globally unique ID of the session. |
-| `connection_id` | [`uint4`]                      | The connection ID of the session. Unique only for active sessions and can be recycled. Corresponds to [`pg_backend_pid()`](/sql/functions/#pg_backend_pid). |
-| `role_id`       | [`text`]                       | The role ID of the role that the session is logged in as. Corresponds to [`mz_catalog.mz_roles`](../mz_catalog#mz_roles). |
-| `connected_at`  | [`timestamp with time zone`]   | The time at which the session connected to the system.                                                                    |
+| Field            | Type                           | Meaning                                                                                                                   |
+| -----------------| ------------------------------ | --------                                                                                                                  |
+| `id`             | [`uuid`]                       | The globally unique ID of the session. |
+| `connection_id`  | [`uint4`]                      | The connection ID of the session. Unique only for active sessions and can be recycled. Corresponds to [`pg_backend_pid()`](/sql/functions/#pg_backend_pid). |
+| `role_id`        | [`text`]                       | The role ID of the role that the session is logged in as. Corresponds to [`mz_catalog.mz_roles`](../mz_catalog#mz_roles). |
+| `client_ip`      | [`text`]                       | The IP address of the client that initiated the session.                                                                  |
+| `connected_at`   | [`timestamp with time zone`]   | The time at which the session connected to the system.                                                                    |
 
 ## `mz_show_all_privileges`
 

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -898,6 +898,11 @@ who = "Parker Timmerman <parker.timmerman@materialize.com>"
 criteria = "safe-to-deploy"
 version = "3.4.0"
 
+[[audits.proxy-header]]
+who = "Justin Bradfield <justin@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+
 [[audits.quanta]]
 who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -639,6 +639,7 @@ class Composition:
         port: int | None = None,
         password: str | None = None,
         ssl_context: ssl.SSLContext | None = None,
+        init_params: dict[str, str] = {},
     ) -> Connection:
         if service is None:
             service = "materialized"
@@ -651,6 +652,7 @@ class Composition:
             password=password,
             port=port,
             ssl_context=ssl_context,
+            init_params=init_params,
         )
         conn.autocommit = True
         return conn
@@ -662,9 +664,12 @@ class Composition:
         port: int | None = None,
         password: str | None = None,
         ssl_context: ssl.SSLContext | None = None,
+        init_params: dict[str, str] = {},
     ) -> Cursor:
         """Get a cursor to run SQL queries against the materialized service."""
-        conn = self.sql_connection(service, user, port, password, ssl_context)
+        conn = self.sql_connection(
+            service, user, port, password, ssl_context, init_params
+        )
         return conn.cursor()
 
     def sql(

--- a/misc/python/stubs/pg8000/__init__.pyi
+++ b/misc/python/stubs/pg8000/__init__.pyi
@@ -47,4 +47,5 @@ def connect(
     timeout: int | None = ...,
     ssl_context: SSLContext | None = ...,
     application_name: str | None = ...,
+    init_params: dict[str, str] | None = ...,
 ) -> Connection: ...

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1929,6 +1929,7 @@ impl CatalogState {
                 Datum::Uuid(conn.uuid()),
                 Datum::UInt32(conn.conn_id().unhandled()),
                 Datum::String(&conn.authenticated_role_id().to_string()),
+                Datum::from(conn.client_ip().map(|ip| ip.to_string()).as_deref()),
                 Datum::TimestampTz(connect_dt.try_into().expect("must fit")),
             ]),
             diff,

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -164,6 +164,7 @@ impl Client {
         let conn_id = session.conn_id().clone();
         let secret_key = session.secret_key();
         let uuid = session.uuid();
+        let client_ip = session.client_ip();
         let application_name = session.application_name().into();
         let notice_tx = session.retain_notice_transmitter();
 
@@ -187,6 +188,7 @@ impl Client {
             conn_id: conn_id.clone(),
             secret_key,
             uuid,
+            client_ip: client_ip.copied(),
             application_name,
             notice_tx,
         });
@@ -360,6 +362,7 @@ Issue a SQL query to get started. Need help?
             conn_id,
             uuid: Uuid::new_v4(),
             user: SUPPORT_USER.name.clone(),
+            client_ip: None,
             external_metadata_rx: None,
         });
         let mut session_client = self.startup(session).await?;

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -9,6 +9,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
+use std::net::IpAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -58,6 +59,7 @@ pub enum Command {
         tx: oneshot::Sender<Result<StartupResponse, AdapterError>>,
         user: User,
         conn_id: ConnectionId,
+        client_ip: Option<IpAddr>,
         secret_key: u32,
         uuid: Uuid,
         application_name: String,

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -32,6 +32,7 @@ impl SystemParameterBackend {
             conn_id,
             uuid: Uuid::new_v4(),
             user: SYSTEM_USER.name.clone(),
+            client_ip: None,
             external_metadata_rx: None,
         });
         let session_client = client.startup(session).await?;

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -80,7 +80,7 @@ use mz_storage_types::read_holds::ReadHold;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::num::NonZeroI64;
 use std::ops::Neg;
 use std::str::FromStr;
@@ -1022,6 +1022,7 @@ pub struct ConnMeta {
     application_name: String,
     uuid: Uuid,
     conn_id: ConnectionId,
+    client_ip: Option<IpAddr>,
 
     /// Sinks that will need to be dropped when the current transaction, if
     /// any, is cleared.
@@ -1064,6 +1065,10 @@ impl ConnMeta {
 
     pub fn uuid(&self) -> Uuid {
         self.uuid
+    }
+
+    pub fn client_ip(&self) -> Option<IpAddr> {
+        self.client_ip
     }
 
     pub fn connected_at(&self) -> EpochMillis {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -14,6 +14,7 @@ use differential_dataflow::lattice::Lattice;
 use mz_adapter_types::dyncfgs::ALLOW_USER_SESSIONS;
 use mz_sql::session::metadata::SessionMetadata;
 use std::collections::{BTreeMap, BTreeSet};
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use futures::future::LocalBoxFuture;
@@ -91,6 +92,7 @@ impl Coordinator {
                     conn_id,
                     secret_key,
                     uuid,
+                    client_ip,
                     application_name,
                     notice_tx,
                 } => {
@@ -102,6 +104,7 @@ impl Coordinator {
                         conn_id,
                         secret_key,
                         uuid,
+                        client_ip,
                         application_name,
                         notice_tx,
                     )
@@ -276,6 +279,7 @@ impl Coordinator {
         conn_id: ConnectionId,
         secret_key: u32,
         uuid: uuid::Uuid,
+        client_ip: Option<IpAddr>,
         application_name: String,
         notice_tx: mpsc::UnboundedSender<AdapterNotice>,
     ) {
@@ -323,6 +327,7 @@ impl Coordinator {
                     user,
                     application_name,
                     uuid,
+                    client_ip,
                     conn_id: conn_id.clone(),
                     authenticated_role: role_id,
                     deferred_lock: None,

--- a/src/adapter/src/coord/validity.rs
+++ b/src/adapter/src/coord/validity.rs
@@ -220,6 +220,7 @@ mod tests {
                     conn_id,
                     uuid: Uuid::new_v4(),
                     user,
+                    client_ip: None,
                     external_metadata_rx: None,
                 },
                 metrics.session_metrics(),

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -40,6 +40,7 @@ mz-pgwire-common = { path = "../pgwire-common" }
 num_cpus = "1.14.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
 prometheus = { version = "0.13.3", default-features = false }
+proxy-header = "0.1.2"
 semver = "1.0.16"
 tokio = { version = "1.38.0", default-features = false }
 tokio-openssl = "0.6.3"

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -192,6 +192,7 @@ async fn test_balancer() {
             None,
             None,
             TracingHandle::disabled(),
+            vec![],
         );
         let balancer_server = BalancerService::new(balancer_cfg).await.unwrap();
         let balancer_pgwire_listen = balancer_server.pgwire.0.local_addr();

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -3341,6 +3341,7 @@ pub static MZ_SESSIONS: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {
         .with_column("id", ScalarType::Uuid.nullable(false))
         .with_column("connection_id", ScalarType::UInt32.nullable(false))
         .with_column("role_id", ScalarType::String.nullable(false))
+        .with_column("client_ip", ScalarType::String.nullable(true))
         .with_column(
             "connected_at",
             ScalarType::TimestampTz { precision: None }.nullable(false),

--- a/src/pgwire-common/src/conn.rs
+++ b/src/pgwire-common/src/conn.rs
@@ -20,6 +20,7 @@ use tokio_postgres::error::SqlState;
 use crate::ErrorResponse;
 
 pub const CONN_UUID_KEY: &str = "mz_connection_uuid";
+pub const MZ_FORWARDED_FOR_KEY: &str = "mz_forwarded_for";
 
 #[derive(Debug)]
 pub enum Conn<A> {

--- a/src/pgwire-common/src/lib.rs
+++ b/src/pgwire-common/src/lib.rs
@@ -22,7 +22,7 @@ pub use codec::{
     decode_startup, input_err, parse_frame_len, CodecError, Cursor, DecodeState, Pgbuf,
     ACCEPT_SSL_ENCRYPTION, MAX_REQUEST_SIZE, REJECT_ENCRYPTION,
 };
-pub use conn::{Conn, CONN_UUID_KEY};
+pub use conn::{Conn, CONN_UUID_KEY, MZ_FORWARDED_FOR_KEY};
 pub use format::Format;
 pub use message::{
     ErrorResponse, FrontendMessage, FrontendStartupMessage, VERSIONS, VERSION_3, VERSION_CANCEL,

--- a/src/pgwire/src/codec.rs
+++ b/src/pgwire/src/codec.rs
@@ -14,6 +14,8 @@
 //!
 //! [1]: https://www.postgresql.org/docs/11/protocol-message-formats.html
 
+use std::net::IpAddr;
+
 use async_trait::async_trait;
 use bytes::{Buf, BufMut, BytesMut};
 use bytesize::ByteSize;
@@ -36,6 +38,7 @@ use crate::message::{BackendMessage, BackendMessageKind};
 /// A connection that manages the encoding and decoding of pgwire frames.
 pub struct FramedConn<A> {
     conn_id: ConnectionId,
+    peer_addr: Option<IpAddr>,
     inner: sink::Buffer<Framed<Conn<A>, Codec>, BackendMessage>,
 }
 
@@ -51,9 +54,10 @@ where
     ///
     /// The supplied `conn_id` is used to identify the connection in logging
     /// messages.
-    pub fn new(conn_id: ConnectionId, inner: Conn<A>) -> FramedConn<A> {
+    pub fn new(conn_id: ConnectionId, peer_addr: Option<IpAddr>, inner: Conn<A>) -> FramedConn<A> {
         FramedConn {
             conn_id,
+            peer_addr,
             inner: Framed::new(inner, Codec::new()).buffer(32),
         }
     }
@@ -172,6 +176,11 @@ where
     /// Returns the ID associated with this connection.
     pub fn conn_id(&self) -> &ConnectionId {
         &self.conn_id
+    }
+
+    /// Returns the peer address of the connection.
+    pub fn peer_addr(&self) -> &Option<IpAddr> {
+        &self.peer_addr
     }
 }
 

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -188,6 +188,7 @@ where
                     conn_id: conn.conn_id().clone(),
                     uuid: conn_uuid,
                     user: auth_session.user().into(),
+                    client_ip: conn.peer_addr().clone(),
                     external_metadata_rx: Some(auth_session.external_metadata_rx()),
                 });
                 let expired = async move { auth_session.expired().await };
@@ -208,6 +209,7 @@ where
             conn_id: conn.conn_id().clone(),
             uuid: conn_uuid,
             user,
+            client_ip: conn.peer_addr().clone(),
             external_metadata_rx: None,
         });
         // No frontegg check, so auth session lasts indefinitely.
@@ -355,7 +357,7 @@ fn parse_option(option: &str) -> Result<(&str, &str), ()> {
     Err(())
 }
 
-/// Splits value by any number of spaces except those preceeded by `\`.
+/// Splits value by any number of spaces except those preceded by `\`.
 fn split_options(value: &str) -> Vec<String> {
     let mut strs = Vec::new();
     // Need to build a string because of the escaping, so we can't simply

--- a/src/server-core/Cargo.toml
+++ b/src/server-core/Cargo.toml
@@ -17,6 +17,7 @@ openssl = { version = "0.10.48", features = ["vendored"] }
 scopeguard = "1.1.0"
 socket2 = "0.5.3"
 tokio-stream = "0.1.11"
+proxy-header = "0.1.2"
 tracing = "0.1.37"
 futures = "0.3.25"
 mz-dyncfg = { path = "../dyncfg" }

--- a/src/sql/src/session/metadata.rs
+++ b/src/sql/src/session/metadata.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::Debug;
+use std::net::IpAddr;
 
 use mz_adapter_types::connection::ConnectionId;
 use mz_repr::role_id::RoleId;
@@ -21,6 +22,8 @@ pub trait SessionMetadata: Debug + Sync {
     fn vars(&self) -> &SessionVars;
     /// Returns the connection ID associated with the session.
     fn conn_id(&self) -> &ConnectionId;
+    /// Returns the client address associated with the session.
+    fn client_ip(&self) -> Option<&IpAddr>;
     /// Returns the current transaction's PlanContext. Panics if there is not a
     /// current transaction.
     fn pcx(&self) -> &PlanContext;

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -345,7 +345,8 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 1  id  uuid
 2  connection_id  uint4
 3  role_id  text
-4  connected_at  timestamp␠with␠time␠zone
+4  client_ip  text
+5  connected_at  timestamp␠with␠time␠zone
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_show_all_privileges' ORDER BY position


### PR DESCRIPTION
Updates pgwire, http, and ws connections
to pass through the peer ip and stuff
it into the new sessions.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
https://github.com/MaterializeInc/materialize/issues/23498
Pre work for https://github.com/MaterializeInc/materialize/issues/16068
Currently we store and report sessions in mz_sessions table. This includes data about when the session was created and the session role, but we don't pass through the IPs of that session. For audit reasons it seems like it be useful to pass this through. There are a few challenges, one being that with the balacner or a proxy in front the actual peer ip may not always be valueable to know. We also need to check `X_FORWARD_FOR` headers for http, and similarly, we need to inject an `X_FORWARD_FOR` param for all connections that go through the balancers (this might not work if balancers can't inject an X_FORWARD_FOR in http traffic)
.

So far I have only handled the base case that we trust the peer id, the headers/params still need taken into consideration. They will end up overriding the peer_ip. 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
