### PR TITLE
platform-checks: Add ZeroDowntimeBumpedVersion scenario

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -17,8 +17,17 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
-if [[ $# -ne 1 ]]; then
-    die "usage: $0 VERSION"
+if [[ $# -ne 1 && $# -ne 2 ]]; then
+    die "usage: $0 VERSION [--no-commit]"
+fi
+
+commit=true
+if [[ $# -eq 2 ]]; then
+    if [[ "$2" == "--no-commit" ]]; then
+        commit=false
+    else
+        die "invalid flag: $2, only --no-commit is supported"
+    fi
 fi
 
 if ! run git diff HEAD --compact-summary --exit-code; then
@@ -55,4 +64,6 @@ cargo update --workspace
 
 bin/bazel gen
 
-git commit -am "release: bump to version v$version"
+if $commit; then
+    git commit -am "release: bump to version v$version"
+fi

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -847,6 +847,18 @@ steps:
               composition: platform-checks
               args: [--scenario=ZeroDowntimeUpgradeEntireMzFourVersions, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-0dt-bump-version
+        label: "Checks 0dt upgrade to a bumped version"
+        depends_on: build-aarch64
+        timeout_in_minutes: 180
+        agents:
+          # TODO(def-): Switch back to hetzner
+          queue: builder-linux-aarch64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=ZeroDowntimeBumpedVersion, "--seed=$BUILDKITE_JOB_ID"]
+
       - id: cloudtest-upgrade
         label: "Platform checks upgrade in Cloudtest/K8s"
         depends_on: build-aarch64

--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -12,7 +12,9 @@ import time
 from inspect import getframeinfo, stack
 from typing import TYPE_CHECKING, Any
 
+from materialize import MZ_ROOT, spawn
 from materialize.checks.executors import Executor
+from materialize.mz_version import MzVersion
 
 if TYPE_CHECKING:
     from materialize.checks.scenarios import Scenario
@@ -113,3 +115,12 @@ class Validate(Action):
     def join(self, e: Executor) -> None:
         for check in self.checks:
             check.join_validate(e)
+
+
+class BumpVersion(Action):
+    def execute(self, e: Executor) -> None:
+        version = MzVersion.parse_cargo().bump_minor()
+        spawn.runv(["bin/bump-version", str(version), "--no-commit"], cwd=MZ_ROOT)
+
+    def join(self, e: Executor) -> None:
+        pass


### PR DESCRIPTION
Helps finding issues like https://github.com/MaterializeInc/materialize/issues/29199 earlier.

Works: https://buildkite.com/materialize/nightly/builds/9232
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
