### PR TITLE
persist: fix bug in `persistcli bench s3-fetch`

### DIFF
--- a/src/persist-client/src/cli/bench.rs
+++ b/src/persist-client/src/cli/bench.rs
@@ -43,7 +43,7 @@ pub struct S3FetchArgs {
     iters: usize,
 
     #[clap(long)]
-    decode: bool,
+    parse: bool,
 }
 
 /// Runs the given bench command.
@@ -56,7 +56,7 @@ pub async fn run(command: BenchArgs) -> Result<(), anyhow::Error> {
 }
 
 async fn bench_s3(args: &S3FetchArgs) -> Result<(), anyhow::Error> {
-    let decode = args.decode;
+    let parse = args.parse;
     let shard_id = args.shard.shard_id();
     let state_versions = args.shard.open().await?;
     let versions = state_versions
@@ -70,9 +70,9 @@ async fn bench_s3(args: &S3FetchArgs) -> Result<(), anyhow::Error> {
         .snapshot(state.since())
         .expect("since should be available for reads");
 
-    let start = Instant::now();
-    println!("iter,key,size_bytes,fetch_secs,decode_secs");
+    println!("iter,key,size_bytes,fetch_secs,parse_secs");
     for iter in 0..args.iters {
+        let start = Instant::now();
         let mut fetches = Vec::new();
         for part in snap.iter().flat_map(|x| x.parts.iter()) {
             let key = match part {
@@ -85,11 +85,11 @@ async fn bench_s3(args: &S3FetchArgs) -> Result<(), anyhow::Error> {
                 let buf = blob.get(&key).await.unwrap().unwrap();
                 let fetch_elapsed = start.elapsed();
                 let buf_len = buf.len();
-                let decode_elapsed = mz_ore::task::spawn_blocking(
+                let parse_elapsed = mz_ore::task::spawn_blocking(
                     || "",
                     move || {
                         let start = Instant::now();
-                        if decode {
+                        if parse {
                             BlobTraceBatchPart::<u64>::decode(&buf, &metrics.columnar).unwrap();
                         }
                         start.elapsed()
@@ -101,16 +101,16 @@ async fn bench_s3(args: &S3FetchArgs) -> Result<(), anyhow::Error> {
                     key,
                     buf_len,
                     fetch_elapsed.as_secs_f64(),
-                    decode_elapsed.as_secs_f64(),
+                    parse_elapsed.as_secs_f64(),
                 )
             });
             fetches.push(fetch);
         }
         for fetch in fetches {
-            let (key, size_bytes, fetch_secs, decode_secs) = fetch.await.unwrap();
+            let (key, size_bytes, fetch_secs, parse_secs) = fetch.await.unwrap();
             println!(
                 "{},{},{},{},{}",
-                iter, key, size_bytes, fetch_secs, decode_secs
+                iter, key, size_bytes, fetch_secs, parse_secs
             );
         }
     }


### PR DESCRIPTION
It was computing the start time once, instead of once-per-iter.

While I'm in here, update the "decode" naming to "parse" to match what I'm trying to establish as the jargon: fetch (s3 -> bytes), parse (bytes -> arrow), decode (arrow -> row).

### Motivation

  * This PR fixes a previously unreported bug.


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
