### PR TITLE
deps: Upgrade `serde_json` to 1.0.125

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9001,12 +9001,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/misc/bazel/cargo-gazelle/Cargo.toml
+++ b/misc/bazel/cargo-gazelle/Cargo.toml
@@ -25,7 +25,7 @@ protobuf-parse = "3.4.0"
 quote = "1.0.23"
 syn = { version = "1.0.107", features = ["extra-traits", "full"] }
 serde = "1.0.152"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "std"] }
 workspace-hack = { version = "0.0.0", path = "../../../src/workspace-hack", optional = true }

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -1005,6 +1005,11 @@ who = "Roshan Jobanputra <roshan@materialize.com>"
 criteria = "safe-to-deploy"
 version = "1.0.202"
 
+[[audits.serde_json]]
+who = "Parker Timmerman <parker.timmerman@materialize.com>"
+criteria = "safe-to-deploy"
+version = "1.0.125"
+
 [[audits.sha2-asm]]
 who = "Petros Angelatos <petrosagg@gmail.com>"
 criteria = "safe-to-deploy"

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -89,7 +89,7 @@ regex = "1.7.0"
 reqwest = "0.11.13"
 semver = "1.0.16"
 serde = "1.0.152"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 serde_plain = "1.0.1"
 sha2 = "0.10.6"
 smallvec = { version = "1.10.0", features = ["union"] }

--- a/src/arrow-util/Cargo.toml
+++ b/src/arrow-util/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 mz-repr = { path = "../repr" }
 mz-ore = { path = "../ore" }
 serde = { version = "1.0.152" }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/audit-log/Cargo.toml
+++ b/src/audit-log/Cargo.toml
@@ -15,7 +15,7 @@ mz-ore = { path = "../ore", features = ["test"] }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 serde_plain = "1.0.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = "1.16.0"
 rand = "0.8.5"
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 sha2 = "0.10.6"
 snap = { version = "1.1.0", optional = true }
 tracing = "0.1.37"

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -26,7 +26,7 @@ mz-secrets = { path = "../secrets" }
 mz-sql = { path = "../sql" }
 once_cell = "1.16.0"
 serde = "1.0.152"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 tokio = "1.38.0"
 tokio-postgres = { version = "0.7.8", features = ["with-serde_json-1"] }
 tracing = "0.1.37"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -53,7 +53,7 @@ postgres-openssl = { version = "0.5.0" }
 rand = "0.8.5"
 semver = { version = "1.0.16" }
 serde = "1.0.152"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 serde_plain = "1.0.1"
 static_assertions = "1.1"
 sha2 = "0.10.6"
@@ -77,7 +77,7 @@ md-5 = "0.10.5"
 mz-build-tools = { path = "../build-tools", default-features = false }
 prost-build = "0.13.1"
 serde = "1.0.152"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 
 [features]
 default = ["mz-build-tools/default"]

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -22,7 +22,7 @@ mz-tls-util = { path = "../tls-util" }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0" }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 url = { version = "2.3.1", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
@@ -31,7 +31,7 @@ hyper = { version = "1.4.1", features = ["server"] }
 hyper-util = "0.1.6"
 once_cell = "1.16.0"
 mz-ore = { path = "../ore", features = ["async", "test"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 tokio = { version = "1.38.0", features = ["macros"] }
 tracing = "0.1.37"
 

--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -20,7 +20,7 @@ mz-ore = { path = "../ore", features = [] }
 mz-repr = { path = "../repr" }
 schemars = { version = "0.8", features = ["uuid1"] }
 serde = "1.0.152"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 uuid = { version = "1.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -25,7 +25,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 thiserror = "1.0.37"
 tokio = "1.38.0"
 tokio-stream = "0.1.11"

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -45,7 +45,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 thiserror = "1.0.37"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = "1.38.0"

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -33,7 +33,7 @@ mz-txn-wal = { path = "../txn-wal" }
 once_cell = "1.16.0"
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = "1.38.0"
 tokio-stream = "0.1.11"

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -98,7 +98,7 @@ semver = "1.0.16"
 sentry = { version = "0.29.1", optional = true }
 sentry-tracing = "0.29.1"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 shell-words = "1.1.0"
 sysctl = "0.5.4"
 tempfile = "3.8.1"
@@ -145,7 +145,7 @@ rdkafka = { version = "0.29.0", features = [
     "zstd",
 ] }
 reqwest = { version = "0.11.13", features = ["blocking"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 serde_urlencoded = "0.7.1"
 similar-asserts = "1.4"
 timely = { version = "0.12.0", default-features = false, features = [

--- a/src/expr-test-util/Cargo.toml
+++ b/src/expr-test-util/Cargo.toml
@@ -17,7 +17,7 @@ mz-repr = { path = "../repr" }
 mz-repr-test-util = { path = "../repr-test-util" }
 proc-macro2 = "1.0.60"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -52,7 +52,7 @@ regex = "1.7.0"
 regex-syntax = "0.8.3"
 seahash = "4.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
 subtle = "2.4.1"

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -25,7 +25,7 @@ postgres-protocol = { version = "0.6.5" }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 prost-types = { version = "0.13.1" }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 sha2 = "0.10.6"
 socket2 = "0.5.3"
 thiserror = "1.0.37"

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -24,7 +24,7 @@ reqwest = { version = "0.11.13", features = ["json"] }
 reqwest-middleware = "0.2.2"
 reqwest-retry = "0.2.2"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", features = ["macros"] }
 tracing = "0.1.37"

--- a/src/frontegg-client/Cargo.toml
+++ b/src/frontegg-client/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 once_cell = "1.16.0"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", features = ["macros"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 uuid = { version = "1.7.0", features = ["serde"] }
 url = "2.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/frontegg-mock/Cargo.toml
+++ b/src/frontegg-mock/Cargo.toml
@@ -21,7 +21,7 @@ jsonwebtoken = "9.2.0"
 mz-frontegg-auth = { path = "../frontegg-auth" }
 mz-ore = { path = "../ore", default-features = false, features = ["cli"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 tokio = { version = "1.38.0", default-features = false }
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -21,7 +21,7 @@ include_dir = "0.7.3"
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "tracing_"] }
 prometheus = { version = "0.13.3", default-features = false }
 serde = "1.0.152"
-serde_json = { version = "1.0.89" }
+serde_json = { version = "1.0.125" }
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "retry", "timeout", "util"] }
 tower-http = { version = "0.5.2", features = ["auth", "cors", "map-response-body", "trace", "util"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -33,7 +33,7 @@ ordered-float = { version = "4.2.0", features = ["serde"] }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 prost-reflect = "0.14.0"
 seahash = "4"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.38.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -30,7 +30,7 @@ prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 tokio = { version = "1.38.0", features = ["macros", "rt", "sync"] }
 thiserror = "1.0.37"
 tracing = "0.1.37"

--- a/src/lowertest/Cargo.toml
+++ b/src/lowertest/Cargo.toml
@@ -14,7 +14,7 @@ mz-lowertest-derive = { path = "../lowertest-derive" }
 mz-ore = { path = "../ore", features = ["test"], default-features = false }
 proc-macro2 = "1.0.60"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]

--- a/src/lsp-server/Cargo.toml
+++ b/src/lsp-server/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 ropey = "1.5.0"
 once_cell = "1.16.0"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 tokio = { version = "1.38.0", features = ["sync"] }
 tower-lsp = { version = "0.20.0", features = ["proposed"]}
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/mysql-util/Cargo.toml
+++ b/src/mysql-util/Cargo.toml
@@ -28,7 +28,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 fancy-regex = "0.11.0"
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89" }
+serde_json = { version = "1.0.125" }
 thiserror = "1.0.37"
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -31,7 +31,7 @@ rpassword = "7.2.0"
 semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 serde-aux = "4.1.2"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 tabled = "0.10.0"
 time = "0.3.17"
 tokio = { version = "1.38.0", features = ["full"] }

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -25,7 +25,7 @@ mz-repr = { path = "../repr" }
 k8s-openapi = { version = "0.22.0", features = ["v1_29"] }
 kube = { version = "0.92.1", default-features = false, features = ["client", "runtime", "ws"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 sha2 = "0.10.6"
 tokio = "1.32.0"
 tracing = "0.1.37"

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -25,7 +25,7 @@ mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets" }
 nix = "0.26.1"
 serde = "1.0.147"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 scopeguard = "1.1.0"
 sha1 = "0.10.5"
 sysinfo = "0.27.2"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -100,7 +100,7 @@ criterion = { version = "0.4.0", features = ["async_tokio"] }
 mz-ore = { path = "../ore", features = ["id_gen"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 scopeguard = "1.1.0"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 tokio-test = "0.4.2"
 tracing-subscriber = "0.3.16"

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -39,7 +39,7 @@ num_cpus = "1.14.0"
 num_enum = "0.5.7"
 prometheus = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -59,7 +59,7 @@ prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 sentry-tracing = "0.29.1"
 semver = { version = "1.0.16", features = ["serde"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -25,7 +25,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89" }
+serde_json = { version = "1.0.125" }
 timely = { version = "0.12.0", default-features = false, features = ["bincode", "getopts"] }
 tracing = "0.1.37"
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -72,7 +72,7 @@ features = ["asm"]
 
 [dev-dependencies]
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 tempfile = "3.8.1"
 
 [build-dependencies]

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -18,7 +18,7 @@ fallible-iterator = "0.2.0"
 mz-ore = { path = "../ore", features = ["cli"] }
 postgres-protocol = { version = "0.6.5" }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -24,7 +24,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive", "rc"] }
-serde_json = { version = "1.0.89", features = ["arbitrary_precision"] }
+serde_json = { version = "1.0.125", features = ["arbitrary_precision"] }
 tokio-postgres = { version = "0.7.8", optional = true }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = "1.2.2"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -67,7 +67,7 @@ prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 regex = "1.7.0"
 ryu = "1.0.12"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89", features = ["arbitrary_precision", "preserve_order"] }
+serde_json = { version = "1.0.125", features = ["arbitrary_precision", "preserve_order"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 static_assertions = "1.1"
 strsim = "0.10"

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -25,7 +25,7 @@ proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 tokio = { version = "1.38.0", features = ["macros", "sync", "rt"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89" }
+serde_json = { version = "1.0.125" }
 thiserror = "1.0.37"
 tracing = "0.1.37"
 # These features use compression code that are licensed with:

--- a/src/segment/Cargo.toml
+++ b/src/segment/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 chrono = { version = "0.4.35", default-features = false, features = ["std"] }
 mz-ore = { path = "../ore", features = ["async"], default-features = false }
 segment = { version = "0.2.1", features = ["native-tls-vendored"], default-features = false }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 time = "0.3.17"
 tokio = { version = "1.38.0", features = ["sync"] }
 tracing = "0.1.37"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -78,7 +78,7 @@ rdkafka = { version = "0.29.0", features = [
 regex = "1.7.0"
 reqwest = "0.11.13"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 static_assertions = "1.1"
 thiserror = "1.0.37"
 tokio = { version = "1.38.0", features = ["fs"] }

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -45,7 +45,7 @@ postgres-protocol = { version = "0.6.5" }
 regex = "1.7.0"
 reqwest = { version = "0.11.13", features = ["json"] }
 shell-words = "1.1.0"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 tempfile = "3.8.1"
 time = "0.3.17"
 tracing = "0.1.37"

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -20,7 +20,7 @@ futures = "0.3.25"
 itertools = "0.10.5"
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89" }
+serde_json = { version = "1.0.125" }
 ssh-key = { version = "0.4.3" }
 tempfile = "3.3.0"
 thiserror = { version = "1.0.37" }

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -44,7 +44,7 @@ rdkafka = { version = "0.29.0", features = [
     "zstd",
 ] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89" }
+serde_json = { version = "1.0.125" }
 static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = [
     "bincode",

--- a/src/storage-controller/Cargo.toml
+++ b/src/storage-controller/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = { version = "1.16.0" }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89" }
+serde_json = { version = "1.0.125" }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -63,7 +63,7 @@ prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89", features = ["preserve_order"] }
+serde_json = { version = "1.0.125", features = ["preserve_order"] }
 thiserror = "1.0.37"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.38.0", features = ["fs", "rt", "sync", "test-util", "time"] }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -82,7 +82,7 @@ regex = { version = "1.7.0" }
 rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", "zstd", "lz4"] }
 seahash = "4"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = { version = "1.0.89" }
+serde_json = { version = "1.0.125" }
 serde_bytes = { version = "0.11.14" }
 sha2 = "0.10.6"
 timely = { version = "0.12.0", default-features = false, features = [

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -66,7 +66,7 @@ regex = "1.7.0"
 reqwest = { version = "0.11.13", features = ["native-tls-vendored"] }
 semver = "1.0.16"
 serde = "1.0.152"
-serde_json = { version = "1.0.89", features = ["raw_value"] }
+serde_json = { version = "1.0.125", features = ["raw_value"] }
 similar = "2.2.1"
 tempfile = "3.8.1"
 termcolor = "1.1.3"

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -31,7 +31,7 @@ mz-expr-test-util = { path = "../expr-test-util" }
 mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore", features = ["test"] }
 proc-macro2 = "1.0.60"
-serde_json = "1.0.89"
+serde_json = "1.0.125"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -106,7 +106,7 @@ schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.203", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.117", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.125", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth"] }
 sha2 = { version = "0.10.6", features = ["asm"] }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "serde", "union", "write"] }
@@ -234,7 +234,7 @@ schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0.203", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.117", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.125", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value", "unbounded_depth"] }
 sha2 = { version = "0.10.6", features = ["asm"] }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new", "serde", "union", "write"] }


### PR DESCRIPTION
Upgrades our `serde_json` dependency to 1.0.125 to pickup some recent performance improvements as detailed [in this blog post](https://purplesyringa.moe/blog/i-sped-up-serde-json-strings-by-20-percent/) and in [release notes](https://github.com/serde-rs/json/releases).

### Motivation

Performance

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
