### PR TITLE
bazel: Support building the `fivetran-destination` and `testdrive`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -507,3 +507,14 @@ rust_repositories()
 
 load("@cxxbridge//:defs.bzl", cxxbridge_cmd_deps = "crate_repositories")
 cxxbridge_cmd_deps()
+
+# git Submodules
+#
+# We include any git Submodules as local Bazel repositories so we can access
+# their contents or build them.
+
+new_local_repository(
+    name = "fivetran_sdk",
+    path = "misc/fivetran-sdk",
+    build_file = "//misc/bazel:git_submodules/BUILD.fivetran_sdk.bazel",
+)

--- a/bin/bazel-temp
+++ b/bin/bazel-temp
@@ -21,4 +21,11 @@ cd "$(dirname "$0")/.."
 . misc/shlib/shlib.bash
 
 # Build `environmentd`, `clusterd`, and `balancerd` with optimizations.
-bin/bazel build //src/environmentd:environmentd //src/clusterd:clusterd //src/balancerd:mz_balancerd_bin -c opt --remote_cache=https://bazel-remote.dev.materialize.com 2>&1 | sed -e 's/INFO/--- INFO/'
+bin/bazel build \
+    //src/environmentd:environmentd \
+    //src/clusterd:clusterd \
+    //src/balancerd:mz_balancerd_bin \
+    //src/sqllogictest:sqllogictest \
+    //src/testdrive:testdrive \
+    //src/fivetran-destination:mz_fivetran_destination_bin \
+    -c opt --remote_cache=https://bazel-remote.dev.materialize.com 2>&1 | sed -e 's/INFO/--- INFO/'

--- a/misc/bazel/git_submodules/BUILD.bazel
+++ b/misc/bazel/git_submodules/BUILD.bazel
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+visibility = ["//visibility:public"]

--- a/misc/bazel/git_submodules/BUILD.fivetran_sdk.bazel
+++ b/misc/bazel/git_submodules/BUILD.fivetran_sdk.bazel
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Our Fivetran Destination references the protobuf files at the top-level of
+# the `fivetran-sdk` repository.
+filegroup(
+	name = "all_protos",
+	srcs = glob(["*.proto"]),
+    visibility = ["//visibility:public"]
+)

--- a/src/build-tools/src/lib.rs
+++ b/src/build-tools/src/lib.rs
@@ -24,6 +24,17 @@ use std::path::PathBuf;
 #[cfg(bazel)]
 extern crate runfiles;
 
+/// Returns if we're currently building with Bazel.
+pub const fn is_bazel_build() -> bool {
+    cfg_if! {
+        if #[cfg(bazel)] {
+            true
+        } else {
+            false
+        }
+    }
+}
+
 /// Returns the path to `protoc`.
 ///
 /// Looks for `protoc` in the following places:

--- a/src/fivetran-destination/BUILD.bazel
+++ b/src/fivetran-destination/BUILD.bazel
@@ -63,7 +63,7 @@ rust_test(
 	size = "medium",
 	compile_data = [],
 	data = [],
-	env = {},
+	env = { "INSTA_WORKSPACE_ROOT": "." },
 	rustc_flags = [],
 	rustc_env = {},
 )
@@ -98,7 +98,7 @@ cargo_build_script(
 		build_proc_macro = True,
 	),
 	build_script_env = {},
-	data = [],
+	data = ["@fivetran_sdk//:all_protos"],
 	compile_data = [],
 	rustc_flags = [],
 	rustc_env = {},

--- a/src/fivetran-destination/Cargo.toml
+++ b/src/fivetran-destination/Cargo.toml
@@ -55,4 +55,10 @@ default = ["mz-build-tools/default", "workspace-hack"]
 normal = ["workspace-hack"]
 
 [package.metadata.cargo-gazelle.build]
+# We depend on protobuf files that live in the fivetran-sdk submodule that
+# cargo-gazelle cannot find.
 skip_proto_search = true
+data = ["@fivetran_sdk//:all_protos"]
+
+[package.metadata.cargo-gazelle.test.lib]
+env = { INSTA_WORKSPACE_ROOT = "." }

--- a/src/testdrive/BUILD.bazel
+++ b/src/testdrive/BUILD.bazel
@@ -161,7 +161,7 @@ cargo_build_script(
 		build_proc_macro = True,
 	),
 	build_script_env = {},
-	data = [],
+	data = ["@fivetran_sdk//:all_protos"],
 	compile_data = [],
 	rustc_flags = [],
 	rustc_env = {},

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -96,4 +96,7 @@ default = ["mz-build-tools/default"]
 normal = ["workspace-hack"]
 
 [package.metadata.cargo-gazelle.build]
+# We depend on protobuf files that live in the fivetran-sdk submodule that
+# cargo-gazelle cannot find.
 skip_proto_search = true
+data = ["@fivetran_sdk//:all_protos"]


### PR DESCRIPTION
This PR adds the `fivetran-sdk` submodule as a Bazel repository which is necessary to access the protobuf files from the submodule. Doing this allows us to build the crates that depend on these protos, namely the `fivetran-destination` and `testdrive`.

### Motivation

Progress towards https://github.com/MaterializeInc/materialize/issues/26796

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
