### PR TITLE
tests: Nightly fix unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,18 +2288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum_dispatch"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6060,7 +6048,6 @@ dependencies = [
  "dec",
  "differential-dataflow",
  "enum-kinds",
- "enum_dispatch",
  "fast-float",
  "flatcontainer",
  "hex",

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -37,7 +37,6 @@ chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
 compact_bytes = "0.1.2"
 dec = "0.4.8"
 differential-dataflow = "0.12.0"
-enum_dispatch = "0.3.11"
 enum-kinds = "0.5.1"
 fast-float = "0.2.0"
 flatcontainer = "0.5.0"


### PR DESCRIPTION
As it says on the tin

### Motivation

Fix nightlies

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
