### PR TITLE
ci: Detect further doc references to issues

### DIFF
--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -56,6 +56,8 @@ REFERENCE_RE = re.compile(
     | tracked\ with
     # Used in proto files
     | //\ buf\ breaking:\ ignore
+    # Used in documentation
+    | in\ the\ future
     )
     """,
     re.VERBOSE | re.IGNORECASE,
@@ -79,6 +81,8 @@ IGNORE_RE = re.compile(
     | issues/20211\>
     # src/sql/src/plan/statement.rs
     | issues/20019\>
+    # src/storage/src/storage_state.rs
+    | \#19907$
     )
     """,
     re.VERBOSE | re.IGNORECASE,


### PR DESCRIPTION
As suggested in https://materializeinc.slack.com/archives/CPNFV9CVB/p1724433400504749?thread_ts=1724429667.230919&cid=CPNFV9CVB

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
