### PR TITLE
persist: Enable dictionary encoding for some CI builds

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -279,6 +279,7 @@ steps:
               args: [
                 --system-param=persist_part_decode_format=arrow,
                 --system-param=persist_batch_columnar_format=both_v2,
+                --system-param=persist_encoding_enable_dictionary=true,
               ]
 
       - id: testdrive-in-cloudtest

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1021,7 +1021,9 @@ class FlipFlagsAction(Action):
             "row_with_validate",
             "arrow",
         ]
-        self.flags_with_values["persist_encoding_enable_dictionary"] = BOOLEAN_FLAG_VALUES
+        self.flags_with_values["persist_encoding_enable_dictionary"] = (
+            BOOLEAN_FLAG_VALUES
+        )
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1021,6 +1021,7 @@ class FlipFlagsAction(Action):
             "row_with_validate",
             "arrow",
         ]
+        self.flags_with_values["persist_encoding_enable_dictionary"] = BOOLEAN_FLAG_VALUES
 
     def run(self, exe: Executor) -> bool:
         flag_name = self.rng.choice(list(self.flags_with_values.keys()))

--- a/src/persist-proc/src/lib.rs
+++ b/src/persist-proc/src/lib.rs
@@ -112,6 +112,11 @@ fn test_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
                     x.add_dynamic("persist_batch_columnar_format", ::mz_dyncfg::ConfigVal::String("both_v2".into()));
                     x.add_dynamic("persist_batch_columnar_format_percent", ::mz_dyncfg::ConfigVal::Usize(100));
                     x
+                },
+                {
+                    let mut x = ::mz_dyncfg::ConfigUpdates::default();
+                    x.add_dynamic("persist_encoding_enable_dictionary", ::mz_dyncfg::ConfigVal::Bool(true));
+                    x
                 }
             ];
 


### PR DESCRIPTION
This PR adds the `persist_encoding_enable_dictionary` flag to a few CI builds to get coverage on it.

### Motivation

Get CI coverage so we're comfortable testing it more broadly

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
