### PR TITLE
storage/sources: Allow kafka sources to export to multiple source exports

### DIFF
--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -50,7 +50,7 @@ breaking:
     # reason: currently does not require backward-compatibility
     - storage-types/src/connections/string_or_secret.proto
     # reason: no reason specified
-    - storage-types/src/sinks.proto
+    - storage-types/src/sources.proto
 lint:
   use:
     - DEFAULT

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -7,11 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// buf breaking: ignore (a compatible change: Field "23" on message
-// "ProtoKafkaSinkConnectionV2" changed type from
-// "mz_storage_types.sinks.ProtoKafkaSinkTopicOptions" to
-// "mz_storage_types.connections.ProtoKafkaTopicOptions".)
-
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -7,6 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+// buf breaking: ignore (a compatible change: Field "1" on message
+// "ProtoSourceExportDetails" changed type from "google.protobuf.Empty"
+// to "mz_storage_types.sources.kafka.ProtoKafkaSourceExportDetails".)
+
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
@@ -72,7 +76,7 @@ message ProtoCompression {
 
 message ProtoSourceExportDetails {
     oneof kind {
-        google.protobuf.Empty kafka = 1;
+        mz_storage_types.sources.kafka.ProtoKafkaSourceExportDetails kafka = 1;
         mz_storage_types.sources.postgres.ProtoPostgresSourceExportDetails postgres = 2;
         mz_storage_types.sources.mysql.ProtoMySqlSourceExportDetails mysql = 3;
         mz_storage_types.sources.load_generator.ProtoLoadGeneratorSourceExportDetails loadgen = 4;

--- a/src/storage-types/src/sources/kafka.proto
+++ b/src/storage-types/src/sources/kafka.proto
@@ -43,6 +43,10 @@ message ProtoKafkaMetadataKind {
     }
 }
 
+message ProtoKafkaSourceExportDetails {
+    repeated ProtoKafkaMetadataColumn metadata_columns = 1;
+}
+
 message ProtoKafkaHeader {
     string key = 1;
     bool use_bytes = 2;

--- a/src/storage-types/src/sources/kafka.rs
+++ b/src/storage-types/src/sources/kafka.rs
@@ -55,6 +55,9 @@ pub struct KafkaSourceConnection<C: ConnectionAccess = InlinedConnection> {
     #[proptest(strategy = "proptest::collection::btree_map(any::<i32>(), any::<i64>(), 0..4)")]
     pub start_offsets: BTreeMap<i32, i64>,
     pub group_id_prefix: Option<String>,
+    // The metadata_columns for the primary source export from this kafka source
+    // TODO: This should be removed once we stop outputting to the primary source collection
+    // and instead only output to source_exports
     #[proptest(strategy = "proptest::collection::vec(any::<(String, KafkaMetadataKind)>(), 0..4)")]
     pub metadata_columns: Vec<(String, KafkaMetadataKind)>,
     pub topic_metadata_refresh_interval: Duration,
@@ -350,6 +353,60 @@ impl RustType<ProtoKafkaSourceConnection> for KafkaSourceConnection<InlinedConne
                 .topic_metadata_refresh_interval
                 .into_rust_if_some("ProtoKafkaSourceConnection::topic_metadata_refresh_interval")?,
         })
+    }
+}
+
+/// The details of a source export from a kafka source.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
+pub struct KafkaSourceExportDetails {
+    #[proptest(strategy = "proptest::collection::vec(any::<(String, KafkaMetadataKind)>(), 0..4)")]
+    pub metadata_columns: Vec<(String, KafkaMetadataKind)>,
+}
+
+impl crate::AlterCompatible for KafkaSourceExportDetails {
+    fn alter_compatible(&self, id: GlobalId, other: &Self) -> Result<(), AlterError> {
+        let Self { metadata_columns } = self;
+        let compatibility_checks = [(
+            metadata_columns == &other.metadata_columns,
+            "metadata_columns",
+        )];
+        for (compatible, field) in compatibility_checks {
+            if !compatible {
+                tracing::warn!(
+                    "KafkaSourceExportDetails incompatible at {field}:\nself:\n{:#?}\n\nother\n{:#?}",
+                    self,
+                    other
+                );
+
+                return Err(AlterError { id });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl RustType<ProtoKafkaSourceExportDetails> for KafkaSourceExportDetails {
+    fn into_proto(&self) -> ProtoKafkaSourceExportDetails {
+        ProtoKafkaSourceExportDetails {
+            metadata_columns: self
+                .metadata_columns
+                .iter()
+                .map(|(name, kind)| ProtoKafkaMetadataColumn {
+                    name: name.into_proto(),
+                    kind: Some(kind.into_proto()),
+                })
+                .collect(),
+        }
+    }
+
+    fn from_proto(proto: ProtoKafkaSourceExportDetails) -> Result<Self, TryFromProtoError> {
+        let mut metadata_columns = Vec::with_capacity(proto.metadata_columns.len());
+        for c in proto.metadata_columns {
+            let kind = c.kind.into_rust_if_some("ProtoKafkaMetadataColumn::kind")?;
+            metadata_columns.push((c.name, kind));
+        }
+
+        Ok(KafkaSourceExportDetails { metadata_columns })
     }
 }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Fixes https://github.com/MaterializeInc/materialize/issues/29209

Note that this PR just enables the kafka source to output it's raw data to multiple source export streams. The work beyond this PR will allow us to modify encoding and envelope's on a per-source-export basis:  https://github.com/MaterializeInc/materialize/issues/29225

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
