### PR TITLE
persist,WIP: add real Subscribe for shards in txn

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -118,6 +118,11 @@ where
         }
     }
 
+    /// [ShardId] of the shard.
+    pub fn shard_id(&self) -> ShardId {
+        self.listen.handle.machine.shard_id()
+    }
+
     /// Returns a `LeasedBatchPart` enriched with the proper metadata.
     ///
     /// First returns snapshot parts, until they're exhausted, at which point

--- a/src/txn-wal/src/operator.rs
+++ b/src/txn-wal/src/operator.rs
@@ -194,7 +194,7 @@ where
         let mut txns_cache = TxnsCache::<T, C>::open(&client, txns_id, Some(data_id)).await;
 
         let _ = txns_cache.update_gt(&as_of).await;
-        let mut subscribe = txns_cache.data_subscribe(data_id, as_of.clone());
+        let mut subscribe = txns_cache.scoped_txn_subscribe(data_id, as_of.clone());
         let data_write = client
             .open_writer::<K, V, T, D>(
                 data_id,
@@ -320,7 +320,7 @@ where
             .await
             .expect("schema shouldn't change");
         let mut rx = txns_read
-            .data_subscribe(data_id, as_of.clone(), Box::new(data_write))
+            .scoped_txn_subscribe(data_id, as_of.clone(), Box::new(data_write))
             .await;
         debug!("{} starting as_of={:?}", name, as_of);
 


### PR DESCRIPTION
Not yet polished, but should bring the idea across. The core logic is quite simple, but I'm not sure I got the song and dance with `TxnsCache` and `TxnsRead` right, or whether we can/want to simplify things there.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
